### PR TITLE
[8.4.0] Add `--module_mirrors`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -16,12 +16,14 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.bazel.bzlmod.ArchiveRepoSpecBuilder.RemoteFile;
 import com.google.devtools.build.lib.bazel.bzlmod.Version.ParseException;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
@@ -45,10 +47,12 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /**
@@ -94,6 +98,8 @@ public class IndexRegistry implements Registry {
   private final ImmutableMap<ModuleKey, String> previouslySelectedYankedVersions;
   @Nullable private final VendorManager vendorManager;
   private final KnownFileHashesMode knownFileHashesMode;
+  private final ImmutableSet<URI> moduleMirrors;
+
   private volatile Optional<BazelRegistryJson> bazelRegistryJson;
   private volatile StoredEventHandler bazelRegistryJsonEvents;
 
@@ -105,7 +111,8 @@ public class IndexRegistry implements Registry {
       ImmutableMap<String, Optional<Checksum>> knownFileHashes,
       KnownFileHashesMode knownFileHashesMode,
       ImmutableMap<ModuleKey, String> previouslySelectedYankedVersions,
-      Optional<Path> vendorDir) {
+      Optional<Path> vendorDir,
+      ImmutableSet<URI> moduleMirrors) {
     this.uri = uri;
     this.clientEnv = clientEnv;
     this.gson =
@@ -116,6 +123,7 @@ public class IndexRegistry implements Registry {
     this.knownFileHashesMode = knownFileHashesMode;
     this.previouslySelectedYankedVersions = previouslySelectedYankedVersions;
     this.vendorManager = vendorDir.map(VendorManager::new).orElse(null);
+    this.moduleMirrors = moduleMirrors;
   }
 
   @Override
@@ -454,19 +462,24 @@ public class IndexRegistry implements Registry {
       throw new IOException(String.format("Missing integrity for module %s", key));
     }
 
+    // Give precedence to mirror specified via the command-line flag.
+    var allMirrors =
+        Stream.concat(
+                moduleMirrors.stream().map(URI::toString),
+                bazelRegistryJson.flatMap(json -> Optional.ofNullable(json.mirrors)).stream()
+                    .flatMap(Arrays::stream))
+            .collect(toImmutableSet());
     ImmutableList.Builder<String> urls = new ImmutableList.Builder<>();
     // For each mirror specified in bazel_registry.json, add a URL that's essentially the mirror
     // URL concatenated with the source URL.
-    if (bazelRegistryJson.isPresent() && bazelRegistryJson.get().mirrors != null) {
-      for (String mirror : bazelRegistryJson.get().mirrors) {
-        try {
-          var unused = new URL(mirror);
-        } catch (MalformedURLException e) {
-          throw new IOException("Malformed mirror URL", e);
-        }
-
-        urls.add(constructUrl(mirror, sourceUrl.getAuthority(), sourceUrl.getFile()));
+    for (String mirror : allMirrors) {
+      try {
+        var unused = new URL(mirror);
+      } catch (MalformedURLException e) {
+        throw new IOException("Malformed mirror URL", e);
       }
+
+      urls.add(constructUrl(mirror, sourceUrl.getAuthority(), sourceUrl.getFile()));
     }
     // Add the original source URL itself.
     urls.add(sourceUrl.toString());

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactory.java
@@ -16,6 +16,7 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.vfs.Path;
@@ -35,6 +36,7 @@ public interface RegistryFactory {
       RepositoryOptions.LockfileMode lockfileMode,
       ImmutableMap<String, Optional<Checksum>> fileHashes,
       ImmutableMap<ModuleKey, String> previouslySelectedYankedVersions,
-      Optional<Path> vendorDir)
+      Optional<Path> vendorDir,
+      ImmutableSet<String> moduleMirrors)
       throws URISyntaxException;
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryImpl.java
@@ -16,6 +16,7 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.bazel.bzlmod.IndexRegistry.KnownFileHashesMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
@@ -40,7 +41,8 @@ public class RegistryFactoryImpl implements RegistryFactory {
       LockfileMode lockfileMode,
       ImmutableMap<String, Optional<Checksum>> knownFileHashes,
       ImmutableMap<ModuleKey, String> previouslySelectedYankedVersions,
-      Optional<Path> vendorDir)
+      Optional<Path> vendorDir,
+      ImmutableSet<String> moduleMirrors)
       throws URISyntaxException {
     URI uri = new URI(url);
     if (uri.getScheme() == null) {
@@ -67,12 +69,17 @@ public class RegistryFactoryImpl implements RegistryFactory {
           default ->
               throw new URISyntaxException(uri.toString(), "Unrecognized registry URL protocol");
         };
+    var moduleMirrorUris = ImmutableSet.<URI>builderWithExpectedSize(moduleMirrors.size());
+    for (var moduleMirror : moduleMirrors) {
+      moduleMirrorUris.add(new URI(moduleMirror));
+    }
     return new IndexRegistry(
         uri,
         clientEnvironmentSupplier.get(),
         knownFileHashes,
         knownFileHashesMode,
         previouslySelectedYankedVersions,
-        vendorDir);
+        vendorDir,
+        moduleMirrorUris.build());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFunction.java
@@ -15,6 +15,7 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
 import com.google.devtools.build.lib.rules.repository.RepositoryDelegatorFunction;
 import com.google.devtools.build.lib.server.FailureDetails;
@@ -40,6 +41,9 @@ public class RegistryFunction implements SkyFunction {
   public static final Precomputed<Instant> LAST_INVALIDATION =
       new Precomputed<>("last_registry_invalidation");
 
+  public static final Precomputed<ImmutableSet<String>> MODULE_MIRRORS =
+      new Precomputed<>("module_mirrors");
+
   /**
    * The interval after which the mutable registry contents cached in memory should be refreshed.
    */
