### PR TITLE
[7.7.0] Add the missing headers

### DIFF
--- a/src/main/cpp/archive_utils.h
+++ b/src/main/cpp/archive_utils.h
@@ -15,6 +15,7 @@
 #ifndef BAZEL_SRC_MAIN_CPP_ARCHIVE_UTILS_H_
 #define BAZEL_SRC_MAIN_CPP_ARCHIVE_UTILS_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/main/cpp/util/logging.h
+++ b/src/main/cpp/util/logging.h
@@ -14,6 +14,7 @@
 #ifndef BAZEL_SRC_MAIN_CPP_LOGGING_H_
 #define BAZEL_SRC_MAIN_CPP_LOGGING_H_
 
+#include <cstdint>
 #include <memory>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/25514

Closes #26963.

PiperOrigin-RevId: 807611171
Change-Id: Ie4102be364146bc142389756b04160cf30e9d39f

Commit https://github.com/bazelbuild/bazel/commit/b39e21fb27cfaf8ee2f6212562ac9e194a78588a