### PR TITLE
Rewrite CLI docs to take advantage of markdown support (chunk 2)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/dynamic/DynamicExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/dynamic/DynamicExecutionOptions.java
@@ -82,13 +82,15 @@ public abstract class DynamicExecutionOptions extends OptionsBase {
       defaultValue = "null",
       allowMultiple = true,
       help =
-          "The local strategies, in order, to use for the given mnemonic - the first applicable "
-              + "strategy is used. For example, `worker,sandboxed` runs actions that support "
-              + "persistent workers using the worker strategy, and all others using the sandboxed "
-              + "strategy. If no mnemonic is given, the list of strategies is used as the "
-              + "fallback for all mnemonics. The default fallback list is `worker,sandboxed`, or"
-              + "`worker,sandboxed,standalone` if `experimental_local_lockfree_output` is set. "
-              + "Takes [mnemonic=]local_strategy[,local_strategy,...]")
+          """
+          The local strategies, in order, to use for the given mnemonic - the first applicable
+          strategy is used. For example, `worker,sandboxed` runs actions that support
+          persistent workers using the worker strategy, and all others using the sandboxed
+          strategy. If no mnemonic is given, the list of strategies is used as the
+          fallback for all mnemonics. The default fallback list is `worker,sandboxed`, or
+          `worker,sandboxed,standalone` if `experimental_local_lockfree_output` is set.
+          Takes `[mnemonic=]local_strategy[,local_strategy,...]`.
+          """)
   public abstract List<Map.Entry<String, List<String>>> getDynamicLocalStrategy();
 
   public abstract void setDynamicLocalStrategy(List<Map.Entry<String, List<String>>> value);
@@ -101,11 +103,13 @@ public abstract class DynamicExecutionOptions extends OptionsBase {
       defaultValue = "null",
       allowMultiple = true,
       help =
-          "The remote strategies, in order, to use for the given mnemonic - the first applicable "
-              + "strategy is used. If no mnemonic is given, the list of strategies is used as the "
-              + "fallback for all mnemonics. The default fallback list is `remote`, so this flag "
-              + "usually does not need to be set explicitly. "
-              + "Takes [mnemonic=]remote_strategy[,remote_strategy,...]")
+          """
+          The remote strategies, in order, to use for the given mnemonic - the first applicable
+          strategy is used. If no mnemonic is given, the list of strategies is used as the
+          fallback for all mnemonics. The default fallback list is `remote`, so this flag
+          usually does not need to be set explicitly.
+          Takes `[mnemonic=]remote_strategy[,remote_strategy,...]`.
+          """)
   public abstract List<Map.Entry<String, List<String>>> getDynamicRemoteStrategy();
 
   public abstract void setDynamicRemoteStrategy(List<Map.Entry<String, List<String>>> value);
@@ -155,16 +159,19 @@ public abstract class DynamicExecutionOptions extends OptionsBase {
       effectTags = {OptionEffectTag.EXECUTION, OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS},
       defaultValue = "0",
       help =
-          "Controls how much load from dynamic execution to put on the local machine."
-              + " This flag adjusts how many actions in dynamic execution we will schedule"
-              + " concurrently. It is based on the number of CPUs Blaze thinks is available,"
-              + " which can be controlled with the --local_resources=cpu= flag."
-              + "\nIf this flag is 0, all actions are scheduled locally immediately. If > 0,"
-              + " the amount of actions scheduled locally is limited by the number of CPUs"
-              + " available. If < 1, the load factor is used to reduce the number of locally"
-              + " scheduled actions when the number of actions waiting to schedule is high."
-              + " This lessens the load on the local machine in the clean build case, where"
-              + " the local machine does not contribute much.")
+          """
+          Controls how much load from dynamic execution to put on the local machine.
+          This flag adjusts how many actions in dynamic execution we will schedule
+          concurrently. It is based on the number of CPUs Blaze thinks is available,
+          which can be controlled with the `--local_resources=cpu=` flag.
+
+          If this flag is `0`, all actions are scheduled locally immediately. If > 0,
+          the amount of actions scheduled locally is limited by the number of CPUs
+          available. If < 1, the load factor is used to reduce the number of locally
+          scheduled actions when the number of actions waiting to schedule is high.
+          This lessens the load on the local machine in the clean build case, where
+          the local machine does not contribute much.
+          """)
   public abstract double getLocalLoadFactor();
 
   public abstract void setLocalLoadFactor(double value);
