### PR TITLE
Flip --incompatible_avoid_hardcoded_objc_compilation_flags

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
@@ -103,7 +103,7 @@ public class ObjcCommandLineOptions extends FragmentOptions {
 
   @Option(
       name = "incompatible_avoid_hardcoded_objc_compilation_flags",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {
         OptionEffectTag.AFFECTS_OUTPUTS,

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -1132,8 +1132,13 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   }
 
   @Test
+  public void testCompilationActionsForDebugLegacyFlags() throws Exception {
+    checkClangCoptsForCompilationMode(RULE_TYPE, CompilationMode.DBG, true);
+  }
+
+  @Test
   public void testCompilationActionsForDebug() throws Exception {
-    checkClangCoptsForCompilationMode(RULE_TYPE, CompilationMode.DBG);
+    checkClangCoptsForCompilationMode(RULE_TYPE, CompilationMode.DBG, false);
   }
 
   @Test
@@ -1170,8 +1175,13 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   }
 
   @Test
+  public void testCompilationActionsForOptimizedLegacyFlags() throws Exception {
+    checkClangCoptsForCompilationMode(RULE_TYPE, CompilationMode.OPT, true);
+  }
+
+  @Test
   public void testCompilationActionsForOptimized() throws Exception {
-    checkClangCoptsForCompilationMode(RULE_TYPE, CompilationMode.OPT);
+    checkClangCoptsForCompilationMode(RULE_TYPE, CompilationMode.OPT, false);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcStarlarkTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcStarlarkTest.java
@@ -832,6 +832,7 @@ swift_binary = rule(
         """);
 
     useConfiguration(
+        "--incompatible_avoid_hardcoded_objc_compilation_flags=false",
         "--compilation_mode=opt",
         "--ios_simulator_device='iPhone 6'",
         "--ios_simulator_version=8.4",


### PR DESCRIPTION
This flag was added a few years ago and would be great to get out of
here. This is always surprising because it passes flags that aren't in
your crosstool.
