### PR TITLE
Fix potential crash in BulkTransferException.getLostArtifacts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/common/BulkTransferException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/BulkTransferException.java
@@ -97,7 +97,7 @@ public class BulkTransferException extends IOException {
           actionInput, "ActionInput not found for filename %s in CacheNotFoundException", execPath);
       byDigestBuilder.put(DigestUtil.toString(missingDigest), actionInput);
     }
-    var byDigest = byDigestBuilder.buildOrThrow();
+    var byDigest = byDigestBuilder.buildKeepingLast();
     return new LostArtifacts(byDigest, Optional.empty());
   }
 


### PR DESCRIPTION
Concurrent fetching can result in duplicate digests.