### PR TITLE
Unwrap interrupts during input prefetching

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
@@ -177,6 +177,7 @@ public interface SpawnRunner {
         if (cause != null) {
           throwIfInstanceOf(cause, IOException.class);
           throwIfInstanceOf(cause, ExecException.class);
+          throwIfInstanceOf(cause, InterruptedException.class);
           throwIfInstanceOf(cause, RuntimeException.class);
         }
         throw new IOException(e);


### PR DESCRIPTION
Speculative fix for this error seen during an interrupted build:
```
ERROR: .../BUILD:21:8: GoLink .../foo_test failed: I/O exception during sandboxed execution: java.util.concurrent.ExecutionException: java.lang.InterruptedException
```