### PR TITLE
Use feature instead of cpp fragment for dSYM generation

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -598,7 +598,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
     # On macOS, if cpp_config.apple_generate_dsym is enabled
     # then a .dSYM file will be built along with the executable.
     dsym_file = None
-    if cpp_config.apple_generate_dsym:
+    if cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "generate_dsym_file"):
         dsym_file = ctx.actions.declare_directory(
             "{name}.dSYM".format(
                 name = target_name,


### PR DESCRIPTION
This was discussed in https://github.com/bazelbuild/bazel/pull/25881
where we believed it was equivalent. This isn't equivalent if the
toolchain does not support dSYM generations but --apple_generate_dsym is
still passed (as is possible on Linux). In this case we let feature
configuration handle this instead, as this feature is requested when
--apple_generate_dsym is passed. In that case because of this mismatch
this directory will be created "successfully" but it will always be
empty (this would be a failure if it wasn't a tree artifact)
