### PR TITLE
Provide a supported replacement for `Target#repr` leak of "aliasness"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1710,6 +1710,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:commandline_item",
+        "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/Args.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/Args.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.lib.actions.CommandLines.CommandLineAndParamFil
 import com.google.devtools.build.lib.actions.ParamFileInfo;
 import com.google.devtools.build.lib.actions.ParameterFile.ParameterFileType;
 import com.google.devtools.build.lib.actions.SingleStringArgFormatter;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
@@ -313,6 +314,13 @@ public abstract class Args implements CommandLineArgsApi {
         throw Starlark.errorf(
             "Args.add() doesn't accept vectorized arguments. Please use Args.add_all() or"
                 + " Args.add_joined() instead.");
+      }
+      if (value instanceof ConfiguredTarget target) {
+        // When including target labels in command lines, use the label as specified by the user,
+        // not the fully resolved label in case of aliases. This ensures that e.g. buildozer fixup
+        // commands work as expected while not exposing the fact that a target is an alias to the
+        // rule implementation.
+        value = target.getOriginalLabel();
       }
       if (value instanceof Label label && !label.getRepository().isMain()) {
         mayStringifyExternalLabel = true;

--- a/src/main/java/com/google/devtools/build/lib/rules/AliasConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/AliasConfiguredTarget.java
@@ -44,6 +44,7 @@ import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.StarlarkSemantics;
+import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.Structure;
 
 /**
@@ -80,7 +81,7 @@ public final class AliasConfiguredTarget implements ConfiguredTarget, Structure 
       ConfiguredTarget actual,
       NestedSet<PackageGroupContents> visibility) {
     return createWithOverrides(
-        ruleContext, actual, visibility, /*overrides=*/ ImmutableClassToInstanceMap.of());
+        ruleContext, actual, visibility, /* overrides= */ ImmutableClassToInstanceMap.of());
   }
 
   /**
@@ -244,6 +245,13 @@ public final class AliasConfiguredTarget implements ConfiguredTarget, Structure 
 
   @Override
   public void repr(Printer printer) {
+    // Don't leak the fact that this is an alias or its alias label to Starlark so that a target is
+    // always safe to be replaced by an alias. debugPrint() safely reveals the alias information.
+    actual.repr(printer);
+  }
+
+  @Override
+  public void debugPrint(Printer printer, StarlarkThread thread) {
     printer.append(
         "<alias target " + actionLookupKey.getLabel() + " of " + actual.getLabel() + ">");
   }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/CommandLineArgsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/CommandLineArgsApi.java
@@ -73,7 +73,11 @@ import net.starlark.java.eval.StarlarkValue;
             + " makes this representation suited for use in BUILD files. While the exact form of"
             + " the representation is not guaranteed, typical examples are"
             + " <code>//foo:bar</code>, <code>@repo//foo:bar</code> and"
-            + " <code>@@canonical_name+//foo:bar.bzl</code>."
+            + " <code>@@canonical_name+//foo:bar.bzl</code>." //
+            + "<li><a href='../builtins/Target.html'><code>Target</code></a> objects are"
+            + " represented as their labels, as per the previous rule. If the target is an "
+            + " <a href='/reference/be/general#alias'><code>alias</code></a>, the label of the "
+            + " alias target itself is used, not that of the actual target."
             + "<li>All other types are turned into strings in an <i>unspecified</i> manner. For "
             + "    this reason, you should avoid passing values that are not of string or "
             + "    <code>File</code> type to <code>add()</code>, and if you pass them to "

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
@@ -190,6 +190,13 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
           tools = ['r1.txt'],
           outs = ['out.txt'],
         )
+        alias(name = 'alias_to_gl', actual = ':gl')
+        genrule(name = 'alias_gen',
+          cmd = 'dummy_cmd',
+          srcs = [":alias_to_gl"],
+          tools = ['t.exe'],
+          outs = ['f.txt'],
+        )
         """);
   }
 
@@ -2801,7 +2808,7 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
 
   @Test
   public void testArgsMainRepoLabel() throws Exception {
-    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:alias_gen");
     setRuleContext(ruleContext);
     ev.exec(
         "actions = ruleContext.actions",
@@ -2811,6 +2818,7 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
         "a.append(actions.args().add('-flag', Label('//bar'), format = '_%s_'))",
         "a.append(actions.args().add_all(['foo', Label('//bar')]))",
         "a.append(actions.args().add_all(depset([Label('//foo'), Label('//bar')])))",
+        "a.append(actions.args().add(ruleContext.attr.srcs[0]))",
         "ruleContext.actions.run(",
         "  inputs = depset(ruleContext.files.srcs),",
         "  outputs = ruleContext.files.srcs,",
@@ -2833,7 +2841,8 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
             "foo",
             "//bar:bar",
             "//foo:foo",
-            "//bar:bar")
+            "//bar:bar",
+            "//foo:alias_to_gl")
         .inOrder();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkStringRepresentationsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkStringRepresentationsTest.java
@@ -409,7 +409,7 @@ public class StarlarkStringRepresentationsTest extends BuildViewTestCase {
       assertThat(checkInfo.getValue("output_target" + suffix))
           .isEqualTo("<output file target //test/starlark:output.txt>");
       assertThat(checkInfo.getValue("alias_target" + suffix))
-          .isEqualTo("<alias target //test/starlark:foobar of //test/starlark:foo>");
+          .isEqualTo("<target //test/starlark:foo>");
       assertThat(checkInfo.getValue("aspect_target" + suffix))
           .isEqualTo("<merged target //test/starlark:bar>");
     }


### PR DESCRIPTION
`repr` of a `Target` leaked the fact that a target is an alias as well as the alias label. This is not desirable as it allows rule implementation to introduce special handling of aliases, which means that they are no longer transparent replacements for their actual targets (see #18100). 

Fix this by moving the alias-specific stringification to `debugPrint`, which is not accessible from Starlark. As a supported replacement that isn't exposed to Starlark rule logic, format `Target`'s as their "original label" (i.e., the `alias`' label if any) when passed to `Args`. This allows rules to emit the correct label into fixup commands while sidestepping the difficult question of whether to expose any alias information to rule logic.

Work towards #11044 