### PR TITLE
New Incompatible flags disable ctx.fragments.[py|bazel_py]

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonConfiguration.java
@@ -79,6 +79,18 @@ public class BazelPythonConfiguration extends Fragment {
                 + "`import myreponame.mytoplevelpackage.package.module` is valid. The latter form "
                 + "is less likely to experience import name collisions.")
     public boolean experimentalPythonImportAllRepositories;
+
+    @Option(
+        name = "incompatible_remove_ctx_bazel_py_fragment",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+        help =
+            "When true, Python build flags are defined with Python rules (in BUIILD files) and"
+                + " ctx.fragments.bazel_py is undefined. This is a migration flag to move all Python"
+                + " flags from core Bazel to Python rules.")
+    public boolean disablePyFragment;
   }
 
   private final Options options;
@@ -106,6 +118,10 @@ public class BazelPythonConfiguration extends Fragment {
                   + "`--incompatible_use_python_toolchains=false`."));
       // TODO(#7901): Also prohibit --python_path here.
     }
+  }
+
+  public boolean shouldInclude() {
+    return !options.disablePyFragment;
   }
 
   @StarlarkConfigurationField(

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PythonConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PythonConfiguration.java
@@ -55,6 +55,7 @@ public class PythonConfiguration extends Fragment implements StarlarkValue {
   private final boolean defaultToExplicitInitPy;
   @Nullable private final Label nativeRulesAllowlist;
   private final boolean disallowNativeRules;
+  private final boolean disablePyFragment;
 
   public PythonConfiguration(BuildOptions buildOptions) {
     PythonOptions pythonOptions = buildOptions.get(PythonOptions.class);
@@ -68,6 +69,12 @@ public class PythonConfiguration extends Fragment implements StarlarkValue {
     this.nativeRulesAllowlist = pythonOptions.nativeRulesAllowlist;
     this.disallowNativeRules = pythonOptions.disallowNativeRules;
     this.includeLabelInLinkstamp = pythonOptions.includeLabelInPyBinariesLinkstamp;
+    this.disablePyFragment = pythonOptions.disablePyFragment;
+  }
+
+  @Override
+  public boolean shouldInclude() {
+    return !disablePyFragment;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PythonOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PythonOptions.java
@@ -174,6 +174,18 @@ public class PythonOptions extends FragmentOptions {
   // Helper field to store hostForcePython in exec configuration
   private PythonVersion defaultPythonVersion = null;
 
+  @Option(
+      name = "incompatible_remove_ctx_py_fragment",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          "When true, Python build flags are defined with Python rules (in BUIILD files) and"
+              + " ctx.fragments.py is undefined. This is a migration flag to move all Python flags "
+              + " from core Bazel to Python rules.")
+  public boolean disablePyFragment;
+
   /**
    * Returns the Python major version ({@code PY2} or {@code PY3}) that targets that do not specify
    * a version should be built for.


### PR DESCRIPTION
`--incompatible_remove_ctx_py_fragment` removes `ctx.fragments.py`.

`--incompatible_remove_ctx_bazel_py_fragment` removes `ctx.fragments.bazel_py`.

`rules_python` can use this to determine if it should read Python flags from Starlark definitions or Bazel-native:

```py
if not hasattr(ctx.fragments, "py"):
  print("I should read Python flags from Starlark.")
````

For https://github.com/bazel-contrib/rules_python/issues/3252.