### PR TITLE
Graveyard deprecated --python_top.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -42,11 +42,10 @@ public final class BazelRulesModule extends BlazeModule {
 
     @Option(
         name = "python_top",
-        converter = LabelConverter.class,
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
         effectTags = {OptionEffectTag.NO_OP},
         help = "Deprecated. No-op.")
-    public Label pythonTop;
+    public String pythonTop;
 
     @Option(
         name = "incompatible_use_python_toolchains",

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -41,6 +41,14 @@ public final class BazelRulesModule extends BlazeModule {
   public static class BuildGraveyardOptions extends OptionsBase {
 
     @Option(
+        name = "python_top",
+        converter = LabelConverter.class,
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        help = "Deprecated. No-op.")
+    public Label pythonTop;
+
+    @Option(
         name = "incompatible_use_python_toolchains",
         defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -42,6 +42,7 @@ public final class BazelRulesModule extends BlazeModule {
 
     @Option(
         name = "python_top",
+        defaultValue = "",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
         effectTags = {OptionEffectTag.NO_OP},
         help = "Deprecated. No-op.")

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonConfiguration.java
@@ -82,7 +82,7 @@ public class BazelPythonConfiguration extends Fragment {
 
   @StarlarkConfigurationField(
       name = "python_top",
-      doc = "Deprecated. Always returns None. Use toolchain resolution instead."
+      doc = "Deprecated. Always returns None. Use toolchain resolution instead.")
   public Label getPythonTop() {
     return null;
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonConfiguration.java
@@ -44,18 +44,6 @@ public class BazelPythonConfiguration extends Fragment {
   /** Bazel-specific Python configuration options. */
   public static final class Options extends FragmentOptions {
     @Option(
-        name = "python_top",
-        converter = LabelConverter.class,
-        defaultValue = "null",
-        documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
-        effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS, OptionEffectTag.AFFECTS_OUTPUTS},
-        help =
-            "The label of a py_runtime representing the Python interpreter invoked to run Python "
-                + "targets on the target platform. Deprecated; disabled by "
-                + "--incompatible_use_python_toolchains.")
-    public Label pythonTop;
-
-    @Option(
         name = "python_path",
         defaultValue = "null",
         documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
@@ -92,27 +80,11 @@ public class BazelPythonConfiguration extends Fragment {
     }
   }
 
-  @Override
-  public void reportInvalidOptions(EventHandler reporter, BuildOptions buildOptions) {
-    Options opts = buildOptions.get(Options.class);
-      // Forbid deprecated flags.
-      if (opts.pythonTop != null) {
-      reporter.handle(
-          Event.error(
-              "`--python_top` is disabled by `--incompatible_use_python_toolchains`. Instead of "
-                  + "configuring the Python runtime directly, register a Python toolchain. See "
-                  + "https://github.com/bazelbuild/bazel/issues/7899. You can temporarily revert "
-                  + "to the legacy flag-based way of specifying toolchains by setting "
-                  + "`--incompatible_use_python_toolchains=false`."));
-      // TODO(#7901): Also prohibit --python_path here.
-    }
-  }
-
   @StarlarkConfigurationField(
       name = "python_top",
-      doc = "The value of the --python_top flag; may be None if not specified")
+      doc = "Deprecated. Always returns None. Use toolchain resolution instead."
   public Label getPythonTop() {
-    return options.pythonTop;
+    return null;
   }
 
   @StarlarkMethod(

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -193,7 +193,6 @@ bazel_fragments["AppleCommandLineOptions"] = fragment(
 
 bazel_fragments["BazelPythonConfiguration$Options"] = fragment(
     propagate = [
-        "//command_line_option:python_top",
         "//command_line_option:python_path",
         "//command_line_option:experimental_python_import_all_repositories",
     ],

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonConfigurationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonConfigurationTest.java
@@ -41,14 +41,4 @@ public class BazelPythonConfigurationTest extends ConfigurationTestCase {
         () -> create("--python_path=pajama"));
     assertThat(expected).hasMessageThat().contains("python_path must be an absolute path");
   }
-
-  @Test
-  public void legacyFlagsDeprecatedByPythonToolchains() throws Exception {
-    checkError(
-        "`--python_top` is disabled by `--incompatible_use_python_toolchains`",
-        "--python_top=//mypkg:my_py_runtime");
-    // TODO(#7901): Also test that --python_path is disallowed (once implemented). Currently we
-    // still need it to communicate the location of python.exe on Windows from the client to the
-    // server.
-  }
 }

--- a/src/test/java/com/google/devtools/build/lib/packages/util/BazelMockPythonSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/BazelMockPythonSupport.java
@@ -133,13 +133,6 @@ public final class BazelMockPythonSupport extends MockPythonSupport {
   }
 
   @Override
-  public String createPythonTopEntryPoint(MockToolsConfig config, String pyRuntimeLabel)
-      throws IOException {
-    // Under BazelPythonSemantics, we can simply set --python_top to be the py_runtime target.
-    return pyRuntimeLabel;
-  }
-
-  @Override
   public Runfiles.EmptyFilesSupplier getEmptyRunfilesSupplier() {
     return BazelPyBuiltins.GET_INIT_PY_FILES;
   }

--- a/src/test/java/com/google/devtools/build/lib/packages/util/MockPythonSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/MockPythonSupport.java
@@ -23,13 +23,5 @@ public abstract class MockPythonSupport {
   /** Setup the support for building Python. */
   public abstract void setup(MockToolsConfig config) throws IOException;
 
-  /**
-   * Setup support for, and return the string label of, a target that can be passed to {@code
-   * --python_top} that causes the {@code py_runtime} consumed by Python rules to be the given
-   * {@code pyRuntimeLabel}.
-   */
-  public abstract String createPythonTopEntryPoint(MockToolsConfig config, String pyRuntimeLabel)
-      throws IOException;
-
   public abstract Runfiles.EmptyFilesSupplier getEmptyRunfilesSupplier();
 }


### PR DESCRIPTION
Python rules have long-since used Bazel's toolchain resolution API instead.

Keep `ctx.fragments.bazel_py.python_top` around until we remove references from `rules_python`. As of this commit, that call always returns `None`.

For https://github.com/bazel-contrib/rules_python/issues/3252.