### PR TITLE
Remove linker_input_params from mock toolchain

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
@@ -6196,17 +6196,6 @@ def _impl(ctx):
                           [ACTION_NAMES.cpp_link_static_library],
                 flag_groups = [
                     flag_group(
-                        flags = ["%{linker_input_params}"],
-                        iterate_over = "linker_input_params",
-                        expand_if_available = "linker_input_params",
-                    ),
-                ],
-            ),
-            flag_set(
-                actions = _NON_OBJC_LINK_ACTIONS +
-                          [ACTION_NAMES.cpp_link_static_library],
-                flag_groups = [
-                    flag_group(
                         iterate_over = "libraries_to_link",
                         flag_groups = [
                             flag_group(


### PR DESCRIPTION
Removed from bazel 9 years ago https://github.com/bazelbuild/bazel/commit/0ca9d7ee67bdf9d5e073bd7b4530c6fd0915beeaf