@@ -61,7 +65,7 @@ public class RegistryFunction implements SkyFunction {
     Optional<Path> vendorDir = RepositoryDelegatorFunction.VENDOR_DIRECTORY.get(env);
 
     if (lockfileMode == LockfileMode.REFRESH) {
-      RegistryFunction.LAST_INVALIDATION.get(env);
+      LAST_INVALIDATION.get(env);
     }
 
     BazelLockFileValue lockfile = (BazelLockFileValue) env.getValue(BazelLockFileValue.KEY);
@@ -76,7 +80,8 @@ public class RegistryFunction implements SkyFunction {
           lockfileMode,
           lockfile.getRegistryFileHashes(),
           lockfile.getSelectedYankedVersions(),
-          vendorDir);
+          vendorDir,
+          MODULE_MIRRORS.get(env));
     } catch (URISyntaxException e) {
       throw new RegistryException(
           ExternalDepsException.withCauseAndMessage(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -19,6 +19,7 @@ import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.util.OptionsUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.common.options.Converter;
+import com.google.devtools.common.options.Converters;
 import com.google.devtools.common.options.Converters.DurationConverter;
 import com.google.devtools.common.options.EnumConverter;
 import com.google.devtools.common.options.Option;
@@ -101,6 +102,22 @@ public class RepositoryOptions extends OptionsBase {
               + " important: modules will be looked up in earlier registries first, and only fall"
               + " back to later registries when they're missing from the earlier ones.")
   public List<String> registries;
+
+  @Option(
+      name = "module_mirrors",
+      defaultValue = "null",
+      converter = Converters.CommaSeparatedNonEmptyOptionListConverter.class,
+      documentationCategory = OptionDocumentationCategory.BZLMOD,
+      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+      help =
+          """
+          A comma-separated list of URLs under which the source URLs of Bazel modules can be found,
+          in addition to and taking precedence over any registry-provided mirror URLs. Set this to
+          an empty value to disable the use of any mirrors not specified by the registries. The
+          default set of mirrors may change over time, but all downloads from mirrors are verified
+          by hashes stored in the registry (and thus pinned by the lockfile).
+          """)
+  public List<String> moduleMirrors;
 
   @Option(
       name = "allow_yanked_versions",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoader.java
@@ -119,6 +119,8 @@ public class BazelPackageLoader extends AbstractPackageLoader {
           PrecomputedValue.injected(RepositoryDelegatorFunction.VENDOR_DIRECTORY, Optional.empty()),
           PrecomputedValue.injected(
               ModuleFileFunction.REGISTRIES, BazelRepositoryModule.DEFAULT_REGISTRIES),
+          PrecomputedValue.injected(
+              RegistryFunction.MODULE_MIRRORS, BazelRepositoryModule.DEFAULT_MODULE_MIRRORS),
           PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
           PrecomputedValue.injected(RepositoryDelegatorFunction.DISABLE_NATIVE_REPO_RULES, false),
           PrecomputedValue.injected(

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisMock.java
@@ -266,6 +266,7 @@ public abstract class AnalysisMock extends LoadingMock {
         PrecomputedValue.injected(RepositoryDelegatorFunction.VENDOR_DIRECTORY, Optional.empty()),
         PrecomputedValue.injected(RepositoryDelegatorFunction.DISABLE_NATIVE_REPO_RULES, false),
         PrecomputedValue.injected(ModuleFileFunction.REGISTRIES, ImmutableSet.of()),
+        PrecomputedValue.injected(RegistryFunction.MODULE_MIRRORS, ImmutableSet.of()),
         PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
         PrecomputedValue.injected(ModuleFileFunction.INJECTED_REPOSITORIES, ImmutableMap.of()),
         PrecomputedValue.injected(ModuleFileFunction.MODULE_OVERRIDES, ImmutableMap.of()),

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisTestCase.java
@@ -49,6 +49,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelLockFileFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.RegistryFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
@@ -239,6 +240,7 @@ public abstract class AnalysisTestCase extends FoundationTestCase {
                 ImmutableList.of(
                     PrecomputedValue.injected(
                         ModuleFileFunction.REGISTRIES, ImmutableSet.of(registry.getUrl())),
+                    PrecomputedValue.injected(RegistryFunction.MODULE_MIRRORS, ImmutableSet.of()),
                     PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
                     PrecomputedValue.injected(
                         ModuleFileFunction.INJECTED_REPOSITORIES, ImmutableMap.of()),
@@ -301,6 +303,7 @@ public abstract class AnalysisTestCase extends FoundationTestCase {
                 RepositoryDelegatorFunction.VENDOR_DIRECTORY, Optional.empty()),
             PrecomputedValue.injected(
                 ModuleFileFunction.REGISTRIES, ImmutableSet.of(registry.getUrl())),
+            PrecomputedValue.injected(RegistryFunction.MODULE_MIRRORS, ImmutableSet.of()),
             PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
             PrecomputedValue.injected(ModuleFileFunction.INJECTED_REPOSITORIES, ImmutableMap.of()),
             PrecomputedValue.injected(RepositoryDelegatorFunction.DISABLE_NATIVE_REPO_RULES, false),

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
@@ -153,6 +153,7 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
     ModuleFileFunction.IGNORE_DEV_DEPS.set(differencer, false);
     ModuleFileFunction.INJECTED_REPOSITORIES.set(differencer, ImmutableMap.of());
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of());
+    RegistryFunction.MODULE_MIRRORS.set(differencer, ImmutableSet.of());
     ModuleFileFunction.MODULE_OVERRIDES.set(differencer, ImmutableMap.of());
     BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES.set(
         differencer, CheckDirectDepsMode.OFF);

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
@@ -177,6 +177,7 @@ public class BazelModuleResolutionFunctionTest extends FoundationTestCase {
     PrecomputedValue.STARLARK_SEMANTICS.set(
         differencer,
         StarlarkSemantics.builder().setBool(BuildLanguageOptions.ENABLE_BZLMOD, true).build());
+    RegistryFunction.MODULE_MIRRORS.set(differencer, ImmutableSet.of());
     ModuleFileFunction.IGNORE_DEV_DEPS.set(differencer, false);
     ModuleFileFunction.INJECTED_REPOSITORIES.set(differencer, ImmutableMap.of());
     ModuleFileFunction.MODULE_OVERRIDES.set(differencer, ImmutableMap.of());

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleFunctionTest.java
@@ -154,6 +154,7 @@ public final class BzlmodRepoRuleFunctionTest extends FoundationTestCase {
 
     PrecomputedValue.STARLARK_SEMANTICS.set(differencer, StarlarkSemantics.DEFAULT);
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of());
+    RegistryFunction.MODULE_MIRRORS.set(differencer, ImmutableSet.of());
     ModuleFileFunction.IGNORE_DEV_DEPS.set(differencer, false);
     ModuleFileFunction.INJECTED_REPOSITORIES.set(differencer, ImmutableMap.of());
     ModuleFileFunction.MODULE_OVERRIDES.set(differencer, ImmutableMap.of());

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
@@ -235,6 +235,7 @@ public class DiscoveryTest extends FoundationTestCase {
     ModuleFileFunction.MODULE_OVERRIDES.set(differencer, ImmutableMap.of());
     YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
     BazelLockFileFunction.LOCKFILE_MODE.set(differencer, LockfileMode.UPDATE);
+    RegistryFunction.MODULE_MIRRORS.set(differencer, ImmutableSet.of());
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
@@ -230,6 +230,7 @@ public class DiscoveryTest extends FoundationTestCase {
         differencer, Optional.empty());
     RepositoryDelegatorFunction.DISABLE_NATIVE_REPO_RULES.set(differencer, true);
     PrecomputedValue.REPO_ENV.set(differencer, ImmutableMap.of());
+    RegistryFunction.MODULE_MIRRORS.set(differencer, ImmutableSet.of());
     ModuleFileFunction.IGNORE_DEV_DEPS.set(differencer, false);
     ModuleFileFunction.INJECTED_REPOSITORIES.set(differencer, ImmutableMap.of());
     ModuleFileFunction.MODULE_OVERRIDES.set(differencer, ImmutableMap.of());

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/FakeRegistry.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/FakeRegistry.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
@@ -140,7 +141,8 @@ public class FakeRegistry implements Registry {
         LockfileMode lockfileMode,
         ImmutableMap<String, Optional<Checksum>> fileHashes,
         ImmutableMap<ModuleKey, String> previouslySelectedYankedVersions,
-        Optional<Path> vendorDir) {
+        Optional<Path> vendorDir,
+        ImmutableSet<String> moduleMirrors) {
       return Preconditions.checkNotNull(registries.get(url), "unknown registry url: %s", url);
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.hash.Hashing;
@@ -100,7 +101,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             LockfileMode.UPDATE,
             ImmutableMap.of(),
             ImmutableMap.of(),
-            Optional.empty());
+            Optional.empty(),
+            ImmutableSet.of());
     assertThat(registry.getModuleFile(createModuleKey("foo", "1.0"), reporter, downloadManager))
         .isEqualTo(
             ModuleFile.create(
@@ -124,7 +126,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             LockfileMode.UPDATE,
             ImmutableMap.of(),
             ImmutableMap.of(),
-            Optional.empty());
+            Optional.empty(),
+            ImmutableSet.of());
 
     var e =
         assertThrows(
@@ -160,7 +163,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             LockfileMode.UPDATE,
             ImmutableMap.of(),
             ImmutableMap.of(),
-            Optional.empty());
+            Optional.empty(),
+            ImmutableSet.of());
     assertThat(registry.getModuleFile(createModuleKey("foo", "1.0"), reporter, downloadManager))
         .isEqualTo(ModuleFile.create("lol".getBytes(UTF_8), file.toURI().toString()));
     assertThrows(
@@ -228,7 +232,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             LockfileMode.UPDATE,
             ImmutableMap.of(),
             ImmutableMap.of(),
-            Optional.empty());
+            Optional.empty(),
+            ImmutableSet.of("https://my.mirror"));
     assertThat(
             registry.getRepoSpec(
                 createModuleKey("foo", "1.0"), moduleFileRegistryHashes, reporter, downloadManager))
@@ -236,6 +241,7 @@ public class IndexRegistryTest extends FoundationTestCase {
             new ArchiveRepoSpecBuilder()
                 .setUrls(
                     ImmutableList.of(
+                        "https://my.mirror/mysite.com/thing.zip",
                         "https://mirror.bazel.build/mysite.com/thing.zip",
                         "file:///home/bazel/mymirror/mysite.com/thing.zip",
                         "http://mysite.com/thing.zip",
@@ -259,6 +265,7 @@ public class IndexRegistryTest extends FoundationTestCase {
             new ArchiveRepoSpecBuilder()
                 .setUrls(
                     ImmutableList.of(
+                        "https://my.mirror/example.com/archive.jar?with=query",
                         "https://mirror.bazel.build/example.com/archive.jar?with=query",
                         "file:///home/bazel/mymirror/example.com/archive.jar?with=query",
                         "https://example.com/archive.jar?with=query"))
@@ -284,6 +291,7 @@ public class IndexRegistryTest extends FoundationTestCase {
             new ArchiveRepoSpecBuilder()
                 .setUrls(
                     ImmutableList.of(
+                        "https://my.mirror/example.com/archive.jar?with=query",
                         "https://mirror.bazel.build/example.com/archive.jar?with=query",
                         "file:///home/bazel/mymirror/example.com/archive.jar?with=query",
                         "https://example.com/archive.jar?with=query"))
@@ -341,7 +349,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             LockfileMode.UPDATE,
             ImmutableMap.of(),
             ImmutableMap.of(),
-            Optional.empty());
+            Optional.empty(),
+            ImmutableSet.of());
     assertThat(
             registry.getRepoSpec(
                 createModuleKey("foo", "1.0"), moduleFileRegistryHashes, reporter, downloadManager))
@@ -376,7 +385,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             LockfileMode.UPDATE,
             ImmutableMap.of(),
             ImmutableMap.of(),
-            Optional.empty());
+            Optional.empty(),
+            ImmutableSet.of());
     assertThat(
             registry.getRepoSpec(
                 createModuleKey("foo", "1.0"), ImmutableMap.of(), reporter, downloadManager))
@@ -402,7 +412,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             LockfileMode.UPDATE,
             ImmutableMap.of(),
             ImmutableMap.of(),
-            Optional.empty());
+            Optional.empty(),
+            ImmutableSet.of());
     assertThat(
             registry.getRepoSpec(
                 createModuleKey("foo", "1.0"),
@@ -452,7 +463,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             LockfileMode.UPDATE,
             ImmutableMap.of(),
             ImmutableMap.of(),
-            Optional.empty());
+            Optional.empty(),
+            ImmutableSet.of());
     assertThrows(
         IOException.class,
         () ->
@@ -488,7 +500,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             LockfileMode.UPDATE,
             ImmutableMap.of(),
             ImmutableMap.of(),
-            Optional.empty());
+            Optional.empty(),
+            ImmutableSet.of());
     Optional<ImmutableMap<Version, String>> yankedVersion =
         registry.getYankedVersions("red-pill", reporter, downloadManager);
     assertThat(yankedVersion)
@@ -518,7 +531,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             LockfileMode.UPDATE,
             ImmutableMap.of(),
             ImmutableMap.of(),
-            Optional.empty());
+            Optional.empty(),
+            ImmutableSet.of());
     assertThat(
             registry.getRepoSpec(
                 createModuleKey("archive_type", "1.0"),
@@ -565,7 +579,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             LockfileMode.UPDATE,
             knownFiles,
             ImmutableMap.of(),
-            Optional.empty());
+            Optional.empty(),
+            ImmutableSet.of());
     assertThat(registry.getModuleFile(createModuleKey("foo", "1.0"), reporter, downloadManager))
         .isEqualTo(
             ModuleFile.create(
@@ -601,7 +616,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             LockfileMode.UPDATE,
             recordedChecksums,
             ImmutableMap.of(),
-            Optional.empty());
+            Optional.empty(),
+            ImmutableSet.of());
     // Test that the recorded hashes are used for repo cache hits even when the server content
     // changes.
     server.unserve("/myreg/modules/foo/1.0/MODULE.bazel");
@@ -645,7 +661,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             LockfileMode.UPDATE,
             knownFiles,
             ImmutableMap.of(),
-            Optional.empty());
+            Optional.empty(),
+            ImmutableSet.of());
     var e =
         assertThrows(
             IOException.class,
@@ -686,7 +703,12 @@ public class IndexRegistryTest extends FoundationTestCase {
             server.getUrl() + "/modules/foo/2.0/source.json", Optional.of(sha256("unused")));
     Registry registry =
         registryFactory.createRegistry(
-            server.getUrl(), LockfileMode.UPDATE, knownFiles, ImmutableMap.of(), Optional.empty());
+            server.getUrl(),
+            LockfileMode.UPDATE,
+            knownFiles,
+            ImmutableMap.of(),
+            Optional.empty(),
+            ImmutableSet.of());
     assertThat(
             registry.getRepoSpec(
                 createModuleKey("foo", "1.0"), ImmutableMap.of(), reporter, downloadManager))
@@ -707,7 +729,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             LockfileMode.UPDATE,
             recordedChecksums,
             ImmutableMap.of(),
-            Optional.empty());
+            Optional.empty(),
+            ImmutableSet.of());
     // Test that the recorded hashes are used for repo cache hits even when the server content
     // changes.
     server.unserve("/bazel_registry.json");
