### PR TITLE
[9.0.0] Compare paths as fragments in `AbstractActionInputPrefetcher`.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -130,7 +130,9 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
     }
 
     private void setWritable(Path dir, DirectoryState newState) throws IOException {
-      if (!dir.startsWith(execRoot)) {
+      // Compare as fragments since execRoot may be located on a file system overlaying the host
+      // file system where downloads are written to.
+      if (!dir.asFragment().startsWith(execRoot.asFragment())) {
         return;
       }
       AtomicReference<IOException> caughtException = new AtomicReference<>();


### PR DESCRIPTION
This is required because `execRoot` might be located on an action file system overlaying the host file system where downloads are written (see the changes in https://github.com/bazelbuild/bazel/commit/b8589c3b278e3f5cee6ef85b0dcabb1cdcd69839 for context).

PiperOrigin-RevId: 830480221
Change-Id: I217b81a81da80f2050c4ec9082ef5f18cb9a0bc9