### PR TITLE
[8.5.0] single_version_override() now accepts patch_cmds with no patches

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
@@ -245,7 +245,9 @@ public abstract class InterimModule extends ModuleBase {
     if (!(override instanceof SingleVersionOverride singleVersion)) {
       return repoSpec;
     }
-    if (singleVersion.patches().isEmpty()) {
+    if (singleVersion.patches().isEmpty()
+        && singleVersion.patchCmds().isEmpty()
+        && singleVersion.patchStrip() == 0) {
       return repoSpec;
     }
     ImmutableMap.Builder<String, Object> attrBuilder = ImmutableMap.builder();


### PR DESCRIPTION
Previously, single_version_override() would only include its patch_cmds attribute in a repo rule if the patches attribute was nonempty.

Many thanks to @fmeum for identifying the location of the bug.

Fixes #27225

Closes #27230.

PiperOrigin-RevId: 819854471
Change-Id: I5a8a7b484ce5bc22f8c5c23e48b447dee7435013

Commit https://github.com/bazelbuild/bazel/commit/49a4aed03793391515cbeb292cc2803aca9c0630