### PR TITLE
[8.4.0] Remove testBuildArmCppBinaryWithMsvcCL on Windows

### DIFF
--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -945,32 +945,6 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertIn('x86\\cl.exe', '\n'.join(stderr))
 
-  def testBuildArmCppBinaryWithMsvcCL(self):
-    self.createModuleDotBazel()
-    self.ScratchFile('BUILD', [
-        'platform(',
-        '  name = "windows_arm",',
-        '  constraint_values = [',
-        '    "@platforms//cpu:arm",',
-        '    "@platforms//os:windows",',
-        '  ]',
-        ')',
-        'cc_binary(',
-        '  name = "main",',
-        '  srcs = ["main.cc"],',
-        ')',
-    ])
-    self.ScratchFile('main.cc', [
-        'int main() {',
-        '  return 0;',
-        '}',
-    ])
-    exit_code, _, stderr = self.RunBazel(
-        ['build', '-s', '--platforms=//:windows_arm', '//:main']
-    )
-    self.AssertExitCode(exit_code, 0, stderr)
-    self.assertIn('arm\\cl.exe', '\n'.join(stderr))
-
   def testBuildArm64CppBinaryWithMsvcCLAndCpuX64Arm64Windows(self):
     self.createModuleDotBazel()
     self.ScratchFile('BUILD', [


### PR DESCRIPTION
It is broken after we updated our Windows VM image https://buildkite.com/bazel/bazel-bazel/builds/32939#0198c1fa-889a-4a10-abd2-e2dbddaa9fbe, and the 32bit arm platform isn't that important to support.

RELNOTES: None
PiperOrigin-RevId: 796863091
Change-Id: Ia9135370fd3f113e2ab76c4284d26b9cadaed25b

Commit https://github.com/bazelbuild/bazel/commit/2158daccc79e2b8769d50346d1d73cd4714b8d9d