### PR TITLE
Add Pyink formatting config to Bazel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+# Python files in this repo are formatted with https://github.com/google/pyink.
+[tool.pyink]
+line-length = 80
+unstable = true
+target-version = []
+pyink-indentation = 2
+pyink-use-majority-quotes = true
+pyink-annotation-pragmas = [
+  "noqa",
+  "pylint:",
+  "type: ignore",
+  "pytype:",
+  "mypy:",
+  "pyright:",
+  "pyre-",
+]


### PR DESCRIPTION
This allows contributors to properly format Python code.