### PR TITLE
Update instructions for starting test remote worker

### DIFF
--- a/src/tools/remote/README.md
+++ b/src/tools/remote/README.md
@@ -7,15 +7,19 @@ The simplest setup is as follows:
 - First build the worker and run it.
 
         bazel build src/tools/remote:all
+
+        mkdir --parents /tmp/worker/work /tmp/worker/cas
+
         bazel-bin/src/tools/remote/worker \
-            --work_path=/tmp/test \
+            --work_path=/tmp/worker/work \
+            --cas_path=/tmp/worker/cas \
             --listen_port=8080
 
 - Then you run Bazel pointing to the worker instance.
 
         bazel build \
-            --spawn_strategy=remote --remote_cache=localhost:8080 \
-            --remote_executor=localhost:8080 src/tools/generate_workspace:all
+            --remote_executor=grpc://localhost:8080 \
+            src/tools/generate_workspace:all
 
 The above command will build generate_workspace with remote spawn strategy that
 uses the local worker as the distributed caching and execution backend.
@@ -24,12 +28,15 @@ uses the local worker as the distributed caching and execution backend.
 
 If you run the worker on Linux, you can also enable sandboxing for increased hermeticity:
 
+        mkdir --parents /tmp/worker/work /tmp/worker/cas /tmp/worker/tmpfs
+
         bazel-bin/src/tools/remote/worker \
-            --work_path=/tmp/test \
+            --work_path=/tmp/worker/work \
+            --cas_path=/tmp/worker/cas \
             --listen_port=8080 \
             --sandboxing \
             --sandboxing_writable_path=/run/shm \
-            --sandboxing_tmpfs_dir=/tmp \
+            --sandboxing_tmpfs_dir=/tmp/worker/tmpfs \
             --sandboxing_block_network
 
 As you can see, the specific behavior of the sandbox can be tuned via the flags


### PR DESCRIPTION
Using small remote execution setup is sometimes helpful when performing some tests, or trying to reproduce issues on minimal setup.

Updated instructions so that worker is actually able to start - I guess a few things changes between those instructions were written.