### PR TITLE
[8.4.0] Clear out stale rdeps before running analysis postprocessors

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
@@ -549,9 +549,8 @@ public abstract class PostAnalysisQueryEnvironment<T> extends AbstractBlazeQuery
         Preconditions.checkState(
             dependency != null,
             "query-requested node '%s' was unavailable in the query environment graph. If you come"
-                + " across this error, please add to"
-                + " https://github.com/bazelbuild/bazel/issues/15079 or contact the bazel"
-                + " configurability team.",
+                + " across this error, please file an issue at https://github.com/bazelbuild/bazel"
+                + " or contact the bazel configurability team.",
             key);
 
         boolean implicitDep;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -3425,10 +3425,9 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
       ExternalFilesHelper tmpExternalFilesHelper =
           externalFilesHelper.cloneWithFreshExternalFilesKnowledge();
 
-      try (SilentCloseable c =
-          Profiler.instance().profile("invalidateValuesMarkedForInvalidation")) {
-        invalidateValuesMarkedForInvalidation(eventHandler);
-      }
+      // Before running the {@link FilesystemValueChecker} ensure that all values marked for
+      // invalidation have actually been invalidated, because checking those is a waste of time.
+      applyInvalidation(eventHandler);
 
       FilesystemValueChecker fsvc =
           new FilesystemValueChecker(
@@ -3539,19 +3538,26 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
   }
 
   /**
-   * Before running the {@link FilesystemValueChecker} ensure that all values marked for
-   * invalidation have actually been invalidated (recall that invalidation happens at the beginning
-   * of the next evaluate() call), because checking those is a waste of time.
+   * Actually invalidates values marked for invalidation.
+   *
+   * <p>Invalidation is delayed because:
+   *
+   * <ul>
+   *   <li>there may never be a next evaluation, so the work to clean up values may be wasted;
+   *   <li>invalidated values may be resurrected due to change pruning.
+   * </ul>
    */
-  protected final void invalidateValuesMarkedForInvalidation(ExtendedEventHandler eventHandler)
+  public final void applyInvalidation(ExtendedEventHandler eventHandler)
       throws InterruptedException {
-    EvaluationContext evaluationContext =
-        newEvaluationContextBuilder()
-            .setKeepGoing(false)
-            .setParallelism(DEFAULT_THREAD_COUNT)
-            .setEventHandler(eventHandler)
-            .build();
-    memoizingEvaluator.evaluate(ImmutableList.of(), evaluationContext);
+    try (SilentCloseable c = Profiler.instance().profile("applyInvalidation")) {
+      EvaluationContext evaluationContext =
+          newEvaluationContextBuilder()
+              .setKeepGoing(false)
+              .setParallelism(DEFAULT_THREAD_COUNT)
+              .setEventHandler(eventHandler)
+              .build();
+      memoizingEvaluator.evaluate(ImmutableList.of(), evaluationContext);
+    }
   }
 
   protected final Set<Root> getDiffPackageRootsUnderWhichToCheck(


### PR DESCRIPTION
The deletion of dirty nodes in the Skyframe graph is delayed for performance reasons, which resulted in rdeps pointing to stale nodes being present when `aquery` or `cquery` walked the graph. Fix this by cleaning up these nodes eagerly when running with an analysis postprocessor.

The PR has been manually verified on the reproducer provided in https://github.com/bazelbuild/bazel/issues/15079#issuecomment-1695781700. The reproducer no longer failed at HEAD since 099f0e50610c9abbdb71c6d88553f99df7bead9f, as it apparently required a more complex setup to evade the existing `null` checks and produce a crash.

The test added with this PR is simpler and did not produce an NPE even prior to this change due to the protective `null` checks. It does produce a failure before this PR and passes with it when these checks are patched out:

```diff
--- a/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
@@ -399,9 +399,7 @@ public abstract class PostAnalysisQueryEnvironment<T> extends AbstractBlazeQuery
       }
       T rdepValue = getValueFromKey(rdepKey);
       if (rdepValue == null) {
-        // Cannot find the actual value, possibly because it failed during analysis.
-        // TODO: b/324419258 - Add a test for this case
-        continue;
+        throw new RuntimeException("Configured target value for " + rdepKey + " not found.");
       }
       var actualParentKey = getConfiguredTargetKey(rdepValue);
       if (actualParentKey.equals(child)) {
@@ -429,9 +427,7 @@ public abstract class PostAnalysisQueryEnvironment<T> extends AbstractBlazeQuery
       }
       T rdepValue = getValueFromKey(rdepKey);
       if (rdepValue == null) {
-        // Cannot find the actual value, possibly because it failed during analysis.
-        // TODO: b/324419258 - Add a test for this case
-        continue;
+        throw new RuntimeException("Configured target value for " + rdepKey + " not found.");
       }
       var actualParentKey = getConfiguredTargetKey(rdepValue);
       if (!actualParentKey.equals(child)) {
```

Speculatively fixes #26312
Speculatively fixes #23022
Fixes #15079

Closes #26746.

PiperOrigin-RevId: 795100780
Change-Id: I0440612f2a5e8ea6860ef687025eab53fb2ae4ab

Commit https://github.com/bazelbuild/bazel/commit/e81e37a497c5f6c41ffa3bbbea26d4ec813b424b