### PR TITLE
[9.0.0] enable gRPC keepalive by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
@@ -116,7 +116,7 @@ public class AuthAndTLSOptions extends OptionsBase {
 
   @Option(
       name = "grpc_keepalive_time",
-      defaultValue = "null",
+      defaultValue = "60s",
       converter = DurationConverter.class,
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
@@ -124,11 +124,7 @@ public class AuthAndTLSOptions extends OptionsBase {
           """
           Configures keep-alive pings for outgoing gRPC connections. If this is set, then Bazel
           sends pings after this much time of no read operations on the connection, but
-          only if there is at least one pending gRPC call. Times are treated as second
-          granularity; it is an error to set a value less than one second. By default,
-          keep-alive pings are disabled. You should coordinate with the service owner
-          before enabling this setting. For example to set a value of 30 seconds to this
-          flag, it should be done as this `--grpc_keepalive_time=30s`.
+          only if there is at least one pending gRPC call. The value 0 disables the keep-alives.
           """)
   public Duration grpcKeepaliveTime;
 

--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.authandtls;
 
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -55,7 +57,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /** Utility methods for using {@link AuthAndTLSOptions} with Google Cloud. */
@@ -89,9 +90,9 @@ public final class GoogleAuthUtils {
               .executor(executor)
               .negotiationType(
                   isTlsEnabled(target) ? NegotiationType.TLS : NegotiationType.PLAINTEXT);
-      if (options.grpcKeepaliveTime != null) {
-        builder.keepAliveTime(options.grpcKeepaliveTime.toSeconds(), TimeUnit.SECONDS);
-        builder.keepAliveTimeout(options.grpcKeepaliveTimeout.toSeconds(), TimeUnit.SECONDS);
+      if (options.grpcKeepaliveTime != null && !options.grpcKeepaliveTime.isZero()) {
+        builder.keepAliveTime(options.grpcKeepaliveTime.toNanos(), NANOSECONDS);
+        builder.keepAliveTimeout(options.grpcKeepaliveTimeout.toNanos(), NANOSECONDS);
       }
       if (interceptors != null) {
         builder.intercept(interceptors);


### PR DESCRIPTION
The keepalive is critical for detecting load balancers and other network middlemen that like to silently drop connection data after periods of idleness.

Closes #27473.

PiperOrigin-RevId: 832225094
Change-Id: I023e34377a19d41bd810b8c3632bf46bea2fe81f

Commit https://github.com/bazelbuild/bazel/commit/d3684789750068b2742a8cb7ac4493ff6f412c43