### PR TITLE
Add devcontainer for local development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+    "name": "Bazel Development Environment",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+    "mounts": [
+        "source=bazel-cache,target=/home/vscode/.cache/bazel,type=volume",
+        "source=bazelisk-cache,target=/home/vscode/.cache/bazelisk,type=volume"
+    ],
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "configureZshAsDefaultShell": true
+            // Get your own dotfiles configured with
+            // https://code.visualstudio.com/docs/devcontainers/containers#_personalizing-with-dotfile-repositories
+        },
+        "ghcr.io/devcontainers/features/git:1": {},
+        "ghcr.io/devcontainers-community/features/bazel:1": {
+            "bazelisk_version": "v1.27.0",
+            "buildifier_version": "v8.2.1"
+        },
+        "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+            "upgradePackages": true,
+            "packages": [
+                "build-essential",
+                "openjdk-21-jdk",
+                "python3",
+                "zip",
+                "unzip"
+            ]
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "BazelBuild.vscode-bazel",
+                "eamodio.gitlens"
+            ]
+        }
+    }
+}

--- a/src/test/shell/bazel/list_source_repository.bzl
+++ b/src/test/shell/bazel/list_source_repository.bzl
@@ -41,7 +41,7 @@ genrule(
   visibility = ["//visibility:public"],
   cmd = " | ".join([
     "cat $<",
-    "grep -Ev '^(\\\\.git|.ijwb|out/|output/|bazel-|derived|tools/defaults/BUILD)'",
+    "grep -Ev '^(\\\\.git|\\\\.devcontainer|.ijwb|out/|output/|bazel-|derived|tools/defaults/BUILD)'",
     "grep -Ev '%s'",
     "sort -u > $@",
   ]),


### PR DESCRIPTION
https://bazel.build/install/compile-source#bootstrap-unix-overview mentions a few dependencies developers need to install to build bazel from source. This devcontainer provides an alternative devenvironment in case someone does not want to install this on their system or just to to get started.

Also, this should allow users to work in github codespaces.