### PR TITLE
xcode_locator respects DEVELOPER_DIR

### DIFF
--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -45,6 +45,20 @@ def _search_sdk_output(output, sdkname):
     """Returns the SDK version given xcodebuild stdout and an sdkname."""
     return _search_string(output, "(%s" % sdkname, ")")
 
+def _xcodebuild_path(repository_ctx):
+    """Returns the xcodebuild path"""
+    developer_dir = repository_ctx.getenv("DEVELOPER_DIR")
+    if developer_dir:
+        xcodebuild_path = repository_ctx.path("{}/usr/bin/xcodebuild".format(developer_dir))
+        if xcodebuild_path.exists:
+            return str(xcodebuild_path)
+
+    xcodebuild_path = repository_ctx.which("xcodebuild")
+    if xcodebuild_path.exists:
+        return str(xcodebuild_path)
+
+    fail("xcodebuild can't be found neither in DEVELOPER_DIR nor by name")
+
 def _xcode_version_output(repository_ctx, name, version, aliases, developer_dir, timeout):
     """Returns a string containing an xcode_version build target."""
     build_contents = ""
@@ -54,7 +68,7 @@ def _xcode_version_output(repository_ctx, name, version, aliases, developer_dir,
         decorated_aliases.append("'%s'" % alias)
     repository_ctx.report_progress("Fetching SDK information for Xcode %s" % version)
     xcodebuild_result = repository_ctx.execute(
-        ["xcrun", "xcodebuild", "-version", "-sdk"],
+        ["xcrun", _xcodebuild_path(repository_ctx), "-version", "-sdk"],
         timeout,
         {"DEVELOPER_DIR": developer_dir},
     )
@@ -197,6 +211,10 @@ def _darwin_build_file(repository_ctx):
     repository_ctx.report_progress("Fetching the default Xcode version")
     env = repository_ctx.os.environ
 
+    xcrun_path = repository_ctx.which("xcrun")
+    if not xcrun_path.exists:
+        fail("Can't find installed xcrun")
+
     if "BAZEL_OSX_EXECUTE_TIMEOUT" in env:
         timeout = int(env["BAZEL_OSX_EXECUTE_TIMEOUT"])
     else:
@@ -207,7 +225,7 @@ def _darwin_build_file(repository_ctx):
         "-i",
         "DEVELOPER_DIR={}".format(env.get("DEVELOPER_DIR", default = "")),
         "xcrun",
-        "xcodebuild",
+        _xcodebuild_path(repository_ctx),
         "-version",
     ], timeout)
 


### PR DESCRIPTION
Ability to build swift code by xcode from user defined DEVELOPER_DIR was significant feature of [bazel 8.3.0](https://github.com/bazelbuild/bazel/releases/tag/8.3.0)

However, if doesn't work fully.

swiftc compiler doesn't run directly in build action. It is launched through [xcode_locator](https://github.com/bazelbuild/bazel/blob/master/tools/osx/xcode_locator.m), which set DEVELOPER_DIR before swiftc call.

Problems are:

xcode_locator doesn't respect DEVELOPER_DIR (defined by me).
xcode_locator selects installed xcodes only.
First problem looks even worse, because [xcode_swift_toolchain](https://github.com/bazelbuild/rules_swift/blob/master/swift/toolchains/xcode_swift_toolchain.bzl) determines "my" xcode and plans to use it (xcode_swift_toolchain analyzes DEVELOPER_DIR), but it doesn't guarantee "my" xcode usage (because of xcode_locator as intermediate lawyer).

As feature user I want to say, that if I set DEVELOPER_DIR, I know better what xcode should be chosen and accept all risks.
This is very important when you try to build swift code on newest MacOS by old xcode. You can't install it due to OS policies, but you would like (and actually can) to use it still by extracting .xip archive.

Issue: #27238 