### PR TITLE
Rely on mtime instead of ctime for change detection.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ArFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ArFunction.java
@@ -64,9 +64,6 @@ public class ArFunction implements Decompressor {
             arStream.transferTo(out);
           }
           filePath.chmod(entry.getMode());
-          // entry.getLastModified() appears to be in seconds, so we need to convert
-          // it into milliseconds for setLastModifiedTime
-          filePath.setLastModifiedTime(entry.getLastModified() * 1000L);
         }
         if (Thread.interrupted()) {
           throw new InterruptedException();

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
@@ -137,11 +137,6 @@ public abstract class CompressedTarFunction implements Decompressor {
               tarStream.transferTo(out);
             }
             filePath.chmod(entry.getMode());
-
-            // This can only be done on real files, not links, or it will skip the reader to
-            // the next "real" file to try to find the mod time info.
-            Date lastModified = entry.getLastModifiedDate();
-            filePath.setLastModifiedTime(lastModified.getTime());
           }
         }
         if (Thread.interrupted()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressor.java
@@ -135,9 +135,6 @@ public class SevenZDecompressor implements Decompressor {
           throw new InterruptedException();
         }
       }
-      if (entry.getHasLastModifiedDate()) {
-        outputPath.setLastModifiedTime(entry.getLastModifiedTime().toMillis());
-      }
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
@@ -168,7 +168,6 @@ public class ZipDecompressor implements Decompressor {
         }
       }
       outputPath.chmod(permissions);
-      outputPath.setLastModifiedTime(entry.getTime());
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
@@ -57,6 +57,7 @@ import com.google.devtools.build.lib.shell.TerminationStatus;
 import com.google.devtools.build.lib.util.NetUtil;
 import com.google.devtools.build.lib.util.StringEncoding;
 import com.google.devtools.build.lib.util.io.FileOutErr;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
@@ -412,6 +413,9 @@ public class LocalSpawnRunner implements SpawnRunner {
             subprocess.waitFor();
             terminationStatus =
                 new TerminationStatus(subprocess.exitValue(), subprocess.timedout());
+            for (ActionInput output : spawn.getOutputFiles()) {
+              FileSystemUtils.updateModifiedTimeIfOtherThanChangeTime(context.getPathResolver().toPath(output));
+            }
           } catch (InterruptedException | IOException e) {
             subprocess.destroyAndWait();
             throw e;

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -47,6 +47,7 @@ import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.FileAccessException;
 import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Symlinks;
@@ -201,6 +202,10 @@ public final class SandboxHelpers {
       try {
         // Prefer to move outputs through a rename, avoiding a more expensive copy.
         source.renameTo(target);
+        // Bazel actions, in general, are expected not to care about Bazel updating the mtime of their outputs because
+        // mtime is not preserved when obtaining a remote cache hit either, and the copyFile fallback below explicitly
+        // states that it does not care about preserving attributes.
+        FileSystemUtils.updateModifiedTimeIfOtherThanChangeTime(target, stat);
       } catch (IOException unused) {
         // Assume that the rename failed because it was cross-device.
         // TODO(tjgq): Distinguish a cross-device rename from other errors.


### PR DESCRIPTION
This commit is experimental and serves as input for discussion on issue #27226.

There are still open questions, failing test cases, lack of new test cases, etc.

Changed functionality:

 * Ensure mtimes are trustworthy for detecting change for all outputs produced by actions and repository rules, including cases when archives with fake mtimes are extracted.

 * Compare mtime but not ctime when detecting changes for caches digests. However, fallback to comparing ctime if mtime is zero.