@@ -748,7 +771,12 @@ public class IndexRegistryTest extends FoundationTestCase {
             Optional.of(sha256(sourceJson)));
     Registry registry =
         registryFactory.createRegistry(
-            server.getUrl(), LockfileMode.UPDATE, knownFiles, ImmutableMap.of(), Optional.empty());
+            server.getUrl(),
+            LockfileMode.UPDATE,
+            knownFiles,
+            ImmutableMap.of(),
+            Optional.empty(),
+            ImmutableSet.of());
     var e =
         assertThrows(
             IOException.class,
@@ -795,7 +823,12 @@ public class IndexRegistryTest extends FoundationTestCase {
             Optional.of(sha256(sourceJson)));
     Registry registry =
         registryFactory.createRegistry(
-            server.getUrl(), LockfileMode.UPDATE, knownFiles, ImmutableMap.of(), Optional.empty());
+            server.getUrl(),
+            LockfileMode.UPDATE,
+            knownFiles,
+            ImmutableMap.of(),
+            Optional.empty(),
+            ImmutableSet.of());
     var e =
         assertThrows(
             IOException.class,

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -286,6 +286,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
     ModuleFileFunction.MODULE_OVERRIDES.set(differencer, ImmutableMap.of());
     YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+    RegistryFunction.MODULE_MIRRORS.set(differencer, ImmutableSet.of());
     BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES.set(
         differencer, CheckDirectDepsMode.WARNING);
     BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE.set(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -216,6 +216,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
     ModuleFileFunction.MODULE_OVERRIDES.set(differencer, ImmutableMap.of());
     YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
     BazelLockFileFunction.LOCKFILE_MODE.set(differencer, LockfileMode.UPDATE);
+    RegistryFunction.MODULE_MIRRORS.set(differencer, ImmutableSet.of());
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -210,6 +210,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
     RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE.set(
         differencer, Optional.empty());
     RepositoryDelegatorFunction.DISABLE_NATIVE_REPO_RULES.set(differencer, true);
+    RegistryFunction.MODULE_MIRRORS.set(differencer, ImmutableSet.of());
     PrecomputedValue.REPO_ENV.set(differencer, ImmutableMap.of());
     ModuleFileFunction.IGNORE_DEV_DEPS.set(differencer, false);
     ModuleFileFunction.INJECTED_REPOSITORIES.set(differencer, ImmutableMap.of());

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
 import java.net.URISyntaxException;
 import java.util.Optional;
@@ -44,7 +45,8 @@ public class RegistryFactoryTest {
                     LockfileMode.UPDATE,
                     ImmutableMap.of(),
                     ImmutableMap.of(),
-                    Optional.empty()));
+                    Optional.empty(),
+                    ImmutableSet.of()));
     assertThat(exception).hasMessageThat().contains("Registry URL has no scheme");
     exception =
         assertThrows(
@@ -55,7 +57,8 @@ public class RegistryFactoryTest {
                     LockfileMode.UPDATE,
                     ImmutableMap.of(),
                     ImmutableMap.of(),
-                    Optional.empty()));
+                    Optional.empty(),
+                    ImmutableSet.of()));
     assertThat(exception).hasMessageThat().contains("Unrecognized registry URL protocol");
   }
 
