### PR TITLE
Provide a `Root` instead of a `Path` on `RepositoryDirectoryValue`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -646,10 +646,9 @@ public class ModuleFileFunction implements SkyFunction {
       }
       // This repo _definitely_ exists, since it has a non-registry override, which directly gets
       // "translated" into a repo spec. So we can cast `repoDir` to `Success`.
-      Path repoDirPath = ((Success) repoDir).getPath();
       RootedPath moduleFilePath =
           RootedPath.toRootedPath(
-              Root.fromPath(repoDirPath), LabelConstants.MODULE_DOT_BAZEL_FILE_NAME);
+              ((Success) repoDir).root(), LabelConstants.MODULE_DOT_BAZEL_FILE_NAME);
       if (env.getValue(FileValue.key(moduleFilePath)) == null) {
         return null;
       }

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/FetchCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/FetchCommand.java
@@ -167,9 +167,7 @@ public final class FetchCommand implements BlazeCommand {
   }
 
   private BlazeCommandResult fetchAll(
-      CommandEnvironment env,
-      LoadingPhaseThreadsOption threadsOption,
-      boolean configureEnabled)
+      CommandEnvironment env, LoadingPhaseThreadsOption threadsOption, boolean configureEnabled)
       throws InterruptedException {
     EvaluationContext evaluationContext =
         EvaluationContext.newBuilder()
@@ -209,8 +207,8 @@ public final class FetchCommand implements BlazeCommand {
         repositoryNamesAndValues.values().stream()
             .flatMap(
                 value ->
-                    value instanceof RepositoryDirectoryValue.Failure failure
-                        ? Stream.of(failure.getErrorMsg())
+                    value instanceof RepositoryDirectoryValue.Failure(String errorMsg)
+                        ? Stream.of(errorMsg)
                         : Stream.of())
             .collect(joining("; "));
     if (!notFoundRepos.isEmpty()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
@@ -258,7 +258,7 @@ public final class VendorCommand implements BlazeCommand {
             reposToVendor.add(entry.getKey());
           }
         }
-        case Failure f -> notFoundRepoErrors.add(f.getErrorMsg());
+        case Failure(String errorMsg) -> notFoundRepoErrors.add(errorMsg);
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryFetchFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryFetchFunction.java
@@ -237,7 +237,7 @@ public final class RepositoryFetchFunction implements SkyFunction {
         }
         if (repoState instanceof DigestWriter.RepoDirectoryState.UpToDate) {
           return new RepositoryDirectoryValue.Success(
-              repoRoot, /* isFetchingDelayed= */ false, excludeRepoFromVendoring);
+              Root.fromPath(repoRoot), /* isFetchingDelayed= */ false, excludeRepoFromVendoring);
         }
 
         // Then check if the global repo contents cache has this.
@@ -257,7 +257,9 @@ public final class RepositoryFetchFunction implements SkyFunction {
               }
               candidate.touch();
               return new RepositoryDirectoryValue.Success(
-                  repoRoot, /* isFetchingDelayed= */ false, excludeRepoFromVendoring);
+                  Root.fromPath(repoRoot),
+                  /* isFetchingDelayed= */ false,
+                  excludeRepoFromVendoring);
             }
           }
         }
@@ -305,7 +307,7 @@ public final class RepositoryFetchFunction implements SkyFunction {
           }
         }
         return new RepositoryDirectoryValue.Success(
-            repoRoot, /* isFetchingDelayed= */ false, excludeRepoFromVendoring);
+            Root.fromPath(repoRoot), /* isFetchingDelayed= */ false, excludeRepoFromVendoring);
       }
 
       if (!repoRoot.exists()) {
@@ -328,7 +330,7 @@ public final class RepositoryFetchFunction implements SkyFunction {
                       repositoryName)));
 
       return new RepositoryDirectoryValue.Success(
-          repoRoot, /* isFetchingDelayed= */ true, excludeRepoFromVendoring);
+          Root.fromPath(repoRoot), /* isFetchingDelayed= */ true, excludeRepoFromVendoring);
     }
   }
 
@@ -800,6 +802,6 @@ public final class RepositoryFetchFunction implements SkyFunction {
           Transience.TRANSIENT);
     }
     return new RepositoryDirectoryValue.Success(
-        source, /* isFetchingDelayed= */ false, /* excludeFromVendoring= */ true);
+        Root.fromPath(source), /* isFetchingDelayed= */ false, /* excludeFromVendoring= */ true);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDirectoryValue.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDirectoryValue.java
@@ -20,6 +20,7 @@ import com.google.devtools.build.lib.skyframe.SkyFunctions;
 import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerialization;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.skyframe.AbstractSkyKey;
 import com.google.devtools.build.skyframe.NotComparableSkyValue;
 import com.google.devtools.build.skyframe.SkyFunctionName;
