### PR TITLE
[8.5.0] Only close BES after background tasks have completed

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/Bazel.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/Bazel.java
@@ -76,7 +76,6 @@ public final class Bazel {
           com.google.devtools.build.lib.bazel.rules.BazelRulesModule.class,
           com.google.devtools.build.lib.bazel.rules.BazelStrategyModule.class,
           com.google.devtools.build.lib.network.NoOpConnectivityModule.class,
-          com.google.devtools.build.lib.buildeventservice.BazelBuildEventServiceModule.class,
           com.google.devtools.build.lib.profiler.memory.AllocationTrackerModule.class,
           com.google.devtools.build.lib.packages.metrics.PackageMetricsModule.class,
           com.google.devtools.build.lib.runtime.ExecutionGraphModule.class,
@@ -87,6 +86,9 @@ public final class Bazel {
           // This module needs to be registered after any module submitting tasks with its {@code
           // submit} method.
           com.google.devtools.build.lib.runtime.BlockWaitingModule.class,
+          // This module needs to come after BlockWaitingModule so that the BES isn't closed until
+          // the background tasks maintained by the module have completed.
+          com.google.devtools.build.lib.buildeventservice.BazelBuildEventServiceModule.class,
           // Modules that are involved in the collection of heap-related metrics of a build. They
           // need to be
           // last in the modules order, so when the GCs happen at the end of the build, we mitigate


### PR DESCRIPTION
Before this change, the BES would be closed even if remote cache uploads were still happening in the background (due to `--remote_cache_async`, which is enabled by default). This means that the user's Bazel invocation may not have exited while the BES backend is led to assume that it has, resulting in incorrect timing information and potentially also misattribution of cache operations.

Closes #27262.

PiperOrigin-RevId: 828956380
Change-Id: I54808b4f6d67fbf457d1722d6a5a7a7249e977f2

Commit https://github.com/bazelbuild/bazel/commit/840b66f27189bea3416ede02b1d3136756b39393