### PR TITLE
[7.7.0] Show a dep chain if a module isn't found

### DIFF
--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -494,8 +494,9 @@ class BazelOverridesTest(test_base.TestBase):
         allow_failure=True,
     )
     self.assertIn(
-        'ERROR: Error computing the main repository mapping: module ss@1.0 not'
-        ' found in registries:',
+        'ERROR: Error computing the main repository mapping: in module'
+        ' dependency chain <root> -> ss@1.0: module ss@1.0 not found in'
+        ' registries:',
         stderr,
     )
 


### PR DESCRIPTION
Otherwise it's difficult to track down where an unmet requirement comes from (say, an override).

Closes #27215.

PiperOrigin-RevId: 818468904
Change-Id: I352b350bd2c8665b8bcfdd52a099312c8d91e0a9

Commit https://github.com/bazelbuild/bazel/commit/450a6fa4f65ea0c086078f5349aeebc2e8825b25