### PR TITLE
[8.5.0] Preserve facts present in the lockfile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -119,6 +119,7 @@ public class BazelLockFileModule extends BlazeModule {
     var newExtensionInfos =
         new HashMap<ModuleExtensionId, LockFileModuleExtension.WithFactors>(numExtensions);
     var combinedFacts = new HashMap<ModuleExtensionId, Facts>(numExtensions);
+    combinedFacts.putAll(oldLockfile.getFacts());
     var doneValues = evaluator.getDoneValues();
     for (var extensionId : depGraphValue.getExtensionUsagesTable().rowKeySet()) {
       if (extensionId.isInnate()) {

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -2906,6 +2906,20 @@ class BazelLockfileTest(test_base.TestBase):
     with open(self.Path('MODULE.bazel.lock'), 'r') as f:
       self.assertEqual(lockfile_contents, f.read())
 
+    # Verify that the facts remain after a bazel shutdown followed by a build
+    # that doesn't trigger the extension evaluation.
+    # Regression test for https://github.com/bazelbuild/bazel/issues/27730
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(['info'])
+    stderr = ''.join(stderr)
+    self.assertNotIn('Hello from this side!', stderr)
+    self.assertNotIn('Fetching metadata for hello...', stderr)
+    self.assertNotIn('hello: hash=olleh', stderr)
+    self.assertNotIn('Fetching metadata for world...', stderr)
+    self.assertNotIn('world: hash=dlrow', stderr)
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      self.assertEqual(lockfile_contents, f.read())
+
     # Clean out the hidden lockfile to ensure that the extension is
     # evaluated again and verify that the reevaluation reuses the facts.
     _, _, stderr = self.RunBazel(['clean', '--expunge'])


### PR DESCRIPTION
Otherwise facts corresponding to extensions that aren't up-to-date in Skyframe after the command (for example, because they haven't been requested) will be dropped.

Fixes #27730

Closes #27744.

PiperOrigin-RevId: 834878573
Change-Id: I828af6b59dc61c42f1e8971843be3a6ed1ac9fe0

Commit https://github.com/bazelbuild/bazel/commit/ade92cfc266dbc12e8f3fda5767394477fc1c8f1