### PR TITLE
ApiExporter: capture missing attributes

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/BUILD
+++ b/src/main/java/com/google/devtools/build/docgen/BUILD
@@ -75,6 +75,8 @@ java_binary(
     deps = [
         ":docgen_javalib",
         "//src/main/java/com/google/devtools/common/options",
+        "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
+        "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/net/starlark/java/annot",
         "//src/main/java/net/starlark/java/eval",
         "//src/main/protobuf:builtin_java_proto",

--- a/src/main/java/com/google/devtools/build/docgen/SymbolFamilies.java
+++ b/src/main/java/com/google/devtools/build/docgen/SymbolFamilies.java
@@ -35,6 +35,7 @@ import net.starlark.java.eval.Starlark;
 public class SymbolFamilies {
   private final ImmutableList<RuleDocumentation> nativeRules;
   private final ImmutableMap<Category, ImmutableList<StarlarkDocPage>> allDocPages;
+  private final ConfiguredRuleClassProvider ruleClassProvider;
 
   // Mappings between Starlark names and Starlark entities generated from the fakebuildapi.
   private final ImmutableMap<String, Object> globals;
@@ -55,18 +56,18 @@ public class SymbolFamilies {
           BuildEncyclopediaDocException,
           ClassNotFoundException,
           IOException {
-    ConfiguredRuleClassProvider configuredRuleClassProvider = createRuleClassProvider(provider);
+    this.ruleClassProvider = createRuleClassProvider(provider);
     this.nativeRules =
         ImmutableList.copyOf(
             collectNativeRules(
                 expander.ruleExpander,
                 urlMapper,
-                configuredRuleClassProvider,
+                ruleClassProvider,
                 inputJavaDirs,
                 buildEncyclopediaStardocProtos,
                 ruleDenyList));
     this.globals = Starlark.UNIVERSE;
-    this.bzlGlobals = collectBzlGlobals(configuredRuleClassProvider);
+    this.bzlGlobals = collectBzlGlobals(ruleClassProvider);
     this.allDocPages =
         StarlarkDocumentationCollector.getAllDocPages(
             expander, ImmutableList.copyOf(apiStardocProtos));
@@ -93,6 +94,10 @@ public class SymbolFamilies {
    */
   public Map<String, Object> getBzlGlobals() {
     return bzlGlobals;
+  }
+
+  public ConfiguredRuleClassProvider getRuleClassProvider() {
+    return ruleClassProvider;
   }
 
   // Returns a mapping between type names and module/type documentation.


### PR DESCRIPTION
There could be special attributes, such as 'package_metadata'
and 'applicable_licenses' defined in lib/packages/RuleClass.java,
that are not part of the exported builtin.pb. This causes language
servers such as starpls to fail diagnosing when encounter these
attributes.

Fix this by exposing ConfiguredRuleClassProvider from SymbolFamilies
and route it down to ApiExporter.collectRuleInfo. There, we include all
the previously unseen attributes into the exported data.

Note that this fix would only add the 'package_metadata' attribute to
the final proto and not 'applicable_licenses' because the latter is
currently an alias of the former.

Part of https://github.com/withered-magic/starpls/issues/410
