### PR TITLE
[8.5.0] Prevent dynamic branches from canceling each other

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/dynamic/DynamicSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/dynamic/DynamicSpawnStrategy.java
@@ -54,6 +54,7 @@ import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future.State;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -650,7 +651,7 @@ public class DynamicSpawnStrategy implements SpawnStrategy {
             // This can happen if the other branch is local under local_lockfree and has returned
             // its result but not yet cancelled this branch, or if the other branch was already
             // cancelled for other reasons. In the latter case, we are good to continue.
-            if (!otherBranch.isCancelled()) {
+            if (otherBranch.future.state() == State.SUCCESS) {
               throw new DynamicInterruptedException(
                   String.format(
                       "Execution of %s strategy stopped because %s strategy could not be cancelled",

--- a/src/main/java/com/google/devtools/build/lib/dynamic/LocalBranch.java
+++ b/src/main/java/com/google/devtools/build/lib/dynamic/LocalBranch.java
@@ -20,7 +20,6 @@ import static com.google.devtools.build.lib.actions.DynamicStrategyRegistry.Dyna
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.flogger.GoogleLogger;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.DynamicStrategyRegistry;
 import com.google.devtools.build.lib.actions.DynamicStrategyRegistry.DynamicMode;
@@ -29,6 +28,7 @@ import com.google.devtools.build.lib.actions.SandboxedSpawnStrategy;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
+import com.google.devtools.build.lib.actions.SpawnStrategy;
 import com.google.devtools.build.lib.dynamic.DynamicExecutionModule.IgnoreFailureCheck;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
@@ -36,7 +36,6 @@ import com.google.devtools.build.lib.util.io.FileOutErr;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -50,7 +49,6 @@ import javax.annotation.Nullable;
 class LocalBranch extends Branch {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
-  private RemoteBranch remoteBranch;
   private final IgnoreFailureCheck ignoreFailureCheck;
   private final Function<Spawn, Optional<Spawn>> getExtraSpawnForLocalExecution;
   private final AtomicBoolean delayLocalExecution;
@@ -139,38 +137,12 @@ class LocalBranch extends Branch {
     throw new AssertionError("canExec passed but no usable local strategy for action " + spawn);
   }
 
-  /** Sets up the {@link Future} used in the local branch to know what remote branch to cancel. */
-  protected void prepareFuture(RemoteBranch remoteBranch) {
-    // TODO(b/203094728): Maybe generify this method and move it up.
-    this.remoteBranch = remoteBranch;
-    future.addListener(
-        () -> {
-          if (starting.compareAndSet(true, false)) {
-            // If the local branch got cancelled before even starting, we release its semaphore
-            // for it.
-            done.release();
-          }
-          if (!future.isCancelled()) {
-            remoteBranch.cancel();
-          }
-          if (options.debugSpawnScheduler) {
-            logger.atInfo().log(
-                "In listener callback, the future of the local branch is %s",
-                future.state().name());
-            try {
-              future.get();
-            } catch (InterruptedException | ExecutionException e) {
-              logger.atInfo().withCause(e).log(
-                  "The future of the local branch failed with an exception.");
-            }
-          }
-        },
-        MoreExecutors.directExecutor());
-  }
-
   @Override
   ImmutableList<SpawnResult> callImpl(ActionExecutionContext context)
       throws InterruptedException, ExecException {
+    if (otherBranch == null) {
+      throw new IllegalStateException("prepareFuture not called");
+    }
     try {
       if (!starting.compareAndSet(true, false)) {
         // If we ever get here, it's because we were cancelled early and the listener
@@ -191,7 +163,7 @@ class LocalBranch extends Branch {
               maybeIgnoreFailure(exitCode, errorMessage, outErr);
             }
             DynamicSpawnStrategy.stopBranch(
-                remoteBranch, this, strategyThatCancelled, options, this.context);
+                otherBranch, this, strategyThatCancelled, options, this.context);
           },
           getExtraSpawnForLocalExecution);
     } catch (DynamicInterruptedException e) {


### PR DESCRIPTION
Fixes #27471
Speculatively fixes #24230

Closes #27483.

PiperOrigin-RevId: 827521983
Change-Id: Ifb31714709a10e4736f60a9ebfa4a56cdb2b1dbe

Commit https://github.com/bazelbuild/bazel/commit/1a67e7b2e8ca6799a13c7dc47587976f2247bbe9