### PR TITLE
Add sw_64 CPU architecture support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -314,6 +314,7 @@ use_repo(
     "openjdk_linux_aarch64_vanilla",
     "openjdk_linux_ppc64le_vanilla",
     "openjdk_linux_riscv64_vanilla",
+    "openjdk_linux_sw_64_vanilla",
     "openjdk_linux_s390x_vanilla",
     "openjdk_linux_vanilla",
     "openjdk_macos_aarch64_vanilla",

--- a/src/BUILD
+++ b/src/BUILD
@@ -175,6 +175,9 @@ filegroup(
         "//src/conditions:linux_riscv64": [
             "@openjdk_linux_riscv64_vanilla//file",
         ],
+        "//src/conditions:linux_sw_64": [
+            "@openjdk_linux_sw_64_vanilla//file",
+        ],
         "//conditions:default": [
             "@openjdk_linux_vanilla//file",
         ],

--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -85,6 +85,15 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_sw_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:sw_64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "linux_x86_64",
     constraint_values = [
         "@platforms//os:linux",

--- a/src/conditions/BUILD.tools
+++ b/src/conditions/BUILD.tools
@@ -68,6 +68,15 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_sw_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:sw_64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "linux_x86_64",
     constraint_values = [
         "@platforms//os:linux",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
@@ -56,6 +56,7 @@ public class AutoCpuConverter extends Converter.Contextless<String> {
               case S390X -> "s390x";
               case MIPS64 -> "mips64";
               case RISCV64 -> "riscv64";
+              case SW64 -> "sw_64";
               default -> "unknown";
             };
         default -> "unknown";

--- a/src/main/java/com/google/devtools/build/lib/util/CPU.java
+++ b/src/main/java/com/google/devtools/build/lib/util/CPU.java
@@ -29,6 +29,7 @@ public enum CPU {
   S390X("s390x", ImmutableSet.of("s390x", "s390")),
   MIPS64("mips64", ImmutableSet.of("mips64el", "mips64")),
   RISCV64("riscv64", ImmutableSet.of("riscv64")),
+  SW64("sw_64", ImmutableSet.of("sw_64")),
   UNKNOWN("unknown", ImmutableSet.<String>of());
 
   private final String canonicalName;

--- a/src/test/java/com/google/devtools/build/lib/packages/util/MockPlatformSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/MockPlatformSupport.java
@@ -111,6 +111,10 @@ public class MockPlatformSupport {
         "    constraint_setting = ':cpu',",
         ")",
         "constraint_value(",
+        "    name = 'sw_64',",
+        "    constraint_setting = ':cpu',",
+        ")",
+        "constraint_value(",
         "    name = 's390x',",
         "    constraint_setting = ':cpu',",
         ")");


### PR DESCRIPTION
 In this commit, support for a new architecture sw_64 is added to bazel. sw_64 is a new RISC ISA, which is a bit like RISC-V. Though it is a rather new ISA, it has been added to openEuler and openAnolis port since 2020. So supporting this new architecture is meaningful. It's PR is to solve compilation failure on sw_64 architecture.
 
platforms merge request: [platforms#124](https://github.com/bazelbuild/platforms/pull/124)

 Binutils has identified EM_SW64 is 268, I hope bazel can accept this patch. Thanks.
 
 https://en.wikipedia.org/wiki/Sunway_(processor)
 
 More information about sw_64 ISA:
 
 ```shell
 $ uname -m
 sw_64
 $ gcc -E -dM - < /dev/null|grep __sw_64__
 #define __sw_64__ 1
 $ gcc -E -dM - < /dev/null|grep BYTE_ORDER
 #define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
 ```
