### PR TITLE
Remove --experimental_objc_fastbuild_options

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
@@ -58,16 +58,6 @@ public class ObjcCommandLineOptions extends FragmentOptions {
   public boolean runMemleaks;
 
   @Option(
-    name = "experimental_objc_fastbuild_options",
-    defaultValue = "-O0,-DDEBUG=1",
-    converter = CommaSeparatedOptionListConverter.class,
-    documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
-    effectTags = {OptionEffectTag.ACTION_COMMAND_LINES},
-    help = "Uses these strings as objc fastbuild compiler options."
-  )
-  public List<String> fastbuildOptions;
-
-  @Option(
     name = "ios_signing_cert_name",
     defaultValue = "null",
     documentationCategory = OptionDocumentationCategory.SIGNING,

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcConfiguration.java
@@ -55,7 +55,6 @@ public class ObjcConfiguration extends Fragment implements ObjcConfigurationApi 
   private final String iosSimulatorDevice;
   private final boolean runMemleaks;
   private final CompilationMode compilationMode;
-  private final ImmutableList<String> fastbuildOptions;
   @Nullable private final String signingCertName;
   private final boolean debugWithGlibcxx;
   private final boolean deviceDebugEntitlements;
@@ -73,7 +72,6 @@ public class ObjcConfiguration extends Fragment implements ObjcConfigurationApi 
     this.iosSimulatorVersion = DottedVersion.maybeUnwrap(objcOptions.iosSimulatorVersion);
     this.runMemleaks = objcOptions.runMemleaks;
     this.compilationMode = Preconditions.checkNotNull(options.compilationMode, "compilationMode");
-    this.fastbuildOptions = ImmutableList.copyOf(objcOptions.fastbuildOptions);
     this.signingCertName = objcOptions.iosSigningCertName;
     this.debugWithGlibcxx = objcOptions.debugWithGlibcxx;
     this.deviceDebugEntitlements = objcOptions.deviceDebugEntitlements;
@@ -128,7 +126,7 @@ public class ObjcConfiguration extends Fragment implements ObjcConfigurationApi 
         }
         return opts.build();
       case FASTBUILD:
-        return fastbuildOptions;
+        return ImmutableList.of();
       case OPT:
         return this.avoidHardcodedCompilationFlags ? ImmutableList.of() : OPT_COPTS;
       default:

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -567,7 +567,6 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
     assertThat(compileActionA.getArguments()).contains("-fobjc-arc");
     assertThat(compileActionA.getArguments()).containsAtLeast("-c", "objc/a.m");
     assertThat(compileActionNonArc.getArguments()).contains("-fno-objc-arc");
-    assertThat(compileActionA.getArguments()).containsAtLeastElementsIn(FASTBUILD_COPTS);
     assertThat(compileActionA.getArguments()).contains("-arch x86_64");
   }
 
@@ -613,7 +612,6 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
     assertThat(compileActionA.getArguments()).containsAtLeast("-c", "objc/a.m");
 
     assertThat(compileActionNonArc.getArguments()).contains("-fno-objc-arc");
-    assertThat(compileActionA.getArguments()).containsAtLeastElementsIn(FASTBUILD_COPTS);
     assertThat(compileActionA.getArguments()).contains("-arch arm64");
   }
 
@@ -1308,7 +1306,6 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
                 .addAll(CompilationSupport.DEFAULT_COMPILER_FLAGS)
                 .add("-arch x86_64")
                 .add("-isysroot", "__BAZEL_XCODE_SDKROOT__")
-                .addAll(FASTBUILD_COPTS)
                 .add("-iquote", ".")
                 .add("-iquote", OUTPUTDIR)
                 .add("-include", "objc/some.pch")

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcRuleTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcRuleTestCase.java
@@ -69,8 +69,6 @@ import org.junit.Before;
  * simply call a check... method) across several rule types.
  */
 public abstract class ObjcRuleTestCase extends BuildViewTestCase {
-  protected static final ImmutableList<String> FASTBUILD_COPTS = ImmutableList.of("-O0", "-DDEBUG");
-
   protected static final DottedVersion DEFAULT_IOS_SDK_VERSION =
       DottedVersion.fromStringUnchecked(AppleCommandLineOptions.DEFAULT_IOS_SDK_VERSION);
 
@@ -123,8 +121,6 @@ public abstract class ObjcRuleTestCase extends BuildViewTestCase {
         return ImmutableList.copyOf(ObjcConfiguration.DBG_COPTS);
       case OPT:
         return ObjcConfiguration.OPT_COPTS;
-      case FASTBUILD:
-        return FASTBUILD_COPTS;
     }
     throw new AssertionError();
   }


### PR DESCRIPTION
This should be handled by the crosstool instead. Since this was always
experimental deleting it should be safe and if folks are using it this
will help them realize they need to use the crosstool instead.
