### PR TITLE
HttpConnector: remove Accept header workaround

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
@@ -126,8 +126,6 @@ class HttpConnector {
       try {
         connection = (HttpURLConnection)
             url.openConnection(proxyHelper.createProxyIfNeeded(url));
-        // TODO(zecke): Revise once https://bugs.openjdk.java.net/browse/JDK-8163921 is fixed.
-        connection.addRequestProperty("Accept", "text/html, image/gif, image/jpeg, */*");
         boolean isAlreadyCompressed =
             COMPRESSED_EXTENSIONS.contains(HttpUtils.getExtension(url.getPath()))
                 || COMPRESSED_EXTENSIONS.contains(HttpUtils.getExtension(originalUrl.getPath()));


### PR DESCRIPTION
The default `HttpURLConnection` Accept header is now `"*/*"`, which seems fine for a generic downloading utility.