### PR TITLE
Cancel `MerkleTreeComputer` futures on interrupts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
@@ -893,6 +893,9 @@ public final class MerkleTreeComputer {
   private static <T> T getFromFuture(Future<T> future) throws IOException, InterruptedException {
     try {
       return future.get();
+    } catch (InterruptedException e) {
+      future.cancel(/* mayInterruptIfRunning= */ true);
+      throw e;
     } catch (ExecutionException e) {
       if (e.getCause() instanceof WrappedException wrappedException) {
         wrappedException.unwrapAndThrow();


### PR DESCRIPTION
Merkle tree computations and uploads should not continue after a build has been interrupted.