### PR TITLE
docs: don't warn about starlark_doc_extract output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractRule.java
@@ -148,7 +148,7 @@ in the Bazel source tree.
 
 ${IMPLICIT_OUTPUTS}
 
-Note: the exact output of this rule and is not a stable public API.
+Note: the exact output of this rule is not a stable public API.
 For example, the set of natively-defined common rule attributes and their docstrings may change even with minor Bazel releases.
 For this reason, documentation generated for user-defined rules is not stable across Bazel releases,
 so we suggest taking care that any "golden" tests based on outputs of this rule are only run with a single Bazel version.


### PR DESCRIPTION
The community already relies on this protobuf format, and that it is a default output of the starlark_doc_extract rule.

Are there specific breaking changes you imagine making here?

FYI @meisterT