### PR TITLE
Fix list comprehension for importing versioned jacoco core jars

### DIFF
--- a/third_party/java/jacoco/BUILD
+++ b/third_party/java/jacoco/BUILD
@@ -77,8 +77,8 @@ distrib_java_import(
     distrib_java_import(
         name = "core-%s" % VERSION,
         enable_distributions = ["debian"],
-        jars = ["org.jacoco.core-%s.jar" % LASTVERSION],
-        srcjar = "org.jacoco.core-%s-sources.jar" % LASTVERSION,
+        jars = ["org.jacoco.core-%s.jar" % VERSION],
+        srcjar = "org.jacoco.core-%s-sources.jar" % VERSION,
         exports = [
             "//third_party:asm",
             "//third_party:asm-commons",


### PR DESCRIPTION
Every import was actually the "latest" version instead of the requested version.

Required for https://github.com/bazelbuild/bazel/issues/26383