### PR TITLE
Deprecate `--incompatible_repo_env_ignores_action_env`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -467,9 +467,6 @@ public abstract class CoreOptions extends FragmentOptions implements Cloneable {
           `=name`, which unsets the variable of that name. This option can be used
           multiple times; for options given for the same variable, the latest wins,
           options for different variables accumulate.
-
-          Note that unless `--incompatible_repo_env_ignores_action_env` is true, all `name=value`
-          pairs will be available to repository rules.
           """)
   public abstract List<EnvVar> getActionEnvironment();
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -1515,6 +1515,16 @@ public final class BazelRulesModule extends BlazeModule {
 
     @Deprecated
     @Option(
+        name = "incompatible_repo_env_ignores_action_env",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.DEPRECATED},
+        help = "No-op.")
+    public abstract boolean getRepoEnvIgnoresActionEnv();
+
+    @Deprecated
+    @Option(
         name = "proto_toolchain_for_j2objc",
         defaultValue = "null",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -350,35 +350,16 @@ public class CommandEnvironment {
                 : clientEnv);
     var nonstrictRepoEnvBuilder = new TreeMap<>(clientEnv);
 
-    // TODO: This only needs to check for loads() rather than analyzes() due to
-    //  the effect of --action_env on the repository env. Revert back to
-    //  analyzes() when --action_env no longer affects it.
-    if (command.buildPhase().loads() || command.name().equals("info")) {
+    if (command.buildPhase().analyzes() || command.name().equals("info")) {
       // Compute the set of environment variables that are allowlisted on the commandline
       // for inheritance.
       for (var envVar : options.getOptions(CoreOptions.class).getActionEnvironment()) {
         switch (envVar) {
-          case EnvVar.Set(String name, String value) -> {
-            visibleActionEnv.remove(name);
-            if (!options.getOptions(CommonCommandOptions.class).getRepoEnvIgnoresActionEnv()) {
-              repoEnvBuilder.put(name, value);
-              nonstrictRepoEnvBuilder.put(name, value);
-            }
-          }
-          case EnvVar.Inherit(String name) -> {
-            visibleActionEnv.add(name);
-          }
-          case EnvVar.Unset(String name) -> {
-            visibleActionEnv.remove(name);
-            if (!options.getOptions(CommonCommandOptions.class).getRepoEnvIgnoresActionEnv()) {
-              repoEnvBuilder.remove(name);
-              nonstrictRepoEnvBuilder.remove(name);
-            }
-          }
+          case EnvVar.Set(String name, String unusedValue) -> visibleActionEnv.remove(name);
+          case EnvVar.Inherit(String name) -> visibleActionEnv.add(name);
+          case EnvVar.Unset(String name) -> visibleActionEnv.remove(name);
         }
       }
-    }
-    if (command.buildPhase().analyzes() || command.name().equals("info")) {
       for (EnvVar envVar : options.getOptions(TestOptions.class).getTestEnvironment()) {
         if (envVar instanceof EnvVar.Inherit(String name)) {
           visibleTestEnv.add(name);
@@ -1011,8 +992,6 @@ public class CommandEnvironment {
    *   <li>the client environment as the base;
    *   <li>if {@code --experimental_strict_repo_env} is set, only the variables {@code PATH} and, on
    *       Windows only, {@code PATHEXT} are kept;
-   *   <li>if {@code --noincompatible_repo_env_ignores_action_env} is set, {@code --action_env} is
-   *       applied on top of that;
    *   <li>finally, {@code --repo_env} is applied on top of that.
    * </ul>
    */
@@ -1027,8 +1006,6 @@ public class CommandEnvironment {
    *
    * <ul>
    *   <li>the client environment as the base;
-   *   <li>if {@code --noincompatible_repo_env_ignores_action_env} is set, {@code --action_env} is
-   *       applied on top of that;
    *   <li>finally, {@code --repo_env} is applied on top of that.
    * </ul>
    *

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -629,19 +629,6 @@ public abstract class CommonCommandOptions extends OptionsBase {
   public abstract List<EnvVar> getRepositoryEnvironment();
 
   @Option(
-      name = "incompatible_repo_env_ignores_action_env",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          """
-          If true, `--action_env=NAME=VALUE` will no longer affect repository rule \
-          and module extension environments.
-          """)
-  public abstract boolean getRepoEnvIgnoresActionEnv();
-
-  @Option(
       name = "experimental_strict_repo_env",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
@@ -651,9 +638,6 @@ public abstract class CommonCommandOptions extends OptionsBase {
           """
           If true, repository rules and module extensions will only inherit `PATH`, `PATHEXT`
           (on Windows), and environment variables explicitly specified by `--repo_env`.
-
-          Note that unless `--incompatible_repo_env_ignores_action_env` is true,
-          `--action_env=NAME=VALUE` will also be included.
           """)
   public abstract boolean getUseStrictRepoEnv();
 

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -2948,7 +2948,6 @@ dummy_repository = use_repo_rule('//:repo.bzl', 'dummy_repository')
 dummy_repository(name = 'foo', build_file = '@@//:BUILD.dummy')
 EOF
 
-  add_to_bazelrc "common --incompatible_repo_env_ignores_action_env"
   add_to_bazelrc "common --experimental_strict_repo_env"
 
   bazel query @foo//:BUILD 2>$TEST_log || fail 'Expected query to succeed'
@@ -2986,7 +2985,6 @@ dummy_repository = use_repo_rule('//:repo.bzl', 'dummy_repository')
 dummy_repository(name = 'foo', build_file = '@@//:BUILD.dummy')
 EOF
 
-  add_to_bazelrc "common --incompatible_repo_env_ignores_action_env"
   add_to_bazelrc "common --noexperimental_strict_repo_env"
 
   bazel query @foo//:BUILD 2>$TEST_log || fail 'Expected query to succeed'
@@ -3012,47 +3010,6 @@ EOF
   PREDECLARED_KEY=val5 MY_VAR=val6 bazel query --action_env=PREDECLARED_KEY=val3 --action_env=MY_VAR=val4 @foo//:BUILD 2>$TEST_log || fail 'Expected query to succeed'
   expect_log "PREDECLARED_KEY=val5"
   expect_log "MY_VAR=val6"
-}
-
-function test_environ_incrementally_without_client_env_with_action_env() {
-  cat > repo.bzl <<EOF
-def _impl(rctx):
-  rctx.symlink(rctx.attr.build_file, 'BUILD')
-  print('PREDECLARED_KEY=%s' % rctx.os.environ.get('PREDECLARED_KEY'))
-  print('MY_VAR=%s' % rctx.getenv('MY_VAR'))
-dummy_repository = repository_rule(
-  implementation = _impl,
-  attrs = {'build_file': attr.label()},
-  environ = ['PREDECLARED_KEY'],
-)
-EOF
-  cat > BUILD.dummy <<EOF
-filegroup(name='dummy', srcs=['BUILD'])
-EOF
-  touch BUILD
-  cat > $(setup_module_dot_bazel) <<EOF
-dummy_repository = use_repo_rule('//:repo.bzl', 'dummy_repository')
-dummy_repository(name = 'foo', build_file = '@@//:BUILD.dummy')
-EOF
-
-  add_to_bazelrc "common --noincompatible_repo_env_ignores_action_env"
-  add_to_bazelrc "common --experimental_strict_repo_env"
-
-  bazel query @foo//:BUILD 2>$TEST_log || fail 'Expected query to succeed'
-  expect_log "PREDECLARED_KEY=None"
-  expect_log "MY_VAR=None"
-
-  PREDECLARED_KEY=val1 MY_VAR=val2 bazel query @foo//:BUILD 2>$TEST_log || fail 'Expected query to succeed'
-  expect_not_log "PREDECLARED_KEY"
-  expect_not_log "MY_VAR"
-
-  PREDECLARED_KEY=val1 MY_VAR=val2 bazel query --action_env=PREDECLARED_KEY=val3 @foo//:BUILD 2>$TEST_log || fail 'Expected query to succeed'
-  expect_log "PREDECLARED_KEY=val3"
-  expect_log "MY_VAR=None"
-
-  PREDECLARED_KEY=val1 MY_VAR=val2 bazel query --action_env=PREDECLARED_KEY=val3 --action_env=MY_VAR=val4 @foo//:BUILD 2>$TEST_log || fail 'Expected query to succeed'
-  expect_log "PREDECLARED_KEY=val3"
-  expect_log "MY_VAR=val4"
 }
 
 function test_environ_build_query_build() {

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -580,37 +580,6 @@ function environ_invalidation_test_template() {
   assert_equals 6 $(cat "${execution_file}")
 }
 
-function environ_invalidation_action_env_test_template() {
-  local startup_flag="${1-}"
-  local command_flag="--noincompatible_repo_env_ignores_action_env"
-  setup_starlark_repository
-
-  # We use a counter to avoid other invalidation to hide repository
-  # invalidation (e.g., --action_env=K=V will cause all repositories to re-run).
-  local execution_file="$(setup_invalidation_test)"
-
-  # Set to FOO=BAZ BAR=FOO
-  FOO=BAZ BAR=FOO bazel ${startup_flag} build "${command_flag}" @foo//:bar >& $TEST_log \
-      || fail "Failed to build"
-  expect_log "<1> FOO=BAZ BAR=FOO BAZ=undefined"
-  assert_equals 1 $(cat "${execution_file}")
-
-  # Test with changing using --action_env
-  bazel ${startup_flag} build "${command_flag}" \
-      --action_env FOO=BAZ --action_env BAR=FOO  --action_env BEZ=BAR \
-      @foo//:bar >& $TEST_log || fail "Failed to build"
-  assert_equals 1 $(cat "${execution_file}")
-  bazel ${startup_flag} build "${command_flag}" \
-      --action_env FOO=BAZ --action_env BAR=FOO --action_env BAZ=BAR \
-      @foo//:bar >& $TEST_log || fail "Failed to build"
-  assert_equals 1 $(cat "${execution_file}")
-  bazel ${startup_flag} build "${command_flag}" \
-      --action_env FOO=BAR --action_env BAR=FOO --action_env BAZ=BAR \
-      @foo//:bar >& $TEST_log || fail "Failed to build"
-  expect_log "<2> FOO=BAR BAR=FOO BAZ=BAR"
-  assert_equals 2 $(cat "${execution_file}")
-}
-
 function test_starlark_repository_environ_invalidation() {
   environ_invalidation_test_template
 }
@@ -618,14 +587,6 @@ function test_starlark_repository_environ_invalidation() {
 # Same test as previous but with server restart between each invocation
 function test_starlark_repository_environ_invalidation_batch() {
   environ_invalidation_test_template --batch
-}
-
-function test_starlark_repository_environ_invalidation_action_env() {
-  environ_invalidation_action_env_test_template
-}
-
-function test_starlark_repository_environ_invalidation_action_env_batch() {
-  environ_invalidation_action_env_test_template --batch
 }
 
 # Regression test for the repository environment being a single whole-map Skyframe
@@ -3097,94 +3058,6 @@ EOF
   CLIENT_ENV_PRESENT=value1 CLIENT_ENV_REMOVED=value2 \
    bazel build \
     --repo_env=REPO_ENV_PRESENT=value3 --repo_env=REPO_ENV_REMOVED=value4 \
-    @repo//... &> $TEST_log || fail "expected Bazel to succeed"
-}
-
-function test_execute_environment_repo_env_ignores_action_env_off() {
-  cat >> $(setup_module_dot_bazel)  <<'EOF'
-my_repo = use_repo_rule("//:repo.bzl", "my_repo")
-my_repo(name="repo")
-EOF
-  touch BUILD
-  cat > repo.bzl <<'EOF'
-def _impl(ctx):
-  st = ctx.execute(
-    ["env"],
-  )
-  if st.return_code:
-    fail("Command did not succeed")
-  vars = {line.partition("=")[0]: line.partition("=")[-1] for line in st.stdout.strip().split("\n")}
-  if vars.get("ACTION_ENV_PRESENT") != "value1":
-    fail("ACTION_ENV_PRESENT has wrong value: " + vars.get("ACTION_ENV_PRESENT"))
-  ctx.file("BUILD", "exports_files(['data.txt'])")
-my_repo = repository_rule(_impl)
-EOF
-
-  bazel build \
-    --noincompatible_repo_env_ignores_action_env \
-    --action_env=ACTION_ENV_PRESENT=value1 \
-    @repo//... &> $TEST_log || fail "expected Bazel to succeed"
-}
-
-function test_execute_environment_repo_env_ignores_action_env_on() {
-  cat >> $(setup_module_dot_bazel)  <<'EOF'
-my_repo = use_repo_rule("//:repo.bzl", "my_repo")
-my_repo(name="repo")
-EOF
-  touch BUILD
-  cat > repo.bzl <<'EOF'
-def _impl(ctx):
-  st = ctx.execute(
-    ["env"],
-  )
-  if st.return_code:
-    fail("Command did not succeed")
-  vars = {line.partition("=")[0]: line.partition("=")[-1] for line in st.stdout.strip().split("\n")}
-  if "ACTION_ENV_REMOVED" in vars:
-    fail("ACTION_ENV_REMOVED should not be in the environment")
-  ctx.file("BUILD", "exports_files(['data.txt'])")
-my_repo = repository_rule(_impl)
-EOF
-
-  bazel build \
-    --incompatible_repo_env_ignores_action_env \
-    --action_env=ACTION_ENV_REMOVED=value1 \
-    @repo//... &> $TEST_log || fail "expected Bazel to succeed"
-}
-
-function test_execute_environment_strict_vars() {
-  cat >> $(setup_module_dot_bazel)  <<'EOF'
-my_repo = use_repo_rule("//:repo.bzl", "my_repo")
-my_repo(name="repo")
-EOF
-  touch BUILD
-  cat > repo.bzl <<'EOF'
-def _impl(ctx):
-  st = ctx.execute(
-    ["env"],
-  )
-  if st.return_code:
-    fail("Command did not succeed")
-  vars = {line.partition("=")[0]: line.partition("=")[-1] for line in st.stdout.strip().split("\n")}
-  if vars.get("CLIENT_ENV_PRESENT") != "value1":
-    fail("CLIENT_ENV_PRESENT has wrong value: " + vars.get("CLIENT_ENV_PRESENT"))
-  if "CLIENT_ENV_REMOVED" in vars:
-    fail("CLIENT_ENV_REMOVED should not be in the environment")
-  if vars.get("REPO_ENV_PRESENT") != "value3":
-    fail("REPO_ENV_PRESENT has wrong value: " + vars.get("REPO_ENV_PRESENT"))
-  if "PATH" not in vars:
-    fail("PATH should be in the environment")
-  if ctx.os.name.startswith("windows") and "PATHEXT" not in vars:
-    fail("PATHEXT should be in the environment (on Windows)")
-  ctx.file("BUILD", "exports_files(['data.txt'])")
-my_repo = repository_rule(_impl)
-EOF
-
-  CLIENT_ENV_PRESENT=value1 CLIENT_ENV_REMOVED=value2 PATHEXT=".COM;.EXE;.BAT;.CMD;"\
-  bazel build \
-    --experimental_strict_repo_env \
-    --repo_env=CLIENT_ENV_PRESENT \
-    --repo_env=REPO_ENV_PRESENT=value3 \
     @repo//... &> $TEST_log || fail "expected Bazel to succeed"
 }
 


### PR DESCRIPTION
This is enabled by default in Bazel v9.

Closes #26222.