### PR TITLE
[9.0.0] Fix counting of internal actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/SpawnStats.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/SpawnStats.java
@@ -39,19 +39,24 @@ public class SpawnStats {
   private final ConcurrentHashMultiset<String> runners = ConcurrentHashMultiset.create();
   private final ConcurrentHashMap<String, String> runnerExecKinds = new ConcurrentHashMap<>();
   private final AtomicLong totalWallTimeMillis = new AtomicLong();
-  private final AtomicInteger totalNumberOfActions = new AtomicInteger();
+  // Counts all actions, where an action can run an arbitrary number of spawns (including zero).
+  private final AtomicInteger allActionsCount = new AtomicInteger();
+  // Counts internal actions, such as SymlinkTree actions, which are recognized by having zero
+  // spawns.
+  private final AtomicInteger nonInternalActionsCount = new AtomicInteger();
   private int actionCacheHitCount = 0;
 
   public void countActionResult(ActionResult actionResult) {
+    // This method is usually not called for internal actions with {@link ActionResult#EMPTY}, but
+    // just in case, we double-check here.
+    if (!actionResult.spawnResults().isEmpty()) {
+      nonInternalActionsCount.incrementAndGet();
+    }
     for (SpawnResult r : actionResult.spawnResults()) {
       storeRunnerExecKind(r);
-      countRunnerName(r.getRunnerName());
+      runners.add(r.getRunnerName());
       totalWallTimeMillis.addAndGet(r.getMetrics().executionWallTimeInMs());
     }
-  }
-
-  public void countRunnerName(String runner) {
-    runners.add(runner);
   }
 
   private void storeRunnerExecKind(SpawnResult r) {
@@ -61,7 +66,7 @@ public class SpawnStats {
   }
 
   public void incrementActionCount() {
-    totalNumberOfActions.incrementAndGet();
+    allActionsCount.incrementAndGet();
   }
 
   public long getTotalWallTimeMillis() {
@@ -84,9 +89,9 @@ public class SpawnStats {
    */
   public ImmutableMap<String, Integer> getSummary(ImmutableList<String> reportFirst) {
     ImmutableMap.Builder<String, Integer> result = ImmutableMap.builder();
-    int numActionsWithoutInternal = runners.size();
-    int numActionsTotal = totalNumberOfActions.get();
-    result.put("total", numActionsTotal);
+    int numNonInternalActions = nonInternalActionsCount.get();
+    int numAllActions = allActionsCount.get();
+    result.put("total", numAllActions);
 
     // First report cache results.
     if (actionCacheHitCount > 0) {
@@ -100,8 +105,10 @@ public class SpawnStats {
     }
 
     // Account for internal actions such as SymlinkTree.
-    if (numActionsWithoutInternal < numActionsTotal) {
-      result.put("internal", numActionsTotal - numActionsWithoutInternal);
+    // This condition is always fulfilled if {@link #incrementActionCount} is called for each
+    // action for which {@link #countActionResult} is called eventually.
+    if (numNonInternalActions < numAllActions) {
+      result.put("internal", numAllActions - numNonInternalActions);
     }
 
     // Sort the rest alphabetically
@@ -120,6 +127,17 @@ public class SpawnStats {
   }
 
   public static String convertSummaryToString(ImmutableMap<String, Integer> spawnSummary) {
+    // This summary is misleading in a number of ways:
+    // - The "processes" count is actually the number of actions, not spawns.
+    // - Even if it were the number of spawns, the "* cache hit" runners do not correspond to
+    //   processes executed, but rather to cache hits that avoided process execution.
+    // - The total count does not include action cache hits, so the sum of the parts is greater than
+    //   the total.
+    // TODO: Find a better way to report this information, e.g.:
+    // 15 cache hits (5 action, 5 disk, 5 remote), 10 processes (2 local, 3 remote, 5 sandboxed), 7
+    // internal.
+    // A large number of integration tests rely on the current format, though, so changing it is
+    // non-trivial.
     Integer total = spawnSummary.get("total");
     if (total == 0) {
       return "0 processes.";

--- a/src/test/java/com/google/devtools/build/lib/runtime/SpawnStatsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/SpawnStatsTest.java
@@ -43,7 +43,13 @@ public final class SpawnStatsTest {
 
   @Test
   public void one() {
-    stats.countRunnerName("foo");
+    ArrayList<SpawnResult> spawns = new ArrayList<>();
+    spawns.add(
+        new SpawnResult.Builder()
+            .setStatus(SpawnResult.Status.SUCCESS)
+            .setRunnerName("foo")
+            .build());
+    stats.countActionResult(ActionResult.create(spawns));
     stats.incrementActionCount();
     assertThat(SpawnStats.convertSummaryToString(stats.getSummary()))
         .isEqualTo("1 process: 1 foo.");
@@ -51,7 +57,13 @@ public final class SpawnStatsTest {
 
   @Test
   public void oneRemote() {
-    stats.countRunnerName("remote cache hit");
+    ArrayList<SpawnResult> spawns = new ArrayList<>();
+    spawns.add(
+        new SpawnResult.Builder()
+            .setStatus(SpawnResult.Status.SUCCESS)
+            .setRunnerName("remote cache hit")
+            .build());
+    stats.countActionResult(ActionResult.create(spawns));
     stats.incrementActionCount();
     assertThat(SpawnStats.convertSummaryToString(stats.getSummary()))
         .isEqualTo("1 process: 1 remote cache hit.");
@@ -60,7 +72,13 @@ public final class SpawnStatsTest {
   @Test
   public void two() {
     for (int i = 0; i < 2; i++) {
-      stats.countRunnerName("foo");
+      ArrayList<SpawnResult> spawns = new ArrayList<>();
+      spawns.add(
+          new SpawnResult.Builder()
+              .setStatus(SpawnResult.Status.SUCCESS)
+              .setRunnerName("foo")
+              .build());
+      stats.countActionResult(ActionResult.create(spawns));
       stats.incrementActionCount();
     }
     assertThat(SpawnStats.convertSummaryToString(stats.getSummary()))
@@ -69,13 +87,31 @@ public final class SpawnStatsTest {
 
   @Test
   public void order() {
-    stats.countRunnerName("a");
-    stats.countRunnerName("b");
-    stats.countRunnerName("b");
-    stats.countRunnerName("c");
-    stats.countRunnerName("c");
-    stats.countRunnerName("c");
-    for (int i = 0; i < 6; i++) {
+    ArrayList<SpawnResult> spawns = new ArrayList<>();
+    spawns.add(
+        new SpawnResult.Builder().setStatus(SpawnResult.Status.SUCCESS).setRunnerName("a").build());
+    stats.countActionResult(ActionResult.create(spawns));
+    stats.incrementActionCount();
+
+    for (int i = 0; i < 2; i++) {
+      spawns = new ArrayList<>();
+      spawns.add(
+          new SpawnResult.Builder()
+              .setStatus(SpawnResult.Status.SUCCESS)
+              .setRunnerName("b")
+              .build());
+      stats.countActionResult(ActionResult.create(spawns));
+      stats.incrementActionCount();
+    }
+
+    for (int i = 0; i < 3; i++) {
+      spawns = new ArrayList<>();
+      spawns.add(
+          new SpawnResult.Builder()
+              .setStatus(SpawnResult.Status.SUCCESS)
+              .setRunnerName("c")
+              .build());
+      stats.countActionResult(ActionResult.create(spawns));
       stats.incrementActionCount();
     }
     assertThat(SpawnStats.convertSummaryToString(stats.getSummary()))
@@ -84,31 +120,77 @@ public final class SpawnStatsTest {
 
   @Test
   public void reverseOrder() {
-    stats.countRunnerName("a");
-    stats.countRunnerName("a");
-    stats.countRunnerName("a");
-    stats.countRunnerName("b");
-    stats.countRunnerName("b");
-    stats.countRunnerName("c");
-    for (int i = 0; i < 6; i++) {
+    for (int i = 0; i < 3; i++) {
+      ArrayList<SpawnResult> spawns = new ArrayList<>();
+      spawns.add(
+          new SpawnResult.Builder()
+              .setStatus(SpawnResult.Status.SUCCESS)
+              .setRunnerName("a")
+              .build());
+      stats.countActionResult(ActionResult.create(spawns));
       stats.incrementActionCount();
     }
+
+    for (int i = 0; i < 2; i++) {
+      ArrayList<SpawnResult> spawns = new ArrayList<>();
+      spawns.add(
+          new SpawnResult.Builder()
+              .setStatus(SpawnResult.Status.SUCCESS)
+              .setRunnerName("b")
+              .build());
+      stats.countActionResult(ActionResult.create(spawns));
+      stats.incrementActionCount();
+    }
+
+    ArrayList<SpawnResult> spawns = new ArrayList<>();
+    spawns.add(
+        new SpawnResult.Builder().setStatus(SpawnResult.Status.SUCCESS).setRunnerName("c").build());
+    stats.countActionResult(ActionResult.create(spawns));
+    stats.incrementActionCount();
+
     assertThat(SpawnStats.convertSummaryToString(stats.getSummary()))
         .isEqualTo("6 processes: 3 a, 2 b, 1 c.");
   }
 
   @Test
   public void cacheFirst() {
-    stats.countRunnerName("a");
-    stats.countRunnerName("a");
-    stats.countRunnerName("a");
-    stats.countRunnerName("b");
-    stats.countRunnerName("remote cache hit");
-    stats.countRunnerName("b");
-    stats.countRunnerName("c");
-    for (int i = 0; i < 7; i++) {
+    for (int i = 0; i < 3; i++) {
+      ArrayList<SpawnResult> spawns = new ArrayList<>();
+      spawns.add(
+          new SpawnResult.Builder()
+              .setStatus(SpawnResult.Status.SUCCESS)
+              .setRunnerName("a")
+              .build());
+      stats.countActionResult(ActionResult.create(spawns));
       stats.incrementActionCount();
     }
+
+    for (int i = 0; i < 2; i++) {
+      ArrayList<SpawnResult> spawns = new ArrayList<>();
+      spawns.add(
+          new SpawnResult.Builder()
+              .setStatus(SpawnResult.Status.SUCCESS)
+              .setRunnerName("b")
+              .build());
+      stats.countActionResult(ActionResult.create(spawns));
+      stats.incrementActionCount();
+    }
+
+    ArrayList<SpawnResult> spawns = new ArrayList<>();
+    spawns.add(
+        new SpawnResult.Builder()
+            .setStatus(SpawnResult.Status.SUCCESS)
+            .setRunnerName("remote cache hit")
+            .build());
+    stats.countActionResult(ActionResult.create(spawns));
+    stats.incrementActionCount();
+
+    spawns = new ArrayList<>();
+    spawns.add(
+        new SpawnResult.Builder().setStatus(SpawnResult.Status.SUCCESS).setRunnerName("c").build());
+    stats.countActionResult(ActionResult.create(spawns));
+    stats.incrementActionCount();
+
     assertThat(SpawnStats.convertSummaryToString(stats.getSummary()))
         .isEqualTo("7 processes: 1 remote cache hit, 3 a, 2 b, 1 c.");
   }
@@ -132,7 +214,7 @@ public final class SpawnStatsTest {
 
   @Test
   public void actionManySpawn() {
-    // Different spawns with the same runner count as one action
+    // One action with multiple spawns - should count as 1 action with 3 spawns
 
     ArrayList<SpawnResult> spawns = new ArrayList<>();
     spawns.add(rA);
@@ -140,16 +222,14 @@ public final class SpawnStatsTest {
     spawns.add(rA);
 
     stats.countActionResult(ActionResult.create(spawns));
-    for (int i = 0; i < 3; i++) {
-      stats.incrementActionCount();
-    }
+    stats.incrementActionCount();
     assertThat(SpawnStats.convertSummaryToString(stats.getSummary()))
-        .isEqualTo("3 processes: 3 abc.");
+        .isEqualTo("1 process: 3 abc.");
   }
 
   @Test
   public void actionManySpawnMixed() {
-    // Different spawns mixed runners
+    // One action with multiple spawns of different runners
 
     ArrayList<SpawnResult> spawns = new ArrayList<>();
     spawns.add(rA);
@@ -157,39 +237,44 @@ public final class SpawnStatsTest {
     spawns.add(rB);
 
     stats.countActionResult(ActionResult.create(spawns));
-    for (int i = 0; i < 3; i++) {
-      stats.incrementActionCount();
-    }
+    stats.incrementActionCount();
     assertThat(SpawnStats.convertSummaryToString(stats.getSummary()))
-        .isEqualTo("3 processes: 2 abc, 1 cde.");
+        .isEqualTo("1 process: 2 abc, 1 cde.");
   }
 
   @Test
   public void actionManyActionsMixed() {
     // Five actions:
-    // abc
-    // abc, abc
-    // abc, abc, cde
-    // abc, abc, cde
-    // abc, abc, cde
+    // Action 1: 1 spawn (abc)
+    // Action 2: 2 spawns (abc, abc)
+    // Action 3: 3 spawns (abc, abc, cde)
+    // Action 4: 3 spawns (abc, abc, cde)
+    // Action 5: 3 spawns (abc, abc, cde)
 
     ArrayList<SpawnResult> spawns = new ArrayList<>();
     spawns.add(rA);
     stats.countActionResult(ActionResult.create(spawns));
+    stats.incrementActionCount();
 
+    spawns = new ArrayList<>();
+    spawns.add(rA);
     spawns.add(rA);
     stats.countActionResult(ActionResult.create(spawns));
+    stats.incrementActionCount();
 
+    spawns = new ArrayList<>();
+    spawns.add(rA);
+    spawns.add(rA);
     spawns.add(rB);
     stats.countActionResult(ActionResult.create(spawns));
+    stats.incrementActionCount();
     stats.countActionResult(ActionResult.create(spawns));
+    stats.incrementActionCount();
     stats.countActionResult(ActionResult.create(spawns));
+    stats.incrementActionCount();
 
-    for (int i = 0; i < 12; i++) {
-      stats.incrementActionCount();
-    }
     assertThat(SpawnStats.convertSummaryToString(stats.getSummary()))
-        .isEqualTo("12 processes: 9 abc, 3 cde.");
+        .isEqualTo("5 processes: 9 abc, 3 cde.");
   }
 
   @Test
@@ -201,18 +286,59 @@ public final class SpawnStatsTest {
 
   @Test
   public void orderCacheInternalRest() {
-    stats.countRunnerName("a");
-    stats.countRunnerName("a");
-    stats.countRunnerName("a");
-    stats.countRunnerName("b");
-    stats.countRunnerName("remote cache hit");
-    stats.countRunnerName("b");
-    stats.countRunnerName("c");
-    stats.countRunnerName("z");
-    stats.countRunnerName("z");
-    for (int i = 0; i < 11; i++) {
+    for (int i = 0; i < 3; i++) {
+      ArrayList<SpawnResult> spawns = new ArrayList<>();
+      spawns.add(
+          new SpawnResult.Builder()
+              .setStatus(SpawnResult.Status.SUCCESS)
+              .setRunnerName("a")
+              .build());
+      stats.countActionResult(ActionResult.create(spawns));
       stats.incrementActionCount();
     }
+
+    for (int i = 0; i < 2; i++) {
+      ArrayList<SpawnResult> spawns = new ArrayList<>();
+      spawns.add(
+          new SpawnResult.Builder()
+              .setStatus(SpawnResult.Status.SUCCESS)
+              .setRunnerName("b")
+              .build());
+      stats.countActionResult(ActionResult.create(spawns));
+      stats.incrementActionCount();
+    }
+
+    ArrayList<SpawnResult> spawns = new ArrayList<>();
+    spawns.add(
+        new SpawnResult.Builder()
+            .setStatus(SpawnResult.Status.SUCCESS)
+            .setRunnerName("remote cache hit")
+            .build());
+    stats.countActionResult(ActionResult.create(spawns));
+    stats.incrementActionCount();
+
+    spawns = new ArrayList<>();
+    spawns.add(
+        new SpawnResult.Builder().setStatus(SpawnResult.Status.SUCCESS).setRunnerName("c").build());
+    stats.countActionResult(ActionResult.create(spawns));
+    stats.incrementActionCount();
+
+    for (int i = 0; i < 2; i++) {
+      spawns = new ArrayList<>();
+      spawns.add(
+          new SpawnResult.Builder()
+              .setStatus(SpawnResult.Status.SUCCESS)
+              .setRunnerName("z")
+              .build());
+      stats.countActionResult(ActionResult.create(spawns));
+      stats.incrementActionCount();
+    }
+
+    // Add 2 internal actions (no spawns)
+    for (int i = 0; i < 2; i++) {
+      stats.incrementActionCount();
+    }
+
     assertThat(SpawnStats.convertSummaryToString(stats.getSummary()))
         .isEqualTo("11 processes: 1 remote cache hit, 2 internal, 3 a, 2 b, 1 c, 2 z.");
   }
@@ -237,5 +363,29 @@ public final class SpawnStatsTest {
     var unused = stats.getSummary();
     assertThat(stats.getExecKindFor("total")).isNull();
     assertThat(stats.getExecKindFor("internal")).isNull();
+  }
+
+  @Test
+  public void internalCountWithMultipleSpawnsPerAction() {
+    // Action 1: 3 spawns (counts as 1 non-internal action)
+    ArrayList<SpawnResult> spawnsA = new ArrayList<>();
+    spawnsA.add(rA);
+    spawnsA.add(rA);
+    spawnsA.add(rA);
+    stats.countActionResult(ActionResult.create(spawnsA));
+    stats.incrementActionCount();
+
+    // Action 2: 2 spawns (counts as 1 non-internal action)
+    ArrayList<SpawnResult> spawnsB = new ArrayList<>();
+    spawnsB.add(rB);
+    spawnsB.add(rB);
+    stats.countActionResult(ActionResult.create(spawnsB));
+    stats.incrementActionCount();
+
+    // Action 3: internal action (no spawns)
+    stats.incrementActionCount();
+
+    assertThat(SpawnStats.convertSummaryToString(stats.getSummary()))
+        .isEqualTo("3 processes: 1 internal, 3 abc, 2 cde.");
   }
 }

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -2772,7 +2772,7 @@ EOF
     --disk_cache=$CACHEDIR \
     //a:test >& $TEST_log || fail "Failed to build //a:test"
 
-  expect_log "7 processes: 5 internal, 2 .*-sandbox"
+  expect_log "7 processes: 6 internal, 2 .*-sandbox"
 
   bazel clean
 
@@ -2780,7 +2780,7 @@ EOF
     --disk_cache=$CACHEDIR \
     //a:test >& $TEST_log || fail "Failed to build //a:test"
 
-  expect_log "7 processes: 2 disk cache hit, 5 internal"
+  expect_log "7 processes: 2 disk cache hit, 6 internal"
 }
 
 # Bazel assumes that non-ASCII characters in file contents (and, in


### PR DESCRIPTION
Before this change, the number of internal actions was computed as `#actions - #spawns`, which is incorrect since a single action can run multiple spawns, not just zero or one.

Also adds a comment explaining all the inconsistencies in the current stats output.

Closes #27495.

PiperOrigin-RevId: 831853687
Change-Id: I82f4dff578f32fac120211286da71ed1380e10e7

Commit https://github.com/bazelbuild/bazel/commit/9f18c800ea28fc497b58ac8054a4f409f1c36635