### PR TITLE
[9.0.0] Delete unrecognized files from the action cache on-disk directory when loading it into memory.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
@@ -96,6 +96,18 @@ public class CompactPersistentActionCacheTest {
   }
 
   @Test
+  public void testDeleteUnrecognizedFiles() throws Exception {
+    Path unrecognizedFile = cacheRoot.getRelative("unrecognized");
+    FileSystemUtils.createEmptyFile(unrecognizedFile);
+
+    cache =
+        CompactPersistentActionCache.create(
+            cacheRoot, corruptedCacheRoot, tmpDir, clock, NullEventHandler.INSTANCE);
+
+    assertThat(unrecognizedFile.exists()).isFalse();
+  }
+
+  @Test
   public void testGetInvalidKey() {
     assertThat(cache.get("key")).isNull();
   }


### PR DESCRIPTION
This works around an incrementality bug when building a runfiles tree while alternating between Bazel versions. Specifically, because the runfiles output manifest is a symlink to the input manifest (and therefore always appears to have the contents of the latter), one can get a spurious cache hit for a stale runfiles tree if the tree was updated in an intervening build without the action cache being updated accordingly. In practice, we expect the failure to update the action cache to be due to an intervening build with a Bazel version that uses different filenames, as in the bug report referenced below; we intentionally do not defend against an intervening build with the same Bazel version and `--nouse_action_cache`, or against external modification of the runfiles tree, as it's currently unclear how to do so without a significant performance regression.

Progress on #26818.

PiperOrigin-RevId: 828008482
Change-Id: I5877a49cc51c552d21b3cb1da68559a48f9a366a