### PR TITLE
Fix parsing of text-formatted invocation policies

### DIFF
--- a/src/main/java/com/google/devtools/common/options/InvocationPolicyParser.java
+++ b/src/main/java/com/google/devtools/common/options/InvocationPolicyParser.java
@@ -43,12 +43,12 @@ public class InvocationPolicyParser {
         // First try decoding the policy as a base64 encoded binary proto.
         return InvocationPolicy.parseFrom(
             BaseEncoding.base64().decode(CharMatcher.whitespace().removeFrom(policy)));
-      } catch (IllegalArgumentException e) {
+      } catch (IllegalArgumentException | InvalidProtocolBufferException e) {
         // If the flag value can't be decoded from base64, try decoding the policy as a text
         // formatted proto.
         return TextFormat.parse(policy, InvocationPolicy.class);
       }
-    } catch (InvalidProtocolBufferException | TextFormat.ParseException e) {
+    } catch (TextFormat.ParseException e) {
       throw new OptionsParsingException("Malformed value of --invocation_policy: " + policy, e);
     }
   }


### PR DESCRIPTION
The --invocation_policy flag is supposed to take either a base64-encoded representation of an InvocationPolicy proto message OR a text representation of it.  Unfortunately, the code to handle the latter case is broken as it is never triggered due to invalid exception handling.

Fix this by catching the correct proto and base64 decoding exception types and falling back to text parsing in those cases.