### PR TITLE
[7.7.0] Remove xcode_locator's no_uuid and codesigning workarounds

### DIFF
--- a/tools/osx/BUILD
+++ b/tools/osx/BUILD
@@ -28,8 +28,7 @@ exports_files([
 
 DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """
   /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices \
-      -framework Foundation -arch arm64 -arch x86_64 -Wl,-no_adhoc_codesign -Wl,-no_uuid -o $@ $< && \
-  env -i codesign --identifier $@ --force --sign - $@
+      -framework Foundation -arch arm64 -arch x86_64 -o $@ $<
 """
 
 genrule(


### PR DESCRIPTION
These workarounds were added (in 76b3c24283, bazelbuild/bazel#14168) to enable hermetic macOS toolchain setup, but are no longer necessary as far as I can tell (see also: bazelbuild/apple_support@44c43c715a, bazelbuild/apple_support#373).

It should be noted that macOS Tahoe seems to have enforced that LC_UUID must be present in executables. Executables without it are rejected by dyld with `dyld: missing LC_UUID load command`, effectively stops Bazel from working. It is therefore necessary to drop these workarounds here and in Apple support (done in bazelbuild/apple_support@44c43c715a) in order for Bazel to function on macOS Tahoe.

CC @keith

Closes #27014.

PiperOrigin-RevId: 811436317
Change-Id: I9d819fdbc2b76ad4ee5abb1fc0c4eb1ee1b442fb

Commit https://github.com/bazelbuild/bazel/commit/433e0e782c14802b6ec3095ccd5fa23b26531dea