### PR TITLE
Fix stashing sandboxes if unable to move directory to _moved_trash_dir

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AsynchronousTreeDeleter.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AsynchronousTreeDeleter.java
@@ -97,7 +97,14 @@ public class AsynchronousTreeDeleter implements TreeDeleter {
       return;
     }
     Path trashPath = trashBase.getRelative(Integer.toString(trashCount.getAndIncrement()));
-    path.renameTo(trashPath);
+    try {
+        path.renameTo(trashPath);
+    } catch (IOException e) {
+        logger.atWarning().withCause(e).log(
+            "Failed to rename %s -> %s for asynchronous removal. Removing synchronously.", path, trashPath);
+        path.deleteTree();
+        return;
+    }
     checkNotNull(service, "Cannot call deleteTree after shutdown")
         .execute(
             () -> {

--- a/src/test/shell/integration/sandboxing_test.sh
+++ b/src/test/shell/integration/sandboxing_test.sh
@@ -951,12 +951,13 @@ EOF
 
   local output_base="$(bazel info output_base)"
   local bazel_bin="$(bazel info bazel-bin)"
+  local bazel_bin_reldir="${bazel_bin#$output_base}"
 
   bazel test --reuse_sandbox_directories //pkg:create_readonly_dir_in_pwd >"${TEST_log}" 2>&1 \
     || fail "Expected first test to succeed"
 
   local sandbox_stash="${output_base}/sandbox/sandbox_stash"
-  [[ -d "${sandbox_stash}/TestRunner/3/execroot/_main/bazel-out/k8-fastbuild/bin/pkg/create_readonly_dir_in_pwd.runfiles/_main/readonly_dir" ]] \
+  [[ -d "${sandbox_stash}/TestRunner/3/$bazel_bin_reldir/pkg/create_readonly_dir_in_pwd.runfiles/_main/readonly_dir" ]] \
     || fail "${sandbox_stash} did not stash readonly_dir"
 
   bazel test --reuse_sandbox_directories --nocache_test_results //pkg:create_readonly_dir_in_pwd >"${TEST_log}" 2>&1 \


### PR DESCRIPTION
Fix for https://github.com/bazelbuild/bazel/issues/26846

If cannot move directory to `_moved_trash_dir` the delete this directory in-place. 