### PR TITLE
Internalize filenames contained in REv2 Tree messages

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1146,7 +1146,7 @@ public class RemoteExecutionService {
     for (FileNode file : dir.getFilesList()) {
       filesBuilder.add(
           new FileMetadata(
-              parent.getRelative(file.getName()),
+              parent.getRelative(unicodeToInternal(file.getName())),
               file.getDigest(),
               file.getIsExecutable(),
               ByteString.EMPTY));
@@ -1156,11 +1156,12 @@ public class RemoteExecutionService {
     for (SymlinkNode symlink : dir.getSymlinksList()) {
       symlinksBuilder.add(
           new SymlinkMetadata(
-              parent.getRelative(symlink.getName()), PathFragment.create(symlink.getTarget())));
+              parent.getRelative(unicodeToInternal(symlink.getName())),
+              PathFragment.create(unicodeToInternal(symlink.getTarget()))));
     }
 
     for (DirectoryNode directoryNode : dir.getDirectoriesList()) {
-      Path childPath = parent.getRelative(directoryNode.getName());
+      Path childPath = parent.getRelative(unicodeToInternal(directoryNode.getName()));
       Directory childDir =
           Preconditions.checkNotNull(childDirectoriesMap.get(directoryNode.getDigest()));
       DirectoryMetadata childMetadata = parseDirectory(childPath, childDir, childDirectoriesMap);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -1038,6 +1038,47 @@ public class RemoteExecutionServiceTest {
   }
 
   @Test
+  public void downloadOutputs_outputDirectoriesWithUnicodeFilenames_works() throws Exception {
+    // arrange
+    Digest internationalizationDigest = cache.addContents(remoteActionExecutionContext, "hello");
+    Tree tree =
+        Tree.newBuilder()
+            .setRoot(
+                Directory.newBuilder()
+                    .addFiles(
+                        FileNode.newBuilder()
+                            .setName("Iñtërnâtiônàlizætiøn")
+                            .setDigest(internationalizationDigest))
+                    .addSymlinks(
+                        SymlinkNode.newBuilder()
+                            .setName("東京都")
+                            .setTarget("京都市")))
+            .build();
+    Digest treeDigest = cache.addContents(remoteActionExecutionContext, tree.toByteArray());
+    ActionResult.Builder builder = ActionResult.newBuilder();
+    builder.addOutputDirectoriesBuilder().setPath("outputs/dir").setTreeDigest(treeDigest);
+    RemoteActionResult result =
+        RemoteActionResult.createFromCache(CachedActionResult.remote(builder.build()));
+    Spawn spawn = newSpawnFromResult(result);
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    createOutputDirectories(spawn);
+    when(remoteOutputChecker.shouldDownloadOutput(ArgumentMatchers.<PathFragment>any(), any()))
+        .thenReturn(true);
+
+    // act
+    service.downloadOutputs(action, result);
+
+    // assert
+    assertThat(readContent(execRoot.getRelative(unicodeToInternal("outputs/dir/Iñtërnâtiônàlizætiøn")), UTF_8))
+        .isEqualTo("hello");
+    assertThat(execRoot.getRelative(unicodeToInternal("outputs/dir/東京都")).readSymbolicLink())
+        .isEqualTo(PathFragment.create(unicodeToInternal("京都市")));
+    assertThat(context.isLockOutputFilesCalled()).isTrue();
+  }
+
+  @Test
   public void downloadOutputs_relativeFileSymlink_success() throws Exception {
     ActionResult.Builder builder = ActionResult.newBuilder();
     builder.addOutputFileSymlinksBuilder().setPath("outputs/a/b/link").setTarget("../../foo");


### PR DESCRIPTION
As Bazel needs to work on platforms that support arbitrary characters in pathnames (e.g., Linux), pathnames are always stored as Latin-1 strings. However, it looks like the remote execution client doesn't perform this conversion when ingesting paths contained inside REv2 Tree messages. When files in these messages are later placed in other input roots, Merkle tree creation can crash as follows:

Caused by: java.lang.IllegalArgumentException: Expected internal string with Latin-1 coder, got: [REDACTED]
    at com.google.devtools.build.lib.unsafe.StringUnsafe.getInternalStringBytes(StringUnsafe.java:95)
    at com.google.devtools.build.lib.util.StringEncoding.internalToUnicode(StringEncoding.java:129)
    at com.google.devtools.build.lib.remote.merkletree.MerkleTree.buildProto(MerkleTree.java:398)
    at com.google.devtools.build.lib.remote.merkletree.MerkleTree.buildMerkleTree(MerkleTree.java:367)
    at com.google.devtools.build.lib.remote.merkletree.MerkleTree.lambda$build$2(MerkleTree.java:310)
    at com.google.devtools.build.lib.remote.merkletree.DirectoryTree.visit(DirectoryTree.java:273)
    at com.google.devtools.build.lib.remote.merkletree.DirectoryTree.visit(DirectoryTree.java:271)
    ...
    at com.google.devtools.build.lib.remote.merkletree.DirectoryTree.visit(DirectoryTree.java:271)
    at com.google.devtools.build.lib.remote.merkletree.DirectoryTree.visit(DirectoryTree.java:261)
    at com.google.devtools.build.lib.remote.merkletree.MerkleTree.build(MerkleTree.java:300)
    at com.google.devtools.build.lib.remote.merkletree.MerkleTree.build(MerkleTree.java:268)