### PR TITLE
[8.5.0] Improve action key computation for command lines with `Label`s

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
@@ -514,7 +514,8 @@ public class StarlarkCustomCommandLine extends CommandLine {
         ActionKeyContext actionKeyContext,
         Fingerprint fingerprint,
         @Nullable ArtifactExpander artifactExpander,
-        CoreOptions.OutputPathsMode outputPathsMode)
+        CoreOptions.OutputPathsMode outputPathsMode,
+        RepositoryMapping mainRepoMapping)
         throws CommandLineExpansionException, InterruptedException {
       StarlarkCallable mapEach = null;
       Location location = null;
@@ -565,6 +566,10 @@ public class StarlarkCustomCommandLine extends CommandLine {
           }
         } else {
           fingerprint.addInt(stringificationType.ordinal());
+          if (stringificationType == StringificationType.LABEL) {
+            fingerprint.addStringMap(
+                Maps.transformValues(mainRepoMapping.entries(), RepositoryName::getName));
+          }
           actionKeyContext.addNestedSetToFingerprint(fingerprint, values);
         }
       } else {
@@ -592,7 +597,7 @@ public class StarlarkCustomCommandLine extends CommandLine {
               starlarkSemantics);
         } else {
           for (Object value : maybeExpandedValues) {
-            addSingleObjectToFingerprint(fingerprint, value);
+            addSingleObjectToFingerprint(fingerprint, value, mainRepoMapping);
           }
         }
       }
@@ -816,9 +821,13 @@ public class StarlarkCustomCommandLine extends CommandLine {
       return argi;
     }
 
