### PR TITLE
Use Cloudflare BCR mirror by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -125,7 +125,7 @@ public class BazelRepositoryModule extends BlazeModule {
   // Default list of registries.
   public static final ImmutableSet<String> DEFAULT_REGISTRIES =
       ImmutableSet.of("https://bcr.bazel.build/");
-  public static final ImmutableSet<String> DEFAULT_MODULE_MIRRORS = ImmutableSet.of();
+  public static final ImmutableSet<String> DEFAULT_MODULE_MIRRORS = ImmutableSet.of("https://bcr.cloudflaremirrors.com");
 
   private final RepositoryCache repositoryCache = new RepositoryCache();
   private final MutableSupplier<Map<String, String>> clientEnvironmentSupplier =


### PR DESCRIPTION
All artifacts downloaded from a module mirror are pinned by hashes recorded in BCR entries and thus by lockfile entries, so this doesn't require any trust in the mirror.