### PR TITLE
[9.0.0] Preserve facts present in the lockfile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -119,6 +119,7 @@ public class BazelLockFileModule extends BlazeModule {
     var newExtensionInfos =
         new HashMap<ModuleExtensionId, LockFileModuleExtension.WithFactors>(numExtensions);
     var combinedFacts = new HashMap<ModuleExtensionId, Facts>(numExtensions);
+    combinedFacts.putAll(oldLockfile.getFacts());
     var doneValues = evaluator.getDoneValues();
     for (var extensionId : depGraphValue.getExtensionUsagesTable().rowKeySet()) {
       if (extensionId.isInnate()) {


### PR DESCRIPTION
Otherwise facts corresponding to extensions that aren't up-to-date in Skyframe after the command (for example, because they haven't been requested) will be dropped.

Fixes #27730

Closes #27744.

PiperOrigin-RevId: 834878573
Change-Id: I828af6b59dc61c42f1e8971843be3a6ed1ac9fe0

Commit https://github.com/bazelbuild/bazel/commit/ade92cfc266dbc12e8f3fda5767394477fc1c8f1