### PR TITLE
Don't unnecessarily materialize the inputs map for the compact exec log

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -187,7 +187,9 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
         spawnLogContext.logSpawn(
             spawn,
             actionExecutionContext.getInputMetadataProvider(),
-            context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ false),
+            () ->
+                context.getInputMapping(
+                    PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ false),
             actionExecutionContext.getActionFileSystem() != null
                 ? actionExecutionContext.getActionFileSystem()
                 : actionExecutionContext.getExecRoot().getFileSystem(),

--- a/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
@@ -65,6 +65,7 @@ import java.util.List;
 import java.util.SortedMap;
 import java.util.UUID;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
@@ -212,7 +213,7 @@ public class CompactSpawnLogContext extends SpawnLogContext {
   public void logSpawn(
       Spawn spawn,
       InputMetadataProvider inputMetadataProvider,
-      SortedMap<PathFragment, ActionInput> inputMap,
+      Supplier<SortedMap<PathFragment, ActionInput>> inputMap,
       FileSystem fileSystem,
       Duration timeout,
       SpawnResult result)

--- a/src/main/java/com/google/devtools/build/lib/exec/ExpandedSpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExpandedSpawnLogContext.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /** A {@link SpawnLogContext} implementation that produces a log in expanded format. */
@@ -148,7 +149,7 @@ public class ExpandedSpawnLogContext extends SpawnLogContext {
   public void logSpawn(
       Spawn spawn,
       InputMetadataProvider inputMetadataProvider,
-      SortedMap<PathFragment, ActionInput> inputMap,
+      Supplier<SortedMap<PathFragment, ActionInput>> inputMap,
       FileSystem fileSystem,
       Duration timeout,
       SpawnResult result)
@@ -170,7 +171,7 @@ public class ExpandedSpawnLogContext extends SpawnLogContext {
               .collect(toImmutableList());
 
       try (SilentCloseable c1 = Profiler.instance().profile("logSpawn/inputs")) {
-        for (Map.Entry<PathFragment, ActionInput> e : inputMap.entrySet()) {
+        for (Map.Entry<PathFragment, ActionInput> e : inputMap.get().entrySet()) {
           PathFragment displayPath = e.getKey();
           ActionInput input = e.getValue();
 

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -77,7 +77,7 @@ public abstract class SpawnLogContext implements ActionContext {
       throws IOException, InterruptedException, ExecException;
 
   @VisibleForTesting
-  public void logSpawn(
+  void logSpawn(
       Spawn spawn,
       InputMetadataProvider inputMetadataProvider,
       SortedMap<PathFragment, ActionInput> inputMap,

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.SortedMap;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /** An {@link ActionContext} providing the ability to log executed spawns. */
@@ -60,7 +61,7 @@ public abstract class SpawnLogContext implements ActionContext {
    *
    * @param spawn the spawn to log
    * @param inputMetadataProvider provides metadata for the spawn inputs
-   * @param inputMap the mapping from input paths to action inputs
+   * @param inputMap the mapping from input paths to action inputs (built lazily)
    * @param fileSystem the filesystem containing the spawn inputs and outputs, which might be an
    *     action filesystem when building without the bytes
    * @param timeout the timeout the spawn was run under
@@ -69,11 +70,23 @@ public abstract class SpawnLogContext implements ActionContext {
   public abstract void logSpawn(
       Spawn spawn,
       InputMetadataProvider inputMetadataProvider,
-      SortedMap<PathFragment, ActionInput> inputMap,
+      Supplier<SortedMap<PathFragment, ActionInput>> inputMap,
       FileSystem fileSystem,
       Duration timeout,
       SpawnResult result)
       throws IOException, InterruptedException, ExecException;
+
+  @VisibleForTesting
+  public void logSpawn(
+      Spawn spawn,
+      InputMetadataProvider inputMetadataProvider,
+      SortedMap<PathFragment, ActionInput> inputMap,
+      FileSystem fileSystem,
+      Duration timeout,
+      SpawnResult result)
+      throws IOException, InterruptedException, ExecException {
+    logSpawn(spawn, inputMetadataProvider, () -> inputMap, fileSystem, timeout, result);
+  }
 
   /**
    * Logs an internal symlink action, which is not backed by a spawn.

--- a/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
@@ -26,8 +26,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
+import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnExecutedEvent;
@@ -44,10 +44,13 @@ import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.SortedMap;
+import java.util.function.Supplier;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -331,11 +334,11 @@ public class AbstractSpawnStrategyTest {
 
     verify(spawnLogContext)
         .logSpawn(
-            SIMPLE_SPAWN,
-            inputMetadataProvider,
-            ImmutableSortedMap.of(),
-            actionFs,
-            Duration.ZERO,
-            spawnResult);
+            eq(SIMPLE_SPAWN),
+            eq(inputMetadataProvider),
+            (Supplier<SortedMap<PathFragment, ActionInput>>) any(),
+            eq(actionFs),
+            eq(Duration.ZERO),
+            eq(spawnResult));
   }
 }


### PR DESCRIPTION
This map isn't needed e.g. for local execution and after #21378 also not for remote execution.