### PR TITLE
Support custom profile file names in coverage scripts

### DIFF
--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -102,7 +102,7 @@ if [[ -z "$GCOV_PREFIX_STRIP" ]]; then
   export GCOV_PREFIX_STRIP=3
 fi
 export GCOV_PREFIX="${COVERAGE_DIR}"
-export LLVM_PROFILE_FILE="${COVERAGE_DIR}/%h-%p-%m.profraw"
+export LLVM_PROFILE_FILE="${COVERAGE_DIR}/${BAZEL_LLVM_PROFILE_FILE:-%h-%p-%m.profraw}"
 if [[ -n "$LLVM_PROFILE_CONTINUOUS_MODE" ]]; then
   # %c enables continuous mode but expands out to nothing, so the position
   # within LLVM_PROFILE_FILE does not matter.

--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -22,6 +22,8 @@
 #   COVERAGE_DIR - optional, location of the coverage temp directory
 #   COVERAGE_OUTPUT_FILE - optional, location of the final lcov file
 #   VERBOSE_COVERAGE - optional, print debug info from the coverage scripts
+#   BAZEL_LLVM_PROFILE_FILE - optional, custom LLVM profile filename pattern
+#     (defaults to "%h-%p-%m.profraw" if not set)
 #
 # Script expects that it will be started in the execution root directory and
 # not in the test's runfiles directory.


### PR DESCRIPTION
Allow `BAZEL_LLVM_PROFILE_FILE` to customize the LLVM profile filename pattern in coverage runs.

Previously, the LLVM profile file name was hardcoded to `%h-%p-%m.profraw`
under `COVERAGE_DIR`. This change introduces the `BAZEL_LLVM_PROFILE_FILE`
environment variable, allowing users to override the default pattern.

Usage:
  --test_env=BAZEL_LLVM_PROFILE_FILE=<custom-pattern>

Example:
  --test_env=BAZEL_LLVM_PROFILE_FILE=default-%p.profraw

If the variable is not set, behavior is unchanged (defaults to
`%h-%p-%m.profraw`).

### Release Notes

RELNOTES[NEW]: The `BAZEL_LLVM_PROFILE_FILE` environment variable can now
be used to customize the LLVM profile filename pattern for C++ coverage
collection (e.g. `--test_env=BAZEL_LLVM_PROFILE_FILE=%p.profraw`).
Defaults to `%h-%p-%m.profraw` when unset.