### PR TITLE
[7.7.0] single_version_override() now accepts patch_cmds with no patches

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
@@ -232,7 +232,9 @@ public abstract class InterimModule extends ModuleBase {
       return repoSpec;
     }
     SingleVersionOverride singleVersion = (SingleVersionOverride) override;
-    if (singleVersion.getPatches().isEmpty()) {
+    if (singleVersion.getPatches().isEmpty()
+        && singleVersion.getPatchCmds().isEmpty()
+        && singleVersion.getPatchStrip() == 0) {
       return repoSpec;
     }
     ImmutableMap.Builder<String, Object> attrBuilder = ImmutableMap.builder();

--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -124,6 +124,54 @@ class BazelOverridesTest(test_base.TestBase):
     self.assertIn('main function => bbb@1.1', stdout)
     self.assertIn('bbb@1.1 => aaa@1.0 (locally patched)', stdout)
 
+  def testSingleVersionOverrideWithPatchCmds(self):
+    self.writeMainProjectFiles()
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'bazel_dep(name = "aaa")',
+            'bazel_dep(name = "bbb", version = "1.1")',
+            # Both main and bbb@1.1 has to depend on the locally patched aaa@1.0
+            'single_version_override(',
+            '  module_name = "aaa",',
+            '  version = "1.0",',
+            '  patch_cmds = [',
+            '''    "sed -e 's|aaa@1.0|aaa@1.0 (locally patched with patch_cmds)|' aaa.cc > aaa.cc.new",''',
+            '    "mv aaa.cc.new aaa.cc",',
+            '  ],',
+            ')',
+        ],
+    )
+    _, stdout, _ = self.RunBazel(['run', '//:main'])
+    self.assertIn('main function => aaa@1.0 (locally patched with patch_cmds)', stdout)
+    self.assertIn('main function => bbb@1.1', stdout)
+    self.assertIn('bbb@1.1 => aaa@1.0 (locally patched with patch_cmds)', stdout)
+
+  def testSingleVersionOverrideWithPatchAndPatchCmds(self):
+    self.writeMainProjectFiles()
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'bazel_dep(name = "aaa")',
+            'bazel_dep(name = "bbb", version = "1.1")',
+            # Both main and bbb@1.1 has to depend on the locally patched aaa@1.0
+            'single_version_override(',
+            '  module_name = "aaa",',
+            '  version = "1.0",',
+            '  patches = ["//:aaa.patch"],',
+            '  patch_strip = 1,',
+            '  patch_cmds = [',
+            '''    "sed -e 's|locally patched|locally patched with patches and patch_cmds|' aaa.cc > aaa.cc.new",''',
+            '    "mv aaa.cc.new aaa.cc",',
+            '  ],',
+            ')',
+        ],
+    )
+    _, stdout, _ = self.RunBazel(['run', '//:main'])
+    self.assertIn('main function => aaa@1.0 (locally patched with patches and patch_cmds)', stdout)
+    self.assertIn('main function => bbb@1.1', stdout)
+    self.assertIn('bbb@1.1 => aaa@1.0 (locally patched with patches and patch_cmds)', stdout)
+
   def testRegistryOverride(self):
     self.writeMainProjectFiles()
     another_registry = BazelRegistry(


### PR DESCRIPTION
Previously, single_version_override() would only include its patch_cmds attribute in a repo rule if the patches attribute was nonempty.

Many thanks to @fmeum for identifying the location of the bug.

Fixes #27234