### PR TITLE
[8.5.0] Speculative fix for repo contents cache race

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -404,7 +404,7 @@ public class BazelRepositoryModule extends BlazeModule {
             Profiler.instance()
                 .profile(ProfilerTask.REPO_CACHE_GC_WAIT, "waiting to acquire repo cache lock")) {
           repositoryCache.getRepoContentsCache().acquireSharedLock();
-        } catch (IOException e) {
+        } catch (IOException | InterruptedException e) {
           throw new AbruptExitException(
               detailedExitCode(
                   "could not acquire lock on repo contents cache", Code.BAD_REPO_CONTENTS_CACHE),

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepoContentsCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepoContentsCache.java
@@ -154,13 +154,10 @@ public final class RepoContentsCache {
    */
   public Path moveToCache(
       Path fetchedRepoDir, Path fetchedRepoMarkerFile, String predeclaredInputHash)
-      throws IOException {
+      throws IOException, InterruptedException {
     Preconditions.checkState(path != null);
 
     Path entryDir = path.getRelative(predeclaredInputHash);
-    if (!entryDir.isDirectory()) {
-      entryDir.delete();
-    }
     String counter = getNextCounterInDir(entryDir);
     Path cacheRecordedInputsFile = entryDir.getChild(counter + RECORDED_INPUTS_SUFFIX);
     Path cacheRepoDir = entryDir.getChild(counter);
@@ -185,8 +182,12 @@ public final class RepoContentsCache {
     return cacheRepoDir;
   }
 
-  private static String getNextCounterInDir(Path entryDir) throws IOException {
+  private static String getNextCounterInDir(Path entryDir)
+      throws IOException, InterruptedException {
     Path counterFile = entryDir.getRelative("counter");
+    // This use of FileSystemLock.get is safe since the predeclared input hash is part of entryDir's
+    // path and in particular includes the canonical repository name. This ensures that the same
+    // lock file will not be acquired concurrently by multiple threads, which isn't supported.
     try (var lock = FileSystemLock.get(entryDir.getRelative("lock"), LockMode.EXCLUSIVE)) {
       int c = 0;
       if (counterFile.exists()) {
@@ -202,7 +203,7 @@ public final class RepoContentsCache {
     }
   }
 
-  public void acquireSharedLock() throws IOException {
+  public void acquireSharedLock() throws IOException, InterruptedException {
     Preconditions.checkState(path != null);
     Preconditions.checkState(sharedLock == null, "this process already has the shared lock");
     sharedLock = FileSystemLock.get(path.getRelative(LOCK_PATH), LockMode.SHARED);

--- a/src/main/java/com/google/devtools/build/lib/util/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/util/BUILD
@@ -48,6 +48,7 @@ java_library(
     srcs = ["FileSystemLock.java"],
     deps = [
         ":string_encoding",
+        "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//third_party:guava",
     ],


### PR DESCRIPTION
The error message observed in #26713 is consistent with `FileChannel#open` failing because the given path doesn't exist. This could happen if one Bazel process observed that `!entryDir.isDirectory()`, which is true if the path doesn't exist, and proceeded to delete the path while another process had just created the directory and is now opening the channel. Since the entry dir is never expected to be an existing non-directory unless the cache has been corrupted, this logic can be removed.

Another possible source of `IOException` during normal operation is on an interrupt (such as the user hitting Ctrl+C). Instead, follow Skyframe best practices by surfacing this as an `InterruptedException` instead of a `FileLockInterruptionException`.

Also document that concurrent use on the same path is not supported (it results in an `OverlappingFileLockException` if the lock is already held, regardless of whether that is in shared or exclusive mode) and why the current usages are safe.

Fixes #26713

Closes #26914.

PiperOrigin-RevId: 805338728
Change-Id: Ie808ebe6113b935180b93c21679d5398aa168802

Commit https://github.com/bazelbuild/bazel/commit/ca1cbfece457915871cc1398a667422410b4c3fc