### PR TITLE
[7.7.1] Don't store local registry hashes in the lockfile

### DIFF
--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -1547,62 +1547,68 @@ class BazelLockfileTest(test_base.TestBase):
 
   def testLockfileWithNoUserSpecificPath(self):
     self.my_registry = BazelRegistry(os.path.join(self._test_cwd, 'registry'))
-    self.my_registry.start()
-    try:
-      self.my_registry.setModuleBasePath('projects')
-      patch_file = self.ScratchFile(
-          'ss.patch',
-          [
-              '--- a/aaa.cc',
-              '+++ b/aaa.cc',
-              '@@ -1,6 +1,6 @@',
-              ' #include <stdio.h>',
-              ' #include "aaa.h"',
-              ' void hello_aaa(const std::string& caller) {',
-              '-    std::string lib_name = "aaa@1.1-1";',
-              '+    std::string lib_name = "aaa@1.1-1 (remotely patched)";',
-              '     printf("%s => %s\\n", caller.c_str(), lib_name.c_str());',
-              ' }',
-          ],
-      )
-      # Module with a local patch & extension
-      self.my_registry.createCcModule(
-          'ss',
-          '1.3-1',
-          {'ext': '1.0'},
-          patches=[patch_file],
-          patch_strip=1,
-          extra_module_file_contents=[
-              'my_ext = use_extension("@ext//:ext.bzl", "ext")',
-              'use_repo(my_ext, "justRepo")',
-          ],
-      )
-      ext_src = [
-          'def _repo_impl(ctx): ctx.file("BUILD")',
-          'repo = repository_rule(_repo_impl)',
-          'def _ext_impl(ctx): repo(name=justRepo)',
-          'ext=module_extension(_ext_impl)',
-      ]
-      self.my_registry.createLocalPathModule('ext', '1.0', 'ext')
-      scratchFile(self.my_registry.projects.joinpath('ext', 'BUILD'))
-      scratchFile(self.my_registry.projects.joinpath('ext', 'ext.bzl'), ext_src)
+    self.my_registry.setModuleBasePath('projects')
+    patch_file = self.ScratchFile(
+        'ss.patch',
+        [
+            '--- a/aaa.cc',
+            '+++ b/aaa.cc',
+            '@@ -1,6 +1,6 @@',
+            ' #include <stdio.h>',
+            ' #include "aaa.h"',
+            ' void hello_aaa(const std::string& caller) {',
+            '-    std::string lib_name = "aaa@1.1-1";',
+            '+    std::string lib_name = "aaa@1.1-1 (remotely patched)";',
+            '     printf("%s => %s\\n", caller.c_str(), lib_name.c_str());',
+            ' }',
+        ],
+    )
+    overlay_file = self.ScratchFile(
+        'ss.overlay',
+        [
+            'def _repo_impl(ctx): ctx.file("BUILD")',
+            'repo = repository_rule(_repo_impl)',
+            'def _ext_impl(ctx): repo(name=justRepo)',
+            'ext=module_extension(_ext_impl)',
+        ],
+    )
+    # Module with a local patch, overlay & extension
+    self.my_registry.createCcModule(
+        'ss',
+        '1.3-1',
+        {'ext': '1.0'},
+        patches=[patch_file],
+        patch_strip=1,
+        overlay={
+            'ext.bzl': overlay_file,
+        },
+        extra_module_file_contents=[
+            'my_ext = use_extension("@ext//:ext.bzl", "ext")',
+            'use_repo(my_ext, "justRepo")',
+        ],
+    )
+    self.my_registry.createLocalPathModule('ext', '1.0', 'ext')
+    scratchFile(self.my_registry.projects.joinpath('ext', 'BUILD'))
 
