### PR TITLE
[7.7.0] Add ctx.configuration.short_id

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -719,6 +719,11 @@ public class BuildConfigurationValue
     return options.collectCodeCoverage;
   }
 
+  @Override
+  public String getShortId() {
+    return buildOptions.shortId();
+  }
+
   public RunUnder getRunUnder() {
     return options.runUnder;
   }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/BuildConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/BuildConfigurationApi.java
@@ -75,6 +75,25 @@ public interface BuildConfigurationApi extends StarlarkValue {
               + " function.")
   boolean isCodeCoverageEnabled();
 
+  @StarlarkMethod(
+      name = "short_id",
+      structField = true,
+      doc =
+          """
+          A short identifier for this configuration understood by the <code>config</code> and \
+          </code>query</code> subcommands. \
+
+          <p>Use this to distinguish different configurations for the same target in a way that \
+          is friendly to humans and tool usage, for example in an aspect used by an IDE. \
+          Keep in mind the following caveats: \
+          <ul> \
+            <li>The value may differ across Bazel versions, including patch releases. \
+            <li>The value encodes the value of <b>every</b> flag, including those that aren't \
+                otherwise relevant for the current target and may thus invalidate caches more \
+                frequently.
+          """)
+  String getShortId();
+
   @StarlarkMethod(name = "stamp_binaries", documented = false, useStarlarkThread = true)
   boolean stampBinariesForStarlark(StarlarkThread thread) throws EvalException;
 


### PR DESCRIPTION
RELNOTES[NEW]: The new `ctx.configuration.short_id` field provides a short identifier for the current configuration that is understood by `bazel config`.

Fixes https://github.com/bazelbuild/bazel/issues/26752

Closes https://github.com/bazelbuild/bazel/pull/27093.

PiperOrigin-RevId: 813744855
Change-Id: Idc8ad94bb7f1fd401d0a0cf081d7bfad4a03ac7e

Commit https://github.com/bazelbuild/bazel/commit/11151aee5ed31e83e66933533fb6d14ebdbe9f41