@@ -175,9 +182,11 @@ public abstract class DynamicExecutionOptions extends OptionsBase {
       effectTags = {OptionEffectTag.EXECUTION, OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS},
       defaultValue = "true",
       help =
-          "When set, targets that are build \"for tool\" are not subject to dynamic execution. Such"
-              + " targets are extremely unlikely to be built incrementally and thus not worth"
-              + " spending local cycles on.")
+          """
+          When set, targets that are build "for tool" are not subject to dynamic execution. Such
+          targets are extremely unlikely to be built incrementally and thus not worth
+          spending local cycles on.
+          """)
   public abstract boolean getExcludeTools();
 
   public abstract void setExcludeTools(boolean value);

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -68,11 +68,15 @@ public abstract class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "Specify how spawn actions are executed by default. Accepts a comma-separated list of"
-              + " strategies from highest to lowest priority. For each action Bazel picks the"
-              + " strategy with the highest priority that can execute the action. The default"
-              + " value is \"remote,worker,sandboxed,local\". See"
-              + " https://blog.bazel.build/2019/06/19/list-strategy.html for details.")
+          """
+          Specify how spawn actions are executed by default. Accepts a comma-separated list of
+          strategies from highest to lowest priority. For each action Bazel picks the
+          strategy with the highest priority that can execute the action. The default
+          value is `remote,worker,sandboxed,local`.
+          See [Automatic execution strategy selection in Bazel 0.27] for details.
+
+          [Automatic execution strategy selection in Bazel 0.27]: https://blog.bazel.build/2019/06/19/list-strategy.html
+          """)
   public abstract List<String> getSpawnStrategy();
 
   @Option(
@@ -82,9 +86,11 @@ public abstract class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "Specify how to execute genrules. This flag will be phased out. Instead, use "
-              + "--spawn_strategy=<value> to control all actions or --strategy=Genrule=<value> "
-              + "to control genrules only.")
+          """
+          Specify how to execute genrules. This flag will be phased out. Instead, use
+          `--spawn_strategy=<value>` to control all actions or `--strategy=Genrule=<value>`
+          to control genrules only.
+          """)
   public abstract List<String> getGenruleStrategy();
 
   @Option(
@@ -95,12 +101,16 @@ public abstract class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "Specify how to distribute compilation of other spawn actions. Accepts a comma-separated"
-              + " list of strategies from highest to lowest priority. For each action Bazel picks"
-              + " the strategy with the highest priority that can execute the action. The default"
-              + " value is \"remote,worker,sandboxed,local\". This flag overrides the values set"
-              + " by --spawn_strategy (and --genrule_strategy if used with mnemonic Genrule). See"
-              + " https://blog.bazel.build/2019/06/19/list-strategy.html for details.")
+          """
+          Specify how to distribute compilation of other spawn actions. Accepts a comma-separated
+          list of strategies from highest to lowest priority. For each action Bazel picks
+          the strategy with the highest priority that can execute the action. The default
+          value is `remote,worker,sandboxed,local`. This flag overrides the values set
+          by `--spawn_strategy` (and `--genrule_strategy` if used with mnemonic Genrule).
+          See [Automatic execution strategy selection in Bazel 0.27] for details.
+
+          [Automatic execution strategy selection in Bazel 0.27]: https://blog.bazel.build/2019/06/19/list-strategy.html
+          """)
   public abstract List<Map.Entry<String, List<String>>> getStrategy();
 
   @Option(
@@ -111,16 +121,20 @@ public abstract class ExecutionOptions extends OptionsBase {
       effectTags = {OptionEffectTag.EXECUTION},
       defaultValue = "null",
       help =
-          "Override which spawn strategy should be used to execute spawn actions that have "
-              + "descriptions matching a certain regex_filter. See --per_file_copt for details on "
-              + "regex_filter matching. "
-              + "The last regex_filter that matches the description is used. "
-              + "This option overrides other flags for specifying strategy. "
-              + "Example: --strategy_regexp=//foo.*\\.cc,-//foo/bar=local means to run actions "
-              + "using local strategy if their descriptions match //foo.*.cc but not //foo/bar. "
-              + "Example: --strategy_regexp='Compiling.*/bar=local "
-              + " --strategy_regexp=Compiling=sandboxed will run 'Compiling //foo/bar/baz' with "
-              + "the 'local' strategy, but reversing the order would run it with 'sandboxed'. ")
+          """
+          Override which spawn strategy should be used to execute spawn actions that have
+          descriptions matching a certain `regex_filter`. See `--per_file_copt` for details on
+          `regex_filter` matching.
+
+          The last `regex_filter` that matches the description is used.
+
+          This option overrides other flags for specifying strategy. e.g.
+          - `--strategy_regexp=//foo.*\\.cc,-//foo/bar=local` means to run actions
+            using local strategy if their descriptions match //foo.*.cc but not //foo/bar.
+          - `--strategy_regexp=Compiling.*/bar=local --strategy_regexp=Compiling=sandboxed`
+            will run `Compiling //foo/bar/baz` with the `local` strategy, but reversing the order
+            would run it with the `sandboxed` strategy.
+          """)
   public abstract List<Map.Entry<RegexFilter, List<String>>> getStrategyByRegexp();
 
   @Option(
@@ -154,9 +168,11 @@ public abstract class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "Writes intermediate parameter files to output tree even when using remote action "
-              + "execution or caching. Useful when debugging actions. This is implied by "
-              + "--subcommands and --verbose_failures.")
+          """
+          Writes intermediate parameter files to output tree even when using remote action
+          execution or caching. Useful when debugging actions. This is implied by
+          `--subcommands` and `--verbose_failures`.
+          """)
   public abstract boolean getMaterializeParamFiles();
 
   @Option(
@@ -190,9 +206,12 @@ public abstract class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
       help =
-          "Display the subcommands executed during a build. Related flags:"
-              + " --execution_log_json_file, --execution_log_binary_file (for logging subcommands"
-              + " to a file in a tool-friendly format).")
+          """
+          Display the subcommands executed during a build.
+
+          Related flags: `--execution_log_json_file`, `--execution_log_binary_file` (for logging
+          subcommands to a file in a tool-friendly format).
+          """)
   public abstract ShowSubcommands getShowSubcommands();
 
   @Option(
@@ -201,10 +220,12 @@ public abstract class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
       help =
-          "When displaying subcommands (--subcommands) or printing the command line of a failed"
-              + " action (--verbose_failures), expand the contents of param files. When enabled,"
-              + " param file references like @path/to/param_file are replaced with the actual"
-              + " arguments they contain.")
+          """
+          When displaying subcommands (`--subcommands`) or printing the command line of a failed
+          action (`--verbose_failures`), expand the contents of param files. When enabled,
+          param file references like `@path/to/param_file` are replaced with the actual
+          arguments they contain.
+          """)
   public abstract boolean getExpandParamFiles();
 
   @Option(
@@ -225,10 +246,12 @@ public abstract class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.TESTING,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "Don't run tests, just check if they are up-to-date.  If all tests results are "
-              + "up-to-date, the testing completes successfully.  If any test needs to be built or "
-              + "executed, an error is reported and the testing fails.  This option implies "
-              + "--check_up_to_date behavior.")
+          """
+          Don't run tests, just check if they are up-to-date. If all tests results are
+          up-to-date, the testing completes successfully. If any test needs to be built or
+          executed, an error is reported and the testing fails. This option implies
+          `--check_up_to_date` behavior.
+          """)
   public abstract boolean getTestCheckUpToDate();
 
   @Option(
@@ -257,19 +280,25 @@ public abstract class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.TESTING,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "Each test will be retried up to the specified number of times in case of any test"
-              + " failure. Tests that required more than one attempt to pass are marked as 'FLAKY'"
-              + " in the test summary. Normally the value specified is just an integer or the"
-              + " string 'default'. If an integer, then all tests will be run up to N times. If"
-              + " 'default', then only a single test attempt will be made for regular tests and"
-              + " three for tests marked explicitly as flaky by their rule (flaky=1 attribute)."
-              + " Alternate syntax: regex_filter@flaky_test_attempts. Where flaky_test_attempts is"
-              + " as above and regex_filter stands for a list of include and exclude regular"
-              + " expression patterns (Also see --runs_per_test). Example:"
-              + " --flaky_test_attempts=//foo/.*,-//foo/bar/.*@3 deflakes all tests in //foo/"
-              + " except those under foo/bar three times. This option can be passed multiple"
-              + " times. The most recently passed argument that matches takes precedence. If"
-              + " nothing matches, behavior is as if 'default' above.")
+          """
+          Each test will be retried up to the specified number of times in case of any test
+          failure. Tests that required more than one attempt to pass are marked as 'FLAKY'
+          in the test summary.
+
+          Normally the value specified is just an integer or the string `default`.
+          - If an integer, then all tests will be run up to `N` times.
+          - If `default`, then only a single test attempt will be made for regular tests and
+            three for tests marked explicitly as flaky by their rule (`flaky=1` attribute).
+
+          Alternate syntax: `regex_filter@flaky_test_attempts`. Where `flaky_test_attempts` is
+          as above and `regex_filter` stands for a list of include and exclude regular
+          expression patterns (also see `--runs_per_test`).\\
+          Example: `--flaky_test_attempts=//foo/.*,-//foo/bar/.*@3` deflakes all tests in `//foo/`
+          except those under `//foo/bar` three times.
+
+          This option can be passed multiple times. The most recently passed argument that matches
+          takes precedence. If nothing matches, behavior is as if `default` above.
+          """)
   public abstract List<PerLabelOptions> getTestAttempts();
 
   @Option(
@@ -317,10 +346,12 @@ public abstract class ExecutionOptions extends OptionsBase {
         OptionEffectTag.EXECUTION
       },
       help =
-          "Specifies maximum per-test-log size that can be emitted when --test_output is 'errors' "
-              + "or 'all'. Useful for avoiding overwhelming the output with excessively noisy test "
-              + "output. The test header is included in the log size. Negative values imply no "
-              + "limit. Output is all or nothing.")
+          """
+          Specifies maximum per-test-log size that can be emitted when `--test_output` is `errors`
+          or `all`. Useful for avoiding overwhelming the output with excessively noisy test
+          output. The test header is included in the log size. Negative values imply no
+          limit. Output is all or nothing.
+          """)
   public abstract int getMaxTestOutputBytes();
 
   @Option(
@@ -354,19 +385,20 @@ public abstract class ExecutionOptions extends OptionsBase {
       allowMultiple = true,
       help =
           "Set the number of resources available to Bazel. "
-              + "Takes in an assignment to a float or "
+              + "Takes in an assignment to a float or `"
               + ResourceConverter.HOST_RAM_KEYWORD
-              + "/"
+              + "`/`"
               + ResourceConverter.HOST_CPUS_KEYWORD
-              + ", optionally "
-              + "followed by [-|*]<float> (eg. memory="
+              + "`, optionally followed by `[-|*]<float>` (eg. `memory="
               + ResourceConverter.HOST_RAM_KEYWORD
-              + "*.5 to use half the available RAM). "
-              + "Can be used multiple times to specify multiple "
-              + "types of resources. Bazel will limit concurrently running actions "
-              + "based on the available resources and the resources required. "
-              + "Tests can declare the amount of resources they need "
-              + "by using a tag of the \"resources:<resource name>:<amount>\" format. ",
+              + "*.5` to use half the available RAM). " +
+          """
+          Can be used multiple times to specify multiple types of resources. Bazel will limit
+          concurrently running actions based on the available resources and the resources required.
+
+          Tests can declare the amount of resources they need by using a tag of the
+          `resources:<resource name>:<amount>` format.
+          """,
       converter = ResourceConverter.AssignmentConverter.class)
   public abstract List<Map.Entry<String, Double>> getLocalResourcesFields();
 
@@ -385,10 +417,13 @@ public abstract class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "Enables the experimental local execution scheduling based on CPU load, not estimation of"
-              + " actions one by one.  Experimental scheduling have showed the large benefit on a"
-              + " large local builds on a powerful machines with the large number of cores."
-              + " Recommended to use with --local_resources=cpu=HOST_CPUS")
+          """
+          Enables the experimental local execution scheduling based on CPU load, not estimation of
+          actions one by one. Experimental scheduling have showed the large benefit on a
+          large local builds on a powerful machines with the large number of cores.
+
+          Recommended to use with `--local_resources=cpu=HOST_CPUS`.
+          """)
   public abstract boolean getExperimentalCpuLoadScheduling();
 
   @Option(
@@ -397,8 +432,10 @@ public abstract class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "The size of window during experimental scheduling of action based on CPU load. Make"
-              + " sense to define only when flag --experimental_cpu_load_scheduling is enabled.")
+          """
+          The size of window during experimental scheduling of action based on CPU load. Make
+          sense to define only when flag `--experimental_cpu_load_scheduling` is enabled.
+          """)
   public abstract Duration getExperimentalCpuLoadSchedulingWindowSize();
 
   @Option(
@@ -411,7 +448,7 @@ public abstract class ExecutionOptions extends OptionsBase {
               + "Takes "
               + ResourceConverter.FLAG_SYNTAX
               + ". 0 means local resources will limit the number of local test jobs to run "
-              + "concurrently instead. Setting this greater than the value for --jobs "
+              + "concurrently instead. Setting this greater than the value for `--jobs` "
               + "is ineffectual.",
       converter = LocalTestJobsConverter.class)
   public abstract int getLocalTestJobs();
@@ -455,62 +492,82 @@ public abstract class ExecutionOptions extends OptionsBase {
   @Option(
       name = "execution_log_binary_file",
       defaultValue = "null",
-      category = "verbosity",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.UNKNOWN},
       converter = ExecutionLogFileConverter.class,
       help =
-          "Log the executed spawns into this file as length-delimited SpawnExec protos, according"
-              + " to src/main/protobuf/spawn.proto. Prefer --execution_log_compact_file, which is"
-              + " significantly smaller and cheaper to produce. The flag accepts boolean and string"
-              + " values. If string, it represents a local path. If true, then"
-              + " --experimental_stream_log_file_uploads must be set, whereby it will stream the"
-              + " execution log to remote storage. If false, then logging to the execution log is"
-              + " disabled. Related flags: --execution_log_compact_file (compact format; mutually"
-              + " exclusive), --execution_log_json_file (text JSON format; mutually exclusive),"
-              + " --execution_log_sort (whether to sort the execution log), --subcommands (for"
-              + " displaying subcommands in terminal output).")
+          """
+          Log the executed spawns into this file as length-delimited `SpawnExec` protos, according
+          to [`src/main/protobuf/spawn.proto`]. Prefer `--execution_log_compact_file`, which is
+          significantly smaller and cheaper to produce.
+
+          The flag accepts boolean and string values. If string, it represents a local path. If
+          `true`, then `--experimental_stream_log_file_uploads` must be set, whereby it will stream
+          the execution log to remote storage. If `false`, then logging to the execution log is
+          disabled.
+
+          Related flags:
+          - `--execution_log_compact_file` (compact format; mutually exclusive)
+          - `--execution_log_json_file` (text JSON format; mutually exclusive)
+          - `--execution_log_sort` (whether to sort the execution log)
+          - `--subcommands` (for displaying subcommands in terminal output)
+
+          [`src/main/protobuf/spawn.proto`]: https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/spawn.proto
+          """)
   public abstract PathFragment getExecutionLogBinaryFile();
 
   @Option(
       name = "execution_log_json_file",
       defaultValue = "null",
-      category = "verbosity",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.UNKNOWN},
       converter = ExecutionLogFileConverter.class,
       help =
