### PR TITLE
[9.0.0] Move default output root on macOS to `$HOME/Library/Caches`

### DIFF
--- a/docs/remote/output-directories.mdx
+++ b/docs/remote/output-directories.mdx
@@ -27,14 +27,16 @@ The solution that's currently implemented:
   subdirectory thereof. In other words, Bazel must be invoked from inside a
   [repository](../external/overview#repository). Otherwise, an error is
   reported.
-* The _outputRoot_ directory defaults to `~/.cache/bazel` on Linux,
-  `/private/var/tmp` on macOS, and on Windows it defaults to `%HOME%` if
-  set, else `%USERPROFILE%` if set, else the result of calling
-  `SHGetKnownFolderPath()` with the `FOLDERID_Profile` flag set. If the
-  environment variable `$XDG_CACHE_HOME` is set on either Linux or
-  macOS, the value `${XDG_CACHE_HOME}/bazel` will override the default.
-  If the environment variable `$TEST_TMPDIR` is set, as in a test of Bazel
-  itself, then that value overrides any defaults.
+* The _outputRoot_ directory defaults to ~/.cache/bazel on Linux,
+  `~/Library/Caches/bazel` on macOS (when using Bazel 9 and newer),
+  and on Windows it defaults to `%HOME%` if set, else `%USERPROFILE%`
+  if set, else the result of calling `SHGetKnownFolderPath()` with the
+  `FOLDERID_Profile` flag set. If the environment variable `$XDG_CACHE_HOME`
+  is set on either Linux or macOS, the value `${XDG_CACHE_HOME}/bazel` will
+  override the default. If the environment variable `$TEST_TMPDIR` is set,
+  as in a test of Bazel itself, then that value overrides any defaults.
+  * Note that Bazel 8.x and earlier on macOS used `/private/var/tmp` as _outputRoot_,
+    and ignored `$XDG_CACHE_HOME`.
 * The Bazel user's build state is located beneath `outputRoot/_bazel_$USER`.
   This is called the _outputUserRoot_ directory.
 * Beneath the `outputUserRoot` directory there is an `install` directory, and in

--- a/site/en/remote/output-directories.md
+++ b/site/en/remote/output-directories.md
@@ -26,25 +26,27 @@ Requirements for an output directory layout:
 
 The solution that's currently implemented:
 
-* Bazel must be invoked from a directory containing a repo boundary file, or a
-  subdirectory thereof. In other words, Bazel must be invoked from inside a
+* Bazel must be invoked from a directory containing a repository boundary file,
+or a subdirectory thereof. In other words, Bazel must be invoked from inside a
   [repository](../external/overview#repository). Otherwise, an error is
   reported.
-* The _outputRoot_ directory defaults to `~/.cache/bazel` on Linux,
-  `/private/var/tmp` on macOS, and on Windows it defaults to `%HOME%` if
-  set, else `%USERPROFILE%` if set, else the result of calling
-  `SHGetKnownFolderPath()` with the `FOLDERID_Profile` flag set. If the
-  environment variable `$XDG_CACHE_HOME` is set on either Linux or
-  macOS, the value `${XDG_CACHE_HOME}/bazel` will override the default.
-  If the environment variable `$TEST_TMPDIR` is set, as in a test of Bazel
-  itself, then that value overrides any defaults.
+* The _outputRoot_ directory defaults to ~/.cache/bazel on Linux,
+  `~/Library/Caches/bazel` on macOS (when using Bazel 9 and newer),
+  and on Windows it defaults to `%HOME%` if set, else `%USERPROFILE%`
+  if set, else the result of calling `SHGetKnownFolderPath()` with the
+  `FOLDERID_Profile` flag set. If the environment variable `$XDG_CACHE_HOME`
+  is set on either Linux or macOS, the value `${XDG_CACHE_HOME}/bazel` will
+  override the default. If the environment variable `$TEST_TMPDIR` is set,
+  as in a test of Bazel itself, then that value overrides any defaults.
+  * Note that Bazel 8.x and earlier on macOS used `/private/var/tmp` as _outputR
+  oot_,and ignored `$XDG_CACHE_HOME`.
 * The Bazel user's build state is located beneath `outputRoot/_bazel_$USER`.
   This is called the _outputUserRoot_ directory.
 * Beneath the `outputUserRoot` directory there is an `install` directory, and in
   it is an `installBase` directory whose name is the MD5 hash of the Bazel
   installation manifest.
 * Beneath the `outputUserRoot` directory, an `outputBase` directory
-  is also created whose name is the MD5 hash of the path name of the workspace
+  is also created whose name is the MD5 hash of the path of the workspace
   root. So, for example, if Bazel is running in the workspace root
   `/home/user/src/my-project` (or in a directory symlinked to that one), then
   an output base directory is created called:

--- a/src/main/cpp/blaze_util_darwin.cc
+++ b/src/main/cpp/blaze_util_darwin.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "src/main/cpp/blaze_util_platform.h"
-
+#include <CoreFoundation/CoreFoundation.h>
 #include <libproc.h>
 #include <pthread/spawn.h>
+#include <pwd.h>
 #include <signal.h>
 #include <spawn.h>
 #include <stdlib.h>
@@ -28,13 +28,12 @@
 #include <time.h>
 #include <unistd.h>
 
-#include <CoreFoundation/CoreFoundation.h>
-
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
 
 #include "src/main/cpp/blaze_util.h"
+#include "src/main/cpp/blaze_util_platform.h"
 #include "src/main/cpp/startup_options.h"
 #include "src/main/cpp/util/errors.h"
 #include "src/main/cpp/util/exit_code.h"
@@ -96,24 +95,42 @@ static string DescriptionFromCFError(CFErrorRef cf_err) {
   return UTF8StringFromCFStringRef(cf_err_string);
 }
 
+// ${XDG_CACHE_HOME}/bazel, falling back to ~/Library/Caches/bazel if
+// ${XDG_CACHE_HOME} is empty.
+//
+// Historically, Bazel 8.x and earlier used /private/var/tmp by default, due to
+// path length limitations stemming from use of Unix domain sockets. However,
+// these limitations are no longer relevant as we do not create Unix domain
+// sockets under the output base. The standard location for application caches
+// on macOS is $HOME/Library/Caches.
+//
+// See also:
+// https://stackoverflow.com/questions/3373948/equivalents-of-xdg-config-home-and-xdg-data-home-on-mac-os-x
 string GetCacheDir() {
-  // On macOS, the standard location for application caches is
-  // $HOME/Library/Caches. Bazel historically has not used this location, and
-  // instead has used /var/tmp, due to Unix domain socket path length
-  // limitations. These limitations are no longer relevant as we no longer
-  // create Unix domain sockets under the output base.
-  //
-  // However, respecting $XDG_CACHE_HOME is still useful as it allows users to
-  // easily override the cache directory, and is respected by many Linux derived
-  // tools.
-  //
-  // See also:
-  // https://stackoverflow.com/questions/3373948/equivalents-of-xdg-config-home-and-xdg-data-home-on-mac-os-x
   string xdg_cache_home = GetPathEnv("XDG_CACHE_HOME");
-  if (!xdg_cache_home.empty()) {
-    return blaze_util::JoinPath(xdg_cache_home, "bazel");
+  if (xdg_cache_home.empty()) {
+    string home = GetHomeDir();  // via $HOME env variable
+    if (home.empty()) {
+      // Fall back to home dir from password database
+      struct passwd pwbuf;
+      struct passwd* pw = nullptr;
+      uid_t uid = getuid();
+      int strbufsize;
+      if ((strbufsize = sysconf(_SC_GETPW_R_SIZE_MAX)) == -1) {
+        return "/var/tmp";
+      }
+      string strbuf(strbufsize, 0);
+      int r = getpwuid_r(uid, &pwbuf, &strbuf[0], strbufsize, &pw);
+      if (r == 0 && pw != nullptr) {
+        home = pw->pw_dir;
+      } else {
+        return "/var/tmp";
+      }
+    }
+    xdg_cache_home = blaze_util::JoinPath(home, "Library/Caches");
   }
-  return "/var/tmp";
+
+  return blaze_util::JoinPath(xdg_cache_home, "bazel");
 }
 
 void WarnFilesystemType(const blaze_util::Path &output_base) {

--- a/src/test/cpp/bazel_startup_options_test.cc
+++ b/src/test/cpp/bazel_startup_options_test.cc
@@ -84,8 +84,8 @@ TEST_F(BazelStartupOptionsTest, EmptyFlagsAreInvalid) {
   EXPECT_FALSE(startup_options_->IsUnary("--"));
 }
 
-#ifdef __linux
-TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxWithHome) {
+#if defined(__linux) || defined(__APPLE__)
+TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxOrDarwinWithHome) {
   SetEnv("USER", "gandalf");
   SetEnv("HOME", "/nonexistent/home");
   UnsetEnv("TEST_TMPDIR");
@@ -93,6 +93,7 @@ TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxWithHome) {
   ReinitStartupOptions();
   UpdateConfiguration();
 
+#ifdef __linux
   ASSERT_EQ(blaze_util::Path("/nonexistent/home/.cache/bazel/_bazel_gandalf"),
             startup_options_->output_user_root);
   ASSERT_EQ(
@@ -102,28 +103,20 @@ TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxWithHome) {
   ASSERT_EQ(blaze_util::Path("/nonexistent/home/.cache/bazel/_bazel_gandalf/"
                              "1629dee48cc4e53161f9b2be8614e062"),
             startup_options_->output_base);
-}
-#endif  // __linux
-
-#ifdef __APPLE__
-TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnDarwin) {
-  SetEnv("USER", "gandalf");
-  SetEnv("HOME", "/nonexistent/home");
-  UnsetEnv("TEST_TMPDIR");
-  ReinitStartupOptions();
-  UpdateConfiguration();
-
-  ASSERT_EQ(blaze_util::Path("/var/tmp/_bazel_gandalf"),
-            startup_options_->output_user_root);
-  ASSERT_EQ(blaze_util::Path("/var/tmp/_bazel_gandalf/install/deadbeef"),
+#elif defined(__APPLE__)
+  ASSERT_EQ(
+      blaze_util::Path("/nonexistent/home/Library/Caches/bazel/_bazel_gandalf"),
+      startup_options_->output_user_root);
+  ASSERT_EQ(blaze_util::Path("/nonexistent/home/Library/Caches/bazel/"
+                             "_bazel_gandalf/install/deadbeef"),
             startup_options_->install_base);
-  ASSERT_EQ(blaze_util::Path("/var/tmp/_bazel_gandalf/"
-                             "1629dee48cc4e53161f9b2be8614e062"),
-            startup_options_->output_base);
+  ASSERT_EQ(
+      blaze_util::Path("/nonexistent/home/Library/Caches/bazel/_bazel_gandalf/"
+                       "1629dee48cc4e53161f9b2be8614e062"),
+      startup_options_->output_base);
+#endif
 }
-#endif  // __APPLE__
 
-#if defined(__linux) || defined(__APPLE__)
 TEST_F(BazelStartupOptionsTest,
        UpdateConfigurationOnLinuxOrDarwinWithTestTmpdir) {
   SetEnv("USER", "gandalf");
@@ -193,7 +186,9 @@ TEST_F(BazelStartupOptionsTest,
                              "/~/home$(echo baz)/.cache/bazel/_bazel_gandalf"),
             startup_options_->output_user_root);
 #elif defined(__APPLE__)
-  ASSERT_EQ(blaze_util::Path("/var/tmp/_bazel_gandalf"),
+  ASSERT_EQ(blaze_util::Path(
+                blaze_util::GetCwd() +
+                "/~/home$(echo baz)/Library/Caches/bazel/_bazel_gandalf"),
             startup_options_->output_user_root);
 #endif
 }


### PR DESCRIPTION
Fixes #25260

Implements the request made [here](https://github.com/bazelbuild/bazel/pull/25205#issuecomment-2637918219) and moves the default output root on macOS from `/private/var/tmp` to `$HOME/Library/Caches`. May constitute an incompatible change, though on a cursory glance I didn't see any precedent for incompatible startup options in source.

Closes #25262.

PiperOrigin-RevId: 840604399
Change-Id: I391b805b2c8e99d3ffe44a76e916d1c9839225e5

Commit https://github.com/bazelbuild/bazel/commit/13da9a14fa834871d6df79cd5152fa46912767b2