### PR TITLE
Don't crash in `MerkleTreeComputer` if a future is cancelled

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
@@ -84,6 +84,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -930,6 +931,8 @@ public final class MerkleTreeComputer {
     } catch (InterruptedException e) {
       future.cancel(/* mayInterruptIfRunning= */ true);
       throw e;
+    } catch (CancellationException e) {
+      throw new InterruptedException();
     } catch (ExecutionException e) {
       if (e.getCause() instanceof WrappedException wrappedException) {
         wrappedException.unwrapAndThrow();


### PR DESCRIPTION
This can happen during shutdown and should be handled just like an interrupt.