### PR TITLE
Git repo rules should respect shallow clone configuration when initializing submodules

### DIFF
--- a/tools/build_defs/repo/git_worker.bzl
+++ b/tools/build_defs/repo/git_worker.bzl
@@ -207,9 +207,9 @@ def update_submodules(ctx, git_repo, recursive = False):
         # "protocol.file.allow=always" allows the submodule command clone from a local directory.
         # It's necessary for Git 2.38.1 and assoicated backport versions.
         # See https://github.com/bazelbuild/bazel/issues/17040
-        _git(ctx, git_repo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--checkout", "--force")
+        _git_maybe_shallow(ctx, git_repo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--checkout", "--force")
     else:
-        _git(ctx, git_repo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--checkout", "--force")
+        _git_maybe_shallow(ctx, git_repo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--checkout", "--force")
 
 def _get_head_commit(ctx, git_repo):
     return _git(ctx, git_repo, "log", "-n", "1", "--pretty=format:%H")


### PR DESCRIPTION
Otherwise the submodules are slow to clone.

It also seems that the `if git_repo.shallow` checks are not needed because `shallow` is always set to either `--depth=1` or `--shallow_since=<..>` by the `git_repo` helper and `_update` is private, but I suppose it's possible for someone to be calling `update_submodules` directly with a `_GitRepoInfo`-shaped struct, so let's leave it alone for now