### PR TITLE
Include targets with non-idempotent rule transition in query output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
@@ -62,6 +62,7 @@ import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.build.skyframe.WalkableGraph;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -343,14 +344,45 @@ public class ConfiguredTargetQueryEnvironment extends PostAnalysisQueryEnvironme
    */
   private ImmutableList<CqueryNode> getConfiguredTargetsForLabel(Label label)
       throws InterruptedException {
-    ImmutableList.Builder<CqueryNode> ans = ImmutableList.builder();
-    for (BuildConfigurationValue config : transitiveConfigurations.values()) {
-      CqueryNode kct = getConfiguredTarget(label, config);
-      if (kct != null) {
-        ans.add(kct);
+    var ans = ImmutableList.<CqueryNode>builder();
+    HashSet<ConfiguredTargetKey> extraConfiguredTargetKeys = null;
+    for (var configurationValue : transitiveConfigurations.values()) {
+      var configurationKey = configurationValue.getKey();
+      var target =
+          getValueFromKey(
+              ConfiguredTargetKey.builder()
+                  .setLabel(label)
+                  .setConfigurationKey(configurationKey)
+                  .build());
+      if (target == null) {
+        continue;
       }
+      // The configurations might not match if the target's configuration changed due to a
+      // transition or trimming. Filter such targets, with one exception: if the target is subject
+      // to a non-idempotent rule transition, we have to keep it once if the keys requested above,
+      // which never have shouldApplyRuleTransition set to false, don't cover it. This case is rare,
+      // so we optimize for it not being hit.
+      if (!Objects.equals(configurationKey, target.getConfigurationKey())) {
+        var targetKey = ConfiguredTargetKey.fromConfiguredTarget(target);
+        if (targetKey.shouldApplyRuleTransition()
+            || getValueFromKey(
+                    ConfiguredTargetKey.builder()
+                        .setLabel(label)
+                        .setConfigurationKey(targetKey.getConfigurationKey())
+                        .build())
+                != null) {
+          continue;
+        }
+        if (extraConfiguredTargetKeys == null) {
+          extraConfiguredTargetKeys = new HashSet<>();
+        }
+        if (!extraConfiguredTargetKeys.add(targetKey)) {
+          continue;
+        }
+      }
+      ans.add(target);
     }
-    CqueryNode nullConfiguredTarget = getNullConfiguredTarget(label);
+    var nullConfiguredTarget = getNullConfiguredTarget(label);
     if (nullConfiguredTarget != null) {
       ans.add(nullConfiguredTarget);
     }

--- a/src/test/java/com/google/devtools/build/lib/query2/testutil/AbstractQueryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/testutil/AbstractQueryTest.java
@@ -242,7 +242,6 @@ public abstract class AbstractQueryTest<T> {
   protected ImmutableList<String> resultSetToListOfStrings(Set<T> results) {
     return results.stream()
         .map(node -> helper.getLabel(node))
-        .distinct()
         .sorted(Ordering.natural())
         .collect(toImmutableList());
   }


### PR DESCRIPTION
Rule transitions that are not idempotent are owned by a `ConfiguredTargetKey` that has `shouldApplyRuleTransition` set to `false`. Since this is not the default, `cquery` and `aquery`'s iteration over all configurations in the build does not pick up these configured targets and their filtering logic removed them when encountered.

This is fixed by augmenting the filtering logic to keep these targets if they wouldn't be encountered in any other way.

Adding a suitable test required removing logic in a test helper that uniquified results.