### PR TITLE
Flip `--incompatible_compact_repo_mapping_manifest`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -625,7 +625,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
 
   @Option(
       name = "incompatible_compact_repo_mapping_manifest",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.OUTPUT_SELECTION,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},


### PR DESCRIPTION
Fixes #26262



RELNOTES[INC]: `--incompatible_compact_repo_mapping_manifest` is now enabled by default. If you encounter issues with runfile lookups failing at runtime, make sure that the language rulesets you use are up-to-date and runfiles libraries support the new format. Further details are available in the tracking issue https://github.com/bazelbuild/bazel/issues/26262.