### PR TITLE
[8.5.0] Propagate errors correctly from WindowsFileSystem symlink methods.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/windows/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/windows/BUILD
@@ -19,6 +19,8 @@ java_11_library(
     deps = [
         ":windows_path_operations",
         "//src/main/java/com/google/devtools/build/lib/jni",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -103,15 +103,9 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   @Override
   protected PathFragment readSymbolicLink(PathFragment path) throws IOException {
     java.nio.file.Path nioPath = getNioPath(path);
-    WindowsFileOperations.ReadSymlinkOrJunctionResult result =
-        WindowsFileOperations.readSymlinkOrJunction(nioPath.toString());
-    if (result.getStatus() == WindowsFileOperations.ReadSymlinkOrJunctionResult.Status.OK) {
-      return PathFragment.create(StringEncoding.platformToInternal(result.getResult()));
-    }
-    if (result.getStatus() == WindowsFileOperations.ReadSymlinkOrJunctionResult.Status.NOT_A_LINK) {
-      throw new NotASymlinkException(path);
-    }
-    throw new IOException(result.getResult());
+    return PathFragment.create(
+        StringEncoding.platformToInternal(
+            WindowsFileOperations.readSymlinkOrJunction(nioPath.toString())));
   }
 
   @Override

--- a/src/main/native/windows/file.cc
+++ b/src/main/native/windows/file.cc
@@ -607,7 +607,10 @@ int ReadSymlinkOrJunction(const wstring& path, wstring* result,
       return ReadSymlinkOrJunctionResult::kNotALink;
     }
     default:
-      return ReadSymlinkOrJunctionResult::kUnknownLinkType;
+      *error =
+          MakeErrorMessage(WSTR(__FILE__), __LINE__, L"ReadSymlinkOrJunction",
+                           path, L"unsupported link type");
+      return ReadSymlinkOrJunctionResult::kError;
   }
 }
 

--- a/src/main/native/windows/file.h
+++ b/src/main/native/windows/file.h
@@ -133,7 +133,6 @@ struct ReadSymlinkOrJunctionResult {
     kAccessDenied = 2,
     kDoesNotExist = 3,
     kNotALink = 4,
-    kUnknownLinkType = 5,
   };
 };
 

--- a/src/main/tools/build-runfiles-windows.cc
+++ b/src/main/tools/build-runfiles-windows.cc
@@ -113,9 +113,6 @@ bool ReadSymlink(const wstring& abs_path, wstring* target, wstring* error) {
     case bazel::windows::ReadSymlinkOrJunctionResult::kNotALink:
       *error = L"path is not a link";
       break;
-    case bazel::windows::ReadSymlinkOrJunctionResult::kUnknownLinkType:
-      *error = L"unknown link type";
-      break;
     default:
       // This is bazel::windows::ReadSymlinkOrJunctionResult::kError (1).
       // The JNI code puts a custom message in 'error'.

--- a/src/test/java/com/google/devtools/build/lib/windows/WindowsFileOperationsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/windows/WindowsFileOperationsTest.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.windows;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
@@ -22,6 +23,7 @@ import com.google.devtools.build.lib.testutil.TestSpec;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.windows.util.WindowsTestUtil;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -76,12 +78,9 @@ public class WindowsFileOperationsTest {
     // Assert deleting the symlink does not remove the target file.
     assertThat(WindowsFileOperations.deletePath(symlinkFile.toString())).isTrue();
     assertThat(helloFile.exists()).isTrue();
-    try {
-      WindowsFileOperations.isSymlinkOrJunction(symlinkFile.toString());
-      fail("Expected to throw: Symlink should no longer exist.");
-    } catch (IOException e) {
-      assertThat(e).hasMessageThat().contains("path does not exist");
-    }
+    assertThrows(
+        FileNotFoundException.class,
+        () -> WindowsFileOperations.isSymlinkOrJunction(symlinkFile.toString()));
   }
 
   @Test
@@ -143,12 +142,9 @@ public class WindowsFileOperationsTest {
     assertThat(WindowsFileOperations.isSymlinkOrJunction(root + "\\longtargetpath\\file2.txt"))
         .isFalse();
     assertThat(WindowsFileOperations.isSymlinkOrJunction(root + "\\longta~1\\file2.txt")).isFalse();
-    try {
-      WindowsFileOperations.isSymlinkOrJunction(root + "\\non-existent");
-      fail("expected to throw");
-    } catch (IOException e) {
-      assertThat(e.getMessage()).contains("path does not exist");
-    }
+    assertThrows(
+        FileNotFoundException.class,
+        () -> WindowsFileOperations.isSymlinkOrJunction(root + "\\non-existent"));
     assertThat(Arrays.asList(new File(root + "/shrtpath/a").list())).containsExactly("file1.txt");
     assertThat(Arrays.asList(new File(root + "/shrtpath/b").list())).containsExactly("file2.txt");
     assertThat(Arrays.asList(new File(root + "/shrtpath/c").list())).containsExactly("file2.txt");


### PR DESCRIPTION
A bare IOException should not be used in place of FileNotFoundException and NotASymlinkException, which are sometimes used for control flow (to minimize the number of syscalls in a fast path).

PiperOrigin-RevId: 733735243
Change-Id: I12b95a61da5ab49a4be15c570df70a5870614bb7