### PR TITLE
Write and read repo marker file as raw bytes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DigestWriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DigestWriter.java
@@ -14,7 +14,7 @@
 //
 package com.google.devtools.build.lib.bazel.repository;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -108,7 +108,7 @@ class DigestWriter {
     }
     String content = builder.toString();
     try {
-      FileSystemUtils.writeContent(markerPath, UTF_8, content);
+      FileSystemUtils.writeContent(markerPath, ISO_8859_1, content);
     } catch (IOException e) {
       throw new RepositoryFunctionException(e, Transience.TRANSIENT);
     }
@@ -143,7 +143,7 @@ class DigestWriter {
     }
 
     try {
-      String content = FileSystemUtils.readContent(markerPath, UTF_8);
+      String content = FileSystemUtils.readContent(markerPath, ISO_8859_1);
       Map<RepoRecordedInput, String> recordedInputValues =
           readMarkerFile(content, Preconditions.checkNotNull(predeclaredInputHash));
       Optional<String> outdatedReason =


### PR DESCRIPTION
This matches how Bazel internally encodes strings and interacts with files in other places and avoids double encoding as the internal representation are already UTF-8 bytes.