-          "Log the executed spawns into this file as newline-delimited JSON representations of"
-              + " SpawnExec protos, according to src/main/protobuf/spawn.proto. Prefer"
-              + " --execution_log_compact_file, which is significantly smaller and cheaper to"
-              + " produce. The flag accepts boolean and string values. If string, it represents a"
-              + " local path. If true, then --experimental_stream_log_file_uploads must be set,"
-              + " whereby it will stream the execution log to remote storage. If false, then"
-              + " logging to the execution log is disabled. Related flags:"
-              + " --execution_log_compact_file (compact format; mutually exclusive),"
-              + " --execution_log_binary_file (binary protobuf format; mutually exclusive),"
-              + " --execution_log_sort (whether to sort the execution log),"
-              + " --subcommands (for displaying subcommands in terminal output).")
+          """
+          Log the executed spawns into this file as newline-delimited JSON representations of
+          `SpawnExec` protos, according to [`src/main/protobuf/spawn.proto`]. Prefer
+          `--execution_log_compact_file`, which is significantly smaller and cheaper to
+          produce.
+
+          The flag accepts boolean and string values. If string, it represents a local path. If
+          `true`, then `--experimental_stream_log_file_uploads` must be set, whereby it will stream
+          the execution log to remote storage. If `false`, then logging to the execution log is
+          disabled.
+
+          Related flags:
+          - `--execution_log_compact_file` (compact format; mutually exclusive)
+          - `--execution_log_binary_file` (binary protobuf format; mutually exclusive)
+          - `--execution_log_sort` (whether to sort the execution log)
+          - `--subcommands` (for displaying subcommands in terminal output)
+
+          [`src/main/protobuf/spawn.proto`]: https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/spawn.proto
+          """)
   public abstract PathFragment getExecutionLogJsonFile();
 
   @Option(
       name = "execution_log_compact_file",
       oldName = "experimental_execution_log_compact_file",
       defaultValue = "null",
-      category = "verbosity",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.UNKNOWN},
       converter = ExecutionLogFileConverter.class,
       help =
