### PR TITLE
[8.4.0] Include targets with non-idempotent rule transition in query output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphQueryEnvironment.java
@@ -55,6 +55,7 @@ import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.WalkableGraph;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -353,16 +354,46 @@ public class ActionGraphQueryEnvironment
    */
   private ImmutableList<ConfiguredTargetValue> getConfiguredTargetsForLabel(Label label)
       throws InterruptedException {
-    ImmutableList.Builder<ConfiguredTargetValue> ans = ImmutableList.builder();
-    for (BuildConfigurationValue config : transitiveConfigurations.values()) {
-      ConfiguredTargetValue configuredTargetValue =
-          createConfiguredTargetValueFromKey(
-              ConfiguredTargetKey.builder().setLabel(label).setConfiguration(config).build());
-      if (configuredTargetValue != null) {
-        ans.add(configuredTargetValue);
+    var ans = ImmutableList.<ConfiguredTargetValue>builder();
+    HashSet<ConfiguredTargetKey> extraConfiguredTargetKeys = null;
+    for (var configurationValue : transitiveConfigurations.values()) {
+      var configurationKey = configurationValue.getKey();
+      var targetValue =
+          getValueFromKey(
+              ConfiguredTargetKey.builder()
+                  .setLabel(label)
+                  .setConfigurationKey(configurationKey)
+                  .build());
+      if (targetValue == null) {
+        continue;
       }
+      // The configurations might not match if the target's configuration changed due to a
+      // transition or trimming. Filter such targets, with one exception: if the target is subject
+      // to a non-idempotent rule transition, we have to keep it once if the keys requested above,
+      // which never have shouldApplyRuleTransition set to false, don't cover it. This case is rare,
+      // so we optimize for it not being hit.
+      if (!Objects.equals(
+          configurationKey, targetValue.getConfiguredTarget().getConfigurationKey())) {
+        var targetKey = ConfiguredTargetKey.fromConfiguredTarget(targetValue.getConfiguredTarget());
+        if (targetKey.shouldApplyRuleTransition()
+            || getValueFromKey(
+                    ConfiguredTargetKey.builder()
+                        .setLabel(label)
+                        .setConfigurationKey(targetKey.getConfigurationKey())
+                        .build())
+                != null) {
+          continue;
+        }
+        if (extraConfiguredTargetKeys == null) {
+          extraConfiguredTargetKeys = new HashSet<>();
+        }
+        if (!extraConfiguredTargetKeys.add(targetKey)) {
+          continue;
+        }
+      }
+      ans.add(targetValue);
     }
-    ConfiguredTargetValue nullConfiguredTarget = getNullConfiguredTarget(label);
+    var nullConfiguredTarget = getNullConfiguredTarget(label);
     if (nullConfiguredTarget != null) {
       ans.add(nullConfiguredTarget);
     }

--- a/src/test/java/com/google/devtools/build/lib/query2/testutil/AbstractQueryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/testutil/AbstractQueryTest.java
@@ -242,7 +242,6 @@ public abstract class AbstractQueryTest<T> {
   protected ImmutableList<String> resultSetToListOfStrings(Set<T> results) {
     return results.stream()
         .map(node -> helper.getLabel(node))
-        .distinct()
         .sorted(Ordering.natural())
         .collect(toImmutableList());
   }

--- a/src/test/java/com/google/devtools/build/lib/query2/testutil/PostAnalysisQueryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/testutil/PostAnalysisQueryTest.java
@@ -42,7 +42,6 @@ import com.google.devtools.build.lib.packages.AttributeMap;
 import com.google.devtools.build.lib.packages.AttributeTransitionData;
 import com.google.devtools.build.lib.packages.RuleTransitionData;
 import com.google.devtools.build.lib.packages.Type;
-import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.QueryFunction;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.Setting;
 import com.google.devtools.build.lib.query2.engine.QueryException;
@@ -58,6 +57,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
@@ -223,7 +223,7 @@ public abstract class PostAnalysisQueryTest<T> extends AbstractQueryTest<T> {
     // Check for implicit dependencies (late bound attributes, implicit attributes, platforms)
     assertThat(evalToListOfStrings("deps(//test:my_rule)"))
         .containsAtLeastElementsIn(
-            evalToListOfStrings(explicits + " + " + implicits + " + " + PLATFORM_LABEL));
+            unique(evalToListOfStrings(explicits + " + " + implicits + " + " + PLATFORM_LABEL)));
 
     helper.setQuerySettings(Setting.NO_IMPLICIT_DEPS);
     assertThat(evalToListOfStrings("deps(//test:my_rule)"))
@@ -236,7 +236,7 @@ public abstract class PostAnalysisQueryTest<T> extends AbstractQueryTest<T> {
   public void testNoImplicitDepsOnOutputFile() throws Exception {
     writeFile(
         "test/BUILD",
-        """
+"""
 load(":defs.bzl", "my_dep", "my_rule")
 my_rule(
     name = "buildme",
@@ -249,7 +249,7 @@ my_dep(name = "implicit_dep")
 
     writeFile(
         "test/defs.bzl",
-        """
+"""
 my_dep = rule(
     implementation = lambda ctx: [],
     attrs = {},
@@ -278,7 +278,7 @@ my_rule = rule(
   public void testImplicitDepsOnOutputFile() throws Exception {
     writeFile(
         "test/BUILD",
-        """
+"""
 load(":defs.bzl", "my_dep", "my_rule")
 my_rule(
     name = "buildme",
@@ -291,7 +291,7 @@ my_dep(name = "implicit_dep")
 
     writeFile(
         "test/defs.bzl",
-        """
+"""
 my_dep = rule(
     implementation = lambda ctx: [],
     attrs = {},
@@ -365,7 +365,8 @@ my_rule = rule(
 
     // Check for implicit toolchain dependencies
     assertThat(evalToListOfStrings("deps(//test:my_rule)"))
-        .containsAtLeast(explicits, implicits, evalToString(PLATFORM_LABEL));
+        .containsAtLeastElementsIn(
+            unique(evalToListOfStrings(explicits + "+" + implicits + "+" + PLATFORM_LABEL)));
 
     helper.setQuerySettings(Setting.NO_IMPLICIT_DEPS);
     ImmutableList<String> filteredDeps = evalToListOfStrings("deps(//test:my_rule)");
@@ -500,7 +501,8 @@ my_rule = rule(
 
     // Check for implicit toolchain dependencies
     assertThat(evalToListOfStrings("deps(//test:my_rule)"))
-        .containsAtLeast(explicits, implicits, evalToString(PLATFORM_LABEL));
+        .containsAtLeastElementsIn(
+            unique(evalToListOfStrings(explicits + "+" + implicits + "+" + PLATFORM_LABEL)));
 
     helper.setQuerySettings(Setting.NO_IMPLICIT_DEPS);
     ImmutableList<String> filteredDeps = evalToListOfStrings("deps(//test:my_rule)");
@@ -532,7 +534,7 @@ my_rule = rule(
     // Check for platform dependencies
     assertThat(evalToListOfStrings("deps(//test:my_rule)"))
         .containsAtLeastElementsIn(
-            evalToListOfStrings("//test:execution_platform + //test:host_platform"));
+            unique(evalToListOfStrings("//test:execution_platform + //test:host_platform")));
     helper.setQuerySettings(Setting.NO_IMPLICIT_DEPS);
     assertThat(evalToListOfStrings("deps(//test:my_rule)")).containsExactly("//test:my_rule");
   }
@@ -866,6 +868,138 @@ my_rule = rule(
   }
 
   @Test
+  public void testNonIdempotentRuleTransition() throws Exception {
+    writeFile(
+        "test/defs.bzl",
+        """
+        StringSettingInfo = provider(fields = ["value"])
+
+        def _string_impl(ctx):
+            return StringSettingInfo(value = ctx.build_setting_value)
+
+        string_setting = rule(
+            implementation = _string_impl,
+            build_setting = config.string(),
+        )
+
+        def _transition_impl(settings, attr):
+            return {
+                k: v + "-transitioned"
+                for k, v in settings.items()
+            }
+
+        _transition = transition(
+            implementation = _transition_impl,
+            inputs = ["//test:string_setting"],
+            outputs = ["//test:string_setting"],
+        )
+
+        def _custom_rule_impl(ctx):
+            out = ctx.actions.declare_file(ctx.attr.name)
+            ctx.actions.write(out, ctx.attr._string_setting[StringSettingInfo].value)
+            return [DefaultInfo(files = depset([out]))]
+
+        custom_rule = rule(
+            cfg = _transition,
+            implementation = _custom_rule_impl,
+            attrs = {
+                "_string_setting": attr.label(default = "//test:string_setting"),
+            },
+         )
+        """);
+    writeFile(
+        "test/BUILD",
+        """
+        load(":defs.bzl", "custom_rule", "string_setting")
+
+        string_setting(
+            name = "string_setting",
+            build_setting_default = "default",
+        )
+
+        custom_rule(name = "custom_rule_name")
+        """);
+
+    ImmutableList<String> output = evalToListOfStrings("//test:custom_rule_name");
+    assertThat(output).hasSize(1);
+  }
+
+  @Test
+  public void testNonIdempotentRuleTransition_transitionedConfigIsAlsoToplevel() throws Exception {
+    writeFile(
+        "test/defs.bzl",
+        """
+        StringSettingInfo = provider(fields = ["value"])
+
+        def _string_impl(ctx):
+            return StringSettingInfo(value = ctx.build_setting_value)
+
+        string_setting = rule(
+            implementation = _string_impl,
+            build_setting = config.string(),
+        )
+
+        def _transition_impl(settings, attr):
+            return {
+                k: v + "-transitioned"
+                for k, v in settings.items()
+            }
+
+        _transition = transition(
+            implementation = _transition_impl,
+            inputs = ["//test:string_setting"],
+            outputs = ["//test:string_setting"],
+        )
+
+        def _custom_rule_impl(ctx):
+            out = ctx.actions.declare_file(ctx.attr.name)
+            ctx.actions.write(out, ctx.attr._string_setting[StringSettingInfo].value)
+            return [DefaultInfo(files = depset([out]))]
+
+        custom_rule = rule(
+            cfg = _transition,
+            implementation = _custom_rule_impl,
+            attrs = {
+                "_string_setting": attr.label(default = "//test:string_setting"),
+            },
+         )
+
+        def _wrapper_impl(_):
+            pass
+
+        wrapper = rule(
+            implementation = _wrapper_impl,
+            attrs = {
+                "dep": attr.label(
+                    cfg = _transition,
+                ),
+            },
+        )
+        """);
+    writeFile(
+        "test/BUILD",
+        """
+        load(":defs.bzl", "custom_rule", "string_setting", "wrapper")
+
+        string_setting(
+            name = "string_setting",
+            build_setting_default = "default",
+        )
+
+        custom_rule(name = "custom_rule_name")
+
+        wrapper(
+            name = "wrapper_name",
+            dep = ":custom_rule_name",
+        )
+        """);
+
+    ImmutableList<String> output =
+        evalToListOfStrings("//test:all intersect //test:custom_rule_name");
+    assertThat(output).hasSize(1);
+  }
+
+  @Test
   public void inconsistentSkyQueryIncremental() throws Exception {
     getHelper().setSyscallCache(TestUtils.makeDisappearingFileCache("bar/BUILD"));
     getHelper().turnOffFailFast();
@@ -1196,5 +1330,9 @@ my_rule = rule(
 
   protected static void assertConfigurableQueryCode(FailureDetail failureDetail, Code code) {
     assertThat(failureDetail.getConfigurableQuery().getCode()).isEqualTo(code);
+  }
+
+  protected static List<String> unique(List<String> list) {
+    return list.stream().distinct().toList();
   }
 }


### PR DESCRIPTION
Rule transitions that are not idempotent are owned by a `ConfiguredTargetKey` that has `shouldApplyRuleTransition` set to `false`. Since this is not the default, `cquery` and `aquery`'s iteration over all configurations in the build does not pick up these configured targets and their filtering logic removed them when encountered.

This is fixed by augmenting the filtering logic to keep these targets if they wouldn't be encountered in any other way.

Adding a suitable test required removing logic in a test helper that uniquified results.

Closes #26738.

PiperOrigin-RevId: 794272905
Change-Id: Ie6fc0716bf75b77c287ff9e09163aeaee9692584

Commit https://github.com/bazelbuild/bazel/commit/90b76d6d412c48b3a0a951db9f10c60c33bd5723