### PR TITLE
Fail if `single_version_override` version is lower than dep spec

### DIFF
--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -108,7 +108,7 @@ class BazelOverridesTest(test_base.TestBase):
     self.ScratchFile(
         'MODULE.bazel',
         [
-            'bazel_dep(name = "aaa", version = "1.1")',
+            'bazel_dep(name = "aaa")',
             'bazel_dep(name = "bbb", version = "1.1")',
             # Both main and bbb@1.1 has to depend on the locally patched aaa@1.0
             'single_version_override(',
@@ -124,6 +124,25 @@ class BazelOverridesTest(test_base.TestBase):
     self.assertIn('main function => aaa@1.0 (locally patched)', stdout)
     self.assertIn('main function => bbb@1.1', stdout)
     self.assertIn('bbb@1.1 => aaa@1.0 (locally patched)', stdout)
+
+  def testSingleVersionOverrideVersionTooLow(self):
+    self.writeMainProjectFiles()
+    self.ScratchFile(
+      'MODULE.bazel',
+      [
+        'bazel_dep(name = "aaa", version = "1.1")',
+        'single_version_override(',
+        '  module_name = "aaa",',
+        '  version = "1.0",',
+        ')',
+      ],
+    )
+    exit_code, _, stderr = self.RunBazel(['mod', 'deps'], allow_failure=True)
+    self.AssertNotExitCode(exit_code, 0, stderr)
+    self.assertIn(
+        "ERROR: module 'aaa' is overridden to use version '1.0', which is lower than the version '1.1' requested by the root module",
+        stderr,
+    )
 
   def testRegistryOverride(self):
     self.writeMainProjectFiles()


### PR DESCRIPTION
Such a request is impossible to satisfy and likely the cause of forgetting to update the version in both places. Previously, the `bazel_dep` requirement was silently ignored.

Note that it isn't possible to entirely forbid `version` on a `bazel_dep` for an overridden module since the override would be ignored if the current module is not a root module and result in a failure in that case due to the missing version.

RELNOTES[INC]: A `single_version_override` that pins a module to a lower version than requested in a `bazel_dep` for that module now results in an error instead of silently ignoring the `bazel_dep` version requirement. This is meant to catch a common source of bugs when updating a `bazel_dep` without noticing that it is overridden.

Fixes #26964