-          "Log the executed spawns into this file as length-delimited ExecLogEntry protos,"
-              + " according to src/main/protobuf/spawn.proto. The entire file is zstd compressed."
-              + " The flag accepts boolean and string values. If string, it represents a local"
-              + " path. If true, then --experimental_stream_log_file_uploads must be set, whereby"
-              + " it will stream the execution log to remote storage. If false, then logging to the"
-              + " execution log is disabled. Related flags: --execution_log_binary_file (binary"
-              + " protobuf format; mutually exclusive), --execution_log_json_file (text JSON"
-              + " format; mutually exclusive), --subcommands (for displaying subcommands in"
-              + " terminal output).")
+          """
+          Log the executed spawns into this file as length-delimited `ExecLogEntry` protos,
+          according to [`src/main/protobuf/spawn.proto`]. The entire file is zstd compressed.
+
+          The flag accepts boolean and string values. If string, it represents a local path. If
+          `true`, then `--experimental_stream_log_file_uploads` must be set, whereby it will stream
+          the execution log to remote storage. If `false`, then logging to the execution log is
+          disabled.
+
+          Related flags:
+          - `--execution_log_binary_file` (binary protobuf format; mutually exclusive)
+          - `--execution_log_json_file` (text JSON format; mutually exclusive)
+          - `--subcommands` (for displaying subcommands in terminal output)
+
+          [`src/main/protobuf/spawn.proto`]: https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/spawn.proto
+          """)
   public abstract PathFragment getExecutionLogCompactFile();
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/exec/local/LocalExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/LocalExecutionOptions.java
@@ -71,9 +71,11 @@ public abstract class LocalExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "When true, make the process-wrapper propagate SIGTERMs (used by the dynamic scheduler "
-              + "to stop process trees) to the subprocesses themselves, giving them the grace "
-              + "period in --local_termination_grace_seconds before forcibly sending a SIGKILL.")
+          """
+          When true, make the process-wrapper propagate `SIGTERM`s (used by the dynamic scheduler
+          to stop process trees) to the subprocesses themselves, giving them the grace
+          period in `--local_termination_grace_seconds` before forcibly sending a `SIGKILL`.
+          """)
   public abstract boolean getProcessWrapperGracefulSigterm();
 
   public abstract void setProcessWrapperGracefulSigterm(boolean value);
