### PR TITLE
[8.5.0] Fix virtual headers symlink action for C++ headers

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_compilation_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_compilation_helper.bzl
@@ -102,7 +102,17 @@ def _compute_public_headers(
     if include_prefix and include_prefix.startswith("/"):
         include_prefix = include_prefix[1:]
 
-    if not strip_prefix and not include_prefix:
+    if strip_prefix == None and not include_prefix:
+        # If CppOptions.experimentalStarlarkCompiling is enabled, then
+        # strip_include_prefix and include_prefix are not None.
+        # If the option is disabled, their default values (from CcCompilationHelper) are None.
+        #
+        # Special case: when "strip_include_prefix = '.'" is set in a target located in
+        # workspace/BUILD.bazel, strip_prefix will be "", not None.
+        # Thus, we check differently for empty values.
+        #
+        # If neither strip_include_prefix nor include_prefix is specified,
+        # we don't need to create virtual headers, so we return the public headers as-is.
         return struct(
             headers = public_headers_artifacts + non_module_map_headers,
             module_map_headers = public_headers_artifacts,
@@ -125,17 +135,16 @@ def _compute_public_headers(
         if include_prefix != None:
             include_path = paths.get_relative(include_prefix, include_path)
 
-        if not original_header.path == include_path:
-            virtual_header = actions.declare_shareable_artifact(paths.join(virtual_include_dir, include_path))
-            actions.symlink(
-                output = virtual_header,
-                target_file = original_header,
-                progress_message = "Symlinking virtual headers for %{label}",
-                use_exec_root_for_source = USE_EXEC_ROOT_FOR_VIRTUAL_INCLUDES_SYMLINKS,
-            )
-            module_map_headers.append(virtual_header)
-            if config.coverage_enabled:
-                virtual_to_original_headers_list.append((virtual_header.path, original_header.path))
+        virtual_header = actions.declare_shareable_artifact(paths.join(virtual_include_dir, include_path))
+        actions.symlink(
+            output = virtual_header,
+            target_file = original_header,
+            progress_message = "Symlinking virtual headers for %{label}",
+            use_exec_root_for_source = USE_EXEC_ROOT_FOR_VIRTUAL_INCLUDES_SYMLINKS,
+        )
+        module_map_headers.append(virtual_header)
+        if config.coverage_enabled:
+            virtual_to_original_headers_list.append((virtual_header.path, original_header.path))
 
         module_map_headers.append(original_header)
 


### PR DESCRIPTION
The virtual headers action should be executed when `strip_include_prefix` attribute is not `None`, because the `.` attribute values are resolved to empty string, which is a valid value.

The virtual headers action should be independent from the original header path and include path to support library target definitions at any `BUILD` file with any project layout.

Fixes #26537

Closes #26538.

PiperOrigin-RevId: 807615188
Change-Id: I49fa14946380c0e827f046c86cdc2c33763187bd

Commit https://github.com/bazelbuild/bazel/commit/fa07aa0dc93dc627cbada65cc777ace540a4c8c6