### PR TITLE
Allow platform-specific startup bazelrc flags

### DIFF
--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -591,6 +591,32 @@ blaze_exit_code::ExitCode OptionProcessor::ParseStartupOptions(
     }
   }
 
+  std::string platform_config;
+#if defined(__linux__)
+  platform_config = "linux";
+#elif defined(__APPLE__)
+  platform_config = "macos";
+#elif defined(_WIN32)
+  platform_config = "windows";
+#elif defined(__FreeBSD__)
+  platform_config = "freebsd";
+#elif defined(__OpenBSD__)
+  platform_config = "openbsd";
+#endif
+
+  if (!platform_config.empty()) {
+    for (const auto* blazerc : rc_files) {
+      const auto iter = blazerc->options().find("startup:" + platform_config);
+      if (iter == blazerc->options().end()) continue;
+
+      for (const RcOption& option : iter->second) {
+        const std::string& source_path =
+            blazerc->canonical_source_paths()[option.source_index];
+        rcstartup_flags.push_back({source_path, option.option});
+      }
+    }
+  }
+
   for (const std::string& arg : cmd_line_->startup_args) {
     if (!IsArg(arg)) {
       break;

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -92,6 +92,9 @@ public final class BlazeOptionHandler {
   // being ignored as long as they are recognized by at least one (other) command.
   static final String COMMON_PSEUDO_COMMAND = "common";
 
+  // Startup options are processed by the C++ client before the Java server starts.
+  private static final String STARTUP_PSEUDO_COMMAND = "startup";
+
   private static final ImmutableSet<String> BUILD_COMMAND_ANCESTORS =
       ImmutableSet.of("build", COMMON_PSEUDO_COMMAND, ALWAYS_PSEUDO_COMMAND);
 
@@ -685,7 +688,8 @@ public final class BlazeOptionHandler {
       }
       if (!validCommands.contains(command)
           && !command.equals(ALWAYS_PSEUDO_COMMAND)
-          && !command.equals(COMMON_PSEUDO_COMMAND)) {
+          && !command.equals(COMMON_PSEUDO_COMMAND)
+          && !command.equals(STARTUP_PSEUDO_COMMAND)) {
         eventHandler.handle(
             Event.warn(
                 "while reading option defaults file '"

--- a/src/test/cpp/rc_options_test.cc
+++ b/src/test/cpp/rc_options_test.cc
@@ -567,5 +567,29 @@ TEST(RemoteFileTest, ParsingRemoteFiles) {
                                                    "--max_idle_secs=123")))))));
 }
 
+TEST_F(RcOptionsTest, StartupConfigurationPlatformSpecific) {
+  WriteRc("startup_config.bazelrc",
+          "startup --max_idle_secs=10800  # Default\n"
+          "startup:linux --max_idle_secs=3600  # Linux specific\n"
+          "startup:linux --connect_timeout_secs=60  # Linux specific\n"
+          "startup:macos --max_idle_secs=1800  # macOS Specific\n"
+          "startup:macos --connect_timeout_secs=120  # macOS Specific\n");
+  SuccessfullyParseRcWithExpectedArgs(
+      "startup_config.bazelrc",
+      {{"startup", {"--max_idle_secs=10800"}},
+       {"startup:linux", {"--max_idle_secs=3600", "--connect_timeout_secs=60"}},
+       {"startup:macos", {"--max_idle_secs=1800", "--connect_timeout_secs=120"}}});
+}
+
+TEST_F(RcOptionsTest, StartupConfigurationMultipleOptionsForPlatform) {
+  WriteRc("startup_config_multiple.bazelrc",
+          "startup:linux --host_jvm_args=-Xms256m\n"
+          "startup:linux --host_jvm_args=-Xmx2g\n"
+          "startup:linux --connect_timeout_secs=120\n");
+  SuccessfullyParseRcWithExpectedArgs(
+      "startup_config_multiple.bazelrc",
+      {{"startup:linux", {"--host_jvm_args=-Xms256m", "--host_jvm_args=-Xmx2g", "--connect_timeout_secs=120"}}});
+}
+
 }  // namespace
 }  // namespace blaze


### PR DESCRIPTION
This enables the use of `startup:linux`, `startup:macos`, etc. This is
always enabled.

Fixes https://github.com/bazelbuild/bazel/issues/22763

RELNOTES[inc]: Add support for `startup:linux`, `startup:macos`, etc
bazelrc options.
