### PR TITLE
[9.0.0] Make remote repo contents cache less spammy

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryFetchFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryFetchFunction.java
@@ -174,7 +174,6 @@ public final class RepositoryFetchFunction implements SkyFunction {
           RepositoryUtils.getExternalRepositoryDirectory(directories)
               .getRelative(repositoryName.getName());
 
-
       RepoDefinition repoDefinition;
       switch ((RepoDefinitionValue) env.getValue(RepoDefinitionValue.key(repositoryName))) {
         case null -> {
@@ -258,10 +257,6 @@ public final class RepositoryFetchFunction implements SkyFunction {
           try {
             if (remoteRepoContentsCache.lookupCache(
                 repositoryName, repoRoot, digestWriter.predeclaredInputHash, env.getListener())) {
-              env.getListener()
-                  .handle(
-                      Event.debug(
-                          "Got %s from the remote repo contents cache".formatted(repositoryName)));
               return new RepositoryDirectoryValue.Success(
                   Root.fromPath(repoRoot), excludeRepoFromVendoring);
             }


### PR DESCRIPTION
Don't print a message when it's successful. Users can always look under `external` to verify which repo came from the cache.

Closes #27699.

PiperOrigin-RevId: 834096735
Change-Id: I3916fb240218a6b68ecf48417142b998ca281598

Commit https://github.com/bazelbuild/bazel/commit/3ca9ce13423393b90564710670b09486955383af