### PR TITLE
[9.0.0] Replace deprecated `ByteStreams.copy(in, out)` with `in.transferTo(out)`.

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/SimpleJavaLibraryBuilder.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/SimpleJavaLibraryBuilder.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.buildjar;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.io.ByteStreams;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
 import com.google.devtools.build.buildjar.instrumentation.JacocoInstrumentationProcessor;
@@ -29,6 +28,7 @@ import com.google.errorprone.annotations.CheckReturnValue;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -209,7 +209,9 @@ public class SimpleJavaLibraryBuilder implements Closeable {
             Files.copy(jarFile.getInputStream(entry), to);
             build.getSourceFiles().add(to);
           } else if (fileName.equals(PROTOBUF_META_NAME)) {
-            ByteStreams.copy(jarFile.getInputStream(entry), protobufMetadataBuffer);
+            try (InputStream in = jarFile.getInputStream(entry)) {
+              in.transferTo(protobufMetadataBuffer);
+            }
           }
         }
       } catch (IOException e) {

--- a/src/java_tools/singlejar/javatests/com/google/devtools/build/zip/ZipReaderTest.java
+++ b/src/java_tools/singlejar/javatests/com/google/devtools/build/zip/ZipReaderTest.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.fail;
 
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.zip.ZipFileEntry.Compression;
 import com.google.devtools.build.zip.ZipFileEntry.Feature;
 import java.io.BufferedInputStream;
@@ -525,7 +524,9 @@ public class ZipReaderTest {
       bigEntry.setCrc(0);
       bigEntry.setTime(ZipUtil.DOS_EPOCH);
       writer.putNextEntry(bigEntry);
-      ByteStreams.copy(new BufferedInputStream(new FileInputStream(bigFile)), writer);
+      try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(bigFile))) {
+        in.transferTo(writer);
+      }
     }
     try (ZipReader reader = new ZipReader(test, UTF_8)) {
       Collection<ZipFileEntry> entries = reader.entries();
@@ -547,7 +548,9 @@ public class ZipReaderTest {
       bigEntry.setCrc(0);
       bigEntry.setTime(ZipUtil.DOS_EPOCH);
       writer.putNextEntry(bigEntry);
-      ByteStreams.copy(new BufferedInputStream(new FileInputStream(biggerFile)), writer);
+      try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(biggerFile))) {
+        in.transferTo(writer);
+      }
     }
     try (ZipReader reader = new ZipReader(test, UTF_8)) {
       Collection<ZipFileEntry> entries = reader.entries();

--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
@@ -23,7 +23,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.analysis.RuleContext.PrerequisiteValidator;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
@@ -514,7 +513,7 @@ public /*final*/ class ConfiguredRuleClassProvider
 
             dest.getParentDirectory().createDirectoryAndParents();
             try (OutputStream os = dest.getOutputStream()) {
-              ByteStreams.copy(zip, os);
+              zip.transferTo(os);
             }
           }
         }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/BinaryFileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/BinaryFileWriteAction.java
