### PR TITLE
Always send hostname and username in BuildStarted BES message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -396,6 +396,12 @@ message BuildStarted {
 
   // The process ID of the Bazel server.
   int64 server_pid = 8;
+
+  // The short hostname of the machine where the build is running.
+  string host = 10;
+
+  // The username of the user who started the build.
+  string user = 11;
 }
 
 // Configuration related to the blaze workspace and output tree.

--- a/src/main/java/com/google/devtools/build/lib/buildtool/buildevent/BuildStartingEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/buildevent/BuildStartingEvent.java
@@ -28,6 +28,8 @@ import com.google.devtools.build.lib.buildeventstream.ProgressEvent;
 import com.google.devtools.build.lib.buildtool.BuildRequest;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.runtime.CommandLineEvent;
+import com.google.devtools.build.lib.util.NetUtil;
+import com.google.devtools.build.lib.util.UserUtils;
 import com.google.protobuf.util.Timestamps;
 import javax.annotation.Nullable;
 
@@ -116,7 +118,9 @@ public abstract class BuildStartingEvent implements BuildEvent {
             .setOptionsDescription(request().getOptionsDescription())
             .setCommand(request().getCommandName())
             .setServerPid(ProcessHandle.current().pid())
-            .setWorkingDirectory(pwd());
+            .setWorkingDirectory(pwd())
+            .setHost(NetUtil.getCachedShortHostName())
+            .setUser(UserUtils.getUserName());
     if (workspace() != null) {
       started.setWorkspaceDirectory(workspace());
     }


### PR DESCRIPTION
Per a review comment (https://github.com/bazelbuild/bazel/pull/27120#issuecomment-3401208923) on #27120, we here propose to send the hostname and username via the BuildStarted BES message rather than the workspace status BES message.