### PR TITLE
feat: add action spawn keys into BES

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutedEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutedEvent.java
@@ -53,6 +53,7 @@ public final class ActionExecutedEvent implements BuildEventWithConfiguration {
   private final Path stdout;
   private final Path stderr;
   private final ErrorTiming timing;
+  private final ImmutableList<String> spawnKeys;
 
   /** Timestamp of the action starting; if no timestamp is available will be {@code null}. */
   @Nullable private final Instant startTime;
@@ -63,6 +64,7 @@ public final class ActionExecutedEvent implements BuildEventWithConfiguration {
   public ActionExecutedEvent(
       PathFragment actionId,
       Action action,
+      ImmutableList<String> spawnKeys,
       @Nullable ActionExecutionException exception,
       Path primaryOutput,
       Artifact outputArtifact,
@@ -72,6 +74,7 @@ public final class ActionExecutedEvent implements BuildEventWithConfiguration {
       ErrorTiming timing,
       @Nullable Instant startTime,
       @Nullable Instant endTime) {
+    this.spawnKeys = spawnKeys;
     this.actionId = actionId;
     this.action = action;
     this.exception = exception;
@@ -178,7 +181,8 @@ public final class ActionExecutedEvent implements BuildEventWithConfiguration {
     BuildEventStreamProtos.ActionExecuted.Builder actionBuilder =
         BuildEventStreamProtos.ActionExecuted.newBuilder()
             .setSuccess(getException() == null)
-            .setType(action.getMnemonic());
+            .setType(action.getMnemonic())
+            .addAllSpawnKeys(spawnKeys);
     if (startTime != null) {
       actionBuilder.setStartTime(timestampProto(startTime));
       if (endTime != null) {

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -559,8 +559,6 @@ message NamedSetOfFiles {
 message ActionExecuted {
   reserved 10;
 
-  repeated string spawn_keys = 16;
-
   bool success = 1;
 
   // The mnemonic of the action that was executed
@@ -604,6 +602,11 @@ message ActionExecuted {
   //
   // The default type will be `tools.proto.SpawnExec` found in `spawn.proto`.
   repeated google.protobuf.Any strategy_details = 14;
+
+  // Digests of spawns remotely cached or executed by this action.
+  // Typically one digest per action, but some actions may have multiple.
+  // In Bazel, each is a build.bazel.remote.execution.v2.Digest.
+  repeated google.protobuf.Any spawn_digests = 16;
 }
 
 // Collection of all output files belonging to that output group.

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -559,6 +559,8 @@ message NamedSetOfFiles {
 message ActionExecuted {
   reserved 10;
 
+  repeated string spawn_keys = 16;
+
   bool success = 1;
 
   // The mnemonic of the action that was executed

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -2578,6 +2578,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/protobuf:failure_details_java_proto",
+        "//src/main/protobuf:spawn_java_proto",
         "//third_party:flogger",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Comparators.max;
 import static com.google.common.collect.Comparators.min;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.devtools.build.lib.buildtool.BuildRequestOptions.MAX_JOBS;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -1880,6 +1881,12 @@ public final class SkyframeActionExecutor {
         findSpawnResultsInActionResultAndException(actionResult, exception);
     Instant firstStartTime = Instant.MAX;
     Instant lastEndTime = Instant.MIN;
+    ImmutableList<String> spawnKeys = spawnResults
+        .stream()
+        .map(sr -> sr.getDigest())
+        .filter(sr -> sr != null)
+        .map(sr -> sr.getHash())
+        .collect(toImmutableList());
     for (SpawnResult spawnResult : spawnResults) {
       // Not all SpawnResults have a start time, and some use Instant.MIN/MAX instead of null.
       @Nullable Instant startTime = spawnResult.getStartTime();
@@ -1893,6 +1900,7 @@ public final class SkyframeActionExecutor {
         new ActionExecutedEvent(
             action.getPrimaryOutput().getExecPath(),
             action,
+            spawnKeys,
             exception,
             primaryOutputPath,
             action.getPrimaryOutput(),


### PR DESCRIPTION
Adds spawn keys into ActionExecuted BES event. 

This is useful for following use cases; 

- remote BES server needs to examine the AC for performing analysis.
- BWOB enabled, the local (something running on the same host as bazel) needs to examine AC entry
- Performing selective delivery; comparing the spawn keys for the same action to decide if additional work needs to performed by the remote BES server.


I am happy to implement something alternative, and more principled. This just seemed the easiest implementation. 

Will look at the tests once i get a positive feedback from the maintainers.