### PR TITLE
[8.5.0] Don't send out `RegistryFileDownloadEvent`s

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFileDownloadEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFileDownloadEvent.java
@@ -24,10 +24,9 @@ import java.util.Collection;
 import java.util.Optional;
 
 /** Event that records the fact that a file has been downloaded from a remote registry. */
-public record RegistryFileDownloadEvent(String uri, Optional<Checksum> checksum)
-    implements Postable {
+record RegistryFileDownloadEvent(String uri, Optional<Checksum> checksum) implements Postable {
 
-  public static RegistryFileDownloadEvent create(String uri, Optional<byte[]> content) {
+  static RegistryFileDownloadEvent create(String uri, Optional<byte[]> content) {
     return new RegistryFileDownloadEvent(uri, content.map(RegistryFileDownloadEvent::computeHash));
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RepoSpecFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RepoSpecFunction.java
@@ -70,7 +70,6 @@ public class RepoSpecFunction implements SkyFunction {
               "Unable to get module repo spec for %s from registry",
               key.moduleKey()));
     }
-    downloadEvents.replayOn(env.getListener());
     return RepoSpecValue.create(
         repoSpec, RegistryFileDownloadEvent.collectToMap(downloadEvents.getPosts()));
   }


### PR DESCRIPTION
These events are no longer handled by `BazelLockFileModule`, but explicity added to ordinary `SkyValue`s.

Closes #27143.

PiperOrigin-RevId: 817558093
Change-Id: I7c36d255af22619d6bbedfabc2e024c8b37284ae

Commit https://github.com/bazelbuild/bazel/commit/129e895a8d1c00a472a62ffd368f499736d4d6ca