### PR TITLE
Add Python first build tutorial (#27824)

### DIFF
--- a/examples/python-tutorial/README.md
+++ b/examples/python-tutorial/README.md
@@ -1,0 +1,81 @@
+# Python Tutorial
+
+This directory contains the example code for the [Bazel Python Tutorial](https://bazel.build/start/python).
+
+## Overview
+
+The tutorial is organized into three stages, each demonstrating increasingly complex Bazel concepts:
+
+- **Stage 1**: A single target in a single package (basic `py_binary`)
+- **Stage 2**: Multiple targets in a single package (`py_binary` + `py_library`)
+- **Stage 3**: Multiple packages with visibility rules
+
+## Prerequisites
+
+- [Bazel](https://bazel.build/install) installed
+- Python 3.11 or later (Bazel will download the toolchain automatically)
+
+## Running the Examples
+
+### Stage 1: Single Target
+
+```bash
+cd stage1
+bazel build //main:hello_world
+bazel-bin/main/hello_world
+```
+
+Or run directly:
+
+```bash
+bazel run //main:hello_world
+```
+
+### Stage 2: Multiple Targets
+
+```bash
+cd stage2
+bazel build //main:hello_world
+bazel run //main:hello_world
+```
+
+### Stage 3: Multiple Packages
+
+```bash
+cd stage3
+bazel build //main:hello_world
+bazel run //main:hello_world
+```
+
+## Directory Structure
+
+```
+python-tutorial/
+├── README.md
+├── stage1/
+│   ├── MODULE.bazel
+│   └── main/
+│       ├── BUILD
+│       └── hello_world.py
+├── stage2/
+│   ├── MODULE.bazel
+│   └── main/
+│       ├── BUILD
+│       ├── greeting.py
+│       └── hello_world.py
+└── stage3/
+    ├── MODULE.bazel
+    ├── lib/
+    │   ├── BUILD
+    │   └── time_utils.py
+    └── main/
+        ├── BUILD
+        ├── greeting.py
+        └── hello_world.py
+```
+
+## Learn More
+
+- [Bazel Python Tutorial](https://bazel.build/start/python)
+- [rules_python Documentation](https://rules-python.readthedocs.io/)
+- [Python Rules Reference](https://bazel.build/reference/be/python)

--- a/examples/python-tutorial/stage1/MODULE.bazel
+++ b/examples/python-tutorial/stage1/MODULE.bazel
@@ -1,0 +1,11 @@
+"""Bazel module for Python tutorial - Stage 1."""
+
+module(
+    name = "python_tutorial_stage1",
+    version = "1.0.0",
+)
+
+bazel_dep(name = "rules_python", version = "1.0.0")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(python_version = "3.11")

--- a/examples/python-tutorial/stage1/main/BUILD
+++ b/examples/python-tutorial/stage1/main/BUILD
@@ -1,0 +1,6 @@
+load("@rules_python//python:py_binary.bzl", "py_binary")
+
+py_binary(
+    name = "hello_world",
+    srcs = ["hello_world.py"],
+)

--- a/examples/python-tutorial/stage1/main/hello_world.py
+++ b/examples/python-tutorial/stage1/main/hello_world.py
@@ -1,0 +1,10 @@
+"""A simple Hello World program."""
+
+
+def main():
+    """Print a greeting message."""
+    print("Hello, World!")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python-tutorial/stage2/MODULE.bazel
+++ b/examples/python-tutorial/stage2/MODULE.bazel
@@ -1,0 +1,11 @@
+"""Bazel module for Python tutorial - Stage 2."""
+
+module(
+    name = "python_tutorial_stage2",
+    version = "1.0.0",
+)
+
+bazel_dep(name = "rules_python", version = "1.0.0")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(python_version = "3.11")

--- a/examples/python-tutorial/stage2/main/BUILD
+++ b/examples/python-tutorial/stage2/main/BUILD
@@ -1,0 +1,15 @@
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+
+py_library(
+    name = "greeting",
+    srcs = ["greeting.py"],
+)
+
+py_binary(
+    name = "hello_world",
+    srcs = ["hello_world.py"],
+    deps = [
+        ":greeting",
+    ],
+)

--- a/examples/python-tutorial/stage2/main/greeting.py
+++ b/examples/python-tutorial/stage2/main/greeting.py
@@ -1,0 +1,13 @@
+"""A module for greeting functionality."""
+
+
+def get_greeting(name: str = "World") -> str:
+    """Return a greeting message.
+
+    Args:
+        name: The name to greet. Defaults to "World".
+
+    Returns:
+        A greeting string.
+    """
+    return f"Hello, {name}!"

--- a/examples/python-tutorial/stage2/main/hello_world.py
+++ b/examples/python-tutorial/stage2/main/hello_world.py
@@ -1,0 +1,17 @@
+"""A Hello World program using a greeting library."""
+
+from main import greeting
+
+
+def main():
+    """Print a greeting message using the greeting module."""
+    message = greeting.get_greeting()
+    print(message)
+
+    # Also greet Bazel!
+    message = greeting.get_greeting("Bazel")
+    print(message)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python-tutorial/stage3/MODULE.bazel
+++ b/examples/python-tutorial/stage3/MODULE.bazel
@@ -1,0 +1,11 @@
+"""Bazel module for Python tutorial - Stage 3."""
+
+module(
+    name = "python_tutorial_stage3",
+    version = "1.0.0",
+)
+
+bazel_dep(name = "rules_python", version = "1.0.0")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(python_version = "3.11")

--- a/examples/python-tutorial/stage3/lib/BUILD
+++ b/examples/python-tutorial/stage3/lib/BUILD
@@ -1,0 +1,7 @@
+load("@rules_python//python:py_library.bzl", "py_library")
+
+py_library(
+    name = "time_utils",
+    srcs = ["time_utils.py"],
+    visibility = ["//main:__pkg__"],
+)

--- a/examples/python-tutorial/stage3/lib/time_utils.py
+++ b/examples/python-tutorial/stage3/lib/time_utils.py
@@ -1,0 +1,28 @@
+"""A module for time-related utilities."""
+
+from datetime import datetime
+
+
+def get_time_of_day() -> str:
+    """Return a time-of-day greeting based on the current hour.
+
+    Returns:
+        A string indicating morning, afternoon, or evening.
+    """
+    hour = datetime.now().hour
+
+    if hour < 12:
+        return "morning"
+    elif hour < 17:
+        return "afternoon"
+    else:
+        return "evening"
+
+
+def get_formatted_time() -> str:
+    """Return the current time in a human-readable format.
+
+    Returns:
+        A formatted time string.
+    """
+    return datetime.now().strftime("%H:%M:%S")

--- a/examples/python-tutorial/stage3/main/BUILD
+++ b/examples/python-tutorial/stage3/main/BUILD
@@ -1,0 +1,16 @@
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+
+py_library(
+    name = "greeting",
+    srcs = ["greeting.py"],
+)
+
+py_binary(
+    name = "hello_world",
+    srcs = ["hello_world.py"],
+    deps = [
+        ":greeting",
+        "//lib:time_utils",
+    ],
+)

--- a/examples/python-tutorial/stage3/main/greeting.py
+++ b/examples/python-tutorial/stage3/main/greeting.py
@@ -1,0 +1,26 @@
+"""A module for greeting functionality."""
+
+
+def get_greeting(name: str = "World") -> str:
+    """Return a greeting message.
+
+    Args:
+        name: The name to greet. Defaults to "World".
+
+    Returns:
+        A greeting string.
+    """
+    return f"Hello, {name}!"
+
+
+def get_time_greeting(name: str, time_of_day: str) -> str:
+    """Return a time-aware greeting message.
+
+    Args:
+        name: The name to greet.
+        time_of_day: The time of day (morning, afternoon, evening).
+
+    Returns:
+        A time-aware greeting string.
+    """
+    return f"Good {time_of_day}, {name}!"

--- a/examples/python-tutorial/stage3/main/hello_world.py
+++ b/examples/python-tutorial/stage3/main/hello_world.py
@@ -1,0 +1,24 @@
+"""A Hello World program using multiple packages."""
+
+from lib import time_utils
+from main import greeting
+
+
+def main():
+    """Print time-aware greeting messages."""
+    # Get the current time of day
+    time_of_day = time_utils.get_time_of_day()
+    current_time = time_utils.get_formatted_time()
+
+    # Print a simple greeting
+    print(greeting.get_greeting())
+
+    # Print a time-aware greeting
+    print(greeting.get_time_greeting("Bazel User", time_of_day))
+
+    # Print the current time
+    print(f"The current time is {current_time}")
+
+
+if __name__ == "__main__":
+    main()

--- a/site/en/start/_index.yaml
+++ b/site/en/start/_index.yaml
@@ -96,6 +96,12 @@ landing_page:
       icon:
         name: grid_view
         position: left
+    - heading: Python
+      classname: fully-clickable
+      path: /start/python
+      icon:
+        name: grid_view
+        position: left
     - heading: Android
       classname: fully-clickable
       path: /start/android-app

--- a/site/en/start/python.md
+++ b/site/en/start/python.md
@@ -1,0 +1,500 @@
+Project: /_project.yaml
+Book: /_book.yaml
+
+# Bazel Tutorial: Build a Python Project
+
+{% include "_buttons.html" %}
+
+## Introduction {:#introduction}
+
+New to Bazel? You're in the right place. Follow this First Build tutorial for a
+simplified introduction to using Bazel with Python. This tutorial defines key 
+terms as they are used in Bazel's context and walks you through the basics of 
+the Bazel workflow. Starting with the tools you need, you will build and run 
+three projects with increasing complexity and learn how and why they get more 
+complex.
+
+Bazel is a [build system](https://bazel.build/basics/build-systems) that
+supports multi-language builds. This tutorial uses a Python project as an 
+example and provides the general guidelines and flow that apply to most 
+languages.
+
+Estimated completion time: 30 minutes.
+
+### Prerequisites {:#prerequisites}
+
+Start by [installing Bazel](https://bazel.build/install), if you haven't
+already. This tutorial uses Git for source control, so for best results 
+[install Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) 
+as well.
+
+Next, retrieve the sample project from Bazel's GitHub repository by running the
+following in your command-line tool of choice:
+
+```posix-terminal
+git clone https://github.com/bazelbuild/examples
+```
+
+The sample project for this tutorial is in the `examples/python-tutorial`
+directory.
+
+Take a look at how it's structured:
+
+```none
+examples
+└── python-tutorial
+    ├──stage1
+    │  ├── main
+    │  │   ├── BUILD
+    │  │   └── hello_world.py
+    │  └── MODULE.bazel
+    ├──stage2
+    │  ├── main
+    │  │   ├── BUILD
+    │  │   ├── hello_world.py
+    │  │   └── greeting.py
+    │  └── MODULE.bazel
+    └──stage3
+       ├── main
+       │   ├── BUILD
+       │   ├── hello_world.py
+       │   └── greeting.py
+       ├── lib
+       │   ├── BUILD
+       │   └── time_utils.py
+       └── MODULE.bazel
+```
+
+There are three sets of files, each set representing a stage in this tutorial.
+In the first stage, you will build a single 
+[target](https://bazel.build/reference/glossary#target) residing in a single 
+[package](https://bazel.build/reference/glossary#package). In the second stage, 
+you will build both a binary and a library from a single package. In the third 
+and final stage, you will build a project with multiple packages and build it 
+with multiple targets.
+
+### Summary: Introduction {:#summary-introduction}
+
+By installing Bazel (and Git) and cloning the repository for this tutorial, you
+have laid the foundation for your first build with Bazel. Continue to the next
+section to define some terms and set up your
+[workspace](https://bazel.build/reference/glossary#workspace).
+
+## Getting started {:#getting-started}
+
+Before you can build a project, you need to set up its workspace. A workspace
+is a directory that holds your project's source files and Bazel's build outputs.
+It also contains these significant files:
+
+*   The `MODULE.bazel` file, which identifies the directory and its contents as
+    a Bazel workspace and lives at the root of the project's directory
+    structure. It's also where you specify your external dependencies, such as
+    `rules_python`.
+*   One or more [`BUILD`
+    files](https://bazel.build/reference/glossary#build-file), which tell Bazel
+    how to build different parts of the project. A directory within the
+    workspace that contains a `BUILD` file is a
+    [package](https://bazel.build/reference/glossary#package). (More on packages
+    later in this tutorial.)
+
+In future projects, to designate a directory as a Bazel workspace, create a
+file named `MODULE.bazel` in that directory. For the purposes of this
+tutorial, a `MODULE.bazel` file is already present in each stage.
+
+### Understand the BUILD file {:#understand-build}
+
+A `BUILD` file contains several different types of instructions for Bazel. Each
+`BUILD` file requires at least one
+[rule](https://bazel.build/reference/glossary#rule) as a set of instructions,
+which tells Bazel how to build the outputs you want, such as executable binaries
+or libraries. Each instance of a build rule in the `BUILD` file is called a
+[target](https://bazel.build/reference/glossary#target) and points to a specific
+set of source files and
+[dependencies](https://bazel.build/reference/glossary#dependency). A target can
+also point to other targets.
+
+Take a look at the `BUILD` file in the `python-tutorial/stage1/main` directory:
+
+```python
+load("@rules_python//python:py_binary.bzl", "py_binary")
+
+py_binary(
+    name = "hello_world",
+    srcs = ["hello_world.py"],
+)
+```
+
+In our example, the `hello_world` target instantiates the
+[`py_binary` rule](https://bazel.build/reference/be/python#py_binary) from 
+`rules_python`. The rule tells Bazel to build a self-contained executable 
+binary from the `hello_world.py` source file with no dependencies.
+
+The `load` statement at the top imports the `py_binary` rule from the 
+`rules_python` module, which is defined as a dependency in the `MODULE.bazel` 
+file.
+
+### Summary: getting started {:#summary-getting-started}
+
+Now you are familiar with some key terms, and what they mean in the context of
+this project and Bazel in general. In the next section, you will build and test
+Stage 1 of the project.
+
+## Stage 1: single target, single package {:#stage-1}
+
+It's time to build the first part of the project. For a visual reference, the
+structure of the Stage 1 section of the project is:
+
+```none
+examples
+└── python-tutorial
+    └──stage1
+       ├── main
+       │   ├── BUILD
+       │   └── hello_world.py
+       └── MODULE.bazel
+```
+
+Run the following to move to the `python-tutorial/stage1` directory:
+
+```posix-terminal
+cd python-tutorial/stage1
+```
+
+Next, run:
+
+```posix-terminal
+bazel build //main:hello_world
+```
+
+In the target label, the `//main:` part is the location of the `BUILD` file
+relative to the root of the workspace, and `hello_world` is the target name in
+the `BUILD` file.
+
+Bazel produces something that looks like this:
+
+```none
+INFO: Analyzed target //main:hello_world (20 packages loaded, 50 targets configured).
+INFO: Found 1 target...
+Target //main:hello_world up-to-date:
+  bazel-bin/main/hello_world
+INFO: Elapsed time: 2.267s, Critical Path: 0.25s
+INFO: Build completed successfully, 1 total action
+```
+
+You just built your first Bazel target. Bazel places build outputs in the
+`bazel-bin` directory at the root of the workspace.
+
+Now test your freshly built binary:
+
+```posix-terminal
+bazel-bin/main/hello_world
+```
+
+This results in a printed "`Hello, World!`" message.
+
+You can also run the target directly using `bazel run`:
+
+```posix-terminal
+bazel run //main:hello_world
+```
+
+Here's the dependency graph of Stage 1:
+
+![Dependency graph for hello_world displays a single target with a single source
+file.](/docs/images/python-tutorial-stage1.svg "Dependency graph for hello_world
+displays a single target with a single source file.")
+
+### Summary: stage 1 {:#summary-stage-1}
+
+Now that you have completed your first build, you have a basic idea of how a
+build is structured. In the next stage, you will add complexity by adding
+another target.
+
+## Stage 2: multiple build targets {:#stage-2}
+
+While a single target is sufficient for small projects, you may want to split
+larger projects into multiple targets and packages. This allows for fast
+incremental builds – that is, Bazel only rebuilds what's changed – and speeds up
+your builds by building multiple parts of a project at once. This stage of the
+tutorial adds a target, and the next adds a package.
+
+This is the directory you are working with for Stage 2:
+
+```none
+    ├──stage2
+    │  ├── main
+    │  │   ├── BUILD
+    │  │   ├── hello_world.py
+    │  │   └── greeting.py
+    │  └── MODULE.bazel
+```
+
+Take a look at the `BUILD` file in the `python-tutorial/stage2/main` directory:
+
+```python
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+
+py_library(
+    name = "greeting",
+    srcs = ["greeting.py"],
+)
+
+py_binary(
+    name = "hello_world",
+    srcs = ["hello_world.py"],
+    deps = [
+        ":greeting",
+    ],
+)
+```
+
+With this `BUILD` file, Bazel first builds the `greeting` library (using
+the [`py_library`
+rule](https://bazel.build/reference/be/python#py_library)), then the
+`hello_world` binary. The `deps` attribute in the `hello_world` target tells
+Bazel that the `greeting` library is required to build the `hello_world`
+binary.
+
+Before you can build this new version of the project, you need to change
+directories, switching to the `python-tutorial/stage2` directory by running:
+
+```posix-terminal
+cd ../stage2
+```
+
+Now you can build the new binary using the following familiar command:
+
+```posix-terminal
+bazel build //main:hello_world
+```
+
+Once again, Bazel produces something that looks like this:
+
+```none
+INFO: Analyzed target //main:hello_world (20 packages loaded, 50 targets configured).
+INFO: Found 1 target...
+Target //main:hello_world up-to-date:
+  bazel-bin/main/hello_world
+INFO: Elapsed time: 2.399s, Critical Path: 0.30s
+INFO: Build completed successfully, 1 total action
+```
+
+Now you can test your freshly built binary:
+
+```posix-terminal
+bazel-bin/main/hello_world
+```
+
+If you now modify `greeting.py` and rebuild the project, Bazel only
+recompiles that file.
+
+Looking at the dependency graph, you can see that `hello_world` depends on an
+additional input named `greeting`:
+
+![Dependency graph for `hello_world` displays dependency changes after
+modification to the file.](/docs/images/python-tutorial-stage2.svg "Dependency
+graph for `hello_world` displays dependency changes after modification to the
+file.")
+
+### Summary: stage 2 {:#summary-stage-2}
+
+You've now built the project with two targets. The `hello_world` target builds
+one source file and depends on one other target (`//main:greeting`), which
+builds an additional source file. In the next section, take it a step further
+and add another package.
+
+## Stage 3: multiple packages {:#stage-3}
+
+This next stage adds another layer of complication and builds a project with
+multiple packages. Take a look at the structure and contents of the
+`python-tutorial/stage3` directory:
+
+```none
+└──stage3
+   ├── main
+   │   ├── BUILD
+   │   ├── hello_world.py
+   │   └── greeting.py
+   ├── lib
+   │   ├── BUILD
+   │   └── time_utils.py
+   └── MODULE.bazel
+```
+
+You can see that now there are two sub-directories, and each contains a `BUILD`
+file. Therefore, to Bazel, the workspace now contains two packages: `lib` and
+`main`.
+
+Take a look at the `lib/BUILD` file:
+
+```python
+load("@rules_python//python:py_library.bzl", "py_library")
+
+py_library(
+    name = "time_utils",
+    srcs = ["time_utils.py"],
+    visibility = ["//main:__pkg__"],
+)
+```
+
+And at the `main/BUILD` file:
+
+```python
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+
+py_library(
+    name = "greeting",
+    srcs = ["greeting.py"],
+)
+
+py_binary(
+    name = "hello_world",
+    srcs = ["hello_world.py"],
+    deps = [
+        ":greeting",
+        "//lib:time_utils",
+    ],
+)
+```
+
+The `hello_world` target in the main package depends on the `time_utils` target
+in the `lib` package (hence the target label `//lib:time_utils`) - Bazel knows
+this through the `deps` attribute. You can see this reflected in the dependency
+graph:
+
+![Dependency graph for `hello_world` displays how the target in the main package
+depends on the target in the `lib`
+package.](/docs/images/python-tutorial-stage3.svg "Dependency graph for
+`hello_world` displays how the target in the main package depends on the target
+in the `lib` package.")
+
+For the build to succeed, you make the `//lib:time_utils` target in `lib/BUILD`
+explicitly visible to targets in `main/BUILD` using the visibility attribute.
+This is because by default targets are only visible to other targets in the same
+`BUILD` file. Bazel uses target visibility to prevent issues such as libraries
+containing implementation details leaking into public APIs.
+
+Now build this final version of the project. Switch to the `python-tutorial/stage3`
+directory by running:
+
+```posix-terminal
+cd ../stage3
+```
+
+Once again, run the following command:
+
+```posix-terminal
+bazel build //main:hello_world
+```
+
+Bazel produces something that looks like this:
+
+```none
+INFO: Analyzed target //main:hello_world (20 packages loaded, 50 targets configured).
+INFO: Found 1 target...
+Target //main:hello_world up-to-date:
+  bazel-bin/main/hello_world
+INFO: Elapsed time: 0.167s, Critical Path: 0.00s
+INFO: Build completed successfully, 1 total action
+```
+
+Now test the last binary of this tutorial:
+
+```posix-terminal
+bazel-bin/main/hello_world
+```
+
+### Summary: stage 3 {:#summary-stage-3}
+
+You've now built the project as two packages with three targets and understand
+the dependencies between them, which equips you to go forth and build future
+projects with Bazel. In the next section, take a look at how to continue your
+Bazel journey.
+
+## Using external dependencies {:#external-dependencies}
+
+For real-world Python projects, you'll often need to use external packages from
+PyPI. Bazel handles this through `rules_python`'s pip integration.
+
+Here's an example of how to add pip dependencies to your `MODULE.bazel` file:
+
+```python
+bazel_dep(name = "rules_python", version = "1.0.0")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(python_version = "3.11")
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse(
+    hub_name = "pypi",
+    python_version = "3.11",
+    requirements_lock = "//:requirements_lock.txt",
+)
+use_repo(pip, "pypi")
+```
+
+Then in your `BUILD` file, you can depend on pip packages:
+
+```python
+load("@rules_python//python:py_binary.bzl", "py_binary")
+
+py_binary(
+    name = "my_app",
+    srcs = ["my_app.py"],
+    deps = [
+        "@pypi//requests",
+    ],
+)
+```
+
+For more details on managing Python dependencies with Bazel, see the
+[rules_python documentation](https://rules-python.readthedocs.io/).
+
+## Testing Python code {:#testing}
+
+Bazel provides the `py_test` rule for running Python tests. Here's an example:
+
+```python
+load("@rules_python//python:py_test.bzl", "py_test")
+
+py_test(
+    name = "greeting_test",
+    srcs = ["greeting_test.py"],
+    deps = [
+        ":greeting",
+    ],
+)
+```
+
+Run tests using:
+
+```posix-terminal
+bazel test //main:greeting_test
+```
+
+Or run all tests in the workspace:
+
+```posix-terminal
+bazel test //...
+```
+
+## Next steps {:#next-steps}
+
+You've now completed your first basic build with Bazel, but this is just the
+start. Here are some more resources to continue learning with Bazel:
+
+*   To learn more about `rules_python` features, see the [rules_python
+    documentation](https://rules-python.readthedocs.io/).
+*   To get started with building other applications with Bazel, see the
+    tutorials for [C++](https://bazel.build/start/cpp),
+    [Java](https://bazel.build/start/java), [Android
+    application](https://bazel.build/start/android-app), or [iOS
+    application](https://bazel.build/start/ios-app).
+*   To learn more about working with local and remote repositories, read about
+    [external dependencies](https://bazel.build/docs/external).
+*   To learn more about Bazel's other rules, see this [reference
+    guide](https://bazel.build/rules).
+
+Happy building!


### PR DESCRIPTION
This commit adds a comprehensive Python first build tutorial to address the missing documentation for Python in the Getting Started guides.

Changes:
- Add site/en/start/python.md with complete tutorial covering:
  - Stage 1: Single target, single package (py_binary)
  - Stage 2: Multiple targets (py_binary + py_library)
  - Stage 3: Multiple packages with visibility
  - External dependencies with pip/PyPI
  - Testing with py_test
- Update site/en/start/_index.yaml to include Python in First build guides
- Add examples/python-tutorial/ with working example code for all stages

Fixes #27824