### PR TITLE
[8.4.0] Respect XDG directory settings on macOS

### DIFF
--- a/site/en/remote/output-directories.md
+++ b/site/en/remote/output-directories.md
@@ -30,13 +30,14 @@ The solution that's currently implemented:
   subdirectory thereof. In other words, Bazel must be invoked from inside a
   [repository](../external/overview#repository). Otherwise, an error is
   reported.
-* The _outputRoot_ directory defaults to `${XDG_CACHE_HOME}/bazel` (or
-  `~/.cache/bazel`, if the `XDG_CACHE_HOME` environment variable is not set) on
-  Linux, `/private/var/tmp` on macOS, and on Windows it defaults to `%HOME%` if
+* The _outputRoot_ directory defaults to `~/.cache/bazel` on Linux,
+  `/private/var/tmp` on macOS, and on Windows it defaults to `%HOME%` if
   set, else `%USERPROFILE%` if set, else the result of calling
   `SHGetKnownFolderPath()` with the `FOLDERID_Profile` flag set. If the
-  environment variable `$TEST_TMPDIR` is set, as in a test of Bazel itself,
-  then that value overrides the default.
+  environment variable `$XDG_CACHE_HOME` is set on either Linux or
+  macOS, the value `${XDG_CACHE_HOME}/bazel` will override the default.
+  If the environment variable `$TEST_TMPDIR` is set, as in a test of Bazel
+  itself, then that value overrides any defaults.
 * The Bazel user's build state is located beneath `outputRoot/_bazel_$USER`.
   This is called the _outputUserRoot_ directory.
 * Beneath the `outputUserRoot` directory there is an `install` directory, and in

--- a/src/main/cpp/blaze_util_darwin.cc
+++ b/src/main/cpp/blaze_util_darwin.cc
@@ -96,7 +96,25 @@ static string DescriptionFromCFError(CFErrorRef cf_err) {
   return UTF8StringFromCFStringRef(cf_err_string);
 }
 
-string GetCacheDir() { return "/var/tmp"; }
+string GetCacheDir() {
+  // On macOS, the standard location for application caches is
+  // $HOME/Library/Caches. Bazel historically has not used this location, and
+  // instead has used /var/tmp, due to Unix domain socket path length
+  // limitations. These limitations are no longer relevant as we no longer
+  // create Unix domain sockets under the output base.
+  //
+  // However, respecting $XDG_CACHE_HOME is still useful as it allows users to
+  // easily override the cache directory, and is respected by many Linux derived
+  // tools.
+  //
+  // See also:
+  // https://stackoverflow.com/questions/3373948/equivalents-of-xdg-config-home-and-xdg-data-home-on-mac-os-x
+  string xdg_cache_home = GetPathEnv("XDG_CACHE_HOME");
+  if (!xdg_cache_home.empty()) {
+    return blaze_util::JoinPath(xdg_cache_home, "bazel");
+  }
+  return "/var/tmp";
+}
 
 void WarnFilesystemType(const blaze_util::Path &output_base) {
   // Check to see if we are on a non-local drive.


### PR DESCRIPTION
Fixes #25167

Copies much of the logic over from `blaze_util_linux.cc` and its tests into the Darwin space to implement the feature request.

Closes #25205.

PiperOrigin-RevId: 725622080
Change-Id: I46a65076bdea4c0b1989b4816bc41efb123b14be

Commit https://github.com/bazelbuild/bazel/commit/f6d71e5950c351a1b91dd685f99a03d2be941ffe