### PR TITLE
[8.5.0] Include context description as top-level Starlark call profile spans

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -570,7 +570,10 @@ public class ModuleFileFunction implements SkyFunction {
         Mutability mu = Mutability.create("module file", moduleKey)) {
       StarlarkThread thread =
           StarlarkThread.create(
-              mu, starlarkSemantics, /* contextDescription= */ "", symbolGenerator);
+              mu,
+              starlarkSemantics,
+              "MODULE.bazel file of " + moduleKey.toDisplayString(),
+              symbolGenerator);
       context.storeInThread(thread);
       if (printIsNoop) {
         thread.setPrintHandler((t, msg) -> {});

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
@@ -280,7 +280,7 @@ final class RegularRunnableExtension implements RunnableExtension {
           StarlarkThread.create(
               mu,
               starlarkSemantics,
-              /* contextDescription= */ "",
+              "module extension " + extensionId,
               SymbolGenerator.create(extensionId));
       thread.setPrintHandler(Event.makeDebugPrintHandler(env.getListener()));
       threadContext.storeInThread(thread);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorFileFunction.java
@@ -126,7 +126,7 @@ public class VendorFileFunction implements SkyFunction {
       Program program = Program.compileFile(vendorFile, predeclaredEnv);
       StarlarkThread thread =
           StarlarkThread.create(
-              mu, starlarkSemantics, /* contextDescription= */ "", SymbolGenerator.create(skyKey));
+              mu, starlarkSemantics, "VENDOR.bazel", SymbolGenerator.create(skyKey));
       VendorThreadContext context = new VendorThreadContext();
       context.storeInThread(thread);
       Starlark.execFileProgram(program, predeclaredEnv, thread);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -265,7 +265,10 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
                 directories)) {
       StarlarkThread thread =
           StarlarkThread.create(
-              mu, starlarkSemantics, /* contextDescription= */ "", SymbolGenerator.create(key));
+              mu,
+              starlarkSemantics,
+              "repository " + ((RepositoryName) key.argument()).getDisplayForm(mainRepoMapping),
+              SymbolGenerator.create(key));
       thread.setPrintHandler(Event.makeDebugPrintHandler(env.getListener()));
       var repoMappingRecorder = new Label.RepoMappingRecorder();
       // For repos defined in Bzlmod, record any used repo mappings in the marker file.

--- a/src/main/java/com/google/devtools/build/lib/packages/MacroClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/MacroClass.java
@@ -398,7 +398,7 @@ public final class MacroClass {
           StarlarkThread.create(
               mu,
               semantics,
-              /* contextDescription= */ "",
+              macro.getShortDescription(),
               SymbolGenerator.create(
                   MacroInstance.UniqueId.create(
                       macro.getPackage().getPackageIdentifier(), macro.getId())));

--- a/src/main/java/com/google/devtools/build/lib/packages/MacroInstance.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/MacroInstance.java
@@ -318,6 +318,17 @@ public final class MacroInstance {
     }
   }
 
