### PR TITLE
[9.0.0] Add executables() query function

### DIFF
--- a/site/en/query/language.md
+++ b/site/en/query/language.md
@@ -511,6 +511,7 @@ functions are available:
 * [`buildfiles`](#buildfiles)
 * [`rbuildfiles`](#rbuildfiles)
 * [`deps`](#deps)
+* [`executables`](#executables)
 * [`filter`](#filter)
 * [`kind`](#kind)
 * [`labels`](#labels)
@@ -1029,6 +1030,20 @@ individual tests that would be executed by `bazel test
 foo:*`: this may include tests belonging to other packages,
 that are referenced directly or indirectly
 via `test_suite` rules.
+
+### Executable targets: executables {:#executables}
+
+```
+expr ::= executables({{ '<var>' }}expr{{ '</var>' }})
+```
+
+The `executables({{ '<var>' }}x{{ '</var>' }})` operator returns the set of all
+executable targets in set {{ '<var>' }}x{{ '</var>' }}. These targets
+are of rule types that can be run with `bazel run`, such as `cc_binary`,
+or any other rule that sets `executable = True` in its definition.
+
+This doesn't include test targets, which can be added to the result with
+the [`tests`](#tests) operator.
 
 ### Package definition files: buildfiles {:#buildfiles}
 

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -72,6 +72,10 @@ public final class TargetUtils {
     return name.equals("test_suite");
   }
 
+  public static boolean isExecutableNonTestRule(Target target) {
+    return target instanceof Rule rule && rule.isExecutable() && !isTestRule(rule);
+  }
+
   /**
    * Returns true iff {@code target} is a {@code *_test} rule; excludes {@code
    * test_suite}.

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ConfiguredTargetValueAccessor.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ConfiguredTargetValueAccessor.java
@@ -89,6 +89,12 @@ public class ConfiguredTargetValueAccessor implements TargetAccessor<ConfiguredT
   }
 
   @Override
+  public boolean isExecutableNonTestRule(ConfiguredTargetValue configuredTargetValue) {
+    Target actualTarget = getTargetFromConfiguredTargetValue(configuredTargetValue);
+    return TargetUtils.isExecutableNonTestRule(actualTarget);
+  }
+
+  @Override
   public boolean isTestRule(ConfiguredTargetValue configuredTargetValue) {
     Target actualTarget = getTargetFromConfiguredTargetValue(configuredTargetValue);
     return TargetUtils.isTestRule(actualTarget);

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetAccessor.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetAccessor.java
@@ -125,6 +125,12 @@ public class ConfiguredTargetAccessor implements TargetAccessor<CqueryNode> {
   }
 
   @Override
+  public boolean isExecutableNonTestRule(CqueryNode target) {
+    Target actualTarget = getTarget(target);
+    return TargetUtils.isExecutableNonTestRule(actualTarget);
+  }
+
+  @Override
   public boolean isTestRule(CqueryNode target) {
     Target actualTarget = getTarget(target);
     return TargetUtils.isTestRule(actualTarget);

--- a/src/main/java/com/google/devtools/build/lib/query2/engine/ExecutablesFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/engine/ExecutablesFunction.java
@@ -1,0 +1,67 @@
+// Copyright 2014 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.query2.engine;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.devtools.build.lib.query2.engine.QueryEnvironment.Argument;
+import com.google.devtools.build.lib.query2.engine.QueryEnvironment.ArgumentType;
+import com.google.devtools.build.lib.query2.engine.QueryEnvironment.QueryFunction;
+import com.google.devtools.build.lib.query2.engine.QueryEnvironment.QueryTaskFuture;
+import com.google.devtools.build.lib.query2.engine.QueryEnvironment.TargetAccessor;
+import java.util.List;
+
+/**
+ * An executables(x) filter expression, which returns all the executables (not including tests) in
+ * set x.
+ *
+ * <pre>expr ::= EXECUTABLES '(' expr ')'</pre>
+ */
+public class ExecutablesFunction implements QueryFunction {
+  @VisibleForTesting
+  public ExecutablesFunction() {}
+
+  @Override
+  public String getName() {
+    return "executables";
+  }
+
+  @Override
+  public int getMandatoryArguments() {
+    return 1;
+  }
+
+  @Override
+  public List<ArgumentType> getArgumentTypes() {
+    return ImmutableList.of(ArgumentType.EXPRESSION);
+  }
+
+  @Override
+  public <T> QueryTaskFuture<Void> eval(
+      QueryEnvironment<T> env,
+      QueryExpressionContext<T> context,
+      QueryExpression expression,
+      List<Argument> args,
+      Callback<T> callback) {
+    TargetAccessor<T> accessor = env.getAccessor();
+
+    return env.eval(
+        args.get(0).getExpression(),
+        context,
+        partialResult -> {
+          callback.process(Iterables.filter(partialResult, accessor::isExecutableNonTestRule));
+        });
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/query2/engine/QueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/engine/QueryEnvironment.java
@@ -670,6 +670,9 @@ public interface QueryEnvironment<T> {
     /** Returns whether the given target is a rule. */
     boolean isRule(T target);
 
+    /** Returns whether the given rule is executable with 'bazel run'. */
+    boolean isExecutableNonTestRule(T target);
+
     /**
      * Returns whether the given target is a test target. If this returns true, then {@link #isRule}
      * must also return true for the target.
@@ -741,6 +744,7 @@ public interface QueryEnvironment<T> {
           new AttrFunction(),
           new BuildFilesFunction(),
           new DepsFunction(),
+          new ExecutablesFunction(),
           new FilterFunction(),
           new KindFunction(),
           new LabelsFunction(),

--- a/src/main/java/com/google/devtools/build/lib/query2/query/BlazeTargetAccessor.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/BlazeTargetAccessor.java
@@ -122,6 +122,11 @@ public final class BlazeTargetAccessor implements TargetAccessor<Target> {
   }
 
   @Override
+  public boolean isExecutableNonTestRule(Target target) {
+    return TargetUtils.isExecutableNonTestRule(target);
+  }
+
+  @Override
   public boolean isTestRule(Target target) {
     return TargetUtils.isTestRule(target);
   }

--- a/src/test/java/com/google/devtools/build/lib/query2/engine/QueryParserTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/engine/QueryParserTest.java
@@ -191,6 +191,7 @@ public final class QueryParserTest {
     checkPrettyPrint("let x = e1 in e2");
     checkPrettyPrint("labels('srcs', x)");
     checkPrettyPrint("tests(x)");
+    checkPrettyPrint("executables(x)");
     checkPrettyPrint("set()");
     checkPrettyPrint("set(//a)");
     checkPrettyPrint("set(//a //b)");

--- a/src/test/java/com/google/devtools/build/lib/query2/testutil/AbstractQueryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/testutil/AbstractQueryTest.java
@@ -1422,6 +1422,36 @@ public abstract class AbstractQueryTest<T> {
     assertThat(eval("//a:a + //a/b:cycle1 + //a/b:cycle2")).isEqualTo(eval("//a/..."));
   }
 
+  /* executables(x) operator */
+
+  @Test
+  public void testExecutablesQuery() throws Exception {
+    writeFile(
+        "donut/BUILD",
+        """
+        load('//test_defs:foo_binary.bzl', 'foo_binary')
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+        load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+        foo_binary(
+            name = "bin",
+            srcs = ["thief.sh"],
+        )
+
+        cc_test(
+            name = "test",
+            srcs = ["shop.cc"],
+        )
+
+        cc_library(
+            name = "lib",
+            srcs = ["shop.cc"],
+        )
+        """);
+
+    assertThat(eval("executables(//donut:all)")).isEqualTo(eval("//donut:bin"));
+  }
+
   /* set(x) operator */
 
   @Test


### PR DESCRIPTION
This is useful for trying to come up with a list of targets that can be
run with `bazel run`. Transitionally to workaround the lack of this
folks would use `*_binary` to approximate this, but there are many
community rules that don't follow that pattern for things that run
scripts, etc.

RELNOTES[NEW]: bazel query/cquery/aquery now supports an `executables()` function to find only the executable targets in a given expression

Closes #26525.

PiperOrigin-RevId: 828832412
Change-Id: I0bd4a37f788b85d4e02171c11608c8dc99cce305

Commit https://github.com/bazelbuild/bazel/commit/88b5e33fb47f46c3beaccfd9350afe649db4393b