### PR TITLE
[9.0.0] Add `isinstance` keyword, and allow isinstance(x,t) to be parsed - but not resolved

### DIFF
--- a/src/main/java/net/starlark/java/eval/Eval.java
+++ b/src/main/java/net/starlark/java/eval/Eval.java
@@ -562,6 +562,9 @@ final class Eval {
         return evalCall(fr, (CallExpression) expr);
       case CAST:
         return eval(fr, ((CastExpression) expr).getValue());
+      case ISINSTANCE:
+        fr.setErrorLocation(expr.getStartLocation());
+        throw new EvalException("isinstance() is not yet supported");
       case IDENTIFIER:
         return evalIdentifier(fr, (Identifier) expr);
       case INDEX:

--- a/src/main/java/net/starlark/java/syntax/BUILD
+++ b/src/main/java/net/starlark/java/syntax/BUILD
@@ -41,6 +41,7 @@ java_library(
         "IfStatement.java",
         "IndexExpression.java",
         "IntLiteral.java",
+        "IsInstanceExpression.java",
         "LambdaExpression.java",
         "Lexer.java",
         "ListExpression.java",

--- a/src/main/java/net/starlark/java/syntax/Expression.java
+++ b/src/main/java/net/starlark/java/syntax/Expression.java
@@ -41,6 +41,7 @@ public abstract class Expression extends Node {
     IDENTIFIER,
     INDEX,
     INT_LITERAL,
+    ISINSTANCE,
     LAMBDA,
     LIST_EXPR,
     SLICE,

--- a/src/main/java/net/starlark/java/syntax/IsInstanceExpression.java
+++ b/src/main/java/net/starlark/java/syntax/IsInstanceExpression.java
@@ -1,0 +1,66 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net.starlark.java.syntax;
+
+/** Syntax node for isinstance() expressions. */
+public final class IsInstanceExpression extends Expression {
+  private final int startOffset;
+  private final Expression value;
+  private final Expression type;
+  private final int rparenOffset;
+
+  IsInstanceExpression(
+      FileLocations locs, int startOffset, Expression value, Expression type, int rparenOffset) {
+    super(locs, Kind.ISINSTANCE);
+    this.startOffset = startOffset;
+    this.value = value;
+    this.type = type;
+    this.rparenOffset = rparenOffset;
+  }
+
+  @Override
+  public int getStartOffset() {
+    return startOffset;
+  }
+
+  @Override
+  public int getEndOffset() {
+    return rparenOffset + 1;
+  }
+
+  public Expression getValue() {
+    return value;
+  }
+
+  public Expression getType() {
+    return type;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buf = new StringBuilder();
+    buf.append("isinstance(");
+    buf.append(value);
+    buf.append(", ");
+    buf.append(type);
+    buf.append(')');
+    return buf.toString();
+  }
+
+  @Override
+  public void accept(NodeVisitor visitor) {
+    visitor.visit(this);
+  }
+}

--- a/src/main/java/net/starlark/java/syntax/NodePrinter.java
+++ b/src/main/java/net/starlark/java/syntax/NodePrinter.java
@@ -405,9 +405,9 @@ final class NodePrinter {
         {
           CastExpression cast = (CastExpression) expr;
           buf.append("cast(");
-          printExpr(cast.getType());
+          printExpr(cast.getType(), /* canSkipParenthesis= */ true);
           buf.append(", ");
-          printExpr(cast.getValue());
+          printExpr(cast.getValue(), /* canSkipParenthesis= */ true);
           buf.append(')');
           break;
         }
@@ -435,6 +435,17 @@ final class NodePrinter {
       case INT_LITERAL:
         {
           buf.append(((IntLiteral) expr).getValue());
+          break;
+        }
+
+      case ISINSTANCE:
+        {
+          IsInstanceExpression isinstance = (IsInstanceExpression) expr;
+          buf.append("isinstance(");
+          printExpr(isinstance.getValue(), /* canSkipParenthesis= */ true);
+          buf.append(", ");
+          printExpr(isinstance.getType(), /* canSkipParenthesis= */ true);
+          buf.append(')');
           break;
         }
 

--- a/src/main/java/net/starlark/java/syntax/NodeVisitor.java
+++ b/src/main/java/net/starlark/java/syntax/NodeVisitor.java
@@ -58,6 +58,10 @@ public class NodeVisitor {
     visit(node.getValue());
   }
 
+  public void visit(IsInstanceExpression node) {
+    visit(node.getValue());
+  }
+
   public void visit(Ellipsis node) {}
 
   public void visit(Identifier node) {}

--- a/src/main/java/net/starlark/java/syntax/Parser.java
+++ b/src/main/java/net/starlark/java/syntax/Parser.java
@@ -569,6 +569,21 @@ final class Parser {
     return new CastExpression(locs, startOffset, typeExpr, valueExpr, rparenOffset);
   }
 
+  // isinstance_expression = 'isinstance' '(' expr ',' TypeExpr [','] ')'
+  private Expression parseIsInstanceExpression() {
+    checkAllowTypeSyntax(token.start, token.kind, token.value);
+    int startOffset = expect(TokenKind.ISINSTANCE);
+    expect(TokenKind.LPAREN);
+    Expression valueExpr = parseTest();
+    expect(TokenKind.COMMA);
+    Expression typeExpr = parseTypeExprWithFallback();
+    if (token.kind == TokenKind.COMMA) {
+      expect(TokenKind.COMMA);
+    }
+    int rparenOffset = expect(TokenKind.RPAREN);
+    return new IsInstanceExpression(locs, startOffset, valueExpr, typeExpr, rparenOffset);
+  }
+
   // Parse a list of call arguments.
   //
   // arg_list = ( (arg ',')* arg ','? )?
@@ -753,6 +768,9 @@ final class Parser {
 
       case CAST:
         return parseCastExpression();
+
+      case ISINSTANCE:
+        return parseIsInstanceExpression();
 
       case ELLIPSIS:
         if (!insideTypeExpr) {

--- a/src/main/java/net/starlark/java/syntax/Resolver.java
+++ b/src/main/java/net/starlark/java/syntax/Resolver.java
@@ -805,6 +805,14 @@ public final class Resolver extends NodeVisitor {
   }
 
   @Override
+  public void visit(IsInstanceExpression node) {
+    // TODO(b/350661266): restrict the types that can be used on the RHS of isinstance(); e.g.
+    // `list` or `list | tuple` (or aliases resolving to those!) are allowed, but `list[int]` isn't,
+    // since a list can subsequently be mutated to add a non-int element.
+    errorf(node, "isinstance() is not yet supported");
+  }
+
+  @Override
   public void visit(TypeAliasStatement node) {
     if (!(locals.syntax instanceof StarlarkFile)) {
       errorf(node, "type alias statement not at top level");

--- a/src/main/java/net/starlark/java/syntax/TokenKind.java
+++ b/src/main/java/net/starlark/java/syntax/TokenKind.java
@@ -68,6 +68,8 @@ public enum TokenKind {
   INDENT("indent"),
   INT("integer literal"),
   IS("is"),
+  /** Emitted only if --experimental_starlark_type_syntax is enabled. */
+  ISINSTANCE("isinstance"),
   LAMBDA("lambda"),
   LBRACE("{"),
   LBRACKET("["),

--- a/src/test/java/net/starlark/java/eval/EvaluationTest.java
+++ b/src/test/java/net/starlark/java/eval/EvaluationTest.java
@@ -907,4 +907,11 @@ public final class EvaluationTest {
         .testEval("y", "\"this is not an int\"")
         .testEval("z", "42");
   }
+
+  // TODO(b/350661266): resolve types in isinstance().
+  @Test
+  public void isinstanceExpression_notYetSupported() throws Exception {
+    ev.setFileOptions(FileOptions.builder().allowTypeSyntax(true).build());
+    ev.new Scenario().testIfExactError("isinstance() is not yet supported", "isinstance(x, list)");
+  }
 }

--- a/src/test/java/net/starlark/java/syntax/NodePrinterTest.java
+++ b/src/test/java/net/starlark/java/syntax/NodePrinterTest.java
@@ -405,8 +405,15 @@ public final class NodePrinterTest {
   @Test
   public void castExpression() throws SyntaxError.Exception {
     setFileOptions(FileOptions.builder().allowTypeSyntax(true).build());
-    assertExprPrettyMatches("cast(list[int],foo())", "cast(list[int], foo())");
+    assertExprPrettyMatches("cast(list[int]|str,x+y)", "cast(list[int] | str, x + y)");
     assertExprTostringMatches("cast(set|None,bar(),)", "cast(set | None, bar())");
+  }
+
+  @Test
+  public void isinstanceExpression() throws SyntaxError.Exception {
+    setFileOptions(FileOptions.builder().allowTypeSyntax(true).build());
+    assertExprPrettyMatches("isinstance(x+y, list|tuple)", "isinstance(x + y, list | tuple)");
+    assertExprTostringMatches("isinstance(foo(), T[U],)", "isinstance(foo(), T[U])");
   }
 
   @Test

--- a/src/test/java/net/starlark/java/syntax/ResolverTest.java
+++ b/src/test/java/net/starlark/java/syntax/ResolverTest.java
@@ -794,6 +794,15 @@ public class ResolverTest {
     assertThat(badFile.ok()).isTrue();
   }
 
+  // TODO(b/350661266): resolve types in isinstance().
+  @Test
+  public void testIsInstanceExpression_notYetSupported() throws Exception {
+    options.allowTypeSyntax(true);
+    StarlarkFile badFile = resolveFile("isinstance(x, list)");
+    assertThat(badFile.ok()).isFalse();
+    assertContainsError(badFile.errors(), "isinstance() is not yet supported");
+  }
+
   // checkBindings verifies the binding (scope and index) of each identifier.
   // Every variable must be followed by a superscript letter (its scope)
   // and a subscript numeral (its index). They are replaced by spaces, the


### PR DESCRIPTION
Note that we parse arbitrary type expressions on the RHS of isinstance, but will be planning to limit the allowed types when resolving (in a follow-up). Consider, for example, something like isinstance(x, list[int]) - we cannot allow it because x may subsequently get a non-int element added to it. By contrast, we may want to allow e.g. `isinstance(f, Callable[[str], bool])` to test if f is a predicate on a string (note that Python doesn't, but in Python this is an eval-time error, not a syntax error). And further consider the possibility of `isinstance(x, T)` - where `T` is a type alias (and which might well be an alias for something we don't want to allow). So we cannot take the simple path of syntactically allowing only identifiers.

Also make a drive-by fix to `cast()`'s pretty-printer.

Working towards #27372 and isinstance().

PiperOrigin-RevId: 829638719
Change-Id: Iad1c4307fb4da262031b5e664f846662a081c210