### PR TITLE
[8.5.0] Add `--test_runner_fail_fast` support to Bazel's Bash test framework

### DIFF
--- a/src/test/shell/unittest.bash
+++ b/src/test/shell/unittest.bash
@@ -788,6 +788,11 @@ function run_suite() {
 
   if [[ "${#TESTS[@]}" -ne 0 ]]; then
     for TEST_name in "${TESTS[@]}"; do
+      if [[ "${TESTBRIDGE_TEST_RUNNER_FAIL_FAST:-0}" == "1" && "$TEST_passed" == "false" ]]; then
+        echo "Skipping test '$TEST_name' due to previous failure and --test_runner_fail_fast set." >&2
+        continue
+      fi
+
       >"$TEST_log" # Reset the log.
       TEST_passed="true"
 


### PR DESCRIPTION
This makes it more efficient to iterate on failing shell integration tests.

Closes #27576.

PiperOrigin-RevId: 829340531
Change-Id: I69e763604440a5679fe43165fd4b9c600882b311

Commit https://github.com/bazelbuild/bazel/commit/1cdafcf86a44f52fe219b7ddc7d31d0b33c5a6ec