### PR TITLE
[9.0.0] Revert "Enable --enable_platform_specific_config by default"

### DIFF
--- a/docs/run/bazelrc.mdx
+++ b/docs/run/bazelrc.mdx
@@ -211,15 +211,12 @@ This syntax does not extend to the use of `startup` to set
 
 #### `--enable_platform_specific_config` {:#enable_platform_specific_config}
 
-In the `.bazelrc` you can use platform specific configs that will be
-automatically enabled based on the host OS. For example, if the host OS
-is Linux and the `build` command is run, the `build:linux` configuration
-will be automatically enabled. Supported OS identifiers are `linux`,
-`macos`, `windows`, `freebsd`, and `openbsd`.
-
-This is equivalent to using `--config=linux` on Linux,
-`--config=windows` on Windows, and so on. This can be disabled with
-`--enable_platform_specific_config=false`.
+Platform specific configs in the `.bazelrc` can be automatically enabled using
+`--enable_platform_specific_config`. For example, if the host OS is Linux and
+the `build` command is run, the `build:linux` configuration will be
+automatically enabled. Supported OS identifiers are `linux`, `macos`, `windows`,
+`freebsd`, and `openbsd`. Enabling this flag is equivalent to using
+`--config=linux` on Linux, `--config=windows` on Windows, and so on.
 
 See [--enable_platform_specific_config](/reference/command-line-reference#flag--enable_platform_specific_config).
 

--- a/site/en/run/bazelrc.md
+++ b/site/en/run/bazelrc.md
@@ -215,15 +215,13 @@ This syntax does not extend to the use of `startup` to set
 
 #### `--enable_platform_specific_config` {:#enable_platform_specific_config}
 
-In the `.bazelrc` you can use platform specific configs that will be
-automatically enabled based on the host OS. For example, if the host OS
-is Linux and the `build` command is run, the `build:linux` configuration
-will be automatically enabled. Supported OS identifiers are `linux`,
-`macos`, `windows`, `freebsd`, and `openbsd`.
-
-This is equivalent to using `--config=linux` on Linux,
-`--config=windows` on Windows, and so on. This can be disabled with
-`--enable_platform_specific_config=false`.
+Platform specific configs in the `.bazelrc` can be automatically enabled using
+`--enable_platform_specific_config`. For example, if the host OS is Linux and
+the `build` command is run, the `build:linux` configuration will be
+automatically enabled. Supported OS identifiers are `linux`, `macos`, `windows`,
+`freebsd`, and `openbsd`. Enabling this flag is equivalent to using
+`--config=linux` on Linux, `--config=windows` on Windows, `--config=macos` on
+macOS, `--config=freebsd` on FreeBSD, and `--config=openbsd` on OpenBSD.
 
 See [--enable_platform_specific_config](/reference/command-line-reference#flag--enable_platform_specific_config).
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -47,7 +47,7 @@ public class CommonCommandOptions extends OptionsBase {
   // value during options parsing based on its (string) name.
   @Option(
       name = "enable_platform_specific_config",
-      defaultValue = "true",
+      defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =

--- a/src/main/java/com/google/devtools/build/lib/runtime/ConfigExpander.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/ConfigExpander.java
@@ -64,7 +64,8 @@ final class ConfigExpander {
       OptionValueDescription enablePlatformSpecificConfigDescription,
       ListMultimap<String, RcChunkOfArgs> commandToRcArgs,
       List<String> commandsToParse) {
-    if (!(boolean) enablePlatformSpecificConfigDescription.getValue()) {
+    if (enablePlatformSpecificConfigDescription == null
+        || !(boolean) enablePlatformSpecificConfigDescription.getValue()) {
       return false;
     }
 
@@ -132,11 +133,6 @@ final class ConfigExpander {
 
     OptionValueDescription enablePlatformSpecificConfigDescription =
         optionsParser.getOptionValueDescription("enable_platform_specific_config");
-    if (enablePlatformSpecificConfigDescription == null) {
-      optionsParser.parse("--enable_platform_specific_config=true");
-      enablePlatformSpecificConfigDescription =
-          optionsParser.getOptionValueDescription("enable_platform_specific_config");
-    }
     if (shouldEnablePlatformSpecificConfig(
         enablePlatformSpecificConfigDescription, commandToRcArgs, commandsToParse)) {
       var expansion =

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
@@ -126,9 +126,6 @@ public class BlazeOptionHandlerTest {
     structuredArgs.put(
         "build:platform_config",
         new RcChunkOfArgs("rc1", ImmutableList.of("--enable_platform_specific_config")));
-    structuredArgs.put(
-        "build:platform_config_disabled",
-        new RcChunkOfArgs("rc1", ImmutableList.of("--enable_platform_specific_config=false")));
     return structuredArgs;
   }
 
@@ -328,14 +325,6 @@ public class BlazeOptionHandlerTest {
   }
 
   @Test
-  public void testExpandConfigOptions_withPlatformSpecificConfigDisabledInConfig()
-      throws Exception {
-    parser.parse("--config=platform_config_disabled");
-    optionHandler.expandConfigOptions(eventHandler, structuredArgsForDifferentPlatforms());
-    assertThat(parser.getResidue()).isEmpty();
-  }
-
-  @Test
   public void testExpandConfigOptions_withPlatformSpecificConfigEnabledWhenNothingSpecified()
       throws Exception {
     parser.parse("--enable_platform_specific_config");
@@ -405,8 +394,7 @@ public class BlazeOptionHandlerTest {
             "--config=config2a",
             "--config=config2b",
             "--test_multiple_string=5",
-            "--test_multiple_string=6",
-            "--enable_platform_specific_config")
+            "--test_multiple_string=6")
         .inOrder();
     assertThat(
             parser.asCompleteListOfParsedOptions().stream()
@@ -422,8 +410,7 @@ public class BlazeOptionHandlerTest {
             "--config=config2a",
             "--config=config2b",
             "--test_multiple_string=5",
-            "--test_multiple_string=6",
-            "--enable_platform_specific_config")
+            "--test_multiple_string=6")
         .inOrder();
   }
 


### PR DESCRIPTION
Reverting until we can fix
https://github.com/bazelbuild/bazel/issues/27063 with this change

This reverts commit 93f57a42389eb3bfe3335e3b1f9fd186e6ddae47.

Closes #27467.

PiperOrigin-RevId: 836253690
Change-Id: I40358d8e8263d669e0f11d964f70e5eef5824bab

Commit https://github.com/bazelbuild/bazel/commit/7a7d94c476148c2d583e82a3c1e0771eccb096dc