### PR TITLE
Preserve facts present in the lockfile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -119,6 +119,7 @@ public class BazelLockFileModule extends BlazeModule {
     var newExtensionInfos =
         new HashMap<ModuleExtensionId, LockFileModuleExtension.WithFactors>(numExtensions);
     var combinedFacts = new HashMap<ModuleExtensionId, Facts>(numExtensions);
+    combinedFacts.putAll(oldLockfile.getFacts());
     var doneValues = evaluator.getDoneValues();
     for (var extensionId : depGraphValue.getExtensionUsagesTable().rowKeySet()) {
       if (extensionId.isInnate()) {


### PR DESCRIPTION
Otherwise facts corresponding to extensions that aren't up-to-date in Skyframe after the command (for example, because they haven't been requested) will be dropped.

Fixes #27730 