### PR TITLE
Update macro style guide

### DIFF
--- a/site/en/rules/bzl-style.md
+++ b/site/en/rules/bzl-style.md
@@ -144,7 +144,7 @@ not instantiated by that macro), follow these best practices:
 *   A macro should take a `name` argument and define a target with that name.
     That target becomes that macro's *main target*.
 *   Generated targets, that is all other targets defined by a macro, should:
-    *   Have their names prefixed by `<name>` or `_<name>`. For example, using
+    *   Have their names prefixed by `<name>`. For example, using
         `name = '%s_bar' % (name)`.
     *   Have restricted visibility (`//visibility:private`), and
     *   Have a `manual` tag to avoid expansion in wildcard targets (`:all`,


### PR DESCRIPTION
Symbolic macros require all targets generated by the macro to be prefixed by name. The style guide recommended a naming convention (`_name`) that was incompatible this requirement. This change updates the style guide to match the symbolic macro naming convention.

https://bazel.build/extending/macros#naming