### PR TITLE
Make child rule override exec groups from parent

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -1020,6 +1020,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
     builder.addToolchainTypes(parseToolchainTypes(toolchains, labelConverter));
 
     if (execGroups != Starlark.NONE) {
+      boolean override = parent != null;
       Map<String, DeclaredExecGroup> execGroupDict =
           Dict.cast(execGroups, String.class, DeclaredExecGroup.class, "exec_group");
       for (String group : execGroupDict.keySet()) {
@@ -1028,11 +1029,11 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
           throw Starlark.errorf("Exec group name '%s' is not a valid name.", group);
         }
       }
-      builder.addExecGroups(execGroupDict);
+      builder.addExecGroups(execGroupDict, override);
     }
     if (test && !builder.hasExecGroup(DEFAULT_TEST_RUNNER_EXEC_GROUP_NAME)) {
       builder.addExecGroups(
-          ImmutableMap.of(DEFAULT_TEST_RUNNER_EXEC_GROUP_NAME, DEFAULT_TEST_RUNNER_EXEC_GROUP));
+          ImmutableMap.of(DEFAULT_TEST_RUNNER_EXEC_GROUP_NAME, DEFAULT_TEST_RUNNER_EXEC_GROUP), false);
     }
 
     if (!buildSetting.equals(Starlark.NONE) && !cfg.equals(Starlark.NONE)) {

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -782,7 +782,7 @@ public class RuleClass implements RuleClassData {
         addToolchainTypes(parent.getToolchainTypes());
         addExecutionPlatformConstraints(parent.getExecutionPlatformConstraints());
         try {
-          addExecGroups(parent.getDeclaredExecGroups());
+          addExecGroups(parent.getDeclaredExecGroups(), false);
         } catch (DuplicateExecGroupError e) {
           throw new IllegalArgumentException(
               String.format(
@@ -1573,10 +1573,10 @@ public class RuleClass implements RuleClassData {
      * same name are added.
      */
     @CanIgnoreReturnValue
-    public Builder addExecGroups(Map<String, DeclaredExecGroup> execGroups) {
+    public Builder addExecGroups(Map<String, DeclaredExecGroup> execGroups, boolean override) {
       for (Map.Entry<String, DeclaredExecGroup> group : execGroups.entrySet()) {
         String name = group.getKey();
-        if (this.execGroups.containsKey(name)) {
+        if (this.execGroups.containsKey(name) && !override) {
           // If trying to add a new execution group with the same name as a execution group that
           // already exists, check if they are equivalent and error out if not.
           DeclaredExecGroup existingGroup = this.execGroups.get(name);

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
@@ -1236,7 +1236,7 @@ public final class RuleClassTest extends PackageLoadingTestCase {
             DeclaredExecGroup.builder()
                 .addToolchainType(ToolchainTypeRequirement.create(toolchain))
                 .execCompatibleWith(ImmutableSet.of(constraint))
-                .build()));
+                .build()), false);
 
     RuleClass ruleClass = ruleClassBuilder.build();
 

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -6159,6 +6159,59 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         .containsExactly("parent_exec_group", "child_exec_group");
   }
 
+  @Test
+  public void extendRule_execGroups_overwritten() throws Exception {
+    registerDummyStarlarkFunction();
+    evalAndExport(
+        ev,
+        """
+        parent_test = rule(
+            implementation = impl,
+            test = True,
+            exec_groups = {
+                "parent_group": exec_group(
+                    exec_compatible_with=[':cv1'],
+                ),
+                "overridden_group": exec_group(
+                    exec_compatible_with=[':cv2'],
+                ),
+            },
+        )
+
+        my_test = rule(
+            implementation = impl,
+            parent = parent_test,
+            exec_groups = {
+                "test": exec_group(
+                    exec_compatible_with=[':cv3'],
+                ),
+                "child_group": exec_group(
+                    exec_compatible_with=[':cv4'],
+                ),
+                "overridden_group": exec_group(
+                    exec_compatible_with=[':cv5'],
+                ),
+            },
+        )
+        """);
+
+    RuleClass ruleClass = ((StarlarkRuleFunction) ev.lookup("my_test")).getRuleClass();
+    assertThat(ruleClass.getDeclaredExecGroups().keySet())
+        .containsExactly("test", "child_group", "overridden_group",
+                         "parent_group");
+    DeclaredExecGroup testExecGroup = ruleClass.getDeclaredExecGroups().get("test");
+    assertThat(testExecGroup).hasExecCompatibleWith("//test:cv3");
+
+    DeclaredExecGroup parentExecGroup = ruleClass.getDeclaredExecGroups().get("parent_group");
+    assertThat(parentExecGroup).hasExecCompatibleWith("//test:cv1");
+
+    DeclaredExecGroup childExecGroup = ruleClass.getDeclaredExecGroups().get("child_group");
+    assertThat(childExecGroup).hasExecCompatibleWith("//test:cv4");
+
+    DeclaredExecGroup overriddenExecGroup = ruleClass.getDeclaredExecGroups().get("overridden_group");
+    assertThat(overriddenExecGroup).hasExecCompatibleWith("//test:cv5");
+  }
+
   private void scratchStarlarkTransition() throws IOException {
     if (!TestConstants.PRODUCT_NAME.equals("bazel")) {
       scratch.overwriteFile(


### PR DESCRIPTION
This allows overriding the exec_group attributes that would otherwise be
inherited from the parent.

Fixes https://github.com/bazelbuild/bazel/issues/26729