### PR TITLE
[8.5.0] Fix updating of action results with a disk cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -308,7 +308,9 @@ public class DiskCacheClient {
   public void saveFile(Digest digest, Store store, InputStream in) throws IOException {
     Path path = toPath(digest, store);
 
-    if (refresh(path)) {
+    // CAS entries are content-addressed and thus automatically have the correct content if they
+    // exist.
+    if (store == Store.CAS && refresh(path)) {
       return;
     }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
@@ -191,18 +191,16 @@ public class DiskCacheClientTest {
   }
 
   @Test
-  public void uploadActionResult_whenPresent_updatesMtime() throws Exception {
+  public void uploadActionResult_whenPresent_updatesContent() throws Exception {
     ActionKey actionKey = new ActionKey(getDigest("key"));
-    ActionResult actionResult = ActionResult.newBuilder().setExitCode(42).build();
+    ActionResult actionResult1 = ActionResult.newBuilder().setExitCode(42).build();
 
-    Path path = populateAc(actionKey, actionResult);
+    Path path = populateAc(actionKey, actionResult1);
 
-    // The contents would match under normal operation. This serves to check that we don't
-    // unnecessarily overwrite the file.
-    var unused =
-        getFromFuture(client.uploadActionResult(actionKey, ActionResult.getDefaultInstance()));
+    ActionResult actionResult2 = ActionResult.newBuilder().setExitCode(43).build();
+    var unused = getFromFuture(client.uploadActionResult(actionKey, actionResult2));
 
-    assertThat(FileSystemUtils.readContent(path)).isEqualTo(actionResult.toByteArray());
+    assertThat(FileSystemUtils.readContent(path)).isEqualTo(actionResult2.toByteArray());
     assertThat(path.getLastModifiedTime()).isNotEqualTo(0);
   }
 


### PR DESCRIPTION
AC entries are not content addressed and thus may change after they have been created.

Closes #27767.

PiperOrigin-RevId: 836566250
Change-Id: If77b0d52c9315d7457e2217c2febc6885b9415bf

Commit https://github.com/bazelbuild/bazel/commit/24d0f85b495e11de04a21093990578fe1c90ad69