### PR TITLE
[8.5.0] Also persist facts in the hidden lockfile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -47,7 +47,7 @@ public abstract class BazelLockFileValue implements SkyValue {
   // https://cs.opensource.google/bazel/bazel/+/release-7.3.0:src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java;l=120-127;drc=5f5355b75c7c93fba1e15f6658f308953f4baf51
   // While this hack exists on 7.x, lockfile version increments should be done 2 at a time (i.e.
   // keep this number even).
-  public static final int LOCK_FILE_VERSION = 18;
+  public static final int LOCK_FILE_VERSION = 24;
 
   /** A valid empty lockfile. */
   public static final BazelLockFileValue EMPTY_LOCKFILE = builder().build();

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -153,7 +153,10 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       if (lockfile == null || hiddenLockfile == null) {
         return null;
       }
-      lockfileFacts = lockfile.getFacts().getOrDefault(extensionId, Facts.EMPTY);
+      lockfileFacts = lockfile.getFacts().get(extensionId);
+      if (lockfileFacts == null) {
+        lockfileFacts = hiddenLockfile.getFacts().getOrDefault(extensionId, Facts.EMPTY);
+      }
       var lockedExtensionMap = lockfile.getModuleExtensions().get(extensionId);
       var lockedExtension =
           lockedExtensionMap == null ? null : lockedExtensionMap.get(extension.getEvalFactors());

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -2888,6 +2888,23 @@ class BazelLockfileTest(test_base.TestBase):
     self.assertIn('hello: hash=olleh', stderr)
     self.assertIn('Fetching metadata for world...', stderr)
     self.assertIn('world: hash=dlrow', stderr)
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile_contents = f.read()
+
+    # Delete the lockfile and verify that it is regenerated identically due to
+    # the hidden lockfile without reevaluation.
+    os.remove(self.Path('MODULE.bazel.lock'))
+    _, _, stderr = self.RunBazel(
+        ['build', '@hello//:all', '--lockfile_mode=update']
+    )
+    stderr = ''.join(stderr)
+    self.assertNotIn('Hello from this side!', stderr)
+    self.assertNotIn('Fetching metadata for hello...', stderr)
+    self.assertNotIn('hello: hash=olleh', stderr)
+    self.assertNotIn('Fetching metadata for world...', stderr)
+    self.assertNotIn('world: hash=dlrow', stderr)
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      self.assertEqual(lockfile_contents, f.read())
 
     # Clean out the hidden lockfile to ensure that the extension is
     # evaluated again and verify that the reevaluation reuses the facts.

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 18,
+  "lockFileVersion": 24,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",


### PR DESCRIPTION
Otherwise facts are not added to the default lockfile when an entry in the hidden lockfile for a reproducible extension is used.

Also bump the lockfile version out of caution - users may already have hidden lockfiles that lack facts.

Along the way fix the `print` behavior of `Facts` which resulted in `Facts(<unknown object net.starlark.java.eval.Dict>)` since it called the wrong `repr` override.

Closes #27522.

PiperOrigin-RevId: 828559479
Change-Id: I77f002fa0e74c23b9fab5bb05948bcbe76f8f49b 
(cherry picked from commit bed7a1f070f27aea2219da7fff5185ecfb71f05e)

Closes #27523