### PR TITLE
[9.0.0] Flip incompatible_strict_action_env

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -73,7 +73,7 @@ public class BazelRuleClassProvider {
     @Option(
         name = "incompatible_strict_action_env",
         oldName = "experimental_strict_action_env",
-        defaultValue = "false",
+        defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
         effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
         metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -739,8 +739,7 @@ public final class RemoteOptions extends CommonRemoteOptions {
               + " affected actions.\n\n"
               + "In order to successfully use this feature, you likely want to set a custom"
               + " --host_platform together with --experimental_platform_in_output_dir (to normalize"
-              + " output prefixes) and --incompatible_strict_action_env (to normalize environment"
-              + " variables).")
+              + " output prefixes).")
   public Scrubber scrubber;
 
   @Option(

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -346,7 +346,7 @@ EOF
 
   # With --action_env=PATH, the local PATH is forwarded to the test.
   PATH=$PATH:$PWD/scripts bazel test //testing:t1 -s --run_under=hello \
-    --test_output=all >& $TEST_log || fail "Expected success"
+    --test_output=all --action_env=PATH >& $TEST_log || fail "Expected success"
   expect_log 'hello script!!! testing/t1'
 
   # We need to forward the PATH to make it work.

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -2897,7 +2897,7 @@ EOF
 
   repo_cache_dir=$TEST_TMPDIR/repository_cache
   trap 'rm -rf ${repo_cache_dir}' EXIT
-  bazel build --repository_cache="$repo_cache_dir" \
+  bazel build --repository_cache="$repo_cache_dir" --action_env=PATH \
     //:unique_hashes >& $TEST_log || fail "expected bazel to succeed"
   assert_equals 1 "$(wc -l < bazel-bin/unique_hashes | tr -d ' ')"
   assert_equals $sha "$(cat bazel-bin/unique_hashes)"


### PR DESCRIPTION
Work towards https://github.com/bazel-contrib/SIG-rules-authors/issues/42.

Fixes https://github.com/bazelbuild/bazel/issues/7026

Closes #26587.

PiperOrigin-RevId: 831944371
Change-Id: I397faa463a709b2367d5a6eebc678077c4029bbb

Commit https://github.com/bazelbuild/bazel/commit/e697ff774eff6c8a708fffca6fd8eeeb7f468bfe