@@ -84,11 +86,13 @@ public abstract class LocalExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "Number of times to retry a local action when we detect that it crashed. This exists "
-              + "to workaround a bug in OSXFUSE which is tickled by the use of the dynamic "
-              + "scheduler and --experimental_local_lockfree_output due to constant process "
-              + "churn. The bug can be triggered by a cancelled process that ran *before* the "
-              + "process we are trying to run, introducing corruption in its file reads.")
+          """
+          Number of times to retry a local action when we detect that it crashed. This exists
+          to workaround a bug in OSXFUSE which is tickled by the use of the dynamic
+          scheduler and `--experimental_local_lockfree_output` due to constant process
+          churn. The bug can be triggered by a cancelled process that ran *before* the
+          process we are trying to run, introducing corruption in its file reads.
+          """)
   public abstract int getLocalRetriesOnCrash();
 
   public abstract void setLocalRetriesOnCrash(int value);

--- a/src/main/java/com/google/devtools/build/lib/includescanning/IncludeScanningOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/IncludeScanningOptions.java
@@ -45,8 +45,10 @@ public abstract class IncludeScanningOptions extends OptionsBase {
       },
       defaultValue = "false",
       help =
-          "If enabled, searching for '#include' lines in generated header files will not "
-              + "touch local disk. This makes include scanning of C++ files less disk-intensive.")
+          """
+          If enabled, searching for `#include` lines in generated header files will not
+          touch local disk. This makes include scanning of C++ files less disk-intensive.
+          """)
   public abstract boolean getInMemoryIncludesFiles();
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/metrics/MetricsModule.java
+++ b/src/main/java/com/google/devtools/build/lib/metrics/MetricsModule.java
@@ -38,12 +38,14 @@ public class MetricsModule extends BlazeModule {
         documentationCategory = OptionDocumentationCategory.LOGGING,
         effectTags = {OptionEffectTag.UNKNOWN},
         help =
-            "Controls the output of BEP ActionSummary and BuildGraphMetrics, limiting the number of"
-                + " mnemonics in ActionData and number of entries reported in"
-                + " BuildGraphMetrics.AspectCount/RuleClassCount. By default the number of types is"
-                + " limited to the top 20, by number of executed actions for ActionData, and"
-                + " instances for RuleClass and Asepcts. Setting this option will write statistics"
-                + " for all mnemonics, rule classes and aspects.")
+            """
+            Controls the output of BEP `ActionSummary` and `BuildGraphMetrics`, limiting the
+            number of mnemonics in `ActionData` and number of entries reported in
+            `BuildGraphMetrics.AspectCount/RuleClassCount`. By default the number of types is
+            limited to the top 20, by number of executed actions for `ActionData`, and
+            instances for `RuleClass` and `Aspect`. Setting this option will write statistics
+            for all mnemonics, rule classes and aspects.
+            """)
     public abstract boolean getRecordMetricsForAllMnemonics();
 
     @Option(
@@ -52,10 +54,12 @@ public class MetricsModule extends BlazeModule {
         documentationCategory = OptionDocumentationCategory.LOGGING,
         effectTags = {OptionEffectTag.UNKNOWN},
         help =
-            "Controls the output of BEP BuildGraphMetrics, including expensive "
-                + "to compute skyframe metrics about Skykeys, RuleClasses and Aspects. "
-                + "With this flag set to false BuildGraphMetrics.rule_count and aspect "
-                + "fields will not be populated in the BEP.")
+            """
+            Controls the output of BEP `BuildGraphMetrics`, including expensive
+            to compute skyframe metrics about `Skykey`s, `RuleClass`es and `Aspect`s.
+            With this flag set to `false` `BuildGraphMetrics.rule_count` and `aspect`
+            fields will not be populated in the BEP.
+            """)
     public abstract boolean getRecordSkyframeMetrics();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/metrics/PostGCMemoryUseRecorder.java
