### PR TITLE
[8.4.0] Write and read repo marker file as raw bytes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -16,7 +16,7 @@
 package com.google.devtools.build.lib.rules.repository;
 
 import static com.google.devtools.build.lib.skyframe.RepositoryMappingFunction.REPOSITORY_OVERRIDES;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -700,7 +700,7 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
       }
       String content = builder.toString();
       try {
-        FileSystemUtils.writeContent(markerPath, UTF_8, content);
+        FileSystemUtils.writeContent(markerPath, ISO_8859_1, content);
       } catch (IOException e) {
         throw new RepositoryFunctionException(e, Transience.TRANSIENT);
       }
@@ -737,7 +737,7 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
       }
 
       try {
-        String content = FileSystemUtils.readContent(markerPath, UTF_8);
+        String content = FileSystemUtils.readContent(markerPath, ISO_8859_1);
         Map<RepoRecordedInput, String> recordedInputValues =
             readMarkerFile(content, Preconditions.checkNotNull(ruleKey));
         Optional<String> outdatedReason =


### PR DESCRIPTION
This matches how Bazel internally encodes strings and interacts with files in other places and avoids double encoding as the internal representation are already UTF-8 bytes.

Cherry-picked from 3984fb397e6994582c1b27acbd81d5505dfd43be

Closes #26780.

PiperOrigin-RevId: 796435247
Change-Id: I7a61d0a2c4917dfa992ca9a43354cc07224cfbf7