### PR TITLE
[9.0.0] Properly gate dynamic type checking with flag

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -700,7 +700,8 @@ public final class BuildLanguageOptions extends OptionsBase {
       metadataTags = {OptionMetadataTag.EXPERIMENTAL},
       help =
           "Enables type checking in files and functions that contain type annotations or related "
-              + "syntax.")
+              + "syntax. (When this flag is disabled, Bazel is more forgiving of invalid types in "
+              + "type annotations.)")
   public boolean experimentalStarlarkTypeChecking;
 
   // TODO: b/350661266 - Delete this flag.
@@ -939,7 +940,9 @@ public final class BuildLanguageOptions extends OptionsBase {
             .setBool(EXPERIMENTAL_RULE_EXTENSION_API, experimentalRuleExtensionApi)
             .setBool(EXPERIMENTAL_DORMANT_DEPS, experimentalDormantDeps)
             .setBool(EXPERIMENTAL_STARLARK_TYPE_SYNTAX, experimentalStarlarkTypeSyntax)
-            .setBool(EXPERIMENTAL_STARLARK_TYPE_CHECKING, experimentalStarlarkTypeChecking)
+            .setBool(
+                StarlarkSemantics.EXPERIMENTAL_STARLARK_TYPE_CHECKING,
+                experimentalStarlarkTypeChecking)
             .set(EXPERIMENTAL_STARLARK_TYPES_ALLOWED_PATHS, experimentalStarlarkTypesAllowedPaths)
             .setBool(INCOMPATIBLE_ENABLE_DEPRECATED_LABEL_APIS, enableDeprecatedLabelApis)
             .setBool(
@@ -1114,8 +1117,6 @@ public final class BuildLanguageOptions extends OptionsBase {
 
   public static final String EXPERIMENTAL_STARLARK_TYPE_SYNTAX =
       FlagConstants.EXPERIMENTAL_STARLARK_TYPE_SYNTAX_FLAG_NAME;
-  public static final String EXPERIMENTAL_STARLARK_TYPE_CHECKING =
-      "-experimental_starlark_type_checking";
   public static final String INCOMPATIBLE_ENABLE_DEPRECATED_LABEL_APIS =
       "+incompatible_enable_deprecated_label_apis";
   public static final String INCOMPATIBLE_STOP_EXPORTING_BUILD_FILE_PATH =

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlCompileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlCompileFunction.java
@@ -212,8 +212,8 @@ public class BzlCompileFunction implements SkyFunction {
             .allowTypeSyntax(
                 semantics.getBool(BuildLanguageOptions.EXPERIMENTAL_STARLARK_TYPE_SYNTAX)
                     && typeSyntaxAllowlistMatchesPath)
-            .allowArbitraryTypeExpressions(
-                !semantics.getBool(BuildLanguageOptions.EXPERIMENTAL_STARLARK_TYPE_CHECKING))
+            .tolerateInvalidTypeExpressions(
+                !semantics.getBool(StarlarkSemantics.EXPERIMENTAL_STARLARK_TYPE_CHECKING))
             .build();
     StarlarkFile file = StarlarkFile.parse(input, options);
 

--- a/src/main/java/net/starlark/java/eval/Eval.java
+++ b/src/main/java/net/starlark/java/eval/Eval.java
@@ -170,6 +170,8 @@ final class Eval {
     int nparams =
         rfn.getParameters().size() - (rfn.hasKwargs() ? 1 : 0) - (rfn.hasVarargs() ? 1 : 0);
     CallableType functionType = rfn.getFunctionType();
+    boolean dynamicTypeCheckingEnabled =
+        fr.thread.getSemantics().getBool(StarlarkSemantics.EXPERIMENTAL_STARLARK_TYPE_CHECKING);
     for (int i = 0; i < nparams; i++) {
       Expression expr = rfn.getParameters().get(i).getDefaultValue();
       if (expr == null && defaults == null) {
@@ -181,15 +183,17 @@ final class Eval {
       Object defaultValue = expr == null ? StarlarkFunction.MANDATORY : eval(fr, expr);
       defaults[i - (nparams - defaults.length)] = defaultValue;
 
-      // Typecheck the default value
-      StarlarkType parameterType = functionType.getParameterTypeByPos(i);
-      if (!TypeChecker.isValueSubtypeOf(defaultValue, parameterType)) {
-        throw Starlark.errorf(
-            "%s(): parameter '%s' has default value of type '%s', declares '%s'",
-            rfn.getName(),
-            rfn.getParameterNames().get(i),
-            TypeChecker.type(defaultValue),
-            parameterType);
+      if (dynamicTypeCheckingEnabled && functionType != null) {
+        // Typecheck the default value
+        StarlarkType parameterType = functionType.getParameterTypeByPos(i);
+        if (!TypeChecker.isValueSubtypeOf(defaultValue, parameterType)) {
+          throw Starlark.errorf(
+              "%s(): parameter '%s' has default value of type '%s', declares '%s'",
+              rfn.getName(),
+              rfn.getParameterNames().get(i),
+              TypeChecker.type(defaultValue),
+              parameterType);
+        }
       }
     }
     if (defaults == null) {

--- a/src/main/java/net/starlark/java/eval/StarlarkSemantics.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkSemantics.java
@@ -266,4 +266,9 @@ public class StarlarkSemantics {
   /** Whether the Starlark interpreter uses UTF-8 byte strings instead of UTF-16 strings. */
   public static final String INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS =
       "-internal_bazel_only_utf_8_byte_strings";
+
+  /** Whether (static and/or dynamic) type checking should be performed. */
+  // TODO: #27370 - Consider splitting this into separate options for static vs dynamic.
+  public static final String EXPERIMENTAL_STARLARK_TYPE_CHECKING =
+      "-experimental_starlark_type_checking";
 }

--- a/src/main/java/net/starlark/java/syntax/FileOptions.java
+++ b/src/main/java/net/starlark/java/syntax/FileOptions.java
@@ -82,15 +82,16 @@ public abstract class FileOptions {
   public abstract boolean allowTypeSyntax();
 
   /**
-   * If true, type expressions may be any valid expression except for unparenthesized tuples.
-   * Otherwise type expressions must represent a valid type.
+   * If true, type expressions in annotations and {@code type} declarations may be any valid
+   * expression (except for unparenthesized tuples, which are grammatically ambiguous). Otherwise
+   * type expressions must represent a valid type.
    *
    * <p>Enabling this boolean is helpful for backwards compatibility, but results in an AST that is
    * not usable for type checking.
    *
    * <p>This has no effect if {@link #allowTypeSyntax} is false.
    */
-  public abstract boolean allowArbitraryTypeExpressions();
+  public abstract boolean tolerateInvalidTypeExpressions();
 
   public static Builder builder() {
     // These are the DEFAULT values.
@@ -101,7 +102,7 @@ public abstract class FileOptions {
         .requireLoadStatementsFirst(true)
         .stringLiteralsAreAsciiOnly(false)
         .allowTypeSyntax(false)
-        .allowArbitraryTypeExpressions(false);
+        .tolerateInvalidTypeExpressions(false);
   }
 
   public abstract Builder toBuilder();
@@ -122,7 +123,7 @@ public abstract class FileOptions {
 
     public abstract Builder allowTypeSyntax(boolean value);
 
-    public abstract Builder allowArbitraryTypeExpressions(boolean value);
+    public abstract Builder tolerateInvalidTypeExpressions(boolean value);
 
     public abstract FileOptions build();
   }

--- a/src/main/java/net/starlark/java/syntax/Parser.java
+++ b/src/main/java/net/starlark/java/syntax/Parser.java
@@ -1089,7 +1089,7 @@ final class Parser {
   private Expression parseTypeExprWithFallback() {
     Expression result;
     this.insideTypeExpr = true;
-    if (options.allowArbitraryTypeExpressions()) {
+    if (options.tolerateInvalidTypeExpressions()) {
       // parseTest, because allowing unparenthesized tuples here would consume subsequent params in
       // function signatures.
       result = parseTest();

--- a/src/test/java/net/starlark/java/eval/BUILD
+++ b/src/test/java/net/starlark/java/eval/BUILD
@@ -13,6 +13,7 @@ filegroup(
 java_test(
     name = "EvalTests",
     srcs = [
+        "DynamicTypeCheckTest.java",
         "EvalTests.java",  # (suite)
         "EvalUtilsTest.java",
         "EvaluationTest.java",
@@ -32,7 +33,6 @@ java_test(
         "StarlarkThreadDebuggingTest.java",
         "StarlarkThreadTest.java",
         "SymbolGeneratorTest.java",
-        "TypeCheckTest.java",
     ],
     jvm_flags = [
         "-Dfile.encoding=UTF8",

--- a/src/test/java/net/starlark/java/eval/DynamicTypeCheckTest.java
+++ b/src/test/java/net/starlark/java/eval/DynamicTypeCheckTest.java
@@ -28,9 +28,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for Starlark types. */
+/** Tests for Starlark type checking at evaluation time. */
 @RunWith(JUnit4.class)
-public class TypeCheckTest {
+public class DynamicTypeCheckTest {
 
   private EvaluationTestCase ev;
 
@@ -38,6 +38,20 @@ public class TypeCheckTest {
   public void setup() {
     ev = new EvaluationTestCase();
     ev.setFileOptions(FileOptions.builder().allowTypeSyntax(true).build());
+    ev.setSemantics(
+        StarlarkSemantics.builder()
+            .setBool(StarlarkSemantics.EXPERIMENTAL_STARLARK_TYPE_CHECKING, true)
+            .build());
+  }
+
+  @Test
+  public void typechecking_disabledByFlag() throws Exception {
+    ev.setSemantics(
+        StarlarkSemantics.builder()
+            .setBool(StarlarkSemantics.EXPERIMENTAL_STARLARK_TYPE_CHECKING, false)
+            .build());
+
+    ev.exec("def f(a : int): pass", "f('abc')");
   }
 
   @Test

--- a/src/test/java/net/starlark/java/eval/EvalTests.java
+++ b/src/test/java/net/starlark/java/eval/EvalTests.java
@@ -19,6 +19,7 @@ import org.junit.runners.Suite;
 /** EvalTests tests the Starlark evaluator. */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+  DynamicTypeCheckTest.class,
   EvaluationTest.class,
   EvalUtilsTest.class,
   FunctionTest.class,
@@ -34,6 +35,5 @@ import org.junit.runners.Suite;
   StarlarkMutableTest.class,
   StarlarkThreadDebuggingTest.class,
   StarlarkThreadTest.class,
-  TypeCheckTest.class
 })
 public class EvalTests {}

--- a/src/test/java/net/starlark/java/eval/EvaluationTestCase.java
+++ b/src/test/java/net/starlark/java/eval/EvaluationTestCase.java
@@ -42,7 +42,7 @@ class EvaluationTestCase {
    * Updates the semantics used to filter predeclared bindings, and carried by subsequently created
    * threads. Causes a new StarlarkThread and Module to be created when next needed.
    */
-  private final void setSemantics(StarlarkSemantics semantics) {
+  public final void setSemantics(StarlarkSemantics semantics) {
     this.semantics = semantics;
 
     // Re-initialize the thread and module with the new semantics when needed.

--- a/src/test/java/net/starlark/java/syntax/NodePrinterTest.java
+++ b/src/test/java/net/starlark/java/syntax/NodePrinterTest.java
@@ -394,7 +394,7 @@ public final class NodePrinterTest {
   @Test
   public void ellipsisExpression() throws SyntaxError.Exception {
     setFileOptions(
-        FileOptions.builder().allowTypeSyntax(true).allowArbitraryTypeExpressions(true).build());
+        FileOptions.builder().allowTypeSyntax(true).tolerateInvalidTypeExpressions(true).build());
     // Use `def` rather than `type` to wrap the type expression, because `type`'s toString()
     // introduces its own metasyntactic "..." placeholder.
     assertStmtTostringMatches(

--- a/src/test/java/net/starlark/java/syntax/ParserTest.java
+++ b/src/test/java/net/starlark/java/syntax/ParserTest.java
@@ -571,7 +571,7 @@ public final class ParserTest {
   @Test
   public void testVarAnnotation_illegalTypeExpression_allowedWithFlag() throws Exception {
     setFileOptions(
-        FileOptions.builder().allowTypeSyntax(true).allowArbitraryTypeExpressions(true).build());
+        FileOptions.builder().allowTypeSyntax(true).tolerateInvalidTypeExpressions(true).build());
     assertThat(((VarStatement) parseStatement("x : (lambda x: x)")).getType())
         .isInstanceOf(LambdaExpression.class);
     assertThat(((AssignmentStatement) parseStatement("x : (lambda x: x) = 123")).getType())
@@ -582,7 +582,7 @@ public final class ParserTest {
   public void testAssignWithAnnotation_illegalTypeExpression_disallowedWithoutFlag()
       throws Exception {
     setFileOptions(
-        FileOptions.builder().allowTypeSyntax(true).allowArbitraryTypeExpressions(false).build());
+        FileOptions.builder().allowTypeSyntax(true).tolerateInvalidTypeExpressions(false).build());
     assertThat(parseStatementError("x : (lambda x: x)"))
         .contains(":1:5: syntax error at '(': expected a type");
     assertThat(parseStatementError("x : (lambda x: x) = 123"))
@@ -1502,7 +1502,7 @@ public final class ParserTest {
   @Test
   public void testIllegalTypeExpression_allowedWithFlag() throws Exception {
     setFileOptions(
-        FileOptions.builder().allowTypeSyntax(true).allowArbitraryTypeExpressions(true).build());
+        FileOptions.builder().allowTypeSyntax(true).tolerateInvalidTypeExpressions(true).build());
 
     parseStatement("def f(a : (lambda x: x)): pass");
     assertThat(parseTypeExpression("lambda x: x")).isInstanceOf(LambdaExpression.class);
@@ -1654,7 +1654,7 @@ public final class ParserTest {
   @Test
   public void testTypeAliasStatement_allowsIllegalDefinition_withFlag() throws Exception {
     setFileOptions(
-        FileOptions.builder().allowTypeSyntax(true).allowArbitraryTypeExpressions(true).build());
+        FileOptions.builder().allowTypeSyntax(true).tolerateInvalidTypeExpressions(true).build());
     TypeAliasStatement stmt = (TypeAliasStatement) parseStatement("type X = lambda x: x");
     assertThat(stmt.getDefinition()).isInstanceOf(LambdaExpression.class);
   }
@@ -1741,7 +1741,7 @@ public final class ParserTest {
   @Test
   public void testEllipsisAllowedInTypeExpressions() throws Exception {
     setFileOptions(
-        FileOptions.builder().allowTypeSyntax(true).allowArbitraryTypeExpressions(true).build());
+        FileOptions.builder().allowTypeSyntax(true).tolerateInvalidTypeExpressions(true).build());
     parseStatement("x : Tuple[int, ...]");
   }
 


### PR DESCRIPTION
Previously https://github.com/bazelbuild/bazel/commit/f60a22e8eff60d6297d2382812a7107c9e2dd3e6 replaced `--experimental_starlark_types` with two separate flags, `--experimental_starlark_type_syntax` and `--experimental_starlark_type_checking`. However, it failed to wire the latter through to the actual type checking logic. This makes it impossible to process bzl files that contain type annotations without also attempting to check those types -- a no-no for Bazel 9.0, which should tolerate but ignore type annotations.

- Clarify type checking flag's description.
- Moved key constant for type checking flag from `BuildLanguageOptions` into `StarlarkSemantics`, since it is referenced within the Starlark interpreter itself.
- Rename `FileOptions#allowArbitraryTypeExpressions` -> `tolerateInvalidTypeExpressions` to make the intent clearer to the reader.
- Guard on flag in `Eval.java` and `StarlarkFunction.java`.
- Rename `TypeCheckTest` -> `DynamicTypeCheckTest` in anticipation of upcoming static type checking.

Fixes #27716.

PiperOrigin-RevId: 839269449
Change-Id: Ieb01c00a30758d7d486ef5ffdb03198fcff233ac