+  /** Returns a human-readable description of the macro suitable for debugging output. */
+  public String getShortDescription() {
+    return String.format(
+        "%smacro %s:%s defined by %s%%%s",
+        macroClass.isFinalizer() ? "finalizer " : "",
+        pkg.getPackageIdentifier().getCanonicalForm(),
+        getName(),
+        macroClass.getDefiningBzlLabel().getCanonicalForm(),
+        macroClass.getName());
+  }
+
   /**
    * Logical tuple of the package and id within the package. Used to label the Starlark evaluation
    * environment.

--- a/src/main/java/com/google/devtools/build/lib/profiler/ProfilerTask.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/ProfilerTask.java
@@ -16,9 +16,9 @@ package com.google.devtools.build.lib.profiler;
 import java.time.Duration;
 
 /**
- * All possible types of profiler tasks. Each type also defines description and
- * minimum duration in nanoseconds for it to be recorded as separate event and
- * not just be aggregated into the parent event.
+ * All possible types of profiler tasks. Each type also defines description and minimum duration in
+ * nanoseconds for it to be recorded as separate event and not just be aggregated into the parent
+ * event.
  */
 public enum ProfilerTask {
   PHASE("build phase marker"),
@@ -73,6 +73,7 @@ public enum ProfilerTask {
   STARLARK_BUILTIN_FN("Starlark builtin function call", Threshold.FIFTY_MILLIS),
   STARLARK_USER_COMPILED_FN("Starlark compiled user function call", Threshold.FIFTY_MILLIS),
   STARLARK_REPOSITORY_FN("Starlark repository function call", Threshold.FIFTY_MILLIS),
+  STARLARK_THREAD_CONTEXT("Starlark thread context", Threshold.FIFTY_MILLIS),
   ACTION_FS_STAGING("Staging per-action file system"),
   REMOTE_CACHE_CHECK("remote action cache check"),
   REMOTE_DOWNLOAD("remote output download", Threshold.TEN_MILLIS),
@@ -102,13 +103,16 @@ public enum ProfilerTask {
 
   /** Human readable description for the task. */
   public final String description;
+
   /**
    * Threshold for skipping tasks in the profile in nanoseconds, unless --record_full_profiler_data
    * is used.
    */
   public final long minDuration;
+
   /** Whether this task collects the slowest instances. */
   public final boolean collectsSlowestInstances;
+
   /** True if the metric records VFS operations */
   private final boolean vfs;
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/RepoFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RepoFileFunction.java
@@ -164,7 +164,7 @@ public class RepoFileFunction implements SkyFunction {
           StarlarkThread.create(
               mu,
               starlarkSemantics,
-              /* contextDescription= */ "",
+              "REPO.bazel file of " + repoDisplayName,
               SymbolGenerator.create(repoName));
       thread.setPrintHandler(Event.makeDebugPrintHandler(handler));
       RepoThreadContext context = new RepoThreadContext();

--- a/src/main/java/net/starlark/java/eval/StarlarkThread.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkThread.java
@@ -297,7 +297,9 @@ public final class StarlarkThread {
     // End wall-time profile span.
     CallProfiler callProfiler = StarlarkThread.callProfiler;
     if (callProfiler != null && fr.profileStartTimeNanos >= 0) {
-      callProfiler.end(fr.profileStartTimeNanos, fr.fn);
+      // Only record the context once since it is the same for all frames.
+      var contextDescription = last == 0 ? getContextDescription() : null;
+      callProfiler.end(fr.profileStartTimeNanos, fr.fn, contextDescription);
     }
 
     // Notify debug tools of the thread's last pop.
@@ -422,7 +424,8 @@ public final class StarlarkThread {
    *     semantics (e.g. via command line flags). Usually, all Starlark evaluation contexts within
    *     the same application would use the same {@code StarlarkSemantics} instance.
    * @param contextDescription a short description of this evaluation, added as context when an
-   *     exception is thrown. The empty String can be used as a default value.
+   *     exception is thrown as well as in profiles. The empty String can be used as a default
+   *     value.
    * @param symbolGenerator a supplier of deterministic, stable IDs for objects created by this
    *     thread
    */
@@ -607,8 +610,14 @@ public final class StarlarkThread {
   public interface CallProfiler {
     long start();
 
+    /**
+     * Records the end time of a function call.
+     *
+     * @param threadContext an optional description of the context in which the function is called.
+     *     Only non-null for the outermost function in a call stack.
+     */
     @SuppressWarnings("GoodTime") // This code is very performance sensitive.
-    void end(long startTimeNanos, StarlarkCallable fn);
+    void end(long startTimeNanos, StarlarkCallable fn, @Nullable String threadContext);
   }
 
   /** Installs a global hook that will be notified of function calls. */


### PR DESCRIPTION
This makes it possible to attribute slow Starlark calls to their context (e.g. the label of a Starlark rule target).

<img width="1848" height="458" alt="image" src="https://github.com/user-attachments/assets/0b957634-dbd6-449c-8138-148238c34937" />

Also make existing context descriptions more useful and uniform. Note that not all of them will show up in profiles since certain top-level frames are injected (e.g. by repo rules), but those usually already contain explicit profiler spans.

Closes #27385.

PiperOrigin-RevId: 822675499
Change-Id: I2ffe7eca61db29775c569a70a717cb7029d3114f 
(cherry picked from commit bf9c0ceee9ace427cc9f9d83ca43b685c3f9950e)

Closes #27387