### PR TITLE
Make download cache entries read-only

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCache.java
@@ -245,6 +245,8 @@ public class DownloadCache {
     Path tmpName = cacheEntry.getRelative(TMP_PREFIX + UUID.randomUUID());
     cacheEntry.createDirectoryAndParents();
     fileWriter.writeTo(tmpName);
+    // Avoid corruption to the cache entry in case it is hardlinked elsewhere.
+    tmpName.setWritable(false);
     try {
       tmpName.renameTo(cacheValue);
     } catch (FileAccessException e) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCacheTest.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -146,6 +148,38 @@ public class DownloadCacheTest {
   public void testPutCacheValueIdempotent() throws Exception {
     downloadCache.put(hash, downloadedFile, keyType, /* canonicalId= */ null);
     downloadCache.put(hash, downloadedFile, keyType, /* canonicalId= */ null);
+
+    Path cacheEntry = keyType.getCachePath(repositoryCachePath).getChild(hash);
+    Path cacheValue = cacheEntry.getChild(DownloadCache.DEFAULT_CACHE_FILENAME);
+
+    assertThat(FileSystemUtils.readContent(downloadedFile, Charset.defaultCharset()))
+        .isEqualTo(FileSystemUtils.readContent(cacheValue, Charset.defaultCharset()));
+  }
+
+  /**
+   * Test that the put method is safe to call concurrently.
+   */
+  @Test
+  public void testPutCacheValueConcurrent() throws Exception {
+    var exceptions = new ConcurrentLinkedQueue<Throwable>();
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (int i = 0; i < 100; i++) {
+        executor.submit(() -> {
+          try {
+            downloadCache.put(hash, downloadedFile, keyType, /* canonicalId= */ null);
+          } catch (Throwable t) {
+            exceptions.add(t);
+          }
+        });
+      }
+    }
+    if (!exceptions.isEmpty()) {
+      var combined = new AssertionError("Exceptions occurred during concurrent puts");
+      for (Throwable t : exceptions) {
+        combined.addSuppressed(t);
+      }
+      throw combined;
+    }
 
     Path cacheEntry = keyType.getCachePath(repositoryCachePath).getChild(hash);
     Path cacheValue = cacheEntry.getChild(DownloadCache.DEFAULT_CACHE_FILENAME);


### PR DESCRIPTION
Avoids silent corruption when the entry is hardlinked into a repo and modified there.

Related to #27446