### PR TITLE
autocodec: suppress removal lints

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec/Initializers.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec/Initializers.java
@@ -51,9 +51,10 @@ class Initializers {
                 .addMember("value", "$S", AutoCodecProcessor.class.getCanonicalName())
                 .build())
         .addAnnotation(
-            AnnotationSpec.builder(ClassName.get(SuppressWarnings.class))
+            AnnotationSpec.builder(SuppressWarnings.class)
                 .addMember("value", "$S", "unchecked")
                 .addMember("value", "$S", "rawtypes")
+                .addMember("value", "$S", "removal")
                 .build())
         .addMethod(defineGetEncodedClassMethod(encodedType, env))
         .addMethod(defineAutoRegisterMethod(annotation));


### PR DESCRIPTION
Now that Bazel builds against Java 25, there are many lints about `Unsafe` deprecation in the generated code.