### PR TITLE
[8.5.0] Fix non-fatal NPE in BazelCoverageReportModule

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/BazelCoverageReportModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/BazelCoverageReportModule.java
@@ -110,6 +110,9 @@ public class BazelCoverageReportModule extends BlazeModule {
                 this::getArgs,
                 this::getLocationMessage,
                 /* htmlReport= */ false);
+        if (wrapper == null) {
+          return null;
+        }
         eventBus.register(new CoverageReportCollector(wrapper));
         return wrapper;
       }


### PR DESCRIPTION
Avoid logging a bug report.

Closes #27250.

PiperOrigin-RevId: 819031588
Change-Id: I11f8ee732f380a415a00a91c5c37ac2b40db67f9

Commit https://github.com/bazelbuild/bazel/commit/df75918b3467fadd7b22821e22dd229c8508c0f7