### PR TITLE
[8.5.0] Add local file overlay support to `http_archive`

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -786,6 +786,14 @@ sh_test(
 )
 
 sh_test(
+    name = "external_files_test",
+    size = "large",
+    srcs = ["external_files_test.sh"],
+    data = [":test-deps"],
+    tags = ["no_windows"],
+)
+
+sh_test(
     name = "external_integration_test",
     size = "large",
     srcs = ["external_integration_test.sh"],

--- a/src/test/shell/bazel/external_files_test.sh
+++ b/src/test/shell/bazel/external_files_test.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Test the local files overlay patching functionality of external repositories.
+#
+
+# Load the test setup defined in the parent directory
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CURRENT_DIR}/../integration_test_setup.sh" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+
+src_only_repo_with_local_include() {
+  # Generates source files in the current directory.
+  mkdir src
+  cat > src/main.c <<'EOF'
+#include <stdio.h>
+#include "src/consts/greeting.h"
+
+int main(int argc, char **argv) {
+  printf("%s\n", GREETING);
+  return 0;
+}
+EOF
+  mkdir src/consts
+  cat > src/consts/greeting.h <<'EOF'
+#define GREETING "Hello World"
+EOF
+}
+
+build_def() {
+  # Generates build and module definition files for `src_only_repo_with_local_include` in the
+  # current directory.
+  cat > _.MODULE <<'EOF'
+module(name = "remote")
+EOF
+  mkdir src
+  cat > _.BUILD <<'EOF'
+cc_binary(
+  name = "hello",
+  srcs = ["main.c", "consts/greeting.h"],
+)
+EOF
+}
+
+test_files_repository() {
+  # Verify that overlaid files are correctly positioned.
+  WRKDIR=$(mktemp -d "${TEST_TMPDIR}/testXXXXXX")
+  cd "${WRKDIR}"
+
+  mkdir remote
+  (cd remote && src_only_repo_with_local_include)
+  tar cvf remote.tar remote
+  rm -rf remote
+
+  mkdir main
+  cd main
+  build_def
+  touch BUILD
+  cat >> $(setup_module_dot_bazel) <<EOF
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+  name = "remote",
+  strip_prefix = "remote",
+  urls = ["file://${WRKDIR}/remote.tar"],
+  files = {
+    "MODULE.bazel": "//:_.MODULE",
+    "src/BUILD.bazel": "//:_.BUILD",
+  },
+)
+EOF
+
+  bazel build @remote//src:hello || fail "Expected build to succeed"
+  bazel run @remote//src:hello | grep 'Hello World' \
+      || fail "Expected output 'Hello World'"
+}
+
+test_files_repository_changed() {
+  # Verify that changes to overlaid files are applied.
+  WRKDIR=$(mktemp -d "${TEST_TMPDIR}/testXXXXXX")
+  cd "${WRKDIR}"
+
+  mkdir remote
+  (cd remote && src_only_repo_with_local_include)
+  tar cvf remote.tar remote
+  rm -rf remote
+
+  mkdir main
+  cd main
+  build_def
+  cat > greeting.h <<'EOF'
+#define GREETING "Hello World"
+EOF
+  touch BUILD
+  cat >> $(setup_module_dot_bazel) <<EOF
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+  name = "remote",
+  strip_prefix = "remote",
+  urls = ["file://${WRKDIR}/remote.tar"],
+  files = {
+    "MODULE.bazel": "//:_.MODULE",
+    "src/BUILD.bazel": "//:_.BUILD",
+    "src/consts/greeting.h": "//:greeting.h",
+  },
+)
+EOF
+
+  bazel build @remote//src:hello || fail "Expected build to succeed"
+  bazel run @remote//src:hello | grep 'Hello World' \
+      || fail "Expected output 'Hello World'"
+  cat > greeting.h <<'EOF'
+#define GREETING "Goodbye World"
+EOF
+  bazel build @remote//src:hello || fail "Expected build to succeed"
+  bazel run @remote//src:hello | grep 'Goodbye World' \
+      || fail "Expected output 'Goodbye World'"
+}
+
+test_files_repository_collision() {
+  # Verify that overlaid files overwrite existing files.
+  WRKDIR=$(mktemp -d "${TEST_TMPDIR}/testXXXXXX")
+  cd "${WRKDIR}"
+
+  mkdir remote
+  (cd remote && src_only_repo_with_local_include)
+  tar cvf remote.tar remote
+  rm -rf remote
+
+  mkdir main
+  cd main
+  build_def
+  touch BUILD
+  cat >> $(setup_module_dot_bazel) <<EOF
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+  name = "remote",
+  strip_prefix = "remote",
+  urls = ["file://${WRKDIR}/remote.tar"],
+  files = {
+    "MODULE.bazel": "//:_.MODULE",
+    "src/BUILD.bazel": "//:_.BUILD",
+  },
+)
+EOF
+
+  bazel build @remote//src:hello || fail "Expected build to succeed"
+  bazel run @remote//src:hello | grep 'Hello World' \
+      || fail "Expected output 'Hello World'"
+}
+
+test_files_repository_bad_label() {
+  # Verify that labels for non-existant source files raise an error.
+  WRKDIR=$(mktemp -d "${TEST_TMPDIR}/testXXXXXX")
+  cd "${WRKDIR}"
+
+  mkdir remote
+  (cd remote && src_only_repo_with_local_include)
+  tar cvf remote.tar remote
+  rm -rf remote
+
+  mkdir main
+  cd main
+  build_def
+  touch BUILD
+  cat >> $(setup_module_dot_bazel) <<EOF
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+  name = "remote",
+  strip_prefix = "remote",
+  urls = ["file://${WRKDIR}/remote.tar"],
+  files = {
+    "MODULE.bazel": "//:_.MODULE",
+    "src/BUILD.bazel": "//:_incorrect_.BUILD",
+  },
+)
+EOF
+
+  bazel build @remote//src:hello >& "${TEST_log}" && fail "Expected to fail"
+  expect_log "ERROR: Input @@//:_incorrect_.BUILD does not exist"
+}
+
+test_files_module() {
+  # Verify that overlaid files are correctly positioned and that `MODULE.bazel` is detected.
+  WRKDIR=$(mktemp -d "${TEST_TMPDIR}/testXXXXXX")
+  cd "${WRKDIR}"
+
+  mkdir remote
+  (cd remote && src_only_repo_with_local_include)
+  tar cvf remote.tar remote
+  rm -rf remote
+
+  mkdir main
+  cd main
+  build_def
+  touch BUILD
+  cat >> $(setup_module_dot_bazel) <<EOF
+bazel_dep(name = "remote")
+archive_override(
+  module_name = "remote",
+  strip_prefix = "remote",
+  urls = ["file://${WRKDIR}/remote.tar"],
+  files = {
+    "MODULE.bazel": "//:_.MODULE",
+    "src/BUILD.bazel": "//:_.BUILD",
+  },
+)
+EOF
+
+  bazel build @remote//src:hello || fail "Expected build to succeed"
+  bazel run @remote//src:hello | grep 'Hello World' \
+      || fail "Expected output 'Hello World'"
+}
+
+run_suite "files tests"

