### PR TITLE
Remove empty cc rule definitions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/CcRules.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/CcRules.java
@@ -45,20 +45,9 @@ public class CcRules implements RuleSet {
     builder.addBzlToplevel("CcSharedLibraryInfo", Starlark.NONE);
     builder.addBzlToplevel("CcSharedLibraryHintInfo", Starlark.NONE);
 
-    builder.addRuleDefinition(new EmptyRule("cc_toolchain") {});
     builder.addRuleDefinition(new EmptyRule("cc_toolchain_suite") {});
     builder.addRuleDefinition(new CcToolchainAliasRule());
     builder.addRuleDefinition(new CcLibcTopAlias());
-    builder.addRuleDefinition(new EmptyRule("cc_binary") {});
-    builder.addRuleDefinition(new EmptyRule("cc_shared_library") {});
-    builder.addRuleDefinition(new EmptyRule("cc_static_library") {});
-    builder.addRuleDefinition(new EmptyRule("cc_test") {});
-    builder.addRuleDefinition(new EmptyRule("cc_library") {});
-    builder.addRuleDefinition(new EmptyRule("cc_import") {});
-    builder.addRuleDefinition(new EmptyRule("fdo_profile") {});
-    builder.addRuleDefinition(new EmptyRule("fdo_prefetch_hints") {});
-    builder.addRuleDefinition(new EmptyRule("memprof_profile") {});
-    builder.addRuleDefinition(new EmptyRule("propeller_optimize") {});
     builder.addStarlarkBuiltinsInternal("cc_common", bazelCcModule);
     builder.addStarlarkBootstrap(new CcBootstrap(bazelCcModule));
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ObjcRules.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ObjcRules.java
@@ -39,8 +39,6 @@ public class ObjcRules implements RuleSet {
     // j2objc shouldn't be here!
     builder.addConfigurationFragment(J2ObjcConfiguration.class);
 
-    builder.addRuleDefinition(new EmptyRule("objc_import") {});
-    builder.addRuleDefinition(new EmptyRule("objc_library") {});
     builder.addRuleDefinition(new EmptyRule("available_xcodes") {});
     builder.addRuleDefinition(new EmptyRule("xcode_config") {});
     builder.addRuleDefinition(new EmptyRule("xcode_config_alias") {});

--- a/src/test/java/com/google/devtools/build/lib/analysis/SymbolicMacroTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/SymbolicMacroTest.java
@@ -803,8 +803,10 @@ public final class SymbolicMacroTest extends BuildViewTestCase {
     scratch.file(
         "pkg/foo.bzl",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
         def _impl(name, visibility):
-            native.cc_binary(name = name + "_lib")
+            cc_binary(name = name + "_lib")
         my_macro = macro(implementation=_impl)
         def query():
             print("existing_rules() keys: %s" % native.existing_rules().keys())
@@ -828,8 +830,10 @@ public final class SymbolicMacroTest extends BuildViewTestCase {
     scratch.file(
         "pkg/foo.bzl",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
         def _impl(name, visibility):
-            native.cc_binary(name = name + "_lib")
+            cc_binary(name = name + "_lib")
         my_macro = macro(implementation=_impl, finalizer=True)
         def query():
             print("existing_rules() keys: %s" % native.existing_rules().keys())
@@ -2042,18 +2046,21 @@ my_macro = macro(
     scratch.file(
         "pkg/inner_legacy_macro.bzl",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
         def inner_legacy_macro(name, **kwargs):
-              native.cc_binary(name = name, **kwargs)
+              cc_binary(name = name, **kwargs)
         """);
     // my_macro is a symbolic macro that instantiates 2 cc_binary rules: one directly, and one
     // wrapped by cc_binary_legacy_macro.
     scratch.file(
         "pkg/my_macro.bzl",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
         load(":inner_legacy_macro.bzl", "inner_legacy_macro")
 
         def _impl(name, visibility, **kwargs):
-            native.cc_binary(name = name + "_lib")
+            cc_binary(name = name + "_lib")
             inner_legacy_macro(name  = name + "_legacy_macro_lib")
 
         my_macro = macro(implementation = _impl)
@@ -2076,7 +2083,7 @@ my_macro = macro(
         .containsExactly(
             StarlarkThread.callStackEntry(StarlarkThread.TOP_LEVEL, foo.getBuildFileLocation()),
             StarlarkThread.callStackEntry(
-                "my_macro", Location.fromFileLineColumn("/workspace/pkg/my_macro.bzl", 7, 1)))
+                "my_macro", Location.fromFileLineColumn("/workspace/pkg/my_macro.bzl", 8, 1)))
         .inOrder();
 
     Rule fooLib = pkg.getRule("foo_lib");
@@ -2091,7 +2098,7 @@ my_macro = macro(
                 .addAll(foo.reconstructParentCallStack())
                 .add(
                     StarlarkThread.callStackEntry(
-                        "_impl", Location.fromFileLineColumn("/workspace/pkg/my_macro.bzl", 4, 21)))
+                        "_impl", Location.fromFileLineColumn("/workspace/pkg/my_macro.bzl", 5, 14)))
                 .build());
 
     Rule fooLegacyLib = pkg.getRule("foo_legacy_macro_lib");
@@ -2106,12 +2113,12 @@ my_macro = macro(
                 .addAll(foo.reconstructParentCallStack())
                 .add(
                     StarlarkThread.callStackEntry(
-                        "_impl", Location.fromFileLineColumn("/workspace/pkg/my_macro.bzl", 5, 23)))
+                        "_impl", Location.fromFileLineColumn("/workspace/pkg/my_macro.bzl", 6, 23)))
                 .add(
                     StarlarkThread.callStackEntry(
                         "inner_legacy_macro",
                         Location.fromFileLineColumn(
-                            "/workspace/pkg/inner_legacy_macro.bzl", 2, 23)))
+                            "/workspace/pkg/inner_legacy_macro.bzl", 4, 16)))
                 .build());
   }
 
@@ -2121,8 +2128,10 @@ my_macro = macro(
     scratch.file(
         "pkg/my_macro.bzl",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
         def _impl(name, visibility, **kwargs):
-            native.cc_binary(name = name + "_bin")
+            cc_binary(name = name + "_bin")
 
         my_macro = macro(implementation = _impl)
         """);
@@ -2156,7 +2165,7 @@ my_macro = macro(
                 "legacy_nameless_wrapper",
                 Location.fromFileLineColumn("/workspace/pkg/legacy_nameless_wrapper.bzl", 4, 13)),
             StarlarkThread.callStackEntry(
-                "my_macro", Location.fromFileLineColumn("/workspace/pkg/my_macro.bzl", 4, 1)))
+                "my_macro", Location.fromFileLineColumn("/workspace/pkg/my_macro.bzl", 6, 1)))
         .inOrder();
 
     Rule fooBin = pkg.getRule("foo_bin");
@@ -2172,7 +2181,7 @@ my_macro = macro(
                 .addAll(foo.reconstructParentCallStack())
                 .add(
                     StarlarkThread.callStackEntry(
-                        "_impl", Location.fromFileLineColumn("/workspace/pkg/my_macro.bzl", 2, 21)))
+                        "_impl", Location.fromFileLineColumn("/workspace/pkg/my_macro.bzl", 4, 14)))
                 .build());
   }
 
@@ -2183,8 +2192,10 @@ my_macro = macro(
     scratch.file(
         "pkg/inner.bzl",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
         def _inner_impl(name, visibility, **kwargs):
-            native.cc_binary(name = name, **kwargs)
+            cc_binary(name = name, **kwargs)
 
         inner_macro = macro(implementation = _inner_impl)
 
@@ -2239,9 +2250,9 @@ my_macro = macro(
                 "_outer_impl", Location.fromFileLineColumn("/workspace/pkg/outer.bzl", 4, 25)),
             StarlarkThread.callStackEntry(
                 "inner_legacy_wrapper",
-                Location.fromFileLineColumn("/workspace/pkg/inner.bzl", 7, 16)),
+                Location.fromFileLineColumn("/workspace/pkg/inner.bzl", 9, 16)),
             StarlarkThread.callStackEntry(
-                "inner_macro", Location.fromFileLineColumn("/workspace/pkg/inner.bzl", 4, 1)))
+                "inner_macro", Location.fromFileLineColumn("/workspace/pkg/inner.bzl", 6, 1)))
         .inOrder();
 
     Rule fooLib = pkg.getRule("foo_inner");
