### PR TITLE
Don't use the gRPC downloader for `file:` URLs

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -126,6 +126,8 @@
     "https://bcr.bazel.build/modules/googletest/1.17.0.bcr.2/MODULE.bazel": "827f54f492a3ce549c940106d73de332c2b30cebd0c20c0bc5d786aba7f116cb",
     "https://bcr.bazel.build/modules/googletest/1.17.0.bcr.2/source.json": "3664514073a819992320ffbce5825e4238459df344d8b01748af2208f8d2e1eb",
     "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
+    "https://bcr.bazel.build/modules/grpc-java/1.66.0/MODULE.bazel": "86ff26209fac846adb89db11f3714b3dc0090fb2fb81575673cc74880cda4e7e",
+    "https://bcr.bazel.build/modules/grpc-java/1.69.0/MODULE.bazel": "53887af6a00b3b406d70175d3d07e84ea9362016ff55ea90b9185f0227bfaf98",
     "https://bcr.bazel.build/modules/grpc-java/1.71.0/MODULE.bazel": "a0ca84909a119ce24f5966978fdb4ab857bcddb5866b34af2e693fc6648db228",
     "https://bcr.bazel.build/modules/grpc-java/1.71.0/source.json": "aa8c2bf0f67e499c450a2a14a05a588eb852ffb82b9a6864274655271995795f",
     "https://bcr.bazel.build/modules/grpc-proto/0.0.0-20240627-ec30f58/MODULE.bazel": "88de79051e668a04726e9ea94a481ec6f1692086735fd6f488ab908b3b909238",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -867,10 +867,6 @@ public final class RemoteModule extends BlazeModule {
                 ServerCapabilitiesRequirement.NONE);
       }
 
-      Downloader fallbackDownloader = null;
-      if (remoteOptions.remoteDownloaderLocalFallback) {
-        fallbackDownloader = env.getHttpDownloader();
-      }
       remoteDownloader =
           new GrpcRemoteDownloader(
               buildRequestId,
@@ -882,7 +878,8 @@ public final class RemoteModule extends BlazeModule {
               digestUtil.getDigestFunction(),
               remoteOptions,
               verboseFailures,
-              fallbackDownloader);
+              env.getHttpDownloader(),
+              remoteOptions.remoteDownloaderLocalFallback);
       downloaderChannel.release();
       env.getDownloaderDelegate().setDelegate(remoteDownloader);
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -88,7 +88,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -107,6 +106,7 @@ public class GrpcRemoteDownloaderTest {
   private final MutableHandlerRegistry serviceRegistry = new MutableHandlerRegistry();
   private final String fakeServerName = "fake server for " + getClass();
   private final StoredEventHandler eventHandler = new StoredEventHandler();
+  private final RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
   private Server fakeServer;
   private RemoteActionExecutionContext context;
   private ListeningScheduledExecutorService retryService;
@@ -144,12 +144,11 @@ public class GrpcRemoteDownloaderTest {
   }
 
   private GrpcRemoteDownloader newDownloader(RemoteCacheClient cacheClient) throws IOException {
-    return newDownloader(cacheClient, /* fallbackDownloader= */ null);
+    return newDownloader(cacheClient, mock(Downloader.class)/* allowFallback= */ );
   }
 
   private GrpcRemoteDownloader newDownloader(
-      RemoteCacheClient cacheClient, @Nullable Downloader fallbackDownloader) throws IOException {
-    final RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+      RemoteCacheClient cacheClient, Downloader httpDownloader) throws IOException {
     final RemoteRetrier retrier =
         TestUtils.newRemoteRetrier(
             () -> new ExponentialBackoff(remoteOptions),
@@ -182,7 +181,8 @@ public class GrpcRemoteDownloaderTest {
         DIGEST_UTIL.getDigestFunction(),
         remoteOptions,
         /* verboseFailures= */ false,
-        fallbackDownloader);
+        httpDownloader,
+        remoteOptions.remoteDownloaderLocalFallback);
   }
 
   private byte[] downloadBlob(GrpcRemoteDownloader downloader, URL url, Optional<Checksum> checksum)
@@ -252,6 +252,7 @@ public class GrpcRemoteDownloaderTest {
 
   @Test
   public void testDownloadFallback() throws Exception {
+    remoteOptions.remoteDownloaderLocalFallback = true;
     final byte[] content = "example content".getBytes(UTF_8);
     serviceRegistry.addService(
         new FetchImplBase() {
@@ -285,6 +286,39 @@ public class GrpcRemoteDownloaderTest {
         .containsExactly(
             new FetchEvent(
                 "http://example.com/content.txt", FetchId.Downloader.GRPC, /* success= */ false));
+  }
+
+  @Test
+  public void testFileUrl() throws Exception {
+    var fileUrl = new URL("file:///my/local/file");
+    byte[] content = "example content".getBytes(UTF_8);
+    serviceRegistry.addService(
+        new FetchImplBase() {
+          @Override
+          public void fetchBlob(
+              FetchBlobRequest request, StreamObserver<FetchBlobResponse> responseObserver) {
+            responseObserver.onError(new IOException("io error"));
+          }
+        });
+    var cacheClient = new InMemoryCacheClient();
+    var fallbackDownloader = mock(Downloader.class);
+    doAnswer(
+            invocation -> {
+              List<URL> urls = invocation.getArgument(0);
+              if (urls.equals(ImmutableList.of(fileUrl))) {
+                Path output = invocation.getArgument(5);
+                FileSystemUtils.writeContent(output, content);
+              }
+              return null;
+            })
+        .when(fallbackDownloader)
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq("context"));
+    GrpcRemoteDownloader downloader = newDownloader(cacheClient, fallbackDownloader);
+
+    byte[] downloaded = downloadBlob(downloader, fileUrl, Optional.empty());
+
+    assertThat(downloaded).isEqualTo(content);
+    assertThat(eventHandler.getPosts()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
Always use the HTTP downloader in this case as it supports these URLs.

Fixes #26810