### PR TITLE
[7.7.0] Fix stashing sandboxes if unable to move directory to _moved_trash_dir

### DIFF
--- a/src/test/shell/integration/sandboxing_test.sh
+++ b/src/test/shell/integration/sandboxing_test.sh
@@ -950,6 +950,59 @@ EOF
   bazel shutdown
 }
 
+# This test does not currently work in Blaze. Not due to the inaccessible dirs
+# in runfiles. Even if the action didn't set the chmod 000 permissions the test
+# would still not work for Blaze. The problem is the difference in how the
+# runfiles are laid out in Blaze vs Bazel:
+# Blaze: <somedir>/sandbox/sandbox_stash/TestRunner/3/execroot/{workspace_name}/runfiles/
+# Bazel: <somedir>/sandbox/sandbox_stash/TestRunner/3//execroot/_main/bazel-out/k8-fastbuild/bin/pkg/create_readonly_dir_in_pwd.runfiles
+
+# The runfiles directory for Blaze has permissions r_xr_xr_x while the runfiles
+# directory for Bazel has permissions rwxr_xr_x. The latter allows writing a
+# new directory from an action (regardless of the permission of that new directory)
+# and then deleting it when reusing the sandbox but when running this test under
+# Blaze due to the missing write permissions we get an error.
+function test_sandbox_reuse_stashes_works_for_actions_creating_inaccessible_dirs_in_runfiles() {
+  if ! is_bazel; then
+    return 0
+  fi
+
+  add_rules_shell "MODULE.bazel"
+
+  mkdir pkg
+  cat >pkg/BUILD <<EOF
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+sh_test(
+  name = "create_readonly_dir_in_pwd",
+  srcs = [ "create_readonly_dir_in_pwd.sh" ],
+)
+EOF
+
+  cat > pkg/create_readonly_dir_in_pwd.sh <<EOF
+#!/bin/sh
+set -e
+mkdir readonly_dir
+touch readonly_dir/some_file
+chmod 000 readonly_dir/some_file
+chmod 000 readonly_dir
+EOF
+  chmod +x pkg/create_readonly_dir_in_pwd.sh
+
+  local output_base="$(bazel info output_base)"
+  local bazel_bin="$(bazel info bazel-bin)"
+  local bazel_bin_reldir="${bazel_bin#$output_base}"
+
+  bazel test --reuse_sandbox_directories //pkg:create_readonly_dir_in_pwd >"${TEST_log}" 2>&1 \
+    || fail "Expected first test to succeed"
+
+  local sandbox_stash="${output_base}/sandbox/sandbox_stash"
+  [[ -d "${sandbox_stash}/TestRunner/3/$bazel_bin_reldir/pkg/create_readonly_dir_in_pwd.runfiles/_main/readonly_dir" ]] \
+    || fail "${sandbox_stash} did not stash readonly_dir"
+
+  bazel test --reuse_sandbox_directories --nocache_test_results //pkg:create_readonly_dir_in_pwd >"${TEST_log}" 2>&1 \
+    || fail "Expected second test to succeed"
+}
+
 function test_hermetic_tmp_with_tmp_sandbox_base() {
   mkdir pkg
   cat >pkg/BUILD <<EOF


### PR DESCRIPTION
Fix for https://github.com/bazelbuild/bazel/issues/26846

If cannot move directory to `_moved_trash_dir` the delete this directory in-place.

Closes #26848.

PiperOrigin-RevId: 805233054
Change-Id: Ib30b08d764299cfdf8b2dbca6fda408db9ee3eba