### PR TITLE
Only use hardlinks in `rctx.download_and_extract`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCache.java
@@ -144,7 +144,8 @@ public class DownloadCache {
    *     return null.
    */
   @Nullable
-  public Path get(String cacheKey, Path targetPath, KeyType keyType, String canonicalId)
+  public Path get(
+      String cacheKey, Path targetPath, KeyType keyType, String canonicalId, boolean mayHardlink)
       throws IOException, InterruptedException {
     Path cacheValue = findCacheValue(cacheKey, keyType, canonicalId);
     if (cacheValue == null) {
@@ -152,7 +153,7 @@ public class DownloadCache {
     }
 
     targetPath.getParentDirectory().createDirectoryAndParents();
-    if (useHardlinks) {
+    if (useHardlinks && mayHardlink) {
       FileSystemUtils.createHardLink(targetPath, cacheValue);
     } else {
       FileSystemUtils.copyFile(cacheValue, targetPath);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -824,7 +824,10 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
               outputPath.getPath(),
               envVariables,
               identifyingStringForLogging,
-              downloadPhaser);
+              downloadPhaser,
+              // The repo rule may modify the file after the download, so we cannot guarantee that
+              // hardlinking is safe.
+              /* mayHardlink= */ false);
       download =
           new PendingDownload(
               executable,
@@ -1061,7 +1064,10 @@ the same path on case-insensitive filesystems.
               downloadDirectory,
               envVariables,
               identifyingStringForLogging,
-              downloadPhaser);
+              downloadPhaser,
+              // The archive is not going to be modified and not accessible to the user, so its safe
+              // to hardlink.
+              /* mayHardlinks= */ true);
       // Ensure that the download is cancelled if the repo rule is restarted as it runs in its own
       // executor.
       PendingDownload pendingTask =

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCacheTest.java
@@ -162,7 +162,9 @@ public class DownloadCacheTest {
 
     Path targetDirectory = scratch.dir("/external");
     Path targetPath = targetDirectory.getChild(downloadedFile.getBaseName());
-    Path actualTargetPath = downloadCache.get(hash, targetPath, keyType, /* canonicalId= */ null);
+    Path actualTargetPath =
+        downloadCache.get(
+            hash, targetPath, keyType, /* canonicalId= */ null, /* mayHardlink= */ true);
 
     // Check that the contents are the same.
     assertThat(FileSystemUtils.readContent(downloadedFile, Charset.defaultCharset()))
@@ -177,7 +179,9 @@ public class DownloadCacheTest {
   public void testGetNullCacheValue() throws Exception {
     Path targetDirectory = scratch.dir("/external");
     Path targetPath = targetDirectory.getChild(downloadedFile.getBaseName());
-    Path actualTargetPath = downloadCache.get(hash, targetPath, keyType, /* canonicalId= */ null);
+    Path actualTargetPath =
+        downloadCache.get(
+            hash, targetPath, keyType, /* canonicalId= */ null, /* mayHardlink= */ true);
 
     assertThat(actualTargetPath).isNull();
   }
@@ -203,7 +207,7 @@ public class DownloadCacheTest {
     thrown.expectMessage("does not match expected");
     thrown.expectMessage("Please delete the directory");
 
-    downloadCache.get(hash, targetPath, keyType, /* canonicalId= */ null);
+    downloadCache.get(hash, targetPath, keyType, /* canonicalId= */ null, /* mayHardlink= */ true);
   }
 
   @Test
@@ -247,13 +251,17 @@ public class DownloadCacheTest {
     Path targetDirectory = scratch.dir("/external");
     Path targetPath = targetDirectory.getChild(downloadedFile.getBaseName());
 
-    Path lookupWithSameId = downloadCache.get(hash, targetPath, keyType, "fooid");
+    Path lookupWithSameId =
+        downloadCache.get(hash, targetPath, keyType, "fooid", /* mayHardlink= */ true);
     assertThat(lookupWithSameId).isEqualTo(targetPath);
 
-    Path lookupOtherId = downloadCache.get(hash, targetPath, keyType, "barid");
+    Path lookupOtherId =
+        downloadCache.get(hash, targetPath, keyType, "barid", /* mayHardlink= */ true);
     assertThat(lookupOtherId).isNull();
 
-    Path lookupNoId = downloadCache.get(hash, targetPath, keyType, /* canonicalId= */ null);
+    Path lookupNoId =
+        downloadCache.get(
+            hash, targetPath, keyType, /* canonicalId= */ null, /* mayHardlink= */ true);
     assertThat(lookupNoId).isEqualTo(targetPath);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -899,7 +899,8 @@ public class HttpDownloaderTest {
               output,
               clientEnv,
               context,
-              downloadPhaser);
+              downloadPhaser,
+              /* mayHardlink= */ true);
       Path downloadedPath = downloadManager.finalizeDownload(future);
       // Should not be in the download phase.
       assertThat(downloadPhaser.getPhase()).isNotEqualTo(0);


### PR DESCRIPTION
The repo rule may modify the file downloaded via `rctx.download`, so it isn't safe to hardlink it.

In the future, when `FileSystemUtils.copyFile` is backed by Java's `Files.copy`, copying can reflink and thus recover the performance gain without using hardlinks.

Related to #27446 