### PR TITLE
Update docs on JetBrains IDE plugins

### DIFF
--- a/docs/install/ide.mdx
+++ b/docs/install/ide.mdx
@@ -42,7 +42,8 @@ Features:
 To install, go to the IDE's plugin browser and search for `Bazel`.
 
 To manually install older versions, download the zip files from the JetBrains
-Marketplace and install the zip file from the IDE's plugin browser.
+Marketplace or from [GitHub Releases](https://github.com/bazelbuild/intellij/releases)
+and install the zip file from the IDE's plugin browser.
 
 ### Xcode
 


### PR DESCRIPTION
We update the link for IntelliJ, which currently points to the legacy plugin, and update some of the surrounding text.