### PR TITLE
[9.0.0] Remove rules_cc from autoloads

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/FlagConstants.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/FlagConstants.java
@@ -27,8 +27,7 @@ class FlagConstants {
 
   // TODO - ilist@: once Java providers are removed, the whole line can be compressed to
   // "@rules_java"
-  public static final String DEFAULT_INCOMPATIBLE_AUTOLOAD_EXTERNALLY =
-      "+@rules_cc";
+  public static final String DEFAULT_INCOMPATIBLE_AUTOLOAD_EXTERNALLY = "";
 
   // Enable annotations, but not actual type checking, with the effect that the parser tolerates
   // arbitrary expressions in annotations for now.

--- a/src/test/py/bazel/bzlmod/external_repo_completion_test.py
+++ b/src/test/py/bazel/bzlmod/external_repo_completion_test.py
@@ -138,7 +138,7 @@ class ExternalRepoCompletionTest(test_base.TestBase):
     ]
 
     self.main_registry.createLocalPathModule(
-        'ext', '1.0', 'ext', {'rules_shell': '0.6.0'}
+        'ext', '1.0', 'ext', {'rules_shell': '0.6.0', 'rules_cc': '0.2.13'}
     )
     scratchFile(
         self.projects_dir.joinpath('ext', 'BUILD'),
@@ -149,11 +149,17 @@ class ExternalRepoCompletionTest(test_base.TestBase):
     )
     scratchFile(
         self.projects_dir.joinpath('ext', 'tools', 'BUILD'),
-        ['cc_binary(name="tool")'],
+        [
+            'load("@rules_cc//cc:cc_binary.bzl", "cc_binary")',
+            'cc_binary(name="tool")'
+        ],
     )
     scratchFile(
         self.projects_dir.joinpath('ext', 'tools', 'zip', 'BUILD'),
-        ['cc_binary(name="zipper")'],
+        [
+            'load("@rules_cc//cc:cc_binary.bzl", "cc_binary")',
+            'cc_binary(name="zipper")'
+        ],
     )
     scratchFile(self.projects_dir.joinpath('ext', 'ext.bzl'), ext_src)
     self.main_registry.createLocalPathModule(

--- a/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
@@ -309,6 +309,9 @@ EOF
   touch other_repo/REPO.bazel
 
   cat > other_repo/BUILD <<'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_library(
     name = "a",
     srcs = ["a.cc"],

--- a/src/test/shell/bazel/external_files_test.sh
+++ b/src/test/shell/bazel/external_files_test.sh
@@ -47,8 +47,11 @@ build_def() {
   cat > _.MODULE <<'EOF'
 module(name = "remote")
 EOF
+  add_rules_cc "_.MODULE"
   mkdir src
   cat > _.BUILD <<'EOF'
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
   name = "hello",
   srcs = ["main.c", "consts/greeting.h"],
@@ -82,6 +85,7 @@ http_archive(
   },
 )
 EOF
+  add_rules_cc "MODULE.bazel"
 
   bazel build @remote//src:hello || fail "Expected build to succeed"
   bazel run @remote//src:hello | grep 'Hello World' \
@@ -118,6 +122,7 @@ http_archive(
   },
 )
 EOF
+  add_rules_cc "MODULE.bazel"
 
   bazel build @remote//src:hello || fail "Expected build to succeed"
   bazel run @remote//src:hello | grep 'Hello World' \
@@ -156,6 +161,7 @@ http_archive(
   },
 )
 EOF
+  add_rules_cc "MODULE.bazel"
 
   bazel build @remote//src:hello || fail "Expected build to succeed"
   bazel run @remote//src:hello | grep 'Hello World' \

--- a/src/test/shell/bazel/local_repository_test.sh
+++ b/src/test/shell/bazel/local_repository_test.sh
@@ -651,6 +651,8 @@ function test_cc_binary_in_local_repository() {
   mkdir $r
   touch $r/REPO.bazel
   cat > $r/BUILD <<EOF
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "bin",
     srcs = ["bin.cc"],
@@ -667,6 +669,7 @@ local_repository(
     path = "$r",
 )
 EOF
+  add_rules_cc "MODULE.bazel"
 
   bazel build @r//:bin || fail "build failed"
 }


### PR DESCRIPTION
With all rules, providers and cc_module now in rules_cc, removing rules_cc from autoloads, now shows how much weight the flag is still bearing.

PiperOrigin-RevId: 829266502
Change-Id: I148589cd0f0a814efbd4da7b635d899b205eaff7

Commit https://github.com/bazelbuild/bazel/commit/eb1b3fc5f4b127583057285e4c24537ef5567de8