### PR TITLE
Restore descriptive error on invalid patch labels

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -47,6 +47,7 @@ import net.starlark.java.eval.NoneType;
 import net.starlark.java.eval.Sequence;
 import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkInt;
+import net.starlark.java.eval.StarlarkList;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.StarlarkValue;
 import net.starlark.java.eval.Structure;
@@ -1094,6 +1095,12 @@ public class ModuleFileGlobals {
     ModuleThreadContext context = ModuleThreadContext.fromOrFail(thread, "archive_override()");
     context.setNonModuleCalled();
     validateModuleName(moduleName);
+    var patches =
+        Sequence.cast(
+            kwargs.getOrDefault("patches", StarlarkList.empty()), String.class, "patches");
+    for (String patch : patches) {
+      convertAndValidatePatchLabel(context.getModuleBuilder(), patch);
+    }
     context.addOverride(
         moduleName,
         new NonRegistryOverride(
@@ -1133,6 +1140,12 @@ public class ModuleFileGlobals {
     ModuleThreadContext context = ModuleThreadContext.fromOrFail(thread, "git_override()");
     context.setNonModuleCalled();
     validateModuleName(moduleName);
+    var patches =
+        Sequence.cast(
+            kwargs.getOrDefault("patches", StarlarkList.empty()), String.class, "patches");
+    for (String patch : patches) {
+      convertAndValidatePatchLabel(context.getModuleBuilder(), patch);
+    }
     context.addOverride(
         moduleName,
         new NonRegistryOverride(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -1691,7 +1691,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
   }
 
   @Test
-  public void testInvalidRepoInPatches() throws Exception {
+  public void testInvalidRepoInSingleVersionOverridePatches() throws Exception {
     scratch.overwriteFile(
         rootDirectory.getRelative("MODULE.bazel").getPathString(),
         "module(name='aaa')",
@@ -1710,6 +1710,51 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
     assertContainsEvent(
         "Error in single_version_override: invalid label in 'patches': only patches in the main"
             + " repository can be applied, not from '@unknown_repo'");
+  }
+
+  @Test
+  public void testInvalidRepoInArchiveOverridePatches() throws Exception {
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa')",
+        "archive_override(",
+        "    module_name = 'bbb',",
+        "    urls = ['https://example.com'],",
+        "    patches = ['@unknown_repo//:patch.bzl'],",
+        ")");
+
+    reporter.removeHandler(failFastHandler);
+    EvaluationResult<RootModuleFileValue> result =
+        evaluator.evaluate(
+            ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
+    assertThat(result.hasError()).isTrue();
+
+    assertContainsEvent(
+        "Error in archive_override: invalid label in 'patches': only patches in the main"
+        + " repository can be applied, not from '@unknown_repo'");
+  }
+
+  @Test
+  public void testInvalidRepoInGitOverridePatches() throws Exception {
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa')",
+        "git_override(",
+        "    module_name = 'bbb',",
+        "    remote = 'https://example.com',",
+        "    commit = 'abcd1234',",
+        "    patches = ['@unknown_repo//:patch.bzl'],",
+        ")");
+
+    reporter.removeHandler(failFastHandler);
+    EvaluationResult<RootModuleFileValue> result =
+        evaluator.evaluate(
+            ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
+    assertThat(result.hasError()).isTrue();
+
+    assertContainsEvent(
+        "Error in git_override: invalid label in 'patches': only patches in the main"
+        + " repository can be applied, not from '@unknown_repo'");
   }
 
   @Test

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -326,9 +326,7 @@ class BazelModuleTest(test_base.TestBase):
     exit_code, _, stderr = self.RunBazel(['run', '//:main'], allow_failure=True)
     self.AssertNotExitCode(exit_code, 0, stderr)
     self.assertIn(
-        "Error in <toplevel>: in call to 'http_archive' repo rule, no"
-        " repository visible as '@bbb' to the root module, but referenced by"
-        " label '@bbb//:aaa.patch' in attribute 'patches'",
+        "Error in archive_override: invalid label in 'patches': only patches in the main repository can be applied, not from '@bbb'",
         '\n'.join(stderr),
     )
 


### PR DESCRIPTION
This extra validation got lost in 3d60f1cf7aaacc98cf06f3c2eb62c2f521ce5868.