### PR TITLE
Add option to continue with local execution if remote cache is unavailable.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -187,10 +187,14 @@ final class RemoteSpawnCache implements SpawnCache {
           }
           throw createExecExceptionForCredentialHelperException(e);
         } catch (RemoteExecutionCapabilitiesException e) {
-          if (thisExecution != null) {
-            thisExecution.close();
+          boolean shouldLocalFallback =
+              options.remoteLocalFallbackForRemoteCache && options.remoteLocalFallback;
+          if (!shouldLocalFallback) {
+            if (thisExecution != null) {
+              thisExecution.close();
+            }
+            throw createExecExceptionFromRemoteExecutionCapabilitiesException(e);
           }
-          throw createExecExceptionFromRemoteExecutionCapabilitiesException(e);
         } catch (IOException e) {
           if (BulkTransferException.allCausedByCacheNotFoundException(e)) {
             // Intentionally left blank

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -283,6 +283,14 @@ public final class RemoteOptions extends CommonRemoteOptions {
           "Whether to fall back to standalone local execution strategy if remote execution fails.")
   public boolean remoteLocalFallback;
 
+  @Option(
+      name = "incompatible_remote_local_fallback_for_remote_cache",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "Whether --remote_local_fallback applies to --remote_cache.")
+  public boolean remoteLocalFallbackForRemoteCache;
+
   @Deprecated
   @Option(
       name = "remote_local_fallback_strategy",

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -552,6 +552,33 @@ EOF
   expect_log "2 processes: 1 internal, 1 local"
 }
 
+function test_local_fallback_if_remote_cache_unavailable() {
+  # Test that when --remote_local_fallback is set and remote_cache is unavailable when build starts, we fallback to
+  # not use remote cache. See https://github.com/bazelbuild/bazel/issues/13487.
+  mkdir -p gen1
+  cat > gen1/BUILD <<'EOF'
+genrule(
+name = "gen1",
+srcs = [],
+outs = ["out1"],
+cmd = "touch \"$@\"",
+)
+EOF
+
+  bazel build \
+      --spawn_strategy=local \
+      --remote_cache=grpc://noexist.invalid \
+      --incompatible_remote_local_fallback_for_remote_cache \
+      --remote_local_fallback \
+      --build_event_text_file=gen1.log \
+      --nobuild_event_text_file_path_conversion \
+      //gen1 >& $TEST_log \
+      || fail "Expected success"
+
+  mv gen1.log $TEST_log
+  expect_log "2 processes: 1 internal, 1 local"
+}
+
 function test_local_fallback_if_remote_executor_unavailable() {
   # Test that when --remote_local_fallback is set and remote_executor is unavailable when build starts, we fallback to
   # local strategy. See https://github.com/bazelbuild/bazel/issues/13487.
@@ -3769,3 +3796,5 @@ EOF
 }
 
 run_suite "Remote execution and remote cache tests"
+
+}


### PR DESCRIPTION
Currently, if the endpoint specified by `--remote_cache` is not available at the start of the build, the build fails with a message saying that the remote cache is not available.

This change introduces a new flag `--incompatible_remote_local_fallback_for_remote_cache`, which when combined with `--remote_local_fallback`, allow build to continue build even if the remote cache is not available initially.

Fixes #27734, #25965.