### PR TITLE
[8.5.0] Include absolute paths of runfiles symlink targets in action key

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
@@ -100,11 +100,19 @@ public final class Runfiles implements RunfilesApi {
   private static final PathFragment REPO_MAPPING_PATH_FRAGMENT =
       PathFragment.create("_repo_mapping");
 
-  private static final CommandLineItem.ExceptionlessMapFn<SymlinkEntry> SYMLINK_ENTRY_MAP_FN =
-      (symlink, args) -> {
-        args.accept(symlink.getPathString());
-        args.accept(symlink.getArtifact().getExecPathString());
-      };
+  private static final CommandLineItem.ExceptionlessMapFn<SymlinkEntry>
+      SYMLINK_ENTRY_ABSOLUTE_PATH_MAP_FN =
+          (symlink, args) -> {
+            args.accept(symlink.getPathString());
+            args.accept(symlink.getArtifact().getPath().getPathString());
+          };
+
+  private static final CommandLineItem.ExceptionlessMapFn<SymlinkEntry>
+      SYMLINK_ENTRY_EXEC_PATH_MAP_FN =
+          (symlink, args) -> {
+            args.accept(symlink.getPathString());
+            args.accept(symlink.getArtifact().getExecPathString());
+          };
 
   private static final CommandLineItem.ExceptionlessMapFn<Artifact>
       RUNFILES_AND_ABSOLUTE_PATH_MAP_FN =
@@ -1087,8 +1095,14 @@ public final class Runfiles implements RunfilesApi {
     fp.addBoolean(legacyExternalRunfiles);
     fp.addString(prefix);
 
-    actionKeyContext.addNestedSetToFingerprint(SYMLINK_ENTRY_MAP_FN, fp, symlinks);
-    actionKeyContext.addNestedSetToFingerprint(SYMLINK_ENTRY_MAP_FN, fp, rootSymlinks);
+    actionKeyContext.addNestedSetToFingerprint(
+        digestAbsolutePaths ? SYMLINK_ENTRY_ABSOLUTE_PATH_MAP_FN : SYMLINK_ENTRY_EXEC_PATH_MAP_FN,
+        fp,
+        symlinks);
+    actionKeyContext.addNestedSetToFingerprint(
+        digestAbsolutePaths ? SYMLINK_ENTRY_ABSOLUTE_PATH_MAP_FN : SYMLINK_ENTRY_EXEC_PATH_MAP_FN,
+        fp,
+        rootSymlinks);
     actionKeyContext.addNestedSetToFingerprint(
         digestAbsolutePaths ? RUNFILES_AND_ABSOLUTE_PATH_MAP_FN : RUNFILES_AND_EXEC_PATH_MAP_FN,
         fp,
@@ -1106,9 +1120,19 @@ public final class Runfiles implements RunfilesApi {
         + String.format("legacyExternalRunfiles: %s\n", legacyExternalRunfiles)
         + String.format("prefix: %s\n", prefix)
         + String.format(
-            "symlinks: %s\n", describeNestedSetFingerprint(SYMLINK_ENTRY_MAP_FN, symlinks))
+            "symlinks: %s\n",
+            describeNestedSetFingerprint(
+                digestAbsolutePaths
+                    ? SYMLINK_ENTRY_ABSOLUTE_PATH_MAP_FN
+                    : SYMLINK_ENTRY_EXEC_PATH_MAP_FN,
+                symlinks))
         + String.format(
-            "rootSymlinks: %s\n", describeNestedSetFingerprint(SYMLINK_ENTRY_MAP_FN, rootSymlinks))
+            "rootSymlinks: %s\n",
+            describeNestedSetFingerprint(
+                digestAbsolutePaths
+                    ? SYMLINK_ENTRY_ABSOLUTE_PATH_MAP_FN
+                    : SYMLINK_ENTRY_EXEC_PATH_MAP_FN,
+                rootSymlinks))
         + String.format(
             "artifacts: %s\n",
             describeNestedSetFingerprint(


### PR DESCRIPTION
This was missed in c9d7ff9384fa06e9fe676c2c8935c675f2238c57.

Closes #26839.

PiperOrigin-RevId: 819855385
Change-Id: Id7815b0994167e7d2fb77c946512564ea54d45d3

Commit https://github.com/bazelbuild/bazel/commit/c1c68bb49fe2580123c61af2053803403f014d51