### PR TITLE
[8.5.0] Include allowed attribute values in Stardoc proto

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkdocextract/AttributeInfoExtractor.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdocextract/AttributeInfoExtractor.java
@@ -69,6 +69,17 @@ public final class AttributeInfoExtractor {
         builder.setDefaultValue(UNREPRESENTABLE_VALUE);
       }
     }
+    if (attribute.getAllowedValues() instanceof Attribute.AllowedValueSet allowedValueSet) {
+      for (Object value : allowedValueSet.getAllowedValues()) {
+        try {
+          builder.addValues(
+              StringEncoding.internalToUnicode(
+                  context.labelRenderer().reprWithoutLabelConstructor(value)));
+        } catch (InvalidStarlarkValueException e) {
+          builder.addValues(UNREPRESENTABLE_VALUE);
+        }
+      }
+    }
     return builder.build();
   }
 

--- a/src/main/protobuf/stardoc_output.proto
+++ b/src/main/protobuf/stardoc_output.proto
@@ -167,6 +167,10 @@ message AttributeInfo {
 
   // If true, the attribute is defined in Bazel's native code, not in Starlark.
   bool natively_defined = 8;
+
+  // If non-empty, the string representations of the allowed values for this
+  // attribute.
+  repeated string values = 9;
 }
 
 // Representation of a set of providers.

--- a/src/test/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractorTest.java
@@ -703,7 +703,7 @@ public final class ModuleInfoExtractorTest {
                 implementation = _my_impl,
                 attrs = {
                     "a": attr.string(doc = "My doc", default = "foo"),
-                    "b": attr.string(mandatory = True),
+                    "b": attr.string(mandatory = True, values = ["foo", "bar"]),
                     "c": attr.label(providers = [MyInfo1, MyInfo2]),
                     "d": attr.label(providers = [[MyInfo1, MyInfo2], [MyInfo3]]),
                     "_e": attr.string(doc = "Hidden attribute"),
@@ -727,6 +727,7 @@ public final class ModuleInfoExtractorTest {
                         .setName("b")
                         .setType(AttributeType.STRING)
                         .setMandatory(true)
+                        .addAllValues(ImmutableList.of("\"foo\"", "\"bar\""))
                         .build(),
                     AttributeInfo.newBuilder()
                         .setName("c")


### PR DESCRIPTION
The set of allowed values of a `string` or `int` attribute is crucial information for users of a rule or aspect.

Closes #25877.

PiperOrigin-RevId: 832334774
Change-Id: Ibe005910905bf045de9ef5eb8218cbe12f509724

Commit https://github.com/bazelbuild/bazel/commit/58cd0a15421529a957bfb0f7fca1b188930dc5b5