### PR TITLE
[7.7.0] Improve incompatible platform skipping + config_setting + label_flag …

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/IncompatibleTargetChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/IncompatibleTargetChecker.java
@@ -197,6 +197,10 @@ public class IncompatibleTargetChecker {
     }
   }
 
+  /** Rules where it doesn't make sense to check for platform compatibility. */
+  private static final ImmutableList<String> NO_COMPATIBILITY_CHECK_RULES =
+      ImmutableList.of("toolchain", "config_setting", "label_flag");
+
   /**
    * Creates an incompatible target if it is "indirectly incompatible".
    *
@@ -223,7 +227,7 @@ public class IncompatibleTargetChecker {
     Target target = targetAndConfiguration.getTarget();
     Rule rule = target.getAssociatedRule();
 
-    if (rule == null || rule.getRuleClass().equals("toolchain")) {
+    if (rule == null || NO_COMPATIBILITY_CHECK_RULES.contains(rule.getRuleClass())) {
       return Optional.empty();
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
@@ -148,7 +148,7 @@ public class TopLevelConstraintSemantics {
     String targetIncompatibleMessage =
         String.format(
             TARGET_INCOMPATIBLE_ERROR_TEMPLATE,
-            configuredTarget.getLabel(),
+            configuredTarget.getOriginalLabel(),
             // We need access to the provider so we pass in the underlying target here that is
             // responsible for the incompatibility.
             reportOnIncompatibility(underlyingTarget));
@@ -269,7 +269,7 @@ public class TopLevelConstraintSemantics {
                 target,
                 eventHandler,
                 /* eagerlyThrowError= */ !keepGoing,
-                explicitTargetPatterns.contains(target.getLabel()),
+                explicitTargetPatterns.contains(target.getOriginalLabel()),
                 skipIncompatibleExplicitTargets);
         if (PlatformCompatibility.INCOMPATIBLE_EXPLICIT.equals(platformCompatibility)) {
           incompatibleButRequestedTargets.add(target);

--- a/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisPhaseRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisPhaseRunner.java
@@ -177,7 +177,7 @@ public final class AnalysisPhaseRunner {
       BuildConfigurationValue config =
           env.getSkyframeExecutor()
               .getConfiguration(env.getReporter(), target.getConfigurationKey());
-      Label label = target.getLabel();
+      Label label = target.getOriginalLabel();
       env.getEventBus()
           .post(
               new AbortedEvent(

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildResultPrinter.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildResultPrinter.java
@@ -287,7 +287,7 @@ class BuildResultPrinter {
       ArrayList<ConfiguredTarget> skipped,
       boolean omitNothingToBuild) {
     for (ConfiguredTarget target : skipped) {
-      outErr.printErr("Target " + target.getLabel() + " was skipped\n");
+      outErr.printErr("Target " + target.getOriginalLabel() + " was skipped\n");
     }
     for (int i = 0; i < succeeded.size(); ++i) {
       ConfiguredTarget target = succeeded.get(i);


### PR DESCRIPTION
…behavior.

Context: https://github.com/bazelbuild/bazel/issues/23003

Technical notes:

This involves a lot of subtle interactions between the concepts of platform skipping, `config_setting`, `label_flag`, and aliases.

This fixes the problem where a `config_setting` keyed on a `label_flag` that references an incompatible target gave the error "not a valid key for the `config_setting"`. The reason is that `config_setting` expects all `flag_values` keys to expose `BuildSettingProvider`. But an incompatible target (whether directly or because one of its deps is incompatible) is a `RuleConfiguredTarget` that only exposes `IncompatiblePlatformProvider`.

I fixed this by exempting `label_flag` from being marked incompatible due to incompatible deps. It therefore returns its normal value, which is a specially created `AliasConfiguredTarget` that adds the right `BuildSettingProvider` via `AliasConfiguredTarget.overrides`.

All well and good. But if you build such a `label_flag directly`, Bazel still returns an error that it's incompatible due to incompatible deps. That's great, and accurate. But why does it do that if we exempted it from being incompatible in that situation?

The reason is that, as an `AliasConfiguredTarget`, it forwards its dependencies' provider. Since its dependency has `IncompatiblePlatformProvider`, that gets forwarded implicitly, so the routine "is the top-level target incompatible?" check still triggers on the `label_flag` the build requested.

That's a bit odd: the `label_flag` both is and isn't indirectly incompatible depending on which logic is checking. But there's no easy way around this: `ConfigSetting` *has* to consider it compatible to avoid it being a special `RuleConfiguredTarget` with `IncompatiblePlatformProvider`. But since i's normal form is an alias that auto-triggers the "forward my incompatible deps" logic

Point is this is all a bit subtle. I vetted reasonable behavior as best I can, but I'm not 100% confident we capture every corner case correctly or intuitively. There's just too much subtle interplay between various delicate parts of the build API.

You could just as well argue, for example, that `$ bazel build //my:label_flag` should *never* produce an incompatibility error since label flags are dependency aliases, and not meant to build anything directly. If you wanted that behavior just use a plain `alias`. But I don't want to scope-creep this fix so I'll just note these API ambiguities and leave this PR's ambition as-is.

Relatedly you'll see I updated a few pieces of "foo was skipped" reporting messages to reflect that `label_flag` is an alias. Note that change *cannot* kick in for requested builds incompatible `alias` targets. Those are properly considered incompatible, which means they get replaced with `RuleConfiguredTarget` with an `IncompatiblePlatformProvider`. So those essentially cease to be aliases for top-level "foo was skipped"-style reporting.

See the test methods I added for specific expectations I encoded.

We should also update the `config_setting` documentation on `label_flag` and `alias` interaction.

Fixes https://github.com/bazelbuild/bazel/issues/23003.

PiperOrigin-RevId: 702118583
Change-Id: Ia6e80af57cc3b4e6d2574bf28a1d8fe0dbff0852

Closes #24542.

Change-Id: Ia6e80af57cc3b4e6d2574bf28a1d8fe0dbff0852
PiperOrigin-RevId: 702478496

Commit https://github.com/bazelbuild/bazel/commit/916e8581bb2861838fbec0cb6e9228caac7efddc