### PR TITLE
[9.0.0] Remove the assertion which disallows stopBranch to be called twice.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/dynamic/DynamicSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/dynamic/DynamicSpawnStrategy.java
@@ -672,13 +672,7 @@ public class DynamicSpawnStrategy implements SpawnStrategy {
     // value of "cancellingStrategy", we do not expect concurrent calls to this method. (If there
     // are, we are in big trouble.)
     DynamicMode current = strategyThatCancelled.get();
-    if (cancellingStrategy.equals(current)) {
-      throw new AssertionError(
-          "stopBranch called more than once by "
-              + cancellingStrategy
-              + " on "
-              + getSpawnReadableId(cancellingBranch.getSpawn()));
-    } else {
+    if (!cancellingStrategy.equals(current)) {
       // Protect against the two branches from cancelling each other. The first branch to set the
       // reference to its own identifier wins and is allowed to issue the cancellation; the other
       // branch just has to give up execution.


### PR DESCRIPTION
Back in the time when this assertion was introduced in 4b1cdfc6df3d662dbc489d21e0ee8d69515e7ee1, it was expected that `stopBranch` should not be called more than once.

However, in the current state, the `stopBranch` function can be called twice when a remote branch wins the race in a dynamic execution, but falls back to a local execution due to issues like downloading error. In that case, the fallback local execution can call `stopBranch` for the second time. We believe this is a valid case and we should remove this assertion to address the issue.

Fixes #27422.

PiperOrigin-RevId: 830370258
Change-Id: Ia8271d8bff66d60596b43d3e908a30ac9e8a5d25

Commit https://github.com/bazelbuild/bazel/commit/3c04b654e816d2cb3e8fe4794e35fbafb2ac5d32