### PR TITLE
[7.7.0] Overlay the registry `MODULE.bazel` file on the module repo

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveRepoSpecBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveRepoSpecBuilder.java
@@ -96,6 +96,13 @@ public class ArchiveRepoSpecBuilder {
   }
 
   @CanIgnoreReturnValue
+  public ArchiveRepoSpecBuilder setRemoteModuleFile(RemoteFile remoteModuleFile) {
+    attrBuilder.put("remote_module_file_urls", remoteModuleFile.urls());
+    attrBuilder.put("remote_module_file_integrity", remoteModuleFile.integrity());
+    return this;
+  }
+
+  @CanIgnoreReturnValue
   public ArchiveRepoSpecBuilder setRemotePatchStrip(int remotePatchStrip) {
     attrBuilder.put("remote_patch_strip", StarlarkInt.of(remotePatchStrip));
     return this;

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
@@ -86,6 +86,14 @@ public class GitRepoSpecBuilder {
     return setAttr("patch_cmds", patchCmds);
   }
 
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setRemoteModuleFile(
+      ArchiveRepoSpecBuilder.RemoteFile remoteModuleFile) {
+    attrBuilder.put("remote_module_file_urls", remoteModuleFile.urls());
+    attrBuilder.put("remote_module_file_integrity", remoteModuleFile.integrity());
+    return this;
+  }
+
   public RepoSpec build() {
     return RepoSpec.builder()
         .setBzlFile(GIT_REPO_PATH)

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Registry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Registry.java
@@ -16,6 +16,7 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.skyframe.NotComparableSkyValue;
@@ -50,7 +51,10 @@ public interface Registry extends NotComparableSkyValue {
    * by {@code key} should be materialized as a repo.
    */
   RepoSpec getRepoSpec(
-      ModuleKey key, ExtendedEventHandler eventHandler, DownloadManager downloadManager)
+      ModuleKey key,
+      ImmutableMap<String, Optional<Checksum>> moduleFileHashes,
+      ExtendedEventHandler eventHandler,
+      DownloadManager downloadManager)
       throws IOException, InterruptedException;
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFileDownloadEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFileDownloadEvent.java
@@ -34,8 +34,8 @@ public record RegistryFileDownloadEvent(String uri, Optional<Checksum> checksum)
   static ImmutableMap<String, Optional<Checksum>> collectToMap(Collection<Postable> postables) {
     ImmutableMap.Builder<String, Optional<Checksum>> builder = ImmutableMap.builder();
     for (Postable postable : postables) {
-      if (postable instanceof RegistryFileDownloadEvent event) {
-        builder.put(event.uri(), event.checksum());
+      if (postable instanceof RegistryFileDownloadEvent(String uri, Optional<Checksum> checksum)) {
+        builder.put(uri, checksum);
       }
     }
     return builder.buildKeepingLast();

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RepoSpecFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RepoSpecFunction.java
@@ -45,13 +45,23 @@ public class RepoSpecFunction implements SkyFunction {
     if (registry == null) {
       return null;
     }
+    ModuleFileValue moduleFileValue =
+        (ModuleFileValue) env.getValue(ModuleFileValue.key(key.getModuleKey()));
+    if (moduleFileValue == null) {
+      return null;
+    }
 
     StoredEventHandler downloadEvents = new StoredEventHandler();
     RepoSpec repoSpec;
     try (SilentCloseable c =
         Profiler.instance()
             .profile(ProfilerTask.BZLMOD, () -> "compute repo spec: " + key.getModuleKey())) {
-      repoSpec = registry.getRepoSpec(key.getModuleKey(), downloadEvents, this.downloadManager);
+      repoSpec =
+          registry.getRepoSpec(
+              key.getModuleKey(),
+              moduleFileValue.registryFileHashes(),
+              downloadEvents,
+              this.downloadManager);
     } catch (IOException e) {
       throw new RepoSpecException(
           ExternalDepsException.withCauseAndMessage(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/FakeRegistry.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/FakeRegistry.java
@@ -81,7 +81,10 @@ public class FakeRegistry implements Registry {
 
   @Override
   public RepoSpec getRepoSpec(
-      ModuleKey key, ExtendedEventHandler eventHandler, DownloadManager downloadManager) {
+      ModuleKey key,
+      ImmutableMap<String, Optional<Checksum>> moduleFileHashes,
+      ExtendedEventHandler eventHandler,
+      DownloadManager downloadManager) {
     RepoSpec repoSpec =
         RepoSpec.builder()
             .setRuleClassName("local_repository")

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -414,12 +414,21 @@ class ModCommandTest(test_base.TestBase):
     )
     self.assertRegex(stdout.pop(4), r'^  urls = \[".*"\],$')
     self.assertRegex(stdout.pop(4), r'^  integrity = ".*",$')
+    self.assertRegex(
+        stdout.pop(7),
+        r'^  remote_module_file_urls = \[".*/modules/bar/2.0/MODULE.bazel"\],$',
+    )
+    self.assertRegex(stdout.pop(7), r'^  remote_module_file_integrity = ".*",$')
     self.assertRegex(stdout.pop(19), r'^  path = ".*",$')
     # lines after 'Rule data_repo defined at (most recent call last):'
     stdout.pop(33)
     stdout.pop(44)
     self.assertRegex(stdout.pop(49), r'^  urls = \[".*"\],$')
     self.assertRegex(stdout.pop(49), r'^  integrity = ".*",$')
+    self.assertRegex(stdout.pop(52), r'^  remote_module_file_urls = \[".*"\],$')
+    self.assertRegex(
+        stdout.pop(52), r'^  remote_module_file_integrity = ".*",$'
+    )
     # lines after '# Rule http_archive defined at (most recent call last):'
     stdout.pop(13)
     stdout.pop(57)
@@ -485,6 +494,8 @@ class ModCommandTest(test_base.TestBase):
             '  strip_prefix = "",',
             '  remote_file_urls = {},',
             '  remote_file_integrity = {},',
+            # pop(52) -- remote_module_file_urls=[...]
+            # pop(52) -- remote_module_file_integrity=...
             '  remote_patches = {},',
             '  remote_patch_strip = 0,',
             ')',

--- a/src/test/py/bazel/bzlmod/test_utils.py
+++ b/src/test/py/bazel/bzlmod/test_utils.py
@@ -227,8 +227,16 @@ class BazelRegistry:
     for foldername, _, filenames in os.walk(str(src_dir)):
       for filename in filenames:
         filepath = os.path.join(foldername, filename)
-        zip_obj.write(filepath,
-                      str(pathlib.Path(filepath).relative_to(src_dir)))
+        arcname = str(pathlib.Path(filepath).relative_to(src_dir))
+        if filename == 'MODULE.bazel':
+          # Verify that MODULE.bazel doesn't have to be included in the archive
+          # by writing an effectively empty one.
+          zip_obj.writestr(
+              arcname,
+              '# FAKE\nmodule(name = "%s", version = "%s")\n' % (name, version),
+          )
+        else:
+          zip_obj.write(filepath, arcname)
     zip_obj.close()
     return zip_path
 

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -83,7 +83,7 @@
     },
     "@@rules_jvm_external~//:extensions.bzl%maven": {
       "general": {
-        "bzlTransitiveDigest": "VW3qd5jCZXYbR9xpSwrhGQ04GCmEIIFPVERY34HHvFE=",
+        "bzlTransitiveDigest": "ZQ7WkJz9gFPqIPdufLEC3Bgpq9LAVjEeYOOLXNVfvzA=",
         "usagesDigest": "LrHQqpB5iw7+xvJG0erQ0h4vkSrdvObnMfY7Zbx7qhY=",
         "recordedFileInputs": {
           "@@rules_jvm_external~//rules_jvm_external_deps_install.json": "10442a5ae27d9ff4c2003e5ab71643bf0d8b48dcf968b4173fa274c3232a8c06"
@@ -1107,7 +1107,7 @@
     },
     "@@rules_jvm_external~//:non-module-deps.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "ZOivBbbZUakRexeLO/N26oX4Bcph6HHnqNmfxt7yoCc=",
+        "bzlTransitiveDigest": "zgoXBCIIFoarNMwvAb/PhdcthQDcTmKo/Xb59yftwUo=",
         "usagesDigest": "Ccxo9D2Jf1yAMLB2+zS+9MGgnKIFhxCAxFkSqwdK/3c=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1135,7 +1135,7 @@
     },
     "@@rules_python~//python/extensions:python.bzl%python": {
       "general": {
-        "bzlTransitiveDigest": "lbXqTyC4ahBb81TIrIp+2d3sWnlurVNqSeAaLJknLUs=",
+        "bzlTransitiveDigest": "he4AQAbdiykyy277R2KXxr5yjk4tMRvX7wE9/x2IiCA=",
         "usagesDigest": "1Y6kbygksx7wAtDStFoHnR90xr8Yeq00I91YcLMbxMI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1165,7 +1165,7 @@
     },
     "@@rules_python~//python/extensions/private:internal_deps.bzl%internal_deps": {
       "general": {
-        "bzlTransitiveDigest": "b6FMQSdoZ1QOssw14AW8bWDn2BvywI4FVkLbO2nTMsE=",
+        "bzlTransitiveDigest": "5ctGZwE8bkEOmXC8w8mH2lWP15NVkjy7g6HqyHBhd2U=",
         "usagesDigest": "KPNj8wxzOk7dXY9StqZ91MCKEIJSEnAyV0Q/dGFP5sw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -22,6 +22,7 @@
 
 load(
     ":utils.bzl",
+    "get_auth",
     "patch",
     "update_attrs",
     "workspace_and_buildfile",
@@ -147,6 +148,14 @@ _common_attrs = {
               "applied. If this attribute is not set, patch_cmds will be executed on Windows, " +
               "which requires Bash binary to exist.",
     ),
+    "remote_module_file_urls": attr.string_list(
+        default = [],
+        doc = "For internal use only.",
+    ),
+    "remote_module_file_integrity": attr.string(
+        default = "",
+        doc = "For internal use only.",
+    ),
     "build_file": attr.label(
         allow_single_file = True,
         doc =
@@ -161,16 +170,10 @@ _common_attrs = {
             "The content for the BUILD file for this repository. ",
     ),
     "workspace_file": attr.label(
-        doc =
-            "The file to use as the `WORKSPACE` file for this repository. " +
-            "Either `workspace_file` or `workspace_file_content` can be " +
-            "specified, or neither, but not both.",
+        doc = "No-op attribute; do not use.",
     ),
     "workspace_file_content": attr.string(
-        doc =
-            "The content for the WORKSPACE file for this repository. " +
-            "Either `workspace_file` or `workspace_file_content` can be " +
-            "specified, or neither, but not both.",
+        doc = "No-op attribute; do not use.",
     ),
 }
 
@@ -180,6 +183,18 @@ def _git_repository_implementation(ctx):
     update = _clone_or_update_repo(ctx)
     workspace_and_buildfile(ctx)
     patch(ctx)
+
+    # Download the module file after applying patches since modules may decide
+    # to patch their packaged module and the patch may not apply to the file
+    # checked in to the registry. This overrides the file if it exists.
+    if ctx.attr.remote_module_file_urls:
+        ctx.download(
+            ctx.attr.remote_module_file_urls,
+            "MODULE.bazel",
+            auth = get_auth(ctx, ctx.attr.remote_module_file_urls),
+            integrity = ctx.attr.remote_module_file_integrity,
+        )
+
     if ctx.attr.strip_prefix:
         ctx.delete(ctx.path(".tmp_git_root/.git"))
     else:

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -148,6 +148,17 @@ def _http_archive_impl(ctx):
     download_remote_files(ctx)
     patch(ctx)
 
+    # Download the module file after applying patches since modules may decide
+    # to patch their packaged module and the patch may not apply to the file
+    # checked in to the registry. This overrides the file if it exists.
+    if ctx.attr.remote_module_file_urls:
+        ctx.download(
+            ctx.attr.remote_module_file_urls,
+            "MODULE.bazel",
+            auth = get_auth(ctx, ctx.attr.remote_module_file_urls),
+            integrity = ctx.attr.remote_module_file_integrity,
+        )
+
     return _update_integrity_attr(ctx, _http_archive_attrs, download_info)
 
 _HTTP_FILE_BUILD = """\
@@ -314,6 +325,14 @@ following: `"zip"`, `"jar"`, `"war"`, `"aar"`, `"tar"`, `"tar.gz"`, `"tgz"`,
             "A map of file relative paths (key) to its integrity value (value). These relative paths should map " +
             "to the files (key) in the `remote_file_urls` attribute.",
     ),
+    "remote_module_file_urls": attr.string_list(
+        default = [],
+        doc = "For internal use only.",
+    ),
+    "remote_module_file_integrity": attr.string(
+        default = "",
+        doc = "For internal use only.",
+    ),
     "remote_patches": attr.string_dict(
         default = {},
         doc =
@@ -371,16 +390,10 @@ following: `"zip"`, `"jar"`, `"war"`, `"aar"`, `"tar"`, `"tar.gz"`, `"tgz"`,
             "not both.",
     ),
     "workspace_file": attr.label(
-        doc =
-            "The file to use as the `WORKSPACE` file for this repository. " +
-            "Either `workspace_file` or `workspace_file_content` can be " +
-            "specified, or neither, but not both.",
+        doc = "No-op attribute; do not use.",
     ),
     "workspace_file_content": attr.string(
-        doc =
-            "The content for the WORKSPACE file for this repository. " +
-            "Either `workspace_file` or `workspace_file_content` can be " +
-            "specified, or neither, but not both.",
+        doc = "No-op attribute; do not use.",
     ),
 }
 

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -38,14 +38,15 @@ load(
 # Temporary directory for downloading remote patch files.
 _REMOTE_PATCH_DIR = ".tmp_remote_patches"
 
+# Name preserved for backwards compatibility only - this function used to
+# write a WORKSPACE file if requested.
 def workspace_and_buildfile(ctx):
-    """Utility function for writing WORKSPACE and, if requested, a BUILD file.
+    """Utility function for writing a BUILD file.
 
     This rule is intended to be used in the implementation function of a
     repository rule.
-    It assumes the parameters `name`, `build_file`, `build_file_content`,
-    `workspace_file`, and `workspace_file_content` to be
-    present in `ctx.attr`; the latter four possibly with value None.
+    It assumes the parameters `name`, `build_file`, and `build_file_content` to
+    be present in `ctx.attr`; the latter two possibly with value None.
 
     Args:
       ctx: The repository context of the repository rule calling this utility
@@ -53,16 +54,6 @@ def workspace_and_buildfile(ctx):
     """
     if ctx.attr.build_file and ctx.attr.build_file_content:
         ctx.fail("Only one of build_file and build_file_content can be provided.")
-
-    if ctx.attr.workspace_file and ctx.attr.workspace_file_content:
-        ctx.fail("Only one of workspace_file and workspace_file_content can be provided.")
-
-    if ctx.attr.workspace_file:
-        ctx.file("WORKSPACE", ctx.read(ctx.attr.workspace_file))
-    elif ctx.attr.workspace_file_content:
-        ctx.file("WORKSPACE", ctx.attr.workspace_file_content)
-    else:
-        ctx.file("WORKSPACE", "workspace(name = \"{name}\")\n".format(name = ctx.name))
 
     if ctx.attr.build_file:
         ctx.file("BUILD.bazel", ctx.read(ctx.attr.build_file))


### PR DESCRIPTION
RELNOTES: Modules backed by `http_archive` or `git_repository` no longer require a MODULE.bazel file to be contained in the source archive.

Fixes #26217

Closes #26332.

PiperOrigin-RevId: 778139801
Change-Id: Ie1d219ce1c219c8bae7657be929e54b9b467abf9

(cherry picked from commit c5a562b6b5f718b39b8211fa1cf47169cfedb300)

Closes #26983 