### PR TITLE
[9.0.0] Use comparator when extracting relevant facts for lockfile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -138,7 +138,8 @@ public class BazelLockFileModule extends BlazeModule {
                 combinedFacts,
                 entry ->
                     depGraphValue.getExtensionUsagesTable().containsRow(entry.getKey())
-                        && !entry.getValue().equals(Facts.EMPTY)));
+                        && !entry.getValue().equals(Facts.EMPTY)),
+            ModuleExtensionId.LEXICOGRAPHIC_COMPARATOR);
 
     Thread updateLockfile =
         Thread.startVirtualThread(


### PR DESCRIPTION
ModuleExtensionId is not comparable by itself and needs a comparator. Before this fix, I was able to crash Bazel with this message:

```
FATAL: bazel crashed due to an internal error. Printing stack trace: java.lang.ClassCastException: class com.google.devtools.build.lib.bazel.bzlmod.ModuleExtensionId cannot be cast to class java.lang.Comparable (com.google.devtools.build.lib.bazel.bzlmod.ModuleExtensionId is in unnamed module of loader 'app'; java.lang.Comparable is in module java.base of loader 'bootstrap')
        at com.google.common.collect.NaturalOrdering.compare(NaturalOrdering.java:29)
        at com.google.common.collect.ImmutableSortedMap.lambda$fromEntries$0(ImmutableSortedMap.java:536)
        at java.base/java.util.TimSort.countRunAndMakeAscending(Unknown Source)
        at java.base/java.util.TimSort.sort(Unknown Source)
        at java.base/java.util.Arrays.sort(Unknown Source)
        at com.google.common.collect.ImmutableSortedMap.fromEntries(ImmutableSortedMap.java:528)
        at com.google.common.collect.ImmutableSortedMap.fromEntries(ImmutableSortedMap.java:495)
        at com.google.common.collect.ImmutableSortedMap.copyOfInternal(ImmutableSortedMap.java:474)
        at com.google.common.collect.ImmutableSortedMap.copyOf(ImmutableSortedMap.java:372)
        at com.google.devtools.build.lib.bazel.bzlmod.BazelLockFileModule.afterCommand(BazelLockFileModule.java:135)
        at com.google.devtools.build.lib.runtime.BlazeRuntime.afterCommand(BlazeRuntime.java:734)
        at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.execExclusively(BlazeCommandDispatcher.java:711)
        at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.exec(BlazeCommandDispatcher.java:257)
        at com.google.devtools.build.lib.server.GrpcServerImpl.executeCommand(GrpcServerImpl.java:607)
        at com.google.devtools.build.lib.server.GrpcServerImpl.lambda$run$0(GrpcServerImpl.java:677)
        at io.grpc.Context$1.run(Context.java:566)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.base/java.lang.Thread.run(Unknown Source)
```

Fixes #27522

Closes #27816.

PiperOrigin-RevId: 840671327
Change-Id: Ia7eb05be4fd099f0e2711065faf4c344d45265b5

Commit https://github.com/bazelbuild/bazel/commit/b2587f641f08897e82043c5987a17ddeff944f1a