### PR TITLE
[7.7.0] Propagate errors correctly from WindowsFileSystem symlink methods.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/windows/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/windows/BUILD
@@ -16,7 +16,12 @@ filegroup(
 java_11_library(
     name = "file",
     srcs = ["WindowsFileOperations.java"],
-    deps = ["//src/main/java/com/google/devtools/build/lib/jni"],
+    deps = [
+        ":windows_path_operations",
+        "//src/main/java/com/google/devtools/build/lib/jni",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+    ],
 )
 
 java_library(

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileOperations.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileOperations.java
@@ -15,6 +15,8 @@
 package com.google.devtools.build.lib.windows;
 
 import com.google.devtools.build.lib.jni.JniLoader;
+import com.google.devtools.build.lib.vfs.FileSystem.NotASymlinkException;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
@@ -47,34 +49,6 @@ public class WindowsFileOperations {
 
   private WindowsFileOperations() {
     // Prevent construction
-  }
-
-  /** Result of {@link #readSymlinkOrJunction}. */
-  public static class ReadSymlinkOrJunctionResult {
-
-    /** Status code, indicating success or failure. */
-    public enum Status {
-      OK,
-      NOT_A_LINK,
-      ERROR
-    }
-
-    private String result;
-    private Status status;
-
-    public ReadSymlinkOrJunctionResult(Status s, String r) {
-      this.status = s;
-      this.result = r;
-    }
-
-    /** Result string (junction target) or error message (depending on {@link status}). */
-    public String getResult() {
-      return result;
-    }
-
-    public Status getStatus() {
-      return status;
-    }
   }
 
   // Keep IS_SYMLINK_OR_JUNCTION_* values in sync with src/main/native/windows/file.cc.
@@ -115,7 +89,6 @@ public class WindowsFileOperations {
   private static final int READ_SYMLINK_OR_JUNCTION_ACCESS_DENIED = 2;
   private static final int READ_SYMLINK_OR_JUNCTION_DOES_NOT_EXIST = 3;
   private static final int READ_SYMLINK_OR_JUNCTION_NOT_A_LINK = 4;
-  private static final int READ_SYMLINK_OR_JUNCTION_UNKNOWN_LINK_TYPE = 5;
 
   private static native int nativeIsSymlinkOrJunction(
       String path, boolean[] result, String[] error);
@@ -142,8 +115,7 @@ public class WindowsFileOperations {
       case IS_SYMLINK_OR_JUNCTION_SUCCESS:
         return result[0];
       case IS_SYMLINK_OR_JUNCTION_DOES_NOT_EXIST:
-        error[0] = "path does not exist";
-        break;
+        throw new FileNotFoundException(path);
       default:
         // This is IS_SYMLINK_OR_JUNCTION_ERROR (1). The JNI code puts a custom message in
         // 'error[0]'.
@@ -264,33 +236,23 @@ public class WindowsFileOperations {
         String.format("Cannot create symlink (name=%s, target=%s): %s", name, target, error[0]));
   }
 
-  public static ReadSymlinkOrJunctionResult readSymlinkOrJunction(String name) {
+  public static String readSymlinkOrJunction(String name) throws IOException {
     String[] target = new String[] {null};
     String[] error = new String[] {null};
     switch (nativeReadSymlinkOrJunction(asLongPath(name), target, error)) {
       case READ_SYMLINK_OR_JUNCTION_SUCCESS:
-        return new ReadSymlinkOrJunctionResult(
-            ReadSymlinkOrJunctionResult.Status.OK, removeUncPrefixAndUseSlashes(target[0]));
+        return WindowsPathOperations.removeUncPrefixAndUseSlashes(target[0]);
       case READ_SYMLINK_OR_JUNCTION_ACCESS_DENIED:
-        error[0] = "access is denied";
-        break;
+        throw new AccessDeniedException(name);
       case READ_SYMLINK_OR_JUNCTION_DOES_NOT_EXIST:
-        error[0] = "path does not exist";
-        break;
+        throw new FileNotFoundException(name);
       case READ_SYMLINK_OR_JUNCTION_NOT_A_LINK:
-        return new ReadSymlinkOrJunctionResult(
-            ReadSymlinkOrJunctionResult.Status.NOT_A_LINK, "path is not a link");
-      case READ_SYMLINK_OR_JUNCTION_UNKNOWN_LINK_TYPE:
-        error[0] = "unknown link type";
-        break;
+        throw new NotASymlinkException(PathFragment.create(name));
       default:
         // This is READ_SYMLINK_OR_JUNCTION_ERROR (1). The JNI code puts a custom message in
         // 'error[0]'.
-        break;
+        throw new IOException(String.format("Cannot read link (name=%s): %s", name, error[0]));
     }
-    return new ReadSymlinkOrJunctionResult(
-        ReadSymlinkOrJunctionResult.Status.ERROR,
-        String.format("Cannot read link (name=%s): %s", name, error[0]));
   }
 
   public static boolean deletePath(String path) throws IOException {

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -101,15 +101,7 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   @Override
   protected PathFragment readSymbolicLink(PathFragment path) throws IOException {
     java.nio.file.Path nioPath = getNioPath(path);
-    WindowsFileOperations.ReadSymlinkOrJunctionResult result =
-        WindowsFileOperations.readSymlinkOrJunction(nioPath.toString());
-    if (result.getStatus() == WindowsFileOperations.ReadSymlinkOrJunctionResult.Status.OK) {
-      return PathFragment.create(result.getResult());
-    }
-    if (result.getStatus() == WindowsFileOperations.ReadSymlinkOrJunctionResult.Status.NOT_A_LINK) {
-      throw new NotASymlinkException(path);
-    }
-    throw new IOException(result.getResult());
+    return PathFragment.create(WindowsFileOperations.readSymlinkOrJunction(nioPath.toString())));
   }
 
   @Override

--- a/src/main/native/windows/file.cc
+++ b/src/main/native/windows/file.cc
@@ -606,7 +606,10 @@ int ReadSymlinkOrJunction(const wstring& path, wstring* result,
       return ReadSymlinkOrJunctionResult::kNotALink;
     }
     default:
-      return ReadSymlinkOrJunctionResult::kUnknownLinkType;
+      *error =
+          MakeErrorMessage(WSTR(__FILE__), __LINE__, L"ReadSymlinkOrJunction",
+                           path, L"unsupported link type");
+      return ReadSymlinkOrJunctionResult::kError;
   }
 }
 

--- a/src/main/native/windows/file.h
+++ b/src/main/native/windows/file.h
@@ -133,7 +133,6 @@ struct ReadSymlinkOrJunctionResult {
     kAccessDenied = 2,
     kDoesNotExist = 3,
     kNotALink = 4,
-    kUnknownLinkType = 5,
   };
 };
 

--- a/src/test/java/com/google/devtools/build/lib/windows/WindowsFileOperationsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/windows/WindowsFileOperationsTest.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.windows;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
@@ -22,6 +23,7 @@ import com.google.devtools.build.lib.testutil.TestSpec;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.windows.util.WindowsTestUtil;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -76,12 +78,9 @@ public class WindowsFileOperationsTest {
     // Assert deleting the symlink does not remove the target file.
     assertThat(WindowsFileOperations.deletePath(symlinkFile.toString())).isTrue();
     assertThat(helloFile.exists()).isTrue();
-    try {
-      WindowsFileOperations.isSymlinkOrJunction(symlinkFile.toString());
-      fail("Expected to throw: Symlink should no longer exist.");
-    } catch (IOException e) {
-      assertThat(e).hasMessageThat().contains("path does not exist");
-    }
+    assertThrows(
+        FileNotFoundException.class,
+        () -> WindowsFileOperations.isSymlinkOrJunction(symlinkFile.toString()));
   }
 
   @Test
@@ -143,12 +142,9 @@ public class WindowsFileOperationsTest {
     assertThat(WindowsFileOperations.isSymlinkOrJunction(root + "\\longtargetpath\\file2.txt"))
         .isFalse();
     assertThat(WindowsFileOperations.isSymlinkOrJunction(root + "\\longta~1\\file2.txt")).isFalse();
-    try {
-      WindowsFileOperations.isSymlinkOrJunction(root + "\\non-existent");
-      fail("expected to throw");
-    } catch (IOException e) {
-      assertThat(e.getMessage()).contains("path does not exist");
-    }
+    assertThrows(
+        FileNotFoundException.class,
+        () -> WindowsFileOperations.isSymlinkOrJunction(root + "\\non-existent"));
     assertThat(Arrays.asList(new File(root + "/shrtpath/a").list())).containsExactly("file1.txt");
     assertThat(Arrays.asList(new File(root + "/shrtpath/b").list())).containsExactly("file2.txt");
     assertThat(Arrays.asList(new File(root + "/shrtpath/c").list())).containsExactly("file2.txt");


### PR DESCRIPTION
A bare IOException should not be used in place of FileNotFoundException and NotASymlinkException, which are sometimes used for control flow (to minimize the number of syscalls in a fast path).

PiperOrigin-RevId: 733735243
Change-Id: I12b95a61da5ab49a4be15c570df70a5870614bb7