### PR TITLE
[9.0.0] Centralize more logic in SymlinkTreeHelper.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
@@ -145,11 +145,12 @@ public class RunfilesTreeUpdater {
     SymlinkTreeHelper helper =
         new SymlinkTreeHelper(inputManifest, outputManifest, runfilesDir, tree.getWorkspaceName());
 
-    if (tree.getSymlinksMode() == RunfileSymlinksMode.CREATE) {
-      helper.createRunfilesSymlinks(tree.getMapping());
-      outputManifest.createSymbolicLink(inputManifest);
-    } else {
-      helper.clearRunfilesDirectory();
+    switch (tree.getSymlinksMode()) {
+      case CREATE -> {
+        helper.createRunfilesSymlinks(tree.getMapping());
+        helper.linkManifest();
+      }
+      case SKIP -> helper.createMinimalRunfilesDirectory();
     }
   }
 


### PR DESCRIPTION
Also make sure that the output manifest is always created last, as it attests to the symlink tree having been updated.

PiperOrigin-RevId: 831838700
Change-Id: Iddd95f170dd27f3a4254fbfccf5ef649c424d469