### PR TITLE
Fix remote worker docs for macOS

### DIFF
--- a/src/tools/remote/README.md
+++ b/src/tools/remote/README.md
@@ -8,7 +8,7 @@ The simplest setup is as follows:
 
         bazel build src/tools/remote:all
 
-        mkdir --parents /tmp/worker/work /tmp/worker/cas
+        mkdir -p /tmp/worker/work /tmp/worker/cas
 
         bazel-bin/src/tools/remote/worker \
             --work_path=/tmp/worker/work \


### PR DESCRIPTION
macOS' `mkdir` doesn't support `--parents`.