### PR TITLE
[9.0.0] Actually fix the NPE when checking the owner of a source artifact.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -317,8 +317,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       // Source artifacts in the main repo don't need to be fetched.
       if (input instanceof Artifact artifact
           && artifact.isSourceArtifact()
-          && (artifact.getArtifactOwner() == null
-              || artifact.getArtifactOwner().getLabel().getRepository().isMain())) {
+          && (artifact.getOwner() == null || artifact.getOwner().getRepository().isMain())) {
         continue;
       }
 


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/commit/f44363ee9b8b927d0967def901a21dd533cc96ff added a check for a null ArtifactOwner, but that's never the case; it's getLabel() that can return null. (Note that `Artifact.getOwner()` is a shorthand for `Artifact.getArtifactOwner().getLabel()`.)

PiperOrigin-RevId: 830430339
Change-Id: Ic1a3b0763693263123b40e04163f387145845eb3