### PR TITLE
Avoid action key change with `expand_directories=False` and no manual expansion

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
@@ -547,7 +547,13 @@ public class StarlarkCustomCommandLine extends CommandLine {
           // fingerprinting stringificationType here.
           CommandLineItemMapEachAdaptor commandLineItemMapFn =
               new CommandLineItemMapEachAdaptor(
-                  mapEach, location, starlarkSemantics, inputMetadataProvider, outputPathsMode);
+                  mapEach,
+                  location,
+                  starlarkSemantics,
+                  (features & EXPAND_DIRECTORIES) != 0 || wantsDirectoryExpander(mapEach)
+                      ? inputMetadataProvider
+                      : null,
+                  outputPathsMode);
           try {
             actionKeyContext.addNestedSetToFingerprint(commandLineItemMapFn, fingerprint, values);
           } finally {
@@ -1121,14 +1127,11 @@ public class StarlarkCustomCommandLine extends CommandLine {
       // TODO(b/77140311): Error if we issue print statements.
       thread.setPrintHandler((th, msg) -> {});
       int count = originalValues.size();
-      // map_each can accept either each object, or each object + a directory expander.
-      boolean wantsDirectoryExpander =
-          mapFn instanceof StarlarkFunction starlarkFunction
-              && starlarkFunction.getParameterNames().size() >= 2;
       // We create a list that we reuse for the args to map_each
       List<Object> args = new ArrayList<>(2);
       args.add(null); // This will be overwritten each iteration.
-      if (wantsDirectoryExpander) {
+      // map_each can accept either each object, or each object + a directory expander.
+      if (wantsDirectoryExpander(mapFn)) {
         DirectoryExpander expander;
         if (inputMetadataProvider != null) {
           expander = new FullExpander(inputMetadataProvider);
@@ -1165,6 +1168,11 @@ public class StarlarkCustomCommandLine extends CommandLine {
       throw new CommandLineExpansionException(
           errorMessage(e.getMessageWithStack(), loc, e.getCause()));
     }
+  }
+
+  private static boolean wantsDirectoryExpander(StarlarkCallable mapFn) {
+    return mapFn instanceof StarlarkFunction starlarkFunction
+        && starlarkFunction.getParameterNames().size() >= 2;
   }
 
   private static class CommandLineItemMapEachAdaptor

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLineTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLineTest.java
@@ -670,6 +670,123 @@ public final class StarlarkCustomCommandLineTest {
         .isNotEqualTo(fingerprintAfter.hexDigestAndReset());
   }
 
+  @Test
+  public void
+      vectorArgArguments_expandDirectoriesDisabled_noMapEach_expansionDoesNotAffectActionKey(
+          @TestParameter boolean useNestedSet) throws Exception {
+    SpecialArtifact tree = createTreeArtifact("tree");
+    TreeFileArtifact child1 = TreeFileArtifact.createTreeOutput(tree, "child1");
+    TreeFileArtifact child2 = TreeFileArtifact.createTreeOutput(tree, "child2");
+    // The files won't be read so MISSING_FILE_MARKER will do
+    TreeArtifactValue treeArtifactValueBefore =
+        TreeArtifactValue.newBuilder(tree)
+            .putChild(child1, FileArtifactValue.MISSING_FILE_MARKER)
+            .putChild(child2, FileArtifactValue.MISSING_FILE_MARKER)
+            .build();
+    TreeArtifactValue treeArtifactValueAfter =
+        TreeArtifactValue.newBuilder(tree)
+            .putChild(child1, FileArtifactValue.MISSING_FILE_MARKER)
+            .build();
+    var vectorArg =
+        useNestedSet
+            ? new VectorArg.Builder(
+                NestedSetBuilder.wrap(Order.STABLE_ORDER, ImmutableList.of(tree)), Artifact.class)
+            : new VectorArg.Builder(Tuple.of(tree));
+    CommandLine commandLine =
+        builder
+            .add(vectorArg.setExpandDirectories(false).setLocation(Location.BUILTIN))
+            .build(/* flagPerLine= */ false, RepositoryMapping.EMPTY);
+
+    var inputMetadataProviderBefore = new FakeActionInputFileCache();
+    inputMetadataProviderBefore.putTreeArtifact(tree, treeArtifactValueBefore);
+    var argumentsBefore = commandLine.arguments(inputMetadataProviderBefore, PathMapper.NOOP);
+    var fingerprintBefore = new Fingerprint();
+    commandLine.addToFingerprint(
+        new ActionKeyContext(),
+        inputMetadataProviderBefore,
+        CoreOptions.OutputPathsMode.OFF,
+        fingerprintBefore);
+    assertThat(argumentsBefore).containsExactly("bin/tree");
+
+    var inputMetadataProviderAfter = new FakeActionInputFileCache();
+    inputMetadataProviderAfter.putTreeArtifact(tree, treeArtifactValueAfter);
+    var argumentsAfter = commandLine.arguments(inputMetadataProviderAfter, PathMapper.NOOP);
+    var fingerprintAfter = new Fingerprint();
+    commandLine.addToFingerprint(
+        new ActionKeyContext(),
+        inputMetadataProviderAfter,
+        CoreOptions.OutputPathsMode.OFF,
+        fingerprintAfter);
+    assertThat(argumentsAfter).containsExactly("bin/tree");
+
+    assertThat(fingerprintBefore.hexDigestAndReset())
+        .isEqualTo(fingerprintAfter.hexDigestAndReset());
+  }
+
+  @Test
+  public void
+      vectorArgArguments_expandDirectoriesDisabled_noManualExpansion_expansionDoesNotAffectActionKey(
+          @TestParameter boolean useNestedSet) throws Exception {
+    SpecialArtifact tree = createTreeArtifact("tree");
+    TreeFileArtifact child1 = TreeFileArtifact.createTreeOutput(tree, "child1");
+    TreeFileArtifact child2 = TreeFileArtifact.createTreeOutput(tree, "child2");
+    // The files won't be read so MISSING_FILE_MARKER will do
+    TreeArtifactValue treeArtifactValueBefore =
+        TreeArtifactValue.newBuilder(tree)
+            .putChild(child1, FileArtifactValue.MISSING_FILE_MARKER)
+            .putChild(child2, FileArtifactValue.MISSING_FILE_MARKER)
+            .build();
+    TreeArtifactValue treeArtifactValueAfter =
+        TreeArtifactValue.newBuilder(tree)
+            .putChild(child1, FileArtifactValue.MISSING_FILE_MARKER)
+            .build();
+    var vectorArg =
+        useNestedSet
+            ? new VectorArg.Builder(
+                NestedSetBuilder.wrap(Order.STABLE_ORDER, ImmutableList.of(tree)), Artifact.class)
+            : new VectorArg.Builder(Tuple.of(tree));
+    CommandLine commandLine =
+        builder
+            .add(
+                vectorArg
+                    .setExpandDirectories(false)
+                    .setLocation(Location.BUILTIN)
+                    .setMapEach(
+                        (StarlarkFunction)
+                            execStarlark(
+                                """
+                                def map_each(x):
+                                  return x.path
+                                map_each
+                                """)))
+            .build(/* flagPerLine= */ false, RepositoryMapping.EMPTY);
+
+    var inputMetadataProviderBefore = new FakeActionInputFileCache();
+    inputMetadataProviderBefore.putTreeArtifact(tree, treeArtifactValueBefore);
+    var argumentsBefore = commandLine.arguments(inputMetadataProviderBefore, PathMapper.NOOP);
+    var fingerprintBefore = new Fingerprint();
+    commandLine.addToFingerprint(
+        new ActionKeyContext(),
+        inputMetadataProviderBefore,
+        CoreOptions.OutputPathsMode.OFF,
+        fingerprintBefore);
+    assertThat(argumentsBefore).containsExactly("bin/tree");
+
+    var inputMetadataProviderAfter = new FakeActionInputFileCache();
+    inputMetadataProviderAfter.putTreeArtifact(tree, treeArtifactValueAfter);
+    var argumentsAfter = commandLine.arguments(inputMetadataProviderAfter, PathMapper.NOOP);
+    var fingerprintAfter = new Fingerprint();
+    commandLine.addToFingerprint(
+        new ActionKeyContext(),
+        inputMetadataProviderAfter,
+        CoreOptions.OutputPathsMode.OFF,
+        fingerprintAfter);
+    assertThat(argumentsAfter).containsExactly("bin/tree");
+
+    assertThat(fingerprintBefore.hexDigestAndReset())
+        .isEqualTo(fingerprintAfter.hexDigestAndReset());
+  }
+
   private static VectorArg.Builder vectorArg(Object... elems) {
     return new VectorArg.Builder(Tuple.of(elems)).setLocation(Location.BUILTIN);
   }


### PR DESCRIPTION
Since 2a3191b8f4a80e20566a6204281521887c08f19a, the action key was sensitive to changes of the expansion of a tree artifact even if expansion is disabled and the custom map_each callback cannot perform manual expansion.

Work towards https://github.com/aspect-build/rules_js/issues/2379