### PR TITLE
Make CacheNotFoundException conversion more targeted

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -49,7 +49,6 @@ import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.util.AsyncTaskCache;
-import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.util.TempPathGenerator;
 import com.google.devtools.build.lib.vfs.FileSymlinkLoopException;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
@@ -591,20 +590,6 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
                           finalizeDownload(
                               metadata, tempPath, finalPath, dirsWithOutputPermissions);
                           alreadyDeleted.set(true);
-                        })
-                    .onErrorResumeNext(
-                        error -> {
-                          if (error instanceof CacheNotFoundException
-                              || error instanceof RuntimeException
-                              || error instanceof Error) {
-                            return Completable.error(error);
-                          }
-
-                          // Treat other download error as CacheNotFoundException so that Bazel can
-                          // correctly rewind the action/build.
-                          var digest =
-                              DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());
-                          return Completable.error(new CacheNotFoundException(digest, execPath));
                         }));
 
     return downloadCache.executeIfNot(

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -14,16 +14,20 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionOutputDirectoryHelper;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.events.Reporter;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
@@ -101,15 +105,28 @@ public class RemoteActionInputFetcher extends AbstractActionInputPrefetcher {
 
     Digest digest = DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());
 
-    return combinedCache.downloadFile(
-        context,
-        execPath.getPathString(),
-        execPath,
-        tempPath,
-        digest,
-        new CombinedCache.DownloadProgressReporter(
-            progress -> progress.postTo(reporter, action),
-            execPath.toString(),
-            digest.getSizeBytes()));
+    // Treat other download error as CacheNotFoundException so that Bazel can
+    // correctly rewind the action/build.
+    // Intentionally, do not transform IOExceptions directly thrown by downloadFile rather than in
+    // the returned future, as those are likely to be caused by local FS issues.
+    return Futures.catchingAsync(
+        combinedCache.downloadFile(
+            context,
+            execPath.getPathString(),
+            execPath,
+            tempPath,
+            digest,
+            new CombinedCache.DownloadProgressReporter(
+                progress -> progress.postTo(reporter, action),
+                execPath.toString(),
+                digest.getSizeBytes())),
+        IOException.class,
+        e ->
+            immediateFailedFuture(
+                switch (e) {
+                  case CacheNotFoundException cacheNotFoundException -> cacheNotFoundException;
+                  default -> new CacheNotFoundException(digest, execPath);
+                }),
+        directExecutor());
   }
 }


### PR DESCRIPTION
This is a follow-up to 8d6f4ae16cbbf663edeb4825f29c56f6bb2d3a0c that makes the exception conversion more targeted and avoids catching unchecked exceptions in the first place.