### PR TITLE
Add `ctx.configuration.short_id`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -728,6 +728,11 @@ public class BuildConfigurationValue
     return options.collectCodeCoverage;
   }
 
+  @Override
+  public String getShortId() {
+    return buildOptions.shortId();
+  }
+
   @Nullable
   public RunUnder getRunUnder() {
     return options.runUnder;

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/BuildConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/BuildConfigurationApi.java
@@ -79,9 +79,17 @@ public interface BuildConfigurationApi extends StarlarkValue {
       name = "short_id",
       structField = true,
       doc = """
-            A short identifier for this configuration understood by <code>bazel config</code>.
+            A short identifier for this configuration understood by the <code>config</code> and \
+            </code>query</code> subcommands. \
 
-            <p>Use of this field should generally be avoided as it hurts cacheability.
+            <p>Use this to distinguish different configurations for the same target in a way that \
+            is friendly to humans and tool usage, for example in an aspect used by an IDE. \
+            Keep in mind the following caveats: \
+            <ul> \
+              <li>The value may differ across Bazel versions, including patch releases. \
+              <li>The value encodes the value of <b>every</b> flag, including those that aren't \
+                  otherwise relevant for the current target and may thus invalidate caches more \
+                  frequently.
             """)
   String getShortId();
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/BuildConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/BuildConfigurationApi.java
@@ -75,6 +75,16 @@ public interface BuildConfigurationApi extends StarlarkValue {
               + " function.")
   boolean isCodeCoverageEnabled();
 
+  @StarlarkMethod(
+      name = "short_id",
+      structField = true,
+      doc = """
+            A short identifier for this configuration understood by <code>bazel config</code>.
+
+            <p>Use of this field should generally be avoided as it hurts cacheability.
+            """)
+  String getShortId();
+
   @StarlarkMethod(name = "stamp_binaries", documented = false, useStarlarkThread = true)
   boolean stampBinariesForStarlark(StarlarkThread thread) throws EvalException;
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationStarlarkTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationStarlarkTest.java
@@ -125,4 +125,41 @@ public final class BuildConfigurationStarlarkTest extends BuildViewTestCase {
         assertThrows(AssertionError.class, () -> getConfiguredTarget("//example:custom"));
     assertThat(e).hasMessageThat().contains("file '//example:rule.bzl' cannot use private API");
   }
+
+  @Test
+  public void testShortId() throws Exception {
+    scratch.file(
+        "example/BUILD",
+        """
+        load(":rule.bzl", "custom_rule")
+
+        custom_rule(name = "custom")
+        """);
+
+    scratch.file(
+        "example/rule.bzl",
+        """
+        MyInfo = provider()
+
+        def _impl(ctx):
+            return [MyInfo(short_id = ctx.configuration.short_id)]
+
+        custom_rule = rule(implementation = _impl)
+        """);
+
+    ConfiguredTarget target = getConfiguredTarget("//example:custom");
+    Provider.Key key =
+        new StarlarkProvider.Key(keyForBuild(Label.parseCanonical("//example:rule.bzl")), "MyInfo");
+    StructImpl myInfo = (StructImpl) target.get(key);
+    String firstShortId = (String) myInfo.getValue("short_id");
+    assertThat(firstShortId).isEqualTo(target.getConfigurationKey().getOptions().shortId());
+
+    useConfiguration("--compilation_mode=dbg");
+    target = getConfiguredTarget("//example:custom");
+    myInfo = (StructImpl) target.get(key);
+    String secondShortId = (String) myInfo.getValue("short_id");
+    assertThat(secondShortId).isEqualTo(target.getConfigurationKey().getOptions().shortId());
+
+    assertThat(firstShortId).isNotEqualTo(secondShortId);
+  }
 }


### PR DESCRIPTION
RELNOTES[NEW]: The new `ctx.configuration.short_id` field provides a short identifier for the current configuration that is understood by `bazel config`.

Fixes #26752