--- a/src/test/shell/bazel/external_remote_file_test.sh
+++ b/src/test/shell/bazel/external_remote_file_test.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Tests the patching functionality of external repositories.
+# Tests the remote files overlay patching functionality of external repositories.
 
 set -euo pipefail
 # --- begin runfiles.bash initialization ---
@@ -385,6 +385,54 @@ EOF
 
   bazel build @hello_world//:hello_world &> $TEST_log 2>&1 && fail "Expected to fail"
   expect_log "Error in download: Cannot write outside of the repository directory"
+}
+
+test_overlay_remote_file_collision() {
+  # hello_world.c
+  EXTREPODIR=`pwd`
+  EXTREPOURL="$(get_extrepourl ${EXTREPODIR})"
+
+  archive_integrity="sha256-$(cat hello_world.zip | openssl dgst -sha256 -binary | openssl base64 -A)"
+
+  # Generate the remote files to overlay
+  cat > BUILD.bazel <<'EOF'
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "hello_world",
+    srcs = ["hello_world.c"],
+)
+EOF
+  touch REPO.bazel
+  cat > hello_world.c <<'EOF'
+#include <stdio.h>
+int main() {
+  printf("Goodbye, world!\n");
+  return 0;
+}
+EOF
+
+  mkdir main
+  cd main
+  cat >> $(setup_module_dot_bazel) <<EOF
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+  name="hello_world",
+  strip_prefix="hello_world-0.1.2",
+  urls=["${EXTREPOURL}/hello_world.zip"],
+  integrity="${archive_integrity}",
+  remote_file_urls={
+    "REPO.bazel": ["${EXTREPOURL}/REPO.bazel"],
+    "BUILD.bazel": ["${EXTREPOURL}/BUILD.bazel"],
+    "hello_world.c": ["${EXTREPOURL}/hello_world.c"],
+  },
+)
+EOF
+  add_rules_cc "MODULE.bazel"
+
+  bazel build @hello_world//:hello_world > "${TEST_log}" 2>&1
+  bazel run @hello_world//:hello_world | grep 'Goodbye, world!' \
+    || fail "Expected output 'Goodbye, world!'"
 }
 
 run_suite "external remote file tests"

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -138,7 +138,7 @@
   "moduleExtensions": {
     "@@pybind11_bazel+//:python_configure.bzl%extension": {
       "general": {
-        "bzlTransitiveDigest": "4rSUGWibZDYLhHR+8eMwTNwAwdIv+xjVrtQ+gHtWHq4=",
+        "bzlTransitiveDigest": "IxPUITv3BpVuVvTM/ivfwT0GvAKWwIv6WUh87P1zELc=",
         "usagesDigest": "fycyB39YnXIJkfWCIXLUKJMZzANcuLy9ZE73hRucjFk=",
         "recordedFileInputs": {
           "@@pybind11_bazel+//MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
@@ -172,7 +172,7 @@
     },
     "@@rules_fuzzing+//fuzzing/private:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "v2H25KPHEkN56IHR41S67Kzp5Xjxd75GBiazhON8jzc=",
+        "bzlTransitiveDigest": "3ZPQpcWr+dKH5EpHApjclXv9VlULkwM/gfRmXuuPMXc=",
         "usagesDigest": "wy6ISK6UOcBEjj/mvJ/S3WeXoO67X+1llb9yPyFtPgc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -255,7 +255,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "OlvsB0HsvxbR8ZN+J9Vf00X/+WVz/Y/5Xrq2LgcVfdo=",
+        "bzlTransitiveDigest": "JIZeWQopFAuTLswK0lroGL1UJYSmB/cUTzZNHRv0MMw=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -319,7 +319,7 @@
     },
     "@@rules_python+//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "hJVUNwFJ9jo6lpnArzZ4jCsm7Jp7yLvo3Y0wLqryVXg=",
+        "bzlTransitiveDigest": "W1DbuIfxQtfqbgIm5/3loVPhuUoRx3+niOvvZcOEyYE=",
         "usagesDigest": "OLoIStnzNObNalKEMRq99FqenhPGLFZ5utVLV4sz7OI=",
         "recordedFileInputs": {
           "@@rules_python+//tools/publish/requirements_darwin.txt": "2994136eab7e57b083c3de76faf46f70fad130bc8e7360a7fed2b288b69e79dc",

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -54,6 +54,7 @@ load(
     "download_remote_files",
     "get_auth",
     "patch",
+    "symlink_files",
     "update_attrs",
     "workspace_and_buildfile",
 )
@@ -166,6 +167,7 @@ def _http_archive_impl(ctx):
 
     remote_files_info = download_remote_files(ctx)
     remote_patches_info = patch(ctx)
+    symlink_files(ctx)
 
     # Download the module file after applying patches since modules may decide
     # to patch their packaged module and the patch may not apply to the file
@@ -320,6 +322,13 @@ The archive will be unpacked into this directory, after applying `strip_prefix`
 `foo-1.2.3/src/foo.h` will be unpacked to `bar/src/foo.h` if `add_prefix = "bar"`
 and `strip_prefix = "foo-1.2.3"`.""",
     ),
+    "files": attr.string_keyed_label_dict(
+        doc = """A map of relative paths (key) to a file label (value) that overlaid on the repo as
+a symlink. This is useful when you want to add REPO.bazel or BUILD.bazel files atop an existing
+repository. Files are symlinked after remote files are downloaded and patches (`remote_patches`,
+`patches`) are applied. Existing files will be overwritten.
+""",
+    ),
     "type": attr.string(
         doc = """The archive type of the downloaded file.
 
@@ -339,12 +348,13 @@ following: `"zip"`, `"jar"`, `"war"`, `"aar"`, `"tar"`, `"tar.gz"`, `"tgz"`,
     ),
     "remote_file_urls": attr.string_list_dict(
         default = {},
-        doc =
-            "A map of relative paths (key) to a list of URLs (value) that are to be downloaded " +
-            "and made available as overlaid files on the repo. This is useful when you want " +
-            "to add WORKSPACE or BUILD.bazel files atop an existing repository. The files " +
-            "are downloaded before applying the patches in the `patches` attribute and the list of URLs " +
-            "should all be possible mirrors of the same file. The URLs are tried in order until one succeeds. ",
+        doc = """A map of relative paths (key) to a list of URLs (value) that are to be downloaded
+and made available as overlaid files on the repo. This is useful when you want to add REPO.bazel or
+BUILD.bazel files atop an existing repository. The files are downloaded before `files` are
+symlinked and patches (`remote_patches`, `patches`) are applied. The list of URLs should all be
+possible mirrors of the same file. The URLs are tried in order until one succeeds. Existing files
+will be overwritten.
+""",
     ),
     "remote_file_integrity": attr.string_dict(
         default = {},

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -89,6 +89,8 @@ def download_remote_files(ctx, auth = None):
     a repository rule. It assumes the parameters `remote_file_urls` and
     `remote_file_integrity` to be present in `ctx.attr`.
 
+    Existing files will be overwritten.
+
     Args:
       ctx: The repository context of the repository rule calling this utility
         function.
@@ -111,6 +113,30 @@ def download_remote_files(ctx, auth = None):
 
     # Wait until the requests are done
     return {path: token.wait() for path, token in pending.items()}
+
+def symlink_files(ctx):
+    # type: (repository_ctx) -> None
+    """Utility function for symlinking local files.
+
+    This is intended to be used in the implementation function of a repository rule. It assumes the
+    parameter `files` is present in `ctx.attr`.
+
+    Existing files will be overwritten.
+
+    Args:
+      ctx: The repository context of the repository rule calling this utility
+        function.
+    """
+    for path, label in ctx.attr.files.items():
+        src_path = ctx.path(label)
+
+        # On Windows `ctx.symlink` may be implemented as a copy, so the file MUST be watched
+        ctx.watch(src_path)
+        if not src_path.exists:
+            fail("Input %s does not exist" % label)
+        if ctx.path(path).exists:
+            ctx.delete(path)
+        ctx.symlink(src_path, path)
 
 def patch(ctx, patches = None, patch_cmds = None, patch_cmds_win = None, patch_tool = None, patch_args = None, auth = None):
     """Implementation of patching an already extracted repository.


### PR DESCRIPTION
This provides an alternative to `remote_file_urls` that can track local file changes and allows the overlay pattern in Bazel registries to be used directly in modules. Useful for making a complete and correct module that can be moved to a registry with minimal refactoring.

e.g.
```starlark
# MODULE.bazel
module(name = "project")

bazel_dep(name = "cairo")
archive_override(
    module_name = "cairo",
    urls = ["https://cairographics.org/releases/cairo-1.18.4.tar.xz"],
    integrity = "...",
    strip_prefix = "cairo-1.18.4",
    files = {
        "MODULE.bazel": "//third_party/cairo/overlay:_.MODULE.bazel",
        "BUILD.bazel": "//third_party/cairo/overlay:_.BUILD.bazel",
        "src/BUILD.bazel": "//third_party/cairo/overlay:src/_.BUILD.bazel",
    },
)
```

Current alternatives are;
1. Using patches, which adds overhead to maintenance (clone+checkout/extract, apply patches, edit, reexport patches).
2. Using `remote_file_urls` with relative `file:` URLs (e.g. `file:third_party/cairo/overlay/_.MODULE.bazel`) and `remote_file_integrity` (required for Bazel to detect content changes). Tricky to automate and error prone.

Closes #26852.

PiperOrigin-RevId: 813365487
Change-Id: I3c80a6d2d5bec3114907793014cf6e015efde571

Commit https://github.com/bazelbuild/bazel/commit/0edf58be80e52f9862b821c0d8aebe3004360ef2