### PR TITLE
[9.0.0] Support `%bazel_workspace%` interpolation in `--repo_env`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -615,7 +615,9 @@ public class CommonCommandOptions extends OptionsBase {
           Specifies additional environment variables to be available only for repository rules. \
           Note that repository rules see the full environment anyway, but in this way \
           variables can be set via command-line flags and <code>.bazelrc</code> entries. \
-          The special syntax <code>=NAME</code> can be used to explicitly unset a variable.
+          The special syntax <code>=NAME</code> can be used to explicitly unset a variable. \
+          The string <code>%bazel_workspace%</code> in a value will be replaced with the absolute \
+          path of the workspace as printed by <code>bazel info workspace</code>.
           """)
   public List<Converters.EnvVar> repositoryEnvironment;
 


### PR DESCRIPTION
`%bazel_workspace%` is used instead of the more conventional `%workspace%` to avoid changing the behavior of existing `--repo_env` usages in which `%workspace%` may already have a meaning.

RELNOTES: In environment variable values set via `--repo_env`, the substring `%bazel_workspace%` is now replaced with the absolute path of the current Bazel workspace. This can, for example, be used to make tools checked into the repository available on the `PATH` for repository rules.

Closes #25608.

PiperOrigin-RevId: 828862407
Change-Id: I644fbb25d80c5353e522c7184d7c57b2ac8bf04f

Commit https://github.com/bazelbuild/bazel/commit/6dc16b91b479ab84066c80c2a37688dda6d4dc1a