### PR TITLE
Validate conflicting constraints in target_compatible_with

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/ConfiguredAttributeMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/ConfiguredAttributeMapper.java
@@ -126,7 +126,7 @@ public class ConfiguredAttributeMapper extends AbstractAttributeMapper {
 
   /** ValidationException indicates an error during attribute validation. */
   public static final class ValidationException extends Exception {
-    private ValidationException(String message) {
+    public ValidationException(String message) {
       super(message);
     }
   }


### PR DESCRIPTION
This makes sure a target's target_compatible_with doesn't include
impossible to satisfy constraints via 2 constraint_values for the same
constraint_setting

Fixes https://github.com/bazelbuild/bazel/issues/27580
