### PR TITLE
[8.5.0] Add a createSymbolicLink argument indicating the file type of the target.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -57,6 +57,7 @@ import com.google.devtools.build.lib.vfs.FileStatusWithDigest;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.SymlinkTargetType;
 import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.inmemoryfs.FileInfo;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryContentInfo;
@@ -579,15 +580,16 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat
   }
 
   @Override
-  protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
+  protected void createSymbolicLink(
+      PathFragment linkPath, PathFragment targetFragment, SymlinkTargetType type)
       throws IOException {
     linkPath = resolveSymbolicLinksForParent(linkPath);
 
     if (isOutput(linkPath)) {
-      remoteOutputTree.getPath(linkPath).createSymbolicLink(targetFragment);
+      remoteOutputTree.getPath(linkPath).createSymbolicLink(targetFragment, type);
     }
 
-    localFs.getPath(linkPath).createSymbolicLink(targetFragment);
+    localFs.getPath(linkPath).createSymbolicLink(targetFragment, type);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.SymlinkTargetType;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -390,7 +391,8 @@ public class UnixFileSystem extends AbstractFileSystemWithCustomStat {
   }
 
   @Override
-  protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
+  protected void createSymbolicLink(
+      PathFragment linkPath, PathFragment targetFragment, SymlinkTargetType type)
       throws IOException {
     var comp = Blocker.begin();
     try {

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -569,13 +569,26 @@ public abstract class FileSystem {
   protected abstract boolean isSpecialFile(PathFragment path, boolean followSymlinks);
 
   /**
+   * Creates a symbolic link. See {@link Path#createSymbolicLink(Path, SymlinkTargetType)} for
+   * specification.
+   *
+   * <p>Note: for {@link FileSystem}s where {@link #supportsSymbolicLinksNatively(PathFragment)}
+   * returns false, this method will throw an {@link UnsupportedOperationException}
+   */
+  protected abstract void createSymbolicLink(
+      PathFragment linkPath, PathFragment targetFragment, SymlinkTargetType hint)
+      throws IOException;
+
+  /**
    * Creates a symbolic link. See {@link Path#createSymbolicLink(Path)} for specification.
    *
    * <p>Note: for {@link FileSystem}s where {@link #supportsSymbolicLinksNatively(PathFragment)}
    * returns false, this method will throw an {@link UnsupportedOperationException}
    */
-  protected abstract void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
-      throws IOException;
+  protected final void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
+      throws IOException {
+    createSymbolicLink(linkPath, targetFragment, SymlinkTargetType.UNSPECIFIED);
+  }
 
   /**
    * Returns the target of a symbolic link. See {@link Path#readSymbolicLink} for specification.

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -279,10 +279,12 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
   }
 
   @Override
-  protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
+  protected void createSymbolicLink(
+      PathFragment linkPath, PathFragment targetFragment, SymlinkTargetType type)
       throws IOException {
     java.nio.file.Path nioPath = getNioPath(linkPath);
     try {
+      // Files.createSymbolicLink does not let us specify the target type.
       Files.createSymbolicLink(
           nioPath,
           Paths.get(StringEncoding.internalToPlatform(targetFragment.getSafePathString())));

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -486,11 +486,43 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
    * referent of the created symlink is is the absolute path "target"; it is not possible to create
    * relative symbolic links via this method.
    *
+   * <p>The {@code type} argument denotes the file type of the target, if known. Some filesystems
+   * require this information to correctly create a symlink. This argument may be ignored if the
+   * target can be observed to exist and is of a different type.
+   *
+   * @param type the target file type
+   * @throws IOException if the creation of the symbolic link was unsuccessful for any reason
+   */
+  public void createSymbolicLink(Path target, SymlinkTargetType type) throws IOException {
+    checkSameFileSystem(target);
+    fileSystem.createSymbolicLink(asFragment(), target.asFragment(), type);
+  }
+
+  /**
+   * Creates a symbolic link with the name of the current path, following symbolic links. The
+   * referent of the created symlink is is the absolute path "target"; it is not possible to create
+   * relative symbolic links via this method.
+   *
    * @throws IOException if the creation of the symbolic link was unsuccessful for any reason
    */
   public void createSymbolicLink(Path target) throws IOException {
-    checkSameFileSystem(target);
-    fileSystem.createSymbolicLink(asFragment(), target.asFragment());
+    createSymbolicLink(target, SymlinkTargetType.UNSPECIFIED);
+  }
+
+  /**
+   * Creates a symbolic link with the name of the current path, following symbolic links. The
+   * referent of the created symlink is is the path fragment "target", which may be absolute or
+   * relative.
+   *
+   * <p>The {@code type} argument denotes the file type of the target, if known. Some filesystems
+   * require this information to correctly create a symlink. This argument may be ignored if the
+   * target can be observed to exist and is of a different type.
+   *
+   * @param type the target file type
+   * @throws IOException if the creation of the symbolic link was unsuccessful for any reason
+   */
+  public void createSymbolicLink(PathFragment target, SymlinkTargetType type) throws IOException {
+    fileSystem.createSymbolicLink(asFragment(), target, type);
   }
 
   /**
@@ -501,7 +533,7 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
    * @throws IOException if the creation of the symbolic link was unsuccessful for any reason
    */
   public void createSymbolicLink(PathFragment target) throws IOException {
-    fileSystem.createSymbolicLink(asFragment(), target);
+    createSymbolicLink(target, SymlinkTargetType.UNSPECIFIED);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
@@ -119,9 +119,10 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
   }
 
   @Override
-  protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
+  protected void createSymbolicLink(
+      PathFragment linkPath, PathFragment targetFragment, SymlinkTargetType type)
       throws IOException {
-    delegateFs.createSymbolicLink(toDelegatePath(linkPath), targetFragment);
+    delegateFs.createSymbolicLink(toDelegatePath(linkPath), targetFragment, type);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/vfs/ReadonlyFileSystemWithCustomStat.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/ReadonlyFileSystemWithCustomStat.java
@@ -81,7 +81,8 @@ public abstract class ReadonlyFileSystemWithCustomStat extends AbstractFileSyste
   }
 
   @Override
-  protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
+  protected void createSymbolicLink(
+      PathFragment linkPath, PathFragment targetFragment, SymlinkTargetType type)
       throws IOException {
     throw modificationException();
   }

--- a/src/main/java/com/google/devtools/build/lib/vfs/SymlinkTargetType.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/SymlinkTargetType.java
@@ -1,0 +1,31 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package com.google.devtools.build.lib.vfs;
+
+/**
+ * Indicates the file type at the other end of a symlink.
+ *
+ * <p>Required by some filesystems (notably on Windows) to correctly create a symlink when its
+ * target does not yet exist, as a different kind of filesystem object might be required depending
+ * on the target type.
+ */
+public enum SymlinkTargetType {
+  /** The target is of unspecified type. */
+  UNSPECIFIED,
+  /** The target is a regular file. */
+  FILE,
+  /** The target is a directory. */
+  DIRECTORY,
+}

--- a/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileSystem.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.vfs.FileAccessException;
 import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.SymlinkTargetType;
 import com.google.errorprone.annotations.CheckReturnValue;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -521,8 +522,8 @@ public class InMemoryFileSystem extends AbstractFileSystemWithCustomStat {
   }
 
   @Override
-  protected void createSymbolicLink(PathFragment path, PathFragment targetFragment)
-      throws IOException {
+  protected void createSymbolicLink(
+      PathFragment path, PathFragment targetFragment, SymlinkTargetType type) throws IOException {
     if (isRootDirectory(path)) {
       throw Errno.EACCES.exception(path);
     }

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -22,11 +22,15 @@ import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.JavaIoFileSystem;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.SymlinkTargetType;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.attribute.DosFileAttributes;
 
 /** File system implementation for Windows. */
@@ -72,30 +76,39 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
-  protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
+  protected void createSymbolicLink(
+      PathFragment linkPath, PathFragment targetFragment, SymlinkTargetType type)
       throws IOException {
     PathFragment targetPath =
         targetFragment.isAbsolute()
             ? targetFragment
             : linkPath.getParentDirectory().getRelative(targetFragment);
+
+    FileStatus stat = statIfFound(targetPath, /* followSymlinks= */ true);
+    boolean existingFile = stat != null && stat.isFile();
+    boolean existingDirectory = stat != null && stat.isDirectory();
+
     try {
       File link = getIoFile(linkPath);
       File target = getIoFile(targetPath);
-      if (target.isDirectory()) {
-        WindowsFileOperations.createJunction(link.toString(), target.toString());
-      } else if (createSymbolicLinks) {
-        WindowsFileOperations.createSymlink(link.toString(), target.toString());
-      } else if (!target.exists()) {
-        // Still Create a dangling junction if the target doesn't exist.
-        WindowsFileOperations.createJunction(link.toString(), target.toString());
-      } else {
+
+      if (!createSymbolicLinks && existingFile) {
+        // If symlinks aren't enabled and the target is an existing file, fall back to a copy.
         Files.copy(target.toPath(), link.toPath());
+      } else if (createSymbolicLinks
+          && (existingFile || (!existingDirectory && type != SymlinkTargetType.DIRECTORY))) {
+        // If symlinks are enabled and the target is not an existing or future directory, create a
+        // symlink.
+        WindowsFileOperations.createSymlink(link.toString(), target.toString());
+      } else {
+        // Otherwise, create a junction.
+        WindowsFileOperations.createJunction(link.toString(), target.toString());
       }
-    } catch (java.nio.file.FileAlreadyExistsException e) {
+    } catch (FileAlreadyExistsException e) {
       throw new IOException(linkPath + ERR_FILE_EXISTS, e);
-    } catch (java.nio.file.AccessDeniedException e) {
+    } catch (AccessDeniedException e) {
       throw new IOException(linkPath + ERR_PERMISSION_DENIED, e);
-    } catch (java.nio.file.NoSuchFileException e) {
+    } catch (NoSuchFileException e) {
       throw new FileNotFoundException(linkPath + ERR_NO_SUCH_FILE_OR_DIR);
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystemTest.java
@@ -101,10 +101,12 @@ public class PathTransformingDelegateFileSystemTest {
   public void createSymbolicLink_callsDelegateWithRewrittenPathNotTarget() throws Exception {
     PathFragment target = PathFragment.create("/original/target");
 
-    fileSystem.createSymbolicLink(PathFragment.create("/original/dir/file"), target);
+    fileSystem.createSymbolicLink(
+        PathFragment.create("/original/dir/file"), target, SymlinkTargetType.UNSPECIFIED);
 
     verify(delegateFileSystem)
-        .createSymbolicLink(PathFragment.create("/transformed/dir/file"), target);
+        .createSymbolicLink(
+            PathFragment.create("/transformed/dir/file"), target, SymlinkTargetType.UNSPECIFIED);
     verifyNoMoreInteractions(delegateFileSystem);
   }
 
@@ -158,7 +160,11 @@ public class PathTransformingDelegateFileSystemTest {
             getFileSystemMethod("getPath", PathFragment.class),
             getFileSystemMethod("readSymbolicLink", PathFragment.class),
             getFileSystemMethod("resolveSymbolicLinks", PathFragment.class),
-            getFileSystemMethod("createSymbolicLink", PathFragment.class, PathFragment.class));
+            getFileSystemMethod(
+                "createSymbolicLink",
+                PathFragment.class,
+                PathFragment.class,
+                SymlinkTargetType.class));
 
     private static Method getFileSystemMethod(String name, Class<?>... parameterTypes) {
       try {

--- a/src/test/java/com/google/devtools/build/lib/windows/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/windows/BUILD
@@ -43,11 +43,13 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/windows:processes",
         "//src/main/java/com/google/devtools/build/lib/windows:windows_path_operations",
         "//src/test/java/com/google/devtools/build/lib/testutil",
+        "//src/test/java/com/google/devtools/build/lib/testutil:TestUtils",
         "//src/test/java/com/google/devtools/build/lib/windows/util",
         "//third_party:guava",
         "//third_party:junit4",
         "//third_party:truth",
         "@bazel_tools//tools/java/runfiles",
+        "@maven//:com_google_testparameterinjector_test_parameter_injector",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
@@ -15,20 +15,23 @@
 package com.google.devtools.build.lib.windows;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assume.assumeTrue;
 
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.testutil.TestSpec;
+import com.google.devtools.build.lib.testutil.TestUtils;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem.NotASymlinkException;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
-import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.SymlinkTargetType;
 import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.windows.util.WindowsTestUtil;
+import com.google.testing.junit.testparameterinjector.TestParameter;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.file.Files;
@@ -39,29 +42,27 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link WindowsFileSystem}. */
-@RunWith(JUnit4.class)
+@RunWith(TestParameterInjector.class)
 @TestSpec(supportedOs = OS.WINDOWS)
 public class WindowsFileSystemTest {
+  @TestParameter boolean createSymbolicLinks;
 
   private WindowsFileSystem fs;
   private Path scratchRoot;
   private WindowsTestUtil testUtil;
 
   @Before
-  public void loadJni() throws Exception {
-    fs = new WindowsFileSystem(DigestHashFunction.SHA256, /*createSymbolicLinks=*/ false);
-    scratchRoot = fs.getPath(System.getenv("TEST_TMPDIR")).getRelative("test").getRelative("x");
-    scratchRoot.createDirectoryAndParents();
+  public void createScratchDir() throws Exception {
+    fs = new WindowsFileSystem(DigestHashFunction.SHA256, createSymbolicLinks);
+    scratchRoot = TestUtils.createUniqueTmpDir(fs);
     testUtil = new WindowsTestUtil(scratchRoot.getPathString());
-    cleanupScratchDir();
   }
 
   @After
-  public void cleanupScratchDir() throws Exception {
-    testUtil.deleteAllUnder("");
+  public void destroyScratchDir() throws Exception {
+    scratchRoot.deleteTree();
   }
 
   @Test
@@ -291,89 +292,146 @@ public class WindowsFileSystemTest {
   }
 
   @Test
-  public void testCreateSymbolicLink() throws Exception {
-    // Create the `scratchRoot` directory.
-    assertThat(scratchRoot.createDirectory()).isTrue();
-    // Create symlink with directory target, relative path.
-    Path link1 = scratchRoot.getRelative("link1");
-    fs.createSymbolicLink(link1.asFragment(), PathFragment.create(".."));
-    // Create symlink with directory target, absolute path.
-    Path link2 = scratchRoot.getRelative("link2");
-    fs.createSymbolicLink(link2.asFragment(), scratchRoot.getRelative("link1").asFragment());
-    // Create scratch files that'll be symlink targets.
-    testUtil.scratchFile("foo.txt", "hello");
-    testUtil.scratchFile("bar.txt", "hello");
-    // Create symlink with file target, relative path.
-    Path link3 = scratchRoot.getRelative("link3");
-    fs.createSymbolicLink(link3.asFragment(), PathFragment.create("foo.txt"));
-    // Create symlink with file target, absolute path.
-    Path link4 = scratchRoot.getRelative("link4");
-    fs.createSymbolicLink(link4.asFragment(), scratchRoot.getRelative("bar.txt").asFragment());
-    // Assert that link1 and link2 are true junctions and have the right contents.
-    for (Path p : ImmutableList.of(link1, link2)) {
-      assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(p.getPathString()))).isTrue();
-      assertThat(p.isSymbolicLink()).isTrue();
-      assertThat(
-              Iterables.transform(
-                  Arrays.asList(new File(p.getPathString()).listFiles()),
-                  new Function<File, String>() {
-                    @Override
-                    public String apply(File input) {
-                      return input.getName();
-                    }
-                  }))
-          .containsExactly("x");
+  public void testSymbolicLinkToExistingFile(@TestParameter SymlinkTargetType targetType)
+      throws Exception {
+    Path linkPath = scratchRoot.getRelative("link");
+    Path targetPath = scratchRoot.getRelative("target");
+    assertThat(targetPath.getParentDirectory().exists()).isTrue();
+    assertThat(targetPath.getParentDirectory().isDirectory()).isTrue();
+    FileSystemUtils.writeContentAsLatin1(targetPath, "hello");
+
+    linkPath.createSymbolicLink(targetPath, targetType);
+
+    if (createSymbolicLinks) {
+      assertThat(linkPath.isSymbolicLink()).isTrue();
+      assertThat(linkPath.readSymbolicLink()).isEqualTo(targetPath.asFragment());
+    } else {
+      assertThat(linkPath.isSymbolicLink()).isFalse();
+      assertThrows(NotASymlinkException.class, () -> linkPath.readSymbolicLink());
     }
-    // Assert that link3 and link4 are copies of files.
-    for (Path p : ImmutableList.of(link3, link4)) {
-      assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(p.getPathString()))).isFalse();
-      assertThat(p.isSymbolicLink()).isFalse();
-      assertThat(p.isFile()).isTrue();
-    }
-  }
+    assertThat(linkPath.exists()).isTrue();
+    assertThat(linkPath.isFile()).isTrue();
+    assertThat(FileSystemUtils.readContent(linkPath, ISO_8859_1)).isEqualTo("hello");
 
-  @Test
-  public void testCreateSymbolicLinkWithRealSymlinks() throws Exception {
-    fs = new WindowsFileSystem(DigestHashFunction.SHA256, /*createSymbolicLinks=*/ true);
-    java.nio.file.Path helloPath = testUtil.scratchFile("hello.txt", "hello");
-    PathFragment targetFragment = PathFragment.create(helloPath.toString());
-    Path linkPath = scratchRoot.getRelative("link.txt");
-    fs.createSymbolicLink(linkPath.asFragment(), targetFragment);
-
-    assertThat(linkPath.isSymbolicLink()).isTrue();
-    assertThat(linkPath.readSymbolicLink()).isEqualTo(targetFragment);
-
-    // Assert deleting the symbolic link keeps the target file.
     linkPath.delete();
     assertThat(linkPath.exists()).isFalse();
-    assertThat(helloPath.toFile().exists()).isTrue();
+    assertThat(targetPath.exists()).isTrue();
   }
 
   @Test
-  public void testReadJunction() throws Exception {
-    testUtil.scratchFile("dir\\hello.txt", "hello");
-    testUtil.createJunctions(ImmutableMap.of("junc", "dir"));
+  public void testSymbolicLinkToExistingDirectory(@TestParameter SymlinkTargetType targetType)
+      throws Exception {
+    Path linkPath = scratchRoot.getRelative("link");
+    Path linkChildPath = linkPath.getRelative("hello.txt");
+    Path targetPath = scratchRoot.getRelative("target");
+    Path targetChildPath = targetPath.getRelative("hello.txt");
+    targetPath.createDirectory();
+    FileSystemUtils.writeContentAsLatin1(targetChildPath, "hello");
 
-    Path dirPath = testUtil.createVfsPath(fs, "dir");
-    Path juncPath = testUtil.createVfsPath(fs, "junc");
+    linkPath.createSymbolicLink(targetPath, targetType);
 
-    assertThat(dirPath.isDirectory()).isTrue();
-    assertThat(juncPath.isDirectory()).isTrue();
+    assertThat(linkPath.isSymbolicLink()).isTrue();
+    assertThat(linkPath.readSymbolicLink()).isEqualTo(targetPath.asFragment());
+    assertThat(linkPath.exists()).isTrue();
+    assertThat(linkPath.isDirectory()).isTrue();
+    assertThat(linkChildPath.exists()).isTrue();
+    assertThat(linkChildPath.isFile()).isTrue();
+    assertThat(FileSystemUtils.readContent(linkChildPath, ISO_8859_1)).isEqualTo("hello");
 
-    assertThat(dirPath.isSymbolicLink()).isFalse();
-    assertThat(juncPath.isSymbolicLink()).isTrue();
+    linkPath.delete();
+    assertThat(linkPath.exists()).isFalse();
+    assertThat(targetPath.exists()).isTrue();
+  }
 
-    assertThrows(
-        FileNotFoundException.class,
-        () -> testUtil.createVfsPath(fs, "does-not-exist").readSymbolicLink());
+  @Test
+  public void testCreateSymbolicLinkToNonExistingTargetOfUnspecifiedType() throws Exception {
+    Path linkPath = scratchRoot.getRelative("link");
+    Path targetPath = scratchRoot.getRelative("target");
 
-    assertThrows(
-        NotASymlinkException.class,
-        () -> testUtil.createVfsPath(fs, "dir\\hello.txt").readSymbolicLink());
+    linkPath.createSymbolicLink(targetPath, SymlinkTargetType.UNSPECIFIED);
 
-    assertThrows(NotASymlinkException.class, () -> dirPath.readSymbolicLink());
+    assertThat(linkPath.isSymbolicLink()).isTrue();
+    assertThat(linkPath.readSymbolicLink()).isEqualTo(targetPath.asFragment());
+    assertThat(linkPath.exists()).isFalse();
 
-    assertThat(juncPath.readSymbolicLink()).isEqualTo(dirPath.asFragment());
+    // Check that a dangling symlink is preferred over a dangling junction when supported.
+    // Do this by creating a target of the corresponding type and verifying that it can be accessed.
+    if (createSymbolicLinks) {
+      FileSystemUtils.writeContentAsLatin1(targetPath, "hello");
+      assertThat(linkPath.exists()).isTrue();
+      assertThat(linkPath.isFile()).isTrue();
+      assertThat(FileSystemUtils.readContent(linkPath, ISO_8859_1)).isEqualTo("hello");
+    } else {
+      targetPath.createDirectory();
+      assertThat(linkPath.exists()).isTrue();
+      assertThat(linkPath.isDirectory()).isTrue();
+    }
+  }
+
+  @Test
+  public void testCreateSymbolicLinkToNonExistingTargetOfFileType() throws Exception {
+    // This is only expected to work if symlinks are enabled.
+    // Otherwise, our only recourse is to create a dangling junction, which does not work for files.
+    assumeTrue(createSymbolicLinks);
+
+    Path linkPath = scratchRoot.getRelative("link");
+    Path targetPath = scratchRoot.getRelative("target");
+
+    linkPath.createSymbolicLink(targetPath, SymlinkTargetType.FILE);
+
+    assertThat(linkPath.isSymbolicLink()).isTrue();
+    assertThat(linkPath.readSymbolicLink()).isEqualTo(targetPath.asFragment());
+
+    FileSystemUtils.writeContentAsLatin1(targetPath, "hello");
+
+    assertThat(linkPath.exists()).isTrue();
+    assertThat(linkPath.isFile()).isTrue();
+    assertThat(FileSystemUtils.readContent(linkPath, ISO_8859_1)).isEqualTo("hello");
+  }
+
+  @Test
+  public void testCreateSymbolicLinkToNonExistingTargetOfDirectoryType() throws Exception {
+    Path linkPath = scratchRoot.getRelative("link");
+    Path linkChildPath = linkPath.getRelative("hello.txt");
+    Path targetPath = scratchRoot.getRelative("target");
+    Path targetChildPath = targetPath.getRelative("hello.txt");
+
+    linkPath.createSymbolicLink(targetPath, SymlinkTargetType.DIRECTORY);
+
+    assertThat(linkPath.isSymbolicLink()).isTrue();
+    assertThat(linkPath.readSymbolicLink()).isEqualTo(targetPath.asFragment());
+
+    targetPath.createDirectory();
+    FileSystemUtils.writeContentAsLatin1(targetChildPath, "hello");
+
+    assertThat(linkPath.exists()).isTrue();
+    assertThat(linkPath.isDirectory()).isTrue();
+    assertThat(linkChildPath.exists()).isTrue();
+    assertThat(linkChildPath.isFile()).isTrue();
+    assertThat(FileSystemUtils.readContent(linkChildPath, ISO_8859_1)).isEqualTo("hello");
+  }
+
+  @Test
+  public void testReadSymbolicLinkForFile() throws Exception {
+    Path filePath = scratchRoot.getRelative("file");
+    FileSystemUtils.writeContentAsLatin1(filePath, "hello");
+
+    assertThrows(NotASymlinkException.class, filePath::readSymbolicLink);
+  }
+
+  @Test
+  public void testReadSymbolicLinkForDirectory() throws Exception {
+    Path dirPath = scratchRoot.getRelative("dir");
+    dirPath.createDirectory();
+
+    assertThrows(NotASymlinkException.class, dirPath::readSymbolicLink);
+  }
+
+  @Test
+  public void testReadSymbolicLinkForNonexistentPath() throws Exception {
+    Path nonexistentPath = scratchRoot.getRelative("nonexistent");
+
+    assertThrows(FileNotFoundException.class, nonexistentPath::readSymbolicLink);
   }
 
   @Test


### PR DESCRIPTION
On Windows, a different kind of filesystem object (junction or symlink) needs to be created depending on the target type, which is not always inspectable in "building without the bytes" scenarios where the symlink is created ahead of its target.

This CL only introduces the formal argument and adjusts the WindowsFileSystem#createSymbolicLink implementation accordingly. A followup CL will pass in the argument where required.

Progress on #21747 and #26701.

PiperOrigin-RevId: 802504976
Change-Id: I912a84ba6734bf0562f369c7659bcc25f259e70f