### PR TITLE
[8.5.0] Show a dep chain if a module isn't found

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
@@ -16,6 +16,7 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Sets.immutableEnumSet;
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.collect.ImmutableMap;
@@ -203,6 +204,11 @@ final class Discovery {
       return nextHorizon.build();
     }
 
+    private static final ImmutableSet<FailureDetails.ExternalDeps.Code> SHOW_DEP_CHAIN =
+        immutableEnumSet(
+            FailureDetails.ExternalDeps.Code.BAD_MODULE,
+            FailureDetails.ExternalDeps.Code.MODULE_NOT_FOUND);
+
     /**
      * When an exception occurs while discovering a new dep, try to add information about the
      * dependency chain that led to that dep.
@@ -210,11 +216,10 @@ final class Discovery {
     private ExternalDepsException maybeReportDependencyChain(
         ExternalDepsException e, ModuleKey depKey) {
       if (e.getDetailedExitCode().getFailureDetail() == null
-          || e.getDetailedExitCode().getFailureDetail().getExternalDeps().getCode()
-              != FailureDetails.ExternalDeps.Code.BAD_MODULE) {
-        // This is not due to a bad module, so don't print a dependency chain. This covers cases
-        // such as a parse error in the lockfile or an I/O exception during registry access,
-        // which aren't related to any particular module dep.
+          || !SHOW_DEP_CHAIN.contains(
+              e.getDetailedExitCode().getFailureDetail().getExternalDeps().getCode())) {
+        // This covers cases such as a parse error in the lockfile or an I/O exception during
+        // registry access, which aren't related to any particular module dep.
         return e;
       }
       // Trace back a dependency chain to the root module. There can be multiple paths to the

--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -495,8 +495,9 @@ class BazelOverridesTest(test_base.TestBase):
         allow_failure=True,
     )
     self.assertIn(
-        'ERROR: Error computing the main repository mapping: module ss@1.0 not'
-        ' found in registries:',
+        'ERROR: Error computing the main repository mapping: in module'
+        ' dependency chain <root> -> ss@1.0: module ss@1.0 not found in'
+        ' registries:',
         stderr,
     )
 


### PR DESCRIPTION
Otherwise it's difficult to track down where an unmet requirement comes from (say, an override).

Closes #27215.

PiperOrigin-RevId: 818468904
Change-Id: I352b350bd2c8665b8bcfdd52a099312c8d91e0a9

Commit https://github.com/bazelbuild/bazel/commit/450a6fa4f65ea0c086078f5349aeebc2e8825b25