### PR TITLE
Add `--test_runner_fail_fast` support to Bazel's Bash test framework

### DIFF
--- a/src/test/shell/unittest.bash
+++ b/src/test/shell/unittest.bash
@@ -788,7 +788,7 @@ function run_suite() {
 
   if [[ "${#TESTS[@]}" -ne 0 ]]; then
     for TEST_name in "${TESTS[@]}"; do
-      if [[ "$TESTBRIDGE_TEST_RUNNER_FAIL_FAST" == "1" && "$TEST_passed" == "false" ]]; then
+      if [[ "${TESTBRIDGE_TEST_RUNNER_FAIL_FAST:-0}" == "1" && "$TEST_passed" == "false" ]]; then
         echo "Skipping test '$TEST_name' due to previous failure and --test_runner_fail_fast set." >&2
         continue
       fi


### PR DESCRIPTION
This makes it more efficient to iterate on failing shell integration tests.