### PR TITLE
Don't use Skyframe event handler for downloader events

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -266,7 +266,8 @@ public class BazelRepositoryModule extends BlazeModule {
         new DownloadManager(
             repositoryCache.getDownloadCache(),
             env.getDownloaderDelegate(),
-            env.getHttpDownloader());
+            env.getHttpDownloader(),
+            env.getReporter());
     this.repositoryFetchFunction.setDownloadManager(downloadManager);
     this.moduleFileFunction.setDownloadManager(downloadManager);
     this.repoSpecFunction.setDownloadManager(downloadManager);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -151,7 +151,7 @@ public class IndexRegistry implements Registry {
       throws IOException, InterruptedException, NotFoundException {
     Optional<byte[]> maybeContent = Optional.empty();
     try {
-      maybeContent = Optional.of(doGrabFile(downloadManager, url, eventHandler, useChecksum));
+      maybeContent = Optional.of(doGrabFile(downloadManager, url, useChecksum));
       return maybeContent.get();
     } finally {
       // We intentionally don't check knownFileHashesMode here: The checksums of module files are
@@ -163,11 +163,7 @@ public class IndexRegistry implements Registry {
     }
   }
 
-  private byte[] doGrabFile(
-      DownloadManager downloadManager,
-      String rawUrl,
-      ExtendedEventHandler eventHandler,
-      boolean useChecksum)
+  private byte[] doGrabFile(DownloadManager downloadManager, String rawUrl, boolean useChecksum)
       throws IOException, InterruptedException, NotFoundException {
     Optional<Checksum> checksum;
     if (knownFileHashesMode != KnownFileHashesMode.IGNORE && useChecksum) {
@@ -236,7 +232,7 @@ public class IndexRegistry implements Registry {
 
     try (SilentCloseable c =
         Profiler.instance().profile(ProfilerTask.BZLMOD, () -> "download file: " + rawUrl)) {
-      return downloadManager.downloadAndReadOneUrlForBzlmod(url, eventHandler, clientEnv, checksum);
+      return downloadManager.downloadAndReadOneUrlForBzlmod(url, clientEnv, checksum);
     } catch (FileNotFoundException e) {
       throw new NotFoundException(String.format("%s: not found", rawUrl));
     } catch (IOException e) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
@@ -383,7 +383,7 @@ public final class VendorCommand implements BlazeCommand {
           vendorManager.vendorRegistryUrl(
               url,
               downloadManager.downloadAndReadOneUrlForBzlmod(
-                  url, env.getReporter(), clientEnvironmentSupplier.get(), checksum));
+                  url, clientEnvironmentSupplier.get(), checksum));
         } catch (IOException e) {
           throw new IOException(
               String.format(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -65,6 +65,7 @@ public class DownloadManager {
   private UrlRewriter rewriter;
   private final Downloader downloader;
   private final HttpDownloader bzlmodHttpDownloader;
+  private final ExtendedEventHandler eventHandler;
   private boolean disableDownload = false;
   private int retries = 0;
   @Nullable private Credentials netrcCreds;
@@ -84,10 +85,14 @@ public class DownloadManager {
    *     registry.
    */
   public DownloadManager(
-      DownloadCache downloadCache, Downloader downloader, HttpDownloader bzlmodHttpDownloader) {
+      DownloadCache downloadCache,
+      Downloader downloader,
+      HttpDownloader bzlmodHttpDownloader,
+      ExtendedEventHandler eventHandler) {
     this.downloadCache = downloadCache;
     this.downloader = downloader;
     this.bzlmodHttpDownloader = bzlmodHttpDownloader;
+    this.eventHandler = eventHandler;
   }
 
   public void setDistdir(List<Path> distdir) {
@@ -124,7 +129,6 @@ public class DownloadManager {
       String canonicalId,
       Optional<String> type,
       Path output,
-      ExtendedEventHandler eventHandler,
       Map<String, String> clientEnv,
       String context,
       Phaser downloadPhaser) {
@@ -143,7 +147,6 @@ public class DownloadManager {
                 canonicalId,
                 type,
                 output,
-                eventHandler,
                 clientEnv,
                 context);
           } finally {
@@ -174,7 +177,6 @@ public class DownloadManager {
    * @param checksum valid checksum which is checked, or absent to disable
    * @param type extension, e.g. "tar.gz" to force on downloaded filename, or empty to not do this
    * @param output destination filename if {@code type} is <i>absent</i>, otherwise output directory
-   * @param eventHandler CLI progress reporter
    * @param clientEnv environment variables in shell issuing this command
    * @param context the context in which the file was fetched; used only for reporting
    * @throws IllegalArgumentException on parameter badness, which should be checked beforehand
@@ -189,7 +191,6 @@ public class DownloadManager {
       String canonicalId,
       Optional<String> type,
       Path output,
-      ExtendedEventHandler eventHandler,
       Map<String, String> clientEnv,
       String context)
       throws IOException, InterruptedException {
@@ -388,7 +389,6 @@ public class DownloadManager {
    * the cache prior to returning the value.
    *
    * @param originalUrl the original URL of the file
-   * @param eventHandler CLI progress reporter
    * @param clientEnv environment variables in shell issuing this command
    * @param checksum checksum of the file used to verify the content and obtain repository cache
    *     hits
@@ -397,10 +397,7 @@ public class DownloadManager {
    * @throws InterruptedException if this thread is being cast into oblivion
    */
   public byte[] downloadAndReadOneUrlForBzlmod(
-      URL originalUrl,
-      ExtendedEventHandler eventHandler,
-      Map<String, String> clientEnv,
-      Optional<Checksum> checksum)
+      URL originalUrl, Map<String, String> clientEnv, Optional<Checksum> checksum)
       throws IOException, InterruptedException {
     if (Thread.interrupted()) {
       throw new InterruptedException();

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -822,7 +822,6 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
               canonicalId,
               Optional.<String>empty(),
               outputPath.getPath(),
-              env.getListener(),
               envVariables,
               identifyingStringForLogging,
               downloadPhaser);
@@ -1060,7 +1059,6 @@ the same path on case-insensitive filesystems.
               canonicalId,
               Optional.of(type),
               downloadDirectory,
-              env.getListener(),
               envVariables,
               identifyingStringForLogging,
               downloadPhaser);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/packages/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/packages/BUILD
@@ -96,6 +96,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/cache",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
         "//src/main/java/com/google/devtools/build/lib/bazel/rules",
+        "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/repository_directory_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:action_environment_function",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoader.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
 import com.google.devtools.build.lib.bazel.rules.BazelRulesModule;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.packages.BuildFileName;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue;
 import com.google.devtools.build.lib.skyframe.ActionEnvironmentFunction;
@@ -130,7 +131,12 @@ public class BazelPackageLoader extends AbstractPackageLoader {
       RepositoryCache repositoryCache = new RepositoryCache();
       HttpDownloader httpDownloader = new HttpDownloader();
       DownloadManager downloadManager =
-          new DownloadManager(repositoryCache.getDownloadCache(), httpDownloader, httpDownloader);
+          new DownloadManager(
+              repositoryCache.getDownloadCache(),
+              httpDownloader,
+              httpDownloader,
+              // Only used in tests, so it's okay to miss download progress events.
+              ExtendedEventHandler.NOOP);
       RegistryFactoryImpl registryFactory =
           new RegistryFactoryImpl(Suppliers.ofInstance(ImmutableMap.of()));
 

--- a/src/main/java/com/google/devtools/build/skyframe/SkyFunction.java
+++ b/src/main/java/com/google/devtools/build/skyframe/SkyFunction.java
@@ -23,6 +23,7 @@ import com.google.common.graph.MutableGraph;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.concurrent.QuiescingExecutor;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
+import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.events.Reportable;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -339,6 +340,15 @@ public interface SkyFunction {
      * events again after it is restarted. Note that if using {@link #getState} to prune work, the
      * function may need to store events in the {@link SkyKeyComputeState} so that they can be
      * replayed on a subsequent invocation.
+     *
+     * <p>The event handler returned by this method:
+     *
+     * <ul>
+     *   <li>is safe for concurrent use by multiple threads if all submitted events return <code>
+     *       false</code> for {@link Event#storeForReplay()} or only a single thread is used to
+     *       submit events that return {@code true}
+     *   <li>must not be used after {@link SkyFunction#compute} returns
+     * </ul>
      */
     ExtendedEventHandler getListener();
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -86,7 +86,7 @@ public class IndexRegistryTest extends FoundationTestCase {
     eventBus.register(eventRecorder);
     downloadCache = new DownloadCache();
     HttpDownloader httpDownloader = new HttpDownloader();
-    downloadManager = new DownloadManager(downloadCache, httpDownloader, httpDownloader);
+    downloadManager = new DownloadManager(downloadCache, httpDownloader, httpDownloader, reporter);
     registryFactory = new RegistryFactoryImpl(Suppliers.ofInstance(ImmutableMap.of()));
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -75,14 +75,14 @@ public class HttpDownloaderTest {
 
   @Rule public final Timeout timeout = new Timeout(30, SECONDS);
 
+  private final ExtendedEventHandler eventHandler = mock(ExtendedEventHandler.class);
   private final DownloadCache downloadCache = mock(DownloadCache.class);
   // Scale timeouts down to make test fast.
   private final HttpDownloader httpDownloader = new HttpDownloader(0, Duration.ZERO, 8, .1f);
   private final DownloadManager downloadManager =
-      new DownloadManager(downloadCache, httpDownloader, httpDownloader);
+      new DownloadManager(downloadCache, httpDownloader, httpDownloader, eventHandler);
 
   private final ExecutorService executor = Executors.newFixedThreadPool(2);
-  private final ExtendedEventHandler eventHandler = mock(ExtendedEventHandler.class);
   private final JavaIoFileSystem fs;
 
   public HttpDownloaderTest() {
@@ -652,7 +652,7 @@ public class HttpDownloaderTest {
     Downloader downloader = mock(Downloader.class);
     HttpDownloader httpDownloader = mock(HttpDownloader.class);
     DownloadManager downloadManager =
-        new DownloadManager(downloadCache, downloader, httpDownloader);
+        new DownloadManager(downloadCache, downloader, httpDownloader, eventHandler);
     // do not retry
     downloadManager.setRetries(0);
     AtomicInteger times = new AtomicInteger(0);
@@ -691,7 +691,7 @@ public class HttpDownloaderTest {
     HttpDownloader httpDownloader = mock(HttpDownloader.class);
     int retries = 5;
     DownloadManager downloadManager =
-        new DownloadManager(downloadCache, downloader, httpDownloader);
+        new DownloadManager(downloadCache, downloader, httpDownloader, eventHandler);
     downloadManager.setRetries(retries);
     AtomicInteger times = new AtomicInteger(0);
     byte[] data = "content".getBytes(UTF_8);
@@ -736,7 +736,7 @@ public class HttpDownloaderTest {
     HttpDownloader httpDownloader = mock(HttpDownloader.class);
     int retries = 5;
     DownloadManager downloadManager =
-        new DownloadManager(downloadCache, downloader, httpDownloader);
+        new DownloadManager(downloadCache, downloader, httpDownloader, eventHandler);
     downloadManager.setRetries(retries);
     AtomicInteger times = new AtomicInteger(0);
     byte[] data = "content".getBytes(UTF_8);
@@ -784,7 +784,7 @@ public class HttpDownloaderTest {
     HttpDownloader httpDownloader = mock(HttpDownloader.class);
     int retries = 5;
     DownloadManager downloadManager =
-        new DownloadManager(downloadCache, downloader, httpDownloader);
+        new DownloadManager(downloadCache, downloader, httpDownloader, eventHandler);
     downloadManager.setRetries(retries);
     AtomicInteger times = new AtomicInteger(0);
     byte[] data = "content".getBytes(UTF_8);
@@ -829,7 +829,7 @@ public class HttpDownloaderTest {
     HttpDownloader httpDownloader = mock(HttpDownloader.class);
     int retries = 5;
     DownloadManager downloadManager =
-        new DownloadManager(downloadCache, downloader, httpDownloader);
+        new DownloadManager(downloadCache, downloader, httpDownloader, eventHandler);
     downloadManager.setRetries(retries);
     AtomicInteger times = new AtomicInteger(0);
     byte[] data = "content".getBytes(UTF_8);
@@ -897,7 +897,6 @@ public class HttpDownloaderTest {
               canonicalId,
               type,
               output,
-              eventHandler,
               clientEnv,
               context,
               downloadPhaser);


### PR DESCRIPTION
These events may be sent during a Skyframe restart, which currently results in a crash. Since downloader events don't have to be stored for replay, they can use the build global event handler instance instead.

Fixes #26995