### PR TITLE
remove references to java_tools prebuilts from MODULE.tools

### DIFF
--- a/src/MODULE.tools
+++ b/src/MODULE.tools
@@ -21,10 +21,6 @@ use_repo(
     java_toolchains,
     "local_jdk",
     "remote_java_tools",
-    "remote_java_tools_linux",
-    "remote_java_tools_windows",
-    "remote_java_tools_darwin_x86_64",
-    "remote_java_tools_darwin_arm64",
 )
 
 remote_coverage_tools_extension = use_extension("//tools/test:extensions.bzl", "remote_coverage_tools_extension")


### PR DESCRIPTION
These don't actually seem to be referenced by `@bazel_tools`.