@@ -72,7 +75,8 @@ public class RegistryFactoryTest {
                     LockfileMode.UPDATE,
                     ImmutableMap.of(),
                     ImmutableMap.of(),
-                    Optional.empty()));
+                    Optional.empty(),
+                    ImmutableSet.of()));
     assertThat(exception).hasMessageThat().contains("Registry URL path is not valid");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/query2/testutil/SkyframeQueryHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/testutil/SkyframeQueryHelper.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleKey;
+import com.google.devtools.build.lib.bazel.bzlmod.RegistryFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
@@ -404,6 +405,7 @@ public abstract class SkyframeQueryHelper extends AbstractQueryHelper<Target> {
                         ModuleFileFunction.MODULE_OVERRIDES, ImmutableMap.of()),
                     PrecomputedValue.injected(
                         ModuleFileFunction.REGISTRIES, ImmutableSet.of(registry.getUrl())),
+                    PrecomputedValue.injected(RegistryFunction.MODULE_MIRRORS, ImmutableSet.of()),
                     PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
                     PrecomputedValue.injected(
                         ModuleFileFunction.INJECTED_REPOSITORIES, ImmutableMap.of()),
@@ -443,6 +445,7 @@ public abstract class SkyframeQueryHelper extends AbstractQueryHelper<Target> {
                 RepositoryDelegatorFunction.VENDOR_DIRECTORY, Optional.empty()),
             PrecomputedValue.injected(
                 ModuleFileFunction.REGISTRIES, ImmutableSet.of(registry.getUrl())),
