### PR TITLE
Remove redundant export LLVM_PROFILE_FILE statements in LLVM coverage  scripts

### DIFF
--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -77,7 +77,6 @@ function init_gcov() {
 # Writes the collected coverage into the given output file.
 function llvm_coverage_lcov() {
   local output_file="${1}"; shift
-  export LLVM_PROFILE_FILE="${COVERAGE_DIR}/%h-%p-%m.profraw"
   "${LLVM_PROFDATA}" merge -output "${output_file}.data" \
       "${COVERAGE_DIR}"/*.profraw
 
@@ -97,7 +96,6 @@ function llvm_coverage_lcov() {
 
 function llvm_coverage_profdata() {
   local output_file="${1}"; shift
-  export LLVM_PROFILE_FILE="${COVERAGE_DIR}/%h-%p-%m.profraw"
   "${LLVM_PROFDATA}" merge -output "${output_file}" \
       "${COVERAGE_DIR}"/*.profraw
 }


### PR DESCRIPTION
The `export LLVM_PROFILE_FILE` in `llvm_coverage_lcov` was introduced in [21b5eb6](https://github.com/bazelbuild/bazel/commit/21b5eb627d78c09d47c4de957e9e6b56a9ae6fad#diff-3b5101191745e73e132b6edf1ca395e63a3e198cf586b55544da3fd793003d65R73-R75). The one in `llvm_coverage` (now `llvm_coverage_profdata`) was introduced in [190d4f8](https://github.com/bazelbuild/bazel/commit/190d4f8e4b51ce17f3c19e43a2a6249dd3c4cc4c#diff-3b5101191745e73e132b6edf1ca395e63a3e198cf586b55544da3fd793003d65R58-R61).

These statements appear to originate from when `tools/test/collect_cc_coverage.sh` was split from `tools/test/collect_coverage.sh`, and were later duplicated when adding `llvm_coverage_lcov` support.

`LLVM_PROFILE_FILE` only specifies the output path for generated profile data; it does not affect how `llvm-profdata` processes profile files. Therefore, exporting it in these scripts is unnecessary and can be safely removed.

see
- https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#running-the-instrumented-program
- https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#running-the-instrumented-program