### PR TITLE
Resolve java_import load before using it in the HTTP_JAR_BUILD template

### DIFF
--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -186,7 +186,7 @@
   "moduleExtensions": {
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "KZmG+HXFo6h6+eo0EHaCTECvOyY2l/VFoUYsOr0Phhk=",
+        "bzlTransitiveDigest": "4VEXn08lWePApHKzwSkIzFd+xxEb26AIvqieviZF5E0=",
         "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
         "recordedFileInputs": {
           "@@pybind11_bazel+//MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
@@ -216,7 +216,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "BcC1+HOMyQbaxCezYLAcpAFojGIgibGrmncgO+T2cCU=",
+        "bzlTransitiveDigest": "cr8a+7g0qU/M4FaIvl0M65frbCtpxV5RHDhaaW1XQ5g=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -217,7 +217,7 @@ def _http_file_impl(ctx):
     return _update_integrity_attr(ctx, _http_file_attrs, download_info)
 
 _HTTP_JAR_BUILD = """\
-load("@rules_java//java:java_import.bzl", "java_import")
+load("{java_import_bzl}", "java_import")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -249,6 +249,7 @@ def _http_jar_impl(ctx):
     )
     ctx.file("WORKSPACE", "workspace(name = \"{name}\")".format(name = ctx.name))
     ctx.file("jar/BUILD", _HTTP_JAR_BUILD.format(
+        java_import_bzl = str(Label("@rules_java//java:java_import.bzl")),
         file_name = downloaded_file_name,
     ))
 


### PR DESCRIPTION
Follow up to https://github.com/bazelbuild/bazel/pull/27614 to expand the java_import load before using it in the HTTP_JAR template