### PR TITLE
[9.0.0] Gracefully handle action outputs when collecting lost inputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/common/CacheNotFoundException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/CacheNotFoundException.java
@@ -62,6 +62,11 @@ public final class CacheNotFoundException extends IOException {
     return execPath;
   }
 
+  @Nullable
+  public String getFilename() {
+    return filename;
+  }
+
   @Override
   public String getMessage() {
     String message =


### PR DESCRIPTION
We previously tried to ensure that `BulkTransferException#getLostArtifacts` was never called with any exceptions mentioning non-inputs, but that still resulted in crashes. As the retrier logic in the remote spawn runner makes this error-prone and it is very unlikely that the `InputMetadataProvider` is actually missing metadata for an input, this change simplifies the logic by treating every `ActionInput` missing from it as an output and raising an error (possibly resulting in a local fallback or retry) instead of crashing.

Speculatively fixes #27229

Closes #27500.

PiperOrigin-RevId: 834106361
Change-Id: Ie002690cf41513d679d653f33ee96ab011f89f88

Commit https://github.com/bazelbuild/bazel/commit/09115bb999c8d100a6e1517f99fe91f5131a0d6f