### PR TITLE
Enable --enable_platform_specific_config by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -47,7 +47,7 @@ public class CommonCommandOptions extends OptionsBase {
   // value during options parsing based on its (string) name.
   @Option(
       name = "enable_platform_specific_config",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =

--- a/src/main/java/com/google/devtools/build/lib/runtime/ConfigExpander.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/ConfigExpander.java
@@ -64,8 +64,7 @@ final class ConfigExpander {
       OptionValueDescription enablePlatformSpecificConfigDescription,
       ListMultimap<String, RcChunkOfArgs> commandToRcArgs,
       List<String> commandsToParse) {
-    if (enablePlatformSpecificConfigDescription == null
-        || !(boolean) enablePlatformSpecificConfigDescription.getValue()) {
+    if (!(boolean) enablePlatformSpecificConfigDescription.getValue()) {
       return false;
     }
 
@@ -133,6 +132,11 @@ final class ConfigExpander {
 
     OptionValueDescription enablePlatformSpecificConfigDescription =
         optionsParser.getOptionValueDescription("enable_platform_specific_config");
+    if (enablePlatformSpecificConfigDescription == null) {
+        optionsParser.parse("--enable_platform_specific_config=true");
+        enablePlatformSpecificConfigDescription =
+            optionsParser.getOptionValueDescription("enable_platform_specific_config");
+    }
     if (shouldEnablePlatformSpecificConfig(
         enablePlatformSpecificConfigDescription, commandToRcArgs, commandsToParse)) {
       var expansion =

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
@@ -126,6 +126,9 @@ public class BlazeOptionHandlerTest {
     structuredArgs.put(
         "build:platform_config",
         new RcChunkOfArgs("rc1", ImmutableList.of("--enable_platform_specific_config")));
+    structuredArgs.put(
+        "build:platform_config_disabled",
+        new RcChunkOfArgs("rc1", ImmutableList.of("--enable_platform_specific_config=false")));
     return structuredArgs;
   }
 
@@ -325,6 +328,13 @@ public class BlazeOptionHandlerTest {
   }
 
   @Test
+  public void testExpandConfigOptions_withPlatformSpecificConfigDisabledInConfig() throws Exception {
+    parser.parse("--config=platform_config_disabled");
+    optionHandler.expandConfigOptions(eventHandler, structuredArgsForDifferentPlatforms());
+    assertThat(parser.getResidue()).isEmpty();
+  }
+
+  @Test
   public void testExpandConfigOptions_withPlatformSpecificConfigEnabledWhenNothingSpecified()
       throws Exception {
     parser.parse("--enable_platform_specific_config");
@@ -394,7 +404,8 @@ public class BlazeOptionHandlerTest {
             "--config=config2a",
             "--config=config2b",
             "--test_multiple_string=5",
-            "--test_multiple_string=6")
+            "--test_multiple_string=6",
+            "--enable_platform_specific_config")
         .inOrder();
     assertThat(
             parser.asCompleteListOfParsedOptions().stream()
@@ -410,7 +421,8 @@ public class BlazeOptionHandlerTest {
             "--config=config2a",
             "--config=config2b",
             "--test_multiple_string=5",
-            "--test_multiple_string=6")
+            "--test_multiple_string=6",
+            "--enable_platform_specific_config")
         .inOrder();
   }
 


### PR DESCRIPTION
I think in the common case this is what users would prefer. It's
possible this conflicts with non-automatic configs with the same
platform name, but that seems low risk since likely they would be
intended for the same purpose.

RELNOTES[inc]: Enable --enable_platform_specific_config by default
