### PR TITLE
Don't rely on the local JDK for integration tests

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -114,6 +114,13 @@ sh_test(
     data = [
         ":test-deps",
         "@bazel_tools//tools/bash/runfiles",
+        "@rules_java//toolchains:current_java_runtime",
+    ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 
@@ -146,9 +153,18 @@ sh_test(
     name = "bazel_embedded_starlark_test",
     size = "medium",
     srcs = ["bazel_embedded_starlark_test.sh"],
-    data = [":test-deps"],
+    data = [
+        ":test-deps",
+        "@rules_java//toolchains:current_java_runtime",
+    ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     tags = [
         "no_windows",  # TODO(laszlocsomor): make this run on Windows
+    ],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 
@@ -757,9 +773,18 @@ sh_test(
     name = "external_starlark_execute_test",
     size = "large",
     srcs = ["external_starlark_execute_test.sh"],
-    data = [":test-deps"],
+    data = [
+        ":test-deps",
+        "@rules_java//toolchains:current_java_runtime",
+    ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     shard_count = 2,
     tags = ["no_windows"],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
+    ],
 )
 
 sh_test(
@@ -777,12 +802,18 @@ sh_test(
     data = [
         ":test-deps",
         "//src/test/shell/bazel/testdata:zstd_test_archive.tar.zst",
-        "@local_jdk//:jdk",  # for remote_helpers setup_localjdk_javabase
+        "@rules_java//toolchains:current_java_runtime",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     shard_count = 15,
     tags = [
         "no_windows",
         "requires-network",
+    ],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 
@@ -815,9 +846,16 @@ sh_test(
     data = [
         ":test-deps",
         "@bazel_tools//tools/bash/runfiles",
+        "@rules_java//toolchains:current_java_runtime",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     shard_count = 6,
     tags = ["no_windows"],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
+    ],
 )
 
 sh_test(
@@ -869,11 +907,17 @@ sh_test(
     data = [
         ":test-deps",
         "@bazel_tools//tools/bash/runfiles",
-        "@local_jdk//:jdk",  # for remote_helpers setup_localjdk_javabase
+        "@rules_java//toolchains:current_java_runtime",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     shard_count = 10,
     tags = [
         "requires-network",
+    ],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 
@@ -1027,11 +1071,18 @@ sh_test(
     data = [
         ":test-deps",
         "//src/test/shell:sandboxing_test_utils.sh",
+        "@rules_java//toolchains:current_java_runtime",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     tags = [
         "no-sandbox",
         "no_windows",
         "requires-network",
+    ],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 
@@ -1105,11 +1156,20 @@ sh_test(
     name = "bazel_repository_cache_test",
     size = "large",
     srcs = ["bazel_repository_cache_test.sh"],
-    data = [":test-deps"],
+    data = [
+        ":test-deps",
+        "@rules_java//toolchains:current_java_runtime",
+    ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     shard_count = 6,
     tags = [
         "no_windows",
         "requires-network",
+    ],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 
@@ -1332,11 +1392,17 @@ sh_test(
     data = [
         ":test-deps",
         "//src/tools/remote:worker",
-        "@local_jdk//:jdk",  # for remote_helpers
+        "@rules_java//toolchains:current_java_runtime",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     tags = [
         "no_windows",
         "requires-network",  # for Bzlmod
+    ],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
     deps = [
         "//src/test/shell/bazel/remote:remote_utils",

--- a/src/test/shell/bazel/bazel_windows_example_test.sh
+++ b/src/test/shell/bazel/bazel_windows_example_test.sh
@@ -48,7 +48,7 @@ if ! is_windows; then
   exit 0
 fi
 
-setup_localjdk_javabase
+setup_javabase
 
 function set_up() {
   copy_examples
@@ -387,4 +387,3 @@ EOF
 }
 
 run_suite "examples on Windows"
-

--- a/src/test/shell/bazel/remote/BUILD
+++ b/src/test/shell/bazel/remote/BUILD
@@ -31,11 +31,17 @@ sh_test(
         "//src/test/shell/bazel:test-deps",
         "//src/tools/remote:worker",
         "@bazel_tools//tools/bash/runfiles",
-        "@local_jdk//:jdk",  # for remote_helpers setup_localjdk_javabase
+        "@rules_java//toolchains:current_java_runtime",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     shard_count = 5,
     tags = [
         "requires-network",  # for Bzlmod (apple_support)
+    ],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 

--- a/src/test/shell/bazel/remote_helpers.sh
+++ b/src/test/shell/bazel/remote_helpers.sh
@@ -16,7 +16,7 @@
 
 set -eu
 
-setup_localjdk_javabase
+setup_javabase
 
 # Serves $1 as a file on localhost:$nc_port.  Sets the following variables:
 #   * nc_port - the port nc is listening on.

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -260,16 +260,15 @@ function try_with_timeout() {
   done
 }
 
-function setup_localjdk_javabase() {
-  if is_windows; then
-    jdk_binary=local_jdk/bin/java.exe
-  else
-    jdk_binary=local_jdk/bin/java
+function setup_javabase() {
+  if [[ -z "${JAVA_ROOTPATH:-}" ]]; then
+    log_fatal "set JAVA_ROOTPATH to the rootpath of a java binary to use setup_javabase"
   fi
-  jdk_binary_rlocation=$(rlocation ${jdk_binary})
+  jdk_binary_rlocation=$(rlocation ${JAVA_ROOTPATH#../}) || {
+    log_fatal "error: failed to find $JAVA_ROOTPATH, make sure you have added it to data" >&2
+  }
   if [[ -z "${jdk_binary_rlocation}" ]]; then
-    echo "error: failed to find $jdk_binary, make sure you have java \
-installed or pass --java_runtime_verison=XX with the correct version" >&2
+    log_fatal "error: failed to find $JAVA_ROOTPATH, make sure you have added it to data" >&2
   fi
   if is_windows; then
     jdk_dir="$(cygpath -m $(cd ${jdk_binary_rlocation}/../..; pwd))"

--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -290,8 +290,8 @@ cc_test(
         "output_jar_simple_test.cc",
     ],
     copts = select({
-        "//src/conditions:windows": ["-DJAR_TOOL_PATH=\\\"local_jdk/bin/jar.exe\\\""],
-        "//conditions:default": ["-DJAR_TOOL_PATH=\\\"local_jdk/bin/jar\\\""],
+        "//src/conditions:windows": ["-DJAR_TOOL_PATH=\\\"$(JAVABASE_ROOTPATH)/bin/jar.exe\\\""],
+        "//conditions:default": ["-DJAR_TOOL_PATH=\\\"$(JAVABASE_ROOTPATH)/bin/jar\\\""],
     }),
     data = [
         ":data1",
@@ -300,11 +300,7 @@ cc_test(
         ":test1",
         ":test2",
         "@rules_java//toolchains:current_java_runtime",
-    ] + select({
-        # TODO: Use the current java runtime instead of local_jdk
-        "//src/conditions:windows": ["@local_jdk//:bin/jar.exe"],
-        "//conditions:default": ["@local_jdk//:bin/jar"],
-    }),
+    ],
     toolchains = ["@rules_java//toolchains:current_java_runtime"],
     deps = [
         ":input_jar",

--- a/src/tools/singlejar/output_jar_simple_test.cc
+++ b/src/tools/singlejar/output_jar_simple_test.cc
@@ -681,7 +681,9 @@ TEST_F(OutputJarSimpleTest, Normalize) {
   string out_path = OutputFilePath("out.jar");
   string testjar_path = OutputFilePath("testinput.jar");
   {
-    std::string jar_tool_path = runfiles->Rlocation(JAR_TOOL_PATH);
+    // Skip over the leading ../ to get the rlocationpath.
+    std::string jar_tool_rlocationpath = std::string(JAR_TOOL_PATH).substr(3);
+    std::string jar_tool_path = runfiles->Rlocation(jar_tool_rlocationpath);
     string textfile_path = CreateTextFile("jar_testinput.txt", "jar_inputtext");
     string classfile_path = CreateTextFile("JarTestInput.class", "Dummy");
     unlink(testjar_path.c_str());
@@ -758,7 +760,9 @@ TEST_F(OutputJarSimpleTest, AddMissingDirectories) {
   string out_path = OutputFilePath("out.jar");
   string testjar_path = OutputFilePath("testinput.jar");
 
-  std::string jar_tool_path = runfiles->Rlocation(JAR_TOOL_PATH);
+  // Skip over the leading ../ to get the rlocationpath.
+  std::string jar_tool_rlocationpath = std::string(JAR_TOOL_PATH).substr(3);
+  std::string jar_tool_path = runfiles->Rlocation(jar_tool_rlocationpath);
   string textfile_path =
       CreateTextFile("a/b/jar_testinput.txt", "jar_inputtext");
   string classfile1_path = CreateTextFile("a/c/Foo.class", "Dummy");


### PR DESCRIPTION
Preparation for updating the default Java runtime to JDK 25.