### PR TITLE
[8.5.0] Add run command option to use current working directory

### DIFF
--- a/src/test/shell/integration/run_test.sh
+++ b/src/test/shell/integration/run_test.sh
@@ -784,6 +784,39 @@ EOF
   expect_log "RUN_ENV_ONLY: 'BAR'"
 }
 
+function test_run_in_cwd() {
+  local -r pkg="pkg${LINENO}"
+  mkdir -p "${pkg}"
+  cat > "$pkg/BUILD" <<'EOF'
+sh_binary(
+  name = "foo",
+  srcs = ["foo.sh"],
+)
+EOF
+  cat > "$pkg/foo.sh" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Running in $(pwd)"
+if [ -f "bar.txt" ]; then
+  echo "BAR_TXT"
+fi
+EOF
+
+  cd "$pkg" || fail "cd $pkg failed"
+  chmod +x "foo.sh"
+  touch "bar.txt"
+
+  bazel run "//$pkg:foo" >& "$TEST_log" || fail "bazel run without --run_in_cwd failed"
+  expect_not_log "BAR_TXT"
+  expect_not_log "Running in $(pwd)"
+
+  bazel run --run_in_cwd "//$pkg:foo" >& "$TEST_log" || fail "bazel run with --run_in_cwd failed"
+  expect_log "BAR_TXT"
+  expect_log "Running in $(pwd)"
+}
+
 # Usage: assert_starts_with PREFIX STRING_TO_CHECK.
 # Asserts that `$1` is a prefix of `$2`.
 function assert_starts_with() {


### PR DESCRIPTION
From the discussion in https://github.com/bazelbuild/bazel/issues/3325#issuecomment-2810070670, this adds a `--run_in_cwd` option to the `bazel run` command, which if enabled runs the target in the current working directory as opposed to running it in the runfiles directory.

The workaround by using `--run_under` to get a target to run in the current directory doesn't always work in every situation or is just unfortunate. This would improve the flow of running tools against source code for things like linting, formatting, running code generators, etc. which are present in `BUILD` files.

Closes #27290.

PiperOrigin-RevId: 820560189
Change-Id: Ib9cc17c9b05926a6cdb43d86c4ac22f9f3ee0500 
(cherry picked from commit 7df1587ab184c5b4e0f1d7094ebb56c6167d441c)

Closes #27395