+++ b/src/main/java/com/google/devtools/build/lib/metrics/PostGCMemoryUseRecorder.java
@@ -329,8 +329,10 @@ public final class PostGCMemoryUseRecorder implements NotificationListener {
           documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
           effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
           help =
-              "If true calls System.gc() after a build to try and get a post-gc peak heap"
-                  + " measurement.")
+              """
+              If true calls `System.gc()` after a build to try and get a post-gc peak heap
+              measurement.
+              """)
       public abstract boolean getExperimentalForceGcAfterBuild();
     }
 

--- a/src/main/java/com/google/devtools/build/lib/outputfilter/OutputFilteringModule.java
+++ b/src/main/java/com/google/devtools/build/lib/outputfilter/OutputFilteringModule.java
@@ -40,16 +40,21 @@ public final class OutputFilteringModule extends BlazeModule {
         name = "auto_output_filter",
         converter = AutoOutputFilter.Converter.class,
         defaultValue = "none",
-        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        documentationCategory = OptionDocumentationCategory.LOGGING,
         effectTags = {OptionEffectTag.UNKNOWN},
         help =
-            "If --output_filter is not specified, then the value for this option is used "
-                + "create a filter automatically. Allowed values are 'none' (filter nothing "
-                + "/ show everything), 'all' (filter everything / show nothing), 'packages' "
-                + "(include output from rules in packages mentioned on the Blaze command line), "
-                + "and 'subpackages' (like 'packages', but also include subpackages). For the "
-                + "'packages' and 'subpackages' values //java/foo and //javatests/foo are treated "
-                + "as one package)'.")
+            """
+            If `--output_filter` is not specified, then the value for this option is used
+            create a filter automatically. Allowed values are;
+            - `none` (filter nothing / show everything),
+            - `all` (filter everything / show nothing),
+            - `packages` (include output from rules in packages mentioned on the Blaze command
+              line) and
+            - `subpackages` (like `packages`, but also include subpackages).
+
+            For the `packages` and `subpackages` values `//java/foo` and `//javatests/foo` are
+            treated as one package.
+            """)
     public abstract AutoOutputFilter getAutoOutputFilter();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/packages/metrics/PackageMetricsModule.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/metrics/PackageMetricsModule.java