@@ -2258,7 +2269,7 @@ my_macro = macro(
                 .add(
                     StarlarkThread.callStackEntry(
                         "_inner_impl",
-                        Location.fromFileLineColumn("/workspace/pkg/inner.bzl", 2, 21)))
+                        Location.fromFileLineColumn("/workspace/pkg/inner.bzl", 4, 14)))
                 .build());
   }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrTransitionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrTransitionProviderTest.java
@@ -922,6 +922,7 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
     scratch.file(
         "test/starlark/BUILD",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
         load("//test/starlark:my_rule.bzl", "my_rule")
 
         my_rule(
@@ -972,6 +973,7 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
     scratch.file(
         "test/starlark/BUILD",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
         load("//test/starlark:my_rule.bzl", "my_rule")
 
         my_rule(
@@ -1072,6 +1074,7 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
     scratch.file(
         "test/starlark/BUILD",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
         load("//test/starlark:my_rule.bzl", "my_rule")
 
         my_rule(
@@ -1120,6 +1123,7 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
     scratch.file(
         "test/starlark/BUILD",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
         load("//test/starlark:my_rule.bzl", "my_rule")
 
         my_rule(
@@ -1168,6 +1172,7 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
     scratch.file(
         "test/starlark/BUILD",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
         load("//test/starlark:my_rule.bzl", "my_rule")
 
         my_rule(
@@ -1218,6 +1223,7 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
     scratch.file(
         "test/starlark/BUILD",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
         load("//test/starlark:my_rule.bzl", "my_rule")
 
         my_rule(
@@ -1266,6 +1272,7 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
     scratch.file(
         "test/starlark/BUILD",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
         load("//test/starlark:my_rule.bzl", "my_rule")
 
         my_rule(
@@ -1314,6 +1321,7 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
     scratch.file(
         "test/starlark/BUILD",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
         load("//test/starlark:my_rule.bzl", "my_rule")
 
         my_rule(
@@ -1364,6 +1372,7 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
     scratch.file(
         "test/starlark/BUILD",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
         load("//test/starlark:my_rule.bzl", "my_rule")
 
         my_rule(
@@ -1406,6 +1415,7 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
     scratch.file(
         "test/starlark/BUILD",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
         load("//test/starlark:my_rule.bzl", "my_rule_test")
 
         my_rule_test(
@@ -1450,6 +1460,7 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
     scratch.file(
         "test/starlark/BUILD",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
         load("//test/starlark:my_rule.bzl", "my_rule_test")
 
         my_rule_test(

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkSubruleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkSubruleTest.java
@@ -148,6 +148,7 @@ public class StarlarkSubruleTest extends BuildViewTestCase {
     scratch.file(
         "subrule_testing/BUILD",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
         load("myrule.bzl", "my_rule")
 
         my_rule(name = "foo")
@@ -182,6 +183,7 @@ public class StarlarkSubruleTest extends BuildViewTestCase {
     scratch.file(
         "subrule_testing/BUILD",
         """
+        load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
         load("//subrule_testing/%s:myrule.bzl", "my_rule")
 
         my_rule(name = "foo")

--- a/src/test/java/com/google/devtools/build/lib/generatedprojecttest/BuildFileContentsGeneratorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/generatedprojecttest/BuildFileContentsGeneratorTest.java
@@ -51,7 +51,7 @@ public final class BuildFileContentsGeneratorTest {
 
   @Test
   public void defaultPackageVisibilityIsAddedToStartOfBuildFile() throws IllegalStateException {
-    generator.addRule(new BuildRuleBuilder("cc_library", generator.uniqueRuleName()));
+    generator.addRule(new BuildRuleBuilder("java_library", generator.uniqueRuleName()));
     generator.setDefaultPackageVisibility("//visibility:private");
     assertThat(generator.getContents())
         .startsWith("package(default_visibility = ['//visibility:private'])");
@@ -59,7 +59,7 @@ public final class BuildFileContentsGeneratorTest {
 
   @Test
   public void defaultPackageVisibilityDefaultsToPublic() throws IllegalStateException {
-    generator.addRule(new BuildRuleBuilder("cc_library", generator.uniqueRuleName()));
+    generator.addRule(new BuildRuleBuilder("java_library", generator.uniqueRuleName()));
     assertThat(generator.getContents())
         .startsWith("package(default_visibility = ['//visibility:public'])");
   }

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleFinalizerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleFinalizerTest.java
@@ -76,6 +76,7 @@ public final class RuleFinalizerTest extends BuildViewTestCase {
     scratch.file(
         "pkg/BUILD",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
         load(":foo.bzl", "my_finalizer")
         cc_library(name = "foo")
         my_finalizer(name = "abc", targets_of_interest = [":foo"])
@@ -113,6 +114,7 @@ public final class RuleFinalizerTest extends BuildViewTestCase {
     scratch.file(
         "pkg/BUILD",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
         load(":foo.bzl", "my_finalizer_outer")
         cc_library(name = "foo")
         my_finalizer_outer(name = "abc")
@@ -149,6 +151,7 @@ public final class RuleFinalizerTest extends BuildViewTestCase {
         "pkg/BUILD",
         """
         load(":foo.bzl", "my_finalizer")
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
         cc_library(name = "foo")
         my_finalizer(name = "abc")
         """);
@@ -199,6 +202,8 @@ public final class RuleFinalizerTest extends BuildViewTestCase {
     scratch.file(
         "pkg/foo.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         EXPECTED = [
             "top_level_lexically_before_finalizer",
             "macro_lexically_before_finalizer_inner_lib",
@@ -227,18 +232,18 @@ public final class RuleFinalizerTest extends BuildViewTestCase {
             print("native.existing_rules and native.existing_rule are as expected")
 
         def _impl_macro(name, visibility):
-            native.cc_library(name = name + "_inner_lib")
+            cc_library(name = name + "_inner_lib")
 
         my_macro = macro(implementation = _impl_macro)
 
         def _impl_inner_finalizer(name, visibility):
-            native.cc_library(name = name + "_inner_lib")
+            cc_library(name = name + "_inner_lib")
             check_existing_rules()
 
         inner_finalizer = macro(implementation = _impl_inner_finalizer, finalizer = True)
 
         def _impl_finalizer(name, visibility):
-            native.cc_library(name = name + "_inner_lib")
+            cc_library(name = name + "_inner_lib")
             my_macro(name = name + "_inner_macro")
             inner_finalizer(name = name + "_inner_finalizer")
             check_existing_rules()
@@ -249,6 +254,7 @@ public final class RuleFinalizerTest extends BuildViewTestCase {
         "pkg/BUILD",
         """
         load(":foo.bzl", "my_finalizer", "my_macro")
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
         cc_library(name = "top_level_lexically_before_finalizer")
         my_macro(name = "macro_lexically_before_finalizer")
         my_finalizer(name = "finalizer")
@@ -268,9 +274,11 @@ public final class RuleFinalizerTest extends BuildViewTestCase {
     scratch.file(
         "pkg/finalizers.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         def _impl(name, visibility):
             print("in my_finalizer")
-            native.cc_library(name = name + "_lib")
+            cc_library(name = name + "_lib")
 
         my_finalizer = macro(implementation = _impl, finalizer = True)
         """);
@@ -278,6 +286,7 @@ public final class RuleFinalizerTest extends BuildViewTestCase {
         "pkg/BUILD",
         """
         load(":finalizers.bzl", "my_finalizer")
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
         my_finalizer(name = "finalize")
         cc_library(name = 1 // 0)  # causes EvalException
         """);
@@ -297,11 +306,13 @@ public final class RuleFinalizerTest extends BuildViewTestCase {
     scratch.file(
         "pkg/finalizers.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         def _fail_impl(name, visibility):
             fail("fail fail fail")
 
         def _good_impl(name, visibility):
-            native.cc_library(name = name + "_lib")
+            cc_library(name = name + "_lib")
 
         fail_finalizer = macro(implementation = _fail_impl, finalizer = True)
         good_finalizer = macro(implementation = _good_impl, finalizer = True)
@@ -309,6 +320,7 @@ public final class RuleFinalizerTest extends BuildViewTestCase {
     scratch.file(
         "pkg/BUILD",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
         load(":finalizers.bzl", "fail_finalizer", "good_finalizer")
         good_finalizer(name = "good_finalizer")
         fail_finalizer(name = "bad_finalizer")

--- a/src/test/java/com/google/devtools/build/lib/packages/TestTargetUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/TestTargetUtilsTest.java
@@ -87,7 +87,7 @@ public final class TestTargetUtilsTest extends PackageLoadingTestCase {
             srcs = ["notest.sh"],
         )
 
-        cc_library(name = "xUnit")
+        java_library(name = "xUnit")
 
         test_suite(
             name = "smallTests",

--- a/src/test/java/com/google/devtools/build/lib/pkgcache/PackageLoadingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/pkgcache/PackageLoadingTest.java
@@ -203,7 +203,7 @@ public class PackageLoadingTest extends FoundationTestCase {
     scratch.file(
         "pkg1/BUILD",
         "load('//test_defs:foo_library.bzl', 'foo_library')",
-        "cc_library(name = 'foo') # a BUILD file");
+        "java_library(name = 'foo') # a BUILD file");
   }
 
   // Check that a substring is present in an error message.
@@ -240,7 +240,7 @@ public class PackageLoadingTest extends FoundationTestCase {
     scratch.file(
         "invalidpackagename:42/BUILD",
         "load('//test_defs:foo_library.bzl', 'foo_library')",
-        "cc_library(name = 'foo') # a BUILD file");
+        "java_library(name = 'foo') # a BUILD file");
     checkGetPackageFails(
         "invalidpackagename:42",
         "no such package 'invalidpackagename:42': Invalid package name 'invalidpackagename:42'");
@@ -397,12 +397,12 @@ public class PackageLoadingTest extends FoundationTestCase {
         scratch.file(
             "pkg/BUILD",
             "load('//test_defs:foo_library.bzl', 'foo_library')",
-            "cc_library(name = 'foo')");
+            "java_library(name = 'foo')");
     Path buildFile2 =
         scratch.file(
             "/otherroot/pkg/BUILD",
             "load('//test_defs:foo_library.bzl', 'foo_library')",
-            "cc_library(name = 'bar')");
+            "java_library(name = 'bar')");
     setOptions("--package_path=/workspace:/otherroot");
 
     Package oldPkg = getPackage("pkg");

--- a/src/test/java/com/google/devtools/build/lib/pkgcache/TargetPatternEvaluatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/pkgcache/TargetPatternEvaluatorTest.java
@@ -79,11 +79,6 @@ public class TargetPatternEvaluatorTest extends AbstractTargetPatternEvaluatorTe
 
   @Before
   public final void createFiles() throws Exception {
-    // TODO(ulfjack): Also disable the implicit C++ outputs in Google's internal version.
-    boolean hasImplicitCcOutputs =
-        ruleClassProvider.getRuleClassMap().get("cc_library").getDefaultImplicitOutputsFunction()
-            != SafeImplicitOutputsFunction.NONE;
-
     scratch.file("BUILD", "filegroup(name = 'fg', srcs = glob(['*.cc']))");
     scratch.file("foo.cc");
 
@@ -150,10 +145,9 @@ public class TargetPatternEvaluatorTest extends AbstractTargetPatternEvaluatorTe
             "//foo:foo1.cc",
             "//foo:foo1.h",
             "//foo:BUILD",
-            "//foo:baz/bang");
-    if (hasImplicitCcOutputs) {
-      targetsInFoo.addAll(labels("//foo:libfoo1.a", "//foo:libfoo1.so"));
-    }
+            "//foo:baz/bang",
+            "//foo:libfoo1.a",
+            "//foo:libfoo1.so");
     targetsInFooBar =
         labels(
             "//foo/bar:bar1",
@@ -163,10 +157,9 @@ public class TargetPatternEvaluatorTest extends AbstractTargetPatternEvaluatorTe
             "//foo/bar:wiz/all",
             "//foo/bar:baz",
             "//foo/bar:baz/bang",
-            "//foo/bar:undeclared.h");
-    if (hasImplicitCcOutputs) {
-      targetsInFooBar.addAll(labels("//foo/bar:libbar1.lo", "//foo/bar:libbar2.a"));
-    }
+            "//foo/bar:undeclared.h",
+            "//foo/bar:libbar1.lo",
+            "//foo/bar:libbar2.a");
     targetsBeneathFoo = Sets.newHashSet();
     targetsBeneathFoo.addAll(targetsInFoo);
     targetsBeneathFoo.addAll(targetsInFooBar);
@@ -179,10 +172,8 @@ public class TargetPatternEvaluatorTest extends AbstractTargetPatternEvaluatorTe
             "//otherrules:BUILD",
             "//otherrules:suite/somefile",
             "//otherrules:wiz",
-            "//otherrules:suite1");
-    if (hasImplicitCcOutputs) {
-      targetsInOtherrules.addAll(labels("//otherrules:libwiz.a"));
-    }
+            "//otherrules:suite1",
+            "//otherrules:libwiz.a");
   }
 
   private void invalidate(String file) throws InterruptedException, AbruptExitException {

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/PlatformInfoApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/PlatformInfoApiTest.java
@@ -104,6 +104,8 @@ public class PlatformInfoApiTest extends PlatformTestCase {
         // Something like "Invalid dependency :lib does not provide ConstraintValueInfo"
         "errors encountered while analyzing target",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         cc_library(name = "lib")
 
         platform(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/EvalMacroFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/EvalMacroFunctionTest.java
@@ -115,8 +115,10 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     scratch.file(
         "pkg/my_macro.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         def _impl(name, visibility):
-            native.cc_library(name = name, visibility = visibility)
+            cc_library(name = name, visibility = visibility)
         my_macro = macro(implementation = _impl)
         """);
     scratch.file(
@@ -135,8 +137,10 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     scratch.file(
         "pkg/inner_macro.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         def _impl(name, visibility):
-            native.cc_library(name = name, visibility = visibility)
+            cc_library(name = name, visibility = visibility)
         inner_macro = macro(implementation = _impl)
         """);
     scratch.file(
@@ -229,8 +233,10 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     scratch.file(
         "pkg/my_macro.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         def _impl(name, visibility):
-            native.cc_library(name = name, visibility = visibility)
+            cc_library(name = name, visibility = visibility)
         my_macro = macro(implementation = _impl)
         """);
     scratch.file(
@@ -249,6 +255,7 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
         """
         load(":my_macro.bzl", "my_macro")
         my_macro(name = "foo")
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
         cc_library(name = "unrelated")
         """);
     getSkyframeExecutor()
@@ -268,11 +275,13 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     scratch.file(
         "pkg/my_macro.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         def _impl(name, visibility):
             # exceed max_computation_steps
             for i in range(1000):
                 pass
-            native.cc_library(name = name, visibility = visibility)
+            cc_library(name = name, visibility = visibility)
 
         my_macro = macro(implementation = _impl)
         """);
@@ -302,8 +311,10 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     scratch.file(
         "pkg/my_macro.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         def _impl(name, visibility):
-            native.cc_library(name = name, visibility = visibility)
+            cc_library(name = name, visibility = visibility)
         my_macro = macro(implementation = _impl)
         """);
     scratch.file(
@@ -323,8 +334,10 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     scratch.file(
         "pkg/my_macro.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         def _impl(name, visibility):
-            native.cc_library(name = name, visibility = visibility)
+            cc_library(name = name, visibility = visibility)
         my_macro = macro(implementation = _impl)
         """);
     scratch.file(
@@ -344,8 +357,10 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     scratch.file(
         "pkg/my_macro.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         def _impl(name, visibility):
-            native.cc_library(name = name, visibility = visibility)
+            cc_library(name = name, visibility = visibility)
             fail("fail fail fail")
         my_macro = macro(implementation = _impl)
         """);
@@ -362,12 +377,12 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     assertThat(((Rule) forMacro.getTarget("foo")).containsErrors()).isTrue();
     assertContainsEvent(
         """
-        ERROR /workspace/pkg/my_macro.bzl:3:9: Traceback (most recent call last):
+        ERROR /workspace/pkg/my_macro.bzl:5:9: Traceback (most recent call last):
         \tFile "/workspace/pkg/BUILD", line 2, column 9, in <toplevel>
         \t\tmy_macro(name = "foo")
-        \tFile "/workspace/pkg/my_macro.bzl", line 4, column 1, in my_macro
+        \tFile "/workspace/pkg/my_macro.bzl", line 6, column 1, in my_macro
         \t\tmy_macro = macro(implementation = _impl)
-        \tFile "/workspace/pkg/my_macro.bzl", line 3, column 9, in _impl
+        \tFile "/workspace/pkg/my_macro.bzl", line 5, column 9, in _impl
         \t\tfail("fail fail fail")
         Error in fail: fail fail fail\
         """);
@@ -391,19 +406,22 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     scratch.file(
         "pkg/other_macro.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         def _other_inner_macro_impl(name, visibility):
-            native.cc_library(name = name, visibility = visibility)
+            cc_library(name = name, visibility = visibility)
         other_inner_macro = macro(implementation = _other_inner_macro_impl)
 
         def _other_macro_impl(name, visibility):
             other_inner_macro(name = name + "_c_inner", visibility = visibility)
-            native.cc_library(name = name + "_b", visibility = visibility)
+            cc_library(name = name + "_b", visibility = visibility)
             other_inner_macro(name = name + "_a_inner", visibility = visibility)
         other_macro = macro(implementation = _other_macro_impl)
         """);
     scratch.file(
         "pkg/BUILD",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
         load(":my_finalizer.bzl", "my_finalizer")
         load(":other_macro.bzl", "other_macro")
         my_finalizer(name = "finalize")
@@ -432,6 +450,8 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     scratch.file(
         "pkg/my_finalizer.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         # Dummy rule used to save native.existing_rules() keys in a string list attribute.
         _existing_rules_saver = rule(
             implementation = lambda ctx: [],
@@ -439,7 +459,7 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
         )
 
         def _impl(name, visibility):
-            native.cc_library(name = name + "_dummy_rule")
+            cc_library(name = name + "_dummy_rule")
             _existing_rules_saver(name = name, existing_rules = list(native.existing_rules()))
         my_finalizer = macro(implementation = _impl, finalizer = True)
         """);
@@ -476,8 +496,10 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     scratch.file(
         "pkg/fail_macro.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         def _impl(name, visibility):
-            native.cc_library(name = name, visibility = visibility)
+            cc_library(name = name, visibility = visibility)
             fail("fail fail fail")
 
         fail_macro = macro(implementation = _impl)
@@ -485,6 +507,7 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     scratch.file(
         "pkg/BUILD",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
         load(":fail_macro.bzl", "fail_macro")
         load(":my_finalizer.bzl", "my_finalizer")
         my_finalizer(name = "finalize")
@@ -504,11 +527,11 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     assertContainsEventsInOrder(
         """
         Traceback (most recent call last):
-        \tFile "/workspace/pkg/BUILD", line 5, column 11, in <toplevel>
+        \tFile "/workspace/pkg/BUILD", line 6, column 11, in <toplevel>
         \t\tfail_macro(name = "failing_macro")
-        \tFile "/workspace/pkg/fail_macro.bzl", line 5, column 1, in fail_macro
+        \tFile "/workspace/pkg/fail_macro.bzl", line 7, column 1, in fail_macro
         \t\tfail_macro = macro(implementation = _impl)
-        \tFile "/workspace/pkg/fail_macro.bzl", line 3, column 9, in _impl
+        \tFile "/workspace/pkg/fail_macro.bzl", line 5, column 9, in _impl
         \t\tfail("fail fail fail")
         Error in fail: fail fail fail\
         """,
@@ -529,8 +552,10 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     scratch.file(
         "pkg/name_conflict_macro.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         def _impl(name, suffix, visibility):
-            native.cc_library(name = name + suffix, visibility = visibility)
+            cc_library(name = name + suffix, visibility = visibility)
 
         name_conflict_macro = macro(
             implementation = _impl,
@@ -540,6 +565,7 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     scratch.file(
         "pkg/BUILD",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
         load(":my_finalizer.bzl", "my_finalizer")
         load(":name_conflict_macro.bzl", "name_conflict_macro")
         my_finalizer(name = "finalize")
@@ -561,13 +587,13 @@ public final class EvalMacroFunctionTest extends BuildViewTestCase {
     assertContainsEventsInOrder(
         """
         Traceback (most recent call last):
-        \tFile "/workspace/pkg/BUILD", line 5, column 20, in <toplevel>
+        \tFile "/workspace/pkg/BUILD", line 6, column 20, in <toplevel>
         \t\tname_conflict_macro(name = "top", suffix = "_level_rule")
-        \tFile "/workspace/pkg/name_conflict_macro.bzl", line 4, column 1, in name_conflict_macro
+        \tFile "/workspace/pkg/name_conflict_macro.bzl", line 6, column 1, in name_conflict_macro
         \t\tname_conflict_macro = macro(
-        \tFile "/workspace/pkg/name_conflict_macro.bzl", line 2, column 22, in _impl
-        \t\tnative.cc_library(name = name + suffix, visibility = visibility)
-        Error: cc_library rule 'top_level_rule' conflicts with existing cc_library rule, defined at /workspace/pkg/BUILD:4:11\
+        \tFile "/workspace/pkg/name_conflict_macro.bzl", line 4, column 15, in _impl
+        \t\tcc_library(name = name + suffix, visibility = visibility)
+        Error: cc_library rule 'top_level_rule' conflicts with existing cc_library rule, defined at /workspace/pkg/BUILD:5:11\
         """,
         "cannot compute package piece for finalizer macro //pkg:finalize defined by"
             + " //pkg:my_finalizer.bzl%my_finalizer");

--- a/src/test/java/com/google/devtools/build/lib/skyframe/GraphBackedRecursivePackageProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/GraphBackedRecursivePackageProviderTest.java
@@ -57,7 +57,7 @@ public final class GraphBackedRecursivePackageProviderTest extends BuildViewTest
 
   @Test
   public void getBuildFile_eagerMacroExpansion() throws Exception {
-    scratch.file("pkg1/BUILD", "cc_library(name = 'foo')");
+    scratch.file("pkg1/BUILD", "java_library(name = 'foo')");
 
     PackageIdentifier pkgId = PackageIdentifier.createInMainRepo("pkg1");
     GraphBackedRecursivePackageProvider packageProvider =
@@ -72,7 +72,7 @@ public final class GraphBackedRecursivePackageProviderTest extends BuildViewTest
   public void getBuildFile_lazyMacroExpansion(@TestParameter boolean graphContainsFullPackage)
       throws Exception {
     setPackageOptions("--experimental_lazy_macro_expansion_packages=*");
-    scratch.file("pkg1/BUILD", "cc_library(name = 'foo')");
+    scratch.file("pkg1/BUILD", "java_library(name = 'foo')");
 
     PackageIdentifier pkgId = PackageIdentifier.createInMainRepo("pkg1");
     PackagePieceIdentifier.ForBuildFile packagePieceId =

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PackageFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PackageFunctionTest.java
@@ -278,7 +278,12 @@ public class PackageFunctionTest extends BuildViewTestCase {
 
   @Test
   public void testValidPackage(@TestParameter ComputationMode computationMode) throws Exception {
-    scratch.file("pkg/BUILD", "cc_library(name = 'foo')");
+    scratch.file(
+        "pkg/BUILD",
+        """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+        cc_library(name = 'foo')
+        """);
     preparePackageLoading(computationMode);
     Packageoid pkg = validPackageoidWithoutErrors("pkg");
     assertThat(pkg.getTargets()).containsKey("foo");
@@ -290,8 +295,10 @@ public class PackageFunctionTest extends BuildViewTestCase {
     scratch.file(
         "pkg/macro.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         def legacy(name, visibility = None, **kwargs):
-            native.cc_library(name = name, visibility = visibility, **kwargs)
+            cc_library(name = name, visibility = visibility, **kwargs)
 
         symbolic = macro(
             implementation = legacy,
@@ -354,7 +361,7 @@ public class PackageFunctionTest extends BuildViewTestCase {
         "pkg/my_macro.bzl",
         """
         def _impl(name, visibility):
-            native.cc_library(name = name, visibility = visibility)
+            native.java_library(name = name, visibility = visibility)
             fail("fail fail fail")
         my_macro = macro(implementation = _impl)
         """);
@@ -400,8 +407,10 @@ public class PackageFunctionTest extends BuildViewTestCase {
         "pkg/my_macro.bzl",
         String.format(
             """
+            load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
             def _impl(name, visibility):
-                native.cc_library(name = name + "_bar")
+                cc_library(name = name + "_bar")
             my_macro = macro(implementation = _impl, finalizer = %s)
             """,
             inFinalizer ? "True" : "False"));
@@ -2121,10 +2130,10 @@ public class PackageFunctionTest extends BuildViewTestCase {
       scratch.file("tools/test_build_rules/BUILD");
       scratch.file(
           "tools/test_build_rules/test_prelude", //
-          "cc_library = 'FOO'");
+          "java_binary = 'FOO'");
       scratch.file(
           "pkg/BUILD", //
-          "print(cc_library)");
+          "print(java_binary)");
 
       invalidatePackages();
 
@@ -2139,16 +2148,16 @@ public class PackageFunctionTest extends BuildViewTestCase {
           "tools/builtins_staging/exports.bzl",
           """
           exported_toplevels = {}
-          exported_rules = {"cc_library": "BAR"}
+          exported_rules = {"cc_toolchain_suite": "BAR"}
           exported_to_java = {}
           """);
       scratch.file("tools/test_build_rules/BUILD");
       scratch.file(
           "tools/test_build_rules/test_prelude", //
-          "cc_library = 'FOO'");
+          "cc_toolchain_suite = 'FOO'");
       scratch.file(
           "pkg/BUILD", //
-          "print(cc_library)");
+          "print(cc_toolchain_suite)");
 
       try {
         invalidatePackages();

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkOptionsParsingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkOptionsParsingTest.java
@@ -364,6 +364,8 @@ public class StarlarkOptionsParsingTest extends StarlarkOptionsTestCase {
     scratch.file(
         "test/BUILD",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         genrule(
             name = "my_gen",
             srcs = ["x.in"],

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -421,8 +421,10 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
     scratch.file(
         "pkg/foo.bzl",
         """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
         def _impl(name, visibility, target_suffix):
-            native.cc_library(name = name + "_" + target_suffix)
+            cc_library(name = name + "_" + target_suffix)
         my_macro = macro(
             implementation=_impl,
             attrs = {
@@ -3337,7 +3339,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         r = foo_rule(name = "foo")
 
         # Native rule should return None
-        c = cc_library(name = "cc")
+        c = java_library(name = "cc")
 
         foo_rule(
             name = "check",
@@ -4790,7 +4792,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
 
         my_binary = rule(
             implementation = _impl,
-            parent = native.cc_binary,
+            parent = native.java_binary,
         )
         """);
     scratch.file(

--- a/src/test/shell/bazel/cc_flags_supplier_test.sh
+++ b/src/test/shell/bazel/cc_flags_supplier_test.sh
@@ -57,6 +57,7 @@ function write_crosstool() {
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_cc//cc/toolchains:cc_toolchain.bzl", "cc_toolchain")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 
 cc_library(

--- a/src/test/shell/integration/loading_phase_test.sh
+++ b/src/test/shell/integration/loading_phase_test.sh
@@ -70,7 +70,7 @@ function test_query_buildfiles_with_load() {
 
     mkdir -p $pkg/x || fail "mkdir $pkg/x failed"
     echo "load('//$pkg/y:rules.bzl', 'a')" >$pkg/x/BUILD
-    echo "cc_library(name='x')"   >>$pkg/x/BUILD
+    echo "java_library(name='x')"   >>$pkg/x/BUILD
     mkdir -p $pkg/y || fail "mkdir $pkg/y failed"
     touch $pkg/y/BUILD
     echo "a=1" >$pkg/y/rules.bzl

--- a/src/test/shell/integration/target_compatible_with_test.sh
+++ b/src/test/shell/integration/target_compatible_with_test.sh
@@ -1088,6 +1088,7 @@ EOF
 # for https://github.com/bazelbuild/bazel/issues/12897.
 function test_incompatible_with_missing_toolchain() {
   set_up_custom_toolchain
+  add_rules_cc "MODULE.bazel"
   cat >> MODULE.bazel <<'EOF'
 local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = 'build_bazel_apple_support', path = 'build_bazel_apple_support')
@@ -1108,6 +1109,7 @@ load(
     "compiler_flag",
     "custom_binary",
 )
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 
 objc_library(
     name = "objc",


### PR DESCRIPTION
Since this commit 71ca0ed111ff3d842a0d23bc3a46bd2e6745491d the load
statements for these cc rules are required but the errors indicating
that were a bit strange:

Before:

```
ERROR: /private/tmp/foo/BUILD.bazel:7:8: //:bar: no such attribute 'srcs' in 'cc_test' rule
ERROR: /private/tmp/foo/BUILD.bazel:7:8: In rule 'bar', size '' is not a valid size.
ERROR: /private/tmp/foo/BUILD.bazel:7:8: In rule 'bar', timeout '' is not a valid timeout.
```

After:

```
ERROR: /private/tmp/foo/BUILD.bazel:7:1: name 'cc_test' is not defined
```
