### PR TITLE
Add run command option to use current working directory

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -181,14 +181,14 @@ public class RunCommand implements BlazeCommand {
     public List<Converters.EnvVar> runEnvironment;
 
     @Option(
-        name = "run_cwd",
+        name = "run_in_cwd",
         defaultValue = "false",
         documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
         effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
         help =
             "If true, runs the target in the current working directory instead of the runfile"
                 + " tree.")
-    public boolean runCwd;
+    public boolean runInCwd;
   }
 
   private static final String NO_TARGET_MESSAGE = "No targets found to run";
@@ -835,7 +835,7 @@ public class RunCommand implements BlazeCommand {
         new RunCommandLine.Builder(
             runEnvironment,
             envVariablesToClear,
-            /* workingDir= */ !runOptions.runCwd && builtTargets.targetToRunRunfilesDir != null
+            /* workingDir= */ !runOptions.runInCwd && builtTargets.targetToRunRunfilesDir != null
                 ? builtTargets.targetToRunRunfilesDir
                 : env.getWorkingDirectory(),
             /* isTestTarget= */ false);

--- a/src/test/shell/integration/run_test.sh
+++ b/src/test/shell/integration/run_test.sh
@@ -1011,7 +1011,7 @@ EOF
   expect_log "RUN_ENV_ONLY: 'BAR'"
 }
 
-function test_run_cwd() {
+function test_run_in_cwd() {
   add_rules_shell "MODULE.bazel"
   local -r pkg="pkg${LINENO}"
   mkdir -p "${pkg}"
@@ -1038,11 +1038,11 @@ EOF
   chmod +x "foo.sh"
   touch "bar.txt"
 
-  bazel run "//$pkg:foo" >& "$TEST_log" || fail "bazel run without --run_cwd failed"
+  bazel run "//$pkg:foo" >& "$TEST_log" || fail "bazel run without --run_in_cwd failed"
   expect_not_log "BAR_TXT"
   expect_not_log "Running in $(pwd)"
 
-  bazel run --run_cwd "//$pkg:foo" >& "$TEST_log" || fail "bazel run with --run_cwd failed"
+  bazel run --run_in_cwd "//$pkg:foo" >& "$TEST_log" || fail "bazel run with --run_in_cwd failed"
   expect_log "BAR_TXT"
   expect_log "Running in $(pwd)"
 }


### PR DESCRIPTION
From the discussion in https://github.com/bazelbuild/bazel/issues/3325#issuecomment-2810070670, this adds a `--run_in_cwd` option to the `bazel run` command, which if enabled runs the target in the current working directory as opposed to running it in the runfiles directory.

The workaround by using `--run_under` to get a target to run in the current directory doesn't always work in every situation or is just unfortunate. This would improve the flow of running tools against source code for things like linting, formatting, running code generators, etc. which are present in `BUILD` files.