@@ -48,20 +49,14 @@ public sealed interface RepositoryDirectoryValue extends NotComparableSkyValue {
   /**
    * Represents a successful repository lookup.
    *
-   * @param path Returns the path to the directory containing the repository's contents. This
-   *     directory is guaranteed to exist. It may contain a full Bazel repository (with a WORKSPACE
-   *     file, directories, and BUILD files) or simply contain a file (or set of files) for, say, a
-   *     jar from Maven.
+   * @param root Returns the root containing the repository's contents. This directory is guaranteed
+   *     to exist.
    * @param excludeFromVendoring Returns if this repo should be excluded from vendoring. The value
-   *     is true for local & configure repos
+   *     is true for local as well as configure repos.
    */
   @AutoCodec
-  record Success(Path path, boolean isFetchingDelayed, boolean excludeFromVendoring)
-      implements RepositoryDirectoryValue {
-    public Path getPath() {
-      return path;
-    }
-  }
+  record Success(Root root, boolean isFetchingDelayed, boolean excludeFromVendoring)
+      implements RepositoryDirectoryValue {}
 
   /**
    * Represents an unsuccessful repository lookup, because the repo doesn't exist.
@@ -70,11 +65,7 @@ public sealed interface RepositoryDirectoryValue extends NotComparableSkyValue {
    *     suitable for reporting to a user.
    */
   @AutoCodec
-  record Failure(String errorMsg) implements RepositoryDirectoryValue {
-    public String getErrorMsg() {
-      return errorMsg;
-    }
-  }
+  record Failure(String errorMsg) implements RepositoryDirectoryValue {}
 
   /** Creates a key from the given repository name. */
   static Key key(RepositoryName repository) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/EnvironmentBackedRecursivePackageProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/EnvironmentBackedRecursivePackageProvider.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.lib.packages.Package;
 import com.google.devtools.build.lib.packages.Packageoid;
 import com.google.devtools.build.lib.pkgcache.AbstractRecursivePackageProvider;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
+import com.google.devtools.build.lib.pkgcache.RecursivePackageProvider;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue.Failure;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue.Success;
@@ -195,12 +196,12 @@ public final class EnvironmentBackedRecursivePackageProvider
         throw new MissingDepException();
       }
 
-      if (repositoryValue instanceof Failure f) {
+      if (repositoryValue instanceof Failure(String errorMsg)) {
         eventHandler.handle(
-            Event.error(String.format("No such repository '%s': %s", repository, f.getErrorMsg())));
+            Event.error(String.format("No such repository '%s': %s", repository, errorMsg)));
         return;
       }
-      roots.add(Root.fromPath(((Success) repositoryValue).getPath()));
+      roots.add(((Success) repositoryValue).root());
     }
 
     IgnoredSubdirectories filteredIgnoredSubdirectories =

