### PR TITLE
add flag_alias function

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphValue.java
@@ -62,7 +62,7 @@ public abstract class BazelDepGraphValue implements SkyValue {
             .setExtensionUsages(ImmutableList.of())
             .setExecutionPlatformsToRegister(ImmutableList.of())
             .setToolchainsToRegister(ImmutableList.of())
-            .setFlagAliases(ImmutableList.of())
+            .setFlagAliases(ImmutableMap.of())
             .build();
 
     ImmutableMap<ModuleKey, Module> emptyDepGraph = ImmutableMap.of(ModuleKey.ROOT, root);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphValue.java
@@ -62,6 +62,7 @@ public abstract class BazelDepGraphValue implements SkyValue {
             .setExtensionUsages(ImmutableList.of())
             .setExecutionPlatformsToRegister(ImmutableList.of())
             .setToolchainsToRegister(ImmutableList.of())
+            .setFlagAliases(ImmutableList.of())
             .build();
 
     ImmutableMap<ModuleKey, Module> emptyDepGraph = ImmutableMap.of(ModuleKey.ROOT, root);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
@@ -160,6 +160,14 @@ public abstract class InterimModule extends ModuleBase {
 
     abstract ImmutableList.Builder<String> bazelCompatibilityBuilder();
 
+    abstract ImmutableList.Builder<String> flagAliasesBuilder();
+
+    @CanIgnoreReturnValue
+    public final Builder addFlagAlias(String nativeName, String starlarkLabel) {
+      flagAliasesBuilder().add(String.format("%s=%s", nativeName, starlarkLabel));
+      return this;
+    }
+
     @CanIgnoreReturnValue
     public final Builder addBazelCompatibilityValues(Iterable<String> values) {
       bazelCompatibilityBuilder().addAll(values);
@@ -243,6 +251,7 @@ public abstract class InterimModule extends ModuleBase {
         .setDeps(ImmutableMap.copyOf(Maps.transformValues(interim.getDeps(), DepSpec::toModuleKey)))
         .setRepoSpec(maybeAppendAdditionalPatches(remoteRepoSpec, override))
         .setExtensionUsages(interim.getExtensionUsages())
+        .setFlagAliases(interim.getFlagAliases())
         .build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
@@ -166,7 +166,7 @@ public abstract class InterimModule extends ModuleBase {
 
     @CanIgnoreReturnValue
     public final Builder addFlagAlias(String nativeName, String starlarkLabel) throws LabelSyntaxException {
-      flagAliasesBuilder().put(nativeName, Label.parseCanonical(starlarkLabel).getUnambiguousCanonicalForm());
+      flagAliasesBuilder().put(nativeName, Label.parseCanonical(starlarkLabel.substring(2)).getUnambiguousCanonicalForm());
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
@@ -166,7 +166,7 @@ public abstract class InterimModule extends ModuleBase {
 
     @CanIgnoreReturnValue
     public final Builder addFlagAlias(String nativeName, String starlarkLabel) throws LabelSyntaxException {
-      flagAliasesBuilder().put(nativeName, Label.parseCanonical(starlarkLabel.substring(2)).getUnambiguousCanonicalForm());
+      flagAliasesBuilder().put(nativeName, Label.parseCanonical(starlarkLabel).getUnambiguousCanonicalForm());
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Optional;
@@ -163,8 +165,8 @@ public abstract class InterimModule extends ModuleBase {
     abstract ImmutableMap.Builder<String, String> flagAliasesBuilder();
 
     @CanIgnoreReturnValue
-    public final Builder addFlagAlias(String nativeName, String starlarkLabel) {
-      flagAliasesBuilder().put(nativeName, starlarkLabel);
+    public final Builder addFlagAlias(String nativeName, String starlarkLabel) throws LabelSyntaxException {
+      flagAliasesBuilder().put(nativeName, Label.parseCanonical(starlarkLabel).getUnambiguousCanonicalForm());
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
@@ -160,11 +160,11 @@ public abstract class InterimModule extends ModuleBase {
 
     abstract ImmutableList.Builder<String> bazelCompatibilityBuilder();
 
-    abstract ImmutableList.Builder<String> flagAliasesBuilder();
+    abstract ImmutableMap.Builder<String, String> flagAliasesBuilder();
 
     @CanIgnoreReturnValue
     public final Builder addFlagAlias(String nativeName, String starlarkLabel) {
-      flagAliasesBuilder().add(String.format("%s=%s", nativeName, starlarkLabel));
+      flagAliasesBuilder().put(nativeName, starlarkLabel);
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Module.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Module.java
@@ -98,6 +98,8 @@ public abstract class Module extends ModuleBase {
 
     abstract ImmutableMap.Builder<String, ModuleKey> depsBuilder();
 
+    public abstract Builder setFlagAliases(ImmutableList<String> value);
+
     @CanIgnoreReturnValue
     public Builder addDep(String depRepoName, ModuleKey depKey) {
       depsBuilder().put(depRepoName, depKey);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Module.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Module.java
@@ -98,7 +98,7 @@ public abstract class Module extends ModuleBase {
 
     abstract ImmutableMap.Builder<String, ModuleKey> depsBuilder();
 
-    public abstract Builder setFlagAliases(ImmutableList<String> value);
+    public abstract Builder setFlagAliases(ImmutableMap<String, String> value);
 
     @CanIgnoreReturnValue
     public Builder addDep(String depRepoName, ModuleKey depKey) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleBase.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleBase.java
@@ -72,6 +72,7 @@ abstract class ModuleBase {
   public abstract ImmutableList<ModuleExtensionUsage> getExtensionUsages();
 
   /** The flag aliases for this module. This is a list of String of the following format
-   * $NATIVE_FLAG=$STARLARK_LABEL*/
+   * {@code ${ALIAS}=${LABEL}}
+   * */
   public abstract ImmutableList<String> getFlagAliases();
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleBase.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleBase.java
@@ -70,4 +70,7 @@ abstract class ModuleBase {
 
   /** The module extensions used in this module. */
   public abstract ImmutableList<ModuleExtensionUsage> getExtensionUsages();
+
+  /** The flag aliases for this module. */
+  public abstract ImmutableList<String> getFlagAliases();
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleBase.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleBase.java
@@ -16,6 +16,7 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /** Represents a node in the external dependency graph. */
 abstract class ModuleBase {
@@ -74,5 +75,5 @@ abstract class ModuleBase {
   /** The flag aliases for this module. This is a list of String of the following format
    * {@code ${ALIAS}=${LABEL}}
    * */
-  public abstract ImmutableList<String> getFlagAliases();
+  public abstract ImmutableMap<String, String> getFlagAliases();
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleBase.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleBase.java
@@ -71,6 +71,7 @@ abstract class ModuleBase {
   /** The module extensions used in this module. */
   public abstract ImmutableList<ModuleExtensionUsage> getExtensionUsages();
 
-  /** The flag aliases for this module. */
+  /** The flag aliases for this module. This is a list of String of the following format
+   * $NATIVE_FLAG=$STARLARK_LABEL*/
   public abstract ImmutableList<String> getFlagAliases();
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -1173,7 +1173,11 @@ public class ModuleFileGlobals {
 
   @StarlarkMethod(
       name = "flag_alias",
-      doc = "maps a command line flag to a Starlark label.",
+      doc =
+        """
+          Maps a command-line flag --foo to a Starlark flag --@repo//defs:foo. Bazel translates all
+          instances of $ bazel build //target --foo to $ bazel build //target --@repo//defs:foo.
+        """,
       parameters = {
           @Param(
               name = "native_name",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -1170,4 +1170,25 @@ public class ModuleFileGlobals {
     validateModuleName(moduleName);
     context.addOverride(moduleName, new NonRegistryOverride(LocalPathRepoSpecs.create(path)));
   }
+
+  @StarlarkMethod(
+      name = "flag_alias",
+      doc = "maps a command line flag to a Starlark label.",
+      parameters = {
+          @Param(
+              name = "native_name",
+              doc = "The name of the native flag.",
+              positional = true),
+          @Param(
+              name = "starlark_label",
+              doc = "The label of the Starlark flag to alias to.",
+              positional = true),
+      },
+      useStarlarkThread = true)
+  public void flagAlias(String nativeName, String starlarkLabel, StarlarkThread thread)
+      throws EvalException {
+    ModuleThreadContext context = ModuleThreadContext.fromOrFail(thread, "flag_alias()");
+    context.setNonModuleCalled();
+    context.getModuleBuilder().addFlagAlias(nativeName, starlarkLabel);
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -1180,8 +1180,8 @@ public class ModuleFileGlobals {
         """,
       parameters = {
           @Param(
-              name = "native_name",
-              doc = "The name of the native flag.",
+              name = "name",
+              doc = "The name of the flag.",
               positional = true),
           @Param(
               name = "starlark_label",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -1192,6 +1192,7 @@ public class ModuleFileGlobals {
   public void flagAlias(String nativeName, String starlarkLabel, StarlarkThread thread)
       throws EvalException, LabelSyntaxException {
     ModuleThreadContext context = ModuleThreadContext.fromOrFail(thread, "flag_alias()");
+    // TODO: add input validation for stalark flag label
     context.setNonModuleCalled();
     context.getModuleBuilder().addFlagAlias(nativeName, starlarkLabel);
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -1190,7 +1190,7 @@ public class ModuleFileGlobals {
       },
       useStarlarkThread = true)
   public void flagAlias(String nativeName, String starlarkLabel, StarlarkThread thread)
-      throws EvalException {
+      throws EvalException, LabelSyntaxException {
     ModuleThreadContext context = ModuleThreadContext.fromOrFail(thread, "flag_alias()");
     context.setNonModuleCalled();
     context.getModuleBuilder().addFlagAlias(nativeName, starlarkLabel);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -1184,7 +1184,7 @@ public class ModuleFileGlobals {
               doc = "The name of the flag.",
               positional = true),
           @Param(
-              name = "starlark_label",
+              name = "starlark_flag",
               doc = "The label of the Starlark flag to alias to.",
               positional = true),
       },

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -636,8 +636,8 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
             Profiler.instance().profile(ProfilerTask.BZLMOD, "compute main repo mapping")) {
           RepositoryMapping mainRepoMapping =
               env.getSkyframeExecutor().getMainRepoMapping(reporter);
-          Map<String, String> flagAlias = env.getSkyframeExecutor().getFlagAlias(reporter);
-          optionsParser = optionsParser.toBuilder().withConversionContext(mainRepoMapping).withAliases(flagAlias).build();
+          optionsParser = optionsParser.toBuilder().withConversionContext(mainRepoMapping)
+              .withAliases(env.getSkyframeExecutor().getFlagAlias(reporter)).build();
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           String message = "command interrupted while computing main repo mapping";

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -87,6 +87,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -635,7 +636,8 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
             Profiler.instance().profile(ProfilerTask.BZLMOD, "compute main repo mapping")) {
           RepositoryMapping mainRepoMapping =
               env.getSkyframeExecutor().getMainRepoMapping(reporter);
-          optionsParser = optionsParser.toBuilder().withConversionContext(mainRepoMapping).build();
+          Map<String, String> flagAlias = env.getSkyframeExecutor().getFlagAlias(reporter);
+          optionsParser = optionsParser.toBuilder().withConversionContext(mainRepoMapping).withAliases(flagAlias).build();
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           String message = "command interrupted while computing main repo mapping";

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -637,7 +637,7 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
           RepositoryMapping mainRepoMapping =
               env.getSkyframeExecutor().getMainRepoMapping(reporter);
           optionsParser = optionsParser.toBuilder().withConversionContext(mainRepoMapping)
-              .withAliases(env.getSkyframeExecutor().getFlagAlias(reporter)).build();
+              .withAliases(env.getSkyframeExecutor().getFlagAliases(reporter)).build();
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           String message = "command interrupted while computing main repo mapping";

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -385,6 +385,7 @@ java_library(
         "//src/main/protobuf:failure_details_java_proto",
         "//src/main/protobuf:memory_pressure_java_proto",
         "//src/main/protobuf:test_status_java_proto",
+        "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:common",
         "//third_party:auto_value",
         "//third_party:caffeine",
         "//third_party:flogger",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -3240,7 +3240,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     return detailedExitCode;
   }
 
-  public Map<String,String> getFlagAlias(ExtendedEventHandler eventHandler) throws InterruptedException {
+  public Map<String,String> getFlagAliases(ExtendedEventHandler eventHandler) throws InterruptedException {
     EvaluationResult<BazelDepGraphValue> evalResult =
         evaluate(
             ImmutableList.of(BazelDepGraphValue.KEY), false, DEFAULT_THREAD_COUNT, eventHandler);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -119,6 +119,7 @@ import com.google.devtools.build.lib.analysis.platform.PlatformValue;
 import com.google.devtools.build.lib.analysis.producers.ConfiguredTargetAndDataProducer;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkAttributeTransitionProvider;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphValue;
+import com.google.devtools.build.lib.bazel.bzlmod.ModuleKey;
 import com.google.devtools.build.lib.bazel.repository.RepoDefinitionFunction;
 import com.google.devtools.build.lib.bazel.repository.RepoDefinitionValue;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions;
@@ -3237,6 +3238,25 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
       traverseException = (Exception) traverseException.getCause();
     }
     return detailedExitCode;
+  }
+
+  public Map<String,String> getFlagAlias(ExtendedEventHandler eventHandler) throws InterruptedException {
+    EvaluationResult<BazelDepGraphValue> evalResult =
+        evaluate(
+            ImmutableList.of(BazelDepGraphValue.KEY), false, DEFAULT_THREAD_COUNT, eventHandler);
+    ImmutableList<String> flagAliases = evalResult.get(BazelDepGraphValue.KEY).getDepGraph().get(
+        ModuleKey.ROOT).getFlagAliases();
+    Map<String, String> aliasesMap = new HashMap<>();
+
+    if (flagAliases == null) {
+      return aliasesMap;
+    }
+
+    for (String alias : flagAliases) {
+      String[] split = alias.split("=");
+      aliasesMap.put(split[0], split[1]);
+    }
+    return aliasesMap;
   }
 
   public RepositoryMapping getMainRepoMapping(ExtendedEventHandler eventHandler)

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -3244,17 +3244,16 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     EvaluationResult<BazelDepGraphValue> evalResult =
         evaluate(
             ImmutableList.of(BazelDepGraphValue.KEY), false, DEFAULT_THREAD_COUNT, eventHandler);
-    ImmutableList<String> flagAliases = evalResult.get(BazelDepGraphValue.KEY).getDepGraph().get(
-        ModuleKey.ROOT).getFlagAliases();
-    Map<String, String> aliasesMap = new HashMap<>();
+    ImmutableMap<String, String> flagAliases = evalResult.get(BazelDepGraphValue.KEY).getDepGraph().get(ModuleKey.ROOT).getFlagAliases();
+    LinkedHashMap<String, String> aliasesMap = new LinkedHashMap<>();
+
 
     if (flagAliases == null) {
       return aliasesMap;
     }
 
-    for (String alias : flagAliases) {
-      String[] split = alias.split("=");
-      aliasesMap.put(split[0], split[1]);
+    for (String flag : flagAliases.keySet()) {
+      aliasesMap.put(flag, flagAliases.get(flag));
     }
     return aliasesMap;
   }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
@@ -181,8 +181,8 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
                     .addDep("rules_java", createModuleKey("rules_java", ""))
                     .setFlagAliases(ImmutableList.of())
                     .build())
-            .put(createModuleKey("dep", "2.0"), buildModule("dep", "2.0").build())
-            .put(createModuleKey("rules_cc", "1.0"), buildModule("rules_cc", "1.0").build())
+            .put(createModuleKey("dep", "2.0"), buildModule("dep", "2.0").setFlagAliases(ImmutableList.of()).build())
+            .put(createModuleKey("rules_cc", "1.0"), buildModule("rules_cc", "1.0").setFlagAliases(ImmutableList.of()).build())
             .put(
                 createModuleKey("rules_java", ""),
                 buildModule("rules_java", "1.0").setKey(createModuleKey("rules_java", "")).setFlagAliases(ImmutableList.of()).build())
@@ -268,9 +268,9 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
             depKey,
             dep,
             rjeKey,
-            buildModule("rules_jvm_external", "1.0").setKey(rjeKey).build(),
+            buildModule("rules_jvm_external", "1.0").setKey(rjeKey).setFlagAliases(ImmutableList.of()).build(),
             rpyKey,
-            buildModule("rules_python", "2.0").setKey(rpyKey).build());
+            buildModule("rules_python", "2.0").setKey(rpyKey).setFlagAliases(ImmutableList.of()).build());
 
     ModuleExtensionId maven =
         ModuleExtensionId.create(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
@@ -173,6 +173,7 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
                     .addDep("my_dep_1", createModuleKey("dep", "1.0"))
                     .addDep("my_dep_2", createModuleKey("dep", "2.0"))
                     .addDep("rules_cc", createModuleKey("rules_cc", "1.0"))
+                    .setFlagAliases(ImmutableList.of())
                     .build())
             .put(
                 createModuleKey("dep", "1.0"),
@@ -244,6 +245,7 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
                 createModuleExtensionUsage("@rje//:defs.bzl", "maven", "av", "autovalue"))
             .addExtensionUsage(
                 createModuleExtensionUsage("@rpy//:defs.bzl", "pip", "numpy", "numpy"))
+            .setFlagAliases(ImmutableList.of())
             .build();
     ModuleKey depKey = createModuleKey("dep", "2.0");
     Module dep =
@@ -346,6 +348,7 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
         buildModule("module", "1.0")
             .setKey(ModuleKey.ROOT)
             .addExtensionUsage(createModuleExtensionUsage("@foo//:defs.bzl", "bar"))
+            .setFlagAliases(ImmutableList.of())
             .build();
     ImmutableMap<ModuleKey, Module> depGraph = ImmutableMap.of(ModuleKey.ROOT, root);
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
@@ -173,19 +173,19 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
                     .addDep("my_dep_1", createModuleKey("dep", "1.0"))
                     .addDep("my_dep_2", createModuleKey("dep", "2.0"))
                     .addDep("rules_cc", createModuleKey("rules_cc", "1.0"))
-                    .setFlagAliases(ImmutableList.of())
+                    .setFlagAliases(ImmutableMap.of())
                     .build())
             .put(
                 createModuleKey("dep", "1.0"),
                 buildModule("dep", "1.0")
                     .addDep("rules_java", createModuleKey("rules_java", ""))
-                    .setFlagAliases(ImmutableList.of())
+                    .setFlagAliases(ImmutableMap.of())
                     .build())
-            .put(createModuleKey("dep", "2.0"), buildModule("dep", "2.0").setFlagAliases(ImmutableList.of()).build())
-            .put(createModuleKey("rules_cc", "1.0"), buildModule("rules_cc", "1.0").setFlagAliases(ImmutableList.of()).build())
+            .put(createModuleKey("dep", "2.0"), buildModule("dep", "2.0").setFlagAliases(ImmutableMap.of()).build())
+            .put(createModuleKey("rules_cc", "1.0"), buildModule("rules_cc", "1.0").setFlagAliases(ImmutableMap.of()).build())
             .put(
                 createModuleKey("rules_java", ""),
-                buildModule("rules_java", "1.0").setKey(createModuleKey("rules_java", "")).setFlagAliases(ImmutableList.of()).build())
+                buildModule("rules_java", "1.0").setKey(createModuleKey("rules_java", "")).setFlagAliases(ImmutableMap.of()).build())
             .buildOrThrow();
 
     resolutionFunctionMock.setDepGraph(depGraph);
@@ -246,7 +246,7 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
                 createModuleExtensionUsage("@rje//:defs.bzl", "maven", "av", "autovalue"))
             .addExtensionUsage(
                 createModuleExtensionUsage("@rpy//:defs.bzl", "pip", "numpy", "numpy"))
-            .setFlagAliases(ImmutableList.of())
+            .setFlagAliases(ImmutableMap.of())
             .build();
     ModuleKey depKey = createModuleKey("dep", "2.0");
     Module dep =
@@ -259,7 +259,7 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
                 createModuleExtensionUsage("//:defs.bzl", "myext", "oneext", "myext"))
             .addExtensionUsage(
                 createModuleExtensionUsage("//incredible:conflict.bzl", "myext", "twoext", "myext"))
-            .setFlagAliases(ImmutableList.of())
+            .setFlagAliases(ImmutableMap.of())
             .build();
     ImmutableMap<ModuleKey, Module> depGraph =
         ImmutableMap.of(
@@ -268,9 +268,9 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
             depKey,
             dep,
             rjeKey,
-            buildModule("rules_jvm_external", "1.0").setKey(rjeKey).setFlagAliases(ImmutableList.of()).build(),
+            buildModule("rules_jvm_external", "1.0").setKey(rjeKey).setFlagAliases(ImmutableMap.of()).build(),
             rpyKey,
-            buildModule("rules_python", "2.0").setKey(rpyKey).setFlagAliases(ImmutableList.of()).build());
+            buildModule("rules_python", "2.0").setKey(rpyKey).setFlagAliases(ImmutableMap.of()).build());
 
     ModuleExtensionId maven =
         ModuleExtensionId.create(
@@ -350,7 +350,7 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
         buildModule("module", "1.0")
             .setKey(ModuleKey.ROOT)
             .addExtensionUsage(createModuleExtensionUsage("@foo//:defs.bzl", "bar"))
-            .setFlagAliases(ImmutableList.of())
+            .setFlagAliases(ImmutableMap.of())
             .build();
     ImmutableMap<ModuleKey, Module> depGraph = ImmutableMap.of(ModuleKey.ROOT, root);
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
@@ -179,12 +179,13 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
                 createModuleKey("dep", "1.0"),
                 buildModule("dep", "1.0")
                     .addDep("rules_java", createModuleKey("rules_java", ""))
+                    .setFlagAliases(ImmutableList.of())
                     .build())
             .put(createModuleKey("dep", "2.0"), buildModule("dep", "2.0").build())
             .put(createModuleKey("rules_cc", "1.0"), buildModule("rules_cc", "1.0").build())
             .put(
                 createModuleKey("rules_java", ""),
-                buildModule("rules_java", "1.0").setKey(createModuleKey("rules_java", "")).build())
+                buildModule("rules_java", "1.0").setKey(createModuleKey("rules_java", "")).setFlagAliases(ImmutableList.of()).build())
             .buildOrThrow();
 
     resolutionFunctionMock.setDepGraph(depGraph);
@@ -258,6 +259,7 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
                 createModuleExtensionUsage("//:defs.bzl", "myext", "oneext", "myext"))
             .addExtensionUsage(
                 createModuleExtensionUsage("//incredible:conflict.bzl", "myext", "twoext", "myext"))
+            .setFlagAliases(ImmutableList.of())
             .build();
     ImmutableMap<ModuleKey, Module> depGraph =
         ImmutableMap.of(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
@@ -162,6 +162,12 @@ public final class BzlmodTestUtil {
     }
 
     @CanIgnoreReturnValue
+    public InterimModuleBuilder addFlagAlias(String nativeFlag, String starlarkFlag) {
+      this.builder.addFlagAlias(nativeFlag, starlarkFlag);
+      return this;
+    }
+
+    @CanIgnoreReturnValue
     public InterimModuleBuilder addExtensionUsage(ModuleExtensionUsage value) {
       this.builder.addExtensionUsage(value);
       return this;

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleInspectorValue.Augm
 import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleInspectorValue.AugmentedModule.ResolutionReason;
 import com.google.devtools.build.lib.bazel.bzlmod.InterimModule.DepSpec;
 import com.google.devtools.build.lib.bazel.bzlmod.Version.ParseException;
+import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.packages.Attribute;
@@ -162,7 +163,7 @@ public final class BzlmodTestUtil {
     }
 
     @CanIgnoreReturnValue
-    public InterimModuleBuilder addFlagAlias(String nativeFlag, String starlarkFlag) {
+    public InterimModuleBuilder addFlagAlias(String nativeFlag, String starlarkFlag) throws LabelSyntaxException {
       this.builder.addFlagAlias(nativeFlag, starlarkFlag);
       return this;
     }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -205,8 +205,8 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
         "bazel_dep(name='ddd',version='3.0',repo_name=None)",
         "register_toolchains('//my:toolchain', '//my:toolchain2')",
         "register_execution_platforms('//my:platform', '//my:platform2')",
-        "flag_alias('native_flag1', '--//my:starlark_label1')",
-        "flag_alias('native_flag2', '--//my:starlark_label2')",
+        "flag_alias('native_flag1', '//my:starlark_label1')",
+        "flag_alias('native_flag2', '//my:starlark_label2')",
         "single_version_override(module_name='ddd',version='18')",
         "local_path_override(module_name='eee',path='somewhere/else')",
         "multiple_version_override(module_name='fff',versions=['1.0','2.0'])",
@@ -230,8 +230,8 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                 .addToolchainsToRegister(ImmutableList.of("//my:toolchain", "//my:toolchain2"))
                 .addDep("bbb", createModuleKey("bbb", "1.0"))
                 .addDep("see", createModuleKey("ccc", "2.0"))
-                .addFlagAlias("native_flag1", "--//my:starlark_label1")
-                .addFlagAlias("native_flag2", "--//my:starlark_label2")
+                .addFlagAlias("native_flag1", "//my:starlark_label1")
+                .addFlagAlias("native_flag2", "//my:starlark_label2")
                 .addNodepDep(createModuleKey("ddd", "3.0"))
                 .build());
     assertThat(rootModuleFileValue.overrides())

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -205,6 +205,8 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
         "bazel_dep(name='ddd',version='3.0',repo_name=None)",
         "register_toolchains('//my:toolchain', '//my:toolchain2')",
         "register_execution_platforms('//my:platform', '//my:platform2')",
+        "flag_alias('native_flag1', 'starlark_label1')",
+        "flag_alias('native_flag2', 'starlark_label2')",
         "single_version_override(module_name='ddd',version='18')",
         "local_path_override(module_name='eee',path='somewhere/else')",
         "multiple_version_override(module_name='fff',versions=['1.0','2.0'])",
@@ -228,6 +230,8 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                 .addToolchainsToRegister(ImmutableList.of("//my:toolchain", "//my:toolchain2"))
                 .addDep("bbb", createModuleKey("bbb", "1.0"))
                 .addDep("see", createModuleKey("ccc", "2.0"))
+                .addFlagAlias("native_flag1", "starlark_label1")
+                .addFlagAlias("native_flag2", "starlark_label2")
                 .addNodepDep(createModuleKey("ddd", "3.0"))
                 .build());
     assertThat(rootModuleFileValue.overrides())

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -205,8 +205,8 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
         "bazel_dep(name='ddd',version='3.0',repo_name=None)",
         "register_toolchains('//my:toolchain', '//my:toolchain2')",
         "register_execution_platforms('//my:platform', '//my:platform2')",
-        "flag_alias('native_flag1', 'starlark_label1')",
-        "flag_alias('native_flag2', 'starlark_label2')",
+        "flag_alias('native_flag1', '//my:starlark_label1')",
+        "flag_alias('native_flag2', '//my:starlark_label2')",
         "single_version_override(module_name='ddd',version='18')",
         "local_path_override(module_name='eee',path='somewhere/else')",
         "multiple_version_override(module_name='fff',versions=['1.0','2.0'])",
@@ -230,8 +230,8 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                 .addToolchainsToRegister(ImmutableList.of("//my:toolchain", "//my:toolchain2"))
                 .addDep("bbb", createModuleKey("bbb", "1.0"))
                 .addDep("see", createModuleKey("ccc", "2.0"))
-                .addFlagAlias("native_flag1", "starlark_label1")
-                .addFlagAlias("native_flag2", "starlark_label2")
+                .addFlagAlias("native_flag1", "//my:starlark_label1")
+                .addFlagAlias("native_flag2", "//my:starlark_label2")
                 .addNodepDep(createModuleKey("ddd", "3.0"))
                 .build());
     assertThat(rootModuleFileValue.overrides())

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -205,8 +205,8 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
         "bazel_dep(name='ddd',version='3.0',repo_name=None)",
         "register_toolchains('//my:toolchain', '//my:toolchain2')",
         "register_execution_platforms('//my:platform', '//my:platform2')",
-        "flag_alias('native_flag1', '//my:starlark_label1')",
-        "flag_alias('native_flag2', '//my:starlark_label2')",
+        "flag_alias('native_flag1', '--//my:starlark_label1')",
+        "flag_alias('native_flag2', '--//my:starlark_label2')",
         "single_version_override(module_name='ddd',version='18')",
         "local_path_override(module_name='eee',path='somewhere/else')",
         "multiple_version_override(module_name='fff',versions=['1.0','2.0'])",
@@ -230,8 +230,8 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                 .addToolchainsToRegister(ImmutableList.of("//my:toolchain", "//my:toolchain2"))
                 .addDep("bbb", createModuleKey("bbb", "1.0"))
                 .addDep("see", createModuleKey("ccc", "2.0"))
-                .addFlagAlias("native_flag1", "//my:starlark_label1")
-                .addFlagAlias("native_flag2", "//my:starlark_label2")
+                .addFlagAlias("native_flag1", "--//my:starlark_label1")
+                .addFlagAlias("native_flag2", "--//my:starlark_label2")
                 .addNodepDep(createModuleKey("ddd", "3.0"))
                 .build());
     assertThat(rootModuleFileValue.overrides())

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleTest.java
@@ -22,6 +22,7 @@ import static com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.createMo
 import static com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.createRepositoryMapping;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.windows.WindowsPathOperations;
 import java.util.stream.Stream;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class ModuleTest {
             .addDep("my_foo", fooKey)
             .addDep("my_bar", barKey)
             .addDep("my_root", ModuleKey.ROOT)
-            .setFlagAliases(ImmutableList.of())
+            .setFlagAliases(ImmutableMap.of())
             .build();
     assertThat(
             module.getRepoMappingWithBazelDepsOnly(
@@ -71,7 +72,7 @@ public class ModuleTest {
             .setKey(ModuleKey.ROOT)
             .addDep("my_foo", createModuleKey("foo", "1.0"))
             .addDep("my_bar", createModuleKey("bar", "2.0"))
-            .setFlagAliases(ImmutableList.of())
+            .setFlagAliases(ImmutableMap.of())
             .build();
     assertThat(
             module.getRepoMappingWithBazelDepsOnly(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleTest.java
@@ -21,6 +21,7 @@ import static com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.buildMod
 import static com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.createModuleKey;
 import static com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.createRepositoryMapping;
 
+import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.windows.WindowsPathOperations;
 import java.util.stream.Stream;
 import org.junit.Test;
@@ -41,6 +42,7 @@ public class ModuleTest {
             .addDep("my_foo", fooKey)
             .addDep("my_bar", barKey)
             .addDep("my_root", ModuleKey.ROOT)
+            .setFlagAliases(ImmutableList.of())
             .build();
     assertThat(
             module.getRepoMappingWithBazelDepsOnly(
@@ -69,6 +71,7 @@ public class ModuleTest {
             .setKey(ModuleKey.ROOT)
             .addDep("my_foo", createModuleKey("foo", "1.0"))
             .addDep("my_bar", createModuleKey("bar", "2.0"))
+            .setFlagAliases(ImmutableList.of())
             .build();
     assertThat(
             module.getRepoMappingWithBazelDepsOnly(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
@@ -88,7 +88,7 @@ public class StarlarkBazelModuleTest {
             .build();
     ModuleKey fooKey = createModuleKey("foo", "");
     ModuleKey barKey = createModuleKey("bar", "2.0");
-    Module module = buildModule("foo", "1.0").setKey(fooKey).addDep("bar", barKey).build();
+    Module module = buildModule("foo", "1.0").setKey(fooKey).addDep("bar", barKey).setFlagAliases(ImmutableList.of()).build();
     AbridgedModule abridgedModule = AbridgedModule.from(module);
 
     Label.RepoMappingRecorder repoMappingRecorder = new Label.RepoMappingRecorder();

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
@@ -88,7 +88,7 @@ public class StarlarkBazelModuleTest {
             .build();
     ModuleKey fooKey = createModuleKey("foo", "");
     ModuleKey barKey = createModuleKey("bar", "2.0");
-    Module module = buildModule("foo", "1.0").setKey(fooKey).addDep("bar", barKey).setFlagAliases(ImmutableList.of()).build();
+    Module module = buildModule("foo", "1.0").setKey(fooKey).addDep("bar", barKey).setFlagAliases(ImmutableMap.of()).build();
     AbridgedModule abridgedModule = AbridgedModule.from(module);
 
     Label.RepoMappingRecorder repoMappingRecorder = new Label.RepoMappingRecorder();
@@ -139,7 +139,7 @@ public class StarlarkBazelModuleTest {
     ModuleExtension extension =
         getBaseExtensionBuilder().setTagClasses(ImmutableMap.of("dep", createTagClass())).build();
     ModuleKey fooKey = createModuleKey("foo", "");
-    Module module = buildModule("foo", "1.0").setKey(fooKey).setFlagAliases(ImmutableList.of()).build();
+    Module module = buildModule("foo", "1.0").setKey(fooKey).setFlagAliases(ImmutableMap.of()).build();
     AbridgedModule abridgedModule = AbridgedModule.from(module);
 
     ExternalDepsException e =

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
@@ -139,7 +139,7 @@ public class StarlarkBazelModuleTest {
     ModuleExtension extension =
         getBaseExtensionBuilder().setTagClasses(ImmutableMap.of("dep", createTagClass())).build();
     ModuleKey fooKey = createModuleKey("foo", "");
-    Module module = buildModule("foo", "1.0").setKey(fooKey).build();
+    Module module = buildModule("foo", "1.0").setKey(fooKey).setFlagAliases(ImmutableList.of()).build();
     AbridgedModule abridgedModule = AbridgedModule.from(module);
 
     ExternalDepsException e =


### PR DESCRIPTION
add flag_alias function to map native flag to its Starlark flag label. The flag aliases map is then injected into the OptionsParser after module resolution is done. 

See detailed proposal in https://docs.google.com/document/d/1yOvi4hVV7Ja32ocwVb4lsEUnijftk8nilXPncYm-BH8/edit?tab=t.0#heading=h.qn3unswby87l