+            PrecomputedValue.injected(RegistryFunction.MODULE_MIRRORS, ImmutableSet.of()),
             PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
             PrecomputedValue.injected(ModuleFileFunction.INJECTED_REPOSITORIES, ImmutableMap.of()),
             PrecomputedValue.injected(RepositoryDelegatorFunction.DISABLE_NATIVE_REPO_RULES, false),

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
@@ -295,6 +295,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
     BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE.set(
         differencer, BazelCompatibilityMode.ERROR);
     BazelLockFileFunction.LOCKFILE_MODE.set(differencer, LockfileMode.UPDATE);
+    RegistryFunction.MODULE_MIRRORS.set(differencer, ImmutableSet.of());
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PrepareDepsOfPatternsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PrepareDepsOfPatternsFunctionTest.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleKey;
+import com.google.devtools.build.lib.bazel.bzlmod.RegistryFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.Version;
 import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
@@ -62,7 +63,7 @@ public class PrepareDepsOfPatternsFunctionTest extends BuildViewTestCase {
   @Test
   public void testFunctionLoadsTargetAndNotUnspecifiedTargets() throws Exception {
     // Given a package "//foo" with independent target rules ":foo" and ":foo2",
-    createFooAndFoo2(/*dependent=*/ false);
+    createFooAndFoo2(/* dependent= */ false);
 
     // Given a target pattern sequence consisting of a single-target pattern for "//foo",
     ImmutableList<String> patternSequence = ImmutableList.of("//foo");
@@ -81,7 +82,7 @@ public class PrepareDepsOfPatternsFunctionTest extends BuildViewTestCase {
   public void testFunctionLoadsTargetDependencies() throws Exception {
     // Given a package "//foo" with target rules ":foo" and ":foo2",
     // And given ":foo" depends on ":foo2",
-    createFooAndFoo2(/*dependent=*/ true);
+    createFooAndFoo2(/* dependent= */ true);
 
     // Given a target pattern sequence consisting of a single-target pattern for "//foo",
     ImmutableList<String> patternSequence = ImmutableList.of("//foo");
@@ -96,7 +97,7 @@ public class PrepareDepsOfPatternsFunctionTest extends BuildViewTestCase {
   @Test
   public void testFunctionExpandsTargetPatterns() throws Exception {
     // Given a package "@//foo" with independent target rules ":foo" and ":foo2",
-    createFooAndFoo2(/*dependent=*/ false);
+    createFooAndFoo2(/* dependent= */ false);
 
     // Given a target pattern sequence consisting of a pattern for "//foo:*",
     ImmutableList<String> patternSequence = ImmutableList.of("//foo:*");
@@ -138,7 +139,7 @@ public class PrepareDepsOfPatternsFunctionTest extends BuildViewTestCase {
     assertValidValue(
         walkableGraph,
         getKeyForLabel(Label.create("@//foo", "foo")),
-        /*expectTransitiveException=*/ true);
+        /* expectTransitiveException= */ true);
 
     // And an entry with a NoSuchPackageException for "//bar:bar",
     Exception e = assertException(walkableGraph, getKeyForLabel(Label.create("@//bar", "bar")));
@@ -161,7 +162,7 @@ public class PrepareDepsOfPatternsFunctionTest extends BuildViewTestCase {
     assertValidValue(
         walkableGraph,
         getKeyForLabel(Label.create("@//foo", "foo")),
-        /*expectTransitiveException=*/ true);
+        /* expectTransitiveException= */ true);
 
     // And an entry with a NoSuchTargetException for "//bar:bar",
     Exception e = assertException(walkableGraph, getKeyForLabel(Label.create("@//bar", "bar")));
@@ -170,7 +171,7 @@ public class PrepareDepsOfPatternsFunctionTest extends BuildViewTestCase {
 
   @Test
   public void testParsingProblemsKeepGoing() throws Exception {
-    parsingProblem(/*keepGoing=*/ true);
+    parsingProblem(/* keepGoing= */ true);
   }
 
   /**
@@ -181,12 +182,12 @@ public class PrepareDepsOfPatternsFunctionTest extends BuildViewTestCase {
    */
   @Test
   public void testParsingProblemsNoKeepGoing() throws Exception {
-    parsingProblem(/*keepGoing=*/ false);
+    parsingProblem(/* keepGoing= */ false);
   }
 
   private void parsingProblem(boolean keepGoing) throws Exception {
     // Given a package "//foo" with target rule ":foo",
-    createFooAndFoo2(/*dependent=*/ false);
+    createFooAndFoo2(/* dependent= */ false);
 
     // Given a target pattern sequence consisting of a pattern with parsing problems followed by
     // a legit target pattern,
@@ -195,7 +196,7 @@ public class PrepareDepsOfPatternsFunctionTest extends BuildViewTestCase {
 
     // When PrepareDepsOfPatternsFunction runs in the selected keep-going mode,
     WalkableGraph walkableGraph =
-        getGraphFromPatternsEvaluation(patternSequence, /*keepGoing=*/ keepGoing);
+        getGraphFromPatternsEvaluation(patternSequence, /* keepGoing= */ keepGoing);
 
     // Then it skips evaluation of the malformed target pattern, but logs about it,
     assertContainsEvent("Skipping '" + bogusPattern + "': ");
@@ -272,6 +273,7 @@ public class PrepareDepsOfPatternsFunctionTest extends BuildViewTestCase {
     return ImmutableList.of(
         PrecomputedValue.injected(
             ModuleFileFunction.REGISTRIES, ImmutableSet.of(registry.getUrl())),
+        PrecomputedValue.injected(RegistryFunction.MODULE_MIRRORS, ImmutableSet.of()),
         PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
         PrecomputedValue.injected(ModuleFileFunction.INJECTED_REPOSITORIES, ImmutableMap.of()),
         PrecomputedValue.injected(
@@ -375,7 +377,7 @@ public class PrepareDepsOfPatternsFunctionTest extends BuildViewTestCase {
 
   private static void assertValidValue(WalkableGraph graph, SkyKey key)
       throws InterruptedException {
-    assertValidValue(graph, key, /*expectTransitiveException=*/ false);
+    assertValidValue(graph, key, /* expectTransitiveException= */ false);
   }
 
   /**


### PR DESCRIPTION
The new flag allows users to specify additional mirrors for Bazel registry source URLs, taking precedence over those specified by registries. This provides a way to add mirrors without changing `bazel_registry.json`, the hash of which is stored in lockfiles.

RELNOTES: The new `--module_mirrors` flag accepts a comma-separated list of mirrors to use for source URLs provided by modules obtained from Bazel registries.

Closes #26832.

PiperOrigin-RevId: 800384242
Change-Id: I3b56eb5fe0405f460568d7563b2ad93f6b7461a5

Commit https://github.com/bazelbuild/bazel/commit/c3889fc68087223d530a04f2db28c69acc7e7473