### PR TITLE
[9.0.0] Add support for decompressing bz2, gz, xz, zst

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/Bz2Function.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/Bz2Function.java
@@ -1,0 +1,38 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.decompressor;
+
+import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorValue.Decompressor;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
+import org.apache.commons.compress.compressors.bzip2.BZip2Utils;
+
+/** Decompresses a bzip2 compressed file. */
+public class Bz2Function extends CompressedFunction {
+  public static final Decompressor INSTANCE = new Bz2Function();
+
+  @Override
+  protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
+      throws IOException {
+    return new BZip2CompressorInputStream(compressedInputStream, true);
+  }
+
+  @Override
+  protected String getUncompressedFileName(InputStream in, String compressedFileName) {
+    return BZip2Utils.getUncompressedFileName(compressedFileName);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedFunction.java
@@ -1,0 +1,83 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.decompressor;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorValue.Decompressor;
+import com.google.devtools.build.lib.vfs.Path;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Common code for decompressing a single compressed file (compressor formats).
+ *
+ * <p>Apache Commons Compress calls all formats that compress a single stream of data compressor
+ * formats while all formats that collect multiple entries inside a single (potentially compressed)
+ * archive are archiver formats. This class handles the former, compressor formats.
+ *
+ * <p>It ignores the {@link DecompressorDescriptor#prefix()} setting because compressed files cannot
+ * contain directories.
+ */
+public abstract class CompressedFunction implements Decompressor {
+
+  protected abstract InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
+      throws IOException;
+
+  /**
+   * Returns the uncompressed file name (eg. file.gz -> file). Some compressors have metadata that
+   * stores the original name. If that's the case, the original name is used (eg. file.gz ->
+   * originalName). Only a basename + ext should be passed in for the compressedFileName.
+   */
+  protected abstract String getUncompressedFileName(
+      InputStream in, final String compressedFileName);
+
+  /**
+   * Set custom file attributes, like last modified time, on the extracted file. Only certain
+   * compressors support this.
+   */
+  protected void setFileAttributes(InputStream in, Path uncompressedFile) throws IOException {}
+
+  // This is the same value as picked for .tar files, which appears to have worked well.
+  private static final int BUFFER_SIZE = 32 * 1024;
+
+  @Override
+  public Path decompress(DecompressorDescriptor descriptor)
+      throws InterruptedException, IOException {
+    if (Thread.interrupted()) {
+      throw new InterruptedException();
+    }
+
+    ImmutableMap<String, String> renameFiles = descriptor.renameFiles();
+    try (InputStream decompressorStream =
+        getDecompressorStream(
+            new BufferedInputStream(descriptor.archivePath().getInputStream(), BUFFER_SIZE))) {
+      String entryName =
+          getUncompressedFileName(decompressorStream, descriptor.archivePath().getBaseName());
+      entryName = renameFiles.getOrDefault(entryName, entryName);
+      Path filePath = descriptor.destinationPath().getRelative(entryName);
+      filePath.getParentDirectory().createDirectoryAndParents();
+      try (OutputStream out = filePath.getOutputStream()) {
+        decompressorStream.transferTo(out);
+      }
+      setFileAttributes(decompressorStream, filePath);
+      if (Thread.interrupted()) {
+        throw new InterruptedException();
+      }
+    }
+    return descriptor.destinationPath();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/DecompressorValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/DecompressorValue.java
@@ -104,12 +104,20 @@ public class DecompressorValue implements SkyValue {
       return TarFunction.INSTANCE;
     } else if (baseName.endsWith(".tar.gz") || baseName.endsWith(".tgz")) {
       return TarGzFunction.INSTANCE;
+    } else if (baseName.endsWith(".gz")) { // Must be after .tar.gz.
+      return GzFunction.INSTANCE;
     } else if (baseName.endsWith(".tar.xz") || baseName.endsWith(".txz")) {
       return TarXzFunction.INSTANCE;
+    } else if (baseName.endsWith(".xz")) { // Must be after .tar.xz.
+      return XzFunction.INSTANCE;
     } else if (baseName.endsWith(".tar.zst") || baseName.endsWith(".tzst")) {
       return TarZstFunction.INSTANCE;
+    } else if (baseName.endsWith(".zst")) { // Must be after .tar.zst.
+      return ZstFunction.INSTANCE;
     } else if (baseName.endsWith(".tar.bz2") || baseName.endsWith(".tbz")) {
       return TarBz2Function.INSTANCE;
+    } else if (baseName.endsWith(".bz2")) { // Must be after .tar.bz2.
+      return Bz2Function.INSTANCE;
     } else if (baseName.endsWith(".ar") || baseName.endsWith(".deb")) {
       return ArFunction.INSTANCE;
     } else if (baseName.endsWith(".7z")) {
@@ -118,7 +126,8 @@ public class DecompressorValue implements SkyValue {
       throw new RepositoryFunctionException(
           Starlark.errorf(
               "Expected a file with a .zip, .jar, .war, .aar, .nupkg, .whl, .tar, .tar.gz, .tgz,"
-                  + " .tar.xz, , .tar.zst, .tzst, .tar.bz2, .tbz, .ar, .deb or .7z suffix (got %s)",
+                  + " .gz, .tar.xz, .txz, .xz, .tar.zst, .tzst, .zst, .tar.bz2, .tbz, .bz2, .ar,"
+                  + " .deb or .7z suffix (got %s)",
               archivePath),
           Transience.PERSISTENT);
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/GzFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/GzFunction.java
@@ -1,0 +1,53 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.decompressor;
+
+import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorValue.Decompressor;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipParameters;
+import org.apache.commons.compress.compressors.gzip.GzipUtils;
+
+/** Decompresses a gzip compressed file. */
+public class GzFunction extends CompressedFunction {
+  public static final Decompressor INSTANCE = new GzFunction();
+
+  @Override
+  protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
+      throws IOException {
+    return new GzipCompressorInputStream(compressedInputStream, true);
+  }
+
+  @Override
+  protected String getUncompressedFileName(InputStream in, String compressedFileName) {
+    String fileName = ((GzipCompressorInputStream) in).getMetaData().getFileName();
+    if (fileName != null && !fileName.isBlank()) {
+      // filename should be the simple basename + ext, but convert to a PathFragment and run
+      // getBaseName to ensure that any path separators and uplevel references are dropped.
+      return PathFragment.create(fileName).getBaseName();
+    }
+    return GzipUtils.getUncompressedFileName(compressedFileName);
+  }
+
+  @Override
+  protected void setFileAttributes(InputStream in, Path uncompressedFile) throws IOException {
+    GzipParameters metaData = ((GzipCompressorInputStream) in).getMetaData();
+    uncompressedFile.setLastModifiedTime(metaData.getModificationTime() * 1000);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/XzFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/XzFunction.java
@@ -1,0 +1,50 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.decompressor;
+
+import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorValue.Decompressor;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
+import org.apache.commons.compress.compressors.xz.XZUtils;
+
+/** Decompresses an xz (LZMA) compressed file. */
+public class XzFunction extends CompressedFunction {
+  public static final Decompressor INSTANCE = new XzFunction();
+
+  /**
+   * Uses {@link XZCompressorInputStream} from Apache Commons Compress to decompress.
+   *
+   * <p>Why not use {@link org.tukaani.xz.XZInputStream} which is used in {@link TarXzFunction}? The
+   * Apache Commons Compress libraries are wrappers around org.tukaani.xz.XZInputStream, so they
+   * should be the same. Since we also use {@link
+   * org.apache.commons.compress.compressors.xz.XZUtils}, we keep consistency and use the Apache
+   * wrapper consistently in this class.
+   *
+   * @see <a
+   *     href="https://commons.apache.org/proper/commons-compress/apidocs/org/apache/commons/compress/compressors/xz/package-summary.html">javadoc</a>
+   */
+  @Override
+  protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
+      throws IOException {
+    return new XZCompressorInputStream(compressedInputStream);
+  }
+
+  @Override
+  protected String getUncompressedFileName(InputStream in, String compressedFileName) {
+    return XZUtils.getUncompressedFileName(compressedFileName);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZstFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZstFunction.java
@@ -1,0 +1,42 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.decompressor;
+
+import com.github.luben.zstd.ZstdInputStreamNoFinalizer;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorValue.Decompressor;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.commons.compress.compressors.FileNameUtil;
+
+/** Decompresses a Zstandard compressed file. */
+public class ZstFunction extends CompressedFunction {
+  public static final Decompressor INSTANCE = new ZstFunction();
+  // Apache Commons Compress does not provide a readily available mapping of compressed ->
+  // uncompressed filenames for Zst, so we make our own.
+  static final FileNameUtil fileNameUtil = new FileNameUtil(ImmutableMap.of(".zst", ""), ".zst");
+
+  @Override
+  protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
+      throws IOException {
+    return new ZstdInputStreamNoFinalizer(compressedInputStream);
+  }
+
+  @Override
+  protected String getUncompressedFileName(InputStream in, String compressedFileName) {
+    return fileNameUtil.getUncompressedFileName(compressedFileName);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -912,8 +912,8 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
                 The archive type of the downloaded file. By default, the archive type is \
                 determined from the file extension of the URL. If the file has no \
                 extension, you can explicitly specify either "zip", "jar", "war", \
-                "aar", "nupkg", "whl", "tar", "tar.gz", "tgz", "tar.xz", "txz", ".tar.zst", \
-                ".tzst", "tar.bz2", ".tbz", ".ar", ".deb", or ".7z" here.
+                "aar", "nupkg", "whl", "tar", "tar.gz", "tgz", "gz", "tar.xz", "txz", "xz", "tar.zst", \
+                "tzst", "zst", "tar.bz2", "tbz", "bz2", "ar", "deb", or "7z" here.
                 """),
         @Param(
             name = "strip_prefix",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/BUILD
@@ -40,6 +40,7 @@ java_library(
         "//third_party:junit4",
         "//third_party:truth",
         "@rules_java//java/runfiles",
+        "@zstd-jni",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedFunctionTest.java
@@ -1,0 +1,176 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.decompressor;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.github.luben.zstd.ZstdOutputStream;
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorValue.Decompressor;
+import com.google.devtools.build.lib.testutil.TestUtils;
+import com.google.devtools.build.lib.vfs.Dirent;
+import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.Symlinks;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class CompressedFunctionTest {
+  @Rule public TestName name = new TestName();
+
+  private final String compressedFileName;
+  private final Class<?> clazz;
+
+  private File archiveDir;
+  private File extractionDir;
+  private FileSystem testFs;
+
+  public CompressedFunctionTest(Class<?> clazz, String compressedFileName) {
+    this.clazz = clazz;
+    this.compressedFileName = compressedFileName;
+  }
+
+  public static final String EXTRACTED_FILE_NAME = "archive.txt";
+
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    return Arrays.asList(
+        new Object[][] {
+          {Bz2Function.class, EXTRACTED_FILE_NAME + ".bz2"},
+          {GzFunction.class, EXTRACTED_FILE_NAME + ".gz"},
+          {XzFunction.class, EXTRACTED_FILE_NAME + ".xz"},
+          {ZstFunction.class, EXTRACTED_FILE_NAME + ".zst"},
+        });
+  }
+
+  @Before
+  public void setUp() throws IOException, CompressorException {
+    // Create an "archives" directory to hold compressed files and an "extracted" directory where
+    // the extraction will occur.
+    String tmpDir = Paths.get(TestUtils.tmpDir()).resolve(name.getMethodName()).toString();
+    archiveDir = Paths.get(tmpDir).resolve("archives").toFile();
+    assertThat(archiveDir.mkdirs()).isTrue();
+    extractionDir = Paths.get(tmpDir).resolve("extracted").toFile();
+    assertThat(extractionDir.mkdirs()).isTrue();
+
+    OutputStream out =
+        Files.newOutputStream(
+            java.nio.file.Path.of(archiveDir.getPath()).resolve(compressedFileName));
+    OutputStream os;
+    if (clazz == Bz2Function.class) {
+      os = new BZip2CompressorOutputStream(out);
+    } else if (clazz == GzFunction.class) {
+      os = new GzipCompressorOutputStream(out);
+    } else if (clazz == XzFunction.class) {
+      os = new XZCompressorOutputStream(out);
+    } else if (clazz == ZstFunction.class) {
+      os = new ZstdOutputStream(out);
+    } else {
+      throw new IllegalArgumentException("Unknown compressor class passed: " + clazz);
+    }
+    os.write(("test compressed " + compressedFileName + " file contents\n").getBytes(UTF_8));
+    os.close();
+
+    testFs = TestArchiveDescriptor.getFileSystem();
+  }
+
+  /** Basic decompression. Verifies that the uncompressed file name and contents are correct. */
+  @Test
+  public void testDecompress() throws Exception {
+    DecompressorDescriptor.Builder descriptor =
+        DecompressorDescriptor.builder()
+            .setDestinationPath(testFs.getPath(extractionDir.getCanonicalPath()))
+            .setArchivePath(
+                testFs.getPath(archiveDir.getCanonicalPath()).getRelative(compressedFileName));
+
+    Path fileDir = decompress(descriptor.build());
+    ImmutableList<String> files =
+        fileDir.readdir(Symlinks.NOFOLLOW).stream().map(Dirent::getName).collect(toImmutableList());
+
+    assertThat(files).containsExactly(EXTRACTED_FILE_NAME);
+    File pathFile = fileDir.getRelative(EXTRACTED_FILE_NAME).getPathFile();
+    assertThat(Files.readString(pathFile.toPath()))
+        .contains("test compressed " + compressedFileName + " file contents\n");
+  }
+
+  /**
+   * Prefixes are ignored, so setting one will not throw and everything still works as the regular
+   * decompression.
+   */
+  @Test
+  public void testDecompressWithPrefixIsIgnored() throws Exception {
+    DecompressorDescriptor.Builder descriptor =
+        DecompressorDescriptor.builder()
+            .setDestinationPath(testFs.getPath(extractionDir.getCanonicalPath()))
+            .setPrefix("archive")
+            .setArchivePath(
+                testFs.getPath(archiveDir.getCanonicalPath()).getRelative(compressedFileName));
+
+    Path fileDir = decompress(descriptor.build());
+    ImmutableList<String> files =
+        fileDir.readdir(Symlinks.NOFOLLOW).stream().map(Dirent::getName).collect(toImmutableList());
+
+    assertThat(files).containsExactly(EXTRACTED_FILE_NAME);
+    File pathFile = fileDir.getRelative(EXTRACTED_FILE_NAME).getPathFile();
+    assertThat(Files.readString(pathFile.toPath()))
+        .contains("test compressed " + compressedFileName + " file contents\n");
+  }
+
+  /** Test renaming the single compressed file. */
+  @Test
+  public void testDecompressWithRenamedFiles() throws Exception {
+    FileSystem testFs = TestArchiveDescriptor.getFileSystem();
+    HashMap<String, String> renameFiles = new HashMap<>();
+    renameFiles.put(EXTRACTED_FILE_NAME, "renamedFile");
+    DecompressorDescriptor.Builder descriptor =
+        DecompressorDescriptor.builder()
+            .setDestinationPath(testFs.getPath(extractionDir.getCanonicalPath()))
+            .setRenameFiles(renameFiles)
+            .setArchivePath(
+                testFs.getPath(archiveDir.getCanonicalPath()).getRelative(compressedFileName));
+
+    Path fileDir = decompress(descriptor.build());
+    ImmutableList<String> files =
+        fileDir.readdir(Symlinks.NOFOLLOW).stream().map(Dirent::getName).collect(toImmutableList());
+
+    assertThat(files).containsExactly("renamedFile");
+    File pathFile = fileDir.getRelative("renamedFile").getPathFile();
+    assertThat(Files.readString(pathFile.toPath()))
+        .contains("test compressed " + compressedFileName + " file contents\n");
+  }
+
+  private Path decompress(DecompressorDescriptor descriptor) throws Exception {
+    return ((Decompressor) clazz.getConstructor().newInstance()).decompress(descriptor);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/DecompressorValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/DecompressorValueTest.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.devtools.build.lib.bazel.repository.RepositoryFunctionException;
-import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorValue.Decompressor;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
@@ -38,37 +37,45 @@ public class DecompressorValueTest {
   @Test
   public void testKnownFileExtensionsDoNotThrow() throws Exception {
     Path path = fs.getPath("/foo/.external-repositories/some-repo/bar.zip");
-    Decompressor unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(ZipDecompressor.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.jar");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(ZipDecompressor.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.zip");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(ZipDecompressor.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.nupkg");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(ZipDecompressor.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.whl");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(ZipDecompressor.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tar.gz");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(TarGzFunction.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tgz");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(TarGzFunction.class);
+    path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.gz");
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(GzFunction.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tar.xz");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(TarXzFunction.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.txz");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(TarXzFunction.class);
+    path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.xz");
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(XzFunction.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tar.zst");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(TarZstFunction.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tzst");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(TarZstFunction.class);
+    path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.zst");
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(ZstFunction.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tar.bz2");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(TarBz2Function.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tbz");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(TarBz2Function.class);
+    path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.bz2");
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(Bz2Function.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.ar");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(ArFunction.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.deb");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(ArFunction.class);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.7z");
-    unused = DecompressorValue.getDecompressor(path);
+    assertThat(DecompressorValue.getDecompressor(path)).isInstanceOf(SevenZDecompressor.class);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/GzFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/GzFunctionTest.java
@@ -1,0 +1,168 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.decompressor;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.testutil.TestConstants.PRODUCT_NAME;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assume.assumeFalse;
+
+import com.google.devtools.build.lib.testutil.TestUtils;
+import com.google.devtools.build.lib.vfs.FileSystem;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipParameters;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+
+/**
+ * Tests "non-core" .gz decompression code. For the "core" decompression, see
+ * CompressedFunctionTest.
+ */
+@RunWith(Enclosed.class)
+public class GzFunctionTest {
+  @Rule public TestName name = new TestName();
+
+  /**
+   * Creates a simple gzip file.
+   *
+   * @param testName used as a directory name in the {@link TestUtils#tmpDir()} where the gzip file
+   *     will be placed.
+   * @param fileName the name of the gzip file to write
+   * @param parameters gzip-specific metadata parameters
+   * @return Path to the gzip file
+   */
+  private static Path createTestGzipFile(
+      String testName, String fileName, GzipParameters parameters) throws IOException {
+    String tmpDir = Path.of(TestUtils.tmpDir()).resolve(testName).toString();
+    Path.of(tmpDir).toFile().mkdirs();
+    Path compressedFile = Path.of(tmpDir, fileName);
+    OutputStream outputStream = Files.newOutputStream(compressedFile);
+
+    try (GzipCompressorOutputStream compressedOutputStream =
+        new GzipCompressorOutputStream(outputStream, parameters)) {
+      compressedOutputStream.write("test file contents\n".getBytes(UTF_8));
+      compressedOutputStream.finish();
+    }
+    return compressedFile;
+  }
+
+  @RunWith(Parameterized.class)
+  public static class FileNameTest {
+    @Rule public TestName name = new TestName();
+
+    public static final String ARCHIVE_NAME = "archive.txt.gz";
+    public static final String BASE_NAME = "archive.txt";
+
+    @Parameterized.Parameters
+    public static List<Object[]> data() {
+      return Arrays.asList(
+          new Object[][] {
+            {"originalFilename", "originalFilename"},
+            {null, BASE_NAME},
+            {"   ", BASE_NAME},
+            {"fake/path/to/originalFilename", "originalFilename"},
+            {"../../path/to/originalFilename", "originalFilename"},
+          });
+    }
+
+    // The filename as stored in the Gzip metadata.
+    private final String metadataFileName;
+
+    // The expected filename when uncompressed.
+    private final String expectedUncompressedFilename;
+
+    public FileNameTest(String metadataFileName, String expectedUncompressedFilename) {
+      this.metadataFileName = metadataFileName;
+      this.expectedUncompressedFilename = expectedUncompressedFilename;
+    }
+
+    /**
+     * If the Gzip metadata parameters have an original filename, it will be used as the
+     * uncompressed filename.
+     */
+    @Test
+    public void uncompressesOriginalFilename() throws IOException {
+      GzipParameters parameters = new GzipParameters();
+      parameters.setFileName(metadataFileName);
+      Path testGzipFile = createTestGzipFile(name.getMethodName(), ARCHIVE_NAME, parameters);
+
+      GzFunction fn = new GzFunction();
+      try (InputStream decompressorStream =
+          fn.getDecompressorStream(
+              new BufferedInputStream(Files.newInputStream(testGzipFile), 32))) {
+        String uncompressedFilename = fn.getUncompressedFileName(decompressorStream, ARCHIVE_NAME);
+        assertThat(uncompressedFilename).isEqualTo(expectedUncompressedFilename);
+      }
+    }
+  }
+
+  @RunWith(JUnit4.class)
+  public static class FileAttributes {
+    @Rule public TestName name = new TestName();
+
+    @Test
+    public void setLastModifiedTime() throws IOException {
+      // TODO(pcloudy): Fix this test in Blaze.
+      assumeFalse(
+          "Skipping setLastModifiedTime test in Blaze environment.", PRODUCT_NAME.equals("blaze"));
+      FileSystem testFs = TestArchiveDescriptor.getFileSystem();
+      com.google.devtools.build.lib.vfs.Path tmpDir = TestUtils.createUniqueTmpDir(testFs);
+      File testFile = new File(tmpDir.getPathFile(), "test_file");
+      assertThat(testFile.createNewFile()).isTrue();
+
+      // Set the modified time gzip metadata.
+      GregorianCalendar testDate = new GregorianCalendar(2000, Calendar.FEBRUARY, 14, 3, 7, 14);
+      GzipParameters parameters = new GzipParameters();
+      // Expects unix time in seconds.
+      long unixTimeSeconds = testDate.getTimeInMillis() / 1000;
+      parameters.setModificationTime(unixTimeSeconds);
+
+      // Create the gzip file with the above metadata.
+      Path testGzipFile = createTestGzipFile(name.getMethodName(), "test.txt.gz", parameters);
+      GzFunction fn = new GzFunction();
+      try (InputStream decompressorStream =
+          fn.getDecompressorStream(
+              new BufferedInputStream(Files.newInputStream(testGzipFile), 32))) {
+        // Calling set attributes will set the modified time according to the metadata.
+        fn.setFileAttributes(decompressorStream, testFs.getPath(testFile.getCanonicalPath()));
+      }
+
+      // There was an error in Apache Commons Compress where the time was improperly divided by
+      // 1000, thus losing 3 digits of precision. This replicates that wrong behavior until we
+      // upgrade the Apache Commons Compress library to 1.28. At which point, you can replace
+      // hackExpectedTimeSeconds below with unixTimeSeconds.
+      // See https://github.com/apache/commons-compress/pull/624
+      long hackExpectedTimeSeconds = unixTimeSeconds / 1000 * 1000;
+      // Time should be in epoch milliseconds.
+      assertThat(testFile.lastModified()).isEqualTo(hackExpectedTimeSeconds * 1000);
+    }
+  }
+}

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -189,7 +189,7 @@
   "moduleExtensions": {
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "KZmG+HXFo6h6+eo0EHaCTECvOyY2l/VFoUYsOr0Phhk=",
+        "bzlTransitiveDigest": "CQyyp0tmZOlk+EXQw1VGTDPUrdFCmSp1ILMkE/WUCOk=",
         "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
         "recordedFileInputs": {
           "@@pybind11_bazel+//MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
@@ -219,7 +219,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "BcC1+HOMyQbaxCezYLAcpAFojGIgibGrmncgO+T2cCU=",
+        "bzlTransitiveDigest": "R6Gq+iIQvAjwdtUd5F03ZG6NPk8e78yYHy8fzNT9lbE=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -283,7 +283,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "dpm2vNTZnKvXszVYIiFyYqs7GF/V1DZfMF372uGaRKo=",
+        "bzlTransitiveDigest": "0nLKVzlylHT8SWZNT23vGondcg/o+6CNGULWK397LWo=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -324,8 +324,8 @@ repository. Files are symlinked after remote files are downloaded and patches (`
 By default, the archive type is determined from the file extension of the
 URL. If the file has no extension, you can explicitly specify one of the
 following: `"zip"`, `"jar"`, `"war"`, `"aar"`, `"tar"`, `"tar.gz"`, `"tgz"`,
-`"tar.xz"`, `"txz"`, `"tar.zst"`, `"tzst"`, `"tar.bz2"`, `"ar"`, `"deb"`, or
-`"7z"`.""",
+`"gz"`, `"tar.xz"`, `"txz"`, `"xz"`, `"tar.zst"`, `"tzst"`, `"zst"`,
+`"tar.bz2"`, `"tbz"`, `"bz2"`, `"ar"`, `"deb"`, or `"7z"`.""",
     ),
     "patches": attr.label_list(
         default = [],
@@ -436,9 +436,9 @@ http_archive = repository_rule(
         """Downloads a Bazel repository as a compressed archive file, decompresses it,
 and makes its targets available for binding.
 
-It supports the following file extensions: `"zip"`, `"jar"`, `"war"`, `"aar"`, `"tar"`,
-`"tar.gz"`, `"tgz"`, `"tar.xz"`, `"txz"`, `"tar.zst"`, `"tzst"`, `tar.bz2`, `"ar"`,
-`"deb"`, or `"7z"`.
+It supports the following file extensions: `"zip"`, `"jar"`, `"war"`, `"aar"`,
+`"tar"`, `"tar.gz"`, `"tgz"`, `"gz"`, `"tar.xz"`, `"txz"`, `"xz"`, `"tar.zst"`,
+`"tzst"`, `"zst"`, `tar.bz2`, `tbz`, `bz2`, `"ar"`, `"deb"`, or `"7z"`.
 
 Examples:
   Suppose the current repository contains the source code for a chat program,


### PR DESCRIPTION
Bazel already supports decompressing tar files compressed with bz2, gz, xz, and zst. This change adds support for decompressing individual files (not in a tar bundle) that are compressed with those compression algorithms.

In other words, support for decompression:

before: .tar.bz2, .tar.gz, .tar.xz, .tar.zst
after : .tar.bz2, .bz2, .tar.gz, .gz, .tar.xz, .xz, .tar.zst, .zst

Fixes: #20125

Closes #27413.

PiperOrigin-RevId: 839740791
Change-Id: I82595436f6ecab23374db7c50a5027a4bb279578

Commit https://github.com/bazelbuild/bazel/commit/80fe2d92fede2373718da0bff529bddafd12298c