### PR TITLE
[8.5.0] Don't use `environ` on Windows

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -79,10 +79,6 @@
 
 using blaze_util::GetLastErrorString;
 
-#if !defined(_WIN32)
-extern char **environ;
-#endif
-
 namespace blaze {
 
 using command_server::CommandServer;
@@ -1297,8 +1293,7 @@ static map<string, EnvVarValue> PrepareEnvironmentForJvm() {
   // environment variables to modify the current process, we may actually use
   // such map to configure a process from scratch (via interfaces like execvpe
   // or posix_spawn), so we need to inherit any untouched variables.
-  for (char **entry = environ; *entry != nullptr; entry++) {
-    const std::string var_value = *entry;
+  for (const auto& var_value : blaze::GetProcessedEnv()) {
     std::string::size_type equals = var_value.find('=');
     if (equals == std::string::npos) {
       // Ignore possibly-bad environment. We don't control what we see in this

--- a/src/main/cpp/option_processor-internal.h
+++ b/src/main/cpp/option_processor-internal.h
@@ -58,8 +58,6 @@ std::string FindRcAlongsideBinary(const std::string& cwd,
 
 blaze_exit_code::ExitCode ParseErrorToExitCode(RcFile::ParseError parse_error);
 
-std::vector<std::string> GetProcessedEnv();
-
 }  // namespace internal
 }  // namespace blaze
 

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -35,11 +35,6 @@
 #include "src/main/cpp/util/strings.h"
 #include "src/main/cpp/workspace_layout.h"
 
-// On OSX, there apparently is no header that defines this.
-#ifndef environ
-extern char **environ;
-#endif
-
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -525,7 +520,7 @@ blaze_exit_code::ExitCode OptionProcessor::ParseOptions(
   }
 
   blazerc_and_env_command_args_ = GetBlazercAndEnvCommandArgs(
-      cwd, rc_file_ptrs, blaze::internal::GetProcessedEnv());
+      cwd, rc_file_ptrs, blaze::GetProcessedEnv());
   return blaze_exit_code::SUCCESS;
 }
 

--- a/src/main/cpp/option_processor.h
+++ b/src/main/cpp/option_processor.h
@@ -168,6 +168,10 @@ blaze_exit_code::ExitCode ParseRcFile(const WorkspaceLayout* workspace_layout,
                                       std::unique_ptr<RcFile>* result_rc_file,
                                       std::string* error);
 
+// Returns the list of environment variables in the form "KEY=value", with
+// synthetic entries (Windows only) filtered out.
+std::vector<std::string> GetProcessedEnv();
+
 }  // namespace blaze
 
 #endif  // BAZEL_SRC_MAIN_CPP_OPTION_PROCESSOR_H_

--- a/src/main/cpp/option_processor_unix.cc
+++ b/src/main/cpp/option_processor_unix.cc
@@ -22,7 +22,7 @@
 extern char** environ;
 #endif
 
-namespace blaze::internal {
+namespace blaze {
 
 std::vector<std::string> GetProcessedEnv() {
   std::vector<std::string> processed_env;
@@ -32,4 +32,4 @@ std::vector<std::string> GetProcessedEnv() {
   return processed_env;
 }
 
-}  // namespace blaze::internal
+}  // namespace blaze

--- a/src/main/cpp/option_processor_windows.cc
+++ b/src/main/cpp/option_processor_windows.cc
@@ -23,7 +23,7 @@
 #include "src/main/cpp/option_processor-internal.h"
 #include "src/main/cpp/util/strings.h"
 
-namespace blaze::internal {
+namespace blaze {
 
 #if defined(__CYGWIN__)
 
@@ -98,4 +98,4 @@ std::vector<std::string> GetProcessedEnv() {
   return processed_env;
 }
 
-}  // namespace blaze::internal
+}  // namespace blaze


### PR DESCRIPTION
Since Bazel uses `wmain`, `environ` is typically `null` until the first call to `getenv()`. This call has been removed in 1744d45c0c57af23f631c2145e8af4b185dca77f, so this usage could result in a crash.

Fixes #26948

Closes #26993.

PiperOrigin-RevId: 812778486
Change-Id: Ied0d564570bbafc00a1bab952c99213da668a32b 
(cherry picked from commit ef8b1d28d7b704fbe25134869e04d8ca6ed1f8d5)

Closes #26994