@@ -17,7 +17,6 @@ package com.google.devtools.build.lib.analysis.actions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.io.ByteSource;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.ActionOwner;
@@ -72,7 +71,7 @@ public final class BinaryFileWriteAction extends AbstractFileWriteAction {
   public DeterministicWriter newDeterministicWriter(ActionExecutionContext ctx) {
     return out -> {
       try (InputStream in = source.openStream()) {
-        ByteStreams.copy(in, out);
+        in.transferTo(out);
       }
       out.flush();
     };

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/FileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/FileWriteAction.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.analysis.actions;
 
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.ActionOwner;
@@ -343,7 +342,7 @@ public abstract class FileWriteAction extends AbstractFileWriteAction
       return out -> {
         try (GZIPInputStream gzipIn =
             new GZIPInputStream(new ByteArrayInputStream(compressedBytes), GZIP_BYTES_BUFFER)) {
-          ByteStreams.copy(gzipIn, out);
+          gzipIn.transferTo(out);
         }
       };
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ArFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ArFunction.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.bazel.repository.decompressor;
 
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorValue.Decompressor;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.BufferedInputStream;
@@ -62,7 +61,7 @@ public class ArFunction implements Decompressor {
           // We do not have to worry about symlinks in .ar files - it's not supported
           // by the .ar file format.
           try (OutputStream out = filePath.getOutputStream()) {
-            ByteStreams.copy(arStream, out);
+            arStream.transferTo(out);
           }
           filePath.chmod(entry.getMode());
           // entry.getLastModified() appears to be in seconds, so we need to convert

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
@@ -18,7 +18,6 @@ import static com.google.devtools.build.lib.bazel.repository.decompressor.StripP
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 import com.google.auto.service.AutoService;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorValue.Decompressor;
 import com.google.devtools.build.lib.util.StringEncoding;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
@@ -135,7 +134,7 @@ public abstract class CompressedTarFunction implements Decompressor {
             }
           } else {
             try (OutputStream out = filePath.getOutputStream()) {
-              ByteStreams.copy(tarStream, out);
+              tarStream.transferTo(out);
             }
             filePath.chmod(entry.getMode());
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressor.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.bazel.repository.RepositoryFunctionException;
 import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorValue.Decompressor;
 import com.google.devtools.build.lib.vfs.Path;
@@ -131,7 +130,7 @@ public class SevenZDecompressor implements Decompressor {
     } else {
       try (InputStream input = sevenZFile.getInputStream(entry);
           OutputStream output = outputPath.getOutputStream()) {
-        ByteStreams.copy(input, output);
+        input.transferTo(output);
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
@@ -19,7 +19,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorValue.Decompressor;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
@@ -163,7 +162,7 @@ public class ZipDecompressor implements Decompressor {
     } else {
       try (InputStream input = reader.getInputStream(entry);
           OutputStream output = outputPath.getOutputStream()) {
-        ByteStreams.copy(input, output);
+        input.transferTo(output);
         if (Thread.interrupted()) {
           throw new InterruptedException();
         }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
@@ -18,7 +18,6 @@ import com.google.auth.Credentials;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId.FetchId;
 import com.google.devtools.build.lib.buildeventstream.FetchEvent;
 import com.google.devtools.build.lib.clock.Clock;
@@ -99,7 +98,7 @@ public class HttpDownloader implements Downloader {
       try (HttpStream payload = multiplexer.connect(url, checksum, headers, credentials, type);
           OutputStream out = destination.getOutputStream()) {
         try {
-          ByteStreams.copy(payload, out);
+          payload.transferTo(out);
         } catch (SocketTimeoutException e) {
           // SocketTimeoutExceptions are InterruptedIOExceptions; however they do not signify
           // an external interruption, but simply a failed download due to some server timing
@@ -157,7 +156,7 @@ public class HttpDownloader implements Downloader {
     semaphore.acquire();
     try (HttpStream payload =
         multiplexer.connect(url, checksum, ImmutableMap.of(), credentials, Optional.empty())) {
-      ByteStreams.copy(payload, out);
+      payload.transferTo(out);
     } catch (SocketTimeoutException e) {
       // SocketTimeoutExceptions are InterruptedIOExceptions; however they do not signify
       // an external interruption, but simply a failed download due to some server timing

--- a/src/main/java/com/google/devtools/build/lib/exec/BinTools.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/BinTools.java
@@ -19,7 +19,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hasher;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
@@ -179,7 +178,7 @@ public final class BinTools {
     @Override
     public void writeTo(OutputStream out) throws IOException {
       try (InputStream in = path.getInputStream()) {
-        ByteStreams.copy(in, out);
+        in.transferTo(out);
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
@@ -356,7 +355,7 @@ public class StandaloneTestStrategy extends TestStrategy {
           }
           try (OutputStream out = outFilePath.getOutputStream(true);
               InputStream in = inFilePath.getInputStream()) {
-            ByteStreams.copy(in, out);
+            in.transferTo(out);
           }
         }
       } finally {

--- a/src/main/java/com/google/devtools/build/lib/exec/StreamedTestOutput.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StreamedTestOutput.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.exec;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.devtools.build.lib.util.io.FileWatcher;
 import com.google.devtools.build.lib.util.io.OutErr;
@@ -66,7 +65,7 @@ public class StreamedTestOutput implements Closeable {
     // It's unclear if writing this after interrupt is desirable, but it's been this way forever.
     if (!headerFilter.foundHeader()) {
       try (InputStream input = testLogPath.getInputStream()) {
-        ByteStreams.copy(input, outErr.getOutputStream());
+        input.transferTo(outErr.getOutputStream());
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/exec/TestLogHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/TestLogHelper.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.exec;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.exec.ExecutionOptions.TestOutputFormat;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.BufferedOutputStream;
@@ -135,12 +134,12 @@ public class TestLogHelper {
   private static void streamTestLog(Path fromPath, PrintStream out) throws IOException {
     FilterTestHeaderOutputStream filteringOutputStream = getHeaderFilteringOutputStream(out);
     try (InputStream input = fromPath.getInputStream()) {
-      ByteStreams.copy(input, filteringOutputStream);
+      input.transferTo(filteringOutputStream);
     }
 
     if (!filteringOutputStream.foundHeader()) {
       try (InputStream inputAgain = fromPath.getInputStream()) {
-        ByteStreams.copy(inputAgain, out);
+        inputAgain.transferTo(out);
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/jni/JniLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/jni/JniLoader.java
@@ -17,7 +17,6 @@ package com.google.devtools.build.lib.jni;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.flogger.GoogleLogger;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.util.OS;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -97,7 +96,7 @@ public final class JniLoader {
           throw new UnsatisfiedLinkError("Resource " + resourceName + " not in JAR");
         }
         try (OutputStream diskFile = new FileOutputStream(tempFile.toString())) {
-          ByteStreams.copy(resource, diskFile);
+          resource.transferTo(diskFile);
         }
       }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -24,7 +24,6 @@ import build.bazel.remote.execution.v2.Tree;
 import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -149,7 +148,7 @@ public class DiskCacheClient {
             throw new CacheNotFoundException(digest);
           }
           try (InputStream in = path.getInputStream()) {
-            ByteStreams.copy(in, out);
+            in.transferTo(out);
           }
           return null;
         });
@@ -317,7 +316,7 @@ public class DiskCacheClient {
 
     try {
       try (OutputStream out = temp.getOutputStream()) {
-        ByteStreams.copy(in, out);
+        in.transferTo(out);
         // Fsync temp before we rename it to avoid data loss in the case of machine
         // crashes (the OS may reorder the writes and the rename).
         if (out instanceof FileOutputStream fos) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -27,7 +27,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.actions.AbstractAction;
 import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
@@ -1605,14 +1604,14 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
       tempOutErr.close();
       if (tempOutErr.hasRecordedStdout()) {
         try (InputStream in = tempOutErr.getOutputPath().getInputStream()) {
-          ByteStreams.copy(
-              in, showIncludesFilterForStdout.getFilteredOutputStream(outErr.getOutputStream()));
+          in.transferTo(
+              showIncludesFilterForStdout.getFilteredOutputStream(outErr.getOutputStream()));
         }
       }
       if (tempOutErr.hasRecordedStderr()) {
         try (InputStream in = tempOutErr.getErrorPath().getInputStream()) {
-          ByteStreams.copy(
-              in, showIncludesFilterForStderr.getFilteredOutputStream(outErr.getErrorStream()));
+          in.transferTo(
+              showIncludesFilterForStderr.getFilteredOutputStream(outErr.getErrorStream()));
         }
       }
     } catch (IOException e) {

--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQueryOutputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQueryOutputStream.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.rules.genquery;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
@@ -195,7 +194,7 @@ class GenQueryOutputStream extends OutputStream {
     public ByteString getBytes() throws IOException {
       ByteString.Output out = ByteString.newOutput(size);
       try (GZIPInputStream gzipIn = new GZIPInputStream(compressedData.newInput())) {
-        ByteStreams.copy(gzipIn, out);
+        gzipIn.transferTo(out);
       }
       return out.toByteString();
     }
@@ -208,7 +207,7 @@ class GenQueryOutputStream extends OutputStream {
     @Override
     public void writeTo(OutputStream out) throws IOException {
       try (GZIPInputStream gzipIn = new GZIPInputStream(compressedData.newInput())) {
-        ByteStreams.copy(gzipIn, out);
+        gzipIn.transferTo(out);
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.flogger.GoogleLogger;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -238,7 +237,7 @@ public final class SandboxHelpers {
   private static void copyFile(Path source, Path target) throws IOException {
     try (InputStream in = source.getInputStream();
         OutputStream out = target.getOutputStream()) {
-      ByteStreams.copy(in, out);
+      in.transferTo(out);
     } catch (FileAccessException e) {
       // Actions may create unreadable output files.
       // Make the source file readable and try again (but only once).
@@ -246,7 +245,7 @@ public final class SandboxHelpers {
       source.chmod(0644);
       try (InputStream in = source.getInputStream();
           OutputStream out = target.getOutputStream()) {
-        ByteStreams.copy(in, out);
+        in.transferTo(out);
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxUtil.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.GoogleLogger;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.shell.Subprocess;
 import com.google.devtools.build.lib.shell.SubprocessBuilder;
 import com.google.devtools.build.lib.shell.SubprocessBuilder.StreamAction;
@@ -64,7 +63,7 @@ public final class WindowsSandboxUtil {
 
     ByteArrayOutputStream outErrBytes = new ByteArrayOutputStream();
     try {
-      ByteStreams.copy(process.getInputStream(), outErrBytes);
+      process.getInputStream().transferTo(outErrBytes);
     } catch (IOException e) {
       try {
         outErrBytes.write(("Failed to read stdout: " + e).getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/com/google/devtools/build/lib/shell/Command.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/Command.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.flogger.LazyArgs;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.shell.Consumers.OutErrConsumers;
 import com.google.devtools.build.lib.util.DescribableExecutionUnit;
 import java.io.File;
@@ -418,7 +417,7 @@ public final class Command implements DescribableExecutionUnit {
   private static void processInput(InputStream stdinInput, Subprocess process) {
     logger.atFiner().log("%s", stdinInput);
     try (OutputStream out = process.getOutputStream()) {
-      ByteStreams.copy(stdinInput, out);
+      stdinInput.transferTo(out);
     } catch (IOException ioe) {
       // Note: this is not an error!  Perhaps the command just isn't hungry for our input and exited
       // with success. Process.waitFor (later) will tell us.

--- a/src/main/java/com/google/devtools/build/lib/util/io/FileOutErr.java
+++ b/src/main/java/com/google/devtools/build/lib/util/io/FileOutErr.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.util.io;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.io.ByteStreams;
 import com.google.common.primitives.Bytes;
 import com.google.devtools.build.lib.concurrent.ThreadSafety;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
@@ -480,7 +479,7 @@ public class FileOutErr extends OutErr {
     void dumpOut(OutputStream out) {
       synchronized (this) {
         try (InputStream in = outputFile.getInputStream()) {
-          ByteStreams.copy(in, out);
+          in.transferTo(out);
           out.flush();
         } catch (FileNotFoundException e) {
           cachedSize = 0L;

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloaderTestUtils.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloaderTestUtils.java
@@ -17,9 +17,9 @@ package com.google.devtools.build.lib.bazel.repository.downloader;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 import com.google.common.base.Joiner;
-import com.google.common.io.ByteStreams;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.Socket;
 import java.net.URL;
@@ -36,9 +36,10 @@ final class DownloaderTestUtils {
   }
 
   static void sendLines(@WillNotClose Socket socket, String... data) throws IOException {
-    ByteStreams.copy(
-        new ByteArrayInputStream(Joiner.on("\r\n").join(data).getBytes(ISO_8859_1)),
-        socket.getOutputStream());
+    try (InputStream in =
+        new ByteArrayInputStream(Joiner.on("\r\n").join(data).getBytes(ISO_8859_1))) {
+      in.transferTo(socket.getOutputStream());
+    }
   }
 
   private DownloaderTestUtils() {}

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.ServerSocket;
@@ -703,7 +704,7 @@ public class HttpDownloaderTest {
                   }
                   Path output = invocationOnMock.getArgument(5, Path.class);
                   try (OutputStream outputStream = output.getOutputStream()) {
-                    ByteStreams.copy(new ByteArrayInputStream(data), outputStream);
+                    new ByteArrayInputStream(data).transferTo(outputStream);
                   }
 
                   return null;
@@ -750,8 +751,9 @@ public class HttpDownloaderTest {
                     throw e;
                   }
                   Path output = invocationOnMock.getArgument(5, Path.class);
-                  try (OutputStream outputStream = output.getOutputStream()) {
-                    ByteStreams.copy(new ByteArrayInputStream(data), outputStream);
+                  try (InputStream in = new ByteArrayInputStream(data);
+                      OutputStream out = output.getOutputStream()) {
+                    in.transferTo(out);
                   }
 
                   return null;
@@ -796,7 +798,7 @@ public class HttpDownloaderTest {
                   }
                   Path output = invocationOnMock.getArgument(5, Path.class);
                   try (OutputStream outputStream = output.getOutputStream()) {
-                    ByteStreams.copy(new ByteArrayInputStream(data), outputStream);
+                    new ByteArrayInputStream(data).transferTo(outputStream);
                   }
 
                   return null;
@@ -843,8 +845,9 @@ public class HttpDownloaderTest {
                     throw e;
                   }
                   Path output = invocationOnMock.getArgument(5, Path.class);
-                  try (OutputStream outputStream = output.getOutputStream()) {
-                    ByteStreams.copy(new ByteArrayInputStream(data), outputStream);
+                  try (InputStream in = new ByteArrayInputStream(data);
+                      OutputStream out = output.getOutputStream()) {
+                    in.transferTo(out);
                   }
 
                   return null;

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStreamTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStreamTest.java
@@ -318,7 +318,7 @@ public class HttpStreamTest {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     try (InputStream input = new ByteArrayInputStream(bytes);
         OutputStream output = new GZIPOutputStream(baos)) {
-      ByteStreams.copy(input, output);
+      input.transferTo(output);
     }
     return baos.toByteArray();
   }

--- a/src/test/java/com/google/devtools/build/lib/buildtool/GenQueryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/GenQueryIntegrationTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.BuildFailedException;
 import com.google.devtools.build.lib.analysis.ViewCreationFailedException;
@@ -916,7 +915,7 @@ public class GenQueryIntegrationTest extends BuildIntegrationTestCase {
 
     ByteArrayOutputStream decompressedOut = new ByteArrayOutputStream();
     try (GZIPInputStream gzipIn = new GZIPInputStream(compressedContent.newInput())) {
-      ByteStreams.copy(gzipIn, decompressedOut);
+      gzipIn.transferTo(decompressedOut);
     }
 
     assertThat(decompressedOut.toString(UTF_8)).isEqualTo("//fruits:melon\n//fruits:papaya\n");

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskHttpCacheServerHandler.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskHttpCacheServerHandler.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.remote.worker;
 
 import build.bazel.remote.execution.v2.Digest;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.remote.Store;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.vfs.Path;
@@ -50,7 +49,7 @@ public class OnDiskHttpCacheServerHandler extends AbstractHttpCacheServerHandler
 
     try (var out = new ByteArrayOutputStream();
         var in = path.getInputStream()) {
-      ByteStreams.copy(in, out);
+      in.transferTo(out);
       return out.toByteArray();
     } catch (FileNotFoundException e) {
       return null;

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
@@ -27,7 +27,6 @@ import com.google.bytestream.ByteStreamGrpc.ByteStreamImplBase;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.flogger.GoogleLogger;
-import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -389,7 +388,7 @@ public final class RemoteWorker {
     try {
       sandboxPath = fs.getPath(remoteWorkerOptions.workPath).getChild("linux-sandbox");
       try (FileOutputStream fos = new FileOutputStream(sandboxPath.getPathString())) {
-        ByteStreams.copy(sandbox, fos);
+        sandbox.transferTo(fos);
       }
       sandboxPath.setExecutable(true);
     } catch (IOException e) {


### PR DESCRIPTION
The latter can take advantage of in-kernel transfer when both sides are files, and falls back to an essentially equivalent copy loop otherwise.

PiperOrigin-RevId: 830348102
Change-Id: I7b64d1abf9682a4e8fdc4a007c0af27632896a90