### PR TITLE
docs: stop advertising Jason's community update

### DIFF
--- a/site/en/community/_index.yaml
+++ b/site/en/community/_index.yaml
@@ -38,11 +38,6 @@ landing_page:
       image_path: /images/why_faq.svg
       description: >
         Get and give support by joining the Bazel community on Slack, Stack Overflow, and more.
-    - heading: Community updates
-      path: /community/update
-      image_path: /images/new_3.svg
-      description: >
-        Tune in for our new monthly community update livestream.
     - heading: Contributor's guide
       path: /contribute/
       image_path: /images/why_overview.svg


### PR DESCRIPTION
Has been dead since 2022.

I left the https://github.com/bazelbuild/bazel/blob/3ebd6adfdc836f456e0bcabac399f2e985c2933f/site/en/community/update.md#L4 page partly because it's an archive of the past and partly because I'm not sure I can send a PR to delete a page in Google DevSite - perhaps my Googler reviewer here would like to clean that up also