### PR TITLE
Remove unused hasConfiguredLinkerPathInActionConfig function

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeatures.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeatures.java
@@ -1222,11 +1222,6 @@ public class CcToolchainFeatures implements StarlarkValue {
       return requestedFeatures;
     }
 
-    /** @return true if tool_path in action_config points to a real tool, not a dummy placeholder */
-    public boolean hasConfiguredLinkerPathInActionConfig() {
-      return isEnabled("has_configured_linker_path");
-    }
-
     /** @return whether an action config for the blaze action with the given name is enabled. */
     boolean actionIsConfigured(String actionName) {
       return enabledActionConfigActionNames.contains(actionName);


### PR DESCRIPTION
The only consumer of this was migrated to starlark and doesn't call this
