### PR TITLE
Let `FileSystem#resolveSymbolicLinks` return `PathFragment`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -321,8 +321,8 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   }
 
   @Override
-  public Path resolveSymbolicLinks(PathFragment path) throws IOException {
-    return getPath(pathCanonicalizer.resolveSymbolicLinks(path));
+  public PathFragment resolveSymbolicLinks(PathFragment path) throws IOException {
+    return pathCanonicalizer.resolveSymbolicLinks(path);
   }
 
   @Override
@@ -346,7 +346,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   private PathFragment resolveSymbolicLinksForParent(PathFragment path) throws IOException {
     PathFragment parentPath = path.getParentDirectory();
     if (parentPath != null) {
-      return resolveSymbolicLinks(parentPath).asFragment().getChild(path.getBaseName());
+      return resolveSymbolicLinks(parentPath).getChild(path.getBaseName());
     }
     return path;
   }
@@ -424,7 +424,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
 
   @Override
   public void setLastModifiedTime(PathFragment path, long newTime) throws IOException {
-    path = resolveSymbolicLinks(path).asFragment();
+    path = resolveSymbolicLinks(path);
 
     FileNotFoundException remoteException = null;
     try {
@@ -460,7 +460,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   @Override
   @Nullable
   public byte[] getFastDigest(PathFragment path) throws IOException {
-    path = resolveSymbolicLinks(path).asFragment();
+    path = resolveSymbolicLinks(path);
     // Try to obtain a fast digest through a stat. This is only possible for in-memory files.
     // The parent path has already been canonicalized by resolveSymbolicLinks, so FOLLOW_NONE is
     // effectively the same as FOLLOW_PARENT, but more efficient.
@@ -473,7 +473,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
 
   @Override
   public byte[] getDigest(PathFragment path) throws IOException {
-    path = resolveSymbolicLinks(path).asFragment();
+    path = resolveSymbolicLinks(path);
     // Try to obtain a fast digest through a stat. This is only possible for in-memory files.
     // The parent path has already been canonicalized by resolveSymbolicLinks, so FOLLOW_NONE is
     // effectively the same as FOLLOW_PARENT, but more efficient.
@@ -486,7 +486,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
 
   @Override
   public boolean isReadable(PathFragment path) throws IOException {
-    path = resolveSymbolicLinks(path).asFragment();
+    path = resolveSymbolicLinks(path);
     try {
       return localFs.getPath(path).isReadable();
     } catch (FileNotFoundException e) {
@@ -497,7 +497,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
 
   @Override
   public boolean isWritable(PathFragment path) throws IOException {
-    path = resolveSymbolicLinks(path).asFragment();
+    path = resolveSymbolicLinks(path);
     try {
       return localFs.getPath(path).isWritable();
     } catch (FileNotFoundException e) {
@@ -508,7 +508,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
 
   @Override
   public boolean isExecutable(PathFragment path) throws IOException {
-    path = resolveSymbolicLinks(path).asFragment();
+    path = resolveSymbolicLinks(path);
     try {
       return localFs.getPath(path).isExecutable();
     } catch (FileNotFoundException e) {
@@ -519,7 +519,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
 
   @Override
   public void setReadable(PathFragment path, boolean readable) throws IOException {
-    path = resolveSymbolicLinks(path).asFragment();
+    path = resolveSymbolicLinks(path);
     try {
       localFs.getPath(path).setReadable(readable);
     } catch (FileNotFoundException e) {
@@ -529,7 +529,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
 
   @Override
   public void setWritable(PathFragment path, boolean writable) throws IOException {
-    path = resolveSymbolicLinks(path).asFragment();
+    path = resolveSymbolicLinks(path);
     try {
       localFs.getPath(path).setWritable(writable);
     } catch (FileNotFoundException e) {
@@ -539,7 +539,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
 
   @Override
   public void setExecutable(PathFragment path, boolean executable) throws IOException {
-    path = resolveSymbolicLinks(path).asFragment();
+    path = resolveSymbolicLinks(path);
     try {
       localFs.getPath(path).setExecutable(executable);
     } catch (FileNotFoundException e) {
@@ -549,7 +549,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
 
   @Override
   public void chmod(PathFragment path, int mode) throws IOException {
-    path = resolveSymbolicLinks(path).asFragment();
+    path = resolveSymbolicLinks(path);
     try {
       localFs.getPath(path).chmod(mode);
     } catch (FileNotFoundException e) {
@@ -668,11 +668,11 @@ public class RemoteActionFileSystem extends AbstractFileSystem
     // Canonicalize the path.
     try {
       if (followMode == FollowMode.FOLLOW_ALL) {
-        path = resolveSymbolicLinks(path).asFragment();
+        path = resolveSymbolicLinks(path);
       } else if (followMode == FollowMode.FOLLOW_PARENT) {
         PathFragment parent = path.getParentDirectory();
         if (parent != null) {
-          path = resolveSymbolicLinks(parent).asFragment().getChild(path.getBaseName());
+          path = resolveSymbolicLinks(parent).getChild(path.getBaseName());
         }
       }
     } catch (FileNotFoundException e) {
@@ -834,7 +834,7 @@ public class RemoteActionFileSystem extends AbstractFileSystem
   private <T extends Comparable<T>> ImmutableSortedSet<T> getDirectoryContents(
       PathFragment path, boolean followSymlinks, Function<Dirent, T> transformer)
       throws IOException {
-    path = resolveSymbolicLinks(path).asFragment();
+    path = resolveSymbolicLinks(path);
 
     HashMap<String, Dirent> entries = new HashMap<>();
     boolean exists = false;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -536,7 +536,7 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
   }
 
   @Override
-  public Path resolveSymbolicLinks(PathFragment path) throws IOException {
+  public PathFragment resolveSymbolicLinks(PathFragment path) throws IOException {
     return fsForPath(path).resolveSymbolicLinks(path);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -188,7 +188,7 @@ public abstract class FileSystem {
     String fileSystem = "unknown";
     int bestMountPointSegmentCount = -1;
     try {
-      Path canonicalPath = resolveSymbolicLinks(path);
+      PathFragment canonicalPath = resolveSymbolicLinks(path);
       PathFragment mountTable = PathFragment.createAlreadyNormalized("/proc/mounts");
       try (InputStreamReader reader =
           new InputStreamReader(getInputStream(mountTable), ISO_8859_1)) {
@@ -453,14 +453,12 @@ public abstract class FileSystem {
    * Returns the canonical path for the given path, which must be absolute. See {@link
    * Path#resolveSymbolicLinks} for specification.
    */
-  public Path resolveSymbolicLinks(PathFragment path) throws IOException {
+  public PathFragment resolveSymbolicLinks(PathFragment path) throws IOException {
     checkArgument(path.isAbsolute());
     PathFragment parentNode = path.getParentDirectory();
     return parentNode == null
-        ? getPath(path) // (root)
-        : getPath(
-            appendSegment(
-                resolveSymbolicLinks(parentNode).asFragment(), path.getBaseName(), MAX_SYMLINKS));
+        ? path // (root)
+        : appendSegment(resolveSymbolicLinks(parentNode), path.getBaseName(), MAX_SYMLINKS);
   }
 
   /** Returns the status of a file. See {@link Path#stat(Symlinks)} for specification. */

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -609,7 +609,7 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
    *     example, the path does not exist)
    */
   public Path resolveSymbolicLinks() throws IOException {
-    return fileSystem.resolveSymbolicLinks(asFragment());
+    return fileSystem.getPath(fileSystem.resolveSymbolicLinks(asFragment()));
   }
 
   /**
@@ -960,7 +960,8 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
   private void checkSameFileSystem(Path that) {
     if (this.fileSystem != that.fileSystem) {
       throw new IllegalArgumentException(
-          "Files are on different filesystems: " + this + ", " + that);
+          "Files are on different filesystems: %s (on %s), %s (on %s)"
+              .formatted(this, this.fileSystem, that, that.fileSystem));
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
@@ -261,9 +261,8 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
   }
 
   @Override
-  public Path resolveSymbolicLinks(PathFragment path) throws IOException {
-    return getPath(
-        fromDelegatePath(delegateFs.resolveSymbolicLinks(toDelegatePath(path)).asFragment()));
+  public PathFragment resolveSymbolicLinks(PathFragment path) throws IOException {
+    return fromDelegatePath(delegateFs.resolveSymbolicLinks(toDelegatePath(path)));
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystemTest.java
@@ -91,12 +91,11 @@ public final class PathTransformingDelegateFileSystemTest {
       throws Exception {
     PathFragment path = PathFragment.create("/original/dir/file");
     when(delegateFileSystem.resolveSymbolicLinks(PathFragment.create("/transformed/dir/file")))
-        .thenReturn(Path.create("/transformed/resolved", delegateFileSystem));
+        .thenReturn(PathFragment.create("/transformed/resolved"));
 
-    Path resolvedPath = fileSystem.resolveSymbolicLinks(path);
+    PathFragment resolvedPath = fileSystem.resolveSymbolicLinks(path);
 
-    assertThat(resolvedPath.asFragment()).isEqualTo(PathFragment.create("/original/resolved"));
-    assertThat(resolvedPath.getFileSystem()).isSameInstanceAs(fileSystem);
+    assertThat(resolvedPath).isEqualTo(PathFragment.create("/original/resolved"));
   }
 
   @Test

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -473,7 +473,7 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     with open(self.Path('bazel-bin/main/out.txt')) as f:
       self.assertEqual(f.read(), 'hello')
 
-  def testUseRepoFileInBuildRule_actionDoesNotUseCache(self):
+  def do_testUseRepoFileInBuildRule_actionDoesNotUseCache(self, extra_flags=[]):
     self.ScratchFile(
         'MODULE.bazel',
         [
@@ -509,7 +509,7 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     repo_dir = self.RepoDir('my_repo')
 
     # First fetch: not cached
-    _, _, stderr = self.RunBazel(['build', '//main:use_data'])
+    _, _, stderr = self.RunBazel(['build', '//main:use_data'] + extra_flags)
     self.assertIn('JUST FETCHED', '\n'.join(stderr))
     self.assertTrue(os.path.exists(os.path.join(repo_dir, 'BUILD')))
     self.assertTrue(os.path.exists(os.path.join(repo_dir, 'data.txt')))
@@ -519,13 +519,20 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
 
     # After expunging: repo and build action cached
     self.RunBazel(['clean', '--expunge'])
-    _, _, stderr = self.RunBazel(['build', '//main:use_data'])
+    _, _, stderr = self.RunBazel(['build', '//main:use_data'] + extra_flags)
     self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
     self.assertFalse(os.path.exists(os.path.join(repo_dir, 'BUILD')))
     self.assertTrue(os.path.exists(os.path.join(repo_dir, 'data.txt')))
     self.assertTrue(os.path.exists(self.Path('bazel-bin/main/out.txt')))
     with open(self.Path('bazel-bin/main/out.txt')) as f:
       self.assertEqual(f.read(), 'hello')
+
+  def testUseRepoFileInBuildRule_actionDoesNotUseCache(self):
+    self.do_testUseRepoFileInBuildRule_actionDoesNotUseCache()
+
+  def testUseRepoFileInBuildRule_actionDoesNotUseCache_withExplicitSandboxBase(self):
+    tmpdir = self.ScratchDir('sandbox_base')
+    self.do_testUseRepoFileInBuildRule_actionDoesNotUseCache(extra_flags=['--sandbox_base='+tmpdir])
 
   def testLostRemoteFile_build(self):
     # Create a repo with two BUILD files (one in a subpackage), build a target


### PR DESCRIPTION
This ensures that composite `FileSystem` implementations that rely on delegation don't return accidentally return a `Path` for one of their constituent file systems. It also simplifies almost all call sites.

Also make the error message emitted by `Path#checkSameFileSystem` more informative. This is motivated by and helped discover the above as the fix for the following crash observed when using the remote repo contents cache with an explicit `--sandbox_base`:

```
Caused by: java.lang.IllegalArgumentException: Files are on different filesystems: /dev/shm/bazel-sandbox.b10976335efa519b0184f3091ac8e21f7beefb92142303f9ab2c3341f45a2f28/linux-sandbox/18/execroot/_main/external/c-ares+/configs/ares_build.h (on com.google.devtools.build.lib.unix.UnixFileSystem@5e0a8154), /home/ubuntu/.cache/bazel/_bazel_ubuntu/123/execroot/_main/external/c-ares+/configs/ares_build.h (on com.google.devtools.build.lib.remote.RemoteExternalOverlayFileSystem@6cd9bfda)
        at com.google.devtools.build.lib.vfs.Path.checkSameFileSystem(Path.java:964)
        at com.google.devtools.build.lib.vfs.Path.createSymbolicLink(Path.java:523)
        at com.google.devtools.build.lib.vfs.Path.createSymbolicLink(Path.java:535)
        at com.google.devtools.build.lib.sandbox.SymlinkedSandboxedSpawn.copyFile(SymlinkedSandboxedSpawn.java:129)
```