### PR TITLE
Remove test wall time from xml_test_generator usage

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -459,7 +459,6 @@ public class StandaloneTestStrategy extends TestStrategy {
                 .getCallablePathStringForOs(action.getExecutionSettings().getExecutionOs()),
             action.getTestLog().getExecPathString(),
             action.getTestXml().getExecPathString(),
-            Integer.toString(result.getWallTimeInMs() / 1000),
             Integer.toString(result.exitCode()));
     ImmutableMap.Builder<String, String> envBuilder = ImmutableMap.builder();
     // "PATH" and "TEST_BINARY" are also required, they should always be set in testEnv.

--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -619,18 +619,13 @@ class TestWrapperTest(test_base.TestBase):
 
     test_xml = os.path.join(bazel_testlogs, 'foo', 'xml_test', 'test.xml')
     self.assertTrue(os.path.exists(test_xml))
-    duration = 0
     xml_contents = []
     stdout_lines = []
     stderr_lines = []
     with open(test_xml, 'rt') as f:
       xml_contents = [line.strip() for line in f]
     for line in xml_contents:
-      if 'duration=' in line:
-        line = line[line.find('duration="') + len('duration="'):]
-        line = line[:line.find('"')]
-        duration = int(line)
-      elif 'stdout_line' in line:
+      if 'stdout_line' in line:
         stdout_lines.append(line)
       elif 'stderr_line' in line:
         stderr_lines.append(line)
@@ -642,8 +637,6 @@ class TestWrapperTest(test_base.TestBase):
     # stdout after L1, then it must be strictly ordered after L1 (but not
     # necessarily after L2).
     # Therefore we only assert partial ordering of lines.
-    if duration <= 1:
-      self._FailWithOutput(xml_contents)
     if (len(stdout_lines) != 2 or 'stdout_line_1' not in stdout_lines[0] or
         'stdout_line_2' not in stdout_lines[1]):
       self._FailWithOutput(xml_contents)

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -735,24 +735,20 @@ EOF
   cat bazel-testlogs/dir/success/test.xml >$TEST_log
   expect_log "errors=\"0\""
   expect_log_once "testcase"
-  expect_log_once "duration=\"[0-9]\+\""
   expect_log "name=\"dir/success\""
   cat bazel-testlogs/dir/fail/test.xml >$TEST_log
   expect_log "errors=\"1\""
   expect_log_once "testcase"
-  expect_log_once "duration=\"[0-9]\+\""
   expect_log "name=\"dir/fail\""
 
   bazel test //dir:all --run_under=exec &> $TEST_log && fail "should have failed" || true
   cp bazel-testlogs/dir/success/test.xml $TEST_log
   expect_log "errors=\"0\""
   expect_log_once "testcase"
-  expect_log_once "duration=\"[0-9]\+\""
   expect_log "name=\"dir/success\""
   cp bazel-testlogs/dir/fail/test.xml $TEST_log
   expect_log "errors=\"1\""
   expect_log_once "testcase"
-  expect_log_once "duration=\"[0-9]\+\""
   expect_log "name=\"dir/fail\""
 }
 

--- a/tools/test/generate-xml.sh
+++ b/tools/test/generate-xml.sh
@@ -18,8 +18,7 @@ set -euo pipefail
 
 TEST_LOG="$1"
 XML_OUTPUT_FILE="$2"
-DURATION_IN_SECONDS="$3"
-EXIT_CODE="$4"
+EXIT_CODE="$3"
 
 function encode_stream {
   # Replace invalid XML characters and invalid sequence in CDATA
@@ -119,7 +118,7 @@ cat >"${XML_OUTPUT_FILE}" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite name="${test_name}" tests="1" failures="0" errors="${errors}">
-    <testcase name="${test_name}" status="run" duration="${DURATION_IN_SECONDS}" time="${DURATION_IN_SECONDS}">${error_msg}</testcase>
+    <testcase name="${test_name}" status="run">${error_msg}</testcase>
       <system-out>
 Generated test.log (if the file is not UTF-8, then this may be unreadable):
 <![CDATA[${ENCODED_LOG}]]>


### PR DESCRIPTION
The duration report introduces unnecessary noise in determinism for build which otherwise represent identical behaviors - each test that varies in execution enough to cross a second threshold would appear with a different action, making it extremely difficult to isolate determinism across a build's worth of actions.

Duration reporting takes place in bazel through alternative means.