### PR TITLE
Don't duplicate buffers in `ParameterFile`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ParameterFile.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ParameterFile.java
@@ -30,9 +30,6 @@ import java.io.OutputStream;
  * Different tools require different parameter file formats, which can be selected via the {@link
  * ParameterFileType} enum.
  *
- * <p>The default charset is ISO-8859-1 (latin1). This also has to match the expectation of the
- * tool.
- *
  * <p>Don't use this class for new code. Use the ParameterFileWriteAction instead!
  */
 public class ParameterFile {
@@ -86,12 +83,11 @@ public class ParameterFile {
   /** Writes an argument list to a parameter file. */
   public static void writeParameterFile(
       OutputStream out, Iterable<String> arguments, ParameterFileType type) throws IOException {
-    OutputStream bufferedOut = new BufferedOutputStream(out);
     switch (type) {
-      case SHELL_QUOTED -> writeContent(bufferedOut, ShellEscaper.escapeAll(arguments));
-      case GCC_QUOTED -> writeContent(bufferedOut, GccParamFileEscaper.escapeAll(arguments));
-      case UNQUOTED -> writeContent(bufferedOut, arguments);
-      case WINDOWS -> writeContent(bufferedOut, WindowsParamFileEscaper.escapeAll(arguments));
+      case SHELL_QUOTED -> writeContent(out, ShellEscaper.escapeAll(arguments));
+      case GCC_QUOTED -> writeContent(out, GccParamFileEscaper.escapeAll(arguments));
+      case UNQUOTED -> writeContent(out, arguments);
+      case WINDOWS -> writeContent(out, WindowsParamFileEscaper.escapeAll(arguments));
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/ParameterFileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/ParameterFileWriteAction.java
@@ -217,16 +217,8 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
     return new ParamFileWriter(arguments, pathMapper, type);
   }
 
-  private static class ParamFileWriter implements DeterministicWriter {
-    private final ArgChunk arguments;
-    private final PathMapper pathMapper;
-    private final ParameterFileType type;
-
-    ParamFileWriter(ArgChunk arguments, PathMapper pathMapper, ParameterFileType type) {
-      this.arguments = arguments;
-      this.pathMapper = pathMapper;
-      this.type = type;
-    }
+  private record ParamFileWriter(ArgChunk arguments, PathMapper pathMapper, ParameterFileType type)
+      implements DeterministicWriter {
 
     @Override
     public void writeTo(OutputStream out) throws IOException {

--- a/src/main/java/com/google/devtools/build/lib/util/DeterministicWriter.java
+++ b/src/main/java/com/google/devtools/build/lib/util/DeterministicWriter.java
@@ -28,6 +28,14 @@ public interface DeterministicWriter {
    *
    * <p>Every invocation of this method writes the same stream of bytes.
    *
+   * <p>Implementations
+   *
+   * <ul>
+   *   <li>must not close the given {@link OutputStream}
+   *   <li>may flush the given {@link OutputStream}
+   *   <li>should not wrap the given {@link OutputStream} in a buffered stream. The caller is
+   *       responsible for providing a buffered stream if necessary.
+   *
    * @param out the {@link OutputStream} to write to
    * @throws IOException only if out throws an IOException
    */


### PR DESCRIPTION
Callers that output to a file already pass in a buffered output stream, other callers don't need it.

Also remove a misleading comment (see StringEncoding for details).