### PR TITLE
Lazily request allowed inputs during input discovery with Bazel's BwoB

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
@@ -238,6 +238,7 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
   private final DiscoveredModulesPruner discoveredModulesPruner;
   private final SyscallCache syscallCache;
   private final ThreadStateReceiver threadStateReceiverForMetrics;
+  private final boolean fileSystemSupportsInputDiscovery;
 
   private ActionExecutionContext(
       Executor executor,
@@ -254,7 +255,8 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
       @Nullable FileSystem actionFileSystem,
       DiscoveredModulesPruner discoveredModulesPruner,
       SyscallCache syscallCache,
-      ThreadStateReceiver threadStateReceiverForMetrics) {
+      ThreadStateReceiver threadStateReceiverForMetrics,
+      boolean fileSystemSupportsInputDiscovery) {
     this.inputMetadataProvider = inputMetadataProvider;
     this.actionInputPrefetcher = actionInputPrefetcher;
     this.actionKeyContext = actionKeyContext;
@@ -273,6 +275,7 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         executor == null ? null : executor.getExecRoot());
     this.discoveredModulesPruner = discoveredModulesPruner;
     this.syscallCache = syscallCache;
+    this.fileSystemSupportsInputDiscovery = fileSystemSupportsInputDiscovery;
   }
 
   public ActionExecutionContext(
@@ -305,7 +308,8 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         actionFileSystem,
         discoveredModulesPruner,
         syscallCache,
-        threadStateReceiverForMetrics);
+        threadStateReceiverForMetrics,
+        /* fileSystemSupportsInputDiscovery= */ false);
   }
 
   public static ActionExecutionContext forInputDiscovery(
@@ -322,7 +326,8 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
       @Nullable FileSystem actionFileSystem,
       DiscoveredModulesPruner discoveredModulesPruner,
       SyscallCache syscalls,
-      ThreadStateReceiver threadStateReceiverForMetrics) {
+      ThreadStateReceiver threadStateReceiverForMetrics,
+      boolean fileSystemSupportsInputDiscovery) {
     return new ActionExecutionContext(
         executor,
         actionInputFileCache,
@@ -338,7 +343,8 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         actionFileSystem,
         discoveredModulesPruner,
         syscalls,
-        threadStateReceiverForMetrics);
+        threadStateReceiverForMetrics,
+        fileSystemSupportsInputDiscovery);
   }
 
   public ActionInputPrefetcher getActionInputPrefetcher() {
@@ -369,6 +375,10 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
   @Nullable
   public FileSystem getActionFileSystem() {
     return actionFileSystem;
+  }
+
+  public boolean fileSystemSupportsInputDiscovery() {
+    return fileSystemSupportsInputDiscovery;
   }
 
   public boolean isRewindingEnabled() {
@@ -553,7 +563,8 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         actionFileSystem,
         discoveredModulesPruner,
         syscallCache,
-        threadStateReceiverForMetrics);
+        threadStateReceiverForMetrics,
+        fileSystemSupportsInputDiscovery);
   }
 
   /**
@@ -606,7 +617,8 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         actionFileSystem,
         discoveredModulesPruner,
         syscallCache,
-        threadStateReceiverForMetrics);
+        threadStateReceiverForMetrics,
+        fileSystemSupportsInputDiscovery);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/includescanning/IncludeParser.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/IncludeParser.java
@@ -881,6 +881,10 @@ class IncludeParser {
               getFileType(),
               isOutputFile);
     } else {
+      if (isOutputFile && !actionExecutionContext.fileSystemSupportsInputDiscovery()) {
+        // Ensure that the file's metadata is available, which possibly requires a Skyframe restart.
+        actionExecutionContext.getInputMetadataProvider().getInputMetadataChecked(file);
+      }
       try (SilentCloseable c =
           Profiler.instance().profile(ProfilerTask.SCANNER, file.getExecPathString())) {
         inclusions =

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -933,7 +933,8 @@ public final class SkyframeActionExecutor {
             actionFileSystem,
             discoveredModulesPruner,
             syscallCache,
-            threadStateReceiverFactory.apply(actionLookupData));
+            threadStateReceiverFactory.apply(actionLookupData),
+            outputService.actionFileSystemType().supportsInputDiscovery());
     if (actionFileSystem != null) {
       updateActionFileSystemContext(
           action, actionFileSystem, THROWING_OUTPUT_METADATA_STORE_FOR_ACTIONFS);

--- a/src/test/java/com/google/devtools/build/lib/actions/util/ActionsTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/util/ActionsTestUtil.java
@@ -233,7 +233,8 @@ public final class ActionsTestUtil {
         /* actionFileSystem= */ null,
         discoveredModulesPruner,
         SyscallCache.NO_CACHE,
-        ThreadStateReceiver.NULL_INSTANCE);
+        ThreadStateReceiver.NULL_INSTANCE,
+        /* fileSystemSupportsInputDiscovery= */ true);
   }
 
   /** Creates an {@link ActionExecutionValue} with only file outputs. */

--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTest.java
@@ -246,7 +246,7 @@ public final class RewindingTest extends BuildIntegrationTestCase {
 
   @Test
   public void generatedHeaderRewound_lostInInputDiscovery() throws Exception {
-    skipIfNotLinux();
+    skipIfBazel();
     helper.runGeneratedHeaderRewound_lostInInputDiscovery_spawnFailed();
   }
 
@@ -258,7 +258,7 @@ public final class RewindingTest extends BuildIntegrationTestCase {
 
   @Test
   public void generatedTransitiveHeaderRewound_lostInInputDiscovery() throws Exception {
-    skipIfNotLinux();
+    skipIfBazel();
     helper.runGeneratedTransitiveHeaderRewound_lostInInputDiscovery_spawnFailed();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTest.java
@@ -246,7 +246,7 @@ public final class RewindingTest extends BuildIntegrationTestCase {
 
   @Test
   public void generatedHeaderRewound_lostInInputDiscovery() throws Exception {
-    skipIfBazel();
+    skipIfNotLinux();
     helper.runGeneratedHeaderRewound_lostInInputDiscovery_spawnFailed();
   }
 
@@ -258,7 +258,7 @@ public final class RewindingTest extends BuildIntegrationTestCase {
 
   @Test
   public void generatedTransitiveHeaderRewound_lostInInputDiscovery() throws Exception {
-    skipIfBazel();
+    skipIfNotLinux();
     helper.runGeneratedTransitiveHeaderRewound_lostInInputDiscovery_spawnFailed();
   }
 


### PR DESCRIPTION
In 6522472dc8a7efaa278b04fd27b3ebb3d467d4d3, which added support for include scanning to Bazel, `ActionExecutionFunction` was changed to always request all allowed derived inputs rather than just the inputs recorded in the action cache. This is overly pessimistic, results in very different behavior between Bazel and Blaze and, most importantly, negatively affects other use cases for input discovery by causing Skyframe cycles that otherwise wouldn't exist.

Instead, request each input only when it is needed in `IncludeParser`, which more closely matches the behavior of Blaze's remote file system.

Along the way delete another unused field on `AllInputs`.

Work towards #4005