--- a/src/main/java/com/google/devtools/build/lib/skyframe/GraphBackedRecursivePackageProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/GraphBackedRecursivePackageProvider.java
@@ -286,7 +286,7 @@ public final class GraphBackedRecursivePackageProvider extends AbstractRecursive
     } else {
       if (graph.getValue(RepositoryDirectoryValue.key(repository))
           instanceof RepositoryDirectoryValue.Success success) {
-        return ImmutableList.of(Root.fromPath(success.getPath()));
+        return ImmutableList.of(success.root());
       }
       // If this key doesn't exist, the repository is outside the universe, so we return
       // "nothing".

--- a/src/main/java/com/google/devtools/build/lib/skyframe/IgnoredSubdirectoriesFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/IgnoredSubdirectoriesFunction.java
@@ -166,8 +166,7 @@ public class IgnoredSubdirectoriesFunction implements SkyFunction {
       }
       if (repositoryValue instanceof RepositoryDirectoryValue.Success success) {
         RootedPath rootedPrefixFile =
-            RootedPath.toRootedPath(
-                Root.fromPath(success.getPath()), BAZELIGNORE_REPOSITORY_RELATIVE_PATH);
+            RootedPath.toRootedPath(success.root(), BAZELIGNORE_REPOSITORY_RELATIVE_PATH);
         FileValue prefixFileValue = (FileValue) env.getValue(FileValue.key(rootedPrefixFile));
         if (prefixFileValue == null) {
           return null;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
@@ -357,8 +357,8 @@ public class PackageLookupFunction implements SkyFunction {
       throw new PackageLookupFunctionException(
           new RepositoryFetchException(id, e.getMessage()), Transience.PERSISTENT);
     }
-    if (repositoryValue instanceof Failure f) {
-      return new NoRepositoryPackageLookupValue(id.getRepository(), f.getErrorMsg());
+    if (repositoryValue instanceof Failure(String errorMsg)) {
+      return new NoRepositoryPackageLookupValue(id.getRepository(), errorMsg);
     }
 
     // Check .bazelignore file after fetching the external repository.
@@ -374,7 +374,7 @@ public class PackageLookupFunction implements SkyFunction {
       return PackageLookupValue.DELETED_PACKAGE_VALUE;
     }
 
-    Root root = Root.fromPath(((Success) repositoryValue).getPath());
+    Root root = ((Success) repositoryValue).root();
 
     // This checks for the build file names in the correct precedence order.
     for (BuildFileName buildFileName : buildFilesByPriority) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PrepareDepsOfPatternFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PrepareDepsOfPatternFunction.java
@@ -321,13 +321,13 @@ public class PrepareDepsOfPatternFunction implements SkyFunction {
           throw new MissingDepException();
         }
 
-        if (repositoryValue instanceof Failure f) {
+        if (repositoryValue instanceof Failure(String errorMsg)) {
           // This shouldn't be possible; we're given a repository, so we assume that the caller has
           // already checked for its existence.
           throw new IllegalStateException(
-              String.format("No such repository '%s': %s", repository, f.getErrorMsg()));
+              String.format("No such repository '%s': %s", repository, errorMsg));
         }
-        roots.add(Root.fromPath(((Success) repositoryValue).getPath()));
+        roots.add(((Success) repositoryValue).root());
       }
 
       for (Root root : roots) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -900,7 +900,8 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
         SkyFunctions.REPO_FILE,
         shouldUseRepoDotBazel
             ? new RepoFileFunction(
-                ruleClassProvider.getBazelStarlarkEnvironment(), directories.getWorkspace())
+                ruleClassProvider.getBazelStarlarkEnvironment(),
+                Root.fromPath(directories.getWorkspace()))
             : (k, env) -> {
               throw new IllegalStateException("supposed to be unused");
             });

--- a/src/main/java/com/google/devtools/build/lib/skyframe/packages/AbstractPackageLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/packages/AbstractPackageLoader.java
@@ -588,7 +588,8 @@ public abstract class AbstractPackageLoader implements PackageLoader {
         .put(
             SkyFunctions.REPO_FILE,
             new RepoFileFunction(
-                ruleClassProvider.getBazelStarlarkEnvironment(), directories.getWorkspace()))
+                ruleClassProvider.getBazelStarlarkEnvironment(),
+                Root.fromPath(directories.getWorkspace())))
         .put(SkyFunctions.REPO_PACKAGE_ARGS, RepoPackageArgsFunction.INSTANCE)
         .put(RepoDefinitionValue.REPO_DEFINITION, new RepoDefinitionFunction())
         .put(SkyFunctions.REPOSITORY_MAPPING, new RepositoryMappingFunction(ruleClassProvider))

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryDelegatorTest.java
@@ -270,7 +270,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
     assertThat(result.hasError()).isFalse();
     RepositoryDirectoryValue repositoryDirectoryValue = (RepositoryDirectoryValue) result.get(key);
     Path expectedPath = scratch.dir("/outputbase/external/foo");
-    Path actualPath = ((Success) repositoryDirectoryValue).getPath();
+    Path actualPath = ((Success) repositoryDirectoryValue).root().asPath();
     assertThat(actualPath).isEqualTo(expectedPath);
     assertThat(actualPath.isSymbolicLink()).isTrue();
     assertThat(actualPath.readSymbolicLink()).isEqualTo(overrideDirectory.asFragment());
@@ -286,7 +286,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
 
     Success usual =
         new Success(
-            rootDirectory.getRelative("a"),
+            Root.fromPath(rootDirectory.getRelative("a")),
             /* isFetchingDelayed= */ false,
             /* excludeFromVendoring= */ false);
 
@@ -296,7 +296,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
 
     Success fetchDelayed =
         new Success(
-            rootDirectory.getRelative("b"),
+            Root.fromPath(rootDirectory.getRelative("b")),
             /* isFetchingDelayed= */ true,
             /* excludeFromVendoring= */ false);
 
@@ -374,7 +374,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
     assertThat(result.hasError()).isFalse();
     RepositoryDirectoryValue repositoryDirectoryValue = (RepositoryDirectoryValue) result.get(key);
     assertThat(repositoryDirectoryValue).isInstanceOf(Failure.class);
