### PR TITLE
Don't send out `RegistryFileDownloadEvent`s

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -187,7 +187,6 @@ public class ModuleFileFunction implements SkyFunction {
     if (getModuleFileResult == null) {
       return null;
     }
-    getModuleFileResult.downloadEventHandler.replayOn(env.getListener());
 
     CompiledModuleFile compiledModuleFile;
     try {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFileDownloadEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFileDownloadEvent.java
@@ -24,10 +24,9 @@ import java.util.Collection;
 import java.util.Optional;
 
 /** Event that records the fact that a file has been downloaded from a remote registry. */
-public record RegistryFileDownloadEvent(String uri, Optional<Checksum> checksum)
-    implements Postable {
+record RegistryFileDownloadEvent(String uri, Optional<Checksum> checksum) implements Postable {
 
-  public static RegistryFileDownloadEvent create(String uri, Optional<byte[]> content) {
+  static RegistryFileDownloadEvent create(String uri, Optional<byte[]> content) {
     return new RegistryFileDownloadEvent(uri, content.map(RegistryFileDownloadEvent::computeHash));
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RepoSpecFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RepoSpecFunction.java
@@ -70,7 +70,6 @@ public class RepoSpecFunction implements SkyFunction {
               "Unable to get module repo spec for %s from registry",
               key.moduleKey()));
     }
-    downloadEvents.replayOn(env.getListener());
     return RepoSpecValue.create(
         repoSpec, RegistryFileDownloadEvent.collectToMap(downloadEvents.getPosts()));
   }


### PR DESCRIPTION
These events are no longer handled by `BazelLockFileModule`, but explicity added to ordinary `SkyValue`s.