### PR TITLE
[7.7.1] Delete unrecognized files from the action cache on-disk directory when loading it into memory.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/cache/PersistentStringIndexer.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/PersistentStringIndexer.java
@@ -17,7 +17,6 @@ import com.google.devtools.build.lib.clock.Clock;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ConditionallyThreadSafe;
 import com.google.devtools.build.lib.util.CanonicalStringIndexer;
 import com.google.devtools.build.lib.util.PersistentMap;
-import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -117,10 +116,9 @@ final class PersistentStringIndexer extends CanonicalStringIndexer {
   /**
    * Instantiates and loads instance of the persistent string indexer.
    */
-  static PersistentStringIndexer newPersistentStringIndexer(Path dataPath,
-                                                            Clock clock) throws IOException {
-    PersistentIndexMap persistentIndexMap = new PersistentIndexMap(dataPath,
-        FileSystemUtils.replaceExtension(dataPath, ".journal"), clock);
+  static PersistentStringIndexer create(
+      Path dataPath, Path journalPath, Clock clock) throws IOException {
+    PersistentIndexMap persistentIndexMap = new PersistentIndexMap(dataPath, journalPath, clock);
     Map<Integer, String> reverseMapping = newConcurrentMap(INITIAL_ENTRIES);
     for (Map.Entry<String, Integer> entry : persistentIndexMap.entrySet()) {
       if (reverseMapping.put(entry.getValue(), entry.getKey()) != null) {

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -103,7 +103,7 @@ public class ActionCacheCheckerTest {
     Scratch scratch = new Scratch();
     Clock clock = new ManualClock();
 
-    cache = new CorruptibleActionCache(scratch.resolve("/cache/test.dat"), clock);
+    cache = new CorruptibleActionCache(scratch.resolve("/cache"), clock);
     cacheChecker = createActionCacheChecker(/*storeOutputMetadata=*/ false);
     digestHashFunction = DigestHashFunction.SHA256;
     fileSystem = new InMemoryFileSystem(digestHashFunction);

--- a/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
@@ -58,13 +58,23 @@ public class CompactPersistentActionCacheTest {
 
   @Before
   public final void createFiles() throws Exception  {
-    dataRoot = scratch.resolve("/cache/test.dat");
+    dataRoot = scratch.resolve("/cache");
     cache = CompactPersistentActionCache.create(dataRoot, clock, NullEventHandler.INSTANCE);
     mapFile = CompactPersistentActionCache.cacheFile(dataRoot);
     journalFile = CompactPersistentActionCache.journalFile(dataRoot);
     artifactRoot =
         ArtifactRoot.asDerivedRoot(
             scratch.getFileSystem().getPath("/output"), ArtifactRoot.RootType.Output, "bin");
+  }
+
+  @Test
+  public void testDeleteUnrecognizedFiles() throws Exception {
+    Path unrecognizedFile = dataRoot.getChild("unrecognized");
+    FileSystemUtils.createEmptyFile(unrecognizedFile);
+
+    cache = CompactPersistentActionCache.create(dataRoot, clock, NullEventHandler.INSTANCE);
+
+    assertThat(unrecognizedFile.exists()).isFalse();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/actions/cache/PersistentStringIndexerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/PersistentStringIndexerTest.java
@@ -71,7 +71,7 @@ public class PersistentStringIndexerTest {
   public final void createIndexer() throws Exception  {
     dataPath = scratch.resolve("/cache/test.dat");
     journalPath = scratch.resolve("/cache/test.journal");
-    psi = PersistentStringIndexer.newPersistentStringIndexer(dataPath, clock);
+    psi = PersistentStringIndexer.create(dataPath, journalPath, clock);
   }
 
   private void assertSize(int expected) {
@@ -160,7 +160,7 @@ public class PersistentStringIndexerTest {
     assertThat(journalPath.exists()).isFalse();
 
     // Now restore data from file and verify it.
-    psi = PersistentStringIndexer.newPersistentStringIndexer(dataPath, clock);
+    psi = PersistentStringIndexer.create(dataPath, journalPath, clock);
     assertThat(journalPath.exists()).isFalse();
     clock.advance(4);
     assertSize(10);
@@ -182,7 +182,7 @@ public class PersistentStringIndexerTest {
     assertThat(journalPath.exists()).isTrue();
 
     // Now restore data from file and verify it. All data should be restored from journal;
-    psi = PersistentStringIndexer.newPersistentStringIndexer(dataPath, clock);
+    psi = PersistentStringIndexer.create(dataPath, journalPath, clock);
     assertThat(dataPath.exists()).isTrue();
     assertThat(journalPath.exists()).isFalse();
     clock.advance(4);
@@ -208,7 +208,7 @@ public class PersistentStringIndexerTest {
     assertThat(journalPath.exists()).isTrue();
 
     // Now restore data from file and verify it. All data should be restored from journal;
-    psi = PersistentStringIndexer.newPersistentStringIndexer(dataPath, clock);
+    psi = PersistentStringIndexer.create(dataPath, journalPath, clock);
     assertThat(dataPath.exists()).isTrue();
     assertThat(journalPath.exists()).isFalse();
     assertThat(dataPath.getFileSize())
@@ -240,7 +240,7 @@ public class PersistentStringIndexerTest {
     assertThat(journalPath.exists()).isTrue();
 
     // Now restore data from file and verify it. All data should be restored from journal;
-    psi = PersistentStringIndexer.newPersistentStringIndexer(dataPath, clock);
+    psi = PersistentStringIndexer.create(dataPath, journalPath, clock);
     assertThat(dataPath.exists()).isTrue();
     assertThat(journalPath.exists()).isFalse();
     assertThat(dataPath.getFileSize())
@@ -257,8 +257,8 @@ public class PersistentStringIndexerTest {
     FileSystemUtils.writeContentAsLatin1(journalPath, "bogus content");
     IOException e =
         assertThrows(
-            IOException.class,
-            () -> psi = PersistentStringIndexer.newPersistentStringIndexer(dataPath, clock));
+            IOException.class, () -> psi = PersistentStringIndexer.create(
+                dataPath, journalPath, clock));
     assertThat(e).hasMessageThat().contains("too short: Only 13 bytes");
 
     journalPath.delete();
@@ -274,7 +274,7 @@ public class PersistentStringIndexerTest {
     byte[] journalContent = FileSystemUtils.readContent(journalPath);
 
     // Now restore data from file and verify it. All data should be restored from journal;
-    psi = PersistentStringIndexer.newPersistentStringIndexer(dataPath, clock);
+    psi = PersistentStringIndexer.create(dataPath, journalPath, clock);
     assertThat(dataPath.exists()).isTrue();
     assertThat(journalPath.exists()).isFalse();
 
@@ -283,8 +283,8 @@ public class PersistentStringIndexerTest {
     FileSystemUtils.writeContent(journalPath,
         Arrays.copyOf(journalContent, journalContent.length - 1));
     assertThrows(
-        EOFException.class,
-        () -> psi = PersistentStringIndexer.newPersistentStringIndexer(dataPath, clock));
+        EOFException.class, () -> psi = PersistentStringIndexer.create(
+            dataPath, journalPath, clock));
 
     // Corrupt the journal with a negative size value.
     byte[] journalCopy = journalContent.clone();
@@ -293,16 +293,16 @@ public class PersistentStringIndexerTest {
     FileSystemUtils.writeContent(journalPath,  journalCopy);
     e =
         assertThrows(
-            IOException.class,
-            () -> psi = PersistentStringIndexer.newPersistentStringIndexer(dataPath, clock));
+            IOException.class, () -> psi = PersistentStringIndexer.create(
+                dataPath, journalPath, clock));
     assertThat(e).hasMessageThat().contains("corrupt key length");
 
     // Now put back corrupted journal. We should get an error.
     journalContent[journalContent.length - 13] = 100;
     FileSystemUtils.writeContent(journalPath,  journalContent);
     assertThrows(
-        IOException.class,
-        () -> psi = PersistentStringIndexer.newPersistentStringIndexer(dataPath, clock));
+        IOException.class, () -> psi = PersistentStringIndexer.create(
+            dataPath, journalPath, clock));
   }
 
   @Test
@@ -337,8 +337,8 @@ public class PersistentStringIndexerTest {
 
     IOException e =
         assertThrows(
-            IOException.class,
-            () -> psi = PersistentStringIndexer.newPersistentStringIndexer(dataPath, clock));
+            IOException.class, () -> psi = PersistentStringIndexer.create(
+                dataPath, journalPath, clock));
     assertThat(e).hasMessageThat().contains("Corrupted filename index has duplicate entry");
   }
 


### PR DESCRIPTION
This works around an incrementality bug when building a runfiles tree while alternating between Bazel versions. Specifically, because the runfiles output manifest is a symlink to the input manifest (and therefore always appears to have the contents of the latter), one can get a spurious cache hit for a stale runfiles tree if the tree was updated in an intervening build without the action cache being updated accordingly. In practice, we expect the failure to update the action cache to be due to an intervening build with a Bazel version that uses different filenames, as in the bug report referenced below; we intentionally do not defend against an intervening build with the same Bazel version and `--nouse_action_cache`, or against external modification of the runfiles tree, as it's currently unclear how to do so without a significant performance regression.

Progress on #26818.