### PR TITLE
Add nowait option to --remote_cache_async

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -30,7 +30,7 @@ import com.google.devtools.build.lib.remote.common.RemotePathResolver;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver.DefaultRemotePathResolver;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver.SiblingRepositoryLayoutResolver;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
-import com.google.devtools.build.lib.remote.options.RemoteOptions.RemoteUploadMode;
+import com.google.devtools.build.lib.remote.options.RemoteOptions.RemoteCacheAsync;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.util.TempPathGenerator;
@@ -246,10 +246,10 @@ final class RemoteActionContextProvider {
   /**
    * Called after a command completes.
    *
-   * @param uploadMode determines whether to wait for uploads to complete
+   * @param cacheAsync determines whether to wait for uploads to complete
    * @return future that completes when uploads are done (immediate for sync mode)
    */
-  public ListenableFuture<Void> afterCommand(RemoteUploadMode uploadMode) {
+  public ListenableFuture<Void> afterCommand(RemoteCacheAsync cacheAsync) {
     // actionInputFetcher uses combinedCache to prefetch inputs, so it must be shut down first.
     if (actionInputFetcher != null) {
       actionInputFetcher.shutdown();
@@ -258,7 +258,7 @@ final class RemoteActionContextProvider {
     ListenableFuture<Void> uploadsFuture = Futures.immediateFuture(null);
 
     if (remoteExecutionService != null) {
-      uploadsFuture = remoteExecutionService.shutdown(uploadMode);
+      uploadsFuture = remoteExecutionService.shutdown(cacheAsync);
     } else {
       if (combinedCache != null) {
         combinedCache.release();

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1808,8 +1808,15 @@ public class RemoteExecutionService {
     try (SilentCloseable c =
         Profiler.instance().profile(ProfilerTask.UPLOAD_TIME, "upload outputs")) {
       UploadManifest manifest = buildUploadManifest(action, spawnResult);
+      // In NOWAIT mode, don't report upload progress to the UI - we don't want the UI to wait.
+      boolean reportUploadProgress =
+          remoteOptions.remoteCacheAsync != RemoteCacheAsync.NOWAIT_FOR_UPLOAD_COMPLETE;
       var unused =
-          manifest.upload(action.getRemoteActionExecutionContext(), combinedCache, reporter);
+          manifest.upload(
+              action.getRemoteActionExecutionContext(),
+              combinedCache,
+              reporter,
+              reportUploadProgress);
     } catch (IOException e) {
       reportUploadError(e);
     } finally {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -2044,10 +2044,11 @@ public class RemoteExecutionService {
       return Futures.immediateFuture(null);
     } else {
       // Async mode - return future, cleanup in listener
-      ListenableFuture<Void> uploadsFuture = Futures.transform(
-          Futures.allAsList(ImmutableList.copyOf(pendingUploads)),
-          unused -> null,
-          directExecutor());
+      ListenableFuture<Void> uploadsFuture =
+          Futures.transform(
+              Futures.allAsList(ImmutableList.copyOf(pendingUploads)),
+              unused -> null,
+              directExecutor());
 
       uploadsFuture.addListener(
           () -> {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -2012,9 +2012,15 @@ public class RemoteExecutionService {
   }
 
   /** Shuts the service down. */
-  public void shutdown() {
+  /**
+   * Shuts the service down.
+   *
+   * @param uploadMode determines whether to wait for uploads to complete
+   * @return future that completes when uploads are done (immediate for sync mode)
+   */
+  public ListenableFuture<Void> shutdown(RemoteUploadMode uploadMode) {
     if (!shutdown.compareAndSet(false, true)) {
-      return;
+      return Futures.immediateFuture(null);
     }
 
     if (buildInterrupted.get()) {
@@ -2023,18 +2029,39 @@ public class RemoteExecutionService {
         combinedCache.shutdownNow();
       }
       Thread.currentThread().interrupt();
+      return Futures.immediateFuture(null);
     }
 
-    // Waits for all background tasks to finish and interrupts them if there is another interrupt.
-    backgroundTaskExecutor.close();
+    if (uploadMode == RemoteUploadMode.WAIT_FOR_UPLOAD_COMPLETE) {
+      // Existing behavior - block until done
+      backgroundTaskExecutor.close();
+      if (combinedCache != null) {
+        combinedCache.release();
+      }
+      if (remoteExecutor != null) {
+        remoteExecutor.close();
+      }
+      return Futures.immediateFuture(null);
+    } else {
+      // Async mode - return future, cleanup in listener
+      ListenableFuture<Void> uploadsFuture = Futures.transform(
+          Futures.allAsList(ImmutableList.copyOf(pendingUploads)),
+          unused -> null,
+          directExecutor());
 
-    // Release the cache only after background tasks are done as they might be using it.
-    if (combinedCache != null) {
-      combinedCache.release();
-    }
+      uploadsFuture.addListener(
+          () -> {
+            backgroundTaskExecutor.close();
+            if (combinedCache != null) {
+              combinedCache.release();
+            }
+            if (remoteExecutor != null) {
+              remoteExecutor.close();
+            }
+          },
+          directExecutor());
 
-    if (remoteExecutor != null) {
-      remoteExecutor.close();
+      return uploadsFuture;
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1785,7 +1785,7 @@ public class RemoteExecutionService {
       return;
     }
 
-    if (remoteOptions.remoteCacheAsync != RemoteCacheAsync.FALSE
+    if (remoteOptions.remoteCacheAsync != RemoteCacheAsync.OFF
         && !action.getSpawn().getResourceOwner().mayModifySpawnOutputsAfterExecution()) {
       backgroundTaskExecutor.execute(
           () -> {
@@ -2036,7 +2036,7 @@ public class RemoteExecutionService {
       return PendingUploads.EMPTY;
     }
 
-    if (cacheAsync != RemoteCacheAsync.NOWAIT) {
+    if (cacheAsync != RemoteCacheAsync.NOWAIT_FOR_UPLOAD_COMPLETE) {
       // Existing behavior - block until done
       backgroundTaskExecutor.close();
       if (combinedCache != null) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -2068,6 +2068,7 @@ public class RemoteExecutionService {
         @Override
         public void cancel() {
           backgroundTaskExecutor.shutdownNow();
+          backgroundTaskExecutor.close();  // Wait for interrupted tasks to terminate
           if (combinedCache != null) {
             combinedCache.shutdownNow();
           }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1793,7 +1793,7 @@ public class RemoteExecutionService {
               doUploadOutputs(action, spawnResult, onUploadComplete);
             } catch (ExecException e) {
               reportUploadError(e);
-            } catch (InterruptedException e) {
+            } catch (InterruptedException ignored) {
               // ThreadPerTaskExecutor does not care about interrupt status.
             }
           });

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -361,6 +361,7 @@ public final class RemoteModule extends BlazeModule {
         Thread.currentThread().interrupt();
       }
     });
+
     waitThread.start();
 
     try {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -1171,20 +1171,8 @@ public final class RemoteModule extends BlazeModule {
     RemoteExecutionService.PendingUploads uploads = pendingUploads;
     pendingUploads = null;
 
-    Thread waitThread = new Thread(() -> {
-      try {
-        uploads.awaitTermination();
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-    });
-    waitThread.start();
-
     try {
-      waitThread.join(60_000);
-      if (waitThread.isAlive()) {
-        uploads.cancel();
-      }
+      uploads.awaitTermination();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       uploads.cancel();

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -23,17 +23,17 @@ import com.google.auth.Credentials;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ImportantOutputHandler;
 import com.google.devtools.build.lib.analysis.AnalysisResult;
@@ -1063,17 +1063,19 @@ public final class RemoteModule extends BlazeModule {
     RemoteActionContextProvider actionContextProviderRef = actionContextProvider;
     TempPathGenerator tempPathGeneratorRef = tempPathGenerator;
     AsynchronousMessageOutputStream<LogEntry> rpcLogFileRef = rpcLogFile;
-    RemoteUploadMode uploadModeRef = remoteOptions != null
-        ? remoteOptions.experimentalRemoteUploadMode
-        : RemoteUploadMode.WAIT_FOR_UPLOAD_COMPLETE;
+    RemoteUploadMode uploadModeRef =
+        remoteOptions != null
+            ? remoteOptions.experimentalRemoteUploadMode
+            : RemoteUploadMode.WAIT_FOR_UPLOAD_COMPLETE;
     if (actionContextProviderRef != null || tempPathGeneratorRef != null || rpcLogFileRef != null) {
       blockWaitingModule.submit(
-          () -> afterCommandTask(
-              actionContextProviderRef,
-              tempPathGeneratorRef,
-              rpcLogFileRef,
-              uploadModeRef,
-              future -> pendingUploadsFuture = future));
+          () ->
+              afterCommandTask(
+                  actionContextProviderRef,
+                  tempPathGeneratorRef,
+                  rpcLogFileRef,
+                  uploadModeRef,
+                  future -> pendingUploadsFuture = future));
     }
 
     lastRemoteOutputChecker = remoteOutputChecker;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -29,11 +29,9 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ImportantOutputHandler;
 import com.google.devtools.build.lib.analysis.AnalysisResult;
@@ -129,13 +127,11 @@ import java.nio.channels.ClosedChannelException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
@@ -163,7 +159,7 @@ public final class RemoteModule extends BlazeModule {
   @Nullable private String lastBuildId;
 
   // Survives across command invocations within the same server for async upload modes
-  @Nullable private ListenableFuture<Void> pendingUploadsFuture = null;
+  @Nullable private RemoteExecutionService.PendingUploads pendingUploads = null;
 
   private ChannelFactory channelFactory =
       new ChannelFactory() {
@@ -350,35 +346,46 @@ public final class RemoteModule extends BlazeModule {
   }
 
   private void waitForPreviousInvocation(Reporter reporter) {
-    if (pendingUploadsFuture == null) {
+    if (pendingUploads == null) {
       return;
     }
 
-    ListenableFuture<Void> future = pendingUploadsFuture;
-    pendingUploadsFuture = null;
+    RemoteExecutionService.PendingUploads uploads = pendingUploads;
+    pendingUploads = null;
 
     Stopwatch stopwatch = Stopwatch.createStarted();
+    Thread waitThread = new Thread(() -> {
+      try {
+        uploads.awaitTermination();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    });
+    waitThread.start();
+
     try {
       // Wait up to 30 seconds for uploads from previous invocation to complete
-      Uninterruptibles.getUninterruptibly(future, 30, SECONDS);
-      long elapsed = stopwatch.elapsed().toMillis();
-      if (elapsed > 1000) {
+      waitThread.join(30_000);
+      if (waitThread.isAlive()) {
         reporter.handle(
-            Event.info(
-                String.format(
-                    "Waited %.1f seconds for remote cache uploads from previous build to complete",
-                    elapsed / 1000.0)));
+            Event.warn(
+                "Timed out waiting for remote cache uploads from previous build to complete. "
+                    + "The build will continue, but some uploads may be lost."));
+        uploads.cancel();
+      } else {
+        long elapsed = stopwatch.elapsed().toMillis();
+        if (elapsed > 1000) {
+          reporter.handle(
+              Event.info(
+                  String.format(
+                      "Waited %.1f seconds for remote cache uploads from previous build to"
+                          + " complete",
+                      elapsed / 1000.0)));
+        }
       }
-    } catch (TimeoutException e) {
-      reporter.handle(
-          Event.warn(
-              "Timed out waiting for remote cache uploads from previous build to complete. "
-                  + "The build will continue, but some uploads may be lost."));
-      future.cancel(true);
-    } catch (ExecutionException e) {
-      reporter.handle(
-          Event.warn(
-              "Remote cache uploads from previous build failed: " + e.getCause().getMessage()));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      uploads.cancel();
     }
   }
 
@@ -1073,7 +1080,7 @@ public final class RemoteModule extends BlazeModule {
                   tempPathGeneratorRef,
                   rpcLogFileRef,
                   cacheAsyncRef,
-                  future -> pendingUploadsFuture = future));
+                  uploads -> pendingUploads = uploads));
     }
 
     lastRemoteOutputChecker = remoteOutputChecker;
@@ -1101,38 +1108,53 @@ public final class RemoteModule extends BlazeModule {
       @Nullable TempPathGenerator tempPathGenerator,
       @Nullable AsynchronousMessageOutputStream<LogEntry> rpcLogFile,
       RemoteCacheAsync cacheAsync,
-      Consumer<ListenableFuture<Void>> pendingUploadsSetter)
+      Consumer<RemoteExecutionService.PendingUploads> pendingUploadsSetter)
       throws AbruptExitException {
-    ListenableFuture<Void> uploadsFuture = null;
+    RemoteExecutionService.PendingUploads uploads = RemoteExecutionService.PendingUploads.EMPTY;
 
     if (actionContextProvider != null) {
-      uploadsFuture = actionContextProvider.afterCommand(cacheAsync);
+      uploads = actionContextProvider.afterCommand(cacheAsync);
     }
 
-    // For NOWAIT mode, store the future for next invocation and defer cleanup
-    if (cacheAsync == RemoteCacheAsync.NOWAIT && uploadsFuture != null) {
-      // Add listener to clean up resources when uploads complete
+    // For NOWAIT mode, store the handle for next invocation and defer cleanup
+    if (cacheAsync == RemoteCacheAsync.NOWAIT && uploads != RemoteExecutionService.PendingUploads.EMPTY) {
+      // Wrap the PendingUploads to clean up resources after awaiting
       Path tempDir = tempPathGenerator != null ? tempPathGenerator.getTempDir() : null;
       AsynchronousMessageOutputStream<LogEntry> logFile = rpcLogFile;
-      uploadsFuture.addListener(
-          () -> {
-            if (tempDir != null) {
-              try {
-                tempDir.deleteTree();
-              } catch (IOException ignored) {
-                // Intentionally ignored.
-              }
+      RemoteExecutionService.PendingUploads innerUploads = uploads;
+      pendingUploadsSetter.accept(new RemoteExecutionService.PendingUploads() {
+        @Override
+        public void awaitTermination() throws InterruptedException {
+          try {
+            innerUploads.awaitTermination();
+          } finally {
+            cleanup();
+          }
+        }
+
+        @Override
+        public void cancel() {
+          innerUploads.cancel();
+          cleanup();
+        }
+
+        private void cleanup() {
+          if (tempDir != null) {
+            try {
+              tempDir.deleteTree();
+            } catch (IOException ignored) {
+              // Intentionally ignored.
             }
-            if (logFile != null) {
-              try {
-                logFile.close();
-              } catch (IOException ignored) {
-                // Intentionally ignored - can't throw from listener.
-              }
+          }
+          if (logFile != null) {
+            try {
+              logFile.close();
+            } catch (IOException ignored) {
+              // Intentionally ignored.
             }
-          },
-          MoreExecutors.directExecutor());
-      pendingUploadsSetter.accept(uploadsFuture);
+          }
+        }
+      });
       return;
     }
 
@@ -1159,20 +1181,32 @@ public final class RemoteModule extends BlazeModule {
 
   @Override
   public void blazeShutdown() {
-    if (pendingUploadsFuture == null) {
+    if (pendingUploads == null) {
       return;
     }
 
     // Wait for pending uploads to complete before server shutdown.
     // Use a longer timeout than waitForPreviousInvocation() since this is the final chance.
+    RemoteExecutionService.PendingUploads uploads = pendingUploads;
+    pendingUploads = null;
+
+    Thread waitThread = new Thread(() -> {
+      try {
+        uploads.awaitTermination();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    });
+    waitThread.start();
+
     try {
-      Uninterruptibles.getUninterruptibly(pendingUploadsFuture, 30, SECONDS);
-    } catch (TimeoutException e) {
-      pendingUploadsFuture.cancel(true);
-    } catch (ExecutionException e) {
-      // Upload failed, nothing more we can do.
-    } finally {
-      pendingUploadsFuture = null;
+      waitThread.join(30_000);
+      if (waitThread.isAlive()) {
+        uploads.cancel();
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      uploads.cancel();
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -384,8 +384,13 @@ public final class RemoteModule extends BlazeModule {
         }
       }
     } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
+      // User pressed Ctrl+C - cancel uploads but continue with the build
+      reporter.handle(
+          Event.warn(
+              "Interrupted while waiting for remote cache uploads from previous build. "
+                  + "Some cache entries may be incomplete."));
       uploads.cancel();
+      // Don't re-interrupt the thread - we want the build to proceed
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -1076,7 +1076,7 @@ public final class RemoteModule extends BlazeModule {
     TempPathGenerator tempPathGeneratorRef = tempPathGenerator;
     AsynchronousMessageOutputStream<LogEntry> rpcLogFileRef = rpcLogFile;
     RemoteCacheAsync cacheAsyncRef =
-        remoteOptions != null ? remoteOptions.remoteCacheAsync : RemoteCacheAsync.TRUE;
+        remoteOptions != null ? remoteOptions.remoteCacheAsync : RemoteCacheAsync.WAIT_FOR_UPLOAD_COMPLETE;
     if (actionContextProviderRef != null || tempPathGeneratorRef != null || rpcLogFileRef != null) {
       blockWaitingModule.submit(
           () ->
@@ -1122,7 +1122,7 @@ public final class RemoteModule extends BlazeModule {
     }
 
     // For NOWAIT mode, store the handle for next invocation and defer cleanup
-    if (cacheAsync == RemoteCacheAsync.NOWAIT && uploads != RemoteExecutionService.PendingUploads.EMPTY) {
+    if (cacheAsync == RemoteCacheAsync.NOWAIT_FOR_UPLOAD_COMPLETE && uploads != RemoteExecutionService.PendingUploads.EMPTY) {
       // Wrap the PendingUploads to clean up resources after awaiting
       Path tempDir = tempPathGenerator != null ? tempPathGenerator.getTempDir() : null;
       AsynchronousMessageOutputStream<LogEntry> logFile = rpcLogFile;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -367,7 +367,7 @@ public final class RemoteModule extends BlazeModule {
       reporter.handle(
           Event.warn(
               "Interrupted while waiting for remote cache uploads from previous build. "
-                  + "Some cache entries may be incomplete."));
+                  + "Some cache entries may be missing."));
       uploads.cancel();
       // Don't re-interrupt the thread - we want the build to proceed
     }
@@ -1168,7 +1168,6 @@ public final class RemoteModule extends BlazeModule {
     }
 
     // Wait for pending uploads to complete before server shutdown.
-    // Use a longer timeout than waitForPreviousInvocation() since this is the final chance.
     RemoteExecutionService.PendingUploads uploads = pendingUploads;
     pendingUploads = null;
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -359,8 +359,8 @@ public final class RemoteModule extends BlazeModule {
 
     Stopwatch stopwatch = Stopwatch.createStarted();
     try {
-      // Wait up to 10 seconds for uploads from previous invocation to complete
-      Uninterruptibles.getUninterruptibly(future, 10, SECONDS);
+      // Wait up to 30 seconds for uploads from previous invocation to complete
+      Uninterruptibles.getUninterruptibly(future, 30, SECONDS);
       long elapsed = stopwatch.elapsed().toMillis();
       if (elapsed > 1000) {
         reporter.handle(

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -1205,7 +1205,7 @@ public final class RemoteModule extends BlazeModule {
     waitThread.start();
 
     try {
-      waitThread.join(30_000);
+      waitThread.join(60_000);
       if (waitThread.isAlive()) {
         uploads.cancel();
       }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
@@ -163,7 +163,7 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
                   /* startTime= */ Instant.now(),
                   /* wallTimeInMs= */ 0,
                   /* preserveExecutableBit= */ true)
-              .upload(context, cache, reporter);
+              .upload(context, cache, reporter, /* reportUploadProgress= */ true);
     } catch (ExecException | IOException e) {
       reporter.handle(
           Event.warn(

--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -605,9 +605,10 @@ public class UploadManifest {
   public ActionResult upload(
       RemoteActionExecutionContext context,
       CombinedCache combinedCache,
-      ExtendedEventHandler reporter)
+      ExtendedEventHandler reporter,
+      boolean reportUploadProgress)
       throws IOException, InterruptedException, ExecException {
-    ActionExecutionMetadata action = context.getSpawnOwner();
+    ActionExecutionMetadata action = reportUploadProgress ? context.getSpawnOwner() : null;
     var allDigests = Sets.union(digestToBlobs.keySet(), digestToFile.keySet()).immutableCopy();
     ImmutableSet<Digest> missingDigests;
     try (var s = Profiler.instance().profile(ProfilerTask.INFO, "findMissingDigests")) {

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -127,6 +127,44 @@ public final class RemoteOptions extends CommonRemoteOptions {
               + " set.")
   public boolean remoteCacheAsync;
 
+  /** Determines the mode for uploading outputs to the remote cache. */
+  public enum RemoteUploadMode {
+    /** Block at the end of the build waiting for all uploads to complete (current behavior). */
+    WAIT_FOR_UPLOAD_COMPLETE,
+    /** Block at the beginning of the next build waiting for upload completion. */
+    NOWAIT_FOR_UPLOAD_COMPLETE,
+    /**
+     * Block at the beginning of the next build waiting for client-side upload completion, but don't
+     * wait for server acknowledgement. Data may be lost on transient failures.
+     */
+    FULLY_ASYNC,
+  }
+
+  /** Converter for {@link RemoteUploadMode}. */
+  public static class RemoteUploadModeConverter extends EnumConverter<RemoteUploadMode> {
+    public RemoteUploadModeConverter() {
+      super(RemoteUploadMode.class, "remote upload mode");
+    }
+  }
+
+  @Option(
+      name = "experimental_remote_upload_mode",
+      defaultValue = "wait_for_upload_complete",
+      converter = RemoteUploadModeConverter.class,
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.EAGERNESS_TO_EXIT},
+      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+      help =
+          "Specifies whether remote cache uploads should block the build completion or should "
+              + "end the invocation immediately and finish the upload in the background. "
+              + "'wait_for_upload_complete' (default): blocks at the end of the current invocation "
+              + "until all uploads complete. "
+              + "'nowait_for_upload_complete': blocks at the beginning of the next invocation "
+              + "until all uploads from the previous invocation complete. "
+              + "'fully_async': blocks at the beginning of the next invocation until all "
+              + "uploads are sent, but does not wait for server acknowledgement.")
+  public RemoteUploadMode experimentalRemoteUploadMode;
+
   @Option(
       name = "remote_cache",
       oldName = "remote_http_cache",

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -133,11 +133,6 @@ public final class RemoteOptions extends CommonRemoteOptions {
     WAIT_FOR_UPLOAD_COMPLETE,
     /** Block at the beginning of the next build waiting for upload completion. */
     NOWAIT_FOR_UPLOAD_COMPLETE,
-    /**
-     * Block at the beginning of the next build waiting for client-side upload completion, but don't
-     * wait for server acknowledgement. Data may be lost on transient failures.
-     */
-    FULLY_ASYNC,
   }
 
   /** Converter for {@link RemoteUploadMode}. */

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -160,11 +160,12 @@ public final class RemoteOptions extends CommonRemoteOptions {
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "Determines how action outputs are uploaded to the remote or disk cache. "
-              + "'true' (default): upload in the background, but block at end of build until "
-              + "uploads complete. "
-              + "'false': block completion of each action until its outputs are uploaded. "
-              + "'nowait': upload in the background and return immediately when the build "
-              + "completes; block at the start of the next build until uploads finish.")
+              + "'wait_for_upload_complete' or 'true' (default): upload in the background, but "
+              + "block at end of build until uploads complete. "
+              + "'off' or 'false': block completion of each action until its outputs are uploaded. "
+              + "'nowait_for_upload_complete': upload in the background and return immediately "
+              + "when the build completes; block at the start of the next build until uploads "
+              + "finish.")
   public RemoteCacheAsync remoteCacheAsync;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -125,25 +125,29 @@ public final class RemoteOptions extends CommonRemoteOptions {
      * Synchronous uploads: block completion of each action until its outputs are uploaded. This is
      * the old {@code --remote_cache_async=false} behavior.
      */
-    FALSE,
+    OFF,
     /**
      * Async uploads with wait at end of build: upload action outputs in the background, but block
      * at the end of the build until all uploads complete. This is the old {@code
      * --remote_cache_async=true} behavior and is the default.
      */
-    TRUE,
+    WAIT_FOR_UPLOAD_COMPLETE,
     /**
      * Async uploads with wait at start of next build: upload action outputs in the background and
      * return immediately when the build completes. Block at the beginning of the next invocation
      * until all uploads from the previous invocation complete.
      */
-    NOWAIT,
+    NOWAIT_FOR_UPLOAD_COMPLETE,
   }
 
   /** Converter for {@link RemoteCacheAsync} that accepts both boolean and enum values. */
   public static class RemoteCacheAsyncConverter extends BoolOrEnumConverter<RemoteCacheAsync> {
     public RemoteCacheAsyncConverter() {
-      super(RemoteCacheAsync.class, "remote cache async mode", RemoteCacheAsync.TRUE, RemoteCacheAsync.FALSE);
+      super(
+          RemoteCacheAsync.class,
+          "remote cache async mode",
+          RemoteCacheAsync.WAIT_FOR_UPLOAD_COMPLETE,
+          RemoteCacheAsync.OFF);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeModule.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeModule.java
@@ -218,6 +218,18 @@ public abstract class BlazeModule implements OptionsSupplier {
   public void beforeCommand(CommandEnvironment env) throws AbruptExitException {}
 
   /**
+   * Called after the UI event handler is set up and stored events have been replayed, but before
+   * the command starts executing. This is an appropriate place for blocking operations that need to
+   * show progress in the UI.
+   *
+   * <p>This method is called after {@link #beforeCommand} and before the command execution begins.
+   *
+   * @param env the command environment
+   * @throws AbruptExitException modules can throw this exception to abort the command
+   */
+  public void afterUiSetup(CommandEnvironment env) throws AbruptExitException {}
+
+  /**
    * Returns additional listeners to the console output stream. Called at the beginning of each
    * command (after #beforeCommand).
    */

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -63,6 +63,7 @@ java_library(
             "BuildWithoutTheBytesIntegrationTest.java",
             "BuildWithoutTheBytesIntegrationTestBase.java",
             "DiskCacheIntegrationTest.java",
+            "RemoteUploadModeIntegrationTest.java",
         ],
     ),
     deps = [
@@ -253,6 +254,33 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/protobuf:failure_details_java_proto",
+        "//src/test/java/com/google/devtools/build/lib/remote/util:integration_test_utils",
+        "//third_party:guava",
+        "//third_party:junit4",
+        "//third_party:truth",
+        "@maven//:com_google_testparameterinjector_test_parameter_injector",
+    ],
+)
+
+java_test(
+    name = "RemoteUploadModeIntegrationTest",
+    size = "large",
+    srcs = ["RemoteUploadModeIntegrationTest.java"],
+    jvm_flags = ["-Djava.lang.Thread.allowVirtualThreads=true"],
+    shard_count = 2,
+    tags = ["requires-network"],
+    runtime_deps = [
+        "//third_party/grpc-java:grpc-jar",
+    ],
+    deps = [
+        ":build_without_the_bytes_integration_test_base",
+        "//src/main/java/com/google/devtools/build/lib:runtime",
+        "//src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper:credential_module",
+        "//src/main/java/com/google/devtools/build/lib/dynamic",
+        "//src/main/java/com/google/devtools/build/lib/remote",
+        "//src/main/java/com/google/devtools/build/lib/standalone",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/test/java/com/google/devtools/build/lib/remote/util:integration_test_utils",
         "//third_party:guava",
         "//third_party:junit4",

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -729,7 +729,8 @@ public class GrpcCacheClientTest {
             /* startTime= */ null,
             /* wallTimeInMs= */ 0,
             /* preserveExecutableBit= */ false);
-    return uploadManifest.upload(context, combinedCache, NullEventHandler.INSTANCE);
+    return uploadManifest.upload(
+        context, combinedCache, NullEventHandler.INSTANCE, /* reportUploadProgress= */ true);
   }
 
   private ActionResult uploadDirectory(CombinedCache combinedCache, List<Path> outputs)

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -3142,26 +3142,25 @@ public class RemoteExecutionServiceTest {
     future.get();
   }
 
-  // ==================== Tests for shutdown(RemoteUploadMode) ====================
+  // ==================== Tests for shutdown(RemoteCacheAsync) ====================
 
   @Test
-  public void shutdown_waitForUploadComplete_blocksUntilDone() throws Exception {
-    // Test that WAIT_FOR_UPLOAD_COMPLETE mode blocks until uploads complete
+  public void shutdown_true_blocksUntilDone() throws Exception {
+    // Test that TRUE mode (wait at end of build) blocks until uploads complete
     RemoteExecutionService service = newRemoteExecutionService();
 
     // Shutdown with default mode should return an immediate future
-    var future = service.shutdown(RemoteOptions.RemoteUploadMode.WAIT_FOR_UPLOAD_COMPLETE);
+    var future = service.shutdown(RemoteOptions.RemoteCacheAsync.TRUE);
 
     assertThat(future.isDone()).isTrue();
   }
 
   @Test
-  public void shutdown_nowaitForUploadComplete_returnsImmediateFutureWhenNoUploads()
-      throws Exception {
-    // Test that NOWAIT_FOR_UPLOAD_COMPLETE returns immediately when there are no pending uploads
+  public void shutdown_nowait_returnsImmediateFutureWhenNoUploads() throws Exception {
+    // Test that NOWAIT returns immediately when there are no pending uploads
     RemoteExecutionService service = newRemoteExecutionService();
 
-    var future = service.shutdown(RemoteOptions.RemoteUploadMode.NOWAIT_FOR_UPLOAD_COMPLETE);
+    var future = service.shutdown(RemoteOptions.RemoteCacheAsync.NOWAIT);
 
     // With no pending uploads, future should be done immediately
     assertThat(future.isDone()).isTrue();
@@ -3172,8 +3171,8 @@ public class RemoteExecutionServiceTest {
     // Test that calling shutdown twice doesn't cause issues
     RemoteExecutionService service = newRemoteExecutionService();
 
-    var future1 = service.shutdown(RemoteOptions.RemoteUploadMode.WAIT_FOR_UPLOAD_COMPLETE);
-    var future2 = service.shutdown(RemoteOptions.RemoteUploadMode.WAIT_FOR_UPLOAD_COMPLETE);
+    var future1 = service.shutdown(RemoteOptions.RemoteCacheAsync.TRUE);
+    var future2 = service.shutdown(RemoteOptions.RemoteCacheAsync.TRUE);
 
     assertThat(future1.isDone()).isTrue();
     assertThat(future2.isDone()).isTrue();
@@ -3184,7 +3183,7 @@ public class RemoteExecutionServiceTest {
     // Test that shutdown releases the cache
     RemoteExecutionService service = newRemoteExecutionService();
 
-    service.shutdown(RemoteOptions.RemoteUploadMode.WAIT_FOR_UPLOAD_COMPLETE);
+    service.shutdown(RemoteOptions.RemoteCacheAsync.TRUE);
 
     verify(cache).release();
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -3150,7 +3150,7 @@ public class RemoteExecutionServiceTest {
     RemoteExecutionService service = newRemoteExecutionService();
 
     // Shutdown with default mode should return EMPTY (already done)
-    var pendingUploads = service.shutdown(RemoteOptions.RemoteCacheAsync.TRUE);
+    var pendingUploads = service.shutdown(RemoteOptions.RemoteCacheAsync.WAIT_FOR_UPLOAD_COMPLETE);
 
     assertThat(pendingUploads).isSameInstanceAs(RemoteExecutionService.PendingUploads.EMPTY);
   }
@@ -3160,7 +3160,7 @@ public class RemoteExecutionServiceTest {
     // Test that NOWAIT returns a PendingUploads handle
     RemoteExecutionService service = newRemoteExecutionService();
 
-    var pendingUploads = service.shutdown(RemoteOptions.RemoteCacheAsync.NOWAIT);
+    var pendingUploads = service.shutdown(RemoteOptions.RemoteCacheAsync.NOWAIT_FOR_UPLOAD_COMPLETE);
 
     // Should return a non-empty handle that can be awaited
     assertThat(pendingUploads).isNotNull();
@@ -3171,8 +3171,8 @@ public class RemoteExecutionServiceTest {
     // Test that calling shutdown twice doesn't cause issues
     RemoteExecutionService service = newRemoteExecutionService();
 
-    var pendingUploads1 = service.shutdown(RemoteOptions.RemoteCacheAsync.TRUE);
-    var pendingUploads2 = service.shutdown(RemoteOptions.RemoteCacheAsync.TRUE);
+    var pendingUploads1 = service.shutdown(RemoteOptions.RemoteCacheAsync.WAIT_FOR_UPLOAD_COMPLETE);
+    var pendingUploads2 = service.shutdown(RemoteOptions.RemoteCacheAsync.WAIT_FOR_UPLOAD_COMPLETE);
 
     assertThat(pendingUploads1).isSameInstanceAs(RemoteExecutionService.PendingUploads.EMPTY);
     assertThat(pendingUploads2).isSameInstanceAs(RemoteExecutionService.PendingUploads.EMPTY);
@@ -3183,7 +3183,7 @@ public class RemoteExecutionServiceTest {
     // Test that shutdown releases the cache
     RemoteExecutionService service = newRemoteExecutionService();
 
-    service.shutdown(RemoteOptions.RemoteCacheAsync.TRUE);
+    service.shutdown(RemoteOptions.RemoteCacheAsync.WAIT_FOR_UPLOAD_COMPLETE);
 
     verify(cache).release();
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -3149,33 +3149,33 @@ public class RemoteExecutionServiceTest {
     // Test that TRUE mode (wait at end of build) blocks until uploads complete
     RemoteExecutionService service = newRemoteExecutionService();
 
-    // Shutdown with default mode should return an immediate future
-    var future = service.shutdown(RemoteOptions.RemoteCacheAsync.TRUE);
+    // Shutdown with default mode should return EMPTY (already done)
+    var pendingUploads = service.shutdown(RemoteOptions.RemoteCacheAsync.TRUE);
 
-    assertThat(future.isDone()).isTrue();
+    assertThat(pendingUploads).isSameInstanceAs(RemoteExecutionService.PendingUploads.EMPTY);
   }
 
   @Test
-  public void shutdown_nowait_returnsImmediateFutureWhenNoUploads() throws Exception {
-    // Test that NOWAIT returns immediately when there are no pending uploads
+  public void shutdown_nowait_returnsPendingUploadsHandle() throws Exception {
+    // Test that NOWAIT returns a PendingUploads handle
     RemoteExecutionService service = newRemoteExecutionService();
 
-    var future = service.shutdown(RemoteOptions.RemoteCacheAsync.NOWAIT);
+    var pendingUploads = service.shutdown(RemoteOptions.RemoteCacheAsync.NOWAIT);
 
-    // With no pending uploads, future should be done immediately
-    assertThat(future.isDone()).isTrue();
+    // Should return a non-empty handle that can be awaited
+    assertThat(pendingUploads).isNotNull();
   }
 
   @Test
-  public void shutdown_calledTwice_secondCallReturnsImmediately() throws Exception {
+  public void shutdown_calledTwice_secondCallReturnsEmpty() throws Exception {
     // Test that calling shutdown twice doesn't cause issues
     RemoteExecutionService service = newRemoteExecutionService();
 
-    var future1 = service.shutdown(RemoteOptions.RemoteCacheAsync.TRUE);
-    var future2 = service.shutdown(RemoteOptions.RemoteCacheAsync.TRUE);
+    var pendingUploads1 = service.shutdown(RemoteOptions.RemoteCacheAsync.TRUE);
+    var pendingUploads2 = service.shutdown(RemoteOptions.RemoteCacheAsync.TRUE);
 
-    assertThat(future1.isDone()).isTrue();
-    assertThat(future2.isDone()).isTrue();
+    assertThat(pendingUploads1).isSameInstanceAs(RemoteExecutionService.PendingUploads.EMPTY);
+    assertThat(pendingUploads2).isSameInstanceAs(RemoteExecutionService.PendingUploads.EMPTY);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteUploadModeIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteUploadModeIntegrationTest.java
@@ -1,0 +1,346 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.vfs.FileSystemUtils.readContent;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialModule;
+import com.google.devtools.build.lib.dynamic.DynamicExecutionModule;
+import com.google.devtools.build.lib.remote.util.IntegrationTestUtils;
+import com.google.devtools.build.lib.remote.util.IntegrationTestUtils.WorkerInstance;
+import com.google.devtools.build.lib.runtime.BlazeModule;
+import com.google.devtools.build.lib.runtime.BlazeRuntime;
+import com.google.devtools.build.lib.runtime.BlockWaitingModule;
+import com.google.devtools.build.lib.runtime.BuildSummaryStatsModule;
+import com.google.devtools.build.lib.standalone.StandaloneModule;
+import com.google.devtools.build.lib.util.OS;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Integration tests for {@code --experimental_remote_upload_mode}.
+ *
+ * <p>Tests the async upload functionality where uploads continue in the background after a build
+ * completes, with the next command waiting for pending uploads.
+ */
+@RunWith(TestParameterInjector.class)
+public class RemoteUploadModeIntegrationTest extends BuildWithoutTheBytesIntegrationTestBase {
+  @ClassRule @Rule public static final WorkerInstance worker = IntegrationTestUtils.createWorker();
+
+  @Override
+  protected ImmutableList<String> getStartupOptions() {
+    return OS.getCurrent() == OS.WINDOWS
+        ? ImmutableList.of("--windows_enable_symlinks")
+        : ImmutableList.of();
+  }
+
+  @Override
+  protected void setupOptions() throws Exception {
+    super.setupOptions();
+
+    addOptions(
+        "--remote_executor=grpc://localhost:" + worker.getPort(),
+        "--remote_download_minimal",
+        "--dynamic_local_strategy=standalone",
+        "--dynamic_remote_strategy=remote");
+
+    if (OS.getCurrent() == OS.WINDOWS) {
+      addOptions("--action_env=MSYS=winsymlinks:native");
+    }
+  }
+
+  @Override
+  protected void setDownloadToplevel() {
+    addOptions("--remote_download_outputs=toplevel");
+  }
+
+  @Override
+  protected void setDownloadAll() {
+    addOptions("--remote_download_outputs=all");
+  }
+
+  @Override
+  protected void enableActionRewinding() {
+    addOptions("--rewind_lost_inputs", "--experimental_remote_cache_eviction_retries=0", "--jobs=1");
+  }
+
+  @Override
+  protected BlazeRuntime.Builder getRuntimeBuilder() throws Exception {
+    return super.getRuntimeBuilder()
+        .addBlazeModule(new RemoteModule())
+        .addBlazeModule(new BuildSummaryStatsModule())
+        .addBlazeModule(new BlockWaitingModule());
+  }
+
+  @Override
+  protected ImmutableList<BlazeModule> getSpawnModules() {
+    return ImmutableList.<BlazeModule>builder()
+        .addAll(super.getSpawnModules())
+        .add(new StandaloneModule())
+        .add(new CredentialModule())
+        .add(new DynamicExecutionModule())
+        .build();
+  }
+
+  @Override
+  protected void assertOutputEquals(Path path, String expectedContent) throws Exception {
+    assertThat(readContent(path, UTF_8)).isEqualTo(expectedContent);
+  }
+
+  @Override
+  protected void assertOutputContains(String content, String contains) throws Exception {
+    assertThat(content).contains(contains);
+  }
+
+  @Override
+  protected void evictAllBlobs() throws Exception {
+    worker.reset();
+  }
+
+  @Override
+  protected boolean hasAccessToRemoteOutputs() {
+    return true;
+  }
+
+  @Override
+  protected void injectFile(byte[] content) {}
+
+  // ==================== Tests for --experimental_remote_upload_mode ====================
+
+  @Test
+  public void nowaitForUploadComplete_uploadsCompleteBeforeNextBuild() throws Exception {
+    // Test that with NOWAIT_FOR_UPLOAD_COMPLETE, uploads from build N complete
+    // before build N+1 executes (due to waitForPreviousInvocation).
+    write(
+        "BUILD",
+        """
+        genrule(
+            name = "foo",
+            srcs = [],
+            outs = ["foo.txt"],
+            cmd = "echo foo > $@",
+        )
+        genrule(
+            name = "bar",
+            srcs = [],
+            outs = ["bar.txt"],
+            cmd = "echo bar > $@",
+        )
+        """);
+    addOptions("--experimental_remote_upload_mode=nowait_for_upload_complete");
+
+    // First build - uploads continue in background
+    buildTarget("//:foo");
+
+    // Second build - should wait for previous uploads before starting
+    // If this succeeds without errors, uploads from first build completed
+    buildTarget("//:bar");
+
+    // Both outputs should be available in the remote cache
+    // Verify by doing a clean build that hits the cache
+    restartServer();
+    addOptions("--experimental_remote_upload_mode=nowait_for_upload_complete");
+
+    ActionEventCollector actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+    buildTarget("//:foo");
+    waitDownloads();
+
+    // Action should be a cache hit (not re-executed)
+    assertThat(actionEventCollector.getActionExecutedEvents()).isEmpty();
+  }
+
+  @Test
+  public void nowaitForUploadComplete_crossInvocationState_survivesAcrossCommands() throws Exception {
+    // Test that pending uploads survive across command invocations within the same server.
+    write(
+        "BUILD",
+        """
+        genrule(
+            name = "gen1",
+            srcs = [],
+            outs = ["gen1.txt"],
+            cmd = "echo gen1 > $@",
+        )
+        genrule(
+            name = "gen2",
+            srcs = [],
+            outs = ["gen2.txt"],
+            cmd = "echo gen2 > $@",
+        )
+        genrule(
+            name = "gen3",
+            srcs = [],
+            outs = ["gen3.txt"],
+            cmd = "echo gen3 > $@",
+        )
+        """);
+    addOptions("--experimental_remote_upload_mode=nowait_for_upload_complete");
+
+    // Run multiple builds in sequence
+    buildTarget("//:gen1");
+    buildTarget("//:gen2");
+    buildTarget("//:gen3");
+
+    // All uploads should have completed (each build waits for the previous one)
+    // Verify by restarting and checking cache hits
+    restartServer();
+    addOptions("--experimental_remote_upload_mode=nowait_for_upload_complete");
+
+    ActionEventCollector collector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(collector);
+    buildTarget("//:gen1", "//:gen2", "//:gen3");
+    waitDownloads();
+
+    // All actions should be cache hits
+    assertThat(collector.getActionExecutedEvents()).isEmpty();
+  }
+
+  @Test
+  public void nowaitForUploadComplete_cacheIsPopulated() throws Exception {
+    // Test that async uploads actually populate the cache correctly.
+    write(
+        "BUILD",
+        """
+        genrule(
+            name = "cached",
+            srcs = [],
+            outs = ["cached.txt"],
+            cmd = "echo cached-content > $@",
+        )
+        """);
+    addOptions("--experimental_remote_upload_mode=nowait_for_upload_complete");
+
+    // Build with async uploads
+    buildTarget("//:cached");
+
+    // Trigger next command to wait for uploads
+    waitDownloads();
+
+    // Evict local state and rebuild - should hit cache
+    restartServer();
+    addOptions("--experimental_remote_upload_mode=wait_for_upload_complete");
+    setDownloadToplevel();
+
+    buildTarget("//:cached");
+    waitDownloads();
+
+    // Output should be downloaded from cache
+    assertValidOutputFile("cached.txt", "cached-content\n");
+  }
+
+  @Test
+  public void waitForUploadComplete_defaultBehavior_unchanged() throws Exception {
+    // Test that the default mode (wait_for_upload_complete) behaves the same as before.
+    write(
+        "BUILD",
+        """
+        genrule(
+            name = "default",
+            srcs = [],
+            outs = ["default.txt"],
+            cmd = "echo default > $@",
+        )
+        """);
+    // Explicitly set default mode (or don't set it at all)
+    addOptions("--experimental_remote_upload_mode=wait_for_upload_complete");
+
+    buildTarget("//:default");
+
+    // Restart and verify cache is populated (uploads completed synchronously)
+    restartServer();
+    addOptions("--experimental_remote_upload_mode=wait_for_upload_complete");
+
+    ActionEventCollector collector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(collector);
+    buildTarget("//:default");
+    waitDownloads();
+
+    // Should be a cache hit
+    assertThat(collector.getActionExecutedEvents()).isEmpty();
+  }
+
+  @Test
+  public void nowaitForUploadComplete_incrementalBuild_works() throws Exception {
+    // Test that incremental builds work correctly with async upload mode.
+    write("input.txt", "original");
+    write(
+        "BUILD",
+        """
+        genrule(
+            name = "incremental",
+            srcs = ["input.txt"],
+            outs = ["output.txt"],
+            cmd = "cat $(SRCS) > $@",
+        )
+        """);
+    addOptions("--experimental_remote_upload_mode=nowait_for_upload_complete");
+    setDownloadToplevel();
+
+    // Initial build
+    buildTarget("//:incremental");
+    waitDownloads();
+    assertValidOutputFile("output.txt", "original\n");
+
+    // Modify source and rebuild
+    write("input.txt", "modified");
+    buildTarget("//:incremental");
+    waitDownloads();
+    assertValidOutputFile("output.txt", "modified\n");
+  }
+
+  @Test
+  public void nowaitForUploadComplete_withDiskCache_works() throws Exception {
+    // Test that async upload mode works correctly with disk cache enabled.
+    write(
+        "BUILD",
+        """
+        genrule(
+            name = "disk_cached",
+            srcs = [],
+            outs = ["disk_cached.txt"],
+            cmd = "echo disk-cached > $@",
+        )
+        """);
+    Path diskCachePath = getOutputBase().getRelative("disk-cache");
+    addOptions(
+        "--experimental_remote_upload_mode=nowait_for_upload_complete",
+        "--disk_cache=" + diskCachePath.getPathString());
+
+    buildTarget("//:disk_cached");
+
+    // Next command waits for uploads
+    waitDownloads();
+
+    // Verify cache is populated
+    restartServer();
+    addOptions(
+        "--experimental_remote_upload_mode=wait_for_upload_complete",
+        "--disk_cache=" + diskCachePath.getPathString());
+
+    ActionEventCollector collector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(collector);
+    buildTarget("//:disk_cached");
+    waitDownloads();
+
+    assertThat(collector.getActionExecutedEvents()).isEmpty();
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteUploadModeIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteUploadModeIntegrationTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Integration tests for {@code --remote_cache_async=nowait}.
+ * Integration tests for {@code --remote_cache_async=nowait_for_upload_complete}.
  *
  * <p>Tests the async upload functionality where uploads continue in the background after a build
  * completes, with the next command waiting for pending uploads.
@@ -128,7 +128,7 @@ public class RemoteUploadModeIntegrationTest extends BuildWithoutTheBytesIntegra
 
   @Test
   public void nowaitForUploadComplete_uploadsCompleteBeforeNextBuild() throws Exception {
-    // Test that with --remote_cache_async=nowait, uploads from build N complete
+    // Test that with --remote_cache_async=nowait_for_upload_complete, uploads from build N complete
     // before build N+1 executes (due to waitForPreviousInvocation).
     write(
         "BUILD",
@@ -146,7 +146,7 @@ public class RemoteUploadModeIntegrationTest extends BuildWithoutTheBytesIntegra
             cmd = "echo bar > $@",
         )
         """);
-    addOptions("--remote_cache_async=nowait");
+    addOptions("--remote_cache_async=nowait_for_upload_complete");
 
     // First build - uploads continue in background
     buildTarget("//:foo");
@@ -158,7 +158,7 @@ public class RemoteUploadModeIntegrationTest extends BuildWithoutTheBytesIntegra
     // Both outputs should be available in the remote cache
     // Verify by doing a clean build that hits the cache
     restartServer();
-    addOptions("--remote_cache_async=nowait");
+    addOptions("--remote_cache_async=nowait_for_upload_complete");
 
     ActionEventCollector actionEventCollector = new ActionEventCollector();
     getRuntimeWrapper().registerSubscriber(actionEventCollector);
@@ -195,7 +195,7 @@ public class RemoteUploadModeIntegrationTest extends BuildWithoutTheBytesIntegra
             cmd = "echo gen3 > $@",
         )
         """);
-    addOptions("--remote_cache_async=nowait");
+    addOptions("--remote_cache_async=nowait_for_upload_complete");
 
     // Run multiple builds in sequence
     buildTarget("//:gen1");
@@ -205,7 +205,7 @@ public class RemoteUploadModeIntegrationTest extends BuildWithoutTheBytesIntegra
     // All uploads should have completed (each build waits for the previous one)
     // Verify by restarting and checking cache hits
     restartServer();
-    addOptions("--remote_cache_async=nowait");
+    addOptions("--remote_cache_async=nowait_for_upload_complete");
 
     ActionEventCollector collector = new ActionEventCollector();
     getRuntimeWrapper().registerSubscriber(collector);
@@ -229,7 +229,7 @@ public class RemoteUploadModeIntegrationTest extends BuildWithoutTheBytesIntegra
             cmd = "echo cached-content > $@",
         )
         """);
-    addOptions("--remote_cache_async=nowait");
+    addOptions("--remote_cache_async=nowait_for_upload_complete");
 
     // Build with async uploads
     buildTarget("//:cached");
@@ -294,7 +294,7 @@ public class RemoteUploadModeIntegrationTest extends BuildWithoutTheBytesIntegra
             cmd = "cat $(SRCS) > $@",
         )
         """);
-    addOptions("--remote_cache_async=nowait");
+    addOptions("--remote_cache_async=nowait_for_upload_complete");
     setDownloadToplevel();
 
     // Initial build
@@ -323,7 +323,7 @@ public class RemoteUploadModeIntegrationTest extends BuildWithoutTheBytesIntegra
         )
         """);
     Path diskCachePath = getOutputBase().getRelative("disk-cache");
-    addOptions("--remote_cache_async=nowait", "--disk_cache=" + diskCachePath.getPathString());
+    addOptions("--remote_cache_async=nowait_for_upload_complete", "--disk_cache=" + diskCachePath.getPathString());
 
     buildTarget("//:disk_cached");
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteUploadModeIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteUploadModeIntegrationTest.java
@@ -79,7 +79,8 @@ public class RemoteUploadModeIntegrationTest extends BuildWithoutTheBytesIntegra
 
   @Override
   protected void enableActionRewinding() {
-    addOptions("--rewind_lost_inputs", "--experimental_remote_cache_eviction_retries=0", "--jobs=1");
+    addOptions(
+        "--rewind_lost_inputs", "--experimental_remote_cache_eviction_retries=0", "--jobs=1");
   }
 
   @Override
@@ -169,7 +170,8 @@ public class RemoteUploadModeIntegrationTest extends BuildWithoutTheBytesIntegra
   }
 
   @Test
-  public void nowaitForUploadComplete_crossInvocationState_survivesAcrossCommands() throws Exception {
+  public void nowaitForUploadComplete_crossInvocationState_survivesAcrossCommands()
+      throws Exception {
     // Test that pending uploads survive across command invocations within the same server.
     write(
         "BUILD",

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
@@ -422,7 +422,9 @@ final class ExecutionServer extends ExecutionImplBase {
                 startTime,
                 (int) wallTime.toMillis(),
                 /* preserveExecutableBit= */ false);
-        result = manifest.upload(context, cache, NullEventHandler.INSTANCE);
+        result =
+            manifest.upload(
+                context, cache, NullEventHandler.INSTANCE, /* reportUploadProgress= */ true);
       } catch (ExecException e) {
         if (errStatus == null) {
           errStatus =


### PR DESCRIPTION
This PR updates `--remote_cache_async` flag to support a new `nowait` mode that controls when Bazel waits for remote cache uploads to complete (similar to `--bes_upload_mode`).

## Motivation

Currently, Bazel blocks at the end of every build waiting for all remote cache uploads to complete. For builds with large outputs, or on slow connections, this can add significant time to the build even though the uploads don't affect build correctness. Users who want faster build completion times should be able to defer this waiting.

## Implementation

- The build completes as soon as action execution finishes
- Uploads continue in the background
- The next command waits up to 30 seconds for uploads to complete
- Server shutdown (`bazel shutdown`) also waits up to 30 seconds
- Temp files and RPC logs are cleaned up via a future listener after uploads complete

## Testing

- Added integration tests in `RemoteUploadModeIntegrationTest.java`
- Added unit tests for `shutdown(RemoteUploadMode)` in `RemoteExecutionServiceTest.java`
- Manually verified async uploads work correctly
- Verified interruption behavior via Ctrl-C.

Closes #14638
