### PR TITLE
Fix URI validation pattern in HTTP cache server

### DIFF
--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/AbstractHttpCacheServerHandler.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/AbstractHttpCacheServerHandler.java
@@ -43,7 +43,7 @@ public abstract class AbstractHttpCacheServerHandler
     extends SimpleChannelInboundHandler<FullHttpRequest> {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
-  private static final Pattern URI_PATTERN = Pattern.compile("^/?(.*/)?(ac/|cas/)([a-f0-9]{64})$");
+  private static final Pattern URI_PATTERN = Pattern.compile("^/?(ac/|cas/)([a-f0-9]{64})$");
 
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {

--- a/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/http/AbstractHttpCacheServerHandlerTest.java
+++ b/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/http/AbstractHttpCacheServerHandlerTest.java
@@ -31,48 +31,15 @@ public class AbstractHttpCacheServerHandlerTest {
   public void testValidUri() {
     assertThat(
             AbstractHttpCacheServerHandler.isUriValid(
-                "http://some-path.co.uk:8080/ac/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
-        .isTrue();
-    assertThat(
-            AbstractHttpCacheServerHandler.isUriValid(
-                "http://127.12.12.0:8080/ac/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
-        .isTrue();
-    assertThat(
-            AbstractHttpCacheServerHandler.isUriValid(
-                "http://localhost:8080/ac/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
-        .isTrue();
-    assertThat(
-            AbstractHttpCacheServerHandler.isUriValid(
-                "https://localhost:8080/ac/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
-        .isTrue();
-    assertThat(
-            AbstractHttpCacheServerHandler.isUriValid(
-                "localhost:8080/ac/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+                "/ac/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
     assertThat(
             AbstractHttpCacheServerHandler.isUriValid(
                 "ac/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
-
     assertThat(
             AbstractHttpCacheServerHandler.isUriValid(
-                "http://some-path.co.uk:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
-        .isTrue();
-    assertThat(
-            AbstractHttpCacheServerHandler.isUriValid(
-                "http://127.12.12.0:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
-        .isTrue();
-    assertThat(
-            AbstractHttpCacheServerHandler.isUriValid(
-                "http://localhost:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
-        .isTrue();
-    assertThat(
-            AbstractHttpCacheServerHandler.isUriValid(
-                "https://localhost:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
-        .isTrue();
-    assertThat(
-            AbstractHttpCacheServerHandler.isUriValid(
-                "localhost:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+                "/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
     assertThat(
             AbstractHttpCacheServerHandler.isUriValid(
@@ -84,24 +51,26 @@ public class AbstractHttpCacheServerHandlerTest {
   public void testInvalidUri() {
     assertThat(
             AbstractHttpCacheServerHandler.isUriValid(
-                "http://localhost:8080/ac_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+                "/ac_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isFalse();
     assertThat(
             AbstractHttpCacheServerHandler.isUriValid(
-                "http://localhost:8080/cas_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+                "/cas_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+        .isFalse();
+    assertThat(AbstractHttpCacheServerHandler.isUriValid("/ac/111111111111111111111"))
+        .isFalse();
+    assertThat(AbstractHttpCacheServerHandler.isUriValid("/cas/111111111111111111111"))
+        .isFalse();
+    assertThat(AbstractHttpCacheServerHandler.isUriValid("/cas/823rhf&*%OL%_^")).isFalse();
+    assertThat(AbstractHttpCacheServerHandler.isUriValid("/ac/823rhf&*%OL%_^")).isFalse();
+    // URIs with path prefixes should be rejected
+    assertThat(
+            AbstractHttpCacheServerHandler.isUriValid(
+                "/prefix/ac/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isFalse();
     assertThat(
             AbstractHttpCacheServerHandler.isUriValid(
-                "http://localhost:8080/ac/111111111111111111111"))
-        .isFalse();
-    assertThat(
-            AbstractHttpCacheServerHandler.isUriValid(
-                "http://localhost:8080/cas/111111111111111111111"))
-        .isFalse();
-    assertThat(
-            AbstractHttpCacheServerHandler.isUriValid("http://localhost:8080/cas/823rhf&*%OL%_^"))
-        .isFalse();
-    assertThat(AbstractHttpCacheServerHandler.isUriValid("http://localhost:8080/ac/823rhf&*%OL%_^"))
+                "/foo/bar/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isFalse();
   }
 }


### PR DESCRIPTION
## Description

This PR fixes an inconsistency in the HTTP cache server's URI validation logic.

## Problem

The URI pattern regex was too permissive, allowing URIs with arbitrary path prefixes before `/ac/` or `/cas/` (e.g., `/foo/ac/hash`). However, the handler implementations (`OnDiskHttpCacheServerHandler` and `InMemoryHttpCacheServerHandler`) only support URIs starting directly with `/ac/` or `/cas/`, causing validation to pass but processing to fail with an IOException.

## Solution

Removed the optional prefix group `(.*/)?` from the regex pattern, ensuring only valid URIs like `/ac/hash` or `/cas/hash` are accepted.

**Before:** `^/?(.*/)?(ac/|cas/)([a-f0-9]{64})$`  
**After:** `^/?(ac/|cas/)([a-f0-9]{64})$`

## Changes

- Updated `AbstractHttpCacheServerHandler.java`: Fixed URI_PATTERN regex
- Updated `AbstractHttpCacheServerHandlerTest.java`: 
  - Corrected test cases to use actual path URIs instead of full URLs (matching what Netty's `request.uri()` provides)
  - Added test cases for rejecting URIs with invalid prefixes

## Testing

Added test cases to verify that URIs with path prefixes are now correctly rejected:
- `/prefix/ac/hash` → rejected ✓
- `/foo/bar/cas/hash` → rejected ✓

Existing valid URI tests continue to pass:
- `/ac/hash` → accepted ✓
- `ac/hash` → accepted ✓
- `/cas/hash` → accepted ✓
- `cas/hash` → accepted ✓