### PR TITLE
Enable cpp coverage on windows

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -482,9 +482,6 @@ sh_test(
         ":test-deps",
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:coverage_output_generator_repo",
     ],
-    tags = [
-        "no_windows",
-    ],
 )
 
 sh_test(
@@ -492,9 +489,6 @@ sh_test(
     srcs = ["bazel_coverage_cc_test_llvm.sh"],
     args = ["released"],
     data = [":test-deps"],
-    tags = [
-        "no_windows",
-    ],
 )
 
 sh_test(

--- a/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
@@ -14,13 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
 
-# Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../integration_test_setup.sh" \
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
-source "${CURRENT_DIR}/coverage_helpers.sh" \
+source "$(rlocation "io_bazel/src/test/shell/bazel/coverage_helpers.sh")" \
   || { echo "coverage_helpers.sh not found!" >&2; exit 1; }
 
 COVERAGE_GENERATOR_DIR="$1"; shift
@@ -64,6 +73,7 @@ function setup_llvm_coverage_tools_for_lcov() {
   add_to_bazelrc "common --repo_env=BAZEL_LLVM_PROFDATA=${llvm_profdata}"
   add_to_bazelrc "common --repo_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1"
   add_to_bazelrc "common --repo_env=CC=${clang}"
+  add_to_bazelrc "common --repo_env=GCOV_COVERAGE=0"
   add_to_bazelrc "common --experimental_generate_llvm_lcov"
 }
 

--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -51,8 +51,8 @@ function uses_llvm() {
 
 # Returns 0 if gcov must be used, 1 otherwise.
 function uses_gcov() {
-  [[ "$GCOV_COVERAGE" -eq "1"  ]] && return 0
-  return 1
+  [[ "$GCOV_COVERAGE" -eq "0"  ]] && return 1
+  return 0
 }
 
 function init_gcov() {
@@ -189,7 +189,6 @@ function main() {
   if uses_gcov; then
     init_gcov
   fi
-
   # If llvm code coverage is used, we output the raw code coverage report in
   # the $COVERAGE_OUTPUT_FILE. This report will not be converted to any other
   # format by LcovMerger.


### PR DESCRIPTION
- I have updated the code to enable code coverage for C++ targets when using Clang.
Specifically, I modified the uses_gcov function so that it now returns true by default.
However, if GCOV_COVERAGE is set to 0 while using Clang, uses_gcov returns false.

- With these changes, code coverage data for C++ targets with Clang will be generated and saved inside the _cc_coverage.dat file within the COVERAGE_DIR, unless coverage is explicitly disabled.