### PR TITLE
Allow negating --remote_grpc_log

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -434,7 +434,7 @@ public final class RemoteOptions extends CommonRemoteOptions {
       defaultValue = "null",
       category = "remote",
       documentationCategory = OptionDocumentationCategory.REMOTE,
-      converter = OptionsUtils.PathFragmentConverter.class,
+      converter = OptionsUtils.EmptyToNullPathFragmentConverter.class,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "If specified, a path to a file to log gRPC call related details. This log consists of a"

--- a/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.common.options.Options;
 import com.google.devtools.common.options.OptionsParsingException;
+import com.google.devtools.common.options.OptionsParser;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.SortedMap;
@@ -103,5 +104,13 @@ public class RemoteOptionsTest {
     RemoteOptions options = Options.getDefaults(RemoteOptions.class);
     int defaultMax = options.maximumOpenFiles;
     assertThat(defaultMax).isEqualTo(-1);
+  }
+
+  @Test
+  public void testRemoteGrpcLogWithEmptyString() throws Exception {
+    OptionsParser parser = OptionsParser.builder().optionsClasses(RemoteOptions.class).build();
+    parser.parse("--remote_grpc_log=test.log", "--remote_grpc_log=");
+    RemoteOptions options = parser.getOptions(RemoteOptions.class);
+    assertThat(options.remoteGrpcLog).isNull();
   }
 }


### PR DESCRIPTION
Previously setting this to an empty string with `--remote_grpc_log=`
would result in it assuming it should be using the current directory as
the output path, and erroring with:

```
ERROR: /tmp/repro (Is a directory)
ERROR: Error initializing RemoteModule
```
