### PR TITLE
Clear out stale rdeps before running analysis postprocessors

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java
@@ -489,14 +489,6 @@ public class BuildTool {
         result.setActualTargets(analysisResult.getTargetsToBuild());
         result.setTestTargets(analysisResult.getTargetsToTest());
 
-        // Dirty nodes from previous builds may still be present in the graph at this point. While
-        // they can't be reached from the scope of the current build via deps, they can appear in
-        // rdeps, which results in analysis post-processors doing unnecessary work or even expecting
-        // stale keys to be present. Clean them up now.
-        if (analysisPostProcessor != NOOP_POST_PROCESSOR) {
-          env.getSkyframeExecutor().deleteOldNodes(0);
-          env.getSkyframeExecutor().performDeferredInvalidation(env.getReporter());
-        }
         try (SilentCloseable c = Profiler.instance().profile("analysisPostProcessor.process")) {
           analysisPostProcessor.process(request, env, runtime, analysisResult);
         }

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java
@@ -489,6 +489,14 @@ public class BuildTool {
         result.setActualTargets(analysisResult.getTargetsToBuild());
         result.setTestTargets(analysisResult.getTargetsToTest());
 
+        // Dirty nodes from previous builds may still be present in the graph at this point. While
+        // they can't be reached from the scope of the current build via deps, they can appear in
+        // rdeps, which results in analysis post-processors doing unnecessary work or even expecting
+        // stale keys to be present. Clean them up now.
+        if (analysisPostProcessor != NOOP_POST_PROCESSOR) {
+          env.getSkyframeExecutor().deleteOldNodes(0);
+          env.getSkyframeExecutor().performDeferredInvalidation(env.getReporter());
+        }
         try (SilentCloseable c = Profiler.instance().profile("analysisPostProcessor.process")) {
           analysisPostProcessor.process(request, env, runtime, analysisResult);
         }

--- a/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
@@ -564,9 +564,8 @@ public abstract class PostAnalysisQueryEnvironment<T> extends AbstractBlazeQuery
         Preconditions.checkState(
             dependency != null,
             "query-requested node '%s' was unavailable in the query environment graph. If you come"
-                + " across this error, please add to"
-                + " https://github.com/bazelbuild/bazel/issues/15079 or contact the bazel"
-                + " configurability team.",
+                + " across this error, please file an issue at https://github.com/bazelbuild/bazel"
+                + " or contact the bazel configurability team.",
             key);
 
         boolean implicitDep;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -3785,10 +3785,9 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
       ExternalFilesHelper tmpExternalFilesHelper =
           externalFilesHelper.cloneWithFreshExternalFilesKnowledge();
 
-      try (SilentCloseable c =
-          Profiler.instance().profile("invalidateValuesMarkedForInvalidation")) {
-        invalidateValuesMarkedForInvalidation(eventHandler);
-      }
+      // Before running the {@link FilesystemValueChecker} ensure that all values marked for
+      // invalidation have actually been invalidated, because checking those is a waste of time.
+      performDeferredInvalidation(eventHandler);
 
       FilesystemValueChecker fsvc =
           new FilesystemValueChecker(
@@ -3901,19 +3900,26 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
   }
 
   /**
-   * Before running the {@link FilesystemValueChecker} ensure that all values marked for
-   * invalidation have actually been invalidated (recall that invalidation happens at the beginning
-   * of the next evaluate() call), because checking those is a waste of time.
+   * Actually invalidates values marked for invalidation by a previous evaluation.
+   *
+   * <p>Invalidation is delayed because:
+   *
+   * <ul>
+   *   <li>there may never be a next evaluation, so the work to clean up values may be wasted;
+   *   <li>invalidated values may be resurrected due to change pruning.
+   * </ul>
    */
-  protected final void invalidateValuesMarkedForInvalidation(ExtendedEventHandler eventHandler)
+  public final void performDeferredInvalidation(ExtendedEventHandler eventHandler)
       throws InterruptedException {
-    EvaluationContext evaluationContext =
-        newEvaluationContextBuilder()
-            .setKeepGoing(false)
-            .setParallelism(DEFAULT_THREAD_COUNT)
-            .setEventHandler(eventHandler)
-            .build();
-    memoizingEvaluator.evaluate(ImmutableList.of(), evaluationContext);
+    try (SilentCloseable c = Profiler.instance().profile("performDeferredInvalidation")) {
+      EvaluationContext evaluationContext =
+          newEvaluationContextBuilder()
+              .setKeepGoing(false)
+              .setParallelism(DEFAULT_THREAD_COUNT)
+              .setEventHandler(eventHandler)
+              .build();
+      memoizingEvaluator.evaluate(ImmutableList.of(), evaluationContext);
+    }
   }
 
   protected final Set<Root> getDiffPackageRootsUnderWhichToCheck(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -3787,7 +3787,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
 
       // Before running the {@link FilesystemValueChecker} ensure that all values marked for
       // invalidation have actually been invalidated, because checking those is a waste of time.
-      performDeferredInvalidation(eventHandler);
+      applyInvalidation(eventHandler);
 
       FilesystemValueChecker fsvc =
           new FilesystemValueChecker(
@@ -3900,7 +3900,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
   }
 
   /**
-   * Actually invalidates values marked for invalidation by a previous evaluation.
+   * Actually invalidates values marked for invalidation.
    *
    * <p>Invalidation is delayed because:
    *
@@ -3909,9 +3909,9 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
    *   <li>invalidated values may be resurrected due to change pruning.
    * </ul>
    */
-  public final void performDeferredInvalidation(ExtendedEventHandler eventHandler)
+  public final void applyInvalidation(ExtendedEventHandler eventHandler)
       throws InterruptedException {
-    try (SilentCloseable c = Profiler.instance().profile("performDeferredInvalidation")) {
+    try (SilentCloseable c = Profiler.instance().profile("applyInvalidation")) {
       EvaluationContext evaluationContext =
           newEvaluationContextBuilder()
               .setKeepGoing(false)

--- a/src/test/shell/integration/configured_query_test.sh
+++ b/src/test/shell/integration/configured_query_test.sh
@@ -1662,4 +1662,40 @@ EOF
   expect_log "//${pkg}:platform is not a valid select.. condition"
 }
 
+function test_stale_rdeps() {
+  local -r pkg=$FUNCNAME
+  mkdir -p $pkg
+  touch $pkg/dep.txt
+  touch $pkg/{1,2,3}.txt
+  cat > $pkg/BUILD <<'EOF'
+filegroup(
+    name = "dep",
+    srcs = ["dep.txt"],
+)
+
+[
+    filegroup(
+        name = "target_{}".format(txt),
+        srcs = [
+            txt,
+            ":dep",
+        ],
+    )
+    for txt in glob(["*.txt"])
+]
+EOF
+
+  bazel cquery "rdeps(//$pkg:all, //$pkg:dep)" > output 2>"$TEST_log" || fail "Unexpected failure"
+  expect_log "//$pkg:target_1.txt"
+  expect_log "//$pkg:target_2.txt"
+  expect_log "//$pkg:target_3.txt"
+
+  rm $pkg/2.txt
+  bazel cquery "rdeps(//$pkg:all, //$pkg:dep)" > output 2>"$TEST_log" || fail "Unexpected failure"
+
+  expect_log "//$pkg:target_1.txt"
+  expect_not_log "//$pkg:target_2.txt"
+  expect_log "//$pkg:target_3.txt"
+}
+
 run_suite "${PRODUCT_NAME} configured query tests"


### PR DESCRIPTION
The deletion of dirty nodes in the Skyframe graph is delayed for performance reasons, which resulted in rdeps pointing to stale nodes being present when `aquery` or `cquery` walked the graph. Fix this by cleaning up these nodes eagerly when running with an analysis postprocessor.

The PR has been manually verified on the reproducer provided in https://github.com/bazelbuild/bazel/issues/15079#issuecomment-1695781700. The reproducer no longer failed at HEAD since 099f0e50610c9abbdb71c6d88553f99df7bead9f, as it apparently required a more complex setup to evade the existing `null` checks and produce a crash. 

The test added with this PR is simpler and did not produce an NPE even prior to this change due to the protective `null` checks. It does produce a failure before this PR and passes with it when these checks are patched out:

```diff
--- a/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
@@ -399,9 +399,7 @@ public abstract class PostAnalysisQueryEnvironment<T> extends AbstractBlazeQuery
       }
       T rdepValue = getValueFromKey(rdepKey);
       if (rdepValue == null) {
-        // Cannot find the actual value, possibly because it failed during analysis.
-        // TODO: b/324419258 - Add a test for this case
-        continue;
+        throw new RuntimeException("Configured target value for " + rdepKey + " not found.");
       }
       var actualParentKey = getConfiguredTargetKey(rdepValue);
       if (actualParentKey.equals(child)) {
@@ -429,9 +427,7 @@ public abstract class PostAnalysisQueryEnvironment<T> extends AbstractBlazeQuery
       }
       T rdepValue = getValueFromKey(rdepKey);
       if (rdepValue == null) {
-        // Cannot find the actual value, possibly because it failed during analysis.
-        // TODO: b/324419258 - Add a test for this case
-        continue;
+        throw new RuntimeException("Configured target value for " + rdepKey + " not found.");
       }
       var actualParentKey = getConfiguredTargetKey(rdepValue);
       if (!actualParentKey.equals(child)) {
```

Speculatively fixes #26312
Speculatively fixes #23022
Fixes #15079