### PR TITLE
Always send hostname and username in workspace status BES message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelWorkspaceStatusModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelWorkspaceStatusModule.java
@@ -272,7 +272,11 @@ public class BazelWorkspaceStatusModule extends BlazeModule {
     @Override
     public ImmutableSortedMap<String, String> createDummyWorkspaceStatus(
         @Nullable WorkspaceInfoFromDiff workspaceInfoFromDiff) {
-      return ImmutableSortedMap.of();
+      // Include this generally useful information in the BES even for commands that don't run the
+      // workspace status action.
+      return ImmutableSortedMap.of(
+          BuildInfo.BUILD_HOST, NetUtil.getCachedShortHostName(),
+          BuildInfo.BUILD_USER, USER_NAME.value());
     }
 
     @Override


### PR DESCRIPTION
This information is generally useful for all builds, not just those that run the workspace status action.