### PR TITLE
Prevent downloadBlob from using ByteString.Output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -324,7 +324,7 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
   public ListenableFuture<Void> downloadBlob(
       RemoteActionExecutionContext context, Digest digest, OutputStream out) {
     if (out instanceof ByteString.Output) {
-      throw IllegalStateException();
+      throw new IllegalStateException();
     }
     if (digest.getSizeBytes() == 0) {
       return Futures.immediateVoidFuture();

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -323,6 +323,9 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
   @Override
   public ListenableFuture<Void> downloadBlob(
       RemoteActionExecutionContext context, Digest digest, OutputStream out) {
+    if (out instanceof ByteString.Output) {
+      throw IllegalStateException();
+    }
     if (digest.getSizeBytes() == 0) {
       return Futures.immediateVoidFuture();
     }


### PR DESCRIPTION
Throw IllegalStateException if output stream is ByteString.Output.