### PR TITLE
[8.5.0] Make download cache entries read-only

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCache.java
@@ -245,6 +245,8 @@ public class DownloadCache {
     Path tmpName = cacheEntry.getRelative(TMP_PREFIX + UUID.randomUUID());
     cacheEntry.createDirectoryAndParents();
     fileWriter.writeTo(tmpName);
+    // Avoid corruption to the cache entry in case it is hardlinked elsewhere.
+    tmpName.setWritable(false);
     try {
       tmpName.renameTo(cacheValue);
     } catch (FileAccessException e) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/cache/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/cache/BUILD
@@ -33,6 +33,7 @@ java_library(
 
 java_test(
     name = "RepositoryCacheTests",
+    jvm_flags = ["-Djava.lang.Thread.allowVirtualThreads=true"],
     tags = ["rules"],
     test_class = "com.google.devtools.build.lib.AllTests",
     runtime_deps = [


### PR DESCRIPTION
Avoids silent corruption when the entry is hardlinked into a repo and modified there.

Related to #27446

Closes #27451.

PiperOrigin-RevId: 825972552
Change-Id: I4d632d4f1e8ee78090436e2860cfecc6e18ea4a5

Commit https://github.com/bazelbuild/bazel/commit/65fe46347318c30df4b9e49827d4439afa8349a7