### PR TITLE
[8.4.0] Check integrity of remote files/patches before marking repo as reproducible

### DIFF
--- a/src/test/shell/bazel/external_patching_test.sh
+++ b/src/test/shell/bazel/external_patching_test.sh
@@ -241,6 +241,76 @@ EOF
   grep -q '/bin/sh' $foopath || fail "expected local patch to be applied"
 }
 
+test_remote_patch_integrity_empty() {
+  EXTREPODIR=`pwd`
+  EXTREPOURL="$(get_extrepourl ${EXTREPODIR})"
+
+  archive_integrity="sha256-$(cat ext.zip | openssl dgst -sha256 -binary | openssl base64 -A)"
+
+  # Generate the remote patch file
+  cat > remote.patch <<'EOF'
+--- a/foo.sh	2018-01-15 10:39:20.183909147 +0100
++++ b/foo.sh	2018-01-15 10:43:35.331566052 +0100
+@@ -1,3 +1,3 @@
+ #!/usr/bin/env sh
+
+-echo Here be dragons...
++echo There are dragons...
+EOF
+
+  mkdir main
+  cd main
+
+  cat > $(setup_module_dot_bazel) <<EOF
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+  name="ext",
+  strip_prefix="ext-0.1.2",
+  urls=["${EXTREPOURL}/ext.zip"],
+  integrity="${archive_integrity}",
+  build_file_content="exports_files([\"foo.sh\"])",
+  remote_patches = {"${EXTREPOURL}/remote.patch": ""},
+  remote_patch_strip = 1,
+)
+EOF
+
+  cat > BUILD <<'EOF'
+genrule(
+  name = "foo",
+  outs = ["foo.sh"],
+  srcs = ["@ext//:foo.sh"],
+  cmd = "cp $< $@; chmod u+x $@",
+  executable = True,
+)
+EOF
+
+  bazel build :foo.sh > "${TEST_log}" 2>&1
+  expect_log "canonical reproducible form can be obtained by modifying arguments \
+remote_patches = {\".*/remote\.patch\": \"[^\"]*\"}\$"
+
+  foopath=`bazel info bazel-bin`/foo.sh
+  grep -q 'There are' $foopath || fail "expected remote patch to be applied"
+
+  # Check that repo is not marked as reproducible and cached
+
+  bazel clean --expunge
+
+  # Modify the remote patch file
+  cat > ../remote.patch <<'EOF'
+--- a/foo.sh	2018-01-15 10:39:20.183909147 +0100
++++ b/foo.sh	2018-01-15 10:43:35.331566052 +0100
+@@ -1,3 +1,3 @@
+ #!/usr/bin/env sh
+
+-echo Here be dragons...
++echo No more dragons...
+EOF
+
+  bazel build :foo.sh
+  foopath=`bazel info bazel-bin`/foo.sh
+  grep -q 'No more' $foopath || fail "expected modified remote patch to be applied"
+}
+
 test_remote_patch_integrity_incorrect() {
   EXTREPODIR=`pwd`
   EXTREPOURL="$(get_extrepourl ${EXTREPODIR})"

--- a/src/test/shell/bazel/external_remote_file_test.sh
+++ b/src/test/shell/bazel/external_remote_file_test.sh
@@ -208,6 +208,8 @@ test_overlay_remote_file_without_integrity() {
   EXTREPODIR=`pwd`
   EXTREPOURL="$(get_extrepourl ${EXTREPODIR})"
 
+  archive_integrity="sha256-$(cat hello_world.zip | openssl dgst -sha256 -binary | openssl base64 -A)"
+
   # Generate the remote files to overlay
   cat > BUILD.bazel <<'EOF'
 load("@rules_cc//cc:defs.bzl", "cc_binary")
@@ -227,6 +229,7 @@ http_archive(
   name="hello_world",
   strip_prefix="hello_world-0.1.2",
   urls=["${EXTREPOURL}/hello_world.zip"],
+  integrity="${archive_integrity}",
   remote_file_urls={
     "REPO.bazel": ["${EXTREPOURL}/REPO.bazel"],
     "BUILD.bazel": ["${EXTREPOURL}/BUILD.bazel"],
@@ -235,7 +238,84 @@ http_archive(
 EOF
   add_rules_cc "MODULE.bazel"
 
-  bazel build @hello_world//:hello_world
+  bazel build @hello_world//:hello_world > "${TEST_log}" 2>&1
+  expect_log "canonical reproducible form can be obtained by modifying arguments \
+remote_file_integrity = {\"REPO\.bazel\": \"[^\"]*\", \"BUILD\.bazel\": \"[^\"]*\"}\$"
+
+  # Check that repo is not marked as reproducible and cached
+
+  bazel clean --expunge
+
+  # Modify the remote files to overlay
+  cat > ../BUILD.bazel <<'EOF'
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "goodbye_world",
+    srcs = ["hello_world.c"],
+)
+EOF
+
+  bazel build @hello_world//:goodbye_world
+}
+
+test_overlay_remote_file_with_empty_integrity() {
+  EXTREPODIR=`pwd`
+  EXTREPOURL="$(get_extrepourl ${EXTREPODIR})"
+
+  archive_integrity="sha256-$(cat hello_world.zip | openssl dgst -sha256 -binary | openssl base64 -A)"
+
+  # Generate the remote files to overlay
+  cat > BUILD.bazel <<'EOF'
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "hello_world",
+    srcs = ["hello_world.c"],
+)
+EOF
+  touch REPO.bazel
+
+  mkdir main
+  cd main
+  cat >> $(setup_module_dot_bazel) <<EOF
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+  name="hello_world",
+  strip_prefix="hello_world-0.1.2",
+  urls=["${EXTREPOURL}/hello_world.zip"],
+  integrity="${archive_integrity}",
+  remote_file_urls={
+    "REPO.bazel": ["${EXTREPOURL}/REPO.bazel"],
+    "BUILD.bazel": ["${EXTREPOURL}/BUILD.bazel"],
+  },
+  remote_file_integrity={
+    "REPO.bazel": "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+    "BUILD.bazel": "",
+  },
+)
+EOF
+  add_rules_cc "MODULE.bazel"
+
+  bazel build @hello_world//:hello_world > "${TEST_log}" 2>&1
+  expect_log "canonical reproducible form can be obtained by modifying arguments \
+remote_file_integrity = {\"REPO\.bazel\": \"[^\"]*\", \"BUILD\.bazel\": \"[^\"]*\"}\$"
+
+  # Check that repo is not marked as reproducible and cached
+
+  bazel clean --expunge
+
+  # Modify the remote files to overlay
+  cat > ../BUILD.bazel <<'EOF'
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "goodbye_world",
+    srcs = ["hello_world.c"],
+)
+EOF
+
+  bazel build @hello_world//:goodbye_world
 }
 
 test_overlay_remote_file_disallow_relative_outside_repo() {

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -138,7 +138,7 @@
   "moduleExtensions": {
     "@@pybind11_bazel+//:python_configure.bzl%extension": {
       "general": {
-        "bzlTransitiveDigest": "Q9eHGkSOelWkhA+dPbe+Gtna/4A6ToVP+iK+P8y99JQ=",
+        "bzlTransitiveDigest": "4rSUGWibZDYLhHR+8eMwTNwAwdIv+xjVrtQ+gHtWHq4=",
         "usagesDigest": "fycyB39YnXIJkfWCIXLUKJMZzANcuLy9ZE73hRucjFk=",
         "recordedFileInputs": {
           "@@pybind11_bazel+//MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
@@ -172,7 +172,7 @@
     },
     "@@rules_fuzzing+//fuzzing/private:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "9Gtqclz3ve0le470OS8PxgZsXORheQh+6RjxC2anJPI=",
+        "bzlTransitiveDigest": "v2H25KPHEkN56IHR41S67Kzp5Xjxd75GBiazhON8jzc=",
         "usagesDigest": "wy6ISK6UOcBEjj/mvJ/S3WeXoO67X+1llb9yPyFtPgc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -255,7 +255,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "liKqgVorbQI0m9bE0Di94bdcX8m1qT4Haz36ZH8+Y/I=",
+        "bzlTransitiveDigest": "OlvsB0HsvxbR8ZN+J9Vf00X/+WVz/Y/5Xrq2LgcVfdo=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -319,7 +319,7 @@
     },
     "@@rules_python+//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "XAvJgMgYOJRb4owHIMLSQxxtzTYrEAqwJPPdH/LuOKE=",
+        "bzlTransitiveDigest": "hJVUNwFJ9jo6lpnArzZ4jCsm7Jp7yLvo3Y0wLqryVXg=",
         "usagesDigest": "OLoIStnzNObNalKEMRq99FqenhPGLFZ5utVLV4sz7OI=",
         "recordedFileInputs": {
           "@@rules_python+//tools/publish/requirements_darwin.txt": "2994136eab7e57b083c3de76faf46f70fad130bc8e7360a7fed2b288b69e79dc",

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -130,6 +130,22 @@ def _update_integrity_attr(ctx, attrs, download_info):
     integrity_override = {"integrity": download_info.integrity}
     return ctx.repo_metadata(attrs_for_reproducibility = update_attrs(ctx.attr, attrs.keys(), integrity_override))
 
+def _update_http_archive_integrity_attrs(ctx, attrs, integrity):
+    integrity_override = {}
+
+    # We don't need to override the integrity attribute if sha256 is already specified.
+    if not ctx.attr.sha256 and not ctx.attr.integrity:
+        integrity_override["integrity"] = integrity.archive
+    if ctx.attr.remote_module_file_urls and not ctx.attr.remote_module_file_integrity:
+        integrity_override["remote_module_file_integrity"] = integrity.remote_module_file
+    if ctx.attr.remote_file_integrity != integrity.remote_files:
+        integrity_override["remote_file_integrity"] = integrity.remote_files
+    if ctx.attr.remote_patches != integrity.remote_patches:
+        integrity_override["remote_patches"] = integrity.remote_patches
+    if not integrity_override:
+        return ctx.repo_metadata(reproducible = True)
+    return ctx.repo_metadata(attrs_for_reproducibility = update_attrs(ctx.attr, attrs.keys(), integrity_override))
+
 def _http_archive_impl(ctx):
     """Implementation of the http_archive rule."""
     if ctx.attr.build_file and ctx.attr.build_file_content:
@@ -148,21 +164,29 @@ def _http_archive_impl(ctx):
     )
     workspace_and_buildfile(ctx)
 
-    download_remote_files(ctx)
-    patch(ctx)
+    remote_files_info = download_remote_files(ctx)
+    remote_patches_info = patch(ctx)
 
     # Download the module file after applying patches since modules may decide
     # to patch their packaged module and the patch may not apply to the file
     # checked in to the registry. This overrides the file if it exists.
+    remote_module_file_integrity = ""
     if ctx.attr.remote_module_file_urls:
-        ctx.download(
+        remote_module_file_integrity = ctx.download(
             ctx.attr.remote_module_file_urls,
             "MODULE.bazel",
             auth = get_auth(ctx, ctx.attr.remote_module_file_urls),
             integrity = ctx.attr.remote_module_file_integrity,
-        )
+        ).integrity
 
-    return _update_integrity_attr(ctx, _http_archive_attrs, download_info)
+    integrity = struct(
+        archive = download_info.integrity,
+        remote_files = {path: info.integrity for path, info in remote_files_info.items()},
+        remote_patches = {url: info.integrity for url, info in remote_patches_info.items()},
+        remote_module_file = remote_module_file_integrity,
+    )
+
+    return _update_http_archive_integrity_attrs(ctx, _http_archive_attrs, integrity)
 
 _HTTP_FILE_BUILD = """\
 package(default_visibility = ["//visibility:public"])

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -73,14 +73,14 @@ def _use_native_patch(patch_args):
 def _download_patch(ctx, patch_url, integrity, auth = None):
     name = patch_url.split("/")[-1]
     patch_path = ctx.path(_REMOTE_PATCH_DIR).get_child(name)
-    ctx.download(
+    download_info = ctx.download(
         patch_url,
         patch_path,
         canonical_id = ctx.attr.canonical_id,
         auth = get_auth(ctx, [patch_url]) if auth == None else auth,
         integrity = integrity,
     )
-    return patch_path
+    return patch_path, download_info
 
 def download_remote_files(ctx, auth = None):
     """Utility function for downloading remote files.
@@ -93,9 +93,12 @@ def download_remote_files(ctx, auth = None):
       ctx: The repository context of the repository rule calling this utility
         function.
       auth: An optional dict specifying authentication information for some of the URLs.
+
+    Returns:
+        dict mapping file paths to a download info.
     """
-    pending = [
-        ctx.download(
+    pending = {
+        path: ctx.download(
             remote_file_urls,
             path,
             canonical_id = ctx.attr.canonical_id,
@@ -104,11 +107,10 @@ def download_remote_files(ctx, auth = None):
             block = False,
         )
         for path, remote_file_urls in ctx.attr.remote_file_urls.items()
-    ]
+    }
 
     # Wait until the requests are done
-    for p in pending:
-        p.wait()
+    return {path: token.wait() for path, token in pending.items()}
 
 def patch(ctx, patches = None, patch_cmds = None, patch_cmds_win = None, patch_tool = None, patch_args = None, auth = None):
     """Implementation of patching an already extracted repository.
@@ -133,6 +135,8 @@ def patch(ctx, patches = None, patch_cmds = None, patch_cmds_win = None, patch_t
       patch_args: Arguments to pass to the patch tool. List of strings.
       auth: An optional dict specifying authentication information for some of the URLs.
 
+    Returns:
+        dict mapping remote patch URLs to a download info.
     """
     bash_exe = ctx.os.environ["BAZEL_SH"] if "BAZEL_SH" in ctx.os.environ else "bash"
     powershell_exe = ctx.os.environ["BAZEL_POWERSHELL"] if "BAZEL_POWERSHELL" in ctx.os.environ else "powershell.exe"
@@ -181,9 +185,11 @@ def patch(ctx, patches = None, patch_cmds = None, patch_cmds_win = None, patch_t
         ctx.report_progress("Patching repository")
 
     # Apply remote patches
+    remote_patches_download_info = {}
     for patch_url in remote_patches:
         integrity = remote_patches[patch_url]
-        patchfile = _download_patch(ctx, patch_url, integrity, auth)
+        patchfile, download_info = _download_patch(ctx, patch_url, integrity, auth)
+        remote_patches_download_info[patch_url] = download_info
         ctx.patch(patchfile, remote_patch_strip)
         ctx.delete(patchfile)
     ctx.delete(ctx.path(_REMOTE_PATCH_DIR))
@@ -224,6 +230,8 @@ def patch(ctx, patches = None, patch_cmds = None, patch_cmds_win = None, patch_t
                 fail("Error applying patch command %s:\n%s%s" %
                      (cmd, st.stdout, st.stderr))
 
+    return remote_patches_download_info
+
 def update_attrs(orig, keys, override):
     """Utility function for altering and adding the specified attributes to a particular repository rule invocation.
 
@@ -240,7 +248,7 @@ def update_attrs(orig, keys, override):
     """
     result = {}
     for key in keys:
-        if getattr(orig, key) != None:
+        if hasattr(orig, key):
             result[key] = getattr(orig, key)
     result["name"] = orig.name
     result.update(override)


### PR DESCRIPTION
Fixes #26694

Closes #26703.

PiperOrigin-RevId: 796789516
Change-Id: I124594e5aa4e10ede254cc1e786b67af5a7de887

Commit https://github.com/bazelbuild/bazel/commit/4d6a8ec5f8e45552b5600e8850c15165efff41ae