### PR TITLE
[8.4.0] Add configuration short ID to analysis error

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/AspectFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/AspectFunction.java
@@ -1025,7 +1025,11 @@ final class AspectFunction implements SkyFunction {
     events.replayOn(env.getListener());
     if (events.hasErrors()) {
       analysisEnvironment.disable(associatedTarget);
-      String msg = "Analysis of target '" + associatedTarget.getLabel() + "' failed";
+      String msg =
+          "Analysis of target '%s' (config: %s) failed"
+              .formatted(
+                  associatedTarget.getLabel(),
+                  configuration != null ? configuration.getOptions().shortId() : "none");
       throw new AspectFunctionException(
           new AspectCreationException(msg, key.getLabel(), configuration));
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
@@ -485,7 +485,10 @@ public final class ConfiguredTargetFunction implements SkyFunction {
       throw new ConfiguredValueCreationException(
           ctgValue.getTarget(),
           null,
-          "Analysis of target '" + target.getLabel() + "' failed",
+          "Analysis of target '%s' (config: %s) failed"
+              .formatted(
+                  target.getLabel(),
+                  configuration != null ? configuration.getOptions().shortId() : "none"),
           rootCauses,
           null);
     }

--- a/src/test/java/com/google/devtools/build/lib/buildtool/OutputArtifactConflictTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/OutputArtifactConflictTest.java
@@ -557,7 +557,8 @@ public class OutputArtifactConflictTest extends BuildIntegrationTestCase {
       events.assertContainsError("/bin/x/y/whatever' (belonging to //x/y:y)");
       events.assertContainsError("/bin/x/y' (belonging to //x:y)");
       events.assertContainsError("is a prefix of the other");
-      events.assertContainsError("Analysis of target '//x:fail_analysis' failed");
+      events.assertContainsError("Analysis of target '//x:fail_analysis' (config: ");
+      events.assertContainsError(") failed");
 
       assertThat(eventListener.analysisFailures).containsAtLeast("//x:y", "//x:fail_analysis");
     } else if (minimizeMemory) {


### PR DESCRIPTION
This makes it possible to debug config-dependent errors.

Closes #26690.

PiperOrigin-RevId: 792275177
Change-Id: I026d6aae8a3dbc1da20a155f4b873d0349b76a8d

Commit https://github.com/bazelbuild/bazel/commit/8e552b02e336a54808ecc8840618a905044fdf27