### PR TITLE
Test cases for escaping of HTML in CLI docs

### DIFF
--- a/src/test/java/com/google/devtools/common/options/OptionsUsageTest.java
+++ b/src/test/java/com/google/devtools/common/options/OptionsUsageTest.java
@@ -621,6 +621,8 @@ public final class OptionsUsageTest {
                \s
                 `<HTML> "syntax" 'within' &codeblocks&`
                \s
+                <div>HTML is escaped</div>
+               \s
                 [ref]: /url (title)
                 [shorthand reference link]: /url (title)
                 [`complex` shorthand reference link]: /url (title)
@@ -658,6 +660,7 @@ public final class OptionsUsageTest {
             <p>paragraph 1</p>
             <p>paragraph 2</p>
             <p><code>&lt;HTML&gt; &quot;syntax&quot; 'within' &amp;codeblocks&amp;</code></p>
+            <p>&lt;div&gt;HTML is escaped&lt;/div&gt;</p>
             </dd>
             """);
   }

--- a/src/test/java/com/google/devtools/common/options/TestOptions.java
+++ b/src/test/java/com/google/devtools/common/options/TestOptions.java
@@ -287,6 +287,8 @@ public class TestOptions extends OptionsBase {
 
           `<HTML> "syntax" 'within' &codeblocks&`
 
+          <div>HTML is escaped</div>
+
           [ref]: /url (title)
           [shorthand reference link]: /url (title)
           [`complex` shorthand reference link]: /url (title)


### PR DESCRIPTION
Escaping of HTML in CLI docs was added in 352211d7662490ae87115f761aa4cc1e08142529, but not validated by any (automated) tests. This was discovered in #27237 which added coverage for escaping of HTML syntax within code blocks (standard markdown behavior that the change fixed) but not anywhere else.

To address this coverage gap the test case `com.google.devtools.common.options.OptionsUsageTest.markdownInHelp_longTerminalOutput` has been extended with a simple HTML snippet to validate the escaping behavior.