### PR TITLE
Fix DefaultSyscallCache for normalizing filesystems

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -273,8 +273,9 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  public boolean isFilePathCaseSensitive() {
-    return localFs.isFilePathCaseSensitive();
+  public boolean mayBeCaseOrNormalizationInsensitive() {
+    return localFs.mayBeCaseOrNormalizationInsensitive()
+        || remoteOutputTree.mayBeCaseOrNormalizationInsensitive();
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1467,9 +1467,13 @@ java_library(
 
 java_library(
     name = "dirents",
-    srcs = ["Dirents.java"],
+    srcs = [
+        "CompactSortedDirents.java",
+        "Dirents.java",
+    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//third_party:guava",
         "//third_party:jsr305",
     ],
 )
@@ -1998,7 +2002,10 @@ java_library(
     name = "default_syscall_cache",
     srcs = ["DefaultSyscallCache.java"],
     deps = [
+        ":dirents",
+        "//src/main/java/com/google/devtools/build/lib/unsafe:string",
         "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//third_party:caffeine",
         "//third_party:error_prone_annotations",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/CompactSortedDirents.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/CompactSortedDirents.java
@@ -1,0 +1,139 @@
+package com.google.devtools.build.lib.skyframe;
+
+import com.google.common.base.Preconditions;
+import com.google.devtools.build.lib.vfs.Dirent;
+import java.util.AbstractCollection;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/** A space-efficient, sorted, immutable dirent structure. */
+final class CompactSortedDirents extends AbstractCollection<Dirent> implements Dirents {
+
+  private final String[] names;
+  private final BitSet packedTypes;
+
+  private CompactSortedDirents(String[] names, BitSet packedTypes) {
+    this.names = names;
+    this.packedTypes = packedTypes;
+  }
+
+  static CompactSortedDirents create(Collection<Dirent> dirents) {
+    final Dirent[] direntArray = dirents.toArray(Dirent[]::new);
+    Integer[] indices = new Integer[dirents.size()];
+    for (int i = 0; i < dirents.size(); i++) {
+      indices[i] = i;
+    }
+    Arrays.sort(indices, Comparator.comparing(o -> direntArray[o]));
+    String[] names = new String[dirents.size()];
+    BitSet packedTypes = new BitSet(dirents.size() * 2);
+    for (int i = 0; i < dirents.size(); i++) {
+      Dirent dirent = direntArray[indices[i]];
+      names[i] = dirent.getName();
+      packType(packedTypes, dirent.getType(), i);
+    }
+    return new CompactSortedDirents(names, packedTypes);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof CompactSortedDirents other)) {
+      return false;
+    }
+    if (this == obj) {
+      return true;
+    }
+    return Arrays.equals(names, other.names) && packedTypes.equals(other.packedTypes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(Arrays.hashCode(names), packedTypes);
+  }
+
+  @Override
+  @Nullable
+  public Dirent maybeGetDirent(String baseName) {
+    int pos = Arrays.binarySearch(names, baseName);
+    return pos < 0 ? null : direntAt(pos);
+  }
+
+  @Override
+  public Iterator<Dirent> iterator() {
+    return new Iterator<>() {
+
+      private int i = 0;
+
+      @Override
+      public boolean hasNext() {
+        return i < size();
+      }
+
+      @Override
+      public Dirent next() {
+        return direntAt(i++);
+      }
+
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  @Override
+  public int size() {
+    return names.length;
+  }
+
+  /** Returns the type of the ith dirent. */
+  private Dirent.Type unpackType(int i) {
+    int start = i * 2;
+    boolean upper = packedTypes.get(start);
+    boolean lower = packedTypes.get(start + 1);
+    if (!upper && !lower) {
+      return Dirent.Type.FILE;
+    } else if (!upper && lower) {
+      return Dirent.Type.DIRECTORY;
+    } else if (upper && !lower) {
+      return Dirent.Type.SYMLINK;
+    } else {
+      return Dirent.Type.UNKNOWN;
+    }
+  }
+
+  /** Sets the type of the ith dirent. */
+  private static void packType(BitSet bitSet, Dirent.Type type, int i) {
+    int start = i * 2;
+    switch (type) {
+      case FILE:
+        pack(bitSet, start, false, false);
+        break;
+      case DIRECTORY:
+        pack(bitSet, start, false, true);
+        break;
+      case SYMLINK:
+        pack(bitSet, start, true, false);
+        break;
+      case UNKNOWN:
+        pack(bitSet, start, true, true);
+        break;
+      default:
+        throw new IllegalStateException("Unknown dirent type: " + type);
+    }
+  }
+
+  private static void pack(BitSet bitSet, int start, boolean upper, boolean lower) {
+    bitSet.set(start, upper);
+    bitSet.set(start + 1, lower);
+  }
+
+  private Dirent direntAt(int i) {
+    Preconditions.checkState(i >= 0 && i < size(), "i: %s, size: %s", i, size());
+    return new Dirent(names[i], unpackType(i));
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/skyframe/DirectoryListingStateValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/DirectoryListingStateValue.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.skyframe;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerialization;
@@ -25,13 +24,7 @@ import com.google.devtools.build.skyframe.AbstractSkyKey;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
-import java.util.Arrays;
-import java.util.BitSet;
 import java.util.Collection;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.Objects;
-import javax.annotation.Nullable;
 
 /**
  * Encapsulates the filesystem operations needed to get the directory entries of a directory.
@@ -120,136 +113,4 @@ public final class DirectoryListingStateValue implements SkyValue {
         .toString();
   }
 
-  /** A space-efficient, sorted, immutable dirent structure. */
-  private static final class CompactSortedDirents implements Dirents {
-
-    private final String[] names;
-    private final BitSet packedTypes;
-
-    private CompactSortedDirents(String[] names, BitSet packedTypes) {
-      this.names = names;
-      this.packedTypes = packedTypes;
-    }
-
-    public static CompactSortedDirents create(Collection<Dirent> dirents) {
-      final Dirent[] direntArray = dirents.toArray(new Dirent[dirents.size()]);
-      Integer[] indices = new Integer[dirents.size()];
-      for (int i = 0; i < dirents.size(); i++) {
-        indices[i] = i;
-      }
-      Arrays.sort(indices,
-          new Comparator<Integer>() {
-            @Override
-            public int compare(Integer o1, Integer o2) {
-              return direntArray[o1].compareTo(direntArray[o2]);
-            }
-          });
-      String[] names = new String[dirents.size()];
-      BitSet packedTypes = new BitSet(dirents.size() * 2);
-      for (int i = 0; i < dirents.size(); i++) {
-        Dirent dirent = direntArray[indices[i]];
-        names[i] = dirent.getName();
-        packType(packedTypes, dirent.getType(), i);
-      }
-      return new CompactSortedDirents(names, packedTypes);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (!(obj instanceof CompactSortedDirents other)) {
-        return false;
-      }
-      if (this == obj) {
-        return true;
-      }
-      return Arrays.equals(names,  other.names) && packedTypes.equals(other.packedTypes);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(Arrays.hashCode(names), packedTypes);
-    }
-
-    @Override
-    @Nullable
-    public Dirent maybeGetDirent(String baseName) {
-      int pos = Arrays.binarySearch(names, baseName);
-      return pos < 0 ? null : direntAt(pos);
-    }
-
-    @Override
-    public Iterator<Dirent> iterator() {
-      return new Iterator<Dirent>() {
-
-        private int i = 0;
-
-        @Override
-        public boolean hasNext() {
-          return i < size();
-        }
-
-        @Override
-        public Dirent next() {
-          return direntAt(i++);
-        }
-
-        @Override
-        public void remove() {
-          throw new UnsupportedOperationException();
-        }
-      };
-    }
-
-    @Override
-    public int size() {
-      return names.length;
-    }
-
-    /** Returns the type of the ith dirent. */
-    private Dirent.Type unpackType(int i) {
-      int start = i * 2;
-      boolean upper = packedTypes.get(start);
-      boolean lower = packedTypes.get(start + 1);
-      if (!upper && !lower) {
-        return Dirent.Type.FILE;
-      } else if (!upper && lower){
-        return Dirent.Type.DIRECTORY;
-      } else if (upper && !lower) {
-        return Dirent.Type.SYMLINK;
-      } else {
-        return Dirent.Type.UNKNOWN;
-      }
-    }
-
-    /** Sets the type of the ith dirent. */
-    private static void packType(BitSet bitSet, Dirent.Type type, int i) {
-      int start = i * 2;
-      switch (type) {
-        case FILE:
-          pack(bitSet, start, false, false);
-          break;
-        case DIRECTORY:
-          pack(bitSet, start, false, true);
-          break;
-        case SYMLINK:
-          pack(bitSet, start, true, false);
-          break;
-        case UNKNOWN:
-          pack(bitSet, start, true, true);
-          break;
-        default:
-          throw new IllegalStateException("Unknown dirent type: " + type);
-      }
-    }
-
-    private static void pack(BitSet bitSet, int start, boolean upper, boolean lower) {
-      bitSet.set(start, upper);
-      bitSet.set(start + 1, lower);
-    }
-
-    private Dirent direntAt(int i) {
-      Preconditions.checkState(i >= 0 && i < size(), "i: %s, size: %s", i, size());
-      return new Dirent(names[i], unpackType(i));
-    }
-  }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/Dirents.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/Dirents.java
@@ -14,18 +14,15 @@
 package com.google.devtools.build.lib.skyframe;
 
 import com.google.devtools.build.lib.vfs.Dirent;
-
+import java.util.Collection;
 import javax.annotation.Nullable;
 
 /**
  * Interface for both iterating over the entries in a directory and getting the entry, if any, for a
  * given basename.
  */
-public interface Dirents extends Iterable<Dirent> {
-
-  int size();
+public interface Dirents extends Collection<Dirent> {
 
   @Nullable
   Dirent maybeGetDirent(String baseName);
 }
-

--- a/src/main/java/com/google/devtools/build/lib/unix/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/unix/BUILD
@@ -23,6 +23,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/jni",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/util:blocker",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",

--- a/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.unix.NativePosixFiles.Dirents;
 import com.google.devtools.build.lib.unix.NativePosixFiles.ReadTypes;
 import com.google.devtools.build.lib.unix.NativePosixFiles.StatErrorHandling;
 import com.google.devtools.build.lib.util.Blocker;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.StringEncoding;
 import com.google.devtools.build.lib.vfs.AbstractFileSystem;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
@@ -255,8 +256,8 @@ public class UnixFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  public boolean isFilePathCaseSensitive() {
-    return true;
+  public boolean mayBeCaseOrNormalizationInsensitive() {
+    return OS.getCurrent() == OS.DARWIN;
   }
 
   @Override
@@ -427,7 +428,7 @@ public class UnixFileSystem extends AbstractFileSystem {
 
   @Override
   public void deleteTreesBelow(PathFragment dir) throws IOException {
-    if (isDirectory(dir, /*followSymlinks=*/ false)) {
+    if (isDirectory(dir, /* followSymlinks= */ false)) {
       long startTime = Profiler.nanoTimeMaybe();
       var comp = Blocker.begin();
       try {

--- a/src/main/java/com/google/devtools/build/lib/vfs/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/vfs/BUILD
@@ -76,6 +76,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
         "//src/main/java/com/google/devtools/build/lib/util:filetype",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -150,9 +150,14 @@ public abstract class FileSystem {
   public abstract boolean supportsHardLinksNatively(PathFragment path);
 
   /***
-   * Returns true if file path is case-sensitive on this file system. Default is true.
+   * Returns true if file paths that differ as raw byte strings may refer to the same file system
+   * entry because of case insensitivity or Unicode normalization.
+   *
+   * <p>Note that common file systems on Windows and macOS that are case-insensitive by default
+   * can be configured to be case-sensitive, possibly even on a per-directory basis. Since it is not
+   * feasible for Bazel to detect this, these file systems must still return true.
    */
-  public abstract boolean isFilePathCaseSensitive();
+  public abstract boolean mayBeCaseOrNormalizationInsensitive();
 
   /**
    * Returns the type of the file system path belongs to.

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -19,6 +19,7 @@ import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.StringEncoding;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -49,7 +50,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   private static final LinkOption[] NO_LINK_OPTION = new LinkOption[0];
   // This isn't generally safe; we rely on the file system APIs not modifying the array.
   private static final LinkOption[] NOFOLLOW_LINKS_OPTION =
-      new LinkOption[] { LinkOption.NOFOLLOW_LINKS };
+      new LinkOption[] {LinkOption.NOFOLLOW_LINKS};
 
   private final Clock clock;
 
@@ -214,8 +215,8 @@ public class JavaIoFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  public boolean isFilePathCaseSensitive() {
-    return true;
+  public boolean mayBeCaseOrNormalizationInsensitive() {
+    return OS.getCurrent() == OS.DARWIN || OS.getCurrent() == OS.WINDOWS;
   }
 
   @Override
@@ -254,7 +255,7 @@ public class JavaIoFileSystem extends AbstractFileSystem {
     } catch (java.nio.file.FileAlreadyExistsException e) {
       // Files.createDirectories will handle this case normally, but if the existing
       // file is a symlink to a directory then it still throws. Swallow this.
-      if (!isDirectory(path, /*followSymlinks=*/ true)) {
+      if (!isDirectory(path, /* followSymlinks= */ true)) {
         throw e;
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
@@ -85,8 +85,8 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
   }
 
   @Override
-  public boolean isFilePathCaseSensitive() {
-    return delegateFs.isFilePathCaseSensitive();
+  public boolean mayBeCaseOrNormalizationInsensitive() {
+    return delegateFs.mayBeCaseOrNormalizationInsensitive();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/vfs/ReadonlyFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/ReadonlyFileSystem.java
@@ -66,11 +66,6 @@ public abstract class ReadonlyFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  public boolean isFilePathCaseSensitive() {
-    return true;
-  }
-
-  @Override
   public boolean createDirectory(PathFragment path) throws IOException {
     throw modificationException();
   }

--- a/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileSystem.java
@@ -455,8 +455,8 @@ public class InMemoryFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  public boolean isFilePathCaseSensitive() {
-    return OS.getCurrent() != OS.WINDOWS;
+  public boolean mayBeCaseOrNormalizationInsensitive() {
+    return false;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -128,8 +128,8 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
-  public boolean isFilePathCaseSensitive() {
-    return false;
+  public boolean mayBeCaseOrNormalizationInsensitive() {
+    return true;
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/vfs/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/vfs/BUILD
@@ -33,7 +33,7 @@ java_library(
     name = "SymlinkAwareFileSystemTest",
     srcs = ["SymlinkAwareFileSystemTest.java"],
     deps = [
-        ":testutil",
+        ":FileSystemTest_lib",
         "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs",
@@ -86,6 +86,7 @@ java_library(
     name = "FileSystemTest_lib",
     srcs = ["FileSystemTest.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/skyframe:default_syscall_cache",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs",
@@ -137,22 +138,5 @@ java_test(
     runtime_deps = [
         ":VfsWindowsTests_lib",
         "//src/test/java/com/google/devtools/build/lib:test_runner",
-    ],
-)
-
-java_library(
-    name = "testutil",
-    testonly = 1,
-    srcs = ["FileSystemTest.java"],
-    deps = [
-        "//src/main/java/com/google/devtools/build/lib/util",
-        "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
-        "//src/main/java/com/google/devtools/build/lib/vfs",
-        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
-        "//src/test/java/com/google/devtools/build/lib/testutil:TestUtils",
-        "//third_party:guava",
-        "//third_party:junit4",
-        "//third_party:truth",
-        "@maven//:com_google_testparameterinjector_test_parameter_injector",
     ],
 )

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.vfs;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.common.truth.TruthJUnit.assume;
 import static java.lang.Math.min;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
@@ -30,6 +31,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.io.BaseEncoding;
+import com.google.devtools.build.lib.skyframe.DefaultSyscallCache;
 import com.google.devtools.build.lib.testutil.TestUtils;
 import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.util.StringEncoding;
@@ -49,9 +51,11 @@ import java.nio.charset.Charset;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermission;
+import java.text.Normalizer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -91,7 +95,7 @@ public abstract class FileSystemTest {
   }
 
   @Before
-  public final void createDirectories() throws Exception  {
+  public final void createDirectories() throws Exception {
     testFS = getFreshFileSystem(digestHashFunction);
     workingDir = testFS.getPath(getTestTmpDir());
     cleanUpWorkingDirectory(workingDir);
@@ -126,17 +130,12 @@ public abstract class FileSystemTest {
     cleanUpWorkingDirectory(workingDir);
   }
 
-  /**
-   * Returns an instance of the file system to test.
-   */
+  /** Returns an instance of the file system to test. */
   protected abstract FileSystem getFreshFileSystem(DigestHashFunction digestHashFunction)
       throws IOException;
 
-  /**
-   * Cleans up the working directory by removing everything.
-   */
-  protected void cleanUpWorkingDirectory(Path workingPath)
-      throws IOException {
+  /** Cleans up the working directory by removing everything. */
+  protected void cleanUpWorkingDirectory(Path workingPath) throws IOException {
     if (workingPath.exists()) {
       removeEntireDirectory(workingPath.getPathFile().toPath()); // uses java.nio.file.Path!
     }
@@ -195,35 +194,35 @@ public abstract class FileSystemTest {
   }
 
   /**
-   * Returns the directory to use as the FileSystem's working directory.
-   * Canonicalized to make tests hermetic against symbolic links in TEST_TMPDIR.
+   * Returns the directory to use as the FileSystem's working directory. Canonicalized to make tests
+   * hermetic against symbolic links in TEST_TMPDIR.
    */
   protected final String getTestTmpDir() throws IOException {
     return new File(TestUtils.tmpDir()).getCanonicalPath() + "/testdir";
   }
 
   /**
-   * Indirection to create links so we can test FileSystems that do not support
-   * link creation.  For example, JavaFileSystemTest overrides this method
-   * and creates the link with an alternate FileSystem.
+   * Indirection to create links so we can test FileSystems that do not support link creation. For
+   * example, JavaFileSystemTest overrides this method and creates the link with an alternate
+   * FileSystem.
    */
   protected void createSymbolicLink(Path link, Path target) throws IOException {
     createSymbolicLink(link, target.asFragment());
   }
 
   /**
-   * Indirection to create links so we can test FileSystems that do not support
-   * link creation.  For example, JavaFileSystemTest overrides this method
-   * and creates the link with an alternate FileSystem.
+   * Indirection to create links so we can test FileSystems that do not support link creation. For
+   * example, JavaFileSystemTest overrides this method and creates the link with an alternate
+   * FileSystem.
    */
   protected void createSymbolicLink(Path link, PathFragment target) throws IOException {
     link.createSymbolicLink(target);
   }
 
   /**
-   * Indirection to {@link Path#setExecutable(boolean)} on FileSystems that do
-   * not support setExecutable.  For example, JavaFileSystemTest overrides this
-   * method and makes the Path executable with an alternate FileSystem.
+   * Indirection to {@link Path#setExecutable(boolean)} on FileSystems that do not support
+   * setExecutable. For example, JavaFileSystemTest overrides this method and makes the Path
+   * executable with an alternate FileSystem.
    */
   protected void setExecutable(Path target, boolean mode) throws IOException {
     target.setExecutable(mode);
@@ -700,8 +699,8 @@ public abstract class FileSystemTest {
   public void testGetDirectoryEntriesThrowsExceptionWhenRunOnFile() throws Exception {
     IOException ex = assertThrows(IOException.class, () -> xFile.getDirectoryEntries());
     if (ex instanceof FileNotFoundException) {
-        fail("The method should throw an object of class IOException.");
-      }
+      fail("The method should throw an object of class IOException.");
+    }
     assertThat(ex).hasMessageThat().endsWith(xFile + " (Not a directory)");
   }
 
@@ -1523,8 +1522,7 @@ public abstract class FileSystemTest {
       outStream.write(1);
     }
 
-    try (OutputStream noAppendOut = xFile.getOutputStream(false)) {
-    }
+    try (OutputStream noAppendOut = xFile.getOutputStream(false)) {}
 
     try (InputStream inStream = xFile.getInputStream()) {
       assertThat(inStream.read()).isEqualTo(-1);
@@ -2151,5 +2149,44 @@ public abstract class FileSystemTest {
       assertThat(tempDirs).doesNotContain(tempDir);
       tempDirs.add(tempDir);
     }
+  }
+
+  @Test
+  public void testTypeViaReaddirCache(
+      @TestParameter({
+            "BUILD", "Å", "K", "Ａ", "ａ", "０", " 𝐀", "𝐴", "𝒜", "Ⅳ", "Ⓑ", "ẞ", "ß", "Ä", "İ", "ı"
+          })
+          String entry)
+      throws Exception {
+    var normalizedEntry =
+        Normalizer.normalize(entry, Normalizer.Form.NFC)
+            .toUpperCase(Locale.ROOT)
+            .toLowerCase(Locale.ROOT);
+    validateGetTypeConsistency(workingDir, entry, normalizedEntry);
+    validateGetTypeConsistency(workingDir, normalizedEntry, entry);
+  }
+
+  private void validateGetTypeConsistency(Path baseDir, String entryToCreate, String entryToCheck)
+      throws IOException {
+    var dir = baseDir.createTempDirectory("readdir_cache-");
+    var pathToCreate = dir.getChild(StringEncoding.unicodeToInternal(entryToCreate));
+    FileSystemUtils.createEmptyFile(pathToCreate);
+
+    var syscallCache = DefaultSyscallCache.newBuilder().build();
+    // Prime the cache by reading the parent directory.
+    syscallCache.readdir(dir);
+    assertWithMessage("expecting entry %s to exist", entryToCreate)
+        .that(syscallCache.getType(pathToCreate, Symlinks.FOLLOW))
+        .isNotNull();
+
+    var pathToCheck = dir.getChild(StringEncoding.unicodeToInternal(entryToCheck));
+    var existsWithCache = syscallCache.getType(pathToCheck, Symlinks.FOLLOW) != null;
+    var existsWithoutCache = pathToCheck.statIfFound() != null;
+    assertWithMessage("created : %s", entryToCreate)
+        .withMessage("checking: %s", entryToCheck)
+        .withMessage("with cache: %s", existsWithCache)
+        .withMessage("w/o cache : %s", existsWithoutCache)
+        .that(existsWithCache)
+        .isEqualTo(existsWithoutCache);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/windows/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/windows/BUILD
@@ -36,7 +36,9 @@ java_test(
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/shell",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:default_syscall_cache",
         "//src/main/java/com/google/devtools/build/lib/util:os",
+        "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/lib/windows",


### PR DESCRIPTION
`DefaultSyscallCache` includes an optimization that answers a query for a file's type via a cached `readdir` result. This optimization didn't work correctly on macOS and Windows for various reasons: it hardcoded whether a file system on these OSes is case-insensitive, didn't reencode strings properly and also ignored Unicode normalization. 

This is fixed by only making assumptions about the case mapping and normalization behavior of ASCII strings, which still allows this optimization to apply to the common case of a `BUILD` file existence check in a directory with only ASCII file names.

Along the way and since any OS now begins with an exact search in the list of `Dirent`s, migrate to `CompactSortedDirents` for reduced peak memory usage.