### PR TITLE
[8.5.0] Unwrap interrupts during input prefetching

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
@@ -193,6 +193,7 @@ public interface SpawnRunner {
           throwIfInstanceOf(cause, IOException.class);
           throwIfInstanceOf(cause, ExecException.class);
           throwIfInstanceOf(cause, ForbiddenActionInputException.class);
+          throwIfInstanceOf(cause, InterruptedException.class);
           throwIfInstanceOf(cause, RuntimeException.class);
         }
         throw new IOException(e);


### PR DESCRIPTION
Speculative fix for this error seen during an interrupted build:
```
ERROR: .../BUILD:21:8: GoLink .../foo_test failed: I/O exception during sandboxed execution: java.util.concurrent.ExecutionException: java.lang.InterruptedException
```

Closes #27295.

PiperOrigin-RevId: 821992852
Change-Id: Ib8d666171ff44b442db23c68fe2be08ad9e4fe24 
(cherry picked from commit 0511b86c051a41e5354e3183eeabdebd2f7df923)

Closes #27298