### PR TITLE
Make non-final methods in `FileSystem` public

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
@@ -125,12 +125,12 @@ public /*final*/ class ConfiguredRuleClassProvider
     // See b/226379109 for details.
 
     @Override
-    protected synchronized byte[] getFastDigest(PathFragment path) {
+    public synchronized byte[] getFastDigest(PathFragment path) {
       return getDigest(path);
     }
 
     @Override
-    protected synchronized byte[] getDigest(PathFragment path) {
+    public synchronized byte[] getDigest(PathFragment path) {
       return getDigestFunction()
           .getHashFunction()
           .hashBytes(StringUnsafe.getInternalStringBytes(path.getPathString()))

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -178,7 +178,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
 
   /**
    * Caches the contents of intermediate subdirectories of tree artifact inputs, to speed up {@link
-   * #stat} and {@link #readdir} operations. Note that actions are not expected to modify their
+   * FileSystem#stat} and {@link FileSystem#readdir} operations. Note that actions are not expected to modify their
    * inputs.
    *
    * <p>Safe for concurrent access.
@@ -314,7 +314,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected Path resolveSymbolicLinks(PathFragment path) throws IOException {
+  public Path resolveSymbolicLinks(PathFragment path) throws IOException {
     return getPath(pathCanonicalizer.resolveSymbolicLinks(path));
   }
 
@@ -345,7 +345,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected boolean delete(PathFragment path) throws IOException {
+  public boolean delete(PathFragment path) throws IOException {
     try {
       path = resolveSymbolicLinksForParent(path);
     } catch (FileNotFoundException ignored) {
@@ -366,7 +366,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected InputStream getInputStream(PathFragment path) throws IOException {
+  public InputStream getInputStream(PathFragment path) throws IOException {
     try {
       downloadIfRemote(path);
     } catch (BulkTransferException e) {
@@ -405,13 +405,13 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected OutputStream getOutputStream(PathFragment path, boolean append, boolean internal)
+  public OutputStream getOutputStream(PathFragment path, boolean append, boolean internal)
       throws IOException {
     return localFs.getPath(path).getOutputStream(append, internal);
   }
 
   @Override
-  protected SeekableByteChannel createReadWriteByteChannel(PathFragment path) throws IOException {
+  public SeekableByteChannel createReadWriteByteChannel(PathFragment path) throws IOException {
     return localFs.getPath(path).createReadWriteByteChannel();
   }
 
@@ -452,7 +452,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
 
   @Override
   @Nullable
-  protected byte[] getFastDigest(PathFragment path) throws IOException {
+  public byte[] getFastDigest(PathFragment path) throws IOException {
     path = resolveSymbolicLinks(path).asFragment();
     // Try to obtain a fast digest through a stat. This is only possible for in-memory files.
     // The parent path has already been canonicalized by resolveSymbolicLinks, so FOLLOW_NONE is
@@ -465,7 +465,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected byte[] getDigest(PathFragment path) throws IOException {
+  public byte[] getDigest(PathFragment path) throws IOException {
     path = resolveSymbolicLinks(path).asFragment();
     // Try to obtain a fast digest through a stat. This is only possible for in-memory files.
     // The parent path has already been canonicalized by resolveSymbolicLinks, so FOLLOW_NONE is
@@ -478,7 +478,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected boolean isReadable(PathFragment path) throws IOException {
+  public boolean isReadable(PathFragment path) throws IOException {
     path = resolveSymbolicLinks(path).asFragment();
     try {
       return localFs.getPath(path).isReadable();
@@ -489,7 +489,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected boolean isWritable(PathFragment path) throws IOException {
+  public boolean isWritable(PathFragment path) throws IOException {
     path = resolveSymbolicLinks(path).asFragment();
     try {
       return localFs.getPath(path).isWritable();
@@ -500,7 +500,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected boolean isExecutable(PathFragment path) throws IOException {
+  public boolean isExecutable(PathFragment path) throws IOException {
     path = resolveSymbolicLinks(path).asFragment();
     try {
       return localFs.getPath(path).isExecutable();
@@ -511,7 +511,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected void setReadable(PathFragment path, boolean readable) throws IOException {
+  public void setReadable(PathFragment path, boolean readable) throws IOException {
     path = resolveSymbolicLinks(path).asFragment();
     try {
       localFs.getPath(path).setReadable(readable);
@@ -531,7 +531,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected void setExecutable(PathFragment path, boolean executable) throws IOException {
+  public void setExecutable(PathFragment path, boolean executable) throws IOException {
     path = resolveSymbolicLinks(path).asFragment();
     try {
       localFs.getPath(path).setExecutable(executable);
@@ -541,7 +541,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected void chmod(PathFragment path, int mode) throws IOException {
+  public void chmod(PathFragment path, int mode) throws IOException {
     path = resolveSymbolicLinks(path).asFragment();
     try {
       localFs.getPath(path).chmod(mode);
@@ -551,7 +551,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected PathFragment readSymbolicLink(PathFragment path) throws IOException {
+  public PathFragment readSymbolicLink(PathFragment path) throws IOException {
     return readSymbolicLinkInternal(resolveSymbolicLinksForParent(path));
   }
 
@@ -586,7 +586,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
+  public void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
       throws IOException {
     linkPath = resolveSymbolicLinksForParent(linkPath);
 
@@ -598,19 +598,19 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected long getLastModifiedTime(PathFragment path, boolean followSymlinks) throws IOException {
+  public long getLastModifiedTime(PathFragment path, boolean followSymlinks) throws IOException {
     FileStatus stat = stat(path, followSymlinks);
     return stat.getLastModifiedTime();
   }
 
   @Override
-  protected long getFileSize(PathFragment path, boolean followSymlinks) throws IOException {
+  public long getFileSize(PathFragment path, boolean followSymlinks) throws IOException {
     FileStatus stat = stat(path, followSymlinks);
     return stat.getSize();
   }
 
   @Override
-  protected boolean exists(PathFragment path, boolean followSymlinks) {
+  public boolean exists(PathFragment path, boolean followSymlinks) {
     try {
       return statIfFound(path, followSymlinks) != null;
     } catch (IOException e) {
@@ -619,7 +619,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
+  public FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
     FileStatus stat = statIfFound(path, followSymlinks);
     if (stat == null) {
       throw new FileNotFoundException(path.getPathString() + " (No such file or directory)");
@@ -629,14 +629,14 @@ public class RemoteActionFileSystem extends AbstractFileSystem
 
   @Nullable
   @Override
-  protected FileStatus statIfFound(PathFragment path, boolean followSymlinks) throws IOException {
+  public FileStatus statIfFound(PathFragment path, boolean followSymlinks) throws IOException {
     return statInternal(
         path, followSymlinks ? FollowMode.FOLLOW_ALL : FollowMode.FOLLOW_PARENT, StatSources.ALL);
   }
 
   @Nullable
   @Override
-  protected FileStatus statNullable(PathFragment path, boolean followSymlinks) {
+  public FileStatus statNullable(PathFragment path, boolean followSymlinks) {
     try {
       return statIfFound(path, followSymlinks);
     } catch (IOException e) {
@@ -814,12 +814,12 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected Collection<String> getDirectoryEntries(PathFragment path) throws IOException {
+  public Collection<String> getDirectoryEntries(PathFragment path) throws IOException {
     return getDirectoryContents(path, /* followSymlinks= */ false, Dirent::getName);
   }
 
   @Override
-  protected Collection<Dirent> readdir(PathFragment path, boolean followSymlinks)
+  public Collection<Dirent> readdir(PathFragment path, boolean followSymlinks)
       throws IOException {
     return getDirectoryContents(path, followSymlinks, Function.identity());
   }
@@ -892,14 +892,14 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  protected void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)
+  public void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)
       throws IOException {
     // Only called by the AbstractFileSystem#createHardLink base implementation, overridden below.
     throw new UnsupportedOperationException();
   }
 
   @Override
-  protected void createHardLink(PathFragment linkPath, PathFragment originalPath)
+  public void createHardLink(PathFragment linkPath, PathFragment originalPath)
       throws IOException {
     localFs.getPath(linkPath).createHardLink(getPath(originalPath));
   }
@@ -925,7 +925,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
     }
 
     @Override
-    protected synchronized OutputStream getOutputStream(
+    public synchronized OutputStream getOutputStream(
         PathFragment path, boolean append, boolean internal) throws IOException {
       // To get an output stream from remote file, we need to first stage it.
       throw new IllegalStateException("Shouldn't be called directly");
@@ -951,7 +951,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
     // Override for access within this class
     @Nullable
     @Override
-    protected FileStatus statNullable(PathFragment path, boolean followSymlinks) {
+    public FileStatus statNullable(PathFragment path, boolean followSymlinks) {
       return super.statNullable(path, followSymlinks);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/testing/vfs/SpiedFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/testing/vfs/SpiedFileSystem.java
@@ -18,16 +18,10 @@ import static org.mockito.Mockito.spy;
 import com.google.devtools.build.lib.vfs.DelegateFileSystem;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
-import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
-import java.io.IOException;
-import java.io.OutputStream;
 
 /**
  * Delegate file system with the sole purpose of creating a {@link org.mockito.Mockito#spy}.
- *
- * <p>This class purposely makes the {@link FileSystem} methods public so that tests can mock those.
- * Please feel free to add any methods you need.
  */
 public class SpiedFileSystem extends DelegateFileSystem {
 
@@ -44,26 +38,5 @@ public class SpiedFileSystem extends DelegateFileSystem {
 
   public static SpiedFileSystem createInMemorySpy() {
     return createSpy(new InMemoryFileSystem(DigestHashFunction.SHA256));
-  }
-
-  @Override
-  public OutputStream getOutputStream(PathFragment path, boolean append, boolean internal)
-      throws IOException {
-    return super.getOutputStream(path, append, internal);
-  }
-
-  @Override
-  public boolean createWritableDirectory(PathFragment path) throws IOException {
-    return super.createWritableDirectory(path);
-  }
-
-  @Override
-  public byte[] getDigest(PathFragment path) throws IOException {
-    return super.getDigest(path);
-  }
-
-  @Override
-  public void chmod(PathFragment path, int mode) throws IOException {
-    super.chmod(path, mode);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
@@ -66,7 +66,7 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected Collection<String> getDirectoryEntries(PathFragment path) throws IOException {
+  public Collection<String> getDirectoryEntries(PathFragment path) throws IOException {
     String name = path.getPathString();
     String[] entries;
     long startTime = Profiler.nanoTimeMaybe();
@@ -80,7 +80,7 @@ public class UnixFileSystem extends AbstractFileSystem {
 
   @Override
   @Nullable
-  protected PathFragment resolveOneLink(PathFragment path) throws IOException {
+  public PathFragment resolveOneLink(PathFragment path) throws IOException {
     // Beware, this seemingly simple code belies the complex specification of
     // FileSystem.resolveOneLink().
     return stat(path, false).isSymbolicLink() ? readSymbolicLink(path) : null;
@@ -106,7 +106,7 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected Collection<Dirent> readdir(PathFragment path, boolean followSymlinks)
+  public Collection<Dirent> readdir(PathFragment path, boolean followSymlinks)
       throws IOException {
     String name = path.getPathString();
     long startTime = Profiler.nanoTimeMaybe();
@@ -126,7 +126,7 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
+  public FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
     String name = path.getPathString();
     long startTime = Profiler.nanoTimeMaybe();
     var comp = Blocker.begin();
@@ -145,7 +145,7 @@ public class UnixFileSystem extends AbstractFileSystem {
   // catch and don't re-throw.
   @Override
   @Nullable
-  protected FileStatus statNullable(PathFragment path, boolean followSymlinks) {
+  public FileStatus statNullable(PathFragment path, boolean followSymlinks) {
     String name = path.getPathString();
     long startTime = Profiler.nanoTimeMaybe();
     var comp = Blocker.begin();
@@ -162,7 +162,7 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected boolean exists(PathFragment path, boolean followSymlinks) {
+  public boolean exists(PathFragment path, boolean followSymlinks) {
     return statNullable(path, followSymlinks) != null;
   }
 
@@ -172,7 +172,7 @@ public class UnixFileSystem extends AbstractFileSystem {
    */
   @Override
   @Nullable
-  protected FileStatus statIfFound(PathFragment path, boolean followSymlinks) throws IOException {
+  public FileStatus statIfFound(PathFragment path, boolean followSymlinks) throws IOException {
     String name = path.getPathString();
     long startTime = Profiler.nanoTimeMaybe();
     var comp = Blocker.begin();
@@ -187,17 +187,17 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected boolean isReadable(PathFragment path) throws IOException {
+  public boolean isReadable(PathFragment path) throws IOException {
     return (stat(path, true).getPermissions() & 0400) != 0;
   }
 
   @Override
-  protected boolean isWritable(PathFragment path) throws IOException {
+  public boolean isWritable(PathFragment path) throws IOException {
     return (stat(path, true).getPermissions() & 0200) != 0;
   }
 
   @Override
-  protected boolean isExecutable(PathFragment path) throws IOException {
+  public boolean isExecutable(PathFragment path) throws IOException {
     return (stat(path, true).getPermissions() & 0100) != 0;
   }
 
@@ -221,7 +221,7 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected void setReadable(PathFragment path, boolean readable) throws IOException {
+  public void setReadable(PathFragment path, boolean readable) throws IOException {
     modifyPermissionBits(path, 0400, readable);
   }
 
@@ -231,12 +231,12 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected void setExecutable(PathFragment path, boolean executable) throws IOException {
+  public void setExecutable(PathFragment path, boolean executable) throws IOException {
     modifyPermissionBits(path, 0111, executable);
   }
 
   @Override
-  protected void chmod(PathFragment path, int mode) throws IOException {
+  public void chmod(PathFragment path, int mode) throws IOException {
     var comp = Blocker.begin();
     try {
       NativePosixFiles.chmod(path.toString(), mode);
@@ -288,7 +288,7 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected boolean createWritableDirectory(PathFragment path) throws IOException {
+  public boolean createWritableDirectory(PathFragment path) throws IOException {
     var comp = Blocker.begin();
     try {
       return NativePosixFiles.mkdirWritable(path.toString());
@@ -309,7 +309,7 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
+  public void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
       throws IOException {
     var comp = Blocker.begin();
     try {
@@ -320,7 +320,7 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected PathFragment readSymbolicLink(PathFragment path) throws IOException {
+  public PathFragment readSymbolicLink(PathFragment path) throws IOException {
     // Note that the default implementation of readSymbolicLinkUnchecked calls this method and thus
     // is optimal since we only make one system call in here.
     String name = path.toString();
@@ -347,12 +347,12 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected long getFileSize(PathFragment path, boolean followSymlinks) throws IOException {
+  public long getFileSize(PathFragment path, boolean followSymlinks) throws IOException {
     return stat(path, followSymlinks).getSize();
   }
 
   @Override
-  protected boolean delete(PathFragment path) throws IOException {
+  public boolean delete(PathFragment path) throws IOException {
     String name = path.toString();
     long startTime = Profiler.nanoTimeMaybe();
     var comp = Blocker.begin();
@@ -365,7 +365,7 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected long getLastModifiedTime(PathFragment path, boolean followSymlinks) throws IOException {
+  public long getLastModifiedTime(PathFragment path, boolean followSymlinks) throws IOException {
     return stat(path, followSymlinks).getLastModifiedTime();
   }
 
@@ -402,14 +402,14 @@ public class UnixFileSystem extends AbstractFileSystem {
 
   @Override
   @Nullable
-  protected byte[] getFastDigest(PathFragment path) throws IOException {
+  public byte[] getFastDigest(PathFragment path) throws IOException {
     // Attempt to obtain the digest from an extended attribute attached to the file. This is much
     // faster than reading and digesting the file's contents on the fly, especially for large files.
     return hashAttributeName.isEmpty() ? null : getxattr(path, hashAttributeName, true);
   }
 
   @Override
-  protected byte[] getDigest(PathFragment path) throws IOException {
+  public byte[] getDigest(PathFragment path) throws IOException {
     String name = path.toString();
     long startTime = Profiler.nanoTimeMaybe();
     try {
@@ -420,7 +420,7 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)
+  public void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)
       throws IOException {
     var comp = Blocker.begin();
     try {
@@ -431,7 +431,7 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected void deleteTreesBelow(PathFragment dir) throws IOException {
+  public void deleteTreesBelow(PathFragment dir) throws IOException {
     if (isDirectory(dir, /*followSymlinks=*/ false)) {
       long startTime = Profiler.nanoTimeMaybe();
       var comp = Blocker.begin();
@@ -445,12 +445,12 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected File getIoFile(PathFragment path) {
+  public File getIoFile(PathFragment path) {
     return new File(StringEncoding.internalToPlatform(path.getPathString()));
   }
 
   @Override
-  protected java.nio.file.Path getNioPath(PathFragment path) {
+  public java.nio.file.Path getNioPath(PathFragment path) {
     return java.nio.file.Path.of(StringEncoding.internalToPlatform(path.getPathString()));
   }
 

--- a/src/main/java/com/google/devtools/build/lib/vfs/AbstractFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/AbstractFileSystem.java
@@ -48,7 +48,7 @@ public abstract class AbstractFileSystem extends FileSystem {
   }
 
   @Override
-  protected InputStream getInputStream(PathFragment path) throws IOException {
+  public InputStream getInputStream(PathFragment path) throws IOException {
     try {
       return createMaybeProfiledInputStream(path);
     } catch (FileNotFoundException e) {
@@ -89,7 +89,7 @@ public abstract class AbstractFileSystem extends FileSystem {
       Sets.immutableEnumSet(READ, WRITE, CREATE, TRUNCATE_EXISTING);
 
   @Override
-  protected SeekableByteChannel createReadWriteByteChannel(PathFragment path) throws IOException {
+  public SeekableByteChannel createReadWriteByteChannel(PathFragment path) throws IOException {
     boolean shouldProfile = profiler.isActive() && profiler.isProfiling(ProfilerTask.VFS_OPEN);
 
     long startTime = Profiler.nanoTimeMaybe();
@@ -126,7 +126,7 @@ public abstract class AbstractFileSystem extends FileSystem {
   }
 
   @Override
-  protected OutputStream getOutputStream(PathFragment path, boolean append, boolean internal)
+  public OutputStream getOutputStream(PathFragment path, boolean append, boolean internal)
       throws IOException {
     try {
       return createFileOutputStream(path, append, internal);

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -190,7 +190,7 @@ public abstract class FileSystem {
    * <p>This method is not atomic -- concurrent modifications for the same path will result in
    * undefined behavior.
    */
-  protected boolean createWritableDirectory(PathFragment path) throws IOException {
+  public boolean createWritableDirectory(PathFragment path) throws IOException {
     FileStatus stat = statNullable(path, /* followSymlinks= */ false);
     if (stat == null) {
       return createDirectory(path);
@@ -218,10 +218,10 @@ public abstract class FileSystem {
    * returns false, this method will throw an {@link UnsupportedOperationException} if {@code
    * followSymLinks=false}.
    */
-  protected abstract long getFileSize(PathFragment path, boolean followSymlinks) throws IOException;
+  public abstract long getFileSize(PathFragment path, boolean followSymlinks) throws IOException;
 
   /** Deletes the file denoted by {@code path}. See {@link Path#delete} for specification. */
-  protected abstract boolean delete(PathFragment path) throws IOException;
+  public abstract boolean delete(PathFragment path) throws IOException;
 
   /**
    * Deletes all directory trees recursively beneath the given path and removes that path as well.
@@ -229,7 +229,7 @@ public abstract class FileSystem {
    * @param path the directory hierarchy to remove
    * @throws IOException if the hierarchy cannot be removed successfully
    */
-  protected void deleteTree(PathFragment path) throws IOException {
+  public void deleteTree(PathFragment path) throws IOException {
     deleteTreesBelow(path);
     delete(path);
   }
@@ -247,7 +247,7 @@ public abstract class FileSystem {
    * @param dir the directory hierarchy to remove
    * @throws IOException if the hierarchy cannot be removed successfully
    */
-  protected void deleteTreesBelow(PathFragment dir) throws IOException {
+  public void deleteTreesBelow(PathFragment dir) throws IOException {
     if (isDirectory(dir, /*followSymlinks=*/ false)) {
       Collection<String> entries;
       try {
@@ -301,7 +301,7 @@ public abstract class FileSystem {
    * returns false, this method will throw an {@link UnsupportedOperationException} if {@code
    * followSymLinks=false}.
    */
-  protected abstract long getLastModifiedTime(PathFragment path, boolean followSymlinks)
+  public abstract long getLastModifiedTime(PathFragment path, boolean followSymlinks)
       throws IOException;
 
   /**
@@ -337,7 +337,7 @@ public abstract class FileSystem {
    * file.
    */
   @Nullable
-  protected byte[] getFastDigest(PathFragment path) throws IOException {
+  public byte[] getFastDigest(PathFragment path) throws IOException {
     return null;
   }
 
@@ -349,7 +349,7 @@ public abstract class FileSystem {
    * @return a new byte array containing the file's digest
    * @throws IOException if the digest could not be computed for any reason
    */
-  protected byte[] getDigest(PathFragment path) throws IOException {
+  public byte[] getDigest(PathFragment path) throws IOException {
     return new ByteSource() {
       @Override
       public InputStream openStream() throws IOException {
@@ -413,7 +413,7 @@ public abstract class FileSystem {
    * @throws IOException if the file did not exist, or a parent directory could not be searched
    */
   @Nullable
-  protected PathFragment resolveOneLink(PathFragment path) throws IOException {
+  public PathFragment resolveOneLink(PathFragment path) throws IOException {
     try {
       return readSymbolicLink(path);
     } catch (NotASymlinkException e) {
@@ -436,7 +436,7 @@ public abstract class FileSystem {
    * Returns the canonical path for the given path, which must be absolute. See {@link
    * Path#resolveSymbolicLinks} for specification.
    */
-  protected Path resolveSymbolicLinks(PathFragment path) throws IOException {
+  public Path resolveSymbolicLinks(PathFragment path) throws IOException {
     checkArgument(path.isAbsolute());
     PathFragment parentNode = path.getParentDirectory();
     return parentNode == null
@@ -447,11 +447,11 @@ public abstract class FileSystem {
   }
 
   /** Returns the status of a file. See {@link Path#stat(Symlinks)} for specification. */
-  protected abstract FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException;
+  public abstract FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException;
 
   /** Like stat(), but returns null on failures instead of throwing. */
   @Nullable
-  protected FileStatus statNullable(PathFragment path, boolean followSymlinks) {
+  public FileStatus statNullable(PathFragment path, boolean followSymlinks) {
     try {
       return stat(path, followSymlinks);
     } catch (IOException e) {
@@ -466,7 +466,7 @@ public abstract class FileSystem {
    * instantiated filesystem can catch such errors, it should override this method to do so.
    */
   @Nullable
-  protected FileStatus statIfFound(PathFragment path, boolean followSymlinks) throws IOException {
+  public FileStatus statIfFound(PathFragment path, boolean followSymlinks) throws IOException {
     try {
       return stat(path, followSymlinks);
     } catch (FileNotFoundException e) {
@@ -478,7 +478,7 @@ public abstract class FileSystem {
    * Returns true iff {@code path} denotes an existing regular or special file. See {@link
    * Path#isFile(Symlinks)} for specification.
    */
-  protected boolean isFile(PathFragment path, boolean followSymlinks) {
+  public boolean isFile(PathFragment path, boolean followSymlinks) {
     FileStatus stat = statNullable(path, followSymlinks);
     return stat != null && stat.isFile();
   }
@@ -487,7 +487,7 @@ public abstract class FileSystem {
    * Returns true iff {@code path} denotes an existing special file. See {@link
    * Path#isSpecialFile(Symlinks)} for specification.
    */
-  protected boolean isSpecialFile(PathFragment path, boolean followSymlinks) {
+  public boolean isSpecialFile(PathFragment path, boolean followSymlinks) {
     FileStatus stat = statNullable(path, followSymlinks);
     return stat != null && stat.isSpecialFile();
   }
@@ -496,7 +496,7 @@ public abstract class FileSystem {
    * Returns true iff {@code path} denotes an existing symbolic link. See {@link
    * Path#isSymbolicLink()} for specification.
    */
-  protected boolean isSymbolicLink(PathFragment path) {
+  public boolean isSymbolicLink(PathFragment path) {
     FileStatus stat = statNullable(path, false);
     return stat != null && stat.isSymbolicLink();
   }
@@ -505,7 +505,7 @@ public abstract class FileSystem {
    * Returns true iff {@code path} denotes an existing directory. See {@link
    * Path#isDirectory(Symlinks)} for specification.
    */
-  protected boolean isDirectory(PathFragment path, boolean followSymlinks) {
+  public boolean isDirectory(PathFragment path, boolean followSymlinks) {
     FileStatus stat = statNullable(path, followSymlinks);
     return stat != null && stat.isDirectory();
   }
@@ -516,7 +516,7 @@ public abstract class FileSystem {
    * <p>Note: for {@link FileSystem}s where {@link #supportsSymbolicLinksNatively(PathFragment)}
    * returns false, this method will throw an {@link UnsupportedOperationException}
    */
-  protected abstract void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
+  public abstract void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
       throws IOException;
 
   /**
@@ -529,7 +529,7 @@ public abstract class FileSystem {
    * @throws NotASymlinkException if the current path is not a symbolic link
    * @throws IOException if the contents of the link could not be read for any reason.
    */
-  protected abstract PathFragment readSymbolicLink(PathFragment path) throws IOException;
+  public abstract PathFragment readSymbolicLink(PathFragment path) throws IOException;
 
   /**
    * Returns the target of a symbolic link, under the assumption that the given path is indeed a
@@ -538,7 +538,7 @@ public abstract class FileSystem {
    *
    * @throws IOException if the contents of the link could not be read for any reason.
    */
-  protected PathFragment readSymbolicLinkUnchecked(PathFragment path) throws IOException {
+  public PathFragment readSymbolicLinkUnchecked(PathFragment path) throws IOException {
     return readSymbolicLink(path);
   }
 
@@ -551,7 +551,7 @@ public abstract class FileSystem {
    * Returns true iff {@code path} denotes an existing file of any kind. See {@link
    * Path#exists(Symlinks)} for specification.
    */
-  protected abstract boolean exists(PathFragment path, boolean followSymlinks);
+  public abstract boolean exists(PathFragment path, boolean followSymlinks);
 
   /**
    * Returns a collection containing the names of all entities within the directory denoted by the
@@ -559,7 +559,7 @@ public abstract class FileSystem {
    *
    * @throws IOException if there was an error reading the directory entries
    */
-  protected abstract Collection<String> getDirectoryEntries(PathFragment path) throws IOException;
+  public abstract Collection<String> getDirectoryEntries(PathFragment path) throws IOException;
 
   protected static Dirent.Type direntFromStat(@Nullable FileStatus stat) {
     if (stat == null) {
@@ -586,8 +586,7 @@ public abstract class FileSystem {
    *     resolving the directory whose entries are to be read.
    * @throws IOException if there was an error reading the directory entries
    */
-  protected Collection<Dirent> readdir(PathFragment path, boolean followSymlinks)
-      throws IOException {
+  public Collection<Dirent> readdir(PathFragment path, boolean followSymlinks) throws IOException {
     Collection<String> children = getDirectoryEntries(path);
     List<Dirent> dirents = Lists.newArrayListWithCapacity(children.size());
     for (String child : children) {
@@ -603,7 +602,7 @@ public abstract class FileSystem {
    *
    * @throws IOException if there was an error reading the file's metadata
    */
-  protected abstract boolean isReadable(PathFragment path) throws IOException;
+  public abstract boolean isReadable(PathFragment path) throws IOException;
 
   /**
    * Sets the file to readable (if the argument is true) or non-readable (if the argument is false)
@@ -614,14 +613,14 @@ public abstract class FileSystem {
    *
    * @throws IOException if there was an error reading or writing the file's metadata
    */
-  protected abstract void setReadable(PathFragment path, boolean readable) throws IOException;
+  public abstract void setReadable(PathFragment path, boolean readable) throws IOException;
 
   /**
    * Returns true iff the file represented by {@code path} is writable.
    *
    * @throws IOException if there was an error reading the file's metadata
    */
-  protected abstract boolean isWritable(PathFragment path) throws IOException;
+  public abstract boolean isWritable(PathFragment path) throws IOException;
 
   /**
    * Sets the file to writable (if the argument is true) or non-writable (if the argument is false)
@@ -638,7 +637,7 @@ public abstract class FileSystem {
    *
    * @throws IOException if there was an error reading the file's metadata
    */
-  protected abstract boolean isExecutable(PathFragment path) throws IOException;
+  public abstract boolean isExecutable(PathFragment path) throws IOException;
 
   /**
    * Sets the file to executable, if the argument is true. It is currently not supported to unset
@@ -650,7 +649,7 @@ public abstract class FileSystem {
    *
    * @throws IOException if there was an error reading or writing the file's metadata
    */
-  protected abstract void setExecutable(PathFragment path, boolean executable) throws IOException;
+  public abstract void setExecutable(PathFragment path, boolean executable) throws IOException;
 
   /**
    * Sets the file permissions. If permission changes on this {@link FileSystem} are slow (e.g. one
@@ -663,7 +662,7 @@ public abstract class FileSystem {
    *
    * @throws IOException if there was an error reading or writing the file's metadata
    */
-  protected void chmod(PathFragment path, int mode) throws IOException {
+  public void chmod(PathFragment path, int mode) throws IOException {
     setReadable(path, (mode & 0400) != 0);
     setWritable(path, (mode & 0200) != 0);
     setExecutable(path, (mode & 0100) != 0);
@@ -675,14 +674,14 @@ public abstract class FileSystem {
    * @throws FileNotFoundException if the file does not exist
    * @throws IOException if there was an error opening the file for reading
    */
-  protected abstract InputStream getInputStream(PathFragment path) throws IOException;
+  public abstract InputStream getInputStream(PathFragment path) throws IOException;
 
   /**
    * Returns a {@link SeekableByteChannel} for writing to a file at provided path.
    *
    * <p>Truncates the target file, therefore it cannot be used to read already existing files.
    */
-  protected abstract SeekableByteChannel createReadWriteByteChannel(PathFragment path)
+  public abstract SeekableByteChannel createReadWriteByteChannel(PathFragment path)
       throws IOException;
 
   /**
@@ -712,8 +711,8 @@ public abstract class FileSystem {
    * @param internal whether the file is a Bazel internal file
    * @throws IOException if there was an error opening the file for writing
    */
-  protected abstract OutputStream getOutputStream(
-      PathFragment path, boolean append, boolean internal) throws IOException;
+  public abstract OutputStream getOutputStream(PathFragment path, boolean append, boolean internal)
+      throws IOException;
 
   /**
    * Renames the file denoted by "sourceNode" to the location "targetNode". See {@link
@@ -731,8 +730,7 @@ public abstract class FileSystem {
    * @param originalPath The path of the original file
    * @throws IOException if the original file does not exist or the link file already exists
    */
-  protected void createHardLink(PathFragment linkPath, PathFragment originalPath)
-      throws IOException {
+  public void createHardLink(PathFragment linkPath, PathFragment originalPath) throws IOException {
 
     if (!exists(originalPath)) {
       throw new FileNotFoundException(
@@ -758,30 +756,30 @@ public abstract class FileSystem {
    * @param originalPath The path of the original file
    * @throws IOException if there was an I/O error
    */
-  protected abstract void createFSDependentHardLink(
-      PathFragment linkPath, PathFragment originalPath) throws IOException;
+  public abstract void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)
+      throws IOException;
 
   /**
    * Prefetch all directories and symlinks within the package rooted at "path". Enter at most
    * "maxDirs" total directories. Specializations for high-latency remote filesystems may wish to
    * implement this in order to warm the filesystem's internal caches.
    */
-  protected void prefetchPackageAsync(PathFragment path, int maxDirs) {}
+  public void prefetchPackageAsync(PathFragment path, int maxDirs) {}
 
   /**
    * Returns a {@link File} object for the given path. This method is only supported by file system
    * implementations that are backed by the local file system.
    */
-  protected File getIoFile(PathFragment path) {
+  public File getIoFile(PathFragment path) {
     throw new UnsupportedOperationException(
         "getIoFile() not supported for " + getClass().getName());
   }
-  
+
   /**
    * Returns a {@link java.nio.file.Path} object for the given path. This method is only supported
    * by file system implementations that are backed by the local file system.
    */
-  protected java.nio.file.Path getNioPath(PathFragment path) {
+  public java.nio.file.Path getNioPath(PathFragment path) {
     throw new UnsupportedOperationException(
         "getNioPath() not supported for " + getClass().getName());
   }
@@ -790,8 +788,7 @@ public abstract class FileSystem {
    * Returns the path of a new temporary directory with the given prefix created under the given
    * parent path, but <b>not</b> necessarily with secure permissions.
    */
-  protected PathFragment createTempDirectory(PathFragment parent, String prefix)
-      throws IOException {
+  public PathFragment createTempDirectory(PathFragment parent, String prefix) throws IOException {
     SecureRandom rand = new SecureRandom();
     while (true) {
       PathFragment candidate = parent.getRelative(prefix + Long.toUnsignedString(rand.nextLong()));

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -65,20 +65,20 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected File getIoFile(PathFragment path) {
+  public File getIoFile(PathFragment path) {
     return new File(StringEncoding.internalToPlatform(path.getPathString()));
   }
 
   /**
    * Returns a {@link java.nio.file.Path} representing the same path as provided {@code path}.
    *
-   * <p>Note: while it's possible to use {@link #getIoFile(PathFragment)} in combination with {@link
+   * <p>Note: while it's possible to use {@link FileSystem#getIoFile(PathFragment)} in combination with {@link
    * File#toPath()} to achieve essentially the same, using this method is preferable because it
    * avoids extra allocations and does not lose track of the underlying Java filesystem, which is
    * useful for some in-memory filesystem implementations like JimFS.
    */
   @Override
-  protected java.nio.file.Path getNioPath(PathFragment path) {
+  public java.nio.file.Path getNioPath(PathFragment path) {
     return Paths.get(StringEncoding.internalToPlatform(path.getPathString()));
   }
 
@@ -87,7 +87,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected Collection<String> getDirectoryEntries(PathFragment path) throws IOException {
+  public Collection<String> getDirectoryEntries(PathFragment path) throws IOException {
     File file = getIoFile(path);
     String[] entries;
     long startTime = Profiler.nanoTimeMaybe();
@@ -107,7 +107,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected boolean exists(PathFragment path, boolean followSymlinks) {
+  public boolean exists(PathFragment path, boolean followSymlinks) {
     long startTime = Profiler.nanoTimeMaybe();
     try {
       java.nio.file.Path nioPath = getNioPath(path);
@@ -120,7 +120,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected boolean isReadable(PathFragment path) throws IOException {
+  public boolean isReadable(PathFragment path) throws IOException {
     File file = getIoFile(path);
     long startTime = Profiler.nanoTimeMaybe();
     try {
@@ -134,7 +134,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected boolean isWritable(PathFragment path) throws IOException {
+  public boolean isWritable(PathFragment path) throws IOException {
     File file = getIoFile(path);
     long startTime = Profiler.nanoTimeMaybe();
     try {
@@ -152,7 +152,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected boolean isExecutable(PathFragment path) throws IOException {
+  public boolean isExecutable(PathFragment path) throws IOException {
     File file = getIoFile(path);
     long startTime = Profiler.nanoTimeMaybe();
     try {
@@ -166,7 +166,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected void setReadable(PathFragment path, boolean readable) throws IOException {
+  public void setReadable(PathFragment path, boolean readable) throws IOException {
     File file = getIoFile(path);
     if (!file.exists()) {
       throw new FileNotFoundException(path + ERR_NO_SUCH_FILE_OR_DIR);
@@ -188,7 +188,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected void setExecutable(PathFragment path, boolean executable) throws IOException {
+  public void setExecutable(PathFragment path, boolean executable) throws IOException {
     File file = getIoFile(path);
     if (!file.exists()) {
       throw new FileNotFoundException(path + ERR_NO_SUCH_FILE_OR_DIR);
@@ -279,7 +279,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
+  public void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
       throws IOException {
     java.nio.file.Path nioPath = getNioPath(linkPath);
     try {
@@ -296,7 +296,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected PathFragment readSymbolicLink(PathFragment path) throws IOException {
+  public PathFragment readSymbolicLink(PathFragment path) throws IOException {
     java.nio.file.Path nioPath = getNioPath(path);
     long startTime = Profiler.nanoTimeMaybe();
     try {
@@ -345,7 +345,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected long getFileSize(PathFragment path, boolean followSymlinks) throws IOException {
+  public long getFileSize(PathFragment path, boolean followSymlinks) throws IOException {
     long startTime = Profiler.nanoTimeMaybe();
     try {
       return stat(path, followSymlinks).getSize();
@@ -355,7 +355,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected boolean delete(PathFragment path) throws IOException {
+  public boolean delete(PathFragment path) throws IOException {
     java.nio.file.Path nioPath = getNioPath(path);
     long startTime = Profiler.nanoTimeMaybe();
     try {
@@ -396,7 +396,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected long getLastModifiedTime(PathFragment path, boolean followSymlinks) throws IOException {
+  public long getLastModifiedTime(PathFragment path, boolean followSymlinks) throws IOException {
     File file = getIoFile(path);
     long startTime = Profiler.nanoTimeMaybe();
     try {
@@ -426,7 +426,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected byte[] getDigest(PathFragment path) throws IOException {
+  public byte[] getDigest(PathFragment path) throws IOException {
     String name = path.toString();
     long startTime = Profiler.nanoTimeMaybe();
     try {
@@ -445,7 +445,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
    * case of permission issues).
    */
   @Override
-  protected FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
+  public FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
     java.nio.file.Path nioPath = getNioPath(path);
     final BasicFileAttributes attributes;
     try {
@@ -504,7 +504,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
 
   @Override
   @Nullable
-  protected FileStatus statIfFound(PathFragment path, boolean followSymlinks) {
+  public FileStatus statIfFound(PathFragment path, boolean followSymlinks) {
     try {
       return stat(path, followSymlinks);
     } catch (FileNotFoundException e) {
@@ -521,7 +521,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)
+  public void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)
       throws IOException {
     Files.createLink(getNioPath(linkPath), getNioPath(originalPath));
   }

--- a/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
@@ -95,7 +95,7 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
   }
 
   @Override
-  protected boolean createWritableDirectory(PathFragment path) throws IOException {
+  public boolean createWritableDirectory(PathFragment path) throws IOException {
     return delegateFs.createWritableDirectory(toDelegatePath(path));
   }
 
@@ -105,17 +105,17 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
   }
 
   @Override
-  protected long getFileSize(PathFragment path, boolean followSymlinks) throws IOException {
+  public long getFileSize(PathFragment path, boolean followSymlinks) throws IOException {
     return delegateFs.getFileSize(toDelegatePath(path), followSymlinks);
   }
 
   @Override
-  protected boolean delete(PathFragment path) throws IOException {
+  public boolean delete(PathFragment path) throws IOException {
     return delegateFs.delete(toDelegatePath(path));
   }
 
   @Override
-  protected long getLastModifiedTime(PathFragment path, boolean followSymlinks) throws IOException {
+  public long getLastModifiedTime(PathFragment path, boolean followSymlinks) throws IOException {
     return delegateFs.getLastModifiedTime(toDelegatePath(path), followSymlinks);
   }
 
@@ -125,38 +125,38 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
   }
 
   @Override
-  protected boolean isSymbolicLink(PathFragment path) {
+  public boolean isSymbolicLink(PathFragment path) {
     return delegateFs.isSymbolicLink(toDelegatePath(path));
   }
 
   @Override
-  protected boolean isDirectory(PathFragment path, boolean followSymlinks) {
+  public boolean isDirectory(PathFragment path, boolean followSymlinks) {
     return delegateFs.isDirectory(toDelegatePath(path), followSymlinks);
   }
 
   @Override
-  protected boolean isFile(PathFragment path, boolean followSymlinks) {
+  public boolean isFile(PathFragment path, boolean followSymlinks) {
     return delegateFs.isFile(toDelegatePath(path), followSymlinks);
   }
 
   @Override
-  protected boolean isSpecialFile(PathFragment path, boolean followSymlinks) {
+  public boolean isSpecialFile(PathFragment path, boolean followSymlinks) {
     return delegateFs.isSpecialFile(toDelegatePath(path), followSymlinks);
   }
 
   @Override
-  protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
+  public void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
       throws IOException {
     delegateFs.createSymbolicLink(toDelegatePath(linkPath), targetFragment);
   }
 
   @Override
-  protected PathFragment readSymbolicLink(PathFragment path) throws IOException {
+  public PathFragment readSymbolicLink(PathFragment path) throws IOException {
     return fromDelegatePath(delegateFs.readSymbolicLink(toDelegatePath(path)));
   }
 
   @Override
-  protected boolean exists(PathFragment path, boolean followSymlinks) {
+  public boolean exists(PathFragment path, boolean followSymlinks) {
     return delegateFs.exists(toDelegatePath(path), followSymlinks);
   }
 
@@ -166,22 +166,22 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
   }
 
   @Override
-  protected Collection<String> getDirectoryEntries(PathFragment path) throws IOException {
+  public Collection<String> getDirectoryEntries(PathFragment path) throws IOException {
     return delegateFs.getDirectoryEntries(toDelegatePath(path));
   }
 
   @Override
-  protected boolean isReadable(PathFragment path) throws IOException {
+  public boolean isReadable(PathFragment path) throws IOException {
     return delegateFs.isReadable(toDelegatePath(path));
   }
 
   @Override
-  protected void setReadable(PathFragment path, boolean readable) throws IOException {
+  public void setReadable(PathFragment path, boolean readable) throws IOException {
     delegateFs.setReadable(toDelegatePath(path), readable);
   }
 
   @Override
-  protected boolean isWritable(PathFragment path) throws IOException {
+  public boolean isWritable(PathFragment path) throws IOException {
     return delegateFs.isWritable(toDelegatePath(path));
   }
 
@@ -191,27 +191,27 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
   }
 
   @Override
-  protected boolean isExecutable(PathFragment path) throws IOException {
+  public boolean isExecutable(PathFragment path) throws IOException {
     return delegateFs.isExecutable(toDelegatePath(path));
   }
 
   @Override
-  protected void setExecutable(PathFragment path, boolean executable) throws IOException {
+  public void setExecutable(PathFragment path, boolean executable) throws IOException {
     delegateFs.setExecutable(toDelegatePath(path), executable);
   }
 
   @Override
-  protected InputStream getInputStream(PathFragment path) throws IOException {
+  public InputStream getInputStream(PathFragment path) throws IOException {
     return delegateFs.getInputStream(toDelegatePath(path));
   }
 
   @Override
-  protected SeekableByteChannel createReadWriteByteChannel(PathFragment path) throws IOException {
+  public SeekableByteChannel createReadWriteByteChannel(PathFragment path) throws IOException {
     return delegateFs.createReadWriteByteChannel(toDelegatePath(path));
   }
 
   @Override
-  protected OutputStream getOutputStream(PathFragment path, boolean append, boolean internal)
+  public OutputStream getOutputStream(PathFragment path, boolean append, boolean internal)
       throws IOException {
     return delegateFs.getOutputStream(toDelegatePath(path), append, internal);
   }
@@ -222,7 +222,7 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
   }
 
   @Override
-  protected void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)
+  public void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)
       throws IOException {
     delegateFs.createFSDependentHardLink(toDelegatePath(linkPath), toDelegatePath(originalPath));
   }
@@ -233,12 +233,12 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
   }
 
   @Override
-  protected void deleteTree(PathFragment path) throws IOException {
+  public void deleteTree(PathFragment path) throws IOException {
     delegateFs.deleteTree(toDelegatePath(path));
   }
 
   @Override
-  protected void deleteTreesBelow(PathFragment dir) throws IOException {
+  public void deleteTreesBelow(PathFragment dir) throws IOException {
     delegateFs.deleteTreesBelow(toDelegatePath(dir));
   }
 
@@ -249,81 +249,78 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
   }
 
   @Override
-  protected byte[] getFastDigest(PathFragment path) throws IOException {
+  public byte[] getFastDigest(PathFragment path) throws IOException {
     return delegateFs.getFastDigest(toDelegatePath(path));
   }
 
   @Override
-  protected byte[] getDigest(PathFragment path) throws IOException {
+  public byte[] getDigest(PathFragment path) throws IOException {
     return delegateFs.getDigest(toDelegatePath(path));
   }
 
   @Override
-  protected PathFragment resolveOneLink(PathFragment path) throws IOException {
+  public PathFragment resolveOneLink(PathFragment path) throws IOException {
     return delegateFs.resolveOneLink(toDelegatePath(path));
   }
 
   @Override
-  protected Path resolveSymbolicLinks(PathFragment path) throws IOException {
+  public Path resolveSymbolicLinks(PathFragment path) throws IOException {
     return getPath(
         fromDelegatePath(delegateFs.resolveSymbolicLinks(toDelegatePath(path)).asFragment()));
   }
 
   @Override
-  protected FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
+  public FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
     return delegateFs.stat(toDelegatePath(path), followSymlinks);
   }
 
   @Override
-  protected FileStatus statNullable(PathFragment path, boolean followSymlinks) {
+  public FileStatus statNullable(PathFragment path, boolean followSymlinks) {
     return delegateFs.statNullable(toDelegatePath(path), followSymlinks);
   }
 
   @Override
-  protected FileStatus statIfFound(PathFragment path, boolean followSymlinks) throws IOException {
+  public FileStatus statIfFound(PathFragment path, boolean followSymlinks) throws IOException {
     return delegateFs.statIfFound(toDelegatePath(path), followSymlinks);
   }
 
   @Override
-  protected PathFragment readSymbolicLinkUnchecked(PathFragment path) throws IOException {
+  public PathFragment readSymbolicLinkUnchecked(PathFragment path) throws IOException {
     return delegateFs.readSymbolicLinkUnchecked(toDelegatePath(path));
   }
 
   @Override
-  protected Collection<Dirent> readdir(PathFragment path, boolean followSymlinks)
-      throws IOException {
+  public Collection<Dirent> readdir(PathFragment path, boolean followSymlinks) throws IOException {
     return delegateFs.readdir(toDelegatePath(path), followSymlinks);
   }
 
   @Override
-  protected void chmod(PathFragment path, int mode) throws IOException {
+  public void chmod(PathFragment path, int mode) throws IOException {
     delegateFs.chmod(toDelegatePath(path), mode);
   }
 
   @Override
-  protected void createHardLink(PathFragment linkPath, PathFragment originalPath)
-      throws IOException {
+  public void createHardLink(PathFragment linkPath, PathFragment originalPath) throws IOException {
     delegateFs.createHardLink(toDelegatePath(linkPath), toDelegatePath(originalPath));
   }
 
   @Override
-  protected void prefetchPackageAsync(PathFragment path, int maxDirs) {
+  public void prefetchPackageAsync(PathFragment path, int maxDirs) {
     delegateFs.prefetchPackageAsync(toDelegatePath(path), maxDirs);
   }
 
   @Override
-  protected File getIoFile(PathFragment path) {
+  public File getIoFile(PathFragment path) {
     return delegateFs.getIoFile(toDelegatePath(path));
   }
 
   @Override
-  protected java.nio.file.Path getNioPath(PathFragment path) {
+  public java.nio.file.Path getNioPath(PathFragment path) {
     return delegateFs.getNioPath(toDelegatePath(path));
   }
 
   @Override
-  protected PathFragment createTempDirectory(PathFragment parent, String prefix)
-      throws IOException {
+  public PathFragment createTempDirectory(PathFragment parent, String prefix) throws IOException {
     return delegateFs.createTempDirectory(toDelegatePath(parent), prefix);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/vfs/ReadonlyFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/ReadonlyFileSystem.java
@@ -30,13 +30,13 @@ public abstract class ReadonlyFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected OutputStream getOutputStream(PathFragment path, boolean append, boolean internal)
+  public OutputStream getOutputStream(PathFragment path, boolean append, boolean internal)
       throws IOException {
     throw modificationException();
   }
 
   @Override
-  protected void setReadable(PathFragment path, boolean readable) throws IOException {
+  public void setReadable(PathFragment path, boolean readable) throws IOException {
     throw modificationException();
   }
 
@@ -46,7 +46,7 @@ public abstract class ReadonlyFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected void setExecutable(PathFragment path, boolean executable) {
+  public void setExecutable(PathFragment path, boolean executable) {
     throw new UnsupportedOperationException("setExecutable");
   }
 
@@ -81,13 +81,13 @@ public abstract class ReadonlyFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
+  public void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
       throws IOException {
     throw modificationException();
   }
 
   @Override
-  protected void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)
+  public void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)
       throws IOException {
     throw modificationException();
   }
@@ -98,7 +98,7 @@ public abstract class ReadonlyFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected boolean delete(PathFragment path) throws IOException {
+  public boolean delete(PathFragment path) throws IOException {
     throw modificationException();
   }
 
@@ -107,4 +107,3 @@ public abstract class ReadonlyFileSystem extends AbstractFileSystem {
     throw modificationException();
   }
 }
-

--- a/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileSystem.java
@@ -354,7 +354,7 @@ public class InMemoryFileSystem extends AbstractFileSystem {
 
   @Override
   @Nullable
-  protected FileStatus statNullable(PathFragment path, boolean followSymlinks) {
+  public FileStatus statNullable(PathFragment path, boolean followSymlinks) {
     return switch (inodeStatErrno(path, followSymlinks)) {
       case InMemoryContentInfo inode -> inode;
       case Errno ignored -> null;
@@ -390,7 +390,7 @@ public class InMemoryFileSystem extends AbstractFileSystem {
    */
   @Nullable
   @Override
-  protected PathFragment resolveOneLink(PathFragment path) throws IOException {
+  public PathFragment resolveOneLink(PathFragment path) throws IOException {
     // Beware, this seemingly simple code belies the complex specification of
     // FileSystem.resolveOneLink().
     InMemoryContentInfo status = inodeStat(path, false);
@@ -398,24 +398,24 @@ public class InMemoryFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected boolean exists(PathFragment path, boolean followSymlinks) {
+  public boolean exists(PathFragment path, boolean followSymlinks) {
     return statNullable(path, followSymlinks) != null;
   }
 
   @Override
-  protected boolean isReadable(PathFragment path) throws IOException {
+  public boolean isReadable(PathFragment path) throws IOException {
     InMemoryContentInfo status = inodeStat(path, true);
     return status.isReadable();
   }
 
   @Override
-  protected synchronized void setReadable(PathFragment path, boolean readable) throws IOException {
+  public synchronized void setReadable(PathFragment path, boolean readable) throws IOException {
     InMemoryContentInfo status = inodeStat(path, true);
     status.setReadable(readable);
   }
 
   @Override
-  protected boolean isWritable(PathFragment path) throws IOException {
+  public boolean isWritable(PathFragment path) throws IOException {
     InMemoryContentInfo status = inodeStat(path, true);
     return status.isWritable();
   }
@@ -427,13 +427,13 @@ public class InMemoryFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected boolean isExecutable(PathFragment path) throws IOException {
+  public boolean isExecutable(PathFragment path) throws IOException {
     InMemoryContentInfo status = inodeStat(path, true);
     return status.isExecutable();
   }
 
   @Override
-  protected synchronized void setExecutable(PathFragment path, boolean executable)
+  public synchronized void setExecutable(PathFragment path, boolean executable)
       throws IOException {
     InMemoryContentInfo status = inodeStat(path, true);
     status.setExecutable(executable);
@@ -503,7 +503,7 @@ public class InMemoryFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected void createSymbolicLink(PathFragment path, PathFragment targetFragment)
+  public void createSymbolicLink(PathFragment path, PathFragment targetFragment)
       throws IOException {
     if (isRootDirectory(path)) {
       throw Errno.EACCES.exception(path);
@@ -520,7 +520,7 @@ public class InMemoryFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected PathFragment readSymbolicLink(PathFragment path) throws IOException {
+  public PathFragment readSymbolicLink(PathFragment path) throws IOException {
     InMemoryContentInfo status = inodeStat(path, false);
     if (status.isSymbolicLink()) {
       Preconditions.checkState(status instanceof InMemoryLinkInfo, status);
@@ -530,12 +530,12 @@ public class InMemoryFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected long getFileSize(PathFragment path, boolean followSymlinks) throws IOException {
+  public long getFileSize(PathFragment path, boolean followSymlinks) throws IOException {
     return stat(path, followSymlinks).getSize();
   }
 
   @Override
-  protected synchronized Collection<String> getDirectoryEntries(PathFragment path)
+  public synchronized Collection<String> getDirectoryEntries(PathFragment path)
       throws IOException {
     InMemoryDirectoryInfo dirInfo = getDirectory(path);
     if (!dirInfo.isReadable()) {
@@ -553,7 +553,7 @@ public class InMemoryFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected boolean delete(PathFragment path) throws IOException {
+  public boolean delete(PathFragment path) throws IOException {
     if (isRootDirectory(path)) {
       throw Errno.EBUSY.exception(path);
     }
@@ -573,7 +573,7 @@ public class InMemoryFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected long getLastModifiedTime(PathFragment path, boolean followSymlinks) throws IOException {
+  public long getLastModifiedTime(PathFragment path, boolean followSymlinks) throws IOException {
     return stat(path, followSymlinks).getLastModifiedTime();
   }
 
@@ -585,19 +585,19 @@ public class InMemoryFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected synchronized InputStream getInputStream(PathFragment path) throws IOException {
+  public synchronized InputStream getInputStream(PathFragment path) throws IOException {
     return statFile(path).getInputStream();
   }
 
   @Override
-  protected synchronized SeekableByteChannel createReadWriteByteChannel(PathFragment path)
+  public synchronized SeekableByteChannel createReadWriteByteChannel(PathFragment path)
       throws IOException {
     InMemoryContentInfo status = getOrCreateWritableInode(path);
     return ((FileInfo) status).createReadWriteByteChannel();
   }
 
   @Override
-  protected synchronized byte[] getFastDigest(PathFragment path) throws IOException {
+  public synchronized byte[] getFastDigest(PathFragment path) throws IOException {
     return statFile(path).getFastDigest();
   }
 
@@ -649,7 +649,7 @@ public class InMemoryFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected synchronized OutputStream getOutputStream(
+  public synchronized OutputStream getOutputStream(
       PathFragment path, boolean append, boolean internal) throws IOException {
     InMemoryContentInfo status = getOrCreateWritableInode(path);
     return ((FileInfo) status).getOutputStream(append);
@@ -704,7 +704,7 @@ public class InMemoryFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  protected void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)
+  public void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)
       throws IOException {
 
     // Same check used when creating a symbolic link

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -52,7 +52,7 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
-  protected boolean delete(PathFragment path) throws IOException {
+  public boolean delete(PathFragment path) throws IOException {
     long startTime = Profiler.nanoTimeMaybe();
     try {
       return WindowsFileOperations.deletePath(
@@ -67,13 +67,13 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
-  protected boolean createWritableDirectory(PathFragment path) throws IOException {
+  public boolean createWritableDirectory(PathFragment path) throws IOException {
     // All directories are writable on Windows.
     return createDirectory(path);
   }
 
   @Override
-  protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
+  public void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
       throws IOException {
     PathFragment targetPath =
         targetFragment.isAbsolute()
@@ -102,7 +102,7 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
-  protected PathFragment readSymbolicLink(PathFragment path) throws IOException {
+  public PathFragment readSymbolicLink(PathFragment path) throws IOException {
     java.nio.file.Path nioPath = getNioPath(path);
     return PathFragment.create(
         StringEncoding.platformToInternal(
@@ -136,7 +136,7 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
-  protected FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
+  public FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
     File file = getIoFile(path);
     final DosFileAttributes attributes;
     try {
@@ -213,12 +213,12 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
-  protected boolean isSymbolicLink(PathFragment path) {
+  public boolean isSymbolicLink(PathFragment path) {
     return fileIsSymbolicLink(getIoFile(path));
   }
 
   @Override
-  protected boolean isDirectory(PathFragment path, boolean followSymlinks) {
+  public boolean isDirectory(PathFragment path, boolean followSymlinks) {
     if (!followSymlinks) {
       try {
         if (isSymlinkOrJunction(getIoFile(path))) {
@@ -232,13 +232,13 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
-  protected void setReadable(PathFragment path, boolean readable) {
+  public void setReadable(PathFragment path, boolean readable) {
     // Windows does not have a notion of readable files.
     // https://github.com/openjdk/jdk/blob/e52a2aeeacaeb26c801b6e31f8e67e61b1ea2de3/src/java.base/windows/native/libjava/WinNTFileSystem_md.c#L473-L476
   }
 
   @Override
-  protected void setExecutable(PathFragment path, boolean executable) {
+  public void setExecutable(PathFragment path, boolean executable) {
     // Windows does not have a notion of executable files.
     // https://github.com/openjdk/jdk/blob/e52a2aeeacaeb26c801b6e31f8e67e61b1ea2de3/src/java.base/windows/native/libjava/WinNTFileSystem_md.c#L473-L476
   }

--- a/src/test/java/com/google/devtools/build/lib/analysis/InterruptedExceptionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/InterruptedExceptionTest.java
@@ -40,7 +40,7 @@ public class InterruptedExceptionTest extends AnalysisTestCase {
   protected FileSystem createFileSystem() {
     return new InMemoryFileSystem(DigestHashFunction.SHA256) {
       @Override
-      protected Collection<Dirent> readdir(PathFragment path, boolean followSymlinks)
+      public Collection<Dirent> readdir(PathFragment path, boolean followSymlinks)
           throws IOException {
         if (path.toString().contains("causes_interrupt")) {
           mainThread.interrupt();

--- a/src/test/java/com/google/devtools/build/lib/analysis/StubbableFSBuildViewTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/StubbableFSBuildViewTest.java
@@ -136,7 +136,7 @@ public class StubbableFSBuildViewTest extends BuildViewTestBase {
 
     @Override
     @SuppressWarnings("UnsynchronizedOverridesSynchronized")
-    protected byte[] getFastDigest(PathFragment path) throws IOException {
+    public byte[] getFastDigest(PathFragment path) throws IOException {
       if (stubbedFastDigestErrors.containsKey(path)) {
         throw stubbedFastDigestErrors.get(path);
       }

--- a/src/test/java/com/google/devtools/build/lib/buildtool/ProgressReportingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/ProgressReportingTest.java
@@ -61,7 +61,7 @@ public class ProgressReportingTest extends BuildIntegrationTestCase {
       }
 
       @Override
-      protected boolean delete(PathFragment path) throws IOException {
+      public boolean delete(PathFragment path) throws IOException {
         recordAccess(PathOp.DELETE, path);
         return super.delete(path);
       }

--- a/src/test/java/com/google/devtools/build/lib/exec/SingleBuildFileCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SingleBuildFileCacheTest.java
@@ -53,7 +53,7 @@ public class SingleBuildFileCacheTest {
     fs =
         new InMemoryFileSystem(DigestHashFunction.SHA256) {
           @Override
-          protected InputStream getInputStream(PathFragment path) throws IOException {
+          public InputStream getInputStream(PathFragment path) throws IOException {
             int c = calls.containsKey(path.toString()) ? calls.get(path.toString()) : 0;
             c++;
             calls.put(path.toString(), c);
@@ -61,13 +61,13 @@ public class SingleBuildFileCacheTest {
           }
 
           @Override
-          protected byte[] getDigest(PathFragment path) throws IOException {
+          public byte[] getDigest(PathFragment path) throws IOException {
             byte[] override = digestOverrides.get(path.getPathString());
             return override != null ? override : super.getDigest(path);
           }
 
           @Override
-          protected byte[] getFastDigest(PathFragment path) throws IOException {
+          public byte[] getFastDigest(PathFragment path) throws IOException {
             return null;
           }
         };

--- a/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
@@ -174,12 +174,12 @@ public abstract class SpawnLogContextTestBase {
     }
 
     @Override
-    protected byte[] getFastDigest(PathFragment path) throws IOException {
+    public byte[] getFastDigest(PathFragment path) throws IOException {
       return super.getDigest(path);
     }
 
     @Override
-    protected byte[] getDigest(PathFragment path) throws IOException {
+    public byte[] getDigest(PathFragment path) throws IOException {
       throw new UnsupportedOperationException();
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/pkgcache/LoadingPhaseRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/pkgcache/LoadingPhaseRunnerTest.java
@@ -1997,7 +1997,7 @@ public final class LoadingPhaseRunnerTest {
     }
 
     @Override
-    protected synchronized InputStream getInputStream(PathFragment path) throws IOException {
+    public synchronized InputStream getInputStream(PathFragment path) throws IOException {
       IOException exnToThrow = pathsToErrorOnGetInputStream.get(path);
       if (exnToThrow != null) {
         throw exnToThrow;

--- a/src/test/java/com/google/devtools/build/lib/pkgcache/TargetPatternEvaluatorIOTest.java
+++ b/src/test/java/com/google/devtools/build/lib/pkgcache/TargetPatternEvaluatorIOTest.java
@@ -88,7 +88,7 @@ public class TargetPatternEvaluatorIOTest extends AbstractTargetPatternEvaluator
       }
 
       @Override
-      protected Collection<Dirent> readdir(PathFragment path, boolean followSymlinks)
+      public Collection<Dirent> readdir(PathFragment path, boolean followSymlinks)
           throws IOException {
         Collection<Dirent> defaultResult = super.readdir(path, followSymlinks);
         return transformer.readdir(defaultResult, path, followSymlinks);

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
@@ -166,7 +166,7 @@ public class SandboxHelpersTest {
         new InMemoryFileSystem(DigestHashFunction.SHA1) {
           @Override
           @SuppressWarnings("UnsynchronizedOverridesSynchronized") // .await() inside
-          protected void setExecutable(PathFragment path, boolean executable) throws IOException {
+          public void setExecutable(PathFragment path, boolean executable) throws IOException {
             try {
               bothWroteTempFile.await();
               finishProcessingSemaphore.acquire();

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTestCase.java
@@ -163,7 +163,7 @@ abstract class ArtifactFunctionTestCase {
 
     @Override
     @SuppressWarnings("UnsynchronizedOverridesSynchronized")
-    protected byte[] getFastDigest(PathFragment path) throws IOException {
+    public byte[] getFastDigest(PathFragment path) throws IOException {
       return fastDigest ? getDigest(path) : null;
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadFunctionTest.java
@@ -1175,7 +1175,7 @@ public class BzlLoadFunctionTest extends BuildViewTestCase {
     }
 
     @Override
-    protected synchronized InputStream getInputStream(PathFragment path) throws IOException {
+    public synchronized InputStream getInputStream(PathFragment path) throws IOException {
       if (badPathForRead != null && badPathForRead.asFragment().equals(path)) {
         throw new IOException("bad");
       }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
@@ -245,7 +245,7 @@ public final class FileArtifactValueTest {
 
           @Override
           @SuppressWarnings("UnsynchronizedOverridesSynchronized")
-          protected byte[] getFastDigest(PathFragment path) throws IOException {
+          public byte[] getFastDigest(PathFragment path) throws IOException {
             throw exception;
           }
         };

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FileFunctionTest.java
@@ -534,7 +534,7 @@ public class FileFunctionTest {
         new CustomInMemoryFs(manualClock) {
           @Override
           @SuppressWarnings("UnsynchronizedOverridesSynchronized")
-          protected byte[] getFastDigest(PathFragment path) {
+          public byte[] getFastDigest(PathFragment path) {
             return digest;
           }
         });
@@ -573,7 +573,7 @@ public class FileFunctionTest {
         new CustomInMemoryFs(manualClock) {
           @Override
           @SuppressWarnings("UnsynchronizedOverridesSynchronized")
-          protected byte[] getFastDigest(PathFragment path) {
+          public byte[] getFastDigest(PathFragment path) {
             return path.getBaseName().equals("unreadable") ? expectedDigest : null;
           }
         });
@@ -875,7 +875,7 @@ public class FileFunctionTest {
     fs =
         new CustomInMemoryFs(manualClock) {
           @Override
-          protected byte[] getDigest(PathFragment path) throws IOException {
+          public byte[] getDigest(PathFragment path) throws IOException {
             digestCalls.incrementAndGet();
             return super.getDigest(path);
           }
@@ -957,7 +957,7 @@ public class FileFunctionTest {
     createFsAndRoot(
         new CustomInMemoryFs(manualClock) {
           @Override
-          protected boolean isReadable(PathFragment path) throws IOException {
+          public boolean isReadable(PathFragment path) throws IOException {
             if (path.getBaseName().equals("unreadable")) {
               throw new IOException("isReadable failed");
             }
@@ -1793,7 +1793,7 @@ public class FileFunctionTest {
 
     @Override
     @SuppressWarnings("UnsynchronizedOverridesSynchronized")
-    protected byte[] getFastDigest(PathFragment path) throws IOException {
+    public byte[] getFastDigest(PathFragment path) throws IOException {
       if (stubbedFastDigestErrors.containsKey(path)) {
         throw stubbedFastDigestErrors.get(path);
       }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/LocalDiffAwarenessIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/LocalDiffAwarenessIntegrationTest.java
@@ -81,7 +81,7 @@ public class LocalDiffAwarenessIntegrationTest extends SkyframeIntegrationTestBa
   public FileSystem createFileSystem() throws Exception {
     return new DelegateFileSystem(super.createFileSystem()) {
       @Override
-      protected FileStatus statIfFound(PathFragment path, boolean followSymlinks)
+      public FileStatus statIfFound(PathFragment path, boolean followSymlinks)
           throws IOException {
         IOException e = throwOnNextStatIfFound.remove(path);
         if (e != null) {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PackageFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PackageFunctionTest.java
@@ -2368,7 +2368,7 @@ public class PackageFunctionTest extends BuildViewTestCase {
     }
 
     @Override
-    protected synchronized InputStream getInputStream(PathFragment path) throws IOException {
+    public synchronized InputStream getInputStream(PathFragment path) throws IOException {
       IOException exnToThrow = pathsToErrorOnGetInputStream.get(path);
       if (exnToThrow != null) {
         throw exnToThrow;

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PrepareDepsOfTargetsUnderDirectoryFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PrepareDepsOfTargetsUnderDirectoryFunctionTest.java
@@ -62,7 +62,7 @@ public class PrepareDepsOfTargetsUnderDirectoryFunctionTest extends BuildViewTes
   protected FileSystem createFileSystem() {
     return new DelegateFileSystem(super.createFileSystem()) {
       @Override
-      protected FileStatus statIfFound(PathFragment path, boolean followSymlinks)
+      public FileStatus statIfFound(PathFragment path, boolean followSymlinks)
           throws IOException {
         @Nullable FileStatus injectedStat = injectedStats.remove(path);
         if (injectedStat != null) {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunctionTest.java
@@ -121,7 +121,7 @@ public final class RecursiveFilesystemTraversalFunctionTest extends FoundationTe
   protected FileSystem createFileSystem() {
     return new DelegateFileSystem(super.createFileSystem()) {
       @Override
-      protected FileStatus statIfFound(PathFragment path, boolean followSymlinks)
+      public FileStatus statIfFound(PathFragment path, boolean followSymlinks)
           throws IOException {
         if (pathsToPretendDontExist.contains(path)) {
           return null;

--- a/src/test/java/com/google/devtools/build/lib/unix/UnixDigestHashAttributeNameTest.java
+++ b/src/test/java/com/google/devtools/build/lib/unix/UnixDigestHashAttributeNameTest.java
@@ -23,7 +23,7 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.SyscallCache;
 import org.junit.Test;
 
-/** Test for {@link com.google.devtools.build.lib.unix.UnixFileSystem#getFastDigest}. */
+/** Test for {@link FileSystem#getFastDigest}. */
 public class UnixDigestHashAttributeNameTest extends FileSystemTest {
   private static final byte[] FAKE_DIGEST = {
     0x18, 0x5f, 0x3d, 0x33, 0x22, 0x71, 0x7e, 0x25,

--- a/src/test/java/com/google/devtools/build/lib/vfs/DigestUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/DigestUtilsTest.java
@@ -40,13 +40,13 @@ public final class DigestUtilsTest {
     FileSystem tracingFileSystem =
         new InMemoryFileSystem(DigestHashFunction.SHA256) {
           @Override
-          protected byte[] getFastDigest(PathFragment path) {
+          public byte[] getFastDigest(PathFragment path) {
             getFastDigestCounter.incrementAndGet();
             return null;
           }
 
           @Override
-          protected byte[] getDigest(PathFragment path) throws IOException {
+          public byte[] getDigest(PathFragment path) throws IOException {
             getDigestCounter.incrementAndGet();
             return super.getDigest(path);
           }
@@ -80,12 +80,12 @@ public final class DigestUtilsTest {
     FileSystem noDigestFileSystem =
         new InMemoryFileSystem(DigestHashFunction.SHA256) {
           @Override
-          protected byte[] getFastDigest(PathFragment path) {
+          public byte[] getFastDigest(PathFragment path) {
             throw new AssertionError("Unexpected call to getFastDigest");
           }
 
           @Override
-          protected byte[] getDigest(PathFragment path) {
+          public byte[] getDigest(PathFragment path) {
             return digest;
           }
         };


### PR DESCRIPTION
Makes it possible to build `FileSystem`s composed out of existing `FileSystem`s outside the `vfs` package. Some methods already had their visibility upgraded for this purpose.