### PR TITLE
Fold `environ` into the predeclared inputs hash

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/DelegateTypeAdapterFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/DelegateTypeAdapterFactory.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
@@ -34,6 +35,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.Dict;
@@ -70,6 +73,14 @@ public final class DelegateTypeAdapterFactory<I, R extends I, D extends I>
           LinkedHashMap.class,
           raw -> new LinkedHashMap<>((Map<?, ?>) raw),
           delegate -> ImmutableMap.copyOf((Map<?, ?>) delegate));
+
+  public static final TypeAdapterFactory IMMUTABLE_SORTED_MAP =
+      new DelegateTypeAdapterFactory<>(
+          ImmutableSortedMap.class,
+          SortedMap.class,
+          TreeMap.class,
+          raw -> new TreeMap<>(raw),
+          delegate -> ImmutableSortedMap.copyOf(delegate));
 
   public static final TypeAdapterFactory IMMUTABLE_BIMAP =
       new DelegateTypeAdapterFactory<>(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/DelegateTypeAdapterFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/DelegateTypeAdapterFactory.java
@@ -79,8 +79,8 @@ public final class DelegateTypeAdapterFactory<I, R extends I, D extends I>
           ImmutableSortedMap.class,
           SortedMap.class,
           TreeMap.class,
-          raw -> new TreeMap<>(raw),
-          delegate -> ImmutableSortedMap.copyOf(delegate));
+          raw -> new TreeMap<>((SortedMap<?, ?>) raw),
+          delegate -> ImmutableSortedMap.copyOf((SortedMap<?, ?>) delegate));
 
   public static final TypeAdapterFactory IMMUTABLE_BIMAP =
       new DelegateTypeAdapterFactory<>(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
@@ -19,6 +19,7 @@ import static com.google.devtools.build.lib.bazel.bzlmod.DelegateTypeAdapterFact
 import static com.google.devtools.build.lib.bazel.bzlmod.DelegateTypeAdapterFactory.IMMUTABLE_LIST;
 import static com.google.devtools.build.lib.bazel.bzlmod.DelegateTypeAdapterFactory.IMMUTABLE_MAP;
 import static com.google.devtools.build.lib.bazel.bzlmod.DelegateTypeAdapterFactory.IMMUTABLE_SET;
+import static com.google.devtools.build.lib.bazel.bzlmod.DelegateTypeAdapterFactory.IMMUTABLE_SORTED_MAP;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
@@ -468,6 +469,7 @@ public final class GsonTypeAdapterUtil {
         .registerTypeAdapterFactory(GenerateTypeAdapter.FACTORY)
         .registerTypeAdapterFactory(DICT)
         .registerTypeAdapterFactory(IMMUTABLE_MAP)
+        .registerTypeAdapterFactory(IMMUTABLE_SORTED_MAP)
         .registerTypeAdapterFactory(IMMUTABLE_LIST)
         .registerTypeAdapterFactory(IMMUTABLE_BIMAP)
         .registerTypeAdapterFactory(IMMUTABLE_SET)

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InnateRunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InnateRunnableExtension.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.bazel.repository.RepoRule;
@@ -209,9 +210,9 @@ final class InnateRunnableExtension implements RunnableExtension {
               "to the %s".formatted(moduleKey.toDisplayString())));
     }
     return new RunModuleExtensionResult(
-        ImmutableMap.of(),
-        ImmutableMap.of(),
-        ImmutableMap.of(),
+        ImmutableSortedMap.of(),
+        ImmutableSortedMap.of(),
+        ImmutableSortedMap.of(),
         generatedRepoSpecs.buildOrThrow(),
         Optional.of(ModuleExtensionMetadata.REPRODUCIBLE),
         ImmutableTable.of());

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/LockFileModuleExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/LockFileModuleExtension.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableTable;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.rules.repository.RepoRecordedInput;
@@ -44,11 +45,11 @@ public abstract class LockFileModuleExtension {
   @SuppressWarnings("mutable")
   public abstract byte[] getUsagesDigest();
 
-  public abstract ImmutableMap<RepoRecordedInput.File, String> getRecordedFileInputs();
+  public abstract ImmutableSortedMap<RepoRecordedInput.File, String> getRecordedFileInputs();
 
-  public abstract ImmutableMap<RepoRecordedInput.Dirents, String> getRecordedDirentsInputs();
+  public abstract ImmutableSortedMap<RepoRecordedInput.Dirents, String> getRecordedDirentsInputs();
 
-  public abstract ImmutableMap<RepoRecordedInput.EnvVar, Optional<String>> getEnvVariables();
+  public abstract ImmutableSortedMap<RepoRecordedInput.EnvVar, Optional<String>> getEnvVariables();
 
   public abstract ImmutableMap<String, RepoSpec> getGeneratedRepoSpecs();
 
@@ -70,13 +71,13 @@ public abstract class LockFileModuleExtension {
     public abstract Builder setUsagesDigest(byte[] digest);
 
     public abstract Builder setRecordedFileInputs(
-        ImmutableMap<RepoRecordedInput.File, String> value);
+        ImmutableSortedMap<RepoRecordedInput.File, String> value);
 
     public abstract Builder setRecordedDirentsInputs(
-        ImmutableMap<RepoRecordedInput.Dirents, String> value);
+        ImmutableSortedMap<RepoRecordedInput.Dirents, String> value);
 
     public abstract Builder setEnvVariables(
-        ImmutableMap<RepoRecordedInput.EnvVar, Optional<String>> value);
+        ImmutableSortedMap<RepoRecordedInput.EnvVar, Optional<String>> value);
 
     public abstract Builder setGeneratedRepoSpecs(ImmutableMap<String, RepoSpec> value);
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RunnableExtension.java
@@ -16,6 +16,7 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableTable;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -55,9 +56,9 @@ interface RunnableExtension {
 
   /* Holds the result data from running a module extension */
   record RunModuleExtensionResult(
-      ImmutableMap<RepoRecordedInput.File, String> recordedFileInputs,
-      ImmutableMap<RepoRecordedInput.Dirents, String> recordedDirentsInputs,
-      ImmutableMap<RepoRecordedInput.EnvVar, Optional<String>> recordedEnvVarInputs,
+      ImmutableSortedMap<RepoRecordedInput.File, String> recordedFileInputs,
+      ImmutableSortedMap<RepoRecordedInput.Dirents, String> recordedDirentsInputs,
+      ImmutableSortedMap<RepoRecordedInput.EnvVar, Optional<String>> recordedEnvVarInputs,
       ImmutableMap<String, RepoSpec> generatedRepoSpecs,
       Optional<ModuleExtensionMetadata> moduleExtensionMetadata,
       ImmutableTable<RepositoryName, String, RepositoryName> recordedRepoMappingEntries) {}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DigestWriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DigestWriter.java
@@ -49,17 +49,33 @@ class DigestWriter {
       ImmutableMap.of(NeverUpToDateRepoRecordedInput.PARSE_FAILURE, "");
 
   private final BlazeDirectories directories;
+  final String predeclaredInputHash;
   final Path markerPath;
-  private final String predeclaredInputHash;
 
-  DigestWriter(
+  private DigestWriter(
+      BlazeDirectories directories, RepositoryName repositoryName, String predeclaredInputHash) {
+    this.directories = directories;
+    this.predeclaredInputHash = predeclaredInputHash;
+    this.markerPath = getMarkerPath(directories, repositoryName);
+  }
+
+  /**
+   * @return null if and only if a Skyframe restart is needed
+   */
+  @Nullable
+  public static DigestWriter create(
+      Environment env,
       BlazeDirectories directories,
       RepositoryName repositoryName,
       RepoDefinition repoDefinition,
-      StarlarkSemantics starlarkSemantics) {
-    this.directories = directories;
-    predeclaredInputHash = computePredeclaredInputHash(repoDefinition, starlarkSemantics);
-    markerPath = getMarkerPath(directories, repositoryName);
+      StarlarkSemantics starlarkSemantics)
+      throws InterruptedException {
+    String predeclaredInputHash =
+        computePredeclaredInputHash(env, repoDefinition, starlarkSemantics);
+    if (predeclaredInputHash == null) {
+      return null;
+    }
+    return new DigestWriter(directories, repositoryName, predeclaredInputHash);
   }
 
   // Escape a value for the marker file
@@ -201,19 +217,30 @@ class DigestWriter {
     return Preconditions.checkNotNull(recordedInputValues);
   }
 
+  @Nullable
   static String computePredeclaredInputHash(
-      RepoDefinition repoDefinition, StarlarkSemantics starlarkSemantics) {
-    return new Fingerprint()
-        .addInt(MARKER_FILE_VERSION)
-        .addBytes(BuildLanguageOptions.stableFingerprint(starlarkSemantics))
-        .addString(repoDefinition.repoRule().id().bzlFileLabel().toString())
-        .addString(repoDefinition.repoRule().id().ruleName())
-        .addBytes(repoDefinition.repoRule().transitiveBzlDigest())
-        .addString(repoDefinition.name())
-        .addString(
-            GsonTypeAdapterUtil.SINGLE_EXTENSION_USAGES_VALUE_GSON.toJson(
-                repoDefinition.attrValues()))
-        .hexDigestAndReset();
+      Environment env, RepoDefinition repoDefinition, StarlarkSemantics starlarkSemantics)
+      throws InterruptedException {
+    var unsortedEnviron = RepositoryUtils.getEnvVarValues(env, repoDefinition.repoRule().environ());
+    if (unsortedEnviron == null) {
+      return null;
+    }
+    var environ = RepoRecordedInput.EnvVar.wrap(unsortedEnviron);
+    var fp =
+        new Fingerprint()
+            .addInt(MARKER_FILE_VERSION)
+            .addBytes(BuildLanguageOptions.stableFingerprint(starlarkSemantics))
+            .addString(repoDefinition.repoRule().id().bzlFileLabel().toString())
+            .addString(repoDefinition.repoRule().id().ruleName())
+            .addBytes(repoDefinition.repoRule().transitiveBzlDigest())
+            .addString(repoDefinition.name())
+            .addString(
+                GsonTypeAdapterUtil.SINGLE_EXTENSION_USAGES_VALUE_GSON.toJson(
+                    repoDefinition.attrValues()))
+            .addInt(environ.size());
+    environ.forEach(
+        (key, value) -> fp.addString(key.toString()).addNullableString(value.orElse(null)));
+    return fp.hexDigestAndReset();
   }
 
   private static Path getMarkerPath(BlazeDirectories directories, RepositoryName repo) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryUtils.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.bazel.repository;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
@@ -73,7 +74,7 @@ public class RepositoryUtils {
    * registering them as dependencies.
    */
   @Nullable
-  public static ImmutableMap<String, Optional<String>> getEnvVarValues(
+  public static ImmutableSortedMap<String, Optional<String>> getEnvVarValues(
       Environment env, Set<String> keys) throws InterruptedException {
     Map<String, Optional<String>> environ = ActionEnvironmentFunction.getEnvironmentView(env, keys);
     if (environ == null) {
@@ -93,7 +94,7 @@ public class RepositoryUtils {
         repoEnv.put(key, Optional.of(value));
       }
     }
-    return repoEnv.buildKeepingLast();
+    return ImmutableSortedMap.copyOf(repoEnv.buildKeepingLast());
   }
 
   protected static Path getExternalRepositoryDirectory(BlazeDirectories directories) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -267,20 +267,19 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
   protected abstract boolean shouldDeleteWorkingDirectoryOnClose(boolean successful);
 
   /** Returns the file digests used by this context object so far. */
-  public ImmutableMap<RepoRecordedInput.File, String> getRecordedFileInputs() {
+  public ImmutableSortedMap<RepoRecordedInput.File, String> getRecordedFileInputs() {
     return ImmutableSortedMap.copyOf(recordedFileInputs);
   }
 
-  public ImmutableMap<Dirents, String> getRecordedDirentsInputs() {
+  public ImmutableSortedMap<Dirents, String> getRecordedDirentsInputs() {
     return ImmutableSortedMap.copyOf(recordedDirentsInputs);
   }
 
-  public ImmutableMap<RepoRecordedInput.EnvVar, Optional<String>> getRecordedEnvVarInputs()
+  public ImmutableSortedMap<RepoRecordedInput.EnvVar, Optional<String>> getRecordedEnvVarInputs()
       throws InterruptedException {
     // getEnvVarValues doesn't return null since the Skyframe dependencies have already been
     // established by getenv calls.
-    return RepoRecordedInput.EnvVar.wrap(
-        ImmutableSortedMap.copyOf(RepositoryUtils.getEnvVarValues(env, accumulatedEnvKeys)));
+    return RepoRecordedInput.EnvVar.wrap(RepositoryUtils.getEnvVarValues(env, accumulatedEnvKeys));
   }
 
   protected void checkInOutputDirectory(String operation, StarlarkPath path)

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -19,6 +19,7 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import com.github.difflib.patch.PatchFailedException;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.devtools.build.docgen.annot.DocCategory;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.bazel.debug.WorkspaceRuleEvent;
@@ -122,8 +123,8 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
     return !successful;
   }
 
-  public ImmutableMap<RepoRecordedInput.DirTree, String> getRecordedDirTreeInputs() {
-    return ImmutableMap.copyOf(recordedDirTreeInputs);
+  public ImmutableSortedMap<RepoRecordedInput.DirTree, String> getRecordedDirTreeInputs() {
+    return ImmutableSortedMap.copyOf(recordedDirTreeInputs);
   }
 
   @StarlarkMethod(

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -278,7 +278,7 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
         GetActionResultRequest.newBuilder()
             .setInstanceName(options.remoteInstanceName)
             .setDigestFunction(digestUtil.getDigestFunction())
-            .setActionDigest(actionKey.getDigest())
+            .setActionDigest(actionKey.digest())
             .setInlineStderr(inlineOutErr)
             .setInlineStdout(inlineOutErr)
             .addAllInlineOutputFiles(inlineOutputFiles)
@@ -309,7 +309,7 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
                                             UpdateActionResultRequest.newBuilder()
                                                 .setInstanceName(options.remoteInstanceName)
                                                 .setDigestFunction(digestUtil.getDigestFunction())
-                                                .setActionDigest(actionKey.getDigest())
+                                                .setActionDigest(actionKey.digest())
                                                 .setActionResult(actionResult)
                                                 .build())),
                             StatusRuntimeException.class,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteAction.java
@@ -99,7 +99,7 @@ public class RemoteAction {
 
   /** Returns the id this is action. */
   public String getActionId() {
-    return actionKey.getDigest().getHash();
+    return actionKey.digest().getHash();
   }
 
   /** Returns the {@link ActionKey} of this action. */

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -674,11 +674,10 @@ public class RemoteExecutionService {
 
       RequestMetadata metadata =
           TracingMetadataUtils.buildMetadata(
-              buildRequestId, commandId, actionKey.getDigest().getHash(), spawn.getResourceOwner());
+              buildRequestId, commandId, actionKey.digest().getHash(), spawn.getResourceOwner());
       RemoteActionExecutionContext remoteActionExecutionContext =
           RemoteActionExecutionContext.create(
               spawn, context, metadata, getWriteCachePolicy(spawn), getReadCachePolicy(spawn));
-
       return new RemoteAction(
           spawn,
           context,
@@ -1978,7 +1977,7 @@ public class RemoteExecutionService {
     RemoteExecutionCache remoteExecutionCache = (RemoteExecutionCache) combinedCache;
     // Upload the command and all the inputs into the remote cache.
     Map<Digest, Message> additionalInputs = Maps.newHashMapWithExpectedSize(2);
-    additionalInputs.put(action.getActionKey().getDigest(), action.getAction());
+    additionalInputs.put(action.getActionKey().digest(), action.getAction());
     additionalInputs.put(action.getCommandHash(), action.getCommand());
 
     // As uploading depends on having the full input root in memory, limit
@@ -2029,7 +2028,7 @@ public class RemoteExecutionService {
         ExecuteRequest.newBuilder()
             .setInstanceName(remoteOptions.remoteInstanceName)
             .setDigestFunction(digestUtil.getDigestFunction())
-            .setActionDigest(action.getActionKey().getDigest())
+            .setActionDigest(action.getActionKey().digest())
             .setSkipCacheLookup(!acceptCachedResult);
     if (remoteOptions.remoteResultCachePriority != 0) {
       requestBuilder

--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -291,7 +291,7 @@ public class UploadManifest {
   private void addAction(RemoteCacheClient.ActionKey actionKey, Action action, Command command) {
     Preconditions.checkState(this.actionKey == null, "Already added an action");
     this.actionKey = actionKey;
-    digestToBlobs.put(actionKey.getDigest(), action.toByteString());
+    digestToBlobs.put(actionKey.digest(), action.toByteString());
     digestToBlobs.put(action.getCommandDigest(), command.toByteString());
   }
 
@@ -683,11 +683,11 @@ public class UploadManifest {
               .doOnSubscribe(
                   d ->
                       reportUploadStarted(
-                          reporter, action, Store.AC, ImmutableList.of(actionKey.getDigest())))
+                          reporter, action, Store.AC, ImmutableList.of(actionKey.digest())))
               .doFinally(
                   () ->
                       reportUploadFinished(
-                          reporter, action, Store.AC, ImmutableList.of(actionKey.getDigest())));
+                          reporter, action, Store.AC, ImmutableList.of(actionKey.digest())));
     }
 
     return Completable.concatArray(uploadOutputs, uploadActionResult).toSingleDefault(actionResult);

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
@@ -45,30 +45,9 @@ public interface RemoteCacheClient extends MissingDigestsFinder {
    * <p>Terminology note: "action" is used here in the remote execution protocol sense, which is
    * equivalent to a Bazel "spawn" (a Bazel "action" being a higher-level concept).
    */
-  final class ActionKey {
-
-    private final Digest digest;
-
-    public Digest getDigest() {
-      return digest;
-    }
-
-    public ActionKey(Digest digest) {
-      this.digest = Preconditions.checkNotNull(digest, "digest");
-    }
-
-    @Override
-    public boolean equals(Object other) {
-      if (!(other instanceof ActionKey otherKey)) {
-        return false;
-      }
-
-      return digest.equals(otherKey.digest);
-    }
-
-    @Override
-    public int hashCode() {
-      return digest.hashCode();
+  record ActionKey(Digest digest) {
+    public ActionKey {
+      Preconditions.checkNotNull(digest, "digest");
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -257,7 +257,7 @@ public class DiskCacheClient {
     return executorService.submit(
         () -> {
           try (InputStream data = actionResult.toByteString().newInput()) {
-            saveFile(actionKey.getDigest(), Store.AC, data);
+            saveFile(actionKey.digest(), Store.AC, data);
           }
           return null;
         });

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -753,7 +753,7 @@ public final class HttpCacheClient implements RemoteCacheClient {
       RemoteActionExecutionContext context, ActionKey actionKey, ActionResult actionResult) {
     ByteString serialized = actionResult.toByteString();
     return uploadAsync(
-        actionKey.getDigest().getHash(),
+        actionKey.digest().getHash(),
         serialized.size(),
         serialized.newInput(),
         /* casUpload= */ false);

--- a/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
@@ -134,8 +134,8 @@ public class DigestUtil {
 
   public com.google.devtools.build.lib.exec.Protos.Digest asSpawnLogProto(ActionKey actionKey) {
     return com.google.devtools.build.lib.exec.Protos.Digest.newBuilder()
-        .setHash(actionKey.getDigest().getHash())
-        .setSizeBytes(actionKey.getDigest().getSizeBytes())
+        .setHash(actionKey.digest().getHash())
+        .setSizeBytes(actionKey.digest().getSizeBytes())
         .setHashFunctionName(getDigestFunction().toString())
         .build();
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -417,7 +417,7 @@ public final class Utils {
       ActionKey actionDigest,
       BiFunction<Digest, OutputStream, ListenableFuture<Void>> downloadFunction) {
     ByteArrayOutputStream data = new ByteArrayOutputStream(/* size= */ 1024);
-    ListenableFuture<Void> download = downloadFunction.apply(actionDigest.getDigest(), data);
+    ListenableFuture<Void> download = downloadFunction.apply(actionDigest.digest(), data);
     return FluentFuture.from(download)
         .transformAsync(
             (v) -> {

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInput.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInput.java
@@ -15,13 +15,14 @@
 package com.google.devtools.build.lib.rules.repository;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.ImmutableSortedMap.toImmutableSortedMap;
+import static java.util.Comparator.naturalOrder;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.io.BaseEncoding;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
@@ -548,10 +549,12 @@ public abstract sealed class RepoRecordedInput implements Comparable<RepoRecorde
 
     final String name;
 
-    public static ImmutableMap<EnvVar, Optional<String>> wrap(
+    public static ImmutableSortedMap<EnvVar, Optional<String>> wrap(
         Map<String, Optional<String>> envVars) {
       return envVars.entrySet().stream()
-          .collect(toImmutableMap(e -> new EnvVar(e.getKey()), Map.Entry::getValue));
+          .collect(
+              toImmutableSortedMap(
+                  naturalOrder(), e -> new EnvVar(e.getKey()), Map.Entry::getValue));
     }
 
     private EnvVar(String name) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModuleTest.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.devtools.build.lib.cmdline.Label;
 import java.util.Optional;
 import net.starlark.java.eval.Starlark;
@@ -44,18 +45,18 @@ public class BazelLockFileModuleTest {
         LockFileModuleExtension.builder()
             .setBzlTransitiveDigest(new byte[] {1, 2, 3})
             .setUsagesDigest(new byte[] {4, 5, 6})
-            .setRecordedFileInputs(ImmutableMap.of())
-            .setRecordedDirentsInputs(ImmutableMap.of())
-            .setEnvVariables(ImmutableMap.of())
+            .setRecordedFileInputs(ImmutableSortedMap.of())
+            .setRecordedDirentsInputs(ImmutableSortedMap.of())
+            .setEnvVariables(ImmutableSortedMap.of())
             .setGeneratedRepoSpecs(ImmutableMap.of())
             .build();
     reproducibleResult =
         LockFileModuleExtension.builder()
             .setBzlTransitiveDigest(new byte[] {1, 2, 3})
             .setUsagesDigest(new byte[] {4, 5, 6})
-            .setRecordedFileInputs(ImmutableMap.of())
-            .setRecordedDirentsInputs(ImmutableMap.of())
-            .setEnvVariables(ImmutableMap.of())
+            .setRecordedFileInputs(ImmutableSortedMap.of())
+            .setRecordedDirentsInputs(ImmutableSortedMap.of())
+            .setEnvVariables(ImmutableSortedMap.of())
             .setGeneratedRepoSpecs(ImmutableMap.of())
             .setModuleExtensionMetadata(
                 Optional.of(

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -143,7 +143,7 @@ public class ByteStreamUploaderTest {
         TracingMetadataUtils.buildMetadata(
             "none",
             "none",
-            DIGEST_UTIL.asActionKey(Digest.getDefaultInstance()).getDigest().getHash(),
+            DIGEST_UTIL.asActionKey(Digest.getDefaultInstance()).digest().getHash(),
             null);
     context = RemoteActionExecutionContext.create(metadata);
 
@@ -1058,7 +1058,7 @@ public class ByteStreamUploaderTest {
           TracingMetadataUtils.buildMetadata(
               "build-req-id",
               "command-id",
-              DIGEST_UTIL.asActionKey(actionDigest).getDigest().getHash(),
+              DIGEST_UTIL.asActionKey(actionDigest).digest().getHash(),
               null);
       RemoteActionExecutionContext remoteActionExecutionContext =
           RemoteActionExecutionContext.create(metadata);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -2359,9 +2359,9 @@ public class RemoteExecutionServiceTest {
             ActionUploadStartedEvent.create(spawn.getResourceOwner(), Store.CAS, digest),
             ActionUploadFinishedEvent.create(spawn.getResourceOwner(), Store.CAS, digest),
             ActionUploadStartedEvent.create(
-                spawn.getResourceOwner(), Store.AC, action.getActionKey().getDigest()),
+                spawn.getResourceOwner(), Store.AC, action.getActionKey().digest()),
             ActionUploadFinishedEvent.create(
-                spawn.getResourceOwner(), Store.AC, action.getActionKey().getDigest()));
+                spawn.getResourceOwner(), Store.AC, action.getActionKey().digest()));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
@@ -378,7 +378,7 @@ public class DiskCacheClientTest {
   }
 
   private Path getAcPath(ActionKey actionKey) {
-    return client.toPath(actionKey.getDigest(), Store.AC);
+    return client.toPath(actionKey.digest(), Store.AC);
   }
 
   @CanIgnoreReturnValue

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -124,7 +124,7 @@ public class GrpcRemoteDownloaderTest {
         TracingMetadataUtils.buildMetadata(
             "none",
             "none",
-            DIGEST_UTIL.asActionKey(Digest.getDefaultInstance()).getDigest().getHash(),
+            DIGEST_UTIL.asActionKey(Digest.getDefaultInstance()).digest().getHash(),
             null);
     context = RemoteActionExecutionContext.create(metadata);
 


### PR DESCRIPTION
This makes repo contents cache lookups more efficient and avoids later Skyframe restarts.

Along the way, switch more `RepoRecordedInputs`-related fields to `ImmutableSortedMap`. This type has a lower memory usage than `ImmutableMap` and guarantees canonical ordering of entries.