### PR TITLE
[8.5.0] Delete unrecognized files from the action cache on-disk directory when loading it into memory.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -18,6 +18,7 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
@@ -202,15 +203,16 @@ public class CompactPersistentActionCache implements ActionCache {
       EventHandler reporterForInitializationErrors,
       boolean alreadyFoundCorruption)
       throws IOException {
-    PersistentMap<Integer, byte[]> map;
+    cacheRoot.createDirectoryAndParents();
+
     Path cacheFile = cacheFile(cacheRoot);
     Path journalFile = journalFile(cacheRoot);
-    Path indexFile = cacheRoot.getChild("filename_index_v" + VERSION + ".blaze");
-    ConcurrentMap<Integer, byte[]> backingMap = new ConcurrentHashMap<>();
+    Path indexFile = indexFile(cacheRoot);
+    Path indexJournalFile = indexJournalFile(cacheRoot);
 
     PersistentStringIndexer indexer;
     try {
-      indexer = PersistentStringIndexer.create(indexFile, clock);
+      indexer = PersistentStringIndexer.create(indexFile, indexJournalFile, clock);
     } catch (IOException e) {
       return logAndThrowOrRecurse(
           cacheRoot,
@@ -221,6 +223,9 @@ public class CompactPersistentActionCache implements ActionCache {
           alreadyFoundCorruption);
     }
 
+    ConcurrentMap<Integer, byte[]> backingMap = new ConcurrentHashMap<>();
+
+    PersistentMap<Integer, byte[]> map;
     try {
       map = new ActionMap(backingMap, indexer, clock, cacheFile, journalFile);
     } catch (IOException e) {
@@ -243,6 +248,14 @@ public class CompactPersistentActionCache implements ActionCache {
       }
     }
 
+    // Delete unrecognized on-disk files left around by previous or future Bazel versions.
+    // This is required to fix an incrementality bug that occurs when building a runfiles tree
+    // while alternating between two Bazel versions (as might occur during a migration).
+    // See https://github.com/bazelbuild/bazel/issues/26818 for details.
+    // Note that Bazel versions differ in the filenames they use: Bazel 8 and earlier embed the
+    // version number in filenames, while Bazel 9 and later use fixed filenames.
+    deleteUnrecognizedFiles(cacheRoot);
+
     // Populate the map now, so that concurrent updates to the values can happen safely.
     Map<MissReason, AtomicInteger> misses = new EnumMap<>(MissReason.class);
     for (MissReason reason : MissReason.values()) {
@@ -253,7 +266,22 @@ public class CompactPersistentActionCache implements ActionCache {
       }
       misses.put(reason, new AtomicInteger(0));
     }
+
     return new CompactPersistentActionCache(indexer, map, Maps.immutableEnumMap(misses));
+  }
+
+  private static void deleteUnrecognizedFiles(Path cacheRoot) throws IOException {
+    ImmutableSet<Path> knownFiles =
+        ImmutableSet.of(
+            cacheFile(cacheRoot),
+            journalFile(cacheRoot),
+            indexFile(cacheRoot),
+            indexJournalFile(cacheRoot));
+    for (Path child : cacheRoot.getDirectoryEntries()) {
+      if (!knownFiles.contains(child)) {
+        child.delete();
+      }
+    }
   }
 
   private static CompactPersistentActionCache logAndThrowOrRecurse(
@@ -340,6 +368,14 @@ public class CompactPersistentActionCache implements ActionCache {
 
   public static Path journalFile(Path cacheRoot) {
     return cacheRoot.getChild("action_journal_v" + VERSION + ".blaze");
+  }
+
+  public static Path indexFile(Path cacheRoot) {
+    return cacheRoot.getChild("filename_index_v" + VERSION + ".blaze");
+  }
+
+  public static Path indexJournalFile(Path cacheRoot) {
+    return cacheRoot.getChild("filename_index_v" + VERSION + ".journal");
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/PersistentStringIndexer.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/PersistentStringIndexer.java
@@ -20,7 +20,6 @@ import com.google.devtools.build.lib.clock.Clock;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ConditionallyThreadSafe;
 import com.google.devtools.build.lib.util.PersistentMap;
 import com.google.devtools.build.lib.util.StringIndexer;
-import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -46,10 +45,8 @@ final class PersistentStringIndexer implements StringIndexer {
   private static final int INITIAL_CAPACITY = 8192;
 
   /** Instantiates and loads instance of the persistent string indexer. */
-  static PersistentStringIndexer create(Path dataPath, Clock clock) throws IOException {
-    PersistentIndexMap stringToInt =
-        new PersistentIndexMap(
-            dataPath, FileSystemUtils.replaceExtension(dataPath, ".journal"), clock);
+  static PersistentStringIndexer create(Path dataPath, Path journalPath, Clock clock) throws IOException {
+    PersistentIndexMap stringToInt = new PersistentIndexMap(dataPath, journalPath, clock);
 
     // INITIAL_CAPACITY or the next power of two greater than the size.
     int capacity = max(INITIAL_CAPACITY, Integer.highestOneBit(stringToInt.size()) << 1);

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -103,7 +103,7 @@ public class ActionCacheCheckerTest {
     Scratch scratch = new Scratch();
     Clock clock = new ManualClock();
 
-    cache = new CorruptibleActionCache(scratch.resolve("/cache/test.dat"), clock);
+    cache = new CorruptibleActionCache(scratch.resolve("/cache"), clock);
     cacheChecker = createActionCacheChecker(/*storeOutputMetadata=*/ false);
     digestHashFunction = DigestHashFunction.SHA256;
     fileSystem = new InMemoryFileSystem(digestHashFunction);

--- a/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
@@ -58,13 +58,23 @@ public class CompactPersistentActionCacheTest {
 
   @Before
   public final void createFiles() throws Exception  {
-    dataRoot = scratch.resolve("/cache/test.dat");
+    dataRoot = scratch.resolve("/cache");
     cache = CompactPersistentActionCache.create(dataRoot, clock, NullEventHandler.INSTANCE);
     mapFile = CompactPersistentActionCache.cacheFile(dataRoot);
     journalFile = CompactPersistentActionCache.journalFile(dataRoot);
     artifactRoot =
         ArtifactRoot.asDerivedRoot(
             scratch.getFileSystem().getPath("/output"), ArtifactRoot.RootType.Output, "bin");
+  }
+
+  @Test
+  public void testDeleteUnrecognizedFiles() throws Exception {
+    Path unrecognizedFile = dataRoot.getChild("unrecognized");
+    FileSystemUtils.createEmptyFile(unrecognizedFile);
+
+    cache = CompactPersistentActionCache.create(dataRoot, clock, NullEventHandler.INSTANCE);
+
+    assertThat(unrecognizedFile.exists()).isFalse();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/actions/cache/PersistentStringIndexerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/PersistentStringIndexerTest.java
@@ -69,7 +69,7 @@ public final class PersistentStringIndexerTest {
 
   @Before
   public void createIndexer() throws Exception {
-    indexer = PersistentStringIndexer.create(dataPath, clock);
+    indexer = PersistentStringIndexer.create(dataPath, journalPath, clock);
   }
 
   private void assertSize(int expected) {
@@ -171,7 +171,7 @@ public final class PersistentStringIndexerTest {
     assertThat(journalPath.exists()).isFalse();
 
     // Now restore data from file and verify it.
-    indexer = PersistentStringIndexer.create(dataPath, clock);
+    indexer = PersistentStringIndexer.create(dataPath, journalPath, clock);
     assertThat(journalPath.exists()).isFalse();
     clock.advance(4);
     assertSize(10);
@@ -193,7 +193,7 @@ public final class PersistentStringIndexerTest {
     assertThat(journalPath.exists()).isTrue();
 
     // Now restore data from file and verify it. All data should be restored from journal;
-    indexer = PersistentStringIndexer.create(dataPath, clock);
+    indexer = PersistentStringIndexer.create(dataPath, journalPath, clock);
     assertThat(dataPath.exists()).isTrue();
     assertThat(journalPath.exists()).isFalse();
     clock.advance(4);
@@ -219,7 +219,7 @@ public final class PersistentStringIndexerTest {
     assertThat(journalPath.exists()).isTrue();
 
     // Now restore data from file and verify it. All data should be restored from journal;
-    indexer = PersistentStringIndexer.create(dataPath, clock);
+    indexer = PersistentStringIndexer.create(dataPath, journalPath, clock);
     assertThat(dataPath.exists()).isTrue();
     assertThat(journalPath.exists()).isFalse();
     assertThat(dataPath.getFileSize())
@@ -251,7 +251,7 @@ public final class PersistentStringIndexerTest {
     assertThat(journalPath.exists()).isTrue();
 
     // Now restore data from file and verify it. All data should be restored from journal;
-    indexer = PersistentStringIndexer.create(dataPath, clock);
+    indexer = PersistentStringIndexer.create(dataPath, journalPath, clock);
     assertThat(dataPath.exists()).isTrue();
     assertThat(journalPath.exists()).isFalse();
     assertThat(dataPath.getFileSize())
@@ -268,7 +268,8 @@ public final class PersistentStringIndexerTest {
     FileSystemUtils.writeContentAsLatin1(journalPath, "bogus content");
     IOException e =
         assertThrows(
-            IOException.class, () -> indexer = PersistentStringIndexer.create(dataPath, clock));
+            IOException.class, () -> indexer = PersistentStringIndexer.create(
+                dataPath, journalPath, clock));
     assertThat(e).hasMessageThat().contains("too short: Only 13 bytes");
 
     journalPath.delete();
@@ -284,7 +285,7 @@ public final class PersistentStringIndexerTest {
     byte[] journalContent = FileSystemUtils.readContent(journalPath);
 
     // Now restore data from file and verify it. All data should be restored from journal;
-    indexer = PersistentStringIndexer.create(dataPath, clock);
+    indexer = PersistentStringIndexer.create(dataPath, journalPath, clock);
     assertThat(dataPath.exists()).isTrue();
     assertThat(journalPath.exists()).isFalse();
 
@@ -293,7 +294,8 @@ public final class PersistentStringIndexerTest {
     FileSystemUtils.writeContent(
         journalPath, Arrays.copyOf(journalContent, journalContent.length - 1));
     assertThrows(
-        EOFException.class, () -> indexer = PersistentStringIndexer.create(dataPath, clock));
+        EOFException.class, () -> indexer = PersistentStringIndexer.create(
+            dataPath, journalPath, clock));
 
     // Corrupt the journal with a negative size value.
     byte[] journalCopy = journalContent.clone();
@@ -302,14 +304,16 @@ public final class PersistentStringIndexerTest {
     FileSystemUtils.writeContent(journalPath, journalCopy);
     e =
         assertThrows(
-            IOException.class, () -> indexer = PersistentStringIndexer.create(dataPath, clock));
+            IOException.class, () -> indexer = PersistentStringIndexer.create(
+                dataPath, journalPath, clock));
     assertThat(e).hasMessageThat().contains("corrupt key length");
 
     // Now put back corrupted journal. We should get an error.
     journalContent[journalContent.length - 13] = 100;
     FileSystemUtils.writeContent(journalPath, journalContent);
     assertThrows(
-        IOException.class, () -> indexer = PersistentStringIndexer.create(dataPath, clock));
+        IOException.class, () -> indexer = PersistentStringIndexer.create(
+            dataPath, journalPath, clock));
   }
 
   @Test
@@ -344,7 +348,8 @@ public final class PersistentStringIndexerTest {
 
     IOException e =
         assertThrows(
-            IOException.class, () -> indexer = PersistentStringIndexer.create(dataPath, clock));
+            IOException.class, () -> indexer = PersistentStringIndexer.create(
+                dataPath, journalPath, clock));
     assertThat(e).hasMessageThat().contains("Corrupted filename index has duplicate entry");
   }
 


### PR DESCRIPTION
This works around an incrementality bug when building a runfiles tree while alternating between Bazel versions. Specifically, because the runfiles output manifest is a symlink to the input manifest (and therefore always appears to have the contents of the latter), one can get a spurious cache hit for a stale runfiles tree if the tree was updated in an intervening build without the action cache being updated accordingly. In practice, we expect the failure to update the action cache to be due to an intervening build with a Bazel version that uses different filenames, as in the bug report referenced below; we intentionally do not defend against an intervening build with the same Bazel version and `--nouse_action_cache`, or against external modification of the runfiles tree, as it's currently unclear how to do so without a significant performance regression.

Progress on #26818.