### PR TITLE
TMP: Update default value for check external repository files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -289,7 +289,7 @@ public class RepositoryOptions extends OptionsBase {
 
   @Option(
       name = "experimental_check_external_repository_files",
-      defaultValue = "true",
+      defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =


### PR DESCRIPTION
Change default value of experimental_check_external_repository_files option from true to false.