### PR TITLE
Remove --extension_filter=all from bzlmod docs

### DIFF
--- a/site/en/external/mod-command.md
+++ b/site/en/external/mod-command.md
@@ -421,7 +421,7 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
     dependency graph.
 
     ```sh
-    bazel mod graph --extension_info=usages --extension_filter=all
+    bazel mod graph --extension_info=usages
     ```
 
     ```none


### PR DESCRIPTION
`--extension_filter=all` is no longer valid, it seems to expect a list of labels for extensions. As far as I can tell, omitting the option includes all extensions anyway.
```sh
$ bazel mod graph --extension_info=usages --extension_filter=all
ERROR: While parsing option --extension_filter=all: Invalid argument all: missing .bzl label
```