### PR TITLE
[8.5.0] Replace RxJava with virtual threads for `--remote_cache_async`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 
 import build.bazel.remote.execution.v2.Digest;
 import com.google.common.base.Preconditions;
@@ -35,13 +34,11 @@ import com.google.devtools.build.lib.util.TempPathGenerator;
 import com.google.devtools.build.lib.vfs.OutputService;
 import com.google.devtools.build.lib.vfs.Path;
 import java.util.Set;
-import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 
 /** Provides a remote execution context. */
 final class RemoteActionContextProvider {
 
-  private final Executor executor;
   private final CommandEnvironment env;
   @Nullable private final CombinedCache combinedCache;
   @Nullable private final RemoteExecutionClient remoteExecutor;
@@ -56,7 +53,6 @@ final class RemoteActionContextProvider {
   private final Set<Digest> knownMissingCasDigests;
 
   private RemoteActionContextProvider(
-      Executor executor,
       CommandEnvironment env,
       @Nullable CombinedCache combinedCache,
       @Nullable RemoteExecutionClient remoteExecutor,
@@ -66,7 +62,6 @@ final class RemoteActionContextProvider {
       @Nullable RemoteOutputChecker remoteOutputChecker,
       @Nullable OutputService outputService,
       Set<Digest> knownMissingCasDigests) {
-    this.executor = executor;
     this.env = Preconditions.checkNotNull(env, "env");
     this.combinedCache = combinedCache;
     this.remoteExecutor = remoteExecutor;
@@ -84,7 +79,6 @@ final class RemoteActionContextProvider {
       DigestUtil digestUtil,
       Set<Digest> knownMissingCasDigests) {
     return new RemoteActionContextProvider(
-        directExecutor(),
         env,
         /* combinedCache= */ null,
         /* remoteExecutor= */ null,
@@ -97,7 +91,6 @@ final class RemoteActionContextProvider {
   }
 
   public static RemoteActionContextProvider createForRemoteCaching(
-      Executor executor,
       CommandEnvironment env,
       CombinedCache combinedCache,
       ListeningScheduledExecutorService retryScheduler,
@@ -106,7 +99,6 @@ final class RemoteActionContextProvider {
       OutputService outputService,
       Set<Digest> knownMissingCasDigests) {
     return new RemoteActionContextProvider(
-        executor,
         env,
         combinedCache,
         /* remoteExecutor= */ null,
@@ -119,7 +111,6 @@ final class RemoteActionContextProvider {
   }
 
   public static RemoteActionContextProvider createForRemoteExecution(
-      Executor executor,
       CommandEnvironment env,
       RemoteExecutionCache remoteCache,
       RemoteExecutionClient remoteExecutor,
@@ -130,7 +121,6 @@ final class RemoteActionContextProvider {
       OutputService outputService,
       Set<Digest> knownMissingCasDigests) {
     return new RemoteActionContextProvider(
-        executor,
         env,
         remoteCache,
         remoteExecutor,
@@ -174,7 +164,6 @@ final class RemoteActionContextProvider {
           checkNotNull(env.getOptions().getOptions(ExecutionOptions.class)).verboseFailures;
       remoteExecutionService =
           new RemoteExecutionService(
-              executor,
               env.getReporter(),
               verboseFailures,
               env.getExecRoot(),

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -259,7 +259,6 @@ public final class RemoteModule extends BlazeModule {
             digestUtil);
     actionContextProvider =
         RemoteActionContextProvider.createForRemoteCaching(
-            executorService,
             env,
             combinedCache,
             /* retryScheduler= */ null,
@@ -666,7 +665,6 @@ public final class RemoteModule extends BlazeModule {
           new RemoteExecutionCache(remoteCacheClient, diskCacheClient, remoteOptions, digestUtil);
       actionContextProvider =
           RemoteActionContextProvider.createForRemoteExecution(
-              executorService,
               env,
               remoteCache,
               remoteExecutor,
@@ -705,7 +703,6 @@ public final class RemoteModule extends BlazeModule {
           new CombinedCache(remoteCacheClient, diskCacheClient, remoteOptions, digestUtil);
       actionContextProvider =
           RemoteActionContextProvider.createForRemoteCaching(
-              executorService,
               env,
               combinedCache,
               retryScheduler,

--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -15,12 +15,9 @@ package com.google.devtools.build.lib.remote;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-import static com.google.devtools.build.lib.remote.util.RxFutures.toCompletable;
-import static com.google.devtools.build.lib.remote.util.RxFutures.toSingle;
-import static com.google.devtools.build.lib.remote.util.RxUtils.mergeBulkTransfer;
-import static com.google.devtools.build.lib.remote.util.RxUtils.toTransferResult;
+import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static com.google.devtools.build.lib.remote.util.Utils.waitForBulkTransfer;
 import static com.google.devtools.build.lib.util.StringEncoding.internalToUnicode;
 import static java.util.Comparator.comparing;
 import static java.util.Comparator.naturalOrder;
@@ -40,15 +37,17 @@ import build.bazel.remote.execution.v2.Tree;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionUploadFinishedEvent;
 import com.google.devtools.build.lib.actions.ActionUploadStartedEvent;
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.concurrent.AbstractQueueVisitor;
@@ -63,7 +62,6 @@ import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
-import com.google.devtools.build.lib.remote.util.RxUtils;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.RemoteExecution;
 import com.google.devtools.build.lib.server.FailureDetails.RemoteExecution.Code;
@@ -73,12 +71,10 @@ import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Symlinks;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.Timestamp;
-import io.reactivex.rxjava3.core.Completable;
-import io.reactivex.rxjava3.core.Flowable;
-import io.reactivex.rxjava3.core.Single;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -86,13 +82,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /** UploadManifest adds output metadata to a {@link ActionResult}. */
@@ -587,136 +581,85 @@ public class UploadManifest {
     return result.build();
   }
 
-  /** Uploads outputs and action result (if exit code is 0) to remote cache. */
+  /** Uploads outputs and action result (if exit code is 0) to the remote and/or disk cache. */
   public ActionResult upload(
       RemoteActionExecutionContext context,
       CombinedCache combinedCache,
       ExtendedEventHandler reporter)
       throws IOException, InterruptedException, ExecException {
-    try {
-      return uploadAsync(context, combinedCache, reporter).blockingGet();
-    } catch (RuntimeException e) {
-      Throwable cause = e.getCause();
-      if (cause != null) {
-        throwIfInstanceOf(cause, InterruptedException.class);
-        throwIfInstanceOf(cause, IOException.class);
-        throwIfInstanceOf(cause, ExecException.class);
-      }
-      throw e;
+    ActionExecutionMetadata action = context.getSpawnOwner();
+    var allDigests = Sets.union(digestToBlobs.keySet(), digestToFile.keySet()).immutableCopy();
+    ImmutableSet<Digest> missingDigests;
+    try (var s = profiler.profile(ProfilerTask.INFO, "findMissingDigests")) {
+      missingDigests = getFromFuture(combinedCache.findMissingDigests(context, allDigests));
     }
+
+    try (var s =
+        profiler.profile(
+            ProfilerTask.UPLOAD_TIME,
+            () -> "upload %d missing blobs".formatted(missingDigests.size()))) {
+      var uploadFutures = new ArrayList<ListenableFuture<Void>>(missingDigests.size());
+      for (var digest : missingDigests) {
+        uploadFutures.add(
+            decorateUploadFuture(
+                uploadSingleDigest(context, combinedCache, digest),
+                reporter,
+                action,
+                Store.CAS,
+                digest));
+      }
+      waitForBulkTransfer(uploadFutures);
+    }
+
+    // The action result must be uploaded after the Action and Command protos per the REAPI
+    // protocol. We choose to upload it after all other blobs since this has historically been the
+    // case and action results may fail to validate server-side if they are accessed before all
+    // blobs they refer to are present.
+    var actionResult = result.build();
+    if (actionResult.getExitCode() == 0 && actionKey != null) {
+      try (var s = profiler.profile(ProfilerTask.UPLOAD_TIME, "upload action result")) {
+        getFromFuture(
+            decorateUploadFuture(
+                combinedCache.uploadActionResult(context, actionKey, actionResult),
+                reporter,
+                action,
+                Store.AC,
+                actionKey.getDigest()));
+      }
+    }
+    return actionResult;
   }
 
-  private Completable upload(
+  private ListenableFuture<Void> uploadSingleDigest(
       RemoteActionExecutionContext context, CombinedCache combinedCache, Digest digest) {
     Path file = digestToFile.get(digest);
     if (file != null) {
-      return toCompletable(() -> combinedCache.uploadFile(context, digest, file), directExecutor());
+      return combinedCache.uploadFile(context, digest, file);
     }
 
     ByteString blob = digestToBlobs.get(digest);
     if (blob == null) {
-      String message = "FindMissingBlobs call returned an unknown digest: " + digest;
-      return Completable.error(new IOException(message));
+      return Futures.immediateFailedFuture(
+          new IOException("FindMissingBlobs call returned an unknown digest: " + digest));
     }
 
-    return toCompletable(() -> combinedCache.uploadBlob(context, digest, blob), directExecutor());
+    return combinedCache.uploadBlob(context, digest, blob);
   }
 
-  private static void reportUploadStarted(
+  @CanIgnoreReturnValue
+  private static <T> ListenableFuture<T> decorateUploadFuture(
+      ListenableFuture<T> future,
       ExtendedEventHandler reporter,
       @Nullable ActionExecutionMetadata action,
       Store store,
-      Iterable<Digest> digests) {
-    if (action != null) {
-      for (Digest digest : digests) {
-        reporter.post(ActionUploadStartedEvent.create(action, store, digest));
-      }
+      Digest digest) {
+    if (action == null) {
+      return future;
     }
-  }
-
-  private static void reportUploadFinished(
-      ExtendedEventHandler reporter,
-      @Nullable ActionExecutionMetadata action,
-      Store store,
-      Iterable<Digest> digests) {
-    if (action != null) {
-      for (Digest digest : digests) {
-        reporter.post(ActionUploadFinishedEvent.create(action, store, digest));
-      }
-    }
-  }
-
-  /**
-   * Returns a {@link Single} which upon subscription will upload outputs and action result (if exit
-   * code is 0) to remote cache.
-   */
-  public Single<ActionResult> uploadAsync(
-      RemoteActionExecutionContext context,
-      CombinedCache combinedCache,
-      ExtendedEventHandler reporter) {
-    Collection<Digest> digests = new ArrayList<>();
-    digests.addAll(digestToFile.keySet());
-    digests.addAll(digestToBlobs.keySet());
-
-    ActionExecutionMetadata action = context.getSpawnOwner();
-
-    Flowable<RxUtils.TransferResult> bulkTransfers =
-        toSingle(() -> findMissingDigests(context, combinedCache, digests), directExecutor())
-            .doOnSubscribe(d -> reportUploadStarted(reporter, action, Store.CAS, digests))
-            .doOnError(error -> reportUploadFinished(reporter, action, Store.CAS, digests))
-            .doOnDispose(() -> reportUploadFinished(reporter, action, Store.CAS, digests))
-            .doOnSuccess(
-                missingDigests -> {
-                  List<Digest> existedDigests =
-                      digests.stream()
-                          .filter(digest -> !missingDigests.contains(digest))
-                          .collect(Collectors.toList());
-                  reportUploadFinished(reporter, action, Store.CAS, existedDigests);
-                })
-            .flatMapPublisher(Flowable::fromIterable)
-            .flatMapSingle(
-                digest ->
-                    toTransferResult(upload(context, combinedCache, digest))
-                        .doFinally(
-                            () ->
-                                reportUploadFinished(
-                                    reporter, action, Store.CAS, ImmutableList.of(digest))));
-    Completable uploadOutputs = mergeBulkTransfer(bulkTransfers);
-
-    ActionResult actionResult = result.build();
-    Completable uploadActionResult = Completable.complete();
-    if (actionResult.getExitCode() == 0 && actionKey != null) {
-      uploadActionResult =
-          toCompletable(
-                  () -> combinedCache.uploadActionResult(context, actionKey, actionResult),
-                  directExecutor())
-              .doOnSubscribe(
-                  d ->
-                      reportUploadStarted(
-                          reporter, action, Store.AC, ImmutableList.of(actionKey.getDigest())))
-              .doFinally(
-                  () ->
-                      reportUploadFinished(
-                          reporter, action, Store.AC, ImmutableList.of(actionKey.getDigest())));
-    }
-
-    return Completable.concatArray(uploadOutputs, uploadActionResult).toSingleDefault(actionResult);
-  }
-
-  private ListenableFuture<ImmutableSet<Digest>> findMissingDigests(
-      RemoteActionExecutionContext context,
-      CombinedCache combinedCache,
-      Collection<Digest> digests) {
-    long startTime = Profiler.nanoTimeMaybe();
-
-    var future = combinedCache.findMissingDigests(context, digests);
-
-    if (profiler.isActive()) {
-      future.addListener(
-          () -> profiler.logSimpleTask(startTime, ProfilerTask.INFO, "findMissingDigests"),
-          directExecutor());
-    }
-
+    reporter.post(ActionUploadStartedEvent.create(action, store, digest));
+    future.addListener(
+        () -> reporter.post(ActionUploadFinishedEvent.create(action, store, digest)),
+        directExecutor());
     return future;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -584,8 +584,12 @@ public final class Utils {
         && !executionInfo.containsKey(ExecutionRequirements.NO_REMOTE_CACHE_UPLOAD);
   }
 
-  public static void waitForBulkTransfer(
-      Iterable<? extends ListenableFuture<?>> transfers, boolean cancelRemainingOnInterrupt)
+  /**
+   * Waits for all transfers to finish.
+   *
+   * <p>If interrupted, all remaining transfers are canceled.
+   */
+  public static void waitForBulkTransfer(Iterable<? extends ListenableFuture<?>> transfers)
       throws BulkTransferException, InterruptedException {
     BulkTransferException bulkTransferException = null;
     InterruptedException interruptedException = null;
@@ -594,7 +598,7 @@ public final class Utils {
       try {
         if (interruptedException == null) {
           // Wait for all transfers to finish.
-          getFromFuture(transfer, cancelRemainingOnInterrupt);
+          getFromFuture(transfer, /* cancelOnInterrupt= */ true);
         } else {
           transfer.cancel(true);
         }
@@ -606,10 +610,6 @@ public final class Utils {
       } catch (InterruptedException e) {
         interrupted = Thread.interrupted() || interrupted;
         interruptedException = e;
-        if (!cancelRemainingOnInterrupt) {
-          // leave the rest of the transfers alone
-          break;
-        }
       }
     }
     if (interrupted) {

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -254,6 +254,7 @@ java_test(
 java_test(
     name = "DiskCacheIntegrationTest",
     srcs = ["DiskCacheIntegrationTest.java"],
+    jvm_flags = ["-Djava.lang.Thread.allowVirtualThreads=true"],
     tags = ["requires-network"],
     runtime_deps = [
         "//third_party/grpc-java:grpc-jar",

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -1685,7 +1685,7 @@ public class ByteStreamUploaderTest {
               context, chunkerEntry.getKey(), chunkerEntry.getValue()));
     }
 
-    waitForBulkTransfer(uploads, /* cancelRemainingOnInterrupt= */ true);
+    waitForBulkTransfer(uploads);
   }
 
   private static class NoopStreamObserver implements StreamObserver<WriteRequest> {

--- a/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
@@ -210,8 +210,7 @@ public class CombinedCacheTest {
         combinedCache.downloadOutErr(
             remoteActionExecutionContext,
             result.build(),
-            new FileOutErr(execRoot.getRelative("stdout"), execRoot.getRelative("stderr"))),
-        true);
+            new FileOutErr(execRoot.getRelative("stdout"), execRoot.getRelative("stderr"))));
 
     assertThat(combinedCache.getNumSuccessfulDownloads()).isEqualTo(0);
     assertThat(combinedCache.getNumFailedDownloads()).isEqualTo(0);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -2703,7 +2703,6 @@ public class RemoteExecutionServiceTest {
 
   private RemoteExecutionService newRemoteExecutionService(RemoteOptions remoteOptions) {
     return new RemoteExecutionService(
-        directExecutor(),
         reporter,
         /* verboseFailures= */ true,
         execRoot,

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -17,7 +17,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -314,7 +313,6 @@ public class RemoteSpawnCacheTest {
     RemoteExecutionService service =
         spy(
             new RemoteExecutionService(
-                directExecutor(),
                 reporter,
                 /* verboseFailures= */ true,
                 execRoot,

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -15,7 +15,6 @@ package com.google.devtools.build.lib.remote;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -1268,7 +1267,6 @@ public class RemoteSpawnRunnerTest {
     ExecutionOptions executionOptions = Options.parse(ExecutionOptions.class, flag).getOptions();
     RemoteExecutionService remoteExecutionService =
         new RemoteExecutionService(
-            directExecutor(),
             reporter,
             /* verboseFailures= */ true,
             execRoot,
@@ -1806,7 +1804,6 @@ public class RemoteSpawnRunnerTest {
     RemoteExecutionService service =
         spy(
             new RemoteExecutionService(
-                directExecutor(),
                 reporter,
                 /* verboseFailures= */ true,
                 execRoot,

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.devtools.build.lib.remote.GrpcCacheClient.getResourceName;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -340,7 +339,6 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
             cacheProtocol, /* diskCacheClient= */ null, remoteOptions, DIGEST_UTIL);
     RemoteExecutionService remoteExecutionService =
         new RemoteExecutionService(
-            directExecutor(),
             reporter,
             /* verboseFailures= */ true,
             execRoot,


### PR DESCRIPTION
All RxJava usage in `RemoteExecutionService` and `UploadManifest` is replaced with regular `Future`s and virtual threads that block on them. By closing the `ExecutorService` that runs these virtual threads in `RemoteExecutionService#shutdown`, all async uploads can be awaited without the need for additional tracking in the form of a `Phaser`.

This hopefully resolves the spurious hangs reported in #25232 and even if not would provide new insights in the form of stack traces of blocked virtual threads.

Along the way, this resolves the issue that upload counts reported on cancellation could be incorrect and often even negative due to double counting. This results in a minor change in behavior: Uploads are only included in the count when they start, not already when the corresponding `FindMissingBlobs` is sent. Present digests are reported as being uploaded.

Speculatively fixes #25232

Closes #27179.

PiperOrigin-RevId: 822992095
Change-Id: Ieb82ab86739cebe25fd7e90a2bc70897fe53b817 
(cherry picked from commit 76dfcc5fe9599d381f69943d3fa8fc4c064035ac)

Closes #27248