### PR TITLE
Unbreak jvm_import_external()

### DIFF
--- a/tools/build_defs/repo/jvm.bzl
+++ b/tools/build_defs/repo/jvm.bzl
@@ -90,9 +90,7 @@ def _jvm_import_external(repository_ctx):
         lines.append(repository_ctx.attr.rule_load)
         lines.append("")
     if repository_ctx.attr.default_visibility:
-        lines.append("package(default_visibility = %s)" % (
-            repository_ctx.attr.default_visibility
-        ))
+        lines.append("package(default_visibility = %s)" % repository_ctx.attr.default_visibility)
         lines.append("")
     lines.append("licenses(%s)" % repr(repository_ctx.attr.licenses))
     lines.append("")
@@ -142,10 +140,7 @@ def _jvm_import_external(repository_ctx):
     repository_ctx.file("%s/BUILD" % extension, "\n".join([
         _HEADER,
         "",
-        "package(default_visibility = %r)" % (
-            repository_ctx.attr.visibility or
-            repository_ctx.attr.default_visibility
-        ),
+        "package(default_visibility = %r)" % repository_ctx.attr.default_visibility,
         "",
         "alias(",
         "    name = \"%s\"," % extension,


### PR DESCRIPTION
I suspect that previous versions of Bazel would add an implicit "visibility" attribute, even to repository rules. In Bazel 9 this no longer seems to be the case, meaning that this leads to unpleasant errors like:

    ERROR: .../external/bazel_tools/tools/build_defs/repo/jvm.bzl:146:32: An error occurred during the fetch of repository 'openapi_tools_generator_bazel++openapi_gen+openapi_tools_generator_bazel_cli':
        Traceback (most recent call last):
            File ".../external/bazel_tools/tools/build_defs/repo/jvm.bzl", line 146, column 32, in _jvm_import_external
                repository_ctx.attr.visibility or
    Error: unknown attribute visibility