-      self.ScratchFile(
-          'MODULE.bazel',
-          [
-              'bazel_dep(name = "ss", version = "1.3-1")',
-          ],
-      )
-      self.ScratchFile('BUILD.bazel', ['filegroup(name = "lala")'])
-      self.RunBazel(
-          ['build', '--registry=file:///%workspace%/registry', '//:lala']
-      )
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'bazel_dep(name = "ss", version = "1.3-1")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel', ['filegroup(name = "lala")'])
+    self.RunBazel(
+        ['build', '--registry=' + self.my_registry.getLocalURL(), '//:lala']
+    )
 
-      with open('MODULE.bazel.lock', 'r') as f:
-        self.assertNotIn(self.my_registry.getURL(), f.read())
-
-    finally:
-      self.my_registry.stop()
+    with open('MODULE.bazel.lock', 'r') as f:
+      module_file = f.read()
+      # Ensure no user-specific path is in the lockfile, but only check the last
+      # two segments to avoid false negatives caused by minor differences in the
+      # absolute path segment (e.g. casing or symbolic links).
+      workspace_basename = pathlib.Path(self._test_cwd).name
+      forbidden_path = pathlib.Path(workspace_basename, 'registry')
+      self.assertNotIn(str(forbidden_path), module_file)
 
   def testExtensionEvaluationRerunsIfDepGraphOrderChanges(self):
     self.ScratchFile(

--- a/src/test/py/bazel/bzlmod/test_utils.py
+++ b/src/test/py/bazel/bzlmod/test_utils.py
@@ -66,6 +66,7 @@ class Module:
     self.strip_prefix = ''
     self.module_dot_bazel = None
     self.patches = []
+    self.overlay = {}
     self.patch_strip = 0
     self.archive_type = None
 
@@ -81,6 +82,10 @@ class Module:
   def set_patches(self, patches, patch_strip):
     self.patches = patches
     self.patch_strip = patch_strip
+    return self
+
+  def set_overlay(self, overlay):
+    self.overlay = overlay
     return self
 
   def set_archive_type(self, archive_type):
@@ -120,6 +125,10 @@ class BazelRegistry:
   def getURL(self):
     """Return the URL of this registry."""
     return self.http_server.getURL()
+
+  def getLocalURL(self):
+    """Return the local file:// URL of this registry."""
+    return self.root.as_uri()
 
   def generateCcSource(
       self,
@@ -267,6 +276,15 @@ class BazelRegistry:
         source['patches'][patch.name] = integrity(read(patch))
         shutil.copy(str(patch), str(patch_dir))
 
+    if module.overlay:
+      overlay_dir = module_dir.joinpath('overlay')
+      overlay_dir.mkdir()
+      source['overlay'] = {}
+      for overlay_rel_path, overlay_file in module.overlay.items():
+        file = pathlib.Path(overlay_file)
+        source['overlay'][overlay_rel_path] = integrity(read(file))
+        shutil.copy(str(file), str(overlay_dir.joinpath(overlay_rel_path)))
+
     if module.archive_type:
       source['archive_type'] = module.archive_type
 
@@ -281,6 +299,7 @@ class BazelRegistry:
       repo_names=None,
       patches=None,
       patch_strip=0,
+      overlay=None,
       archive_pattern=None,
       archive_type=None,
       extra_module_file_contents=None,
@@ -300,6 +319,8 @@ class BazelRegistry:
     module.set_module_dot_bazel(src_dir.joinpath('MODULE.bazel'))
     if patches:
       module.set_patches(patches, patch_strip)
+    if overlay:
+      module.set_overlay(overlay)
     if archive_type:
       module.set_archive_type(archive_type)
 


### PR DESCRIPTION
This regressed in c5a562b6b5f718b39b8211fa1cf47169cfedb300 since the relevant test had become ineffective when it was incorrectly ported to HTTP registries.

Fixes #26835

Closes #26841.

PiperOrigin-RevId: 800357483
Change-Id: I86e3a4927cc97fb44ac8b5ceb205a6d738a0de6d 
(cherry picked from commit 9d961b96f5d601b8fd743dffadc313e6b407c1d1)