### PR TITLE
Fix specialization check for aliased constraint values

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
@@ -153,7 +153,7 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
             ruleContext.getLabel(),
             settings.nativeFlagSettings,
             userDefinedFlags.getSpecifiedFlagValues(),
-            ImmutableSet.copyOf(settings.constraintValueSettings),
+            ImmutableSet.copyOf(getSpecifiedConstraintValues(ruleContext)),
             Stream.of(userDefinedFlags.result(), nativeFlagsResult, constraintValuesResult)
                 .reduce(MatchResult::combine)
                 .get());
@@ -836,5 +836,20 @@ Either remove one of these settings or ensure they match the same value.
       // Swallow this: the subsequent type conversion already checks for this.
       return expectedValue;
     }
+  }
+
+  /**
+   * Returns a list of labels for all prerequisite constraint values for this rule.
+   *
+   * <p>If any of the constraint values are provided via an alias, this method will resolve them
+   * to their concrete targets. This is needed for specialization checking in select() statements.
+   *
+   * @param ruleContext this rule's RuleContext
+   */
+  private static List<Label> getSpecifiedConstraintValues(RuleContext ruleContext) {
+    return ruleContext.getPrerequisites(ConfigSettingRule.CONSTRAINT_VALUES_ATTRIBUTE)
+        .stream()
+        .map(TransitiveInfoCollection::getLabel)
+        .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
This addresses an incorrect behavior when passing constraint values to `config_setting()` via an alias.

If a `select()` statement has two matching conditions where one is a specialization of the other, it's supposed to pick the specialization. The specialization check verifies that the prerequisites for the more specialized condition is a strict superset of the prerequisites for the less specialized condition. However, this check currently only considers the explicit labels when looking at constraint values, even though these labels may be aliases.

This problem can be seen by running `bazel build --platforms=//:my_platform --//:my_string=hello :my_target` with the following `BUILD.bazel` file, which incorrectly raises an ambiguity error:

```Python
load("@bazel_skylib//rules:common_settings.bzl", "string_flag")


genrule(
    name = "my_target",
    outs = ["my_out.txt"],
    cmd = select({
        ":config1": "echo 1 > $@",
        ":config2": "echo 2 > $@",
    }),
)

config_setting(
    name = "config1",
    constraint_values = [":mv"],
)

config_setting(
    name = "config2",
    constraint_values = [":my_value"],
    flag_values = {
        ":my_string": "hello",
    },
)

string_flag(
    name = "my_string",
    build_setting_default = "",
)

platform(
    name = "my_platform",
    constraint_values = [":my_value"],
)

constraint_setting(name = "my_setting")

constraint_value(
    name = "my_value",
    constraint_setting = ":my_setting",
)

alias(
    name = "mv",
    actual = ":my_value",
)
```

According to the documentation for aliases:

> The alias rule has its own visibility declaration. In all other respects, it behaves like the rule it references (e.g. testonly on the alias is ignored; the testonly-ness of the referenced rule is used instead) with some minor exceptions:
> 
> * Tests are not run if their alias is mentioned on the command line. To define an alias that runs the referenced test, use a [test_suite](https://bazel.build/reference/be/general#test_suite) rule with a single target in its [tests](https://bazel.build/reference/be/general#test_suite.tests) attribute.
> * When defining environment groups, the aliases to environment rules are not supported. They are not supported in the --target_environment command line option, either.

Since this case is not covered by any of the exceptions, I would consider the current behavior incorrect.