### PR TITLE
[8.5.0] Don't crash when profiling virtual threads after profiler has stopped

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
@@ -966,15 +966,20 @@ public final class Profiler {
   private class MultiLaneGenerator {
     private final Map<String, LaneGenerator> laneGenerators = Maps.newConcurrentMap();
 
+    /**
+     * @return the lane if it's active, otherwise null.
+     */
+    @Nullable
     private Lane acquire(String prefix) {
-      checkState(isActive());
+      if (!isActive()) {
+        return null;
+      }
       var laneGenerator =
           laneGenerators.computeIfAbsent(prefix, unused -> new LaneGenerator(prefix));
       return laneGenerator.acquire();
     }
 
     private void release(Lane lane) {
-      checkState(isActive());
       var laneGenerator = lane.laneGenerator;
       laneGenerator.release(lane);
     }
@@ -1040,6 +1045,9 @@ public final class Profiler {
           () -> {
             var prefix = virtualThreadPrefix.get();
             var lane = multiLaneGenerator.acquire(prefix);
+            if (lane == null) {
+              return null;
+            }
             checkState(lane.refCount == 0);
             return lane;
           });
@@ -1051,6 +1059,9 @@ public final class Profiler {
     }
 
     var lane = borrowedLane.get();
+    if (lane == null) {
+      return null;
+    }
     lane.refCount += 1;
     return lane;
   }

--- a/src/test/java/com/google/devtools/build/lib/profiler/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/profiler/BUILD
@@ -18,6 +18,9 @@ filegroup(
 java_test(
     name = "ProfilerTests",
     srcs = glob(["*.java"]),
+    jvm_flags = [
+        "-Djava.lang.Thread.allowVirtualThreads=true",
+    ],
     test_class = "com.google.devtools.build.lib.AllTests",
     runtime_deps = [
         "//src/test/java/com/google/devtools/build/lib:test_runner",


### PR DESCRIPTION
Work towards #25232

Closes #27270.

PiperOrigin-RevId: 821574165
Change-Id: I250eef0070c9d3e6968620815b5bd3a44e895280 
(cherry picked from commit ef47f25ed91c581838f663c6c116bf04d75441b4)

Closes #27272