### PR TITLE
Fix IntelliJ project view to analyze the full transitive closure

### DIFF
--- a/scripts/ij.bazelproject
+++ b/scripts/ij.bazelproject
@@ -28,4 +28,6 @@ java_language_level: 21
 workspace_type: java
 
 # Import targets at arbitrary depths beneath //src:bazel.
+# Workaround for https://youtrack.jetbrains.com/issue/BAZEL-2737.
+# TODO: Remove after the next IntelliJ plugin release.
 import_depth: -1


### PR DESCRIPTION
Without this setting, a number of classes under `src/main/java` are not analyzed by IntelliJ.

Context: https://bazelbuild.slack.com/archives/C025SBYFC4E/p1764837525451319?thread_ts=1764584838.077219&cid=C025SBYFC4E (suggested by `aehlig`)