### PR TITLE
Fix encoding/decoding of UTF-8 strings in the lockfile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/AttributeValuesAdapter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/AttributeValuesAdapter.java
@@ -15,6 +15,9 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
+import static com.google.devtools.build.lib.util.StringEncoding.internalToUnicode;
+import static com.google.devtools.build.lib.util.StringEncoding.unicodeToInternal;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -148,7 +151,7 @@ public class AttributeValuesAdapter extends TypeAdapter<AttributeValues> {
     if (obj instanceof Label label) {
       String labelString = label.getUnambiguousCanonicalForm();
       Preconditions.checkState(labelString.startsWith("@@"));
-      return labelString;
+      return internalToUnicode(labelString);
     }
     String string = (String) obj;
     // Strings that start with "@@" need to be escaped to avoid being interpreted as a label. We
@@ -157,19 +160,20 @@ public class AttributeValuesAdapter extends TypeAdapter<AttributeValues> {
     // sequence also have to be escaped.
     if (string.startsWith("@@")
         || (string.startsWith(STRING_ESCAPE_SEQUENCE) && string.endsWith(STRING_ESCAPE_SEQUENCE))) {
-      return STRING_ESCAPE_SEQUENCE + string + STRING_ESCAPE_SEQUENCE;
+      return internalToUnicode(STRING_ESCAPE_SEQUENCE + string + STRING_ESCAPE_SEQUENCE);
     }
-    return string;
+    return internalToUnicode(string);
   }
 
   /**
    * Deserializes a string to either a label or a String depending on the prefix and presence of the
    * escape sequence.
    *
-   * @param value String to be deserialized
+   * @param unicodeValue String to be deserialized
    * @return Object of type String of Label
    */
-  private Object deserializeStringToObject(String value) {
+  private Object deserializeStringToObject(String unicodeValue) {
+    String value = unicodeToInternal(unicodeValue);
     // A string represents a label if and only if it starts with "@@".
     if (value.startsWith("@@")) {
       return Label.parseCanonicalUnchecked(value);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -223,6 +223,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/repo_recorded_input",
+        "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/net/starlark/java/eval",
         "//third_party:auto_value",
         "//third_party:gson",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -47,7 +47,7 @@ public abstract class BazelLockFileValue implements SkyValue {
   // https://cs.opensource.google/bazel/bazel/+/release-7.3.0:src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java;l=120-127;drc=5f5355b75c7c93fba1e15f6658f308953f4baf51
   // While this hack exists on 7.x, lockfile version increments should be done 2 at a time (i.e.
   // keep this number even).
-  public static final int LOCK_FILE_VERSION = 20;
+  public static final int LOCK_FILE_VERSION = 22;
 
   /** A valid empty lockfile. */
   public static final BazelLockFileValue EMPTY_LOCKFILE = builder().build();

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 20,
+  "lockFileVersion": 22,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",


### PR DESCRIPTION
Since Gson isn't aware of Bazel's special String encoding, all strings going into it and coming out of it may need to be reencoded.