### PR TITLE
Use builtin HTML escaper in markdown renderer

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/util/Markdown.java
+++ b/src/main/java/com/google/devtools/build/lib/util/Markdown.java
@@ -20,7 +20,7 @@ import org.commonmark.renderer.html.HtmlRenderer;
 /** Helpers for markdown. */
 public class Markdown {
   private static final Parser PARSER = Parser.builder().build();
-  private static final HtmlRenderer HTML_RENDERER = HtmlRenderer.builder().build();
+  private static final HtmlRenderer HTML_RENDERER = HtmlRenderer.builder().escapeHtml(true).build();
 
   /** Parses a string as markdown and renders it as HTML. */
   public static String renderToHtml(String md) {

--- a/src/main/java/com/google/devtools/common/options/HtmlUtils.java
+++ b/src/main/java/com/google/devtools/common/options/HtmlUtils.java
@@ -150,7 +150,7 @@ public class HtmlUtils {
     usage.append("</dt>\n");
     usage.append("<dd>\n");
     if (!optionDefinition.getHelpText().isEmpty()) {
-      usage.append(Markdown.renderToHtml(escaper.escape(optionDefinition.getHelpText())));
+      usage.append(Markdown.renderToHtml(optionDefinition.getHelpText()));
       usage.append('\n');
     }
 

--- a/src/test/java/com/google/devtools/common/options/OptionsUsageTest.java
+++ b/src/test/java/com/google/devtools/common/options/OptionsUsageTest.java
@@ -619,6 +619,8 @@ public final class OptionsUsageTest {
                \s
                 paragraph 2
                \s
+                `<HTML> "syntax" 'within' &codeblocks&`
+               \s
                 [ref]: /url (title)
                 [shorthand reference link]: /url (title)
                 [`complex` shorthand reference link]: /url (title)
@@ -655,6 +657,7 @@ public final class OptionsUsageTest {
             </ol>
             <p>paragraph 1</p>
             <p>paragraph 2</p>
+            <p><code>&lt;HTML&gt; &quot;syntax&quot; 'within' &amp;codeblocks&amp;</code></p>
             </dd>
             """);
   }

--- a/src/test/java/com/google/devtools/common/options/TestOptions.java
+++ b/src/test/java/com/google/devtools/common/options/TestOptions.java
@@ -276,6 +276,8 @@ public class TestOptions extends OptionsBase {
 
           paragraph 2
 
+          `<HTML> "syntax" 'within' &codeblocks&` 
+
           [ref]: /url (title)
           [shorthand reference link]: /url (title)
           [`complex` shorthand reference link]: /url (title)


### PR DESCRIPTION
Address double-escape issues within Markdown codeblocks containing `<>"'&`.