### PR TITLE
Delete Kubernetes description from users.md

### DIFF
--- a/site/en/community/users.md
+++ b/site/en/community/users.md
@@ -634,13 +634,6 @@ system.
 An elegant, formally-specified config generation language for JSON.
 (Bazel is a supported build system.)
 
-### [Kubernetes](https://github.com/kubernetes/kubernetes){: .external}
-
-<img src="https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png" width="80" align="right">
-Kubernetes is an open source system for managing containerized applications
-across multiple hosts, providing basic mechanisms for deployment, maintenance,
-and scaling of applications.
-
 ### [Kythe](https://github.com/google/kythe){: .external}
 
 An ecosystem for building tools that work with code.


### PR DESCRIPTION
Removed Kubernetes section from users.md

Bazel has been removed from the Kubernetes project: https://github.com/kubernetes/kubernetes/issues/88553