### PR TITLE
Remove redundant flags `--enable_bzlmod` and `--noenable_workspace` from `testenv.sh`

### DIFF
--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -296,12 +296,6 @@ build --incompatible_skip_genfiles_symlink=false
 
 build --incompatible_use_toolchain_resolution_for_java_rules
 
-# Enable Bzlmod in all shell integration tests
-common --enable_bzlmod
-
-# Disable WORKSPACE in all shell integration tests
-common --noenable_workspace
-
 # Support JDK 21, data dependencies that get compiled and used tools need to be
 # run with 21 runtime.
 build --java_runtime_version=21


### PR DESCRIPTION
The state of these flags match the default and are deprecated.