### PR TITLE
Fix object file extensions in cc_compilation_outputs

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/compile/cc_compilation_outputs.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/compile/cc_compilation_outputs.bzl
@@ -151,7 +151,7 @@ def create_compilation_outputs(
     dwo_objects = _to_list(dwo_objects)
     pic_dwo_objects = _to_list(pic_dwo_objects)
 
-    obj_extensions = ["o", "obj", ".opb", ".bc"]
+    obj_extensions = ["o", "obj", "opb", "bc"]
     _validate_extensions("objects", objects, obj_extensions)
     _validate_extensions("pic_objects", pic_objects, obj_extensions)
 


### PR DESCRIPTION
Removed leading dots from object file extensions like `opbc` and `bc`.

Fixes issues in rules_swift like:

```
Error in fail: 'bazel-out/darwin_arm64-fastbuild-ST-7b57690fdc56/bin/test/fixtures/debug_settings/simple_objs/Empty.swift.bc' has wrong extension. The list of possible extensions for 'objects' is: o, obj, .opb, .bc
```

As the docs mention `File.extension` returns the extension without the leading `.`:

>The file extension of this file, following (not including) the rightmost period. Empty string if the file's basename includes no periods.