### PR TITLE
Avoid unnecessary stats when copying files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCache.java
@@ -156,7 +156,7 @@ public class DownloadCache {
     if (useHardlinks && mayHardlink) {
       FileSystemUtils.createHardLink(targetPath, cacheValue);
     } else {
-      FileSystemUtils.copyFile(cacheValue, targetPath);
+      FileSystemUtils.copyRegularFile(cacheValue, targetPath);
     }
 
     return targetPath;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1612,7 +1612,7 @@ public class RemoteExecutionService {
           } else if (outputArtifact.isSymlink()) {
             FileSystemUtils.ensureSymbolicLink(tmpPath, sourcePath.readSymbolicLink());
           } else {
-            FileSystemUtils.copyFile(sourcePath, tmpPath);
+            FileSystemUtils.copyRegularFile(sourcePath, tmpPath);
           }
           realToTmpPath.put(targetPath, tmpPath);
         } catch (FileNotFoundException e) {

--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
@@ -163,7 +163,7 @@ public abstract class AbstractContainerizingSandboxedSpawn implements SandboxedS
       if (inputs.files().containsKey(fragment)) {
         Path fileDest = inputs.files().get(fragment);
         if (fileDest != null) {
-          materializeRegularFile(fileDest, key);
+          materializeFile(fileDest, key);
         } else {
           FileSystemUtils.createEmptyFile(key);
         }
@@ -180,7 +180,7 @@ public abstract class AbstractContainerizingSandboxedSpawn implements SandboxedS
     }
   }
 
-  protected abstract void materializeRegularFile(Path source, Path target) throws IOException;
+  protected abstract void materializeFile(Path source, Path target) throws IOException;
 
   protected abstract void materializeDirectory(Path source, Path target) throws IOException;
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
@@ -174,7 +174,7 @@ public abstract class AbstractContainerizingSandboxedSpawn implements SandboxedS
         }
         PathFragment symlinkDest = inputs.symlinks().get(fragment);
         if (symlinkDest != null) {
-          key.createSymbolicLink(symlinkDest);
+          FileSystemUtils.ensureSymbolicLink(key, symlinkDest);
         }
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
@@ -17,6 +17,7 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/analysis:test/test_configuration",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/collect/compacthashmap",

--- a/src/main/java/com/google/devtools/build/lib/sandbox/CopyingSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/CopyingSandboxedSpawn.java
@@ -66,7 +66,7 @@ public class CopyingSandboxedSpawn extends AbstractContainerizingSandboxedSpawn 
   }
 
   @Override
