### PR TITLE
Treat action results with missing mandatory outputs as cache misses

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -150,6 +150,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -807,6 +808,33 @@ public class RemoteExecutionService {
       }
 
       return actionResult.getExitCode() == 0;
+    }
+
+    /**
+     * Returns an output that is mandatory for the given spawn but missing from this result if any.
+     */
+    public Optional<? extends ActionInput> maybeGetMissingMandatoryOutput(RemoteAction action) {
+      var outputFiles = Iterables.transform(getOutputFiles(), OutputFile::getPath);
+      var outputDirPaths = Iterables.transform(getOutputDirectories(), OutputDirectory::getPath);
+      var outputSymlinkPaths =
+          Iterables.transform(
+              Iterables.concat(
+                  getOutputSymlinks(), getOutputFileSymlinks(), getOutputDirectorySymlinks()),
+              OutputSymlink::getPath);
+      ImmutableSet<String> allOutputPaths =
+          ImmutableSet.copyOf(
+              Iterables.transform(
+                  Iterables.concat(outputFiles, outputDirPaths, outputSymlinkPaths),
+                  StringEncoding::unicodeToInternal));
+      // Check that all mandatory outputs are created.
+      var spawn = action.getSpawn();
+      var remotePathResolver = action.getRemotePathResolver();
+      return spawn.getOutputFiles().stream()
+          .filter(spawn::isMandatoryOutput)
+          .filter(
+              output ->
+                  !(allOutputPaths.contains(remotePathResolver.localPathToOutputPath(output))))
+          .findFirst();
     }
 
     /** Returns {@code true} if this result is from a cache. */
