### PR TITLE
Correct int size for attribute length in prolog

### DIFF
--- a/third_party/ijar/classfile.cc
+++ b/third_party/ijar/classfile.cc
@@ -450,7 +450,7 @@ struct Attribute {
   virtual void ExtractClassNames() {}
   virtual bool KeepForCompile() const { return false; }
 
-  void WriteProlog(u1 *&p, u2 length) {
+  void WriteProlog(u1 *&p, u4 length) {
     put_u2be(p, attribute_name_->slot());
     put_u4be(p, length);
   }


### PR DESCRIPTION
The attribute length is a u4 per [class file format](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html) and it is indeed written with `put_u4be(p, length)`, but the parameter is a `u2` meaning that for very large attributes, this will cause overflows.