### PR TITLE
Refactor path handling in `AbstractActionInputPrefetcher`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -15,7 +15,6 @@ package com.google.devtools.build.lib.remote;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -47,7 +46,6 @@ import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
-import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.util.AsyncTaskCache;
 import com.google.devtools.build.lib.util.TempPathGenerator;
 import com.google.devtools.build.lib.vfs.FileSymlinkLoopException;
@@ -194,16 +192,16 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
 
   private final DirectoryTracker directoryTracker = new DirectoryTracker();
 
-  /** A symlink in the output tree. */
-  record Symlink(PathFragment linkExecPath, PathFragment targetExecPath) {
+  /** A symlink in the output tree that points to another artifact's absolute path. */
+  record Symlink(Path linkPath, Path targetPath) {
     Symlink {
-      requireNonNull(linkExecPath, "linkExecPath");
-      requireNonNull(targetExecPath, "targetExecPath");
-      checkArgument(!linkExecPath.equals(targetExecPath));
+      requireNonNull(linkPath, "linkPath");
+      requireNonNull(targetPath, "targetPath");
+      checkArgument(!linkPath.equals(targetPath));
     }
 
-    static Symlink of(PathFragment linkExecPath, PathFragment targetExecPath) {
-      return new Symlink(linkExecPath, targetExecPath);
+    static Symlink of(Path linkPath, Path targetPath) {
+      return new Symlink(linkPath, targetPath);
     }
   }
 
@@ -257,8 +255,8 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
   protected abstract ListenableFuture<Void> doDownloadFile(
       ActionExecutionMetadata action,
       Reporter reporter,
+      ActionInput input,
       Path tempPath,
-      PathFragment execPath,
       FileArtifactValue metadata,
       Priority priority,
       Reason reason)
@@ -381,44 +379,40 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
         return immediateVoidFuture();
       }
 
-      PathFragment execPath = input.getExecPath();
+      Path inputPath =
+          input instanceof Artifact artifact
+              ? artifact.getPath()
+              : execRoot.getRelative(input.getExecPath());
 
       // Metadata may legitimately be missing, e.g. if this is an optional test output.
       FileArtifactValue metadata = metadataSupplier.getMetadata(input);
-      if (metadata == null || !canDownloadFile(execRoot.getRelative(execPath), metadata)) {
+      if (metadata == null || !canDownloadFile(inputPath, metadata)) {
         return immediateVoidFuture();
       }
 
-      @Nullable Symlink symlink = maybeGetSymlink(input, metadata, metadataSupplier);
+      @Nullable
+      Symlink symlink = maybeGetSymlink(input, inputPath, metadata, metadataSupplier);
 
       if (symlink != null) {
-        checkState(execPath.startsWith(symlink.linkExecPath()));
-        execPath =
-            symlink.targetExecPath().getRelative(execPath.relativeTo(symlink.linkExecPath()));
+        // Symlink tracks the parent of a TreeFileArtifact, so the parent relative path has to be
+        // translated relative to it.
+        var parentRelativePath = inputPath.relativeTo(symlink.linkPath());
+        inputPath = symlink.targetPath().getRelative(parentRelativePath);
       }
 
-      @Nullable PathFragment treeRootExecPath = maybeGetTreeRoot(input, metadataSupplier);
+      @Nullable Path treeRootPath = maybeGetTreeRoot(input, metadataSupplier);
 
       Completable result =
           downloadFileNoCheckRx(
-                  action,
-                  execRoot.getRelative(execPath),
-                  treeRootExecPath != null ? execRoot.getRelative(treeRootExecPath) : null,
-                  dirsWithOutputPermissions,
-                  input,
-                  metadata,
-                  priority,
-                  reason)
-              .onErrorResumeNext(
-                  t -> {
-                    if (t instanceof CacheNotFoundException cacheNotFoundException) {
-                      // Only the symlink itself is guaranteed to be an input to the action, so
-                      // report its path for rewinding.
-                      cacheNotFoundException.setExecPath(input.getExecPath());
-                      return Completable.error(cacheNotFoundException);
-                    }
-                    return Completable.error(t);
-                  });
+              action,
+              input,
+              inputPath,
+              treeRootPath,
+              dirsWithOutputPermissions,
+              input,
+              metadata,
+              priority,
+              reason);
 
       if (symlink != null) {
         result = result.andThen(plantSymlink(symlink));
@@ -431,15 +425,15 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
   }
 
   /**
-   * For an input belonging to a tree artifact, returns the prefetch exec path of the tree artifact
-   * root. Otherwise, returns null.
+   * For an input belonging to a tree artifact, returns the path of the tree artifact root.
+   * Otherwise, returns null.
    *
    * <p>Some artifacts (notably, those created by {@code ctx.actions.symlink}) are materialized in
    * the output tree as a symlink to another artifact, as indicated by the {@link
    * FileArtifactValue#getResolvedPath()} field in their metadata.
    */
   @Nullable
-  private PathFragment maybeGetTreeRoot(ActionInput input, MetadataSupplier metadataSupplier)
+  private Path maybeGetTreeRoot(ActionInput input, MetadataSupplier metadataSupplier)
       throws IOException, InterruptedException {
     if (!(input instanceof TreeFileArtifact treeFile)) {
       return null;
@@ -458,9 +452,9 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
     }
     PathFragment resolvedPath = treeMetadata.getResolvedPath();
     if (resolvedPath != null) {
-      return resolvedPath.relativeTo(execRoot.asFragment());
+      return treeArtifact.getPath().getFileSystem().getPath(resolvedPath);
     }
-    return treeArtifact.getExecPath();
+    return treeArtifact.getPath();
   }
 
   /**
@@ -474,6 +468,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
   @Nullable
   private Symlink maybeGetSymlink(
       ActionInput input,
+      Path inputPath,
       FileArtifactValue metadata,
       MetadataSupplier metadataSupplier)
       throws IOException, InterruptedException {
@@ -490,17 +485,16 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
         //  available for case (2).
         return null;
       }
-      return maybeGetSymlink(treeArtifact, treeMetadata, metadataSupplier);
+      return maybeGetSymlink(treeArtifact, treeArtifact.getPath(), treeMetadata, metadataSupplier);
     }
-    PathFragment execPath = input.getExecPath();
-    PathFragment resolvedExecPath = execPath;
-    if (metadata.getResolvedPath() != null) {
-      resolvedExecPath = metadata.getResolvedPath().relativeTo(execRoot.asFragment());
+    if (metadata.getResolvedPath() == null) {
+      return null;
     }
-    if (!resolvedExecPath.equals(execPath)) {
-      return Symlink.of(execPath, resolvedExecPath);
+    Path resolvedPath = inputPath.getFileSystem().getPath(metadata.getResolvedPath());
+    if (resolvedPath.equals(inputPath)) {
+      return null;
     }
-    return null;
+    return Symlink.of(inputPath, resolvedPath);
   }
 
   private static Path resolveOneSymlink(Path path) throws IOException {
@@ -535,6 +529,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
 
   private Completable downloadFileNoCheckRx(
       ActionExecutionMetadata action,
+      ActionInput input,
       Path path,
       @Nullable Path treeRoot,
       Set<Path> dirsWithOutputPermissions,
@@ -575,7 +570,6 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
     }
 
     Path finalPath = path;
-    PathFragment execPath = finalPath.relativeTo(execRoot);
 
     Completable download =
         usingTempPath(
@@ -583,7 +577,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
                 toCompletable(
                         () ->
                             doDownloadFile(
-                                action, reporter, tempPath, execPath, metadata, priority, reason),
+                                action, reporter, input, tempPath, metadata, priority, reason),
                         directExecutor())
                     .doOnComplete(
                         () -> {
@@ -672,15 +666,13 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
 
   private Completable plantSymlink(Symlink symlink) {
     return downloadCache.executeIfNot(
-        execRoot.getRelative(symlink.linkExecPath()),
+        symlink.linkPath(),
         Completable.defer(
             () -> {
-              Path link = execRoot.getRelative(symlink.linkExecPath());
-              Path target = execRoot.getRelative(symlink.targetExecPath());
               // Delete the link path if it already exists. This is the case for tree artifacts,
               // whose root directory is created before the action runs.
-              link.delete();
-              link.createSymbolicLink(target);
+              symlink.linkPath().delete();
+              symlink.linkPath().createSymbolicLink(symlink.targetPath());
               return Completable.complete();
             }));
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -302,7 +302,7 @@ public abstract class ActionInputPrefetcherTestBase {
             action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
 
     verify(prefetcher, never())
-        .doDownloadFile(eq(action), any(), any(), any(), any(), any(), any());
+        .doDownloadFile(eq(action), any(), eq(a), any(), any(), any(), any());
     assertThat(prefetcher.downloadedFiles()).containsExactly(a.getPath());
     assertThat(prefetcher.downloadsInProgress()).isEmpty();
   }
@@ -321,7 +321,7 @@ public abstract class ActionInputPrefetcherTestBase {
             action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
 
     verify(prefetcher)
-        .doDownloadFile(eq(action), any(), any(), eq(a.getExecPath()), any(), any(), any());
+        .doDownloadFile(eq(action), any(), eq(a), any(), any(), any(), any());
     assertThat(prefetcher.downloadedFiles()).containsExactly(a.getPath());
     assertThat(prefetcher.downloadsInProgress()).isEmpty();
     assertThat(FileSystemUtils.readContent(a.getPath(), UTF_8)).isEqualTo("hello world remote");
@@ -911,7 +911,7 @@ public abstract class ActionInputPrefetcherTestBase {
       throws IOException {
     doAnswer(
             invocation -> {
-              Path path = invocation.getArgument(2);
+              Path path = invocation.getArgument(3);
               FileArtifactValue metadata = invocation.getArgument(4);
               byte[] content = cas.get(HashCode.fromBytes(metadata.getDigest()));
               if (content == null) {


### PR DESCRIPTION
This avoids repeated `relativeTo` and `getRelative` conversions using the `execRoot`. Instead, the `Path` of an input is computed in a single location. By passing the `ActionInput` to `RemoteActionInputFetcher`, the logic that modifies `CacheNotFoundException`'s exec path after construction can be removed.

This change is motivated by plans to support downloading of lazily fetched source artifacts whose `getPath` method returns paths that don't lie under the exec root.

Currently stacked on #26815 