### PR TITLE
Take Starlark semantics defaults into account for repo digests

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/BUILD
@@ -62,6 +62,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/starlark",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/packages/semantics",
         "//src/main/java/com/google/devtools/build/lib/pkgcache",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/repository:repository_events",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DigestWriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DigestWriter.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.bazel.bzlmod.GsonTypeAdapterUtil;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.rules.repository.RepoRecordedInput;
 import com.google.devtools.build.lib.rules.repository.RepoRecordedInput.NeverUpToDateRepoRecordedInput;
 import com.google.devtools.build.lib.util.Fingerprint;
@@ -204,9 +205,7 @@ class DigestWriter {
       RepoDefinition repoDefinition, StarlarkSemantics starlarkSemantics) {
     return new Fingerprint()
         .addInt(MARKER_FILE_VERSION)
-        // TODO: Using the hashCode() method for StarlarkSemantics here is suboptimal as
-        //   it doesn't include any default values.
-        .addInt(starlarkSemantics.hashCode())
+        .addBytes(BuildLanguageOptions.stableFingerprint(starlarkSemantics))
         .addString(repoDefinition.repoRule().id().bzlFileLabel().toString())
         .addString(repoDefinition.repoRule().id().ruleName())
         .addBytes(repoDefinition.repoRule().transitiveBzlDigest())

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BUILD
@@ -22,8 +22,10 @@ java_library(
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/concurrent",
+        "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/java/net/starlark/java/eval",
         "//third_party:guava",
+        "@com_google_protobuf//:protobuf_java",
     ],
 )


### PR DESCRIPTION
This ensures that semantics can be compared across Bazel versions, which is important for the reliablity of repo invalidation (including the repo contents cache).