-  protected void materializeRegularFile(Path source, Path target) throws IOException {
+  protected void materializeFile(Path source, Path target) throws IOException {
     FileSystemUtils.copyRegularFile(source, target);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/CopyingSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/CopyingSandboxedSpawn.java
@@ -19,10 +19,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.exec.TreeDeleter;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
-import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
-import com.google.devtools.build.lib.vfs.Symlinks;
 import java.io.IOException;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -68,13 +66,13 @@ public class CopyingSandboxedSpawn extends AbstractContainerizingSandboxedSpawn 
   }
 
   @Override
-  protected void copyFile(Path source, Path target) throws IOException {
-    FileStatus stat = source.stat(Symlinks.NOFOLLOW);
-    if (stat.isSymbolicLink() || stat.isFile()) {
-      FileSystemUtils.copyFile(source, target);
-    } else if (stat.isDirectory()) {
-      target.createDirectory();
-      FileSystemUtils.copyTreesBelow(source, target);
-    }
+  protected void materializeRegularFile(Path source, Path target) throws IOException {
+    FileSystemUtils.copyRegularFile(source, target);
+  }
+
+  @Override
+  protected void materializeDirectory(Path source, Path target) throws IOException {
+    target.createDirectory();
+    FileSystemUtils.copyTreesBelow(source, target);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
@@ -54,12 +54,10 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   /** Path to the {@code getconf} system tool to use. */
-  @VisibleForTesting
-  static String getconfBinary = "/usr/bin/getconf";
+  @VisibleForTesting static String getconfBinary = "/usr/bin/getconf";
 
   /** Path to the {@code sandbox-exec} system tool to use. */
-  @VisibleForTesting
-  static String sandboxExecBinary = "/usr/bin/sandbox-exec";
+  @VisibleForTesting static String sandboxExecBinary = "/usr/bin/sandbox-exec";
 
   // Since checking if sandbox is supported is expensive, we remember what we've checked.
   private static Boolean isSupported = null;
@@ -217,7 +215,8 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     SandboxInputs inputs =
         SandboxHelpers.processInputFiles(
             context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-            execRoot);
+            execRoot,
+            context.getInputMetadataProvider());
     SandboxOutputs outputs = SandboxHelpers.getOutputs(spawn);
 
     final Path sandboxConfigPath = sandboxPath.getRelative("sandbox.sb");

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
@@ -218,7 +218,8 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     SandboxInputs inputs =
         SandboxHelpers.processInputFiles(
             context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-            execRoot);
+            execRoot,
+            context.getInputMetadataProvider());
     SandboxOutputs outputs = SandboxHelpers.getOutputs(spawn);
 
     Duration timeout = context.getTimeout();

--- a/src/main/java/com/google/devtools/build/lib/sandbox/HardlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/HardlinkedSandboxedSpawn.java
@@ -106,7 +106,7 @@ public class HardlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpa
       if (type == Dirent.Type.FILE) {
         materializeRegularFile(fromPath, toPath);
       } else {
-        materializeDirectory(source, target);
+        materializeDirectory(fromPath, toPath);
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/HardlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/HardlinkedSandboxedSpawn.java
@@ -22,12 +22,11 @@ import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
 import com.google.devtools.build.lib.util.CommandDescriptionForm;
 import com.google.devtools.build.lib.util.CommandFailureUtils;
-import com.google.devtools.build.lib.vfs.FileStatus;
+import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.Symlinks;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -72,8 +71,16 @@ public class HardlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpa
   }
 
   @Override
-  protected void copyFile(Path source, Path target) throws IOException {
-    hardLinkRecursive(source, target);
+  protected void materializeRegularFile(Path source, Path target) throws IOException {
+    try {
+      source.createHardLink(target);
+    } catch (IOException e) {
+      if (sandboxDebug) {
+        logger.atInfo().log(
+            "File %s could not be hardlinked, file will be copied instead.", source);
+      }
+      FileSystemUtils.copyRegularFile(source, target);
+    }
   }
 
   /**
@@ -82,33 +89,24 @@ public class HardlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpa
    * be made instead. Throws IllegalArgumentException if source path is a subdirectory of target
    * path.
    */
-  private void hardLinkRecursive(Path source, Path target) throws IOException {
-    FileStatus stat = source.stat(Symlinks.NOFOLLOW);
-
-    if (stat.isSymbolicLink()) {
-      source = source.resolveSymbolicLinks();
-      stat = source.stat();
+  @Override
+  protected void materializeDirectory(Path source, Path target) throws IOException {
+    if (source.startsWith(target)) {
+      throw new IllegalArgumentException(source + " is a subdirectory of " + target);
     }
-
-    if (stat.isFile()) {
-      try {
-        source.createHardLink(target);
-      } catch (IOException e) {
-        if (sandboxDebug) {
-          logger.atInfo().log(
-              "File %s could not be hardlinked, file will be copied instead.", source);
-        }
-        FileSystemUtils.copyFile(source, target);
+    target.createDirectory();
+    for (Dirent entry : source.readdir(Symlinks.FOLLOW)) {
+      Path fromPath = source.getChild(entry.getName());
+      Path toPath = target.getChild(entry.getName());
+      Dirent.Type type = entry.getType();
+      if (type == Dirent.Type.SYMLINK) {
+        fromPath = fromPath.resolveSymbolicLinks();
+        type = fromPath.stat().isDirectory() ? Dirent.Type.DIRECTORY : Dirent.Type.FILE;
       }
-    } else if (stat.isDirectory()) {
-      if (source.startsWith(target)) {
-        throw new IllegalArgumentException(source + " is a subdirectory of " + target);
-      }
-      target.createDirectory();
-      Collection<Path> entries = source.getDirectoryEntries();
-      for (Path entry : entries) {
-        Path toPath = target.getChild(entry.getBaseName());
-        hardLinkRecursive(entry, toPath);
+      if (type == Dirent.Type.FILE) {
+        materializeRegularFile(fromPath, toPath);
+      } else {
+        materializeDirectory(source, target);
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/HardlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/HardlinkedSandboxedSpawn.java
@@ -104,7 +104,7 @@ public class HardlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpa
         type = fromPath.stat().isDirectory() ? Dirent.Type.DIRECTORY : Dirent.Type.FILE;
       }
       if (type == Dirent.Type.FILE) {
-        materializeRegularFile(fromPath, toPath);
+        materializeFile(fromPath, toPath);
       } else {
         materializeDirectory(fromPath, toPath);
       }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -261,7 +261,8 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     SandboxInputs inputs =
         SandboxHelpers.processInputFiles(
             context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-            execRoot);
+            execRoot,
+            context.getInputMetadataProvider());
 
     ImmutableMap<String, String> environment =
         localEnvProvider.rewriteLocalEnv(spawn.getEnvironment(), binTools, "/tmp");

--- a/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
@@ -89,7 +89,8 @@ final class ProcessWrapperSandboxedSpawnRunner extends AbstractSandboxSpawnRunne
     SandboxInputs inputs =
         SandboxHelpers.processInputFiles(
             context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-            execRoot);
+            execRoot,
+            context.getInputMetadataProvider());
     SandboxOutputs outputs = SandboxHelpers.getOutputs(spawn);
 
     return new SymlinkedSandboxedSpawn(

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -674,8 +674,13 @@ public final class SandboxHelpers {
                 inputSymlinks.put(
                     pathFragment,
                     PathFragment.createAlreadyNormalized(metadata.getUnresolvedSymlinkTarget()));
-            default ->
-                inputFiles.put(pathFragment, execRoot.getRelative(actionInput.getExecPath()));
+            default -> {
+              inputFiles.put(
+                  pathFragment,
+                  metadata.getResolvedPath() != null
+                      ? execRoot.getRelative(metadata.getResolvedPath())
+                      : execRoot.getRelative(actionInput.getExecPath()));
+            }
           }
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -31,6 +31,8 @@ import com.google.common.flogger.GoogleLogger;
 import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
@@ -58,14 +60,14 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -466,11 +468,15 @@ public final class SandboxHelpers {
    */
   private static Optional<PathFragment> getExpectedSymlinkTargetPath(
       PathFragment path, SandboxInputs inputs) {
-    Path file = inputs.getFiles().get(path);
+    Path file = inputs.files().get(path);
     if (file != null) {
       return Optional.of(file.asFragment());
     }
-    return Optional.ofNullable(inputs.getSymlinks().get(path));
+    Path directory = inputs.directories().get(path);
+    if (directory != null) {
+      return Optional.of(directory.asFragment());
+    }
+    return Optional.ofNullable(inputs.symlinks().get(path));
   }
 
   /** Populates the provided sets with the inputs and directories that need to be created. */
@@ -603,54 +609,27 @@ public final class SandboxHelpers {
     }
   }
 
-  /** Wrapper class for the inputs of a sandbox. */
-  public static final class SandboxInputs {
-    private final Map<PathFragment, Path> files;
-    private final Map<VirtualActionInput, byte[]> virtualInputs;
-    private final Map<PathFragment, PathFragment> symlinks;
-
-    private static final SandboxInputs EMPTY_INPUTS =
-        new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
-
-    public SandboxInputs(
-        Map<PathFragment, Path> files,
-        Map<VirtualActionInput, byte[]> virtualInputs,
-        Map<PathFragment, PathFragment> symlinks) {
-      this.files = files;
-      this.virtualInputs = virtualInputs;
-      this.symlinks = symlinks;
-    }
-
-    public static SandboxInputs getEmptyInputs() {
-      return EMPTY_INPUTS;
-    }
-
-    public Map<PathFragment, Path> getFiles() {
-      return files;
-    }
-
-    public Map<PathFragment, PathFragment> getSymlinks() {
-      return symlinks;
-    }
-
-    public ImmutableMap<VirtualActionInput, byte[]> getVirtualInputDigests() {
-      return ImmutableMap.copyOf(virtualInputs);
-    }
+  /**
+   * Wrapper class for the inputs of a sandbox.
+   *
+   * @param files values may be null to indicate empty files
+   */
+  public record SandboxInputs(
+      Map<PathFragment, Path> files,
+      Map<PathFragment, Path> directories,
+      Map<PathFragment, PathFragment> symlinks,
+      ImmutableMap<VirtualActionInput, byte[]> virtualInputs) {
 
     /**
      * Returns a new SandboxInputs instance with only the inputs/symlinks listed in {@code allowed}
-     * included.
+     * included and no VirtualActionInputs.
      */
     public SandboxInputs limitedCopy(Set<PathFragment> allowed) {
       return new SandboxInputs(
           Maps.filterKeys(files, allowed::contains),
-          ImmutableMap.of(),
-          Maps.filterKeys(symlinks, allowed::contains));
-    }
-
-    @Override
-    public String toString() {
-      return "Files: " + files + "\nVirtualInputs: " + virtualInputs + "\nSymlinks: " + symlinks;
+          Maps.filterKeys(directories, allowed::contains),
+          Maps.filterKeys(symlinks, allowed::contains),
+          ImmutableMap.of());
     }
   }
 
@@ -659,16 +638,19 @@ public final class SandboxHelpers {
    * host filesystem where the input files can be found.
    *
    * @param inputMap the map of action inputs and where they should be visible in the action
-   * @param execRoot the exec root
    * @throws IOException if processing symlinks fails
    */
   @CanIgnoreReturnValue
   public static SandboxInputs processInputFiles(
-      Map<PathFragment, ActionInput> inputMap, Path execRoot)
+      Map<PathFragment, ActionInput> inputMap,
+      Path execRoot,
+      InputMetadataProvider inputMetadataProvider)
       throws IOException, InterruptedException {
-    Map<PathFragment, Path> inputFiles = new TreeMap<>();
-    Map<PathFragment, PathFragment> inputSymlinks = new TreeMap<>();
-    Map<VirtualActionInput, byte[]> virtualInputs = new HashMap<>();
+    // Values may be null to represent an empty action input.
+    var inputFiles = new LinkedHashMap<PathFragment, Path>();
+    var inputDirectories = ImmutableMap.<PathFragment, Path>builder();
+    var inputSymlinks = ImmutableMap.<PathFragment, PathFragment>builder();
+    var virtualInputs = ImmutableMap.<VirtualActionInput, byte[]>builder();
 
     for (Map.Entry<PathFragment, ActionInput> e : inputMap.entrySet()) {
       if (Thread.interrupted()) {
@@ -681,18 +663,29 @@ public final class SandboxHelpers {
         virtualInputs.put(input, digest);
       }
 
-      if (actionInput.isSymlink()) {
-        Path inputPath = execRoot.getRelative(actionInput.getExecPath());
-        inputSymlinks.put(pathFragment, inputPath.readSymbolicLink());
+      if (actionInput instanceof EmptyActionInput) {
+        inputFiles.put(pathFragment, null);
       } else {
-        Path inputPath =
-            actionInput instanceof EmptyActionInput
-                ? null
-                : execRoot.getRelative(actionInput.getExecPath());
-        inputFiles.put(pathFragment, inputPath);
+        FileArtifactValue metadata =
+            checkNotNull(
+                inputMetadataProvider.getInputMetadata(actionInput),
+                "missing metadata: %s",
+                actionInput);
+        switch (metadata.getType()) {
+          case DIRECTORY ->
+              inputDirectories.put(pathFragment, execRoot.getRelative(actionInput.getExecPath()));
+          case SYMLINK ->
+              inputSymlinks.put(
+                  pathFragment, execRoot.getRelative(actionInput.getExecPath()).readSymbolicLink());
+          default -> inputFiles.put(pathFragment, execRoot.getRelative(actionInput.getExecPath()));
+        }
       }
     }
-    return new SandboxInputs(inputFiles, virtualInputs, inputSymlinks);
+    return new SandboxInputs(
+        Collections.unmodifiableSequencedMap(inputFiles),
+        inputDirectories.buildOrThrow(),
+        inputSymlinks.buildOrThrow(),
+        virtualInputs.buildOrThrow());
   }
 
   /**
@@ -801,7 +794,8 @@ public final class SandboxHelpers {
   public static SandboxContents createContentMap(
       Path workDir, SandboxInputs inputs, SandboxOutputs outputs) {
     Map<PathFragment, SandboxContents> contentsMap = CompactHashMap.create();
-    for (Map.Entry<PathFragment, Path> entry : inputs.getFiles().entrySet()) {
+    for (Map.Entry<PathFragment, Path> entry :
+        Iterables.concat(inputs.files().entrySet(), inputs.directories().entrySet())) {
       if (entry.getValue() == null) {
         continue;
       }
@@ -813,7 +807,7 @@ public final class SandboxHelpers {
           .put(entry.getKey().getBaseName(), entry.getValue().asFragment());
       addAllParents(contentsMap, parentWasPresent, parent);
     }
-    for (Map.Entry<PathFragment, PathFragment> entry : inputs.getSymlinks().entrySet()) {
+    for (Map.Entry<PathFragment, PathFragment> entry : inputs.symlinks().entrySet()) {
       if (entry.getValue() == null) {
         continue;
       }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.devtools.build.lib.vfs.Dirent.Type.DIRECTORY;
+import static com.google.devtools.build.lib.vfs.Dirent.Type.FILE;
 import static com.google.devtools.build.lib.vfs.Dirent.Type.SYMLINK;
 import static java.util.Objects.requireNonNull;
 
@@ -673,8 +674,17 @@ public final class SandboxHelpers {
                 inputSymlinks.put(
                     pathFragment,
                     execRoot.getRelative(actionInput.getExecPath()).readSymbolicLink());
-            default ->
+            default -> {
+              if (metadata.getResolvedPath() != null) {
+                // The input is a symlink that resolves to a regular file. For sandboxing
+                // implementations, that should be handled like a declared symlink.
+                inputSymlinks.put(
+                    pathFragment,
+                    execRoot.getRelative(actionInput.getExecPath()).readSymbolicLink());
+              } else {
                 inputFiles.put(pathFragment, execRoot.getRelative(actionInput.getExecPath()));
+              }
+            }
           }
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -673,18 +673,9 @@ public final class SandboxHelpers {
             case SYMLINK ->
                 inputSymlinks.put(
                     pathFragment,
-                    execRoot.getRelative(actionInput.getExecPath()).readSymbolicLink());
-            default -> {
-              if (metadata.getResolvedPath() != null) {
-                // The input is a symlink that resolves to a regular file. For sandboxing
-                // implementations, that should be handled like a declared symlink.
-                inputSymlinks.put(
-                    pathFragment,
-                    execRoot.getRelative(actionInput.getExecPath()).readSymbolicLink());
-              } else {
+                    PathFragment.createAlreadyNormalized(metadata.getUnresolvedSymlinkTarget()));
+            default ->
                 inputFiles.put(pathFragment, execRoot.getRelative(actionInput.getExecPath()));
-              }
-            }
           }
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
@@ -125,7 +125,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
   }
 
   @Override
-  protected void materializeRegularFile(Path source, Path target) throws IOException {
+  protected void materializeFile(Path source, Path target) throws IOException {
     target.createSymbolicLink(source);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
@@ -125,7 +125,12 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
   }
 
   @Override
-  protected void copyFile(Path source, Path target) throws IOException {
+  protected void materializeRegularFile(Path source, Path target) throws IOException {
+    target.createSymbolicLink(source);
+  }
+
+  @Override
+  protected void materializeDirectory(Path source, Path target) throws IOException {
     target.createSymbolicLink(source);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxUtil.java
@@ -107,7 +107,7 @@ public final class WindowsSandboxUtil {
     private Path stdoutPath;
     private Path stderrPath;
     private Set<Path> writableFilesAndDirectories = ImmutableSet.of();
-    private Map<PathFragment, Path> readableFilesAndDirectories = new TreeMap<>();
+    private Set<Path> readableFilesAndDirectories = ImmutableSet.of();
     private Set<Path> inaccessiblePaths = ImmutableSet.of();
     private boolean useDebugMode = false;
     private List<String> commandArguments = ImmutableList.of();
@@ -166,7 +166,7 @@ public final class WindowsSandboxUtil {
     /** Sets the files or directories to make readable for the sandboxed process, if any. */
     @CanIgnoreReturnValue
     public CommandLineBuilder setReadableFilesAndDirectories(
-        Map<PathFragment, Path> readableFilesAndDirectories) {
+        Set<Path> readableFilesAndDirectories) {
       this.readableFilesAndDirectories = readableFilesAndDirectories;
       return this;
     }
@@ -213,7 +213,7 @@ public final class WindowsSandboxUtil {
       for (Path writablePath : writableFilesAndDirectories) {
         commandLineBuilder.add("-w", writablePath.getPathString());
       }
-      for (Path readablePath : readableFilesAndDirectories.values()) {
+      for (Path readablePath : readableFilesAndDirectories) {
         commandLineBuilder.add("-r", readablePath.getPathString());
       }
       for (Path writablePath : inaccessiblePaths) {

--- a/src/main/java/com/google/devtools/build/lib/worker/SandboxedWorkerProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/SandboxedWorkerProxy.java
@@ -89,7 +89,7 @@ public class SandboxedWorkerProxy extends WorkerProxy {
         ImmutableSet.of(),
         inputsToCreate,
         dirsToCreate,
-        Iterables.concat(inputFiles.getFiles().keySet(), inputFiles.getSymlinks().keySet()),
+        Iterables.concat(inputFiles.files().keySet(), inputFiles.symlinks().keySet()),
         outputs);
     SandboxHelpers.cleanExisting(
         sandboxDir.getParentDirectory(),

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerExecRoot.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerExecRoot.java
@@ -67,7 +67,7 @@ final class WorkerExecRoot {
         ImmutableSet.of(),
         inputsToCreate,
         dirsToCreate,
-        Iterables.concat(workerFiles, inputs.getFiles().keySet(), inputs.getSymlinks().keySet()),
+        Iterables.concat(workerFiles, inputs.files().keySet(), inputs.symlinks().keySet()),
         outputs);
 
     // If we have information about the previous contents of the sandbox, update it to reflect
@@ -111,15 +111,15 @@ final class WorkerExecRoot {
         throw new InterruptedException();
       }
       Path key = dir.getRelative(fragment);
-      if (inputs.getFiles().containsKey(fragment)) {
-        Path fileDest = inputs.getFiles().get(fragment);
+      if (inputs.files().containsKey(fragment)) {
+        Path fileDest = inputs.files().get(fragment);
         if (fileDest != null) {
           key.createSymbolicLink(fileDest);
         } else {
           FileSystemUtils.createEmptyFile(key);
         }
-      } else if (inputs.getSymlinks().containsKey(fragment)) {
-        PathFragment symlinkDest = inputs.getSymlinks().get(fragment);
+      } else if (inputs.symlinks().containsKey(fragment)) {
+        PathFragment symlinkDest = inputs.symlinks().get(fragment);
         if (symlinkDest != null) {
           key.createSymbolicLink(symlinkDest);
         }

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -197,7 +197,8 @@ final class WorkerSpawnRunner implements SpawnRunner {
             SandboxHelpers.processInputFiles(
                 context.getInputMapping(
                     PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-                execRoot);
+                execRoot,
+                context.getInputMetadataProvider());
       }
       SandboxOutputs outputs = SandboxHelpers.getOutputs(spawn);
 
@@ -207,7 +208,7 @@ final class WorkerSpawnRunner implements SpawnRunner {
 
       spawnMetrics =
           SpawnMetrics.Builder.forWorkerExec()
-              .setInputFiles(inputFiles.getFiles().size() + inputFiles.getSymlinks().size());
+              .setInputFiles(inputFiles.files().size() + inputFiles.symlinks().size());
       response =
           execInWorker(
               spawn, key, context, inputFiles, outputs, flagFiles, inputFileCache, spawnMetrics);
@@ -310,7 +311,7 @@ final class WorkerSpawnRunner implements SpawnRunner {
         throw new InterruptedException();
       }
       String argValue = arg.substring(1);
-      Path path = inputs.getFiles().get(PathFragment.create(argValue));
+      Path path = inputs.files().get(PathFragment.create(argValue));
       if (path == null) {
         throw new IOException(
             String.format(
@@ -383,7 +384,7 @@ final class WorkerSpawnRunner implements SpawnRunner {
     WorkRequest request;
     ActionExecutionMetadata owner = spawn.getResourceOwner();
     ImmutableMap<VirtualActionInput, byte[]> virtualInputDigests =
-        inputFiles.getVirtualInputDigests();
+        inputFiles.virtualInputs();
 
     Stopwatch setupInputsStopwatch = Stopwatch.createStarted();
     boolean hasOutputFileLock = false;

--- a/src/test/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawnTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawnTest.java
@@ -361,7 +361,7 @@ public class AbstractContainerizingSandboxedSpawnTest {
         "Mnemonic") {
 
       @Override
-      protected void materializeRegularFile(Path source, Path target) {
+      protected void materializeFile(Path source, Path target) {
         throw new UnsupportedOperationException();
       }
 

--- a/src/test/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawnTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawnTest.java
@@ -189,9 +189,10 @@ public class AbstractContainerizingSandboxedSpawnTest {
   @Test
   public void createFileSystem_createsDirectoriesForAndInputFiles() throws Exception {
     SandboxInputs sandboxInputs =
-        createSandboxInputs(/*files=*/ ImmutableList.of("a/b"), /*symlinks=*/ ImmutableList.of());
+        createSandboxInputs(
+            /* files= */ ImmutableList.of("a/b"), /* symlinks= */ ImmutableList.of());
     SandboxOutputs sandboxOutputs =
-        SandboxOutputs.create(/*files=*/ ImmutableSet.of(), /*dirs=*/ ImmutableSet.of());
+        SandboxOutputs.create(/* files= */ ImmutableSet.of(), /* dirs= */ ImmutableSet.of());
     AbstractContainerizingSandboxedSpawn sandboxedSpawn =
         createContainerizingSandboxedSpawn(sandboxInputs, sandboxOutputs);
 
@@ -203,9 +204,10 @@ public class AbstractContainerizingSandboxedSpawnTest {
   @Test
   public void createFileSystem_createsDirectoriesForAndInputSymlinks() throws Exception {
     SandboxInputs sandboxInputs =
-        createSandboxInputs(/*files=*/ ImmutableList.of(), /*symlinks=*/ ImmutableList.of("a/b/c"));
+        createSandboxInputs(
+            /* files= */ ImmutableList.of(), /* symlinks= */ ImmutableList.of("a/b/c"));
     SandboxOutputs sandboxOutputs =
-        SandboxOutputs.create(/*files=*/ ImmutableSet.of(), /*dirs=*/ ImmutableSet.of());
+        SandboxOutputs.create(/* files= */ ImmutableSet.of(), /* dirs= */ ImmutableSet.of());
     AbstractContainerizingSandboxedSpawn sandboxedSpawn =
         createContainerizingSandboxedSpawn(sandboxInputs, sandboxOutputs);
 
@@ -219,9 +221,9 @@ public class AbstractContainerizingSandboxedSpawnTest {
   public void createFileSystem_uplevelReference_createsSiblingDirectory() throws Exception {
     SandboxInputs sandboxInputs =
         createSandboxInputs(
-            /*files=*/ ImmutableList.of("../a/b"), /*symlinks=*/ ImmutableList.of());
+            /* files= */ ImmutableList.of("../a/b"), /* symlinks= */ ImmutableList.of());
     SandboxOutputs sandboxOutputs =
-        SandboxOutputs.create(/*files=*/ ImmutableSet.of(), /*dirs=*/ ImmutableSet.of());
+        SandboxOutputs.create(/* files= */ ImmutableSet.of(), /* dirs= */ ImmutableSet.of());
     AbstractContainerizingSandboxedSpawn sandboxedSpawn =
         createContainerizingSandboxedSpawn(sandboxInputs, sandboxOutputs);
 
@@ -234,11 +236,11 @@ public class AbstractContainerizingSandboxedSpawnTest {
   @Test
   public void createFileSystem_createsDirectoriesForOutputFiles() throws Exception {
     SandboxInputs sandboxInputs =
-        createSandboxInputs(/*files=*/ ImmutableList.of(), /*symlinks=*/ ImmutableList.of());
+        createSandboxInputs(/* files= */ ImmutableList.of(), /* symlinks= */ ImmutableList.of());
     SandboxOutputs sandboxOutputs =
         SandboxOutputs.create(
-            /*files=*/ ImmutableSet.of(PathFragment.create("a/b"), PathFragment.create("c/d/e")),
-            /*dirs=*/ ImmutableSet.of());
+            /* files= */ ImmutableSet.of(PathFragment.create("a/b"), PathFragment.create("c/d/e")),
+            /* dirs= */ ImmutableSet.of());
     AbstractContainerizingSandboxedSpawn sandboxedSpawn =
         createContainerizingSandboxedSpawn(sandboxInputs, sandboxOutputs);
 
@@ -251,11 +253,11 @@ public class AbstractContainerizingSandboxedSpawnTest {
   @Test
   public void createFileSystem_createsOutputDirectories() throws Exception {
     SandboxInputs sandboxInputs =
-        createSandboxInputs(/*files=*/ ImmutableList.of(), /*symlinks=*/ ImmutableList.of());
+        createSandboxInputs(/* files= */ ImmutableList.of(), /* symlinks= */ ImmutableList.of());
     SandboxOutputs sandboxOutputs =
         SandboxOutputs.create(
-            /*files=*/ ImmutableSet.of(),
-            /*dirs=*/ ImmutableSet.of(PathFragment.create("a/b"), PathFragment.create("c/d/e")));
+            /* files= */ ImmutableSet.of(),
+            /* dirs= */ ImmutableSet.of(PathFragment.create("a/b"), PathFragment.create("c/d/e")));
     AbstractContainerizingSandboxedSpawn sandboxedSpawn =
         createContainerizingSandboxedSpawn(sandboxInputs, sandboxOutputs);
 
@@ -270,10 +272,10 @@ public class AbstractContainerizingSandboxedSpawnTest {
   public void createFileSystem_nestedFileAndDirectory_createsDirectoriesAndFile() throws Exception {
     SandboxInputs sandboxInputs =
         createSandboxInputs(
-            /*files=*/ ImmutableList.of("a/b/file"), /*symlinks=*/ ImmutableList.of());
+            /* files= */ ImmutableList.of("a/b/file"), /* symlinks= */ ImmutableList.of());
     SandboxOutputs sandboxOutputs =
         SandboxOutputs.create(
-            /*files=*/ ImmutableSet.of(), /*dirs=*/ ImmutableSet.of(PathFragment.create("a")));
+            /* files= */ ImmutableSet.of(), /* dirs= */ ImmutableSet.of(PathFragment.create("a")));
     AbstractContainerizingSandboxedSpawn sandboxedSpawn =
         createContainerizingSandboxedSpawn(sandboxInputs, sandboxOutputs);
 
@@ -287,12 +289,12 @@ public class AbstractContainerizingSandboxedSpawnTest {
   public void createFileSystem_overlappingPaths_createsAllDirectories() throws Exception {
     SandboxInputs sandboxInputs =
         createSandboxInputs(
-            /*files=*/ ImmutableList.of("1/2/file1"),
-            /*symlinks=*/ ImmutableList.of("1/2/3/symlink"));
+            /* files= */ ImmutableList.of("1/2/file1"),
+            /* symlinks= */ ImmutableList.of("1/2/3/symlink"));
     SandboxOutputs sandboxOutputs =
         SandboxOutputs.create(
-            /*files=*/ ImmutableSet.of(PathFragment.create("1/2/file2")),
-            /*dirs=*/ ImmutableSet.of(PathFragment.create("1"), PathFragment.create("2/3/4")));
+            /* files= */ ImmutableSet.of(PathFragment.create("1/2/file2")),
+            /* dirs= */ ImmutableSet.of(PathFragment.create("1"), PathFragment.create("2/3/4")));
     AbstractContainerizingSandboxedSpawn sandboxedSpawn =
         createContainerizingSandboxedSpawn(sandboxInputs, sandboxOutputs);
 
@@ -314,9 +316,9 @@ public class AbstractContainerizingSandboxedSpawnTest {
   public void createFileSystem_fileInUpUpLevelReference_fails() {
     SandboxInputs sandboxInputs =
         createSandboxInputs(
-            /*files=*/ ImmutableList.of("../../file"), /*symlinks=*/ ImmutableList.of());
+            /* files= */ ImmutableList.of("../../file"), /* symlinks= */ ImmutableList.of());
     SandboxOutputs sandboxOutputs =
-        SandboxOutputs.create(/*files=*/ ImmutableSet.of(), /*dirs=*/ ImmutableSet.of());
+        SandboxOutputs.create(/* files= */ ImmutableSet.of(), /* dirs= */ ImmutableSet.of());
     AbstractContainerizingSandboxedSpawn sandboxedSpawn =
         createContainerizingSandboxedSpawn(sandboxInputs, sandboxOutputs);
 
@@ -328,10 +330,10 @@ public class AbstractContainerizingSandboxedSpawnTest {
       throws Exception {
     SandboxInputs sandboxInputs =
         createSandboxInputs(
-            /*files=*/ ImmutableList.of("1/2/3/file", "1/4/file"),
-            /*symlinks=*/ ImmutableMap.of("1/2", "4"));
+            /* files= */ ImmutableList.of("1/2/3/file", "1/4/file"),
+            /* symlinks= */ ImmutableMap.of("1/2", "4"));
     SandboxOutputs sandboxOutputs =
-        SandboxOutputs.create(/*files=*/ ImmutableSet.of(), /*dirs=*/ ImmutableSet.of());
+        SandboxOutputs.create(/* files= */ ImmutableSet.of(), /* dirs= */ ImmutableSet.of());
     AbstractContainerizingSandboxedSpawn sandboxedSpawn =
         createContainerizingSandboxedSpawn(sandboxInputs, sandboxOutputs);
 
@@ -359,7 +361,12 @@ public class AbstractContainerizingSandboxedSpawnTest {
         "Mnemonic") {
 
       @Override
-      protected void copyFile(Path source, Path target) {
+      protected void materializeRegularFile(Path source, Path target) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      protected void materializeDirectory(Path source, Path target) {
         throw new UnsupportedOperationException();
       }
     };

--- a/src/test/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawnTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawnTest.java
@@ -387,11 +387,12 @@ public class AbstractContainerizingSandboxedSpawnTest {
     }
     return new SandboxInputs(
         filesMap,
-        /* virtualInputs= */ ImmutableMap.of(),
+        /* directories= */ ImmutableMap.of(),
         symlinks.entrySet().stream()
             .collect(
                 toImmutableMap(
-                    e -> PathFragment.create(e.getKey()), e -> PathFragment.create(e.getValue()))));
+                    e -> PathFragment.create(e.getKey()), e -> PathFragment.create(e.getValue()))),
+        /* virtualInputs= */ ImmutableMap.of());
   }
 
   /** Return a list of all entries under the provided directory recursively. */

--- a/src/test/java/com/google/devtools/build/lib/sandbox/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/BUILD
@@ -62,6 +62,7 @@ java_test(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/exec:bin_tools",
         "//src/main/java/com/google/devtools/build/lib/exec:tree_deleter",
         "//src/main/java/com/google/devtools/build/lib/sandbox:sandbox_helpers",

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
@@ -123,9 +123,9 @@ public class SandboxHelpersTest {
 
     SandboxInputs inputs = SandboxHelpers.processInputFiles(inputMap(paramFile), execRoot);
 
-    assertThat(inputs.getFiles())
+    assertThat(inputs.files())
         .containsExactly(PathFragment.create("paramFile"), execRoot.getChild("paramFile"));
-    assertThat(inputs.getSymlinks()).isEmpty();
+    assertThat(inputs.symlinks()).isEmpty();
     assertThat(FileSystemUtils.readLines(execRoot.getChild("paramFile"), UTF_8))
         .containsExactly("-a", "-b")
         .inOrder();
@@ -141,10 +141,10 @@ public class SandboxHelpersTest {
 
     SandboxInputs inputs = SandboxHelpers.processInputFiles(inputMap(tool), execRoot);
 
-    assertThat(inputs.getFiles())
+    assertThat(inputs.files())
         .containsExactly(
             PathFragment.create("_bin/say_hello"), execRoot.getRelative("_bin/say_hello"));
-    assertThat(inputs.getSymlinks()).isEmpty();
+    assertThat(inputs.symlinks()).isEmpty();
     assertThat(FileSystemUtils.readLines(execRoot.getRelative("_bin/say_hello"), UTF_8))
         .containsExactly("#!/bin/bash", "echo hello")
         .inOrder();
@@ -248,6 +248,7 @@ public class SandboxHelpersTest {
         new SandboxInputs(
             ImmutableMap.of(input1, inputTxt, input2, inputTxt, input3, inputTxt),
             ImmutableMap.of(),
+            ImmutableMap.of(),
             ImmutableMap.of());
     Set<PathFragment> inputsToCreate = new LinkedHashSet<>();
     LinkedHashSet<PathFragment> dirsToCreate = new LinkedHashSet<>();
@@ -255,8 +256,7 @@ public class SandboxHelpersTest {
         ImmutableSet.of(),
         inputsToCreate,
         dirsToCreate,
-        Iterables.concat(
-            ImmutableSet.of(), inputs.getFiles().keySet(), inputs.getSymlinks().keySet()),
+        Iterables.concat(ImmutableSet.of(), inputs.files().keySet(), inputs.symlinks().keySet()),
         SandboxOutputs.create(
             ImmutableSet.of(PathFragment.create("out/dir/output.txt")), ImmutableSet.of()));
 
@@ -288,6 +288,7 @@ public class SandboxHelpersTest {
     SandboxInputs inputs2 =
         new SandboxInputs(
             ImmutableMap.of(input1, inputTxt, input2, inputTxt, input3, inputTxt, input4, inputTxt),
+            ImmutableMap.of(),
             ImmutableMap.of(),
             ImmutableMap.of());
     SandboxHelpers.cleanExisting(

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
@@ -52,7 +52,6 @@ import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.testing.junit.testparameterinjector.TestParameter;
 import com.google.testing.junit.testparameterinjector.TestParameterInjector;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -218,13 +217,9 @@ public class SandboxHelpersTest {
     var inputMetadataProvider = new FakeActionInputFileCache();
     for (var input : inputs) {
       switch (input) {
-        case VirtualActionInput virtualActionInput -> {
-          var out = new ByteArrayOutputStream();
-          virtualActionInput.writeTo(out);
-          inputMetadataProvider.put(
-              virtualActionInput,
-              FileArtifactValue.createForInlineFile(
-                  out.toByteArray(), fs.getDigestFunction().getHashFunction()));
+        case VirtualActionInput ignored -> {
+          // Intentionally left blank as virtual inputs are not recorded in the
+          // InputMetadataProvider.
         }
         case Artifact artifact ->
             inputMetadataProvider.put(artifact, FileArtifactValue.createForTesting(artifact));

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawnTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawnTest.java
@@ -72,6 +72,7 @@ public class SymlinkedSandboxedSpawnTest {
             new SandboxInputs(
                 ImmutableMap.of(PathFragment.create("such/input.txt"), helloTxt),
                 ImmutableMap.of(),
+                ImmutableMap.of(),
                 ImmutableMap.of()),
             SandboxOutputs.create(
                 ImmutableSet.of(PathFragment.create("very/output.txt")), ImmutableSet.of()),
@@ -103,7 +104,8 @@ public class SymlinkedSandboxedSpawnTest {
             execRoot,
             ImmutableList.of("/bin/true"),
             ImmutableMap.of(),
-            new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+            new SandboxInputs(
+                ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
             SandboxOutputs.create(
                 ImmutableSet.of(outputFile.relativeTo(execRoot)), ImmutableSet.of()),
             ImmutableSet.of(),

--- a/src/test/java/com/google/devtools/build/lib/vfs/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/vfs/BUILD
@@ -1,4 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_library", "java_test")
+load("//src:java_opt_binary.bzl", "java_opt_binary")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -53,6 +54,7 @@ java_library(
         exclude = ALL_WINDOWS_TESTS + [
             "SymlinkAwareFileSystemTest.java",
             "FileSystemTest.java",
+            "CopyFileBenchmark.java",
         ],
     ),
     deps = [
@@ -159,5 +161,23 @@ java_library(
         "//third_party:junit4",
         "//third_party:truth",
         "@maven//:com_google_testparameterinjector_test_parameter_injector",
+    ],
+)
+
+java_opt_binary(
+    name = "CopyFileBenchmark",
+    srcs = ["CopyFileBenchmark.java"],
+    jvm_flags = [
+        "--enable-native-access=ALL-UNNAMED",
+    ],
+    main_class = "org.openjdk.jmh.Main",
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/unix",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
+        "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/windows",
+        "//third_party:guava",
+        "//third_party:jmh",
     ],
 )

--- a/src/test/java/com/google/devtools/build/lib/vfs/CopyFileBenchmark.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/CopyFileBenchmark.java
@@ -1,0 +1,101 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.vfs;
+
+import com.google.common.io.ByteStreams;
+import com.google.devtools.build.lib.unix.UnixFileSystem;
+import com.google.devtools.build.lib.util.OS;
+import com.google.devtools.build.lib.windows.WindowsFileSystem;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.SecureRandom;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.Throughput)
+@State(Scope.Benchmark)
+@Fork(value = 1, warmups = 1)
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 5, time = 1)
+public class CopyFileBenchmark {
+
+  private Path sourceFile;
+  private Path targetFile;
+
+  @Setup(Level.Iteration)
+  public void setup() throws IOException {
+    var fs =
+        OS.getCurrent() == OS.WINDOWS
+            ? new WindowsFileSystem(DigestHashFunction.SHA256, /* enableSymlinks= */ true)
+            : new UnixFileSystem(DigestHashFunction.SHA256, "");
+    var tmpDir = fs.getPath(Files.createTempDirectory("").toString());
+    var destDir = tmpDir.createTempDirectory("benchmark");
+    destDir.createDirectoryAndParents();
+
+    sourceFile = tmpDir.getChild("benchmark_file");
+    var buffer = new byte[1024 * 1024];
+    var random = new SecureRandom();
+    random.nextBytes(buffer);
+    try (var out = sourceFile.getOutputStream()) {
+      out.write(buffer);
+    }
+
+    targetFile = destDir.getChild("copied_benchmark_file");
+  }
+
+  @Setup(Level.Invocation)
+  public void prepareTarget() throws IOException {
+    targetFile.delete();
+  }
+
+  @Benchmark
+  public void baselineCopy() throws IOException {
+    try (var in = sourceFile.getInputStream();
+        var out = targetFile.getOutputStream()) {
+      ByteStreams.copy(in, out);
+    }
+  }
+
+  @Benchmark
+  public void transferTo() throws IOException {
+    try (var in = sourceFile.getInputStream();
+        var out = targetFile.getOutputStream()) {
+      in.transferTo(out);
+    }
+  }
+
+  @Benchmark
+  public void symlink() throws IOException {
+    targetFile.createSymbolicLink(sourceFile);
+  }
+
+  @Benchmark
+  public void copyFile() throws IOException {
+    FileSystemUtils.copyFile(sourceFile, targetFile);
+  }
+
+  @Benchmark
+  public void copyRegularFile() throws IOException {
+    FileSystemUtils.copyRegularFile(sourceFile, targetFile);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/worker/SandboxHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/SandboxHelper.java
@@ -16,7 +16,9 @@ package com.google.devtools.build.lib.worker;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
@@ -185,7 +187,11 @@ class SandboxHelper {
   }
 
   public SandboxInputs getSandboxInputs() {
-    return new SandboxInputs(inputs, virtualInputs, symlinks);
+    return new SandboxInputs(
+        ImmutableSortedMap.copyOf(inputs),
+        ImmutableSortedMap.of(),
+        ImmutableSortedMap.copyOf(symlinks),
+        ImmutableMap.copyOf(virtualInputs));
   }
 
   public SandboxOutputs getSandboxOutputs() {

--- a/src/test/java/com/google/devtools/build/lib/worker/SandboxHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/SandboxHelper.java
@@ -29,9 +29,9 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.SequencedMap;
 
 /**
  * Helper class that sets up a sandbox in a more comprehensible way. Handles setting up
@@ -40,11 +40,11 @@ import java.util.Map;
 class SandboxHelper {
 
   /** Map from workdir-relative input path to optional real file path. */
-  private final Map<PathFragment, Path> inputs = new HashMap<>();
+  private final SequencedMap<PathFragment, Path> inputs = new LinkedHashMap<>();
 
-  private final Map<VirtualActionInput, byte[]> virtualInputs = new HashMap<>();
-  private final Map<PathFragment, PathFragment> symlinks = new HashMap<>();
-  private final Map<PathFragment, Path> workerFiles = new HashMap<>();
+  private final SequencedMap<VirtualActionInput, byte[]> virtualInputs = new LinkedHashMap<>();
+  private final SequencedMap<PathFragment, PathFragment> symlinks = new LinkedHashMap<>();
+  private final SequencedMap<PathFragment, Path> workerFiles = new LinkedHashMap<>();
   private final List<PathFragment> outputFiles = new ArrayList<>();
   private final List<PathFragment> outputDirs = new ArrayList<>();
 
@@ -188,10 +188,7 @@ class SandboxHelper {
 
   public SandboxInputs getSandboxInputs() {
     return new SandboxInputs(
-        ImmutableSortedMap.copyOf(inputs),
-        ImmutableSortedMap.of(),
-        ImmutableSortedMap.copyOf(symlinks),
-        ImmutableMap.copyOf(virtualInputs));
+        inputs, ImmutableSortedMap.of(), symlinks, ImmutableMap.copyOf(virtualInputs));
   }
 
   public SandboxOutputs getSandboxOutputs() {

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnRunnerTest.java
@@ -121,7 +121,8 @@ public class WorkerSpawnRunnerTest {
             spawn,
             key,
             context,
-            new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+            new SandboxInputs(
+                ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
             SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
             ImmutableList.of(),
             inputFileCache,
@@ -162,8 +163,7 @@ public class WorkerSpawnRunnerTest {
     sandboxHelper.addAndCreateVirtualInput("input", "content");
 
     VirtualActionInput virtualActionInput =
-        Iterables.getOnlyElement(
-            sandboxHelper.getSandboxInputs().getVirtualInputDigests().keySet());
+        Iterables.getOnlyElement(sandboxHelper.getSandboxInputs().virtualInputs().keySet());
 
     when(worker.getResponse(0))
         .thenReturn(WorkResponse.newBuilder().setExitCode(0).setOutput("out").build());
@@ -210,7 +210,8 @@ public class WorkerSpawnRunnerTest {
                 spawn,
                 key,
                 context,
-                new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+                new SandboxInputs(
+                    ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
                 SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
                 ImmutableList.of(),
                 inputFileCache,
@@ -252,7 +253,8 @@ public class WorkerSpawnRunnerTest {
                 spawn,
                 key,
                 context,
-                new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+                new SandboxInputs(
+                    ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
                 SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
                 ImmutableList.of(),
                 inputFileCache,
@@ -293,7 +295,8 @@ public class WorkerSpawnRunnerTest {
                 spawn,
                 key,
                 context,
-                new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+                new SandboxInputs(
+                    ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
                 SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
                 ImmutableList.of(),
                 inputFileCache,
@@ -325,7 +328,8 @@ public class WorkerSpawnRunnerTest {
             spawn,
             key,
             context,
-            new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+            new SandboxInputs(
+                ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
             SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
             ImmutableList.of(),
             inputFileCache,
@@ -362,7 +366,8 @@ public class WorkerSpawnRunnerTest {
                     spawn,
                     key,
                     context,
-                    new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+                    new SandboxInputs(
+                        ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
                     SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
                     ImmutableList.of(),
                     inputFileCache,
@@ -411,6 +416,7 @@ public class WorkerSpawnRunnerTest {
                 PathFragment.create("file2"),
                 fs.getPath("/file2")),
             ImmutableMap.of(),
+            ImmutableMap.of(),
             ImmutableMap.of());
     WorkerSpawnRunner.expandArgument(inputs, "@file", requestBuilder);
     assertThat(requestBuilder.getArgumentsList())
@@ -425,6 +431,7 @@ public class WorkerSpawnRunnerTest {
         new SandboxInputs(
             ImmutableMap.of(PathFragment.create("file"), fs.getPath("/file")),
             ImmutableMap.of(),
+            ImmutableMap.of(),
             ImmutableMap.of());
     WorkerSpawnRunner.expandArgument(inputs, "@file", requestBuilder);
     assertThat(requestBuilder.getArgumentsList())
@@ -437,6 +444,7 @@ public class WorkerSpawnRunnerTest {
     SandboxInputs inputs =
         new SandboxInputs(
             ImmutableMap.of(PathFragment.create("file"), fs.getPath("/dir/file")),
+            ImmutableMap.of(),
             ImmutableMap.of(),
             ImmutableMap.of());
     IOException e =
@@ -551,7 +559,8 @@ public class WorkerSpawnRunnerTest {
   public void testExpandArgument_failsOnUndeclaredInput() {
     WorkRequest.Builder requestBuilder = WorkRequest.newBuilder();
     SandboxInputs inputs =
-        new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
+        new SandboxInputs(
+            ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
     IOException e =
         assertThrows(
             IOException.class,

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnStrategyTest.java
@@ -56,6 +56,7 @@ public class WorkerSpawnStrategyTest {
         new SandboxInputs(
             ImmutableMap.of(PathFragment.create("flagfile.txt"), path),
             ImmutableMap.of(),
+            ImmutableMap.of(),
             ImmutableMap.of());
     WorkerSpawnRunner.expandArgument(inputs, "@flagfile.txt", requestBuilder);
 


### PR DESCRIPTION
This avoids one stat for most calls to `FileSystemUtils.copyFile` that were certain to operate on a regular file (or symlink to one). It also avoids an additional stat for the fallback or directory case of a hardlinked sandbox as well as for copying sandboxes. This requires wiring up `InputMetadataProvider` in `SandboxHelpers`, which provides the relevant metadata without I/O.

Along the way this commit no longer uses sorted maps in `SandboxInputs`. The sorting doesn't appear to matter and even if it did, the maps are already created by iterating over the sorted inputs map and preserve order.

The change is accompanied by a benchmark for the various ways of copying a 1 MB file:
```
Linux (ext4):
Benchmark                           Mode  Cnt       Score      Error  Units
CopyFileBenchmark.baselineCopy     thrpt    5    1205.563 ±   48.179  ops/s
CopyFileBenchmark.copyFile         thrpt    5    1863.193 ±  107.196  ops/s
CopyFileBenchmark.copyRegularFile  thrpt    5    1909.037 ±   22.616  ops/s
CopyFileBenchmark.symlink          thrpt    5  141343.808 ± 5222.305  ops/s
CopyFileBenchmark.transferTo       thrpt    5    1982.662 ±   58.852  ops/s

macOS (APFS+):
Benchmark                           Mode  Cnt      Score      Error  Units
CopyFileBenchmark.baselineCopy     thrpt    5   1436.071 ±  104.329  ops/s
CopyFileBenchmark.copyFile         thrpt    5   7673.546 ±  440.189  ops/s
CopyFileBenchmark.copyRegularFile  thrpt    5   7803.180 ±  114.904  ops/s
CopyFileBenchmark.symlink          thrpt    5  22501.789 ± 1020.649  ops/s
CopyFileBenchmark.transferTo       thrpt    5   5577.165 ±  581.416  ops/s

Windows (NTFS):
Benchmark                           Mode  Cnt     Score      Error  Units
CopyFileBenchmark.baselineCopy     thrpt    5  1028,414 ±  248,784  ops/s
CopyFileBenchmark.copyFile         thrpt    5  1313,476 ±  219,426  ops/s
CopyFileBenchmark.copyRegularFile  thrpt    5  1253,456 ±  242,172  ops/s
CopyFileBenchmark.symlink          thrpt    5  4597,534 ± 2148,745  ops/s
CopyFileBenchmark.transferTo       thrpt    5  1498,011 ±  854,424  ops/s

Windows (Dev Drive):
Benchmark                           Mode  Cnt      Score      Error  Units
CopyFileBenchmark.baselineCopy     thrpt    5   1752,549 ±  107,718  ops/s
CopyFileBenchmark.copyFile         thrpt    5   3442,199 ±  165,566  ops/s
CopyFileBenchmark.copyRegularFile  thrpt    5   3468,470 ±   39,007  ops/s
CopyFileBenchmark.symlink          thrpt    5  15573,427 ± 1029,027  ops/s
CopyFileBenchmark.transferTo       thrpt    5   2416,399 ±  396,850  ops/s
```