### PR TITLE
[8.5.0] Don't add apple env if Xcode version isn't set

### DIFF
--- a/src/main/starlark/builtins_bzl/common/objc/apple_env.bzl
+++ b/src/main/starlark/builtins_bzl/common/objc/apple_env.bzl
@@ -15,7 +15,7 @@
 """Functions to retrieve the environment to set for Apple actions."""
 
 def apple_host_system_env(xcode_version_info):
-    if not xcode_version_info:
+    if not xcode_version_info or not xcode_version_info.xcode_version():
         return {}
     return {"XCODE_VERSION_OVERRIDE": str(xcode_version_info.xcode_version())}
 


### PR DESCRIPTION
In the case no Xcode versions are installed, but something is requesting
this, like when you try to build an objc_library with only the CLT
installed, the `xcode_version` here is `None`. This fails with a
surprising crash in bazel when the `None` version is parsed. Now we just
don't set this, which cascades to later failures, but has slightly nicer
error messages.

Work towards: https://github.com/bazelbuild/bazel/issues/25728

Closes #27043.

PiperOrigin-RevId: 822013040
Change-Id: If7bed42e5c9f6bdbb731ff1239b32190131177b7

Commit https://github.com/bazelbuild/bazel/commit/907ef586d1bc66ad3b5e5ee60a471a4296a81e7b