### PR TITLE
[8.5.0] Treat action results with missing mandatory outputs as cache misses

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -147,9 +147,11 @@ final class RemoteSpawnCache implements SpawnCache {
               prof.profile(ProfilerTask.REMOTE_CACHE_CHECK, "check cache hit")) {
             result = remoteExecutionService.lookupCache(action);
           }
-          // In case the remote cache returned a failed action (exit code != 0) we treat it as a
-          // cache miss
-          if (result != null && result.getExitCode() == 0) {
+          // In case the remote cache returned a failed action (exit code != 0) or failed to create
+          // a mandatory output, we treat it as a cache miss.
+          if (result != null
+              && result.getExitCode() == 0
+              && result.maybeGetMissingMandatoryOutput(action).isEmpty()) {
             if (thisExecution != null) {
               thisExecution.close();
             }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -78,10 +78,13 @@ import com.google.devtools.build.lib.util.ExitCode;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
+import com.google.rpc.RetryInfo;
 import io.grpc.Status.Code;
+import io.grpc.protobuf.StatusProto;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -217,7 +220,8 @@ public class RemoteSpawnRunner implements SpawnRunner {
       }
 
       if (cachedResult != null) {
-        if (cachedResult.getExitCode() != 0) {
+        if (cachedResult.getExitCode() != 0
+            || cachedResult.maybeGetMissingMandatoryOutput(action).isPresent()) {
           // Failed actions are treated as a cache miss mostly in order to avoid caching flaky
           // actions (tests).
           // Set acceptCachedResult to false in order to force the action re-execution
@@ -311,6 +315,19 @@ public class RemoteSpawnRunner implements SpawnRunner {
             // status.
             // It's already late at this stage, but we should at least report once.
             reporter.reportExecutingIfNot();
+
+            if (result.cacheHit()
+                && (!result.success()
+                    || result.maybeGetMissingMandatoryOutput(action).isPresent())) {
+              // Instead of failing in downloadAndFinalizeSpawnResult, retry with forced execution.
+              useCachedResult.set(false);
+              var status =
+                  com.google.rpc.Status.newBuilder()
+                      .setCode(com.google.rpc.Code.NOT_FOUND_VALUE)
+                      .addDetails(Any.pack(RetryInfo.getDefaultInstance()))
+                      .build();
+              throw StatusProto.toStatusRuntimeException(status);
+            }
 
             maybePrintExecutionMessages(context, result.getMessage(), result.success());
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -142,6 +142,7 @@ public class RemoteSpawnCacheTest {
   private TempPathGenerator tempPathGenerator;
   private SimpleSpawn simpleSpawn;
   private SpawnExecutionContext simplePolicy;
+  private ActionResult successfulResult;
   @Mock private CombinedCache combinedCache;
   private FileOutErr outErr;
 
@@ -287,6 +288,19 @@ public class RemoteSpawnCacheTest {
             execPath.subFragment(0, 1).getRelative("cfg").getRelative(execPath.subFragment(2)));
   }
 
+  private ActionResult createSuccessfulResult(Spawn spawn) {
+    var result = ActionResult.newBuilder().setExitCode(0);
+    for (var output : spawn.getOutputFiles()) {
+      if (spawn.isMandatoryOutput(output)) {
+        result.addOutputFiles(
+            OutputFile.newBuilder()
+                .setPath(spawn.getPathMapper().getMappedExecPathString(output))
+                .setDigest(digestUtil.computeAsUtf8("content")));
+      }
+    }
+    return result.build();
+  }
+
   private RemoteSpawnCache createRemoteSpawnCache() {
     return remoteSpawnCacheWithOptions(Options.getDefaults(RemoteOptions.class));
   }
@@ -331,6 +345,7 @@ public class RemoteSpawnCacheTest {
     tempPathGenerator = new TempPathGenerator(fs.getPath("/execroot/_tmp/actions/remote"));
     FakeActionInputFileCache fakeFileCache = new FakeActionInputFileCache(execRoot);
     simpleSpawn = simpleSpawnWithExecutionInfo(ImmutableMap.of());
+    successfulResult = createSuccessfulResult(simpleSpawn);
 
     Path stdout = fs.getPath("/tmp/stdout");
     Path stderr = fs.getPath("/tmp/stderr");
@@ -356,7 +371,6 @@ public class RemoteSpawnCacheTest {
     RemoteSpawnCache cache = createRemoteSpawnCache();
     RemoteExecutionService service = cache.getRemoteExecutionService();
     ArgumentCaptor<ActionKey> actionKeyCaptor = ArgumentCaptor.forClass(ActionKey.class);
-    ActionResult actionResult = ActionResult.getDefaultInstance();
     when(combinedCache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             actionKeyCaptor.capture(),
@@ -370,7 +384,7 @@ public class RemoteSpawnCacheTest {
                 RequestMetadata meta = context.getRequestMetadata();
                 assertThat(meta.getCorrelatedInvocationsId()).isEqualTo(BUILD_REQUEST_ID);
                 assertThat(meta.getToolInvocationId()).isEqualTo(COMMAND_ID);
-                return CachedActionResult.remote(actionResult);
+                return CachedActionResult.remote(successfulResult);
               }
             });
     doAnswer(
@@ -385,7 +399,8 @@ public class RemoteSpawnCacheTest {
                 })
         .when(service)
         .downloadOutputs(
-            any(), eq(RemoteActionResult.createFromCache(CachedActionResult.remote(actionResult))));
+            any(),
+            eq(RemoteActionResult.createFromCache(CachedActionResult.remote(successfulResult))));
 
     // act
     CacheHandle entry = cache.lookup(simpleSpawn, simplePolicy);
@@ -398,7 +413,8 @@ public class RemoteSpawnCacheTest {
         .isEqualTo(digestUtil.asSpawnLogProto(actionKeyCaptor.getValue()));
     verify(service)
         .downloadOutputs(
-            any(), eq(RemoteActionResult.createFromCache(CachedActionResult.remote(actionResult))));
+            any(),
+            eq(RemoteActionResult.createFromCache(CachedActionResult.remote(successfulResult))));
     verify(service, never()).uploadOutputs(any(), any(), any(), any());
     assertThat(result.getDigest())
         .isEqualTo(digestUtil.asSpawnLogProto(actionKeyCaptor.getValue()));
@@ -743,13 +759,12 @@ public class RemoteSpawnCacheTest {
     remoteOptions.remoteOutputsMode = RemoteOutputsMode.MINIMAL;
     RemoteSpawnCache cache = remoteSpawnCacheWithOptions(remoteOptions);
 
-    ActionResult success = ActionResult.newBuilder().setExitCode(0).build();
     when(combinedCache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(),
             /* inlineOutErr= */ eq(false),
             /* inlineOutputFiles= */ eq(ImmutableSet.of())))
-        .thenReturn(CachedActionResult.remote(success));
+        .thenReturn(CachedActionResult.remote(successfulResult));
     doReturn(null).when(cache.getRemoteExecutionService()).downloadOutputs(any(), any());
 
     // act
@@ -760,7 +775,8 @@ public class RemoteSpawnCacheTest {
     assertThat(cacheHandle.getResult().exitCode()).isEqualTo(0);
     verify(cache.getRemoteExecutionService())
         .downloadOutputs(
-            any(), eq(RemoteActionResult.createFromCache(CachedActionResult.remote(success))));
+            any(),
+            eq(RemoteActionResult.createFromCache(CachedActionResult.remote(successfulResult))));
   }
 
   @Test
@@ -772,17 +788,17 @@ public class RemoteSpawnCacheTest {
 
     IOException downloadFailure = new IOException("downloadMinimal failed");
 
-    ActionResult success = ActionResult.newBuilder().setExitCode(0).build();
     when(combinedCache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(),
             /* inlineOutErr= */ eq(false),
             /* inlineOutputFiles= */ eq(ImmutableSet.of())))
-        .thenReturn(CachedActionResult.remote(success));
+        .thenReturn(CachedActionResult.remote(successfulResult));
     doThrow(downloadFailure)
         .when(cache.getRemoteExecutionService())
         .downloadOutputs(
-            any(), eq(RemoteActionResult.createFromCache(CachedActionResult.remote(success))));
+            any(),
+            eq(RemoteActionResult.createFromCache(CachedActionResult.remote(successfulResult))));
 
     // act
     CacheHandle cacheHandle = cache.lookup(simpleSpawn, simplePolicy);
@@ -791,7 +807,8 @@ public class RemoteSpawnCacheTest {
     assertThat(cacheHandle.hasResult()).isFalse();
     verify(cache.getRemoteExecutionService())
         .downloadOutputs(
-            any(), eq(RemoteActionResult.createFromCache(CachedActionResult.remote(success))));
+            any(),
+            eq(RemoteActionResult.createFromCache(CachedActionResult.remote(successfulResult))));
     assertThat(eventHandler.getEvents().size()).isEqualTo(1);
     Event evt = eventHandler.getEvents().get(0);
     assertThat(evt.getKind()).isEqualTo(EventKind.WARNING);
@@ -1141,7 +1158,7 @@ public class RemoteSpawnCacheTest {
     RemoteExecutionService remoteExecutionService = cache.getRemoteExecutionService();
     Mockito.doReturn(
             RemoteActionResult.createFromCache(
-                CachedActionResult.remote(ActionResult.getDefaultInstance())))
+                CachedActionResult.remote(createSuccessfulResult(spawn))))
         .when(remoteExecutionService)
         .lookupCache(any());
     Mockito.doReturn(null).when(remoteExecutionService).downloadOutputs(any(), any());
@@ -1235,7 +1252,7 @@ public class RemoteSpawnCacheTest {
     RemoteExecutionService remoteExecutionService = cache.getRemoteExecutionService();
     Mockito.doReturn(
             RemoteActionResult.createFromCache(
-                CachedActionResult.remote(ActionResult.getDefaultInstance())))
+                CachedActionResult.remote(createSuccessfulResult(spawn))))
         .when(remoteExecutionService)
         .lookupCache(any());
     Mockito.doThrow(new CredentialHelperException("credential helper failed"))
@@ -1302,5 +1319,25 @@ public class RemoteSpawnCacheTest {
             .containsExactly("--foo", "--bar");
       }
     }
+  }
+
+  @Test
+  public void missingMandatoryOutputs_noCacheHit() throws Exception {
+    // Test that an AC which misses mandatory outputs is correctly ignored.
+    // arrange
+    RemoteSpawnCache cache = createRemoteSpawnCache();
+    when(combinedCache.downloadActionResult(
+            any(RemoteActionExecutionContext.class),
+            any(),
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
+        .thenReturn(CachedActionResult.remote(ActionResult.getDefaultInstance()));
+
+    // act
+    var cacheHandle = cache.lookup(simpleSpawn, simplePolicy);
+
+    // assert
+    assertThat(cacheHandle.hasResult()).isFalse();
+    assertThat(cacheHandle.willStore()).isTrue();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -42,6 +42,7 @@ import build.bazel.remote.execution.v2.ExecutedActionMetadata;
 import build.bazel.remote.execution.v2.ExecutionCapabilities;
 import build.bazel.remote.execution.v2.ExecutionStage.Value;
 import build.bazel.remote.execution.v2.LogFile;
+import build.bazel.remote.execution.v2.OutputFile;
 import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.collect.ClassToInstanceMap;
 import com.google.common.collect.ImmutableClassToInstanceMap;
@@ -71,6 +72,7 @@ import com.google.devtools.build.lib.actions.SpawnMetrics;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
 import com.google.devtools.build.lib.actions.StaticInputMetadataProvider;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
@@ -474,6 +476,107 @@ public class RemoteSpawnRunnerTest {
 
     runner.exec(spawn, policy);
 
+    verify(service).executeRemotely(any(), eq(false), any());
+  }
+
+  @Test
+  public void treatCachedActionWithMissingOutputAsCacheMiss_duringRemoteCacheCheck()
+      throws Exception {
+    // Test that bazel treats a cached action with missing mandatory outputs as a cache miss and
+    // attempts to execute the action remotely.
+
+    var runner = newSpawnRunner();
+    var service = runner.getRemoteExecutionService();
+    var actionWithoutOutputs = CachedActionResult.remote(ActionResult.getDefaultInstance());
+    doReturn(RemoteActionResult.createFromCache(actionWithoutOutputs))
+        .when(service)
+        .lookupCache(any(RemoteAction.class));
+
+    var output =
+        ActionsTestUtil.createArtifactWithExecPath(
+            artifactRoot, PathFragment.create("outputs/out"));
+    var successfulResponse =
+        ExecuteResponse.newBuilder()
+            .setResult(
+                ActionResult.newBuilder()
+                    .setExitCode(0)
+                    .addOutputFiles(
+                        OutputFile.newBuilder()
+                            .setPath(output.getExecPathString())
+                            .setDigest(digestUtil.computeAsUtf8("content")))
+                    .build())
+            .build();
+    when(executor.executeRemotely(
+            any(RemoteActionExecutionContext.class),
+            any(ExecuteRequest.class),
+            any(OperationObserver.class)))
+        .thenReturn(successfulResponse);
+    var spawn = newSimpleSpawn(output);
+    var spawnExecutionContext = getSpawnContext(spawn);
+
+    var result = runner.exec(spawn, spawnExecutionContext);
+    assertThat(result.status()).isEqualTo(Status.SUCCESS);
+
+    verify(service).executeRemotely(any(), eq(false), any());
+  }
+
+  @Test
+  public void treatCachedActionWithMissingOutputAsCacheMiss_duringRemoteExecution()
+      throws Exception {
+    // Test that bazel treats a cached execute result with missing mandatory outputs as a cache miss
+    // and reattempts to execute the action remotely, this time ignoring cached results.
+
+    var runner = newSpawnRunner();
+    var service = runner.getRemoteExecutionService();
+    // Ensure that the initial cache lookup doesn't already return a result with missing outputs -
+    // this case is covered by the previous test.
+    doReturn(null).when(service).lookupCache(any(RemoteAction.class));
+
+    var actionWithoutOutputs = CachedActionResult.remote(ActionResult.getDefaultInstance());
+    when(cache.downloadActionResult(
+            any(RemoteActionExecutionContext.class),
+            any(ActionKey.class),
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
+        .thenReturn(actionWithoutOutputs);
+
+    var output =
+        ActionsTestUtil.createArtifactWithExecPath(
+            artifactRoot, PathFragment.create("outputs/out"));
+    var responseWithoutOutput =
+        ExecuteResponse.newBuilder()
+            .setResult(ActionResult.newBuilder().setExitCode(0).build())
+            .setCachedResult(true)
+            .build();
+    var responseWithOutput =
+        ExecuteResponse.newBuilder()
+            .setResult(
+                ActionResult.newBuilder()
+                    .setExitCode(0)
+                    .addOutputFiles(
+                        OutputFile.newBuilder()
+                            .setPath(output.getExecPathString())
+                            .setDigest(digestUtil.computeAsUtf8("content")))
+                    .build())
+            .build();
+    when(executor.executeRemotely(
+            any(RemoteActionExecutionContext.class),
+            any(ExecuteRequest.class),
+            any(OperationObserver.class)))
+        .thenAnswer(
+            answer ->
+                answer.getArgument(1, ExecuteRequest.class).getSkipCacheLookup()
+                    ? responseWithOutput
+                    : responseWithoutOutput);
+    var spawn = newSimpleSpawn(output);
+    var spawnExecutionContext = getSpawnContext(spawn);
+
+    var result = runner.exec(spawn, spawnExecutionContext);
+    assertThat(result.status()).isEqualTo(Status.SUCCESS);
+
+    // The first execution attempt hits the cache and returns the result with missing outputs, the
+    // second attempt forcibly re-executes the action.
+    verify(service).executeRemotely(any(), eq(true), any());
     verify(service).executeRemotely(any(), eq(false), any());
   }
 


### PR DESCRIPTION
This allows builds to recover from a polluted remote cache that contains an action result with an exit code of 0 that hasn't produced the required output files.

The check added in unknown commit is moved closer to the lookup so that the cached result can be ignored instead of resulting in an error, with forced re-execution in the case of remote execution.

Closes #27105.

PiperOrigin-RevId: 821651398
Change-Id: I067c668598f9ee83e670b4636854185282112f86 (cherry picked from commit 29d442bc02e4829dc88ba5f79a3d626d1ca8680e)

Closes #27363