### PR TITLE
Add remote golden test coverage for source directories

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/FakeActionInputFileCache.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/FakeActionInputFileCache.java
@@ -46,7 +46,7 @@ import javax.annotation.Nullable;
 /** A fake implementation of the {@link InputMetadataProvider} interface. */
 final class FakeActionInputFileCache implements InputMetadataProvider {
   private final Path execRoot;
-  private final BiMap<ActionInput, String> cas = HashBiMap.create();
+  private final BiMap<PathFragment, String> cas = HashBiMap.create();
   private final Map<ActionInput, RunfilesArtifactValue> runfilesMap = new HashMap<>();
   private final Map<ActionInput, TreeArtifactValue> trees = new HashMap<>();
   private final List<RunfilesTree> runfilesTrees = new ArrayList<>();
@@ -60,9 +60,12 @@ final class FakeActionInputFileCache implements InputMetadataProvider {
 
   @Override
   public FileArtifactValue getInputMetadataChecked(ActionInput input) throws IOException {
-    String hexDigest = Preconditions.checkNotNull(cas.get(input), input);
+    String hexDigest = Preconditions.checkNotNull(cas.get(input.getExecPath()), input);
     Path path = execRoot.getRelative(input.getExecPath());
     FileStatus stat = path.stat(Symlinks.FOLLOW);
+    if (stat.isDirectory()) {
+      return FileArtifactValue.createForDirectoryWithHash(HashCode.fromString(hexDigest).asBytes());
+    }
     return FileArtifactValue.createForNormalFile(
         HashCode.fromString(hexDigest).asBytes(), FileContentsProxy.create(stat), stat.getSize());
   }
@@ -107,7 +110,7 @@ final class FakeActionInputFileCache implements InputMetadataProvider {
   }
 
   private void setDigest(ActionInput input, String digest) {
-    cas.put(input, digest);
+    cas.put(input.getExecPath(), digest);
   }
 
   public void addTreeArtifact(ActionInput treeArtifact, TreeArtifactValue value) {


### PR DESCRIPTION
The test covers the case of a partial overlap with a set of source files.