-    static int addToFingerprint(List<Object> arguments, int argi, Fingerprint fingerprint) {
+    static int addToFingerprint(
+        List<Object> arguments,
+        int argi,
+        Fingerprint fingerprint,
+        @Nullable RepositoryMapping mainRepoMapping) {
       Object object = arguments.get(argi++);
-      addSingleObjectToFingerprint(fingerprint, object);
+      addSingleObjectToFingerprint(fingerprint, object, mainRepoMapping);
       String formatStr = (String) arguments.get(argi++);
       fingerprint.addString(formatStr);
       fingerprint.addUUID(SINGLE_FORMATTED_ARG_UUID);
@@ -950,7 +959,7 @@ public class StarlarkCustomCommandLine extends CommandLine {
   private static Object /* String | DerivedArtifact */ expandToCommandLine(
       Object object, @Nullable RepositoryMapping mainRepoMapping) {
     // Label arguments are rare, so we don't bother rendering them lazily.
-    if (mainRepoMapping != null && object instanceof Label label) {
+    if (object instanceof Label label) {
       return label.getDisplayForm(mainRepoMapping);
     }
 
@@ -960,13 +969,14 @@ public class StarlarkCustomCommandLine extends CommandLine {
         : CommandLineItem.expandToCommandLine(object);
   }
 
-  private static void addSingleObjectToFingerprint(Fingerprint fingerprint, Object object) {
+  private static void addSingleObjectToFingerprint(
+      Fingerprint fingerprint, Object object, @Nullable RepositoryMapping mainRepoMapping) {
+    if (object instanceof Label label) {
+      fingerprint.addString(label.getDisplayForm(mainRepoMapping));
+      return;
+    }
     StringificationType stringificationType =
-        switch (object) {
-          case FileApi ignored -> StringificationType.FILE;
-          case Label ignored -> StringificationType.LABEL;
-          default -> StringificationType.DEFAULT;
-        };
+        object instanceof FileApi ? StringificationType.FILE : StringificationType.DEFAULT;
     fingerprint.addInt(stringificationType.ordinal());
     fingerprint.addString(CommandLineItem.expandToCommandLine(object));
   }
@@ -1038,11 +1048,12 @@ public class StarlarkCustomCommandLine extends CommandLine {
       throws CommandLineExpansionException, InterruptedException {
     List<Object> arguments = rawArgsAsList();
     int size;
-    if (arguments.getLast() instanceof RepositoryMapping mainRepoMapping) {
-      fingerprint.addStringMap(
-          Maps.transformValues(mainRepoMapping.entries(), RepositoryName::getName));
+    RepositoryMapping mainRepoMapping;
+    if (arguments.getLast() instanceof RepositoryMapping mapping) {
+      mainRepoMapping = mapping;
       size = arguments.size() - 1;
     } else {
+      mainRepoMapping = null;
       size = arguments.size();
     }
     for (int argi = 0; argi < size; ) {
@@ -1056,11 +1067,12 @@ public class StarlarkCustomCommandLine extends CommandLine {
                     actionKeyContext,
                     fingerprint,
                     artifactExpander,
-                    effectiveOutputPathsMode);
+                    effectiveOutputPathsMode,
+                    mainRepoMapping);
       } else if (arg == SingleFormattedArg.MARKER) {
-        argi = SingleFormattedArg.addToFingerprint(arguments, argi, fingerprint);
+        argi = SingleFormattedArg.addToFingerprint(arguments, argi, fingerprint, mainRepoMapping);
       } else {
-        addSingleObjectToFingerprint(fingerprint, arg);
+        addSingleObjectToFingerprint(fingerprint, arg, mainRepoMapping);
       }
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
@@ -3567,6 +3567,151 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
   }
 
   @Test
+  public void starlarkCustomCommandLineKeyComputation_singleLabel_repoMappingChanges_relevant()
+      throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+
+    var mainRepoMapping1 =
+        RepositoryMapping.create(
+            ImmutableMap.of("apparent1", RepositoryName.createUnvalidated("canonical+")),
+            RepositoryName.MAIN);
+    var mainRepoMapping2 =
+        RepositoryMapping.create(
+            ImmutableMap.of("apparent2", RepositoryName.createUnvalidated("canonical+")),
+            RepositoryName.MAIN);
+    var args =
+        """
+        args = ruleContext.actions.args()
+        args.add(Label("@@canonical+//foo:bar"))
+        """;
+    var commandLine1 = getCommandLine(mainRepoMapping1, args);
+    var commandLine2 = getCommandLine(mainRepoMapping2, args);
+
+    assertThat(ImmutableList.copyOf(commandLine1.arguments()))
+        .isNotEqualTo(ImmutableList.copyOf(commandLine2.arguments()));
+    assertThat(getDigest(commandLine1)).isNotEqualTo(getDigest(commandLine2));
+  }
+
+  @Test
+  public void starlarkCustomCommandLineKeyComputation_singleLabel_repoMappingChanges_notRelevant()
+      throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+
+    var mainRepoMapping1 =
+        RepositoryMapping.create(
+            ImmutableMap.of(
+                "apparent", RepositoryName.createUnvalidated("canonical+"),
+                "other_repo1", RepositoryName.createUnvalidated("other_repo+")),
+            RepositoryName.MAIN);
+    var mainRepoMapping2 =
+        RepositoryMapping.create(
+            ImmutableMap.of(
+                "apparent", RepositoryName.createUnvalidated("canonical+"),
+                "other_repo2", RepositoryName.createUnvalidated("other_repo+")),
+            RepositoryName.MAIN);
+    var args =
+        """
+        args = ruleContext.actions.args()
+        args.add(Label("@@canonical+//foo:bar"))
+        """;
+    var commandLine1 = getCommandLine(mainRepoMapping1, args);
+    var commandLine2 = getCommandLine(mainRepoMapping2, args);
+
+    assertThat(commandLine1.arguments())
+        .containsExactlyElementsIn(commandLine2.arguments())
+        .inOrder();
+    assertThat(getDigest(commandLine1)).isEqualTo(getDigest(commandLine2));
+  }
+
+  @Test
+  public void starlarkCustomCommandLineKeyComputation_listOfLabels_repoMappingChanges_relevant()
+      throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+
+    var mainRepoMapping1 =
+        RepositoryMapping.create(
+            ImmutableMap.of("apparent1", RepositoryName.createUnvalidated("canonical+")),
+            RepositoryName.MAIN);
+    var mainRepoMapping2 =
+        RepositoryMapping.create(
+            ImmutableMap.of("apparent2", RepositoryName.createUnvalidated("canonical+")),
+            RepositoryName.MAIN);
+    var args =
+        """
+        args = ruleContext.actions.args()
+        args.add_all([Label("@@canonical+//foo:bar"), Label("@@canonical+//foo:baz")])
+        """;
+    var commandLine1 = getCommandLine(mainRepoMapping1, args);
+    var commandLine2 = getCommandLine(mainRepoMapping2, args);
+
+    assertThat(ImmutableList.copyOf(commandLine1.arguments()))
+        .isNotEqualTo(ImmutableList.copyOf(commandLine2.arguments()));
+    assertThat(getDigest(commandLine1)).isNotEqualTo(getDigest(commandLine2));
+  }
+
+  @Test
+  public void starlarkCustomCommandLineKeyComputation_listOfLabels_repoMappingChanges_notRelevant()
+      throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+
+    var mainRepoMapping1 =
+        RepositoryMapping.create(
+            ImmutableMap.of(
+                "apparent",
+                RepositoryName.createUnvalidated("canonical+"),
+                "other_repo1",
+                RepositoryName.createUnvalidated("other_repo+")),
+            RepositoryName.MAIN);
+    var mainRepoMapping2 =
+        RepositoryMapping.create(
+            ImmutableMap.of(
+                "apparent",
+                RepositoryName.createUnvalidated("canonical+"),
+                "other_repo2",
+                RepositoryName.createUnvalidated("other_repo+")),
+            RepositoryName.MAIN);
+    var args =
+        """
+        args = ruleContext.actions.args()
+        args.add_all([Label("@@canonical+//foo:bar"), Label("@@canonical+//foo:baz")])
+        """;
+    var commandLine1 = getCommandLine(mainRepoMapping1, args);
+    var commandLine2 = getCommandLine(mainRepoMapping2, args);
+
+    assertThat(commandLine1.arguments())
+        .containsExactlyElementsIn(commandLine2.arguments())
+        .inOrder();
+    assertThat(getDigest(commandLine1)).isEqualTo(getDigest(commandLine2));
+  }
+
+  @Test
+  public void
+      starlarkCustomCommandLineKeyComputation_nestedSetOfLabels_repoMappingChanges_relevant()
+          throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+
+    var mainRepoMapping1 =
+        RepositoryMapping.create(
+            ImmutableMap.of("apparent1", RepositoryName.createUnvalidated("canonical+")),
+            RepositoryName.MAIN);
+    var mainRepoMapping2 =
+        RepositoryMapping.create(
+            ImmutableMap.of("apparent2", RepositoryName.createUnvalidated("canonical+")),
+            RepositoryName.MAIN);
+    var args =
+        """
+        args = ruleContext.actions.args()
+        args.add_all(depset([Label("@@canonical+//foo:bar"), Label("@@canonical+//foo:baz")]))
+        """;
+    var commandLine1 = getCommandLine(mainRepoMapping1, args);
+    var commandLine2 = getCommandLine(mainRepoMapping2, args);
+
+    assertThat(ImmutableList.copyOf(commandLine1.arguments()))
+        .isNotEqualTo(ImmutableList.copyOf(commandLine2.arguments()));
+    assertThat(getDigest(commandLine1)).isNotEqualTo(getDigest(commandLine2));
+  }
+
+  @Test
   public void starlarkCustomCommandLineKeyComputation_labelVsString() throws Exception {
     setRuleContext(createRuleContext("//foo:foo"));
 


### PR DESCRIPTION
This avoids rerunning an action when the main repo mapping changes in unrelated ways, for example because a new repo is added.

Clean up one unnecessary `null` check on `mainRepositoryMapping`.

Fixes #27061

Closes #27081.

PiperOrigin-RevId: 818857131
Change-Id: I5036444dd6b39b12063f927ad807e2a93aeaf69f 
(cherry picked from commit fe3f455a331d06a2a1086baddaa571521e5ee67c)