@@ -1487,23 +1515,11 @@ public class RemoteExecutionService {
 
     if (result.success()) {
       // Check that all mandatory outputs are created.
-      for (ActionInput output : action.getSpawn().getOutputFiles()) {
-        if (action.getSpawn().isMandatoryOutput(output)) {
-          // In the past, remote execution did not create output directories if the action didn't do
-          // this explicitly. This check only remains so that old remote cache entries that do not
-          // include empty output directories remain valid.
-          if (output instanceof Artifact && ((Artifact) output).isTreeArtifact()) {
-            continue;
-          }
-
-          Path localPath = execRoot.getRelative(output.getExecPath());
-          if (!metadata.files.containsKey(localPath)
-              && !metadata.directories.containsKey(localPath)
-              && !metadata.symlinks.containsKey(localPath)) {
-            throw new IOException(
-                String.format("mandatory output %s was not created", prettyPrint(output)));
-          }
-        }
+      var missingMandatoryOutput = result.maybeGetMissingMandatoryOutput(action);
+      if (missingMandatoryOutput.isPresent()) {
+        throw new IOException(
+            "mandatory output %s was not created"
+                .formatted(prettyPrint(missingMandatoryOutput.get())));
       }
 
       if (result.executeResponse != null && !knownMissingCasDigests.isEmpty()) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -142,9 +142,11 @@ final class RemoteSpawnCache implements SpawnCache {
               prof.profile(ProfilerTask.REMOTE_CACHE_CHECK, "check cache hit")) {
             result = remoteExecutionService.lookupCache(action);
           }
-          // In case the remote cache returned a failed action (exit code != 0) we treat it as a
-          // cache miss
-          if (result != null && result.getExitCode() == 0) {
+          // In case the remote cache returned a failed action (exit code != 0) or failed to create
+          // the required outputs, we treat it as a cache miss.
+          if (result != null
+              && result.getExitCode() == 0
+              && result.maybeGetMissingMandatoryOutput(action).isEmpty()) {
             if (thisExecution != null) {
               thisExecution.close();
             }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -71,10 +71,13 @@ import com.google.devtools.build.lib.util.ExitCode;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
+import com.google.rpc.RetryInfo;
 import io.grpc.Status.Code;
+import io.grpc.protobuf.StatusProto;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -204,7 +207,8 @@ public class RemoteSpawnRunner implements SpawnRunner {
       }
 
       if (cachedResult != null) {
-        if (cachedResult.getExitCode() != 0) {
+        if (cachedResult.getExitCode() != 0
+            || cachedResult.maybeGetMissingMandatoryOutput(action).isPresent()) {
           // Failed actions are treated as a cache miss mostly in order to avoid caching flaky
           // actions (tests).
           // Set acceptCachedResult to false in order to force the action re-execution
@@ -296,6 +300,19 @@ public class RemoteSpawnRunner implements SpawnRunner {
             // status.
             // It's already late at this stage, but we should at least report once.
             reporter.reportExecutingIfNot();
+
+            if (result.cacheHit()
+                && (!result.success()
+                    || result.maybeGetMissingMandatoryOutput(action).isPresent())) {
+              // Instead of failing in downloadAndFinalizeSpawnResult, retry with forced execution.
+              useCachedResult.set(false);
+              var status =
+                  com.google.rpc.Status.newBuilder()
+                      .setCode(com.google.rpc.Code.NOT_FOUND_VALUE)
+                      .addDetails(Any.pack(RetryInfo.getDefaultInstance()))
+                      .build();
+              throw StatusProto.toStatusRuntimeException(status);
+            }
 
             maybePrintExecutionMessages(context, result.getMessage(), result.success());
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -42,6 +42,7 @@ import build.bazel.remote.execution.v2.ExecutedActionMetadata;
 import build.bazel.remote.execution.v2.ExecutionCapabilities;
 import build.bazel.remote.execution.v2.ExecutionStage.Value;
 import build.bazel.remote.execution.v2.LogFile;
+import build.bazel.remote.execution.v2.OutputFile;
 import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.collect.ClassToInstanceMap;
 import com.google.common.collect.ImmutableClassToInstanceMap;
@@ -70,6 +71,7 @@ import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
@@ -471,6 +473,107 @@ public class RemoteSpawnRunnerTest {
 
     runner.exec(spawn, policy);
 
+    verify(service).executeRemotely(any(), eq(false), any());
+  }
+
+  @Test
+  public void treatCachedActionWithMissingOutputAsCacheMiss_duringRemoteCacheCheck()
+      throws Exception {
+    // Test that bazel treats a cached action with missing mandatory outputs as a cache miss and
+    // attempts to execute the action remotely.
+
+    var runner = newSpawnRunner();
+    var service = runner.getRemoteExecutionService();
+    var actionWithoutOutputs = CachedActionResult.remote(ActionResult.getDefaultInstance());
+    doReturn(RemoteActionResult.createFromCache(actionWithoutOutputs))
+        .when(service)
+        .lookupCache(any(RemoteAction.class));
+
+    var output =
+        ActionsTestUtil.createArtifactWithExecPath(
+            artifactRoot, PathFragment.create("outputs/out"));
+    var successfulResponse =
+        ExecuteResponse.newBuilder()
+            .setResult(
+                ActionResult.newBuilder()
+                    .setExitCode(0)
+                    .addOutputFiles(
+                        OutputFile.newBuilder()
+                            .setPath(output.getExecPathString())
+                            .setDigest(digestUtil.computeAsUtf8("content")))
+                    .build())
+            .build();
+    when(executor.executeRemotely(
+            any(RemoteActionExecutionContext.class),
+            any(ExecuteRequest.class),
+            any(OperationObserver.class)))
+        .thenReturn(successfulResponse);
+    var spawn = newSimpleSpawn(output);
+    var spawnExecutionContext = getSpawnContext(spawn);
+
+    var result = runner.exec(spawn, spawnExecutionContext);
+    assertThat(result.status()).isEqualTo(Status.SUCCESS);
+
+    verify(service).executeRemotely(any(), eq(false), any());
+  }
+
+  @Test
+  public void treatCachedActionWithMissingOutputAsCacheMiss_duringRemoteExecution()
+      throws Exception {
+    // Test that bazel treats a cached execute result with missing mandatory outputs as a cache miss
+    // and reattempts to execute the action remotely, this time ignoring cached results.
+
+    var runner = newSpawnRunner();
+    var service = runner.getRemoteExecutionService();
+    // Ensure that the initial cache lookup doesn't already return a result with missing outputs -
+    // this case is covered by the previous test.
+    doReturn(null).when(service).lookupCache(any(RemoteAction.class));
+
+    var actionWithoutOutputs = CachedActionResult.remote(ActionResult.getDefaultInstance());
+    when(cache.downloadActionResult(
+            any(RemoteActionExecutionContext.class),
+            any(ActionKey.class),
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
+        .thenReturn(actionWithoutOutputs);
+
+    var output =
+        ActionsTestUtil.createArtifactWithExecPath(
+            artifactRoot, PathFragment.create("outputs/out"));
+    var responseWithoutOutput =
+        ExecuteResponse.newBuilder()
+            .setResult(ActionResult.newBuilder().setExitCode(0).build())
+            .setCachedResult(true)
+            .build();
+    var responseWithOutput =
+        ExecuteResponse.newBuilder()
+            .setResult(
+                ActionResult.newBuilder()
+                    .setExitCode(0)
+                    .addOutputFiles(
+                        OutputFile.newBuilder()
+                            .setPath(output.getExecPathString())
+                            .setDigest(digestUtil.computeAsUtf8("content")))
+                    .build())
+            .build();
+    when(executor.executeRemotely(
+            any(RemoteActionExecutionContext.class),
+            any(ExecuteRequest.class),
+            any(OperationObserver.class)))
+        .thenAnswer(
+            answer ->
+                answer.getArgument(1, ExecuteRequest.class).getSkipCacheLookup()
+                    ? responseWithOutput
+                    : responseWithoutOutput);
+    var spawn = newSimpleSpawn(output);
+    var spawnExecutionContext = getSpawnContext(spawn);
+
+    var result = runner.exec(spawn, spawnExecutionContext);
+    assertThat(result.status()).isEqualTo(Status.SUCCESS);
+
+    // The first execution attempt hits the cache and returns the result with missing outputs, the
+    // second attempt forcibly re-executes the action.
+    verify(service).executeRemotely(any(), eq(true), any());
     verify(service).executeRemotely(any(), eq(false), any());
   }
 


### PR DESCRIPTION
This allows builds to recover from a polluted remote cache that contains an action result with an exit code of 0 that hasn't produced the required output files.

The check added in a151116f7f671efea9a95f3e251561e53e535cca is moved closer to the lookup so that the cached result can be ignored instead of resulting in an error, with forced re-execution in the case of remote execution.