### PR TITLE
Verify that genhtml accepts the combined report

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -157,9 +157,9 @@ maven.install(
         # keep sorted
         "args4j:args4j:2.37",
         "com.beust:jcommander:1.82",
+        "com.dylibso.chicory:log:1.5.2",
         "com.dylibso.chicory:runtime:1.5.2",
         "com.dylibso.chicory:wasm:1.5.2",
-        "com.dylibso.chicory:log:1.5.2",
         "com.github.ben-manes.caffeine:caffeine:3.1.8",
         "com.github.stephenc.jcip:jcip-annotations:1.0-1",
         "com.google.api-client:google-api-client:1.35.2",
@@ -434,6 +434,7 @@ use_repo(
 # =========================================
 
 bazel_dep(name = "bazel_ci_rules", version = "1.0.0")
+bazel_dep(name = "lcov", version = "2.3.1")
 bazel_dep(name = "rules_fuzzing", version = "0.6.0")
 bazel_dep(name = "wabt", version = "1.0.37")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -129,6 +129,8 @@
     "https://bcr.bazel.build/modules/grpc/1.73.1/source.json": "38ddb26495a5241da802af9b80c51bf0cbc13d06dce4a1e68e2f898d9d981ea0",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
+    "https://bcr.bazel.build/modules/lcov/2.3.1/MODULE.bazel": "1bb190a279362311dd52da27765c425cd970d20b8f62d6101f03d628a651369b",
+    "https://bcr.bazel.build/modules/lcov/2.3.1/source.json": "1b884cbe61863a1832a1e1775ab209bd4ef2316c59d9fd2602bea299e753c576",
     "https://bcr.bazel.build/modules/libpfm/4.11.0.bcr.1/MODULE.bazel": "e5362dadc90aab6724c83a2cc1e67cbed9c89a05d97fb1f90053c8deb1e445c8",
     "https://bcr.bazel.build/modules/libpfm/4.11.0.bcr.1/source.json": "0646414d9037f8aad148781dd760bec90b0b25ac12fda5e03f8aadbd6b9c61e6",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
@@ -252,7 +254,8 @@
     "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
     "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
     "https://bcr.bazel.build/modules/rules_perl/0.2.4/MODULE.bazel": "5f5af7be4bf5fb88d91af7469518f0fd2161718aefc606188f7cd51f436ca938",
-    "https://bcr.bazel.build/modules/rules_perl/0.2.4/source.json": "574317d6b3c7e4843fe611b76f15e62a1889949f5570702e1ee4ad335ea3c339",
+    "https://bcr.bazel.build/modules/rules_perl/0.4.1/MODULE.bazel": "4d09ad3a3cf71e606faab258a753ba9f0516b5d3c6aff9b813d06ea65c04702f",
+    "https://bcr.bazel.build/modules/rules_perl/0.4.1/source.json": "70e943e2deea44c1b2ddfafe178a294b82f8b8a24ee25d547eaaa202142f1b4d",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
@@ -280,6 +283,7 @@
     "https://bcr.bazel.build/modules/rules_python/1.4.1/source.json": "8ec8c90c70ccacc4de8ca1b97f599e756fb59173e898ee08b733006650057c07",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
+    "https://bcr.bazel.build/modules/rules_shell/0.4.0/MODULE.bazel": "0f8f11bb3cd11755f0b48c1de0bbcf62b4b34421023aa41a2fc74ef68d9584f0",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/source.json": "20ec05cd5e592055e214b2da8ccb283c7f2a421ea0dc2acbf1aa792e11c03d0c",
     "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
@@ -753,80 +757,6 @@
             "rules_kotlin+",
             "bazel_tools",
             "bazel_tools"
-          ]
-        ]
-      }
-    },
-    "@@rules_perl+//perl:extensions.bzl%perl_repositories": {
-      "general": {
-        "bzlTransitiveDigest": "2b+Kf0VvFQTw7hCgirLBKaJFU952JUAVdFELnLdMuf0=",
-        "usagesDigest": "qSSNDdCNVxNhY36wMndEAFacdhR0ooLTmumfad0km9s=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "perl_darwin_arm64": {
-            "repoRuleId": "@@rules_perl+//perl:repo.bzl%perl_download",
-            "attributes": {
-              "strip_prefix": "perl-darwin-arm64",
-              "sha256": "285769f3c50c339fb59a3987b216ae3c5c573b95babe6875a1ef56fb178433da",
-              "urls": [
-                "https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-darwin-arm64.tar.xz"
-              ]
-            }
-          },
-          "perl_darwin_amd64": {
-            "repoRuleId": "@@rules_perl+//perl:repo.bzl%perl_download",
-            "attributes": {
-              "strip_prefix": "perl-darwin-amd64",
-              "sha256": "63bc5ee36f5394d71c50cca6cafdd333ee58f9eaa40bca63c85f9bd06f2c1fd6",
-              "urls": [
-                "https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-darwin-amd64.tar.xz"
-              ]
-            }
-          },
-          "perl_linux_amd64": {
-            "repoRuleId": "@@rules_perl+//perl:repo.bzl%perl_download",
-            "attributes": {
-              "strip_prefix": "perl-linux-amd64",
-              "sha256": "3bdffa9d7a3f97c0207314637b260ba5115b1d0829f97e3e2e301191a4d4d076",
-              "urls": [
-                "https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-linux-amd64.tar.xz"
-              ]
-            }
-          },
-          "perl_linux_arm64": {
-            "repoRuleId": "@@rules_perl+//perl:repo.bzl%perl_download",
-            "attributes": {
-              "strip_prefix": "perl-linux-arm64",
-              "sha256": "6fa4ece99e790ecbc2861f6ecb7b52694c01c2eeb215b4370f16a3b12d952117",
-              "urls": [
-                "https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-linux-arm64.tar.xz"
-              ]
-            }
-          },
-          "perl_windows_x86_64": {
-            "repoRuleId": "@@rules_perl+//perl:repo.bzl%perl_download",
-            "attributes": {
-              "strip_prefix": "",
-              "sha256": "aeb973da474f14210d3e1a1f942dcf779e2ae7e71e4c535e6c53ebabe632cc98",
-              "urls": [
-                "https://mirror.bazel.build/strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
-                "https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip"
-              ]
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_perl+",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "rules_perl+",
-            "rules_perl",
-            "rules_perl+"
           ]
         ]
       }

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -526,7 +526,11 @@ sh_test(
     data = [
         ":gen_rules_java_repo_name",
         ":test-deps",
+        "@lcov//:genhtml",
     ],
+    env = {
+        "GENHTML": "$(rlocationpath @lcov//:genhtml)",
+    },
     tags = [
         "no_windows",
     ],
@@ -550,7 +554,11 @@ sh_test(
         data = [
             ":gen_rules_java_repo_name",
             ":test-deps",
+            "@lcov//:genhtml",
         ],
+        env = {
+            "GENHTML": "$(rlocationpath @lcov//:genhtml)",
+        },
         tags = [
             "no_windows",
         ],
@@ -580,7 +588,11 @@ sh_test(
             "//src:java_tools_zip",
             "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:coverage_empty_workspace",
             "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:coverage_output_generator_repo",
+            "@lcov//:genhtml",
         ],
+        env = {
+            "GENHTML": "$(rlocationpath @lcov//:genhtml)",
+        },
         tags = ["no_windows"],
     )
     for java_version in JAVA_VERSIONS_COVERAGE
@@ -618,7 +630,13 @@ sh_test(
     name = "bazel_coverage_starlark_test",
     srcs = ["bazel_coverage_starlark_test.sh"],
     args = ["released"],
-    data = [":test-deps"],
+    data = [
+        ":test-deps",
+        "@lcov//:genhtml",
+    ],
+    env = {
+        "GENHTML": "$(rlocationpath @lcov//:genhtml)",
+    },
     tags = [
         # TODO: Drop after the next coverage tools release.
         "no_windows",
@@ -636,7 +654,11 @@ sh_test(
         ":test-deps",
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:coverage_empty_workspace",
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:coverage_output_generator_repo",
+        "@lcov//:genhtml",
     ],
+    env = {
+        "GENHTML": "$(rlocationpath @lcov//:genhtml)",
+    },
 )
 
 sh_test(

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -235,7 +235,7 @@ end_of_record"
   # Verify that genhtml can process the file.
   "$(rlocation $GENHTML)" bazel-out/_coverage/_coverage_report.dat \
     --output-directory="$TEST_UNDECLARED_OUTPUTS_DIR/$TEST_name/coverage" &> $TEST_log \
-    || fail "genhtml failed on the coverage report but should have succeeded.
+    || fail "genhtml failed on the coverage report but should have succeeded."
 }
 
 function test_java_test_java_import_coverage() {

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -232,10 +232,12 @@ LF:6
 end_of_record"
 
   assert_coverage_result "$expected_result" "./bazel-out/_coverage/_coverage_report.dat"
-  # Verify that genhtml can process the file.
-  "$(rlocation $GENHTML)" bazel-out/_coverage/_coverage_report.dat \
-    --output-directory="$TEST_UNDECLARED_OUTPUTS_DIR/$TEST_name/coverage" &> $TEST_log \
-    || fail "genhtml failed on the coverage report but should have succeeded."
+  if ! is_windows; then
+    # Verify that genhtml can process the file.
+    "$(rlocation $GENHTML)" bazel-out/_coverage/_coverage_report.dat \
+      --output-directory="$TEST_UNDECLARED_OUTPUTS_DIR/$TEST_name/coverage" &> $TEST_log \
+      || fail "genhtml failed on the coverage report but should have succeeded."
+  fi
 }
 
 function test_java_test_java_import_coverage() {

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -232,6 +232,10 @@ LF:6
 end_of_record"
 
   assert_coverage_result "$expected_result" "./bazel-out/_coverage/_coverage_report.dat"
+  # Verify that genhtml can process the file.
+  "$(rlocation $GENHTML)" bazel-out/_coverage/_coverage_report.dat \
+    --output-directory="$TEST_UNDECLARED_OUTPUTS_DIR/$TEST_name/coverage" &> $TEST_log \
+    || fail "genhtml failed on the coverage report but should have succeeded.
 }
 
 function test_java_test_java_import_coverage() {

--- a/src/test/shell/bazel/bazel_coverage_starlark_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_starlark_test.sh
@@ -635,7 +635,23 @@ my_test(
     deps = [":tested_libs"],
 )
 EOF
-    touch test/{untested_1.txt,untested_2.txt,covered_1.txt,covered_2.txt,test_1.txt,test_2.txt}
+    touch test/test_{1,2}.txt
+    cat <<EOF > test/covered_1.txt
+hit
+not hit
+EOF
+    cat <<EOF > test/covered_2.txt
+hit
+not hit
+EOF
+    cat <<EOF > test/untested_1.txt
+nonempty
+line
+EOF
+    cat <<EOF > test/untested_2.txt
+nonempty
+line
+EOF
 
     bazel coverage //test:my_test //test:all_libs --combined_report=lcov &> $TEST_log \
         || fail "Coverage run failed but should have succeeded."
@@ -706,6 +722,14 @@ end_of_record"
 
     assert_coverage_result "$expected_coverage" bazel-out/_coverage/_coverage_report.dat
     assert_coverage_result "$expected_baseline_coverage" bazel-out/_coverage/_baseline_report.dat
+
+    # Verify that genhtml can process the files.
+    "$(rlocation $GENHTML)" bazel-out/_coverage/_coverage_report.dat \
+        --output-directory="$TEST_UNDECLARED_OUTPUTS_DIR/$TEST_name/coverage" &> $TEST_log \
+        || fail "genhtml failed on the coverage report but should have succeeded."
+    "$(rlocation $GENHTML)" bazel-out/_coverage/_baseline_report.dat \
+        --output-directory="$TEST_UNDECLARED_OUTPUTS_DIR/$TEST_name/baseline" &> $TEST_log \
+        || fail "genhtml failed on the baseline report but should have succeeded."
 }
 
 function test_starlark_rule_custom_baseline_coverage() {

--- a/src/test/shell/bazel/bazel_coverage_starlark_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_starlark_test.sh
@@ -723,13 +723,15 @@ end_of_record"
     assert_coverage_result "$expected_coverage" bazel-out/_coverage/_coverage_report.dat
     assert_coverage_result "$expected_baseline_coverage" bazel-out/_coverage/_baseline_report.dat
 
-    # Verify that genhtml can process the files.
-    "$(rlocation $GENHTML)" bazel-out/_coverage/_coverage_report.dat \
-        --output-directory="$TEST_UNDECLARED_OUTPUTS_DIR/$TEST_name/coverage" &> $TEST_log \
-        || fail "genhtml failed on the coverage report but should have succeeded."
-    "$(rlocation $GENHTML)" bazel-out/_coverage/_baseline_report.dat \
-        --output-directory="$TEST_UNDECLARED_OUTPUTS_DIR/$TEST_name/baseline" &> $TEST_log \
-        || fail "genhtml failed on the baseline report but should have succeeded."
+    if ! is_windows; then
+      # Verify that genhtml can process the files.
+      "$(rlocation $GENHTML)" bazel-out/_coverage/_coverage_report.dat \
+          --output-directory="$TEST_UNDECLARED_OUTPUTS_DIR/$TEST_name/coverage" &> $TEST_log \
+          || fail "genhtml failed on the coverage report but should have succeeded."
+      "$(rlocation $GENHTML)" bazel-out/_coverage/_baseline_report.dat \
+          --output-directory="$TEST_UNDECLARED_OUTPUTS_DIR/$TEST_name/baseline" &> $TEST_log \
+          || fail "genhtml failed on the baseline report but should have succeeded."
+    fi
 }
 
 function test_starlark_rule_custom_baseline_coverage() {


### PR DESCRIPTION
This provides additional end-to-end assurance on Bazel-generated coverage.