### PR TITLE
Don't attempt to emulate case insensitivity on Windows

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/Actions.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Actions.java
@@ -269,9 +269,9 @@ public final class Actions {
     }
   }
 
+  // TODO(fmeum): Replace with comparator in PathFragment.
   private static final Comparator<Artifact> EXEC_PATH_PREFIX_COMPARATOR =
       (lhs, rhs) -> {
-        // We need to use the OS path policy in case the OS is case insensitive.
         OsPathPolicy os = OsPathPolicy.getFilePathOs();
         String str1 = lhs.getExecPathString();
         String str2 = rhs.getExecPathString();
@@ -281,7 +281,7 @@ public final class Actions {
         for (int i = 0; i < n; ++i) {
           char c1 = str1.charAt(i);
           char c2 = str2.charAt(i);
-          int res = os.compare(c1, c2);
+          int res = Character.compare(c1, c2);
           if (res != 0) {
             if (c1 == PathFragment.SEPARATOR_CHAR) {
               return -1;

--- a/src/main/java/com/google/devtools/build/lib/actions/Actions.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Actions.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.actions;
 
+import static java.util.Comparator.comparing;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 import com.google.common.base.Preconditions;
@@ -25,7 +26,6 @@ import com.google.common.escape.Escapers;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
 import com.google.devtools.build.lib.cmdline.Label;
-import com.google.devtools.build.lib.vfs.OsPathPolicy;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.skyframe.WalkableGraph;
 import java.util.Arrays;
@@ -269,30 +269,8 @@ public final class Actions {
     }
   }
 
-  // TODO(fmeum): Replace with comparator in PathFragment.
   private static final Comparator<Artifact> EXEC_PATH_PREFIX_COMPARATOR =
-      (lhs, rhs) -> {
-        OsPathPolicy os = OsPathPolicy.getFilePathOs();
-        String str1 = lhs.getExecPathString();
-        String str2 = rhs.getExecPathString();
-        int len1 = str1.length();
-        int len2 = str2.length();
-        int n = Math.min(len1, len2);
-        for (int i = 0; i < n; ++i) {
-          char c1 = str1.charAt(i);
-          char c2 = str2.charAt(i);
-          int res = Character.compare(c1, c2);
-          if (res != 0) {
-            if (c1 == PathFragment.SEPARATOR_CHAR) {
-              return -1;
-            } else if (c2 == PathFragment.SEPARATOR_CHAR) {
-              return 1;
-            }
-            return res;
-          }
-        }
-        return len1 - len2;
-      };
+      comparing(Artifact::getExecPath, PathFragment.HIERARCHICAL_COMPARATOR);
 
   /**
    * Check whether two artifacts are a runfiles tree - runfiles output manifest pair.

--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
@@ -30,7 +30,6 @@ import com.google.devtools.build.lib.skyframe.serialization.autocodec.Serializat
 import com.google.devtools.build.lib.util.HashCodes;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.util.StringUtilities;
-import com.google.devtools.build.lib.vfs.OsPathPolicy;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
@@ -165,9 +164,7 @@ public final class RepositoryName {
     this.name = name;
     this.contextRepoIfNotVisible = contextRepoIfNotVisible;
     this.didYouMeanSuffix = didYouMeanSuffix;
-    this.hashCode =
-        31 * OsPathPolicy.getFilePathOs().hash(name)
-            + HashCodes.hashObjects(contextRepoIfNotVisible, didYouMeanSuffix);
+    this.hashCode = HashCodes.hashObjects(name, contextRepoIfNotVisible, didYouMeanSuffix);
   }
 
   private RepositoryName(String name) {
@@ -361,7 +358,7 @@ public final class RepositoryName {
     if (!(object instanceof RepositoryName other)) {
       return false;
     }
-    return OsPathPolicy.getFilePathOs().equals(name, other.name)
+    return Objects.equals(name, other.name)
         && Objects.equals(contextRepoIfNotVisible, other.contextRepoIfNotVisible)
         && Objects.equals(didYouMeanSuffix, other.didYouMeanSuffix);
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -58,6 +58,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/path_mappers",
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/symlink_action",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
+        "//src/main/java/com/google/devtools/build/lib/analysis:constraints/constraint_constants",
         "//src/main/java/com/google/devtools/build/lib/analysis:rule_definition_environment",
         "//src/main/java/com/google/devtools/build/lib/analysis:rule_error_consumer",
         "//src/main/java/com/google/devtools/build/lib/analysis:starlark/args",

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
@@ -13,20 +13,17 @@
 // limitations under the License.
 package com.google.devtools.build.lib.rules.cpp;
 
+import static com.google.devtools.build.lib.util.FileType.hasExtension;
+
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.util.FileType;
 import com.google.devtools.build.lib.util.FileTypeSet;
-import com.google.devtools.build.lib.vfs.OsPathPolicy;
 import java.util.regex.Pattern;
 
-/**
- * C++-related file type definitions.
- */
+/** C++-related file type definitions. */
 public final class CppFileTypes {
-  private static final OsPathPolicy OS = OsPathPolicy.getFilePathOs();
-
   // .cu and .cl are CUDA and OpenCL source extensions, respectively. They are expected to only be
   // supported with clang. Bazel is not officially supporting these targets, and the extensions are
   // listed only as long as they work with the existing C++ actions.
@@ -102,7 +99,7 @@ public final class CppFileTypes {
 
         @Override
         public boolean apply(String path) {
-          return OS.endsWith(path, ext) && !PIC_PREPROCESSED_C.matches(path);
+          return hasExtension(path, ext) && !PIC_PREPROCESSED_C.matches(path);
         }
 
         @Override
@@ -117,7 +114,7 @@ public final class CppFileTypes {
 
         @Override
         public boolean apply(String path) {
-          return OS.endsWith(path, ext) && !PIC_PREPROCESSED_CPP.matches(path);
+          return hasExtension(path, ext) && !PIC_PREPROCESSED_CPP.matches(path);
         }
 
         @Override
@@ -149,7 +146,7 @@ public final class CppFileTypes {
 
         @Override
         public boolean apply(String path) {
-          return OS.endsWith(path, ext) && path.endsWith(".s");
+          return hasExtension(path, ext) && path.endsWith(".s");
         }
 
         @Override
@@ -165,7 +162,7 @@ public final class CppFileTypes {
 
         @Override
         public boolean apply(String path) {
-          return (path.endsWith(ext) && !PIC_ASSEMBLER.matches(path)) || OS.endsWith(path, ".asm");
+          return (path.endsWith(ext) && !PIC_ASSEMBLER.matches(path)) || hasExtension(path, ".asm");
         }
 
         @Override
@@ -183,15 +180,10 @@ public final class CppFileTypes {
         public boolean apply(String path) {
           if (PIC_ARCHIVE.matches(path)
               || ALWAYS_LINK_LIBRARY.matches(path)
-              || OS.endsWith(path, ".if.lib")) {
+              || hasExtension(path, ".if.lib")) {
             return false;
           }
-          for (String ext : extensions) {
-            if (OS.endsWith(path, ext)) {
-              return true;
-            }
-          }
-          return false;
+          return hasAnyExtension(path, extensions);
         }
 
         @Override
@@ -207,8 +199,8 @@ public final class CppFileTypes {
 
         @Override
         public boolean apply(String path) {
-          return (OS.endsWith(path, ext) && !ALWAYS_LINK_PIC_LIBRARY.matches(path))
-              || OS.endsWith(path, ".lo.lib");
+          return (hasExtension(path, ext) && !ALWAYS_LINK_PIC_LIBRARY.matches(path))
+              || hasExtension(path, ".lo.lib");
         }
 
         @Override
@@ -224,8 +216,8 @@ public final class CppFileTypes {
 
         @Override
         public boolean apply(String path) {
-          return (OS.endsWith(path, ext) && !PIC_OBJECT_FILE.matches(path))
-              || OS.endsWith(path, ".obj");
+          return (hasExtension(path, ext) && !PIC_OBJECT_FILE.matches(path))
+              || hasExtension(path, ".obj");
         }
 
         @Override
@@ -300,7 +292,7 @@ public final class CppFileTypes {
           // The current clang (clang-600.0.57) on Darwin doesn't support 'textual', so we can't
           // have '.inc' files in the module map (since they're implictly textual).
           // TODO(bazel-team): Use HEADERS file type once clang-700 is the base clang we support.
-          return OS.endsWith(artifact.getFilename(), ".h");
+          return hasExtension(artifact.getFilename(), ".h");
         }
       };
 

--- a/src/main/java/com/google/devtools/build/lib/util/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/util/BUILD
@@ -311,6 +311,7 @@ java_library(
         "FileTypeSet.java",
     ],
     deps = [
+        ":os",
         ":string",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization:visible-for-serialization",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",

--- a/src/main/java/com/google/devtools/build/lib/vfs/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/vfs/BUILD
@@ -49,6 +49,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/unsafe:string",
         "//src/main/java/com/google/devtools/build/lib/util:filetype",
         "//src/main/java/com/google/devtools/build/lib/util:os",
+        "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//third_party:error_prone_annotations",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
@@ -888,10 +888,7 @@ public class FileSystemUtils {
     return path.getFileSystem().getFileSystemType(path.asFragment());
   }
 
-  /**
-   * Returns whether the given path starts with any of the paths in the given
-   * list of prefixes.
-   */
+  /** Returns whether the given path starts with any of the paths in the given list of prefixes. */
   public static boolean startsWithAny(Path path, Iterable<Path> prefixes) {
     for (Path prefix : prefixes) {
       if (path.startsWith(prefix)) {
@@ -902,9 +899,19 @@ public class FileSystemUtils {
   }
 
   /**
-   * Returns whether the given path starts with any of the paths in the given
-   * list of prefixes.
+   * Returns whether the given path starts with any of the paths in the given list of prefixes,
+   * ignoring case.
    */
+  public static boolean startsWithAnyIgnoringCase(Path path, Iterable<Path> prefixes) {
+    for (Path prefix : prefixes) {
+      if (path.startsWithIgnoringCase(prefix)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Returns whether the given path starts with any of the paths in the given list of prefixes. */
   public static boolean startsWithAny(PathFragment path, Iterable<PathFragment> prefixes) {
     for (PathFragment prefix : prefixes) {
       if (path.startsWith(prefix)) {

--- a/src/main/java/com/google/devtools/build/lib/vfs/OsPathPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/OsPathPolicy.java
@@ -42,6 +42,13 @@ public interface OsPathPolicy {
    */
   String normalize(String path, int normalizationLevel);
 
+  /** Compares two path strings, using the given OS case sensitivity. */
+  // TODO: Inline and delete this.
+  default int compare(String s1, String s2) {
+    return s1.compareTo(s2);
+  }
+   
+
   /**
    * Returns the length of the mount, eg. 1 for unix '/', 3 for Windows 'C:/'.
    *

--- a/src/main/java/com/google/devtools/build/lib/vfs/OsPathPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/OsPathPolicy.java
@@ -42,19 +42,18 @@ public interface OsPathPolicy {
    */
   String normalize(String path, int normalizationLevel);
 
-  /** Compares two path strings, using the given OS case sensitivity. */
-  // TODO: Inline and delete this.
-  default int compare(String s1, String s2) {
-    return s1.compareTo(s2);
-  }
-   
-
   /**
    * Returns the length of the mount, eg. 1 for unix '/', 3 for Windows 'C:/'.
    *
    * <p>If the path is relative, 0 is returned
    */
   int getDriveStrLength(String path);
+
+  /** Compares two path strings, using the given OS case sensitivity. */
+  // TODO: Inline and delete this.
+  default int compare(String s1, String s2) {
+    return s1.compareTo(s2);
+  }
 
   /** Returns whether the unnormalized character c is a separator. */
   boolean isSeparator(char c);

--- a/src/main/java/com/google/devtools/build/lib/vfs/OsPathPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/OsPathPolicy.java
@@ -49,32 +49,6 @@ public interface OsPathPolicy {
    */
   int getDriveStrLength(String path);
 
-  /** Compares two path strings, using the given OS case sensitivity. */
-  int compare(String s1, String s2);
-
-  /** Compares two characters, using the given OS case sensitivity. */
-  int compare(char c1, char c2);
-
-  /** Tests two path strings for equality, using the given OS case sensitivity. */
-  boolean equals(String s1, String s2);
-
-  /** Computes the hash code for a path string. */
-  int hash(String s);
-
-  /**
-   * Returns whether the passed string starts with the given prefix, given the OS case sensitivity.
-   *
-   * <p>This is a pure string operation and doesn't account for path separators.
-   */
-  boolean startsWith(String path, String prefix);
-
-  /**
-   * Returns whether the passed string ends with the given suffix, given the OS case sensitivity.
-   *
-   * <p>This is a pure string operation and doesn't account for path separators.
-   */
-  boolean endsWith(String path, String suffix);
-
   /** Returns whether the unnormalized character c is a separator. */
   boolean isSeparator(char c);
 
@@ -83,8 +57,6 @@ public interface OsPathPolicy {
    * there is no such additional character.
    */
   char additionalSeparator();
-
-  boolean isCaseSensitive();
 
   /**
    * Modifies the given string to be suitable for execution on the OS represented by this policy.
@@ -142,7 +114,7 @@ public interface OsPathPolicy {
               ++shift;
               break;
             }
-            // Fall through
+          // Fall through
           default:
             ++segmentCount;
             if (shift > 0) {

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -51,7 +51,7 @@ import javax.annotation.Nullable;
  * slashes ('/') even on Windows, so backslashes '\' get converted to forward slashes during
  * normalization.
  *
- * <p>Mac and Windows file paths are case insensitive. Case is preserved.
+ * <p>All paths are case-sensitive.
  */
 @ThreadSafe
 @AutoCodec
@@ -176,6 +176,18 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
       return false;
     }
     return pathFragment.startsWith(other.pathFragment);
+  }
+
+  /**
+   * Returns whether another path is an ancestor of this path, ignoring case.
+   *
+   * <p>A path is considered an ancestor of itself.
+   */
+  public boolean startsWithIgnoringCase(Path other) {
+    if (fileSystem != other.fileSystem) {
+      return false;
+    }
+    return pathFragment.startsWithIgnoringCase(other.pathFragment);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/vfs/RootedPath.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/RootedPath.java
@@ -36,12 +36,7 @@ import javax.annotation.Nullable;
 @AutoCodec
 public final class RootedPath implements Comparable<RootedPath>, FileStateKey {
 
-  // Interning on Windows (case-insensitive) surfaces a bug where paths that only differ in casing
-  // use the same RootedPath instance.
-  // TODO(#17904): Investigate this bug and add test coverage.
-  @Nullable
-  private static final SkyKeyInterner<RootedPath> interner =
-      OsPathPolicy.getFilePathOs().isCaseSensitive() ? SkyKey.newInterner() : null;
+  @Nullable private static final SkyKeyInterner<RootedPath> interner = SkyKey.newInterner();
 
   private final Root root;
   private final PathFragment rootRelativePath;

--- a/src/main/java/com/google/devtools/build/lib/vfs/UnixOsPathPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/UnixOsPathPolicy.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.vfs;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
-import java.util.Objects;
 
 @VisibleForTesting
 class UnixOsPathPolicy implements OsPathPolicy {
@@ -93,39 +92,6 @@ class UnixOsPathPolicy implements OsPathPolicy {
   }
 
   @Override
-  public int compare(String s1, String s2) {
-    return s1.compareTo(s2);
-  }
-
-  @Override
-  public int compare(char c1, char c2) {
-    return Character.compare(c1, c2);
-  }
-
-  @Override
-  public boolean equals(String s1, String s2) {
-    return Objects.equals(s1, s2);
-  }
-
-  @Override
-  public int hash(String s) {
-    if (s == null) {
-      return 0;
-    }
-    return s.hashCode();
-  }
-
-  @Override
-  public boolean startsWith(String path, String prefix) {
-    return path.startsWith(prefix);
-  }
-
-  @Override
-  public boolean endsWith(String path, String suffix) {
-    return path.endsWith(suffix);
-  }
-
-  @Override
   public boolean isSeparator(char c) {
     return c == '/';
   }
@@ -133,11 +99,6 @@ class UnixOsPathPolicy implements OsPathPolicy {
   @Override
   public char additionalSeparator() {
     return 0;
-  }
-
-  @Override
-  public boolean isCaseSensitive() {
-    return true;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/vfs/WindowsOsPathPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/WindowsOsPathPolicy.java
@@ -189,63 +189,6 @@ class WindowsOsPathPolicy implements OsPathPolicy {
   }
 
   @Override
-  public int compare(String s1, String s2) {
-    // Windows is case-insensitive
-    return s1.compareToIgnoreCase(s2);
-  }
-
-  @Override
-  public int compare(char c1, char c2) {
-    return Character.compare(Character.toLowerCase(c1), Character.toLowerCase(c2));
-  }
-
-  @Override
-  public boolean equals(String s1, String s2) {
-    return (s1 == null && s2 == null) || (s1 != null && s1.equalsIgnoreCase(s2));
-  }
-
-  @Override
-  public int hash(String s) {
-    // Windows is case-insensitive
-    if (s == null) {
-      return 0;
-    }
-    return s.toLowerCase().hashCode();
-  }
-
-  @Override
-  public boolean startsWith(String path, String prefix) {
-    int pathn = path.length();
-    int prefixn = prefix.length();
-    if (pathn < prefixn) {
-      return false;
-    }
-    for (int i = 0; i < prefixn; ++i) {
-      if (Character.toLowerCase(path.charAt(i)) != Character.toLowerCase(prefix.charAt(i))) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  @Override
-  public boolean endsWith(String path, String suffix) {
-    int pathn = path.length();
-    int suffixLength = suffix.length();
-    if (pathn < suffixLength) {
-      return false;
-    }
-    int offset = pathn - suffixLength;
-    for (int i = 0; i < suffixLength; ++i) {
-      if (Character.toLowerCase(path.charAt(i + offset))
-          != Character.toLowerCase(suffix.charAt(i))) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  @Override
   public boolean isSeparator(char c) {
     return c == '/' || c == '\\';
   }
@@ -253,11 +196,6 @@ class WindowsOsPathPolicy implements OsPathPolicy {
   @Override
   public char additionalSeparator() {
     return '\\';
-  }
-
-  @Override
-  public boolean isCaseSensitive() {
-    return false;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryDirectoryInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryDirectoryInfo.java
@@ -13,12 +13,9 @@
 // limitations under the License.
 package com.google.devtools.build.lib.vfs.inmemoryfs;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Collections2;
 import com.google.devtools.build.lib.clock.Clock;
-import com.google.devtools.build.lib.concurrent.ThreadSafety;
-import com.google.devtools.build.lib.vfs.OsPathPolicy;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,11 +29,7 @@ import javax.annotation.Nullable;
  */
 final class InMemoryDirectoryInfo extends InMemoryContentInfo {
 
-  private static final boolean CASE_SENSITIVE = OsPathPolicy.getFilePathOs().isCaseSensitive();
-
-  // Keys in this map are usually strings, except on case-insensitive operating systems (e.g.
-  // Windows) where we use CaseInsensitiveFilename.
-  private final Map<Object, InMemoryContentInfo> directoryContent = new HashMap<>();
+  private final Map<String, InMemoryContentInfo> directoryContent = new HashMap<>();
 
   InMemoryDirectoryInfo(Clock clock) {
     super(clock);
@@ -50,7 +43,7 @@ final class InMemoryDirectoryInfo extends InMemoryContentInfo {
   void addChild(String name, InMemoryContentInfo inode) {
     Preconditions.checkNotNull(name);
     Preconditions.checkNotNull(inode);
-    if (directoryContent.put(key(name), inode) != null) {
+    if (directoryContent.put(name, inode) != null) {
       throw new IllegalArgumentException("File already exists: " + name);
     }
     markModificationTime();
@@ -62,12 +55,12 @@ final class InMemoryDirectoryInfo extends InMemoryContentInfo {
    */
   @Nullable
   InMemoryContentInfo getChild(String name) {
-    return directoryContent.get(key(name));
+    return directoryContent.get(name);
   }
 
   /** Removes a previously existing child from the directory specified by this object. */
   void removeChild(String name) {
-    if (directoryContent.remove(key(name)) == null) {
+    if (directoryContent.remove(name) == null) {
       throw new IllegalArgumentException(name + " is not a member of this directory");
     }
     markModificationTime();
@@ -75,9 +68,7 @@ final class InMemoryDirectoryInfo extends InMemoryContentInfo {
 
   /** Returns the contents of this directory. */
   Collection<String> getAllChildren() {
-    return Collections2.transform(
-        directoryContent.keySet(),
-        CASE_SENSITIVE ? String.class::cast : name -> ((CaseInsensitiveFilename) name).name);
+    return directoryContent.keySet();
   }
 
   @Override
@@ -101,8 +92,8 @@ final class InMemoryDirectoryInfo extends InMemoryContentInfo {
   }
 
   /**
-   * In the InMemory hierarchy, the getSize on a directory always returns the
-   * number of children in the directory.
+   * In the InMemory hierarchy, the getSize on a directory always returns the number of children in
+   * the directory.
    */
   @Override
   public long getSize() {
@@ -112,39 +103,5 @@ final class InMemoryDirectoryInfo extends InMemoryContentInfo {
   @Override
   InMemoryDirectoryInfo asDirectory() {
     return this;
-  }
-
-  private static Object key(String name) {
-    return CASE_SENSITIVE ? name : new CaseInsensitiveFilename(name);
-  }
-
-  @ThreadSafety.Immutable
-  private static final class CaseInsensitiveFilename {
-    private final String name;
-
-    private CaseInsensitiveFilename(String name) {
-      this.name = name;
-    }
-
-    @Override
-    public int hashCode() {
-      return OsPathPolicy.getFilePathOs().hash(name);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (obj == this) {
-        return true;
-      }
-      if (!(obj instanceof CaseInsensitiveFilename)) {
-        return false;
-      }
-      return OsPathPolicy.getFilePathOs().equals(this.name, ((CaseInsensitiveFilename) obj).name);
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this).add("name", name).toString();
-    }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/util/DependencySetWindowsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/DependencySetWindowsTest.java
@@ -29,9 +29,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DependencySetWindowsTest {
 
-  private Scratch scratch = new Scratch();
+  private final Scratch scratch = new Scratch();
   private final FileSystem fileSystem =
-      new WindowsFileSystem(DigestHashFunction.SHA256, /*createSymbolicLinks=*/ false);
+      new WindowsFileSystem(DigestHashFunction.SHA256, /* createSymbolicLinks= */ false);
   private final Path root = fileSystem.getPath("C:/");
 
   private DependencySet newDependencySet() {
@@ -95,17 +95,5 @@ public class DependencySetWindowsTest {
             fileSystem.getPath("C:/Program Files (x86)/LLVM/lib/clang/3.5.0/include/stdarg.h"));
 
     assertThat(newDependencySet().read(dotd).getDependencies()).containsExactlyElementsIn(expected);
-  }
-
-  @Test
-  public void dotDParser_caseInsensitive() throws Exception {
-    Path file1 = fileSystem.getPath("C:/blah/blah/genhello/hello.cc");
-    Path file2 = fileSystem.getPath("C:/blah/blah/genhello/hello.h");
-    Path file2DiffCase = fileSystem.getPath("C:/Blah/blah/Genhello/hello.h");
-    String filename = "hello.o";
-    Path dotd =
-        scratch.file("/tmp/foo.d", filename + ": \\", " " + file1 + " \\", " " + file2 + " ");
-    assertThat(newDependencySet().read(dotd).getDependencies())
-        .containsExactly(file1, file2DiffCase);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/vfs/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/vfs/BUILD
@@ -62,6 +62,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/testutils",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/testutils:round-tripping",
+        "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:ospathpolicy",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",

--- a/src/test/java/com/google/devtools/build/lib/vfs/PathAbstractTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/PathAbstractTest.java
@@ -28,12 +28,10 @@ import org.junit.Test;
 public abstract class PathAbstractTest {
 
   private FileSystem fileSystem;
-  private boolean isCaseSensitive;
 
   @Before
   public void setup() {
     fileSystem = new InMemoryFileSystem(BlazeClock.instance(), DigestHashFunction.SHA256);
-    isCaseSensitive = OsPathPolicy.getFilePathOs().isCaseSensitive();
   }
 
   @Test
@@ -75,12 +73,7 @@ public abstract class PathAbstractTest {
     Collections.sort(list);
     List<String> result = list.stream().map(Path::getPathString).collect(toList());
 
-    if (isCaseSensitive) {
-      assertThat(result).containsExactly("/ABC", "/AbC", "/ZZZ", "/aBc", "/abc", "/zzz").inOrder();
-    } else {
-      // Partial ordering among case-insensitive items guaranteed by Collections.sort stability
-      assertThat(result).containsExactly("/ABC", "/aBc", "/AbC", "/abc", "/zzz", "/ZZZ").inOrder();
-    }
+    assertThat(result).containsExactly("/ABC", "/AbC", "/ZZZ", "/aBc", "/abc", "/zzz").inOrder();
   }
 
   protected Path create(String path) {

--- a/src/test/java/com/google/devtools/build/lib/vfs/PathFragmentTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/PathFragmentTest.java
@@ -415,11 +415,11 @@ public final class PathFragmentTest {
     assertThat(foobar.startsWith(create("/Foo"))).isFalse();
     assertThat(
             create(unicodeToInternal("/ÄÖÜ/bar"))
-                .startsWithIgnoringCase(create(unicodeToInternal("/äöü"))))
+                .startsWith(create(unicodeToInternal("/äöü"))))
         .isFalse();
     assertThat(
             create(unicodeToInternal("ÄÖÜ/bar"))
-                .startsWithIgnoringCase(create(unicodeToInternal("äöü"))))
+                .startsWith(create(unicodeToInternal("äöü"))))
         .isFalse();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/vfs/PathFragmentTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/PathFragmentTest.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.vfs;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.util.StringEncoding.unicodeToInternal;
 import static com.google.devtools.build.lib.vfs.PathFragment.EMPTY_FRAGMENT;
 import static com.google.devtools.build.lib.vfs.PathFragment.HIERARCHICAL_COMPARATOR;
 import static com.google.devtools.build.lib.vfs.PathFragment.create;
@@ -408,6 +409,61 @@ public final class PathFragmentTest {
     // (path, sibling) => false
     assertThat(create("/foo/wiz").startsWith(foobar)).isFalse();
     assertThat(foobar.startsWith(create("/foo/wiz"))).isFalse();
+
+    // (path, different case) => false
+    assertThat(foobar.startsWith(create("/Foo/bar"))).isFalse();
+    assertThat(foobar.startsWith(create("/Foo"))).isFalse();
+    assertThat(
+            create(unicodeToInternal("/ÄÖÜ/bar"))
+                .startsWithIgnoringCase(create(unicodeToInternal("/äöü"))))
+        .isFalse();
+    assertThat(
+            create(unicodeToInternal("ÄÖÜ/bar"))
+                .startsWithIgnoringCase(create(unicodeToInternal("äöü"))))
+        .isFalse();
+  }
+
+  @Test
+  public void testStartsWithIgnoringCase() {
+    PathFragment foobar = create("/foo/bar");
+    PathFragment foobarRelative = create("foo/bar");
+
+    // (path, prefix) => true
+    assertThat(foobar.startsWithIgnoringCase(foobar)).isTrue();
+    assertThat(foobar.startsWithIgnoringCase(create("/"))).isTrue();
+    assertThat(foobar.startsWithIgnoringCase(create("/foo"))).isTrue();
+    assertThat(foobar.startsWithIgnoringCase(create("/foo/"))).isTrue();
+    assertThat(foobar.startsWithIgnoringCase(create("/foo/bar/")))
+        .isTrue(); // Includes trailing slash.
+
+    // (prefix, path) => false
+    assertThat(create("/foo").startsWithIgnoringCase(foobar)).isFalse();
+    assertThat(create("/").startsWithIgnoringCase(foobar)).isFalse();
+
+    // (absolute, relative) => false
+    assertThat(foobar.startsWithIgnoringCase(foobarRelative)).isFalse();
+    assertThat(foobarRelative.startsWithIgnoringCase(foobar)).isFalse();
+
+    // (relative path, relative prefix) => true
+    assertThat(foobarRelative.startsWithIgnoringCase(foobarRelative)).isTrue();
+    assertThat(foobarRelative.startsWithIgnoringCase(create("foo"))).isTrue();
+    assertThat(foobarRelative.startsWithIgnoringCase(create(""))).isTrue();
+
+    // (path, sibling) => false
+    assertThat(create("/foo/wiz").startsWithIgnoringCase(foobar)).isFalse();
+    assertThat(foobar.startsWithIgnoringCase(create("/foo/wiz"))).isFalse();
+
+    // (path, different case) => false
+    assertThat(foobar.startsWithIgnoringCase(create("/Foo/bar"))).isTrue();
+    assertThat(foobar.startsWithIgnoringCase(create("/Foo"))).isTrue();
+    assertThat(
+            create(unicodeToInternal("/ÄÖÜ/bar"))
+                .startsWithIgnoringCase(create(unicodeToInternal("/äöü"))))
+        .isTrue();
+    assertThat(
+            create(unicodeToInternal("ÄÖÜ/bar"))
+                .startsWithIgnoringCase(create(unicodeToInternal("äöü"))))
+        .isTrue();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/vfs/WindowsPathTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/WindowsPathTest.java
@@ -53,8 +53,8 @@ public class WindowsPathTest extends PathAbstractTest {
   @Test
   public void testEqualsAndHashcodeWindows() {
     new EqualsTester()
-        .addEqualityGroup(create("/a/b"), create("/A/B"))
-        .addEqualityGroup(create("c:/a/b"), create("C:\\A\\B"))
+        .addEqualityGroup(create("/a/b"))
+        .addEqualityGroup(create("c:/a/b"))
         .addEqualityGroup(create("C:/something/else"))
         .testEquals();
   }
@@ -77,9 +77,6 @@ public class WindowsPathTest extends PathAbstractTest {
     assertThat(create("C:/").startsWith(create("C:/"))).isTrue();
     assertThat(create("C:/foo").startsWith(create("C:/"))).isTrue();
     assertThat(create("C:/foo").startsWith(create("D:/"))).isFalse();
-
-    // Case insensitivity test
-    assertThat(create("C:/foo/bar").startsWith(create("C:/FOO"))).isTrue();
   }
 
   @Test
@@ -99,8 +96,6 @@ public class WindowsPathTest extends PathAbstractTest {
   @Test
   public void testRelativeToWindows() {
     assertThat(create("C:/foo").relativeTo(create("C:/")).getPathString()).isEqualTo("foo");
-    // Case insensitivity test
-    assertThat(create("C:/foo/bar").relativeTo(create("C:/FOO")).getPathString()).isEqualTo("bar");
     assertThrows(IllegalArgumentException.class, () -> create("D:/foo").relativeTo(create("C:/")));
   }
 

--- a/src/test/java/com/google/devtools/build/lib/vfs/WindowsPathTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/WindowsPathTest.java
@@ -80,6 +80,24 @@ public class WindowsPathTest extends PathAbstractTest {
   }
 
   @Test
+  public void testStartsWithIgnoringCaseWindows() {
+    assertThat(create("C:/").startsWithIgnoringCase(create("C:/"))).isTrue();
+    assertThat(create("C:/").startsWithIgnoringCase(create("c:/"))).isTrue();
+    assertThat(create("c:/").startsWithIgnoringCase(create("C:/"))).isTrue();
+    assertThat(create("c:/").startsWithIgnoringCase(create("c:/"))).isTrue();
+
+    assertThat(create("C:/foo").startsWithIgnoringCase(create("C:/"))).isTrue();
+    assertThat(create("C:/foo").startsWithIgnoringCase(create("c:/"))).isTrue();
+    assertThat(create("c:/foo").startsWithIgnoringCase(create("C:/"))).isTrue();
+    assertThat(create("c:/foo").startsWithIgnoringCase(create("c:/"))).isTrue();
+
+    assertThat(create("C:/foo").startsWithIgnoringCase(create("D:/"))).isFalse();
+    assertThat(create("C:/foo").startsWithIgnoringCase(create("d:/"))).isFalse();
+    assertThat(create("c:/foo").startsWithIgnoringCase(create("D:/"))).isFalse();
+    assertThat(create("c:/foo").startsWithIgnoringCase(create("d:/"))).isFalse();
+  }
+
+  @Test
   public void testGetParentDirectoryWindows() {
     assertThat(create("C:/foo").getParentDirectory()).isEqualTo(create("C:/"));
     assertThat(create("C:/").getParentDirectory()).isNull();


### PR DESCRIPTION
Before this change, Bazel attempted to emulate case insensitivity of `PathFragment`s on Windows, but not macOS. This was flawed in a number of ways:
* Windows and macOS support both case-sensitive and case-insensitive file systems, but the logic applied to all file systems on Windows and none on macOS.
* The choice whether to apply case normalization depends on the host OS running Bazel, not the OS on which the action consuming the `PathFragment` runs.
* Due to the peculiarities of Bazel's internal `String` encoding, non-ASCII characters were not compared correctly, resulting in both false positives and false negatives.
* Interning of data structures containing `PathFragment`s could result in Bazel picking a representative of an equivalence class in a non-deterministic fashion.

This PR removes all generic case insensitivity handling from `PathFragment` and only keeps it in places in which it is clearly needed:
* File type matching, in particular for C++, remains case insensitive. Assuming that file types are ASCII only, this doesn't require any Unicode handling.
* System include paths in `.d` files may not match the case declared by the toolchain. They are now compared case-insensitively when the C++ compilation action executes on Windows and also correctly convert to Unicode if needed.

Further improvements for case-insensitive file systems will be made as part of #8799.

Fixes #7627
Fixes #9432
Fixes #17904 
Work towards #8799