### PR TITLE
[9.0.0] Add `attr.label_list_dict`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -1574,6 +1574,9 @@ public class RuleContext extends TargetContext
       for (String attributeName : attributes.getAttributeNames()) {
         Attribute attr = attributes.getAttributeDefinition(attributeName);
         if (attr.getType() != BuildType.LABEL_LIST) {
+          // It is not obvious but correct to skip LABEL_LIST_DICT here: since concatenating selects
+          // of dicts of lists does not concatenate the lists but picks the last one for each key,
+          // all possible duplicates have already been ruled out by AggregatingAttributeMapper.
           continue;
         }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrModule.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrModule.java
@@ -1014,6 +1014,60 @@ public final class StarlarkAttrModule implements StarlarkAttrModuleApi {
   }
 
   @Override
+  public Descriptor labelListDictAttribute(
+      Boolean allowEmpty,
+      Object configurable,
+      Dict<?, ?> defaultValue,
+      Object doc,
+      Object allowFiles,
+      Object allowRules,
+      Sequence<?> providers,
+      Object forDependencyResolution,
+      Sequence<?> flags,
+      Boolean mandatory,
+      Boolean skipValidations,
+      Object cfg,
+      Sequence<?> aspects,
+      StarlarkThread thread)
+      throws EvalException {
+    checkContext(thread, "attr.label_list_dict()");
+    Map<String, Object> kwargs =
+        optionMap(
+            CONFIGURABLE_ARG,
+            configurable,
+            DEFAULT_ARG,
+            defaultValue,
+            ALLOW_FILES_ARG,
+            allowFiles,
+            ALLOW_RULES_ARG,
+            allowRules,
+            PROVIDERS_ARG,
+            providers,
+            FOR_DEPENDENCY_RESOLUTION_ARG,
+            forDependencyResolution,
+            FLAGS_ARG,
+            flags,
+            MANDATORY_ARG,
+            mandatory,
+            SKIP_VALIDATIONS_ARG,
+            skipValidations,
+            ALLOW_EMPTY_ARG,
+            allowEmpty,
+            CONFIGURATION_ARG,
+            cfg,
+            ASPECTS_ARG,
+            aspects);
+    ImmutableAttributeFactory attribute =
+        createAttributeFactory(
+            BuildType.LABEL_LIST_DICT,
+            Starlark.toJavaOptional(doc, String.class),
+            kwargs,
+            thread,
+            "label_list_dict");
+    return new Descriptor("label_list_dict", attribute);
+  }
+
+  @Override
   public Descriptor boolAttribute(
       Object configurable,
       Boolean defaultValue,

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
@@ -539,8 +539,18 @@ public final class StarlarkRuleContext
               StarlarkAttributesCollection.Builder.convertStringToLabelMap(
                   ruleContext.attributes().get(attr.getName(), BuildType.LABEL_DICT_UNARY),
                   prerequisites);
+        } else if (attr.getType() == BuildType.LABEL_LIST_DICT) {
+          ImmutableList<ConfiguredTarget> prerequisites =
+              splitPrereq.getValue().stream()
+                  .map(ConfiguredTargetAndData::getConfiguredTarget)
+                  .collect(ImmutableList.toImmutableList());
+
+          value =
+              StarlarkAttributesCollection.Builder.convertStringToLabelListMap(
+                  ruleContext.attributes().get(attr.getName(), BuildType.LABEL_LIST_DICT),
+                  prerequisites);
         } else {
-          // BuildType.LABEL_LIST
+          Preconditions.checkState(attr.getType() == BuildType.LABEL_LIST, attr);
           value =
               StarlarkList.immutableCopyOf(
                   splitPrereq.getValue().stream()

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -2105,10 +2105,10 @@ public class RuleClass implements RuleClassData {
   private static void checkForDuplicateLabels(Rule rule, EventHandler eventHandler) {
     AggregatingAttributeMapper mapper = AggregatingAttributeMapper.of(rule);
     for (Attribute attribute : rule.getAttributeProvider().getAttributes()) {
-      if (attribute.getType() != BuildType.LABEL_LIST) {
+      Set<Label> duplicates = mapper.checkForDuplicateLabels(attribute);
+      if (duplicates.isEmpty()) {
         continue;
       }
-      Set<Label> duplicates = mapper.checkForDuplicateLabels(attribute);
       for (Label label : duplicates) {
         rule.reportError(
             String.format(

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkAttrModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkAttrModuleApi.java
@@ -1011,6 +1011,128 @@ public interface StarlarkAttrModuleApi extends StarlarkValue {
       throws EvalException;
 
   @StarlarkMethod(
+      name = "label_list_dict",
+      doc =
+          "<p>Creates a schema for an attribute holding a dictionary, where the keys are strings "
+              + "and the values are list of labels. This is a dependency attribute.</p>"
+              + DEPENDENCY_ATTR_TEXT,
+      parameters = {
+        @Param(name = ALLOW_EMPTY_ARG, defaultValue = "True", doc = ALLOW_EMPTY_DOC, named = true),
+        @Param(
+            name = CONFIGURABLE_ARG,
+            allowedTypes = {
+              @ParamType(type = Boolean.class),
+              @ParamType(type = Starlark.UnboundMarker.class),
+            },
+            defaultValue = "unbound",
+            doc = CONFIGURABLE_ARG_DOC,
+            named = true,
+            positional = false),
+        @Param(
+            name = DEFAULT_ARG,
+            defaultValue = "{}",
+            named = true,
+            positional = false,
+            doc =
+                DEFAULT_DOC
+                    + """
+                    Use strings or the <a href="../builtins/Label.html#Label"><code>Label</code>
+                    </a> function to specify default values, for example,
+                    <code>attr.label_list_dict(default = {"key1": ["//a:b", "//a:c"], "key2":
+                    [Label("@my_repo//d:e")]})</code>.\
+                    """),
+        @Param(
+            name = DOC_ARG,
+            allowedTypes = {@ParamType(type = String.class), @ParamType(type = NoneType.class)},
+            defaultValue = "None",
+            doc = DOC_DOC,
+            named = true,
+            positional = false),
+        @Param(
+            name = ALLOW_FILES_ARG,
+            allowedTypes = {
+              @ParamType(type = Boolean.class),
+              @ParamType(type = Sequence.class, generic1 = String.class),
+              @ParamType(type = NoneType.class),
+            },
+            defaultValue = "None",
+            named = true,
+            positional = false,
+            doc = ALLOW_FILES_DOC),
+        @Param(
+            name = ALLOW_RULES_ARG,
+            allowedTypes = {
+              @ParamType(type = Sequence.class, generic1 = String.class),
+              @ParamType(type = NoneType.class),
+            },
+            defaultValue = "None",
+            named = true,
+            positional = false,
+            doc = ALLOW_RULES_DOC),
+        @Param(
+            name = PROVIDERS_ARG,
+            defaultValue = "[]",
+            named = true,
+            positional = false,
+            doc = PROVIDERS_DOC),
+        @Param(
+            name = FOR_DEPENDENCY_RESOLUTION_ARG,
+            defaultValue = "unbound",
+            named = true,
+            positional = false,
+            doc = FOR_DEPENDENCY_RESOLUTION_DOC),
+        @Param(
+            name = FLAGS_ARG,
+            allowedTypes = {@ParamType(type = Sequence.class, generic1 = String.class)},
+            defaultValue = "[]",
+            named = true,
+            positional = false,
+            doc = FLAGS_DOC),
+        @Param(
+            name = MANDATORY_ARG,
+            defaultValue = "False",
+            named = true,
+            positional = false,
+            doc = MANDATORY_DOC),
+        @Param(
+            name = SKIP_VALIDATIONS_ARG,
+            defaultValue = "False",
+            named = true,
+            positional = false,
+            doc = SKIP_VALIDATIONS_ARG_DOC),
+        @Param(
+            name = CONFIGURATION_ARG,
+            defaultValue = "None",
+            named = true,
+            positional = false,
+            doc = CONFIGURATION_DOC),
+        @Param(
+            name = ASPECTS_ARG,
+            allowedTypes = {@ParamType(type = Sequence.class, generic1 = StarlarkAspectApi.class)},
+            defaultValue = "[]",
+            named = true,
+            positional = false,
+            doc = ASPECTS_ARG_DOC)
+      },
+      useStarlarkThread = true)
+  Descriptor labelListDictAttribute(
+      Boolean allowEmpty,
+      Object configurable,
+      Dict<?, ?> defaultValue,
+      Object doc,
+      Object allowFiles,
+      Object allowRules,
+      Sequence<?> providers,
+      Object forDependencyResolution,
+      Sequence<?> flags,
+      Boolean mandatory,
+      Boolean skipValidations,
+      Object cfg,
+      Sequence<?> aspects,
+      StarlarkThread thread)
+      throws EvalException;
+
+  @StarlarkMethod(
       name = "bool",
       doc =
           "Creates a schema for a boolean attribute. The corresponding <a"

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkAspectAttrAspectsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkAspectAttrAspectsFunctionTest.java
@@ -1075,6 +1075,7 @@ attr_map = {
   'string_keyed_label_dict': {'key1': Label('//pkg1:dep_1'), 'key2': Label('//pkg1:dep_2')},
   'string_list': ['string_value_1', 'string_value_2'],
   'string_list_dict': {'key1': ['string_value_1', 'string_value_2'], 'key2': ['string_value_3', 'string_value_4']},
+  'label_list_dict': {'key1': [Label('//pkg1:dep_1')], 'key2': [Label('//pkg1:dep_2')]},
 }
 def _propagation_attrs(ctx):
   for attr_name, expected_val in attr_map.items():
@@ -1118,6 +1119,7 @@ my_rule = rule(
     "string_keyed_label_dict": attr.string_keyed_label_dict(),
     "string_list": attr.string_list(),
     "string_list_dict": attr.string_list_dict(),
+    "label_list_dict": attr.label_list_dict(),
     })
 """);
     scratch.file(
@@ -1139,6 +1141,7 @@ my_rule(
     string_keyed_label_dict = {'key1': ':dep_1', 'key2': ':dep_2'},
     string_list = ['string_value_1', 'string_value_2'],
     string_list_dict = {'key1': ['string_value_1', 'string_value_2'], 'key2': ['string_value_3', 'string_value_4']},
+    label_list_dict = {'key1': [':dep_1'], 'key2': [':dep_2']},
 )
 
 my_rule(name = 'dep_1')

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkDefinedAspectsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkDefinedAspectsTest.java
@@ -867,6 +867,53 @@ my_rule = rule(
   }
 
   @Test
+  public void labelListDictAllowsAspects() throws Exception {
+    scratch.file(
+        "test/aspect.bzl",
+        """
+        AspectInfo = provider()
+        def _aspect_impl(target, ctx):
+           return AspectInfo(aspect_data=target.label.name)
+
+        RuleInfo = provider()
+        def _rule_impl(ctx):
+           return RuleInfo(
+               data=','.join(['{}:{}'.format(dep[AspectInfo].aspect_data, val)
+                              for val, deps in ctx.attr.attr.items() for dep in deps]))
+
+        MyAspect = aspect(
+           implementation=_aspect_impl,
+        )
+        my_rule = rule(
+           implementation=_rule_impl,
+           attrs = { 'attr' : attr.label_list_dict(aspects = [MyAspect]) },
+        )
+        """);
+
+    scratch.file(
+        "test/BUILD",
+        """
+        load('//test:aspect.bzl', 'my_rule')
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+        cc_library(
+             name = 'yyy1',
+        )
+        cc_library(
+             name = 'yyy2',
+        )
+        my_rule(
+             name = 'xxx',
+             attr = {'zzz': [':yyy1', ':yyy2']},
+        )
+        """);
+
+    AnalysisResult analysisResult = update("//test:xxx");
+    ConfiguredTarget target = analysisResult.getTargetsToBuild().iterator().next();
+    String value = getStarlarkProvider(target, "RuleInfo").getValue("data", String.class);
+    assertThat(value).isEqualTo("yyy1:zzz,yyy2:zzz");
+  }
+
+  @Test
   public void aspectsDoNotAttachToFiles() throws Exception {
     scratch.file(
         "test/aspect.bzl",

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkStringRepresentationsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkStringRepresentationsTest.java
@@ -394,6 +394,7 @@ public class StarlarkStringRepresentationsTest extends BuildViewTestCase {
     assertStringRepresentation("attr.output_list()", "<attr.output_list>");
     assertStringRepresentation("attr.string_dict()", "<attr.string_dict>");
     assertStringRepresentation("attr.string_list_dict()", "<attr.string_list_dict>");
+    assertStringRepresentation("attr.label_list_dict()", "<attr.label_list_dict>");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractorTest.java
@@ -828,6 +828,7 @@ public final class ModuleInfoExtractorTest {
                     "j": attr.string_list_dict(),
                     "k": attr.output(),
                     "l": attr.output_list(),
+                    "m": attr.label_list_dict(),
                 },
             )
             """);
@@ -898,6 +899,11 @@ public final class ModuleInfoExtractorTest {
                         .setType(AttributeType.OUTPUT_LIST)
                         .setDefaultValue("[]")
                         .setNonconfigurable(true)
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("m")
+                        .setType(AttributeType.LABEL_LIST_DICT)
+                        .setDefaultValue("{}")
                         .build())
                 .build());
   }
@@ -1145,6 +1151,9 @@ my_macro = macro(
                     "label_keyed_string_dict": attr.label_keyed_string_dict(
                         default = {"//x": "label_in_main", "@@canonical//y": "label_in_dep"},
                     ),
+                    "label_list_dict": attr.label_list_dict(
+                        default = {"a": ["//x", "@@canonical//y", "@@canonical//y:z"]},
+                    ),
                 },
             )
             """);
@@ -1159,7 +1168,8 @@ my_macro = macro(
         .containsExactly(
             "\"@my_repo//test:foo\"",
             "[\"@my_repo//x\", \"@local//y\", \"@local//y:z\"]",
-            "{\"@my_repo//x\": \"label_in_main\", \"@local//y\": \"label_in_dep\"}");
+            "{\"@my_repo//x\": \"label_in_main\", \"@local//y\": \"label_in_dep\"}",
+            "{\"a\": [\"@my_repo//x\", \"@local//y\", \"@local//y:z\"]}");
   }
 
   @Test


### PR DESCRIPTION
Motivating examples for adding this type:
* Packaging rules that bundle targets into substructures (e.g. subdirectories).
* Providing hints to aspects via a well-known implicit attribute mapping the names of other attributes to a list of well-known targets representing the semantic meaning of an edge (e.g. "compile time dep", "runtime dep", "third party dep", ...) for use in SBOM generation and packaging.
* rules_js and other rulesets have `patches` parameters on their module extensions that accept lists of patches to apply per external dependency. With WORKSPACE, they relied on `attr.string_list_dict`, but the lack of repo mapping means that there is no direct port. Users would need to migrate to individual tags per hub repo and dep to supply patches.

Adding this type doesn't incur a significant maintenance cost:
* The native attribute type `LABEL_LIST_DICT` already exists (added for `exec_group_compatible_with`), so this only requires wiring it up in Starlark. In fact, some of the added logic (duplicate checking) is relevant for this existing use case, we just forgot to add it.
* A Starlark type with equivalent BUILD syntax already exists (`attr.string_list_dict`), so there is no need for tooling to explicitly support the new type.

Fixes #7989

RELNOTES[NEW]: The new `attr.label_list_dict` type accepts a dict in which keys are strings and values are lists of labels.

Closes #27119.

PiperOrigin-RevId: 828510272
Change-Id: Ibf5ba97d049e592af2f61d91dbaa42cfe264f0bb

Commit https://github.com/bazelbuild/bazel/commit/b0f51a9502713e25270a7716bfd4e98a32639c9d