### PR TITLE
[9.0.0] Prevent NPE on a null ActionOwner.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -317,7 +317,8 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       // Source artifacts in the main repo don't need to be fetched.
       if (input instanceof Artifact artifact
           && artifact.isSourceArtifact()
-          && artifact.getArtifactOwner().getLabel().getRepository().isMain()) {
+          && (artifact.getArtifactOwner() == null
+              || artifact.getArtifactOwner().getLabel().getRepository().isMain())) {
         continue;
       }
 


### PR DESCRIPTION
PiperOrigin-RevId: 829423373
Change-Id: I410165513abfa19846b89990c1988832878ade80

Commit https://github.com/bazelbuild/bazel/commit/f44363ee9b8b927d0967def901a21dd533cc96ff