### PR TITLE
[8.5.0] Avoid action key change with `expand_directories=False` and no manual expansion

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
@@ -549,7 +549,13 @@ public class StarlarkCustomCommandLine extends CommandLine {
           // fingerprinting stringificationType here.
           CommandLineItemMapEachAdaptor commandLineItemMapFn =
               new CommandLineItemMapEachAdaptor(
-                  mapEach, location, starlarkSemantics, artifactExpander, outputPathsMode);
+                  mapEach,
+                  location,
+                  starlarkSemantics,
+                  (features & EXPAND_DIRECTORIES) != 0 || wantsDirectoryExpander(mapEach)
+                      ? artifactExpander
+                      : null,
+                  outputPathsMode);
           try {
             actionKeyContext.addNestedSetToFingerprint(commandLineItemMapFn, fingerprint, values);
           } finally {
@@ -1117,14 +1123,11 @@ public class StarlarkCustomCommandLine extends CommandLine {
       // TODO(b/77140311): Error if we issue print statements.
       thread.setPrintHandler((th, msg) -> {});
       int count = originalValues.size();
-      // map_each can accept either each object, or each object + a directory expander.
-      boolean wantsDirectoryExpander =
-          mapFn instanceof StarlarkFunction starlarkFunction
-              && starlarkFunction.getParameterNames().size() >= 2;
       // We create a list that we reuse for the args to map_each
       List<Object> args = new ArrayList<>(2);
       args.add(null); // This will be overwritten each iteration.
-      if (wantsDirectoryExpander) {
+      // map_each can accept either each object, or each object + a directory expander.
+      if (wantsDirectoryExpander(mapFn)) {
         DirectoryExpander expander;
         if (artifactExpander != null) {
           expander = new FullExpander(artifactExpander);
@@ -1161,6 +1164,11 @@ public class StarlarkCustomCommandLine extends CommandLine {
       throw new CommandLineExpansionException(
           errorMessage(e.getMessageWithStack(), loc, e.getCause()));
     }
+  }
+
+  private static boolean wantsDirectoryExpander(StarlarkCallable mapFn) {
+    return mapFn instanceof StarlarkFunction starlarkFunction
+        && starlarkFunction.getParameterNames().size() >= 2;
   }
 
   private static class CommandLineItemMapEachAdaptor


### PR DESCRIPTION
Since 2a3191b8f4a80e20566a6204281521887c08f19a, the action key was sensitive to changes of the expansion of a tree artifact even if expansion is disabled and the custom map_each callback cannot perform manual expansion.

Work towards https://github.com/aspect-build/rules_js/issues/2379

Closes #27163.

PiperOrigin-RevId: 816229224
Change-Id: If56a9d54e52556e8bef4cabc5c6be3b2c8e150d9 
(cherry picked from commit 5b68c32bceec9f1c510870310a6edf391b22c0d2)