### PR TITLE
Delete content-based path infrastructure

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionInput.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionInput.java
@@ -46,12 +46,4 @@ public interface ActionInput {
 
   /** The input is a symlink that is supposed to stay un-dereferenced. */
   boolean isSymlink();
-
-  /**
-   * Returns if this input's file system path includes a digest of its content. See {@link
-   * com.google.devtools.build.lib.analysis.config.BuildConfigurationValue#useContentBasedOutputPaths}.
-   */
-  default boolean contentBasedPath() {
-    return false;
-  }
 }

--- a/src/main/java/com/google/devtools/build/lib/actions/Artifact.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Artifact.java
@@ -166,8 +166,7 @@ public abstract sealed class Artifact
    */
   @ThreadSafety.ThreadSafe
   public static SkyKey key(Artifact artifact) {
-    if (artifact.isTreeArtifact()
-        || !artifact.hasKnownGeneratingAction()) {
+    if (artifact.isTreeArtifact() || !artifact.hasKnownGeneratingAction()) {
       return artifact;
     }
 
@@ -225,42 +224,18 @@ public abstract sealed class Artifact
      */
     private Object owner;
 
-    /**
-     * Content-based output paths are experimental. Only derived artifacts that are explicitly opted
-     * in by their creating rules should use them and only when {@link
-     * com.google.devtools.build.lib.analysis.config.BuildConfigurationValue#useContentBasedOutputPaths}
-     * is on.
-     */
-    private final boolean contentBasedPath;
-
     /** Standard factory method for derived artifacts. */
     public static DerivedArtifact create(
         ArtifactRoot root, PathFragment execPath, ActionLookupKey owner) {
-      return create(root, execPath, owner, /*contentBasedPath=*/ false);
-    }
-
-    /**
-     * Same as {@link #create(ArtifactRoot, PathFragment, ActionLookupKey)} but includes the option
-     * to use a content-based path for this artifact (see {@link
-     * com.google.devtools.build.lib.analysis.config.BuildConfigurationValue#useContentBasedOutputPaths}).
-     */
-    public static DerivedArtifact create(
-        ArtifactRoot root, PathFragment execPath, ActionLookupKey owner, boolean contentBasedPath) {
-      return new DerivedArtifact(root, execPath, owner, contentBasedPath);
+      return new DerivedArtifact(root, execPath, owner);
     }
 
     @VisibleForSerialization
     DerivedArtifact(ArtifactRoot root, PathFragment execPath, Object owner) {
-      this(root, execPath, owner, /*contentBasedPath=*/ false);
-    }
-
-    private DerivedArtifact(
-        ArtifactRoot root, PathFragment execPath, Object owner, boolean contentBasedPath) {
       super(root, execPath, HashCodes.hashObjects(execPath, getOwnerToUseForHashCode(owner)));
       Preconditions.checkState(
           !root.getExecPath().isEmpty(), "Derived root has no exec path: %s, %s", root, execPath);
       this.owner = Preconditions.checkNotNull(owner);
-      this.contentBasedPath = contentBasedPath;
     }
 
     /**
@@ -342,11 +317,6 @@ public abstract sealed class Artifact
     }
 
     @Override
-    public boolean contentBasedPath() {
-      return contentBasedPath;
-    }
-
-    @Override
     public String expand(UnaryOperator<PathFragment> stripPaths) {
       return stripPaths.apply(getExecPath()).getPathString();
     }
@@ -406,7 +376,7 @@ public abstract sealed class Artifact
   /**
    * Returns the directory name of this artifact, similar to dirname(1).
    *
-   * <p> The directory name is always a relative path to the execution directory.
+   * <p>The directory name is always a relative path to the execution directory.
    */
   public final String getDirname() {
     return getDirname(execPath);
@@ -1219,8 +1189,7 @@ public abstract sealed class Artifact
    *
    * @param artifacts the files to filter
    * @param allowedType the allowed filetype
-   * @return all members of filesToBuild that are of one of the
-   *     allowed filetypes
+   * @return all members of filesToBuild that are of one of the allowed filetypes
    */
   public static List<Artifact> filterFiles(Iterable<Artifact> artifacts, FileType allowedType) {
     List<Artifact> filesToBuild = new ArrayList<>();
@@ -1232,20 +1201,15 @@ public abstract sealed class Artifact
     return filesToBuild;
   }
 
-  /**
-   * Converts artifacts into their exec paths. Returns an immutable list.
-   */
+  /** Converts artifacts into their exec paths. Returns an immutable list. */
   public static List<PathFragment> asPathFragments(Iterable<? extends Artifact> artifacts) {
     return Streams.stream(artifacts).map(Artifact::getExecPath).collect(toImmutableList());
   }
 
-  /**
-   * Returns the exec paths of the input artifacts in alphabetical order.
-   */
+  /** Returns the exec paths of the input artifacts in alphabetical order. */
   public static ImmutableList<PathFragment> asSortedPathFragments(Iterable<Artifact> input) {
     return Streams.stream(input).map(Artifact::getExecPath).sorted().collect(toImmutableList());
   }
-
 
   @Override
   public boolean isImmutable() {

--- a/src/main/java/com/google/devtools/build/lib/analysis/AnalysisEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AnalysisEnvironment.java
@@ -23,7 +23,6 @@ import com.google.devtools.build.lib.actions.ActionRegistry;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
-import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -61,14 +60,6 @@ public interface AnalysisEnvironment extends ActionRegistry {
    * method on {@link RuleContext} mentioned above.
    */
   Artifact.DerivedArtifact getDerivedArtifact(PathFragment rootRelativePath, ArtifactRoot root);
-
-  /**
-   * Same as {@link #getDerivedArtifact(PathFragment, ArtifactRoot)} but includes the option to use
-   * a content-based path for this artifact (see {@link
-   * BuildConfigurationValue#useContentBasedOutputPaths()}).
-   */
-  Artifact.DerivedArtifact getDerivedArtifact(
-      PathFragment rootRelativePath, ArtifactRoot root, boolean contentBasedPath);
 
   /**
    * Returns an artifact for the derived file {@code rootRelativePath} whose changes do not cause a

--- a/src/main/java/com/google/devtools/build/lib/analysis/CachingAnalysisEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/CachingAnalysisEnvironment.java
@@ -261,15 +261,9 @@ public final class CachingAnalysisEnvironment implements AnalysisEnvironment {
   @Override
   public Artifact.DerivedArtifact getDerivedArtifact(
       PathFragment rootRelativePath, ArtifactRoot root) {
-    return getDerivedArtifact(rootRelativePath, root, /*contentBasedPath=*/ false);
-  }
-
-  @Override
-  public Artifact.DerivedArtifact getDerivedArtifact(
-      PathFragment rootRelativePath, ArtifactRoot root, boolean contentBasedPath) {
     Preconditions.checkState(enabled);
     return dedupAndTrackArtifactAndOrigin(
-        artifactFactory.getDerivedArtifact(rootRelativePath, root, owner, contentBasedPath),
+        artifactFactory.getDerivedArtifact(rootRelativePath, root, owner),
         extendedSanityChecks ? new Throwable() : null);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -720,17 +720,7 @@ public class RuleContext extends TargetContext
   @Override
   public Artifact.DerivedArtifact getPackageRelativeArtifact(
       PathFragment relative, ArtifactRoot root) {
-    return getPackageRelativeArtifact(relative, root, /* contentBasedPath= */ false);
-  }
-
-  /**
-   * Same as {@link #getPackageRelativeArtifact(PathFragment, ArtifactRoot)} but includes the option
-   * option to use a content-based path for this artifact (see {@link
-   * BuildConfigurationValue#useContentBasedOutputPaths()}).
-   */
-  private Artifact.DerivedArtifact getPackageRelativeArtifact(
-      PathFragment relative, ArtifactRoot root, boolean contentBasedPath) {
-    return getDerivedArtifact(getPackageDirectory().getRelative(relative), root, contentBasedPath);
+    return getDerivedArtifact(getPackageDirectory().getRelative(relative), root);
   }
 
   /**
@@ -738,17 +728,7 @@ public class RuleContext extends TargetContext
    * guaranteeing that it never clashes with artifacts created by rules in other packages.
    */
   public Artifact getPackageRelativeArtifact(String relative, ArtifactRoot root) {
-    return getPackageRelativeArtifact(relative, root, /* contentBasedPath= */ false);
-  }
-
-  /**
-   * Same as {@link #getPackageRelativeArtifact(String, ArtifactRoot)} but includes the option to
-   * use a content-based path for this artifact (see {@link
-   * BuildConfigurationValue#useContentBasedOutputPaths()}).
-   */
-  private Artifact getPackageRelativeArtifact(
-      String relative, ArtifactRoot root, boolean contentBasedPath) {
-    return getPackageRelativeArtifact(PathFragment.create(relative), root, contentBasedPath);
+    return getPackageRelativeArtifact(PathFragment.create(relative), root);
   }
 
   @Override
@@ -768,24 +748,15 @@ public class RuleContext extends TargetContext
   @Override
   public Artifact.DerivedArtifact getDerivedArtifact(
       PathFragment rootRelativePath, ArtifactRoot root) {
-    return getDerivedArtifact(rootRelativePath, root, /* contentBasedPath= */ false);
-  }
-
-  /**
-   * Same as {@link #getDerivedArtifact(PathFragment, ArtifactRoot)} but includes the option to use
-   * a content-based path for this artifact (see {@link
-   * BuildConfigurationValue#useContentBasedOutputPaths()}).
-   */
-  public Artifact.DerivedArtifact getDerivedArtifact(
-      PathFragment rootRelativePath, ArtifactRoot root, boolean contentBasedPath) {
     Preconditions.checkState(
         rootRelativePath.startsWith(getPackageDirectory()),
         "Output artifact '%s' not under package directory '%s' for target '%s'",
         rootRelativePath,
         getPackageDirectory(),
         getLabel());
-    return getAnalysisEnvironment().getDerivedArtifact(rootRelativePath, root, contentBasedPath);
+    return getAnalysisEnvironment().getDerivedArtifact(rootRelativePath, root);
   }
+
 
   @Override
   public SpecialArtifact getTreeArtifact(PathFragment rootRelativePath, ArtifactRoot root) {
@@ -1353,16 +1324,6 @@ public class RuleContext extends TargetContext
   @Override
   public Artifact getImplicitOutputArtifact(ImplicitOutputsFunction function)
       throws InterruptedException {
-    return getImplicitOutputArtifact(function, /* contentBasedPath= */ false);
-  }
-
-  /**
-   * Same as {@link #getImplicitOutputArtifact(ImplicitOutputsFunction)} but includes the option to
-   * use a content-based path for this artifact (see {@link
-   * BuildConfigurationValue#useContentBasedOutputPaths()}).
-   */
-  public Artifact getImplicitOutputArtifact(
-      ImplicitOutputsFunction function, boolean contentBasedPath) throws InterruptedException {
     Iterable<String> result;
     try {
       result =
@@ -1372,23 +1333,12 @@ public class RuleContext extends TargetContext
       // It's ok as long as we don't use this method from Starlark.
       throw new IllegalStateException(e);
     }
-    return getImplicitOutputArtifact(Iterables.getOnlyElement(result), contentBasedPath);
+    return getImplicitOutputArtifact(Iterables.getOnlyElement(result));
   }
 
   /** Only use from Starlark. Returns the implicit output artifact for a given output path. */
   public Artifact getImplicitOutputArtifact(String path) {
-    return getImplicitOutputArtifact(path, /* contentBasedPath= */ false);
-  }
-
-  /**
-   * Same as {@link #getImplicitOutputArtifact(String)} but includes the option to use a a
-   * content-based path for this artifact (see {@link
-   * BuildConfigurationValue#useContentBasedOutputPaths()}).
-   */
-  // TODO(bazel-team): Consider removing contentBasedPath stuff, which is unused as of 18 months
-  // after its introduction in cl/252148134.
-  private Artifact getImplicitOutputArtifact(String path, boolean contentBasedPath) {
-    return getPackageRelativeArtifact(path, getBinOrGenfilesDirectory(), contentBasedPath);
+    return getPackageRelativeArtifact(path, getBinOrGenfilesDirectory());
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -785,21 +785,6 @@ public class BuildConfigurationValue
     return options.actionListeners;
   }
 
-  /**
-   * <b>>Experimental feature:</b> if true, qualifying outputs use path prefixes based on their
-   * content instead of the traditional <code>blaze-out/$CPU-$COMPILATION_MODE</code>.
-   *
-   * <p>This promises both more intrinsic correctness (outputs with different contents can't write
-   * to the same path) and efficiency (outputs with the <i>same</i> contents share the same path and
-   * therefore permit better action caching). But it's highly experimental and should not be relied
-   * on in any serious way any time soon.
-   *
-   * <p>See <a href="https://github.com/bazelbuild/bazel/issues/6526">#6526</a> for details.
-   */
-  public boolean useContentBasedOutputPaths() {
-    return options.outputPathsMode == CoreOptions.OutputPathsMode.CONTENT;
-  }
-
   public boolean allowUnresolvedSymlinks() {
     return options.allowUnresolvedSymlinks;
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -797,16 +797,6 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
     /** Use the production output path model. */
     OFF,
     /**
-     * Use <a href="https://github.com/bazelbuild/bazel/issues/6526#issuecomment-488103473">
-     * content-based paths</a>.
-     *
-     * <p>Rule implementations also have to individually opt into this. So this setting doesn't mean
-     * all outputs follow this. Non-opted-in outputs continue to use the production model.
-     *
-     * <p>Follow the above link for latest details on exact scope.
-     */
-    CONTENT,
-    /**
      * Strip the config prefix (i.e. {@code /x86-fastbuild/} from output paths for actions that are
      * registered to support this feature.
      *

--- a/src/test/java/com/google/devtools/build/lib/actions/ArtifactTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ArtifactTest.java
@@ -500,20 +500,6 @@ public final class ArtifactTest {
   }
 
   @Test
-  public void canDeclareContentBasedOutput() {
-    Path execRoot = scratch.getFileSystem().getPath("/");
-    ArtifactRoot root = ArtifactRoot.asDerivedRoot(execRoot, RootType.OUTPUT, "newRoot");
-    assertThat(
-            DerivedArtifact.create(
-                    root,
-                    PathFragment.create("newRoot/my.output"),
-                    ActionsTestUtil.NULL_ARTIFACT_OWNER,
-                    /*contentBasedPath=*/ true)
-                .contentBasedPath())
-        .isTrue();
-  }
-
-  @Test
   public void testGetRepositoryRelativePathExternalSourceArtifacts() throws IOException {
     ArtifactRoot externalRoot =
         ArtifactRoot.asExternalSourceRoot(

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisTestUtil.java
@@ -133,12 +133,6 @@ public final class AnalysisTestUtil {
     }
 
     @Override
-    public Artifact.DerivedArtifact getDerivedArtifact(
-        PathFragment rootRelativePath, ArtifactRoot root, boolean contentBasedPath) {
-      return original.getDerivedArtifact(rootRelativePath, root, contentBasedPath);
-    }
-
-    @Override
     public Artifact getConstantMetadataArtifact(PathFragment rootRelativePath, ArtifactRoot root) {
       return original.getConstantMetadataArtifact(rootRelativePath, root);
     }

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
@@ -174,6 +174,7 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.skyframe.InMemoryMemoizingEvaluator;
+import com.google.devtools.build.skyframe.MemoizingEvaluator;
 import com.google.devtools.build.skyframe.SkyFunction;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyKey;
@@ -2200,12 +2201,6 @@ public abstract class BuildViewTestCase extends FoundationTestCase {
     @Override
     public Artifact.DerivedArtifact getDerivedArtifact(
         PathFragment rootRelativePath, ArtifactRoot root) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Artifact.DerivedArtifact getDerivedArtifact(
-        PathFragment rootRelativePath, ArtifactRoot root, boolean contentBasedPath) {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
This experiment was never completed and path mapping can serve as a replacement. By dropping a field, `DerivedArtifact` instances will be 8 bytes smaller with Project Lilliput enabled (which it is for Bazel).

Reverts 11f3b0ecafcc15fdf90ab80736afc0f959a95b38 and removes the option value.