### PR TITLE
[7.7.0] Invalidate subtrees when a directory is deleted

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/FileSystemValueCheckerInferringAncestors.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/FileSystemValueCheckerInferringAncestors.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -73,6 +74,7 @@ public final class FileSystemValueCheckerInferringAncestors {
   private final SyscallCache syscallCache;
   private final SkyValueDirtinessChecker skyValueDirtinessChecker;
 
+  private final Set<RootedPath> deletedDirectories = Sets.newConcurrentHashSet();
   private final Set<SkyKey> valuesToInvalidate = Sets.newConcurrentHashSet();
   private final ConcurrentMap<SkyKey, Delta> valuesToInject = new ConcurrentHashMap<>();
 
@@ -165,7 +167,7 @@ public final class FileSystemValueCheckerInferringAncestors {
         // list of deleted children and listing. It is possible for the diff to report a deleted
         // directory without listing all of the files under it as deleted.
         if (existingState == null) {
-          state = new NodeVisitState(/*collectMaybeDeletedChildren=*/ path != top);
+          state = new NodeVisitState(/* collectMaybeDeletedChildren= */ !path.equals(top));
           nodeStates.put(path, state);
         } else {
           state = existingState;
@@ -223,11 +225,51 @@ public final class FileSystemValueCheckerInferringAncestors {
       }
     }
 
+    // If any directory was deleted, invalidate all FSVs and DLSVs under it since the diff may only
+    // report the root of the deleted subtree.
+    if (!deletedDirectories.isEmpty()) {
+      var treesToInvalidate = new TreeSet<>(deletedDirectories);
+      // Optimize the walk over all keys below by trimming those trees that are subtrees of other
+      // trees to be invalidated. This allows for O(log r) lookup instead of O(n) for each key
+      // where r is the number of deleted directories that aren't transitive subdirectories of other
+      // deleted directories and n is the number of deleted directories.
+      RootedPath lastTree = null;
+      for (var treeIterator = treesToInvalidate.iterator(); treeIterator.hasNext(); ) {
+        var tree = treeIterator.next();
+        if (lastTree != null && tree.asPath().startsWith(lastTree.asPath())) {
+          treeIterator.remove();
+        } else {
+          lastTree = tree;
+        }
+      }
+
+      // FSVs and DLSVs do not track their parents, so we need to look at all keys.
+      inMemoryGraph.parallelForEach(
+          entry -> {
+            var key = entry.getKey();
+            RootedPath path;
+            if (key instanceof FileStateKey fsk) {
+              path = fsk.argument();
+            } else if (key instanceof DirectoryListingStateValue.Key dlsk) {
+              path = dlsk.argument();
+            } else {
+              return;
+            }
+            var floorPath = treesToInvalidate.floor(path);
+            if (floorPath != null
+                && path.asPath().startsWith(floorPath.asPath())
+                && !valuesToInject.containsKey(key)) {
+              valuesToInvalidate.add(key);
+            }
+          });
+    }
+
     return new ImmutableDiff(valuesToInvalidate, valuesToInject);
   }
 
   private void processEntry(RootedPath path, NodeVisitState state) throws StatFailedException {
-    NodeVisitState rootParentSentinel = new NodeVisitState(/*collectMaybeDeletedChildren=*/ false);
+    NodeVisitState rootParentSentinel =
+        new NodeVisitState(/* collectMaybeDeletedChildren= */ false);
 
     while (state != rootParentSentinel) {
       RootedPath parentPath = path.getParentDirectory();
@@ -299,6 +341,9 @@ public final class FileSystemValueCheckerInferringAncestors {
     boolean typeChanged = newFsv.getType() != oldFsv.getType();
     if (typeChanged) {
       parentListingKey(path).ifPresent(valuesToInvalidate::add);
+      if (oldFsv.isDirectory() && !newFsv.exists()) {
+        deletedDirectories.add(path);
+      }
     }
     return typeChanged;
   }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FileSystemValueCheckerInferringAncestorsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FileSystemValueCheckerInferringAncestorsTest.java
@@ -624,8 +624,14 @@ public final class FileSystemValueCheckerInferringAncestorsTest
     FileStateValue file1Value = fileStateValue("dir/file1");
     FileStateKey file2Key = fileStateValueKey("dir/file2");
     FileStateValue file2Value = fileStateValue("dir/file2");
+    FileStateKey subdirFileKey = fileStateValueKey("dir/subdir/file");
+    FileStateValue subdirFileValue = fileStateValue("dir/subdir/file");
     FileStateKey dirKey = fileStateValueKey("dir");
     FileStateValue dirValue = fileStateValue("dir");
+    FileStateKey subdirKey = fileStateValueKey("dir/subdir");
+    FileStateValue subdirValue = fileStateValue("dir/subdir");
+    SkyKey subdirListingKey = directoryListingStateValueKey("dir/subdir");
+    DirectoryListingStateValue subdirListingValue = directoryListingStateValue(file("file"));
     file1.getParentDirectory().deleteTree();
     addDoneNodesAndThenMarkChanged(
         ImmutableMap.of(
@@ -633,8 +639,14 @@ public final class FileSystemValueCheckerInferringAncestorsTest
             file1Value,
             file2Key,
             file2Value,
+            subdirFileKey,
+            subdirFileValue,
             dirKey,
             dirValue,
+            subdirKey,
+            subdirValue,
+            subdirListingKey,
+            subdirListingValue,
             fileStateValueKey(""),
             fileStateValue("")));
 
@@ -650,7 +662,13 @@ public final class FileSystemValueCheckerInferringAncestorsTest
     assertThat(diff.changedKeysWithNewValues())
         .containsExactly(dirKey, NONEXISTENT_FILE_STATE_NODE_DELTA);
     assertThat(diff.changedKeysWithoutNewValues())
-        .containsExactly(directoryListingStateValueKey(""));
+        .containsExactly(
+            directoryListingStateValueKey(""),
+            file1Key,
+            file2Key,
+            subdirKey,
+            subdirListingKey,
+            subdirFileKey);
     assertThat(statedPaths).containsExactly("dir", "");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/LocalDiffAwarenessTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/LocalDiffAwarenessTest.java
@@ -38,14 +38,13 @@ import java.util.Set;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Integration tests for LocalDiffAwareness.
- */
+/** Integration tests for LocalDiffAwareness. */
 @RunWith(JUnit4.class)
 public class LocalDiffAwarenessTest extends BuildIntegrationTestCase {
 
@@ -58,11 +57,10 @@ public class LocalDiffAwarenessTest extends BuildIntegrationTestCase {
   private Path testCaseRoot;
   private Path testCaseIgnoredDir;
 
-  @org.junit.Rule
-  public TestName name = new TestName();
+  @Rule public TestName name = new TestName();
 
   @Before
-  public final void initializeSettings() throws Exception  {
+  public final void initializeSettings() throws Exception {
     LocalDiffAwareness.Factory factory = new LocalDiffAwareness.Factory(ImmutableList.<String>of());
     // Make sure all test functions have their own directory to test
     testCaseRoot = testRoot.getChild(name.getMethodName());
@@ -197,9 +195,25 @@ public class LocalDiffAwarenessTest extends BuildIntegrationTestCase {
     touch("equestria/foo.txt");
     new ModifiedFileSetChecker().modify("equestria").modify("equestria/foo.txt").check();
 
-
     rm("equestria");
     new ModifiedFileSetChecker().modify("equestria").modify("equestria/foo.txt").check();
+  }
+
+  @Test
+  public void testMoveDirectory() throws Exception {
+    captureFirstView(watchFsEnabledProvider);
+
+    mkdir("equestria");
+    touch("equestria/foo.txt");
+    new ModifiedFileSetChecker().modify("equestria").modify("equestria/foo.txt").check();
+
+    testCaseRoot.getRelative("equestria").renameTo(testCaseRoot.getRelative("equestria2"));
+    // The contents of a moved directory are *not* reported as modified.
+    new ModifiedFileSetChecker()
+        .modify("equestria")
+        .modify("equestria2")
+        .modify("equestria2/foo.txt")
+        .check();
   }
 
   @Test
@@ -220,12 +234,12 @@ public class LocalDiffAwarenessTest extends BuildIntegrationTestCase {
     mkdir("a/b");
     touch("a/b/b1.txt");
     new ModifiedFileSetChecker()
-    .modify("a")
-    .modify("a/a1.txt")
-    .modify("a/a2.txt")
-    .modify("a/b")
-    .modify("a/b/b1.txt")
-    .check();
+        .modify("a")
+        .modify("a/a1.txt")
+        .modify("a/a2.txt")
+        .modify("a/b")
+        .modify("a/b/b1.txt")
+        .check();
 
     rm("a/b/b1.txt");
     touch("a/b/b2.txt");
@@ -235,11 +249,11 @@ public class LocalDiffAwarenessTest extends BuildIntegrationTestCase {
     mkdir("a/b");
     touch("a/b/b3.txt");
     new ModifiedFileSetChecker()
-    .modify("a/b")
-    .modify("a/b/b1.txt")
-    .modify("a/b/b2.txt")
-    .modify("a/b/b3.txt")
-    .check();
+        .modify("a/b")
+        .modify("a/b/b1.txt")
+        .modify("a/b/b2.txt")
+        .modify("a/b/b3.txt")
+        .check();
 
     rm("a/b/b3.txt");
     new ModifiedFileSetChecker().modify("a/b/b3.txt").check();
@@ -288,12 +302,12 @@ public class LocalDiffAwarenessTest extends BuildIntegrationTestCase {
 
     View oldView =
         new LocalDiffAwareness.SequentialView(
-            localDiff, /*position=*/ 0, /*modifiedAbsolutePaths=*/ ImmutableSet.of());
+            localDiff, /* position= */ 0, /* modifiedAbsolutePaths= */ ImmutableSet.of());
     View newView =
         new LocalDiffAwareness.SequentialView(
             localDiff,
-            /*position=*/ 1,
-            /*modifiedAbsolutePaths=*/ ImmutableSet.of(
+            /* position= */ 1,
+            /* modifiedAbsolutePaths= */ ImmutableSet.of(
                 otherRootDirectoryNioPath.resolve("foo.txt")));
     Throwable throwable =
         assertThrows(BrokenDiffAwarenessException.class, () -> localDiff.getDiff(oldView, newView));


### PR DESCRIPTION
`FileSystemValueCheckerInferringAncestors` claims that it is resilient to diffs which only report the root of a deleted subtree, but this wasn't true. Stale `FileStateValue`s and `DirectoryListingStateValue`s could linger around after moving an entire directory tree out of the workspace watched with `--watchfs`.

This is fixed by invalidating all FSVs and DLSVs under any deleted directory. Since these values and their keys do not depend on their parents, this requires a manual walk of the entire graph, making use of a prefix-free sorted map to speed up lookups per key.

Fixes #26863
Fixes #26866

Closes #26920.

PiperOrigin-RevId: 812740160
Change-Id: Id55329b5ffd3cf3e109ec102e86b6fb46335531b

Commit https://github.com/bazelbuild/bazel/commit/8df327a150a98bec1c77f71151a74406e1923320