### PR TITLE
Add `--remote_max_concurrency_per_connection`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -495,12 +495,10 @@ public final class RemoteModule extends BlazeModule {
       return;
     }
 
-    // The number of concurrent requests for one connection to a gRPC server is limited by
-    // MAX_CONCURRENT_STREAMS which is normally being 100+. We assume 50 concurrent requests for
-    // each connection should be fairly well. The number of connections opened by one channel is
-    // based on the resolved IPs of that server. We assume servers normally have 2 IPs. So the
-    // max concurrency per connection is 100.
-    int maxConcurrencyPerConnection = 100;
+    int maxConcurrencyPerConnection = 0;
+    if (remoteOptions.remoteMaxConcurrencyPerConnection > 0) {
+      maxConcurrencyPerConnection = remoteOptions.remoteMaxConcurrencyPerConnection;
+    }
     int maxConnections = 0;
     if (remoteOptions.remoteMaxConnections > 0) {
       maxConnections = remoteOptions.remoteMaxConnections;

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -68,14 +68,31 @@ public final class RemoteOptions extends CommonRemoteOptions {
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS},
       help =
-          "Limit the max number of concurrent connections to remote cache/executor. By default the"
-              + " value is 100. Setting this to 0 means no limitation.\n"
-              + "For HTTP remote cache, one TCP connection could handle one request at one time, so"
-              + " Bazel could make up to --remote_max_connections concurrent requests.\n"
-              + "For gRPC remote cache/executor, one gRPC channel could usually handle 100+"
-              + " concurrent requests, so Bazel could make around `--remote_max_connections * 100`"
-              + " concurrent requests.")
+          """
+          Limit the max number of concurrent connections to remote cache/executor. By default the \
+          value is 100. Setting this to 0 means no limitation.
+          For HTTP remote cache, one TCP connection could handle one request at one time, so \
+          Bazel could make up to --remote_max_connections concurrent requests.
+          For gRPC remote cache/executor, one gRPC channel could usually handle 100+ \
+          concurrent requests (controlled by --remote_max_concurrency_per_connection), so \
+          Bazel could make around `--remote_max_connections * 100` concurrent requests.""")
   public int remoteMaxConnections;
+
+  @Option(
+      name = "remote_max_concurrency_per_connection",
+      // The number of concurrent requests for one connection to a gRPC server is limited by
+      // MAX_CONCURRENT_STREAMS which is normally being 100+. We assume 50 concurrent requests for
+      // each connection should be fairly well. The number of connections opened by one channel is
+      // based on the resolved IPs of that server. We assume servers normally have 2 IPs. So the
+      // max concurrency per connection is 100.
+      defaultValue = "100",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS},
+      help =
+          """
+          Limit the max number of concurrent requests per gRPC connection. By default the value \
+          is 100.""")
+  public int remoteMaxConcurrencyPerConnection;
 
   @Option(
       name = "remote_executor",


### PR DESCRIPTION
The stack traces obtained https://github.com/bazelbuild/bazel/issues/25232#issuecomment-3462392254 indicate that all gRPC threads are waiting on events when the hang reported in #25232 occurs, with no other threads being active except for the virtual threads blocked on upload futures. 

This situation is reminiscent of https://github.com/grpc/grpc-java/issues/8334#issuecomment-892230301 and further experimentation showed that reducing the maximum number of concurrent requests per gRPC connection down to 20 (from 100) resolved the hangs. Reducing the number to 50 made them less likely. Since it is not clear that there is a single number that avoids hangs for all backends while not sacrificing performance with some, this change makes the limit configurable for further experimentation.

RELNOTES: The new `--remote_max_concurrency_per_connection` can be used to specify the maximum number of concurrent gRPC requests Bazel will issue on a single connection to the server. The default value of 100 matches the previous behavior.

Work towards #25232