### PR TITLE
[8.5.0] Allow running hermetic `--sandbox_debug` command multiple times

### DIFF
--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -100,6 +100,23 @@ static void LinkFile(const char *path) {
   }
 }
 
+// Creates a symlink from 'target' -> 'path'. If 'path' already existed then
+// unlink and try again.
+static void SymlinkFile(const char* target, const char* path) {
+  if (symlink(target, path) < 0) {
+    if (errno == EEXIST) {
+      // Try to remove the existing file first.
+      if (unlink(path) < 0) {
+        DIE("unlink %s", path);
+      }
+      if (symlink(target, path) == 0) {
+        return;
+      }
+    }
+    DIE("symlink %s", path);
+  }
+}
+
 // Recursively creates the file or directory specified in "path" and its parent
 // directories.
 // Return -1 on failure and sets errno to:
@@ -595,9 +612,7 @@ static void MountDev() {
       DIE("mount");
     }
   }
-  if (symlink("/proc/self/fd", "dev/fd") < 0) {
-    DIE("symlink");
-  }
+  SymlinkFile("/proc/self/fd", "dev/fd");
 }
 
 static void MountAllMounts() {


### PR DESCRIPTION
Fixes:
```
src/main/tools/linux-sandbox-pid1.cc:599: "symlink": File exists
```

This is a problem for `--experimental_use_hermetic_linux_sandbox` cases.

Continuation of #26437

Work towards #24081

Closes #26811.

PiperOrigin-RevId: 808023044
Change-Id: Ic152d3407010e2ddb8363012dafda1037ba7738d

Commit https://github.com/bazelbuild/bazel/commit/e5e8f4aecf8947d11524f1700629f5403c5a3293