### PR TITLE
[8.5.0] Preserve corrupted files after detecting action cache corruption.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -276,7 +276,11 @@ public class CompactPersistentActionCache implements ActionCache {
             cacheFile(cacheRoot),
             journalFile(cacheRoot),
             indexFile(cacheRoot),
-            indexJournalFile(cacheRoot));
+            indexJournalFile(cacheRoot),
+            corruptedPath(cacheFile(cacheRoot)),
+            corruptedPath(journalFile(cacheRoot)),
+            corruptedPath(indexFile(cacheRoot)),
+            corruptedPath(indexJournalFile(cacheRoot)));
     for (Path child : cacheRoot.getDirectoryEntries()) {
       if (!knownFiles.contains(child)) {
         child.delete();
@@ -320,19 +324,23 @@ public class CompactPersistentActionCache implements ActionCache {
           new UnixGlob.Builder(cacheRoot, SyscallCache.NO_CACHE)
               .addPattern("action_*_v" + VERSION + ".*")
               .glob()) {
-        path.renameTo(path.getParentDirectory().getChild(path.getBaseName() + ".bad"));
+        path.renameTo(corruptedPath(path));
       }
       for (Path path :
           new UnixGlob.Builder(cacheRoot, SyscallCache.NO_CACHE)
               .addPattern("filename_*_v" + VERSION + ".*")
               .glob()) {
-        path.renameTo(path.getParentDirectory().getChild(path.getBaseName() + ".bad"));
+        path.renameTo(corruptedPath(path));
       }
     } catch (UnixGlob.BadPattern ex) {
       throw new IllegalStateException(ex); // can't happen
     } catch (IOException e) {
       logger.atWarning().withCause(e).log("Unable to rename corrupted action cache files");
     }
+  }
+
+  public static Path corruptedPath(Path path) {
+    return path.getParentDirectory().getChild(path.getBaseName() + ".bad");
   }
 
   private static final String FAILURE_PREFIX = "Failed action cache referential integrity check: ";

--- a/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
@@ -52,6 +52,8 @@ public class CompactPersistentActionCacheTest {
   private Path dataRoot;
   private Path mapFile;
   private Path journalFile;
+  private Path indexFile;
+  private Path indexJournalFile;
   private final ManualClock clock = new ManualClock();
   private CompactPersistentActionCache cache;
   private ArtifactRoot artifactRoot;
@@ -62,6 +64,8 @@ public class CompactPersistentActionCacheTest {
     cache = CompactPersistentActionCache.create(dataRoot, clock, NullEventHandler.INSTANCE);
     mapFile = CompactPersistentActionCache.cacheFile(dataRoot);
     journalFile = CompactPersistentActionCache.journalFile(dataRoot);
+    indexFile = CompactPersistentActionCache.indexFile(dataRoot);
+    indexJournalFile = CompactPersistentActionCache.indexJournalFile(dataRoot);
     artifactRoot =
         ArtifactRoot.asDerivedRoot(
             scratch.getFileSystem().getPath("/output"), ArtifactRoot.RootType.Output, "bin");
@@ -75,6 +79,21 @@ public class CompactPersistentActionCacheTest {
     cache = CompactPersistentActionCache.create(dataRoot, clock, NullEventHandler.INSTANCE);
 
     assertThat(unrecognizedFile.exists()).isFalse();
+  }
+
+  @Test
+  public void testRenameCorruptedFiles() throws Exception {
+    FileSystemUtils.writeContentAsLatin1(mapFile, "corrupted data");
+    FileSystemUtils.writeContentAsLatin1(journalFile, "corrupted data");
+    FileSystemUtils.writeContentAsLatin1(indexFile, "corrupted data");
+    FileSystemUtils.writeContentAsLatin1(indexJournalFile, "corrupted data");
+
+    cache = CompactPersistentActionCache.create(dataRoot, clock, NullEventHandler.INSTANCE);
+
+    assertThat(CompactPersistentActionCache.corruptedPath(mapFile).exists()).isTrue();
+    assertThat(CompactPersistentActionCache.corruptedPath(journalFile).exists()).isTrue();
+    assertThat(CompactPersistentActionCache.corruptedPath(indexFile).exists()).isTrue();
+    assertThat(CompactPersistentActionCache.corruptedPath(indexJournalFile).exists()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
The logic introduced in 5e22e0c is too aggressive, and would also delete files that have been renamed to *.bad after detecting corruption.