### PR TITLE
Improve `bazel mod show_extension` display for use_repo_rule

### DIFF
--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -109,6 +109,8 @@ class ModCommandTest(test_base.TestBase):
             'my_ext2 = use_extension("@ext2//:ext.bzl", "ext")',
             'my_ext2.dep(name="repo3")',
             'use_repo(my_ext2, my_repo2="repo3")',
+            'http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")',
+            'http_file(name="file", url="https://example.com/", integrity="sha256-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN/20=")',
         ],
     )
 
@@ -181,6 +183,8 @@ class ModCommandTest(test_base.TestBase):
             '|   |   |___repo1',
             '|   |___ext@1.0 (*)',
             '|   |___bar@2.0',
+            '|       |___$@@bar+//:MODULE.bazel%@bazel_tools//tools/build_defs/repo:http.bzl http_file',
+            '|       |   |___file',
             '|       |___$@@ext+//:ext.bzl%ext ...',
             '|       |   |___repo3',
             '|       |___$@@ext2+//:ext.bzl%ext ...',
@@ -266,6 +270,8 @@ class ModCommandTest(test_base.TestBase):
             '|   |   |___repo1',
             '|   |___ext@1.0 (*)',
             '|   |___bar@2.0',
+            '|       |___$@@bar+//:MODULE.bazel%@bazel_tools//tools/build_defs/repo:http.bzl http_file',
+            '|       |   |___file',
             '|       |___$@@ext+//:ext.bzl%ext ...',
             '|       |   |___repo3',
             '|       |___$@@ext2+//:ext.bzl%ext ...',
@@ -438,6 +444,33 @@ class ModCommandTest(test_base.TestBase):
     self.assertIn(
         'No extension @@ext+//foo:unknown.bzl%x exists in the dependency graph',
         '\n'.join(stderr),
+    )
+
+  def testShowExtensionUseRepoRule(self):
+    _, stdout, _ = self.RunBazel(
+        [
+            'mod',
+            'show_extension',
+            '@@bar+//:MODULE.bazel%@bazel_tools//tools/build_defs/repo:http.bzl http_file',
+        ],
+        rstrip=True,
+    )
+    self.assertRegex(
+        stdout.pop(5), r'^## Usage in bar@2\.0 from .*MODULE\.bazel:15$',
+    )
+    self.assertListEqual(
+        stdout,
+        [
+            '## @@bar+//:MODULE.bazel%@bazel_tools//tools/build_defs/repo:http.bzl http_file:',
+            '',
+            'Fetched repositories:',
+            '  - file (imported by bar@2.0)',
+            '',
+            # pop(5)
+            'http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")',
+            'http_file(name="file", integrity="sha256-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN/20=", url="https://example.com/")',
+            '',
+        ],
     )
 
   def testShowModuleAndExtensionReposFromBaseModule(self):


### PR DESCRIPTION
Before:
```starlark
## Usage in rules_jvm_external@6.6 from https://bcr.bazel.build/modules/rules_jvm_external/6.6/MODULE.bazel:118
@bazel_tools//tools/build_defs/repo:http.bzl http_file.repo(sha256="2b78bfdd3ef13fd1f42f158de0f029d7cbb1f4f652d51773445cf2b6f7918a87", urls=["https://github.com/coursier/coursier/releases/download/v2.1.8/coursier.jar"], name="coursier_cli")
@bazel_tools//tools/build_defs/repo:http.bzl http_file.repo(sha256="c22a44eee37b8927167ee6ee67573303f4e31171e7ec3a8ea021a6a660040437", urls=["https://github.com/bazelbuild/buildtools/releases/download/v7.1.2/buildifier-linux-arm64"], name="buildifier-linux-arm64")
@bazel_tools//tools/build_defs/repo:http.bzl http_file.repo(sha256="28285fe7e39ed23dc1a3a525dfcdccbc96c0034ff1d4277905d2672a71b38f13", urls=["https://github.com/bazelbuild/buildtools/releases/download/v7.1.2/buildifier-linux-amd64"], name="buildifier-linux-x86_64")
...
use_repo(
  @bazel_tools//tools/build_defs/repo:http.bzl http_file,
  "coursier_cli",
  "buildifier-linux-arm64",
  "buildifier-linux-x86_64"
  ...
)
```

After:
```starlark
## Usage in rules_jvm_external@6.6 from https://bcr.bazel.build/modules/rules_jvm_external/6.6/MODULE.bazel:118
http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
http_file(name="coursier_cli", sha256="2b78bfdd3ef13fd1f42f158de0f029d7cbb1f4f652d51773445cf2b6f7918a87", urls=["https://github.com/coursier/coursier/releases/download/v2.1.8/coursier.jar"])
http_file(name="buildifier-linux-arm64", sha256="c22a44eee37b8927167ee6ee67573303f4e31171e7ec3a8ea021a6a660040437", urls=["https://github.com/bazelbuild/buildtools/releases/download/v7.1.2/buildifier-linux-arm64"])
...
```

Fixes #27243.