-    assertThat(((Failure) repositoryDirectoryValue).getErrorMsg())
+    assertThat(((Failure) repositoryDirectoryValue).errorMsg())
         .contains("Repository '@@foo' is not defined");
   }
 
@@ -397,7 +397,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
     assertThat(result.hasError()).isFalse();
     RepositoryDirectoryValue repositoryDirectoryValue = (RepositoryDirectoryValue) result.get(key);
     assertThat(repositoryDirectoryValue).isInstanceOf(Failure.class);
-    assertThat(((Failure) repositoryDirectoryValue).getErrorMsg())
+    assertThat(((Failure) repositoryDirectoryValue).errorMsg())
         .contains("No repository visible as '@foo' from repository '@@fake_owner_repo'");
   }
 
@@ -421,7 +421,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
     assertThat(result.hasError()).isFalse();
     RepositoryDirectoryValue repositoryDirectoryValue = (RepositoryDirectoryValue) result.get(key);
     assertThat(repositoryDirectoryValue).isInstanceOf(Failure.class);
-    assertThat(((Failure) repositoryDirectoryValue).getErrorMsg())
+    assertThat(((Failure) repositoryDirectoryValue).errorMsg())
         .contains("No repository visible as '@foo' from main repository");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/GlobTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/GlobTestBase.java
@@ -160,7 +160,8 @@ public abstract class GlobTestBase {
     skyFunctions.put(
         SkyFunctions.REPO_FILE,
         new RepoFileFunction(
-            ruleClassProvider.getBazelStarlarkEnvironment(), directories.getWorkspace()));
+            ruleClassProvider.getBazelStarlarkEnvironment(),
+            Root.fromPath(directories.getWorkspace())));
     skyFunctions.put(SkyFunctions.IGNORED_SUBDIRECTORIES, IgnoredSubdirectoriesFunction.INSTANCE);
     skyFunctions.put(
         FileStateKey.FILE_STATE,

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PackageLookupFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PackageLookupFunctionTest.java
@@ -98,8 +98,11 @@ public abstract class PackageLookupFunctionTest extends FoundationTestCase {
             rootDirectory,
             /* defaultSystemJavabase= */ null,
             analysisMock.getProductName());
-    ExternalFilesHelper externalFilesHelper = ExternalFilesHelper.createForTesting(
-        pkgLocator, ExternalFileAction.DEPEND_ON_EXTERNAL_PKG_FOR_EXTERNAL_REPO_PATHS, directories);
+    ExternalFilesHelper externalFilesHelper =
+        ExternalFilesHelper.createForTesting(
+            pkgLocator,
+            ExternalFileAction.DEPEND_ON_EXTERNAL_PKG_FOR_EXTERNAL_REPO_PATHS,
+            directories);
 
     RuleClassProvider ruleClassProvider = analysisMock.createRuleClassProvider();
     Map<SkyFunctionName, SkyFunction> skyFunctions = new HashMap<>();
@@ -124,7 +127,8 @@ public abstract class PackageLookupFunctionTest extends FoundationTestCase {
     skyFunctions.put(
         SkyFunctions.REPO_FILE,
         new RepoFileFunction(
-            ruleClassProvider.getBazelStarlarkEnvironment(), directories.getWorkspace()));
+            ruleClassProvider.getBazelStarlarkEnvironment(),
+            Root.fromPath(directories.getWorkspace())));
     skyFunctions.put(SkyFunctions.IGNORED_SUBDIRECTORIES, IgnoredSubdirectoriesFunction.INSTANCE);
     skyFunctions.put(
         SkyFunctions.LOCAL_REPOSITORY_LOOKUP,
@@ -206,8 +210,8 @@ public abstract class PackageLookupFunctionTest extends FoundationTestCase {
   @Test
   public void testDeletedPackage() throws Exception {
     scratch.file("parentpackage/deletedpackage/BUILD");
-    deletedPackages.set(ImmutableSet.of(
-        PackageIdentifier.createInMainRepo("parentpackage/deletedpackage")));
+    deletedPackages.set(
+        ImmutableSet.of(PackageIdentifier.createInMainRepo("parentpackage/deletedpackage")));
     PackageLookupValue packageLookupValue = lookupPackage("parentpackage/deletedpackage");
     assertThat(packageLookupValue.packageExists()).isFalse();
     assertThat(packageLookupValue.getErrorReason()).isEqualTo(ErrorReason.DELETED_PACKAGE);


### PR DESCRIPTION
All consumers transform the path into a root. This also makes it easier to experiment with alternative approaches to invalidation of external repo files, such as returning distinct `Root`s per fetch.

Work towards #26450