### PR TITLE
fix compact strings error message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/util/StringEncoding.java
+++ b/src/main/java/com/google/devtools/build/lib/util/StringEncoding.java
@@ -91,7 +91,7 @@ public final class StringEncoding {
       Field compactStrings = String.class.getDeclaredField("COMPACT_STRINGS");
       compactStrings.setAccessible(true);
       Preconditions.checkState(
-          (boolean) compactStrings.get(null), "Bazel requires -XX:-CompactStrings");
+          (boolean) compactStrings.get(null), "Bazel requires -XX:+CompactStrings");
     } catch (NoSuchFieldException | IllegalAccessException e) {
       throw new IllegalStateException(e);
     }


### PR DESCRIPTION
Bazel requires that, and this precondition checks that, compact strings are enabled.