@@ -38,7 +38,7 @@ public class PackageMetricsModule extends BlazeModule {
         defaultValue = "10",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
         effectTags = {OptionEffectTag.BAZEL_MONITORING},
-        help = "Configures number of packages included in top-package INFO logging, <= 0 disables.")
+        help = "Configures number of packages included in top-package `INFO` logging, <= 0 disables.")
     public abstract int getNumberOfPackagesToTrack();
 
     @Option(
@@ -47,8 +47,8 @@ public class PackageMetricsModule extends BlazeModule {
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
         effectTags = {OptionEffectTag.BAZEL_MONITORING},
         help =
-            "Configures PackageMetrics to record all metrics for all packages. Disables Top-n INFO"
-                + " logging.")
+            "Configures `PackageMetrics` to record all metrics for all packages. Disables"
+                + " Top-`n` `INFO` logging.")
     public abstract boolean getEnableAllMetrics();
 
     @Option(


### PR DESCRIPTION
A mass update to CLI documentation consisting of;

- Adding code spans (mostly this).
- Fixing links (rewriting to use MD link syntax, adding link names, using link references to shift URLs to end of text blocks to improve readability for authors and reviewers.
- Adding links to source for references to source (e.g. `src/main/protobuf/spawn.proto`).
- Adding lists.

Some option documentation will need a follow up (e.g. `local_test_jobs` which contains unescaped MD syntax via `ResourceConverter.FLAG_SYNTAX`).

Touched documentation has been rewritten to use Java text blocks (where possible and if spanning multiple lines).

The following flags have further changes;
- `execution_log_binary_file`, `execution_log_json_file` and `execution_log_compact_file`;
  - Removed deprecated annotation field `category`.
  - `OptionDocumentationCategory.LOGGING` added.
- `auto_output_filter`
  - `OptionDocumentationCategory.LOGGING` added, replacing `OptionDocumentationCategory.UNCATEGORIZED`.

This is a follow up to #26432 (MD support) and #26588 (chunk 1).