### PR TITLE
Don't use `environ` on Windows

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -82,10 +82,6 @@
 
 using blaze_util::GetLastErrorString;
 
-#if !defined(_WIN32)
-extern char **environ;
-#endif
-
 namespace blaze {
 
 using command_server::CommandServer;
@@ -1311,8 +1307,7 @@ static map<string, EnvVarValue> PrepareEnvironmentForJvm() {
   // environment variables to modify the current process, we may actually use
   // such map to configure a process from scratch (via interfaces like execvpe
   // or posix_spawn), so we need to inherit any untouched variables.
-  for (char **entry = environ; *entry != nullptr; entry++) {
-    const std::string var_value = *entry;
+  for (const auto &var_value : blaze::GetProcessedEnv()) {
     std::string::size_type equals = var_value.find('=');
     if (equals == std::string::npos) {
       // Ignore possibly-bad environment. We don't control what we see in this

--- a/src/main/cpp/option_processor-internal.h
+++ b/src/main/cpp/option_processor-internal.h
@@ -58,8 +58,6 @@ std::string FindRcAlongsideBinary(const std::string& cwd,
 
 blaze_exit_code::ExitCode ParseErrorToExitCode(RcFile::ParseError parse_error);
 
-std::vector<std::string> GetProcessedEnv();
-
 }  // namespace internal
 }  // namespace blaze
 

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -41,11 +41,6 @@
 #include "src/main/cpp/startup_options.h"
 #include "src/main/cpp/util/exit_code.h"
 
-// On OSX, there apparently is no header that defines this.
-#ifndef environ
-extern char **environ;
-#endif
-
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -531,7 +526,7 @@ blaze_exit_code::ExitCode OptionProcessor::ParseOptions(
 
   parsed_blazercs_ = GetBlazercOptions(cwd, rc_file_ptrs);
   blazerc_and_env_command_args_ = GetBlazercAndEnvCommandArgs(
-      cwd, parsed_blazercs_, blaze::internal::GetProcessedEnv());
+      cwd, parsed_blazercs_, blaze::GetProcessedEnv());
   return blaze_exit_code::SUCCESS;
 }
 

--- a/src/main/cpp/option_processor.h
+++ b/src/main/cpp/option_processor.h
@@ -188,6 +188,10 @@ blaze_exit_code::ExitCode ParseRcFile(const WorkspaceLayout* workspace_layout,
                                       std::unique_ptr<RcFile>* result_rc_file,
                                       std::string* error);
 
+// Returns the list of environment variables in the form "KEY=value", with
+// synthetic entries (Windows only) filtered out.
+std::vector<std::string> GetProcessedEnv();
+
 }  // namespace blaze
 
 #endif  // BAZEL_SRC_MAIN_CPP_OPTION_PROCESSOR_H_

--- a/src/main/cpp/option_processor_unix.cc
+++ b/src/main/cpp/option_processor_unix.cc
@@ -22,7 +22,7 @@
 extern char** environ;
 #endif
 
-namespace blaze::internal {
+namespace blaze {
 
 std::vector<std::string> GetProcessedEnv() {
   std::vector<std::string> processed_env;

--- a/src/main/cpp/option_processor_windows.cc
+++ b/src/main/cpp/option_processor_windows.cc
@@ -23,7 +23,7 @@
 #include "src/main/cpp/option_processor-internal.h"
 #include "src/main/cpp/util/strings.h"
 
-namespace blaze::internal {
+namespace blaze {
 
 #if defined(__CYGWIN__)
 
@@ -98,4 +98,4 @@ std::vector<std::string> GetProcessedEnv() {
   return processed_env;
 }
 
-}  // namespace blaze::internal
+}  // namespace blaze


### PR DESCRIPTION
Since Bazel uses `wmain`, `environ` is typically `null` until the first call to `getenv()`. This call has been removed in 1744d45c0c57af23f631c2145e8af4b185dca77f, so this usage could result in a crash.

Fixes #26948