### PR TITLE
Fix runfiles directory staleness issues caused by symlinking the output manifest

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
@@ -21,7 +21,6 @@ import com.google.devtools.build.lib.actions.RunfilesTree;
 import com.google.devtools.build.lib.analysis.RunfilesSupport;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue.RunfileSymlinksMode;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
-import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.DigestUtils;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
@@ -120,19 +119,19 @@ public class RunfilesTreeUpdater {
       // Avoid rebuilding the runfiles directory if the manifest in it matches the input manifest,
       // implying the symlinks exist and are already up to date. If the output manifest is a
       // symbolic link, it is likely a symbolic link to the input manifest, so we cannot trust it as
-      // an up-to-date check.
-      // On Windows, where symlinks may be silently replaced by copies, a previous run in SKIP mode
-      // could have resulted in an output manifest that is an identical copy of the input manifest,
-      // which we must not treat as up to date, but we also don't want to unnecessarily rebuild the
-      // runfiles directory all the time. Instead, check for the presence of the first runfile in
-      // the manifest. If it is present, we can be certain that the previous mode wasn't SKIP.
+      // an up-to-date check. Ignoring external interference, this situation can only arise if an
+      // older version of Bazel created the runfiles tree - before 8.4.0, Bazel created a symlink.
+      // A previous run in SKIP mode could have resulted in an output manifest that is an
+      // identical copy of the input manifest, which we must not treat as up to date. Since we also
+      // don't want to unnecessarily rebuild the runfiles directory all the time, instead check for
+      // the presence of the first runfile in the manifest. If it is present, we can be certain that
+      // the previous mode wasn't SKIP.
       if (tree.getSymlinksMode() == RunfileSymlinksMode.CREATE
           && !outputManifest.isSymbolicLink()
           && Arrays.equals(
               DigestUtils.getDigestWithManualFallback(outputManifest, xattrProvider),
               DigestUtils.getDigestWithManualFallback(inputManifest, xattrProvider))
-          && (OS.getCurrent() != OS.WINDOWS
-              || isRunfilesDirectoryPopulated(runfilesDir, outputManifest))) {
+          && isRunfilesDirectoryPopulated(runfilesDir, outputManifest)) {
         return;
       }
     } catch (IOException e) {

--- a/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue.Run
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.DigestUtils;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Symlinks;
@@ -147,7 +148,8 @@ public class RunfilesTreeUpdater {
 
     if (tree.getSymlinksMode() == RunfileSymlinksMode.CREATE) {
       helper.createRunfilesSymlinks(tree.getMapping());
-      outputManifest.createSymbolicLink(inputManifest);
+      // See SymlinkTreeStrategy#createOutput for why we copy instead of hardlink or symlink.
+      FileSystemUtils.copyFile(inputManifest, outputManifest);
     } else {
       helper.clearRunfilesDirectory();
     }

--- a/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
@@ -175,7 +175,7 @@ public final class SymlinkTreeHelper {
       outputManifest.delete();
       FileSystemUtils.copyFile(inputManifest, outputManifest);
     } catch (IOException e) {
-      throw new EnvironmentalExecException(e, Code.SYMLINK_TREE_MANIFEST_LINK_IO_EXCEPTION);
+      throw new EnvironmentalExecException(e, Code.SYMLINK_TREE_MANIFEST_COPY_IO_EXCEPTION);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
@@ -145,12 +145,12 @@ public final class SymlinkTreeHelper {
   }
 
   /**
-   * Ensures that the runfiles directory is empty except for the symlinked MANIFEST and the
-   * workspace subdirectory. This is the expected state with --noenable_runfiles.
+   * Ensures that the runfiles directory is empty except for the copied MANIFEST and the workspace
+   * subdirectory. This is the expected state with --noenable_runfiles.
    */
   public void clearRunfilesDirectory() throws ExecException {
     deleteRunfilesDirectory();
-    linkManifest();
+    copyManifest();
     try {
       createWorkspaceSubdirectory();
     } catch (IOException e) {
@@ -167,13 +167,13 @@ public final class SymlinkTreeHelper {
     }
   }
 
-  /** Links the output manifest to the input manifest. */
-  private void linkManifest() throws ExecException {
-    // Pretend we created the runfiles tree by symlinking the output manifest to the input manifest.
+  /** Copies the output manifest to the input manifest. */
+  private void copyManifest() throws ExecException {
+    // Pretend we created the runfiles tree by copying the output manifest to the input manifest.
     try {
       symlinkTreeRoot.createDirectoryAndParents();
       outputManifest.delete();
-      outputManifest.createSymbolicLink(inputManifest);
+      FileSystemUtils.copyFile(inputManifest, outputManifest);
     } catch (IOException e) {
       throw new EnvironmentalExecException(e, Code.SYMLINK_TREE_MANIFEST_LINK_IO_EXCEPTION);
     }

--- a/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeStrategy.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.profiler.GoogleAutoProfilerUtils;
 import com.google.devtools.build.lib.server.FailureDetails.Execution;
 import com.google.devtools.build.lib.server.FailureDetails.Execution.Code;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.OutputService;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -131,11 +132,14 @@ public final class SymlinkTreeStrategy implements SymlinkTreeActionContext {
       SymlinkTreeAction action, ActionExecutionContext actionExecutionContext, Path inputManifest)
       throws EnvironmentalExecException {
     Path outputManifest = actionExecutionContext.getInputPath(action.getOutputManifest());
-    // Link output manifest on success. We avoid a file copy as these manifests may be
-    // large. Note that this step has to come last because the OutputService may delete any
-    // pre-existing symlink tree before creating a new one.
+    // Copy output manifest on success. We can't use a symlink or hardlink here because
+    // SymlinkTreeAction is executed for its side effect (the symlink tree creation) and could
+    // erroneously be considered up-to-date if the input manifest changed back to a different state
+    // that had previously been recorded in the action cache.
+    // Note that this step has to come last because the OutputService may delete any pre-existing
+    // symlink tree before creating a new one.
     try {
-      outputManifest.createSymbolicLink(inputManifest);
+      FileSystemUtils.copyFile(inputManifest, outputManifest);
     } catch (IOException e) {
       throw createLinkFailureException(outputManifest, e);
     }

--- a/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeStrategy.java
@@ -141,7 +141,7 @@ public final class SymlinkTreeStrategy implements SymlinkTreeActionContext {
     try {
       FileSystemUtils.copyFile(inputManifest, outputManifest);
     } catch (IOException e) {
-      throw createLinkFailureException(outputManifest, e);
+      throw createCopyFailureException(outputManifest, e);
     }
   }
 
@@ -160,14 +160,15 @@ public final class SymlinkTreeStrategy implements SymlinkTreeActionContext {
         workspaceName);
   }
 
-  private static EnvironmentalExecException createLinkFailureException(
+  private static EnvironmentalExecException createCopyFailureException(
       Path outputManifest, IOException e) {
     return new EnvironmentalExecException(
         e,
         FailureDetail.newBuilder()
-            .setMessage("Failed to link output manifest '" + outputManifest.getPathString() + "'")
+            .setMessage(
+                "Failed to copy output manifest '%s'".formatted(outputManifest.getPathString()))
             .setExecution(
-                Execution.newBuilder().setCode(Code.SYMLINK_TREE_MANIFEST_LINK_IO_EXCEPTION))
+                Execution.newBuilder().setCode(Code.SYMLINK_TREE_MANIFEST_COPY_IO_EXCEPTION))
             .build());
   }
 }

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -496,8 +496,7 @@ message Execution {
     TEST_OUT_ERR_IO_EXCEPTION = 14 [(metadata) = { exit_code: 36 }];
     SYMLINK_TREE_MANIFEST_COPY_IO_EXCEPTION = 15
         [(metadata) = { exit_code: 36 }];
-    SYMLINK_TREE_MANIFEST_LINK_IO_EXCEPTION = 16
-        [(metadata) = { exit_code: 36 }];
+    reserved 16;
     SYMLINK_TREE_CREATION_IO_EXCEPTION = 17 [(metadata) = { exit_code: 36 }];
     SYMLINK_TREE_CREATION_COMMAND_EXCEPTION = 18
         [(metadata) = { exit_code: 36 }];

--- a/src/test/java/com/google/devtools/build/lib/exec/SymlinkTreeStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SymlinkTreeStrategyTest.java
@@ -74,6 +74,7 @@ public final class SymlinkTreeStrategyTest extends BuildViewTestCase {
     when(outputService.canCreateSymlinkTree()).thenReturn(true);
 
     Artifact inputManifest = getBinArtifactWithNoOwner("dir/manifest.in");
+    FileSystemUtils.createEmptyFile(inputManifest.getPath());
     Artifact outputManifest = getBinArtifactWithNoOwner("dir.runfiles/MANIFEST");
     Artifact runfile = getBinArtifactWithNoOwner("dir/runfile");
     doAnswer(
@@ -137,6 +138,7 @@ public final class SymlinkTreeStrategyTest extends BuildViewTestCase {
     when(outputService.canCreateSymlinkTree()).thenReturn(false);
 
     Artifact inputManifest = getBinArtifactWithNoOwner("dir/manifest.in");
+    FileSystemUtils.createEmptyFile(inputManifest.getPath());
     Artifact outputManifest = getBinArtifactWithNoOwner("dir.runfiles/MANIFEST");
     Artifact runfile = getBinArtifactWithNoOwner("dir/runfile");
 

--- a/src/test/java/com/google/devtools/build/lib/exec/SymlinkTreeStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SymlinkTreeStrategyTest.java
@@ -74,6 +74,7 @@ public final class SymlinkTreeStrategyTest extends BuildViewTestCase {
     when(outputService.canCreateSymlinkTree()).thenReturn(true);
 
     Artifact inputManifest = getBinArtifactWithNoOwner("dir/manifest.in");
+    inputManifest.getPath().getParentDirectory().createDirectoryAndParents();
     FileSystemUtils.createEmptyFile(inputManifest.getPath());
     Artifact outputManifest = getBinArtifactWithNoOwner("dir.runfiles/MANIFEST");
     Artifact runfile = getBinArtifactWithNoOwner("dir/runfile");
@@ -138,6 +139,7 @@ public final class SymlinkTreeStrategyTest extends BuildViewTestCase {
     when(outputService.canCreateSymlinkTree()).thenReturn(false);
 
     Artifact inputManifest = getBinArtifactWithNoOwner("dir/manifest.in");
+    inputManifest.getPath().getParentDirectory().createDirectoryAndParents();
     FileSystemUtils.createEmptyFile(inputManifest.getPath());
     Artifact outputManifest = getBinArtifactWithNoOwner("dir.runfiles/MANIFEST");
     Artifact runfile = getBinArtifactWithNoOwner("dir/runfile");

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1014,7 +1014,7 @@ function test_execroot_sibling_layout_null_build_for_external_subpackages() {
   # Null build.
   bazel build --experimental_sibling_repository_layout //baz:binary &> "$TEST_log" \
     || fail "expected build success"
-  expect_log "INFO: 1 process: 1 internal"
+  expect_log "INFO: 1 process: 1 action cache hit, 1 internal"
 }
 
 function test_execroot_sibling_layout_header_scanning_in_external_subpackage() {

--- a/src/test/shell/integration/runfiles_test.sh
+++ b/src/test/shell/integration/runfiles_test.sh
@@ -800,4 +800,117 @@ EOF
     //pkg:gen >&$TEST_log || fail "build failed"
 }
 
+function test_runfile_manifest_only_change_not_stale() {
+  if "$is_windows"; then
+    # Can't run shell scripts directly.
+    return
+  fi
+
+  mkdir -p pkg
+  cat > pkg/constants.bzl <<'EOF'
+SYMLINK_PATH = "old_name"
+EOF
+  cat > pkg/defs.bzl <<'EOF'
+load(":constants.bzl", "SYMLINK_PATH")
+
+def _my_script_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name)
+    print(SYMLINK_PATH)
+    ctx.actions.write(
+        out,
+        """#!/usr/bin/env sh
+set -eu
+[ -f {} ] || exit 1
+""".format(SYMLINK_PATH),
+        is_executable = True,
+    )
+    runfiles = ctx.runfiles(
+        symlinks = {
+            SYMLINK_PATH: out,
+        },
+    )
+    return [DefaultInfo(executable = out, runfiles = runfiles)]
+
+my_script = rule(
+    implementation = _my_script_impl,
+    executable = True,
+)
+EOF
+  cat > pkg/BUILD <<'EOF'
+load(":defs.bzl", "my_script")
+
+my_script(
+    name = "foo",
+)
+EOF
+
+  bazel run //pkg:foo $EXTRA_BUILD_FLAGS >&$TEST_log || fail "first run failed"
+
+  # Modify the symlink path only while not overwriting the existing action cache entry for the SymlinkTreeAction.
+  inplace-sed 's/old_name/new_name/' pkg/constants.bzl
+  bazel run --nouse_action_cache //pkg:foo $EXTRA_BUILD_FLAGS >&$TEST_log || fail "second run failed"
+
+  # Revert the symlink path.
+  inplace-sed 's/new_name/old_name/' pkg/constants.bzl
+  bazel run //pkg:foo $EXTRA_BUILD_FLAGS >&$TEST_log || fail "third run failed"
+}
+
+function test_runfile_manifest_only_change_not_stale_legacy_bazel_version() {
+  if "$is_windows"; then
+    # Can't run shell scripts directly.
+    return
+  fi
+
+  mkdir -p pkg
+  cat > pkg/constants.bzl <<'EOF'
+SYMLINK_PATH = "old_name"
+EOF
+  cat > pkg/defs.bzl <<'EOF'
+load(":constants.bzl", "SYMLINK_PATH")
+
+def _my_script_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name)
+    print(SYMLINK_PATH)
+    ctx.actions.write(
+        out,
+        """#!/usr/bin/env sh
+set -eu
+[ -f {} ] || exit 1
+""".format(SYMLINK_PATH),
+        is_executable = True,
+    )
+    runfiles = ctx.runfiles(
+        symlinks = {
+            SYMLINK_PATH: out,
+        },
+    )
+    return [DefaultInfo(executable = out, runfiles = runfiles)]
+
+my_script = rule(
+    implementation = _my_script_impl,
+    executable = True,
+)
+EOF
+  cat > pkg/BUILD <<'EOF'
+load(":defs.bzl", "my_script")
+
+my_script(
+    name = "foo",
+)
+EOF
+
+  bazel run //pkg:foo $EXTRA_BUILD_FLAGS >&$TEST_log || fail "first run failed"
+
+  # Simulate the effect of an old version of Bazel that doesn't override the action cache entry and also symlinks
+  # instead of copies the input manifest to the output manifest.
+  inplace-sed 's/old_name/new_name/' bazel-bin/pkg/foo${EXT}.runfiles_manifest
+  rm bazel-bin/pkg/foo${EXT}.runfiles/MANIFEST
+  ln -s "$(pwd)/bazel-bin/pkg/foo${EXT}.runfiles_manifest" bazel-bin/pkg/foo${EXT}.runfiles/MANIFEST
+  mv bazel-bin/pkg/foo${EXT}.runfiles/_main/old_name bazel-bin/pkg/foo${EXT}.runfiles/_main/new_name
+
+  # Revert the symlink path.
+  inplace-sed 's/new_name/old_name/' pkg/constants.bzl
+  bazel run //pkg:foo $EXTRA_BUILD_FLAGS >&$TEST_log || fail "third run failed"
+}
+
 run_suite "runfiles"


### PR DESCRIPTION
`SymlinkTreeAction` is only executed for its side effect of updating the runfiles tree, but its up-to-dateness is tracked solely by the digest of its output, the manifest under the runfiles directory. If this manifest is a symlink to the input manifest and a previous build modified the runfiles directory while not updating the action cache entry for `SymlinkTreeAction`, this would cause Bazel to consider the action up-to-date even though the runfiles directory is stale.

The fix consists of two parts:
* Always copy the manifest instead of symlinking it, matching the behavior of the former `--noexperimental_inprocess_symlink_creation` flag. This fixes staleness issues when only using versions of Bazel with this fix.
* Detect stale state left behind by older versions of Bazel by skipping action cache hits if the output manifest is a symlink. Since this situation is no longer created by fixed versions of Bazel, we could consider removing this logic in the future.

Fixes #26818