### PR TITLE
Add `--incompatible_enforce_strict_label_casing`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -334,6 +334,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/packages",
+        "//src/main/java/com/google/devtools/build/lib/packages/semantics",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/repo_recorded_input",
         "//src/main/java/com/google/devtools/build/lib/skyframe:bzl_load_failed_exception",

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -819,6 +819,15 @@ public final class BuildLanguageOptions extends OptionsBase {
       help = "If true enables the repository_ctx `load_wasm` and `execute_wasm` methods.")
   public boolean repositoryCtxExecuteWasm;
 
+  @Option(
+      name = "incompatible_enforce_strict_label_casing",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.INPUT_STRICTNESS,
+      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help = "If enabled, enforce strict label casing.")
+  public boolean enforceStrictLabelCasing;
+
   /**
    * An interner to reduce the number of StarlarkSemantics instances. A single Blaze instance should
    * never accumulate a large number of these and being able to shortcut on object identity makes a
@@ -951,7 +960,8 @@ public final class BuildLanguageOptions extends OptionsBase {
             return this;
           }
         });
-    return INTERNER.intern(builder.build());
+    return INTERNER.intern(builder.setBool(INCOMPATIBLE_ENFORCE_STRICT_LABEL_CASING, enforceStrictLabelCasing)
+            .build());
   }
 
   /**
@@ -1101,6 +1111,8 @@ public final class BuildLanguageOptions extends OptionsBase {
       "+incompatible_locations_prefers_executable";
   public static final String EXPERIMENTAL_REPOSITORY_CTX_EXECUTE_WASM =
       "-experimental_repository_ctx_execute_wasm";
+  public static final String INCOMPATIBLE_ENFORCE_STRICT_LABEL_CASING =
+      "-incompatible_enforce_strict_label_casing";
   // non-booleans
   public static final StarlarkSemantics.Key<List<String>> INCOMPATIBLE_DISABLE_TRANSITIONS_OPTIONS =
       new StarlarkSemantics.Key<>("incompatible_disable_transitions_on", ImmutableList.of());

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1909,6 +1909,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/pkgcache",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/repository_directory_value",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
@@ -379,6 +379,19 @@ public class SequencedSkyframeExecutor extends SkyframeExecutor {
     deletedPackages.set(newDeletedPackagesSet);
   }
 
+  @Override
+  void setEnforceStrictLabelCasing(boolean newEnforceStrictLabelCasing) {
+    // enforceStrictLabelCasing.get() may be null if this is the first time the executor is being
+    // used.
+    Boolean oldEnforceStrictLabelCasing =
+        enforceStrictLabelCasing.getAndSet(newEnforceStrictLabelCasing);
+    if (oldEnforceStrictLabelCasing != null
+        && oldEnforceStrictLabelCasing != newEnforceStrictLabelCasing) {
+      // PackageLookupValue is a HERMETIC node type, so we can't invalidate it.
+      memoizingEvaluator.delete(k -> k.functionName().equals(SkyFunctions.PACKAGE_LOOKUP));
+    }
+  }
+
   /**
    * {@inheritDoc}
    *

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -403,6 +403,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
   private final AtomicReference<PathPackageLocator> pkgLocator = new AtomicReference<>();
   final AtomicReference<ImmutableSet<PackageIdentifier>> deletedPackages =
       new AtomicReference<>(ImmutableSet.of());
+  final AtomicReference<Boolean> enforceStrictLabelCasing = new AtomicReference<>();
   private final AtomicReference<EventBus> eventBus = new AtomicReference<>();
   final AtomicReference<TimestampGranularityMonitor> tsgm = new AtomicReference<>();
   private final AtomicReference<Map<String, String>> clientEnv = new AtomicReference<>();
@@ -786,7 +787,10 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     map.put(
         SkyFunctions.PACKAGE_LOOKUP,
         new PackageLookupFunction(
-            deletedPackages, crossRepositoryLabelViolationStrategy, buildFilesByPriority));
+            deletedPackages,
+            crossRepositoryLabelViolationStrategy,
+            buildFilesByPriority,
+            enforceStrictLabelCasing));
     map.put(SkyFunctions.CONTAINING_PACKAGE_LOOKUP, new ContainingPackageLookupFunction());
     map.put(SkyFunctions.PROJECT, new ProjectFunction());
     map.put(SkyFunctions.PROJECT_FILES_LOOKUP, new ProjectFilesLookupFunction());
@@ -1658,6 +1662,11 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
   /** Sets the packages that should be treated as deleted and ignored. */
   @VisibleForTesting // productionVisibility = Visibility.PRIVATE
   public abstract void setDeletedPackages(Iterable<PackageIdentifier> pkgs);
+
+  /**
+   * Sets whether the casing of labels (and thus packages) should be checked against the filesystem.
+   */
+  abstract void setEnforceStrictLabelCasing(boolean enforceStrictLabelCasing);
 
   /**
    * Prepares the evaluator for loading.
@@ -3029,6 +3038,8 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     try (SilentCloseable c = Profiler.instance().profile("setDeletedPackages")) {
       setDeletedPackages(packageOptions.getDeletedPackages());
     }
+    setEnforceStrictLabelCasing(
+        options.getOptions(BuildLanguageOptions.class).enforceStrictLabelCasing);
 
     incrementalBuildMonitor = new SkyframeIncrementalBuildMonitor();
     invalidateTransientErrors();

--- a/src/main/java/com/google/devtools/build/lib/skyframe/packages/AbstractPackageLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/packages/AbstractPackageLoader.java
@@ -569,7 +569,8 @@ public abstract class AbstractPackageLoader implements PackageLoader {
             new PackageLookupFunction(
                 /* deletedPackages= */ new AtomicReference<>(ImmutableSet.of()),
                 getCrossRepositoryLabelViolationStrategy(),
-                getBuildFilesByPriority()))
+                getBuildFilesByPriority(),
+                /* enforceStrictLabelCasing= */ new AtomicReference<>(false)))
         .put(SkyFunctions.IGNORED_SUBDIRECTORIES, IgnoredSubdirectoriesFunction.NOOP)
         .put(SkyFunctions.CONTAINING_PACKAGE_LOOKUP, new ContainingPackageLookupFunction())
         .put(

--- a/src/main/java/com/google/devtools/build/lib/unix/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/unix/BUILD
@@ -23,6 +23,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/jni",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/util:blocker",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -827,4 +827,17 @@ public abstract class FileSystem {
       }
     }
   }
+
+  /**
+   * Returns the path of an existing file with the case of its segments normalized to reflect the
+   * actual state of the case-preserving but possibly case-insensitive filesystem.
+   *
+   * <p>The returned path is guaranteed to have the same number of segments as this path.
+   *
+   * <p>The default implementation returns the path unchanged, which is appropriate for
+   * case-sensitive filesystems.
+   */
+  protected PathFragment canonicalizeCase(PathFragment path) throws IOException {
+    return path;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -49,7 +49,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   private static final LinkOption[] NO_LINK_OPTION = new LinkOption[0];
   // This isn't generally safe; we rely on the file system APIs not modifying the array.
   private static final LinkOption[] NOFOLLOW_LINKS_OPTION =
-      new LinkOption[] { LinkOption.NOFOLLOW_LINKS };
+      new LinkOption[] {LinkOption.NOFOLLOW_LINKS};
 
   private final Clock clock;
 
@@ -526,5 +526,17 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   public void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)
       throws IOException {
     Files.createLink(getNioPath(linkPath), getNioPath(originalPath));
+  }
+
+  @Override
+  protected PathFragment canonicalizeCase(PathFragment path) throws IOException {
+    var canonical =
+        PathFragment.create(
+            StringEncoding.platformToInternal(
+                getNioPath(path).toRealPath(NOFOLLOW_LINKS_OPTION).toString()));
+    if (canonical.segmentCount() != path.segmentCount()) {
+      throw new IOException("Unexpected case canonicalization: " + path + " -> " + canonical);
+    }
+    return canonical;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -100,6 +100,16 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
   }
 
   /**
+   * Returns the path of an existing file with the case of its segments normalized to reflect the
+   * actual state of the case-preserving but possibly case-insensitive filesystem.
+   *
+   * <p>The returned path is guaranteed to have the same number of segments as this path.
+   */
+  public Path canonicalizeCase() throws IOException {
+    return fileSystem.getPath(fileSystem.canonicalizeCase(asFragment()));
+  }
+
+  /**
    * Returns a {@link Path} formed by appending {@code newName} to this {@link Path}'s parent
    * directory. If this {@link Path} has zero segments, returns {@code null}. If {@code newName} is
    * absolute, the value of {@code this} will be ignored and a {@link Path} corresponding to {@code

--- a/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
@@ -325,6 +325,11 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
     return delegateFs.createTempDirectory(toDelegatePath(parent), prefix);
   }
 
+  @Override
+  protected PathFragment canonicalizeCase(PathFragment path) throws IOException {
+    return fromDelegatePath(delegateFs.canonicalizeCase(toDelegatePath(path)));
+  }
+
   /** Transform original path to a different one to be used with the {@code delegateFs}. */
   protected abstract PathFragment toDelegatePath(PathFragment path);
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -151,7 +151,8 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                     new PackageLookupFunction(
                         new AtomicReference<>(ImmutableSet.of()),
                         CrossRepositoryLabelViolationStrategy.ERROR,
-                        BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY))
+                        BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY,
+                        /* enforceStrictLabelCasing= */ new AtomicReference<>(true)))
                 .put(SkyFunctions.IGNORED_SUBDIRECTORIES, IgnoredSubdirectoriesFunction.NOOP)
                 .put(SkyFunctions.LOCAL_REPOSITORY_LOOKUP, new LocalRepositoryLookupFunction())
                 .put(SkyFunctions.PRECOMPUTED, new PrecomputedFunction())

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryDelegatorTest.java
@@ -165,7 +165,8 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
                     new PackageLookupFunction(
                         new AtomicReference<>(ImmutableSet.of()),
                         CrossRepositoryLabelViolationStrategy.ERROR,
-                        BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY))
+                        BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY,
+                        /* enforceStrictLabelCasing= */ new AtomicReference<>(true)))
                 .put(SkyFunctions.LOCAL_REPOSITORY_LOOKUP, new LocalRepositoryLookupFunction())
                 .put(SkyFunctions.PRECOMPUTED, new PrecomputedFunction())
                 .put(

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -146,6 +146,7 @@ public class ConsistencyTest {
                 rand.nextInt(BuildLanguageOptions.Utf8EnforcementMode.values().length)]
                 .toString()
                 .toLowerCase(Locale.ROOT),
+        "--incompatible_enforce_strict_label_casing=" + rand.nextBoolean(),
         "--incompatible_locations_prefers_executable=" + rand.nextBoolean(),
         "--incompatible_no_attr_license=" + rand.nextBoolean(),
         "--incompatible_no_implicit_file_export=" + rand.nextBoolean(),
@@ -190,6 +191,7 @@ public class ConsistencyTest {
             BuildLanguageOptions.INCOMPATIBLE_ENFORCE_STARLARK_UTF8,
             BuildLanguageOptions.Utf8EnforcementMode.values()[
                 rand.nextInt(BuildLanguageOptions.Utf8EnforcementMode.values().length)])
+        .setBool(BuildLanguageOptions.INCOMPATIBLE_ENFORCE_STRICT_LABEL_CASING, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_LOCATIONS_PREFERS_EXECUTABLE, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_NO_ATTR_LICENSE, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_NO_IMPLICIT_FILE_EXPORT, rand.nextBoolean())

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTestCase.java
@@ -118,7 +118,8 @@ abstract class ArtifactFunctionTestCase {
                     new PackageLookupFunction(
                         null,
                         CrossRepositoryLabelViolationStrategy.ERROR,
-                        BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY))
+                        BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY,
+                        /* enforceStrictLabelCasing= */ new AtomicReference<>(true)))
                 .put(
                     SkyFunctions.ACTION_TEMPLATE_EXPANSION,
                     new ActionTemplateExpansionFunction(actionKeyContext))

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ContainingPackageLookupFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ContainingPackageLookupFunctionTest.java
@@ -101,7 +101,8 @@ public class ContainingPackageLookupFunctionTest extends FoundationTestCase {
         new PackageLookupFunction(
             deletedPackages,
             CrossRepositoryLabelViolationStrategy.ERROR,
-            BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY));
+            BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY,
+            /* enforceStrictLabelCasing= */ new AtomicReference<>(true)));
     skyFunctions.put(SkyFunctions.PACKAGE, PackageFunction.newBuilder().build());
     skyFunctions.put(SkyFunctions.IGNORED_SUBDIRECTORIES, IgnoredSubdirectoriesFunction.NOOP);
     skyFunctions.put(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FileFunctionTest.java
@@ -179,7 +179,8 @@ public class FileFunctionTest {
                     new PackageLookupFunction(
                         new AtomicReference<>(ImmutableSet.of()),
                         CrossRepositoryLabelViolationStrategy.ERROR,
-                        BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY))
+                        BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY,
+                        /* enforceStrictLabelCasing= */ new AtomicReference<>(true)))
                 .put(SkyFunctions.LOCAL_REPOSITORY_LOOKUP, new LocalRepositoryLookupFunction())
                 .put(
                     SkyFunctions.REPOSITORY_DIRECTORY,

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
@@ -318,7 +318,8 @@ public final class FilesystemValueCheckerTest {
         new PackageLookupFunction(
             new AtomicReference<>(ImmutableSet.of()),
             CrossRepositoryLabelViolationStrategy.ERROR,
-            BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY));
+            BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY,
+            /* enforceStrictLabelCasing= */ new AtomicReference<>(true)));
 
     differencer = new SequencedRecordingDifferencer();
     evaluator = new InMemoryMemoizingEvaluator(skyFunctions.buildOrThrow(), differencer);

--- a/src/test/java/com/google/devtools/build/lib/skyframe/GlobTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/GlobTestBase.java
@@ -156,7 +156,8 @@ public abstract class GlobTestBase {
         new PackageLookupFunction(
             deletedPackages,
             CrossRepositoryLabelViolationStrategy.ERROR,
-            BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY));
+            BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY,
+            /* enforceStrictLabelCasing= */ new AtomicReference<>(true)));
     skyFunctions.put(
         SkyFunctions.REPO_FILE,
         new RepoFileFunction(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/LocalRepositoryLookupFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/LocalRepositoryLookupFunctionTest.java
@@ -87,7 +87,8 @@ public class LocalRepositoryLookupFunctionTest extends FoundationTestCase {
         new PackageLookupFunction(
             new AtomicReference<>(),
             CrossRepositoryLabelViolationStrategy.ERROR,
-            BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY));
+            BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY,
+            /* enforceStrictLabelCasing= */ new AtomicReference<>(true)));
     skyFunctions.put(
         FileStateKey.FILE_STATE,
         new FileStateFunction(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PackageLookupFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PackageLookupFunctionTest.java
@@ -110,7 +110,8 @@ public abstract class PackageLookupFunctionTest extends FoundationTestCase {
         new PackageLookupFunction(
             deletedPackages,
             crossRepositoryLabelViolationStrategy(),
-            BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY));
+            BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY,
+            /* enforceStrictLabelCasing= */ new AtomicReference<>(true)));
     skyFunctions.put(SkyFunctions.PACKAGE, PackageFunction.newBuilder().build());
     skyFunctions.put(
         FileStateKey.FILE_STATE,

--- a/src/test/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunctionTest.java
@@ -174,7 +174,8 @@ public final class RecursiveFilesystemTraversalFunctionTest extends FoundationTe
         new PackageLookupFunction(
             deletedPackages,
             CrossRepositoryLabelViolationStrategy.ERROR,
-            BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY));
+            BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY,
+            /* enforceStrictLabelCasing= */ new AtomicReference<>(true)));
     skyFunctions.put(SkyFunctions.IGNORED_SUBDIRECTORIES, IgnoredSubdirectoriesFunction.NOOP);
     skyFunctions.put(SkyFunctions.PACKAGE, PackageFunction.newBuilder().build());
     skyFunctions.put(SkyFunctions.LOCAL_REPOSITORY_LOOKUP, new LocalRepositoryLookupFunction());

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TimestampBuilderTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TimestampBuilderTestCase.java
@@ -185,7 +185,7 @@ public abstract class TimestampBuilderTestCase extends FoundationTestCase {
   }
 
   protected BuilderWithResult createBuilder(ActionCache actionCache) throws Exception {
-    return createBuilder(actionCache, 1, /*keepGoing=*/ false);
+    return createBuilder(actionCache, 1, /* keepGoing= */ false);
   }
 
   /** Create a ParallelBuilder with a DatabaseDependencyChecker using the specified ActionCache. */
@@ -281,7 +281,8 @@ public abstract class TimestampBuilderTestCase extends FoundationTestCase {
                     new PackageLookupFunction(
                         null,
                         CrossRepositoryLabelViolationStrategy.ERROR,
-                        BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY))
+                        BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY,
+                        /* enforceStrictLabelCasing= */ new AtomicReference<>(true)))
                 .put(
                     SkyFunctions.ACTION_TEMPLATE_EXPANSION,
                     new DelegatingActionTemplateExpansionFunction())

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
@@ -2152,4 +2152,18 @@ public abstract class FileSystemTest {
       tempDirs.add(tempDir);
     }
   }
+
+  @Test
+  public void testCanonicalizeCase() throws Exception {
+    Path canonicalCase = absolutize(StringEncoding.unicodeToInternal("ThiS/pAtH/HÄs/MIXED/case"));
+    canonicalCase.getParentDirectory().createDirectoryAndParents();
+    FileSystemUtils.createEmptyFile(canonicalCase);
+    assertThat(canonicalCase.canonicalizeCase()).isEqualTo(canonicalCase);
+
+    Path nonCanonicalCase =
+        absolutize(StringEncoding.unicodeToInternal("this/path/häs/mixed/CASE"));
+    // Only continue on case-insensitive filesystems.
+    assume().that(nonCanonicalCase.exists()).isTrue();
+    assertThat(nonCanonicalCase.canonicalizeCase()).isEqualTo(canonicalCase);
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystemTest.java
@@ -166,7 +166,8 @@ public final class PathTransformingDelegateFileSystemTest {
                 "createSymbolicLink",
                 PathFragment.class,
                 PathFragment.class,
-                SymlinkTargetType.class));
+                SymlinkTargetType.class),
+            getFileSystemMethod("canonicalizeCase", PathFragment.class));
 
     private static Method getFileSystemMethod(String name, Class<?>... parameterTypes) {
       try {

--- a/src/test/shell/integration/loading_phase_test.sh
+++ b/src/test/shell/integration/loading_phase_test.sh
@@ -671,7 +671,7 @@ function test_case_sensitive_pkg_names_incrementality() {
   bazel query --incompatible_enforce_strict_label_casing \
       //$pkg1/$pkg2:all >&"$TEST_log" \
       && fail "Expected failure" || true
-  expect_log "ERROR: no such package '$pkg1/$pkg2': use the canonical form '$pkg1/$pkg2_upper' instead"
+  expect_log "ERROR: no such package '$pkg1/$pkg2': use the canonical form '$pkg1_upper/$pkg2' instead"
 
   mv "$pkg1_upper/$pkg2" "$pkg1_upper/$pkg2_upper"
   bazel query --incompatible_enforce_strict_label_casing \
@@ -722,7 +722,8 @@ function test_case_sensitive_build_file_names_incrementality() {
       || fail "Expected case-insensitive semantics"
 
   bazel query --incompatible_enforce_strict_label_casing \
-      //$pkg:all >&"$TEST_log" || fail "Expected success"
+      //$pkg:all >&"$TEST_log" && fail "Expected failure"
+  expect_log "ERROR: no such package '$pkg': 'BuIlD' is not a valid build file name, use 'BUILD' instead"
 
   mv "$pkg/BuIlD" "$pkg/BUILD"
   bazel query --incompatible_enforce_strict_label_casing \
@@ -730,8 +731,7 @@ function test_case_sensitive_build_file_names_incrementality() {
 
   mv "$pkg/BUILD" "$pkg/BuIlD"
   bazel query --incompatible_enforce_strict_label_casing \
-      //$pkg:all >&"$TEST_log" \
-      && fail "Expected failure" || true
+      //$pkg:all >&"$TEST_log" && fail "Expected failure"
   expect_log "ERROR: no such package '$pkg': 'BuIlD' is not a valid build file name, use 'BUILD' instead"
 }
 


### PR DESCRIPTION
With the new `--incompatible_enforce_strict_label_casing` flag enabled, Bazel will fail with an error if:
* two repositories in the build differ only in casing
* a package is referenced via a name that differs from the canonical casing as determined by the case-preserving, but possibly case-insensitive file system.

This avoids surprising errors and cache misses users could experience on macOS and Windows with case-insensitive file systems.

Input file name casing is not enforced, but referring to the same file in different ways can only happen in BUILD files, not via the CLI, so this can be caught by a linter such as buildifier.
 
Work towards #8799