### PR TITLE
Allow excluding entries using patterns in singlejar

### DIFF
--- a/src/tools/singlejar/options.cc
+++ b/src/tools/singlejar/options.cc
@@ -44,6 +44,7 @@ bool Options::ParseToken(ArgTokenStream *tokens) {
       tokens->MatchAndSet("--classpath_resources", &classpath_resources) ||
       tokens->MatchAndSet("--include_prefixes", &include_prefixes) ||
       tokens->MatchAndSet("--exclude_zip_entries", &exclude_zip_entries) ||
+      tokens->MatchAndSet("--exclude_zip_entry_patterns", &exclude_zip_entry_patterns) ||
       tokens->MatchAndSet("--exclude_build_data", &exclude_build_data) ||
       tokens->MatchAndSet("--build_target", &build_target) ||
       tokens->MatchAndSet("--compression", &force_compression) ||

--- a/src/tools/singlejar/options.h
+++ b/src/tools/singlejar/options.h
@@ -60,6 +60,7 @@ class Options {
   std::vector<std::string> build_info_lines;
   std::vector<std::string> include_prefixes;
   std::set<std::string> exclude_zip_entries;
+  std::vector<std::string> exclude_zip_entry_patterns;
   std::vector<std::string> nocompress_suffixes;
   bool exclude_build_data;
   bool force_compression;

--- a/src/tools/singlejar/options_test.cc
+++ b/src/tools/singlejar/options_test.cc
@@ -184,3 +184,17 @@ TEST(OptionTest, DefaultCreatedBy) {
   options.ParseCommandLine(arraysize(args), args);
   EXPECT_EQ("singlejar", options.output_jar_creator);
 }
+
+TEST(OptionsTest, ExcludeZipEntryPatterns) {
+  const char *args[] = {"--output", "output_file",
+                        "--exclude_zip_entry_patterns", ".*\\.class$",
+                        "META-INF/.*",
+                        ".*test.*"};
+  Options options;
+  options.ParseCommandLine(arraysize(args), args);
+  
+  ASSERT_EQ(3UL, options.exclude_zip_entry_patterns.size());
+  EXPECT_EQ(".*\\.class$", options.exclude_zip_entry_patterns[0]);
+  EXPECT_EQ("META-INF/.*", options.exclude_zip_entry_patterns[1]);
+  EXPECT_EQ(".*test.*", options.exclude_zip_entry_patterns[2]);
+}


### PR DESCRIPTION
This is useful for cases where multiple files under a directory or multiple files of the same kind need to be excluded.

e.g.
```
 lib/arm64-v8a/*
 *.so
```