### PR TITLE
[8.5.0] Use comparator when extracting relevant facts for lockfile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -138,7 +138,8 @@ public class BazelLockFileModule extends BlazeModule {
                 combinedFacts,
                 entry ->
                     depGraphValue.getExtensionUsagesTable().containsRow(entry.getKey())
-                        && !entry.getValue().equals(Facts.EMPTY)));
+                        && !entry.getValue().equals(Facts.EMPTY)),
+            ModuleExtensionId.LEXICOGRAPHIC_COMPARATOR);
 
     Thread updateLockfile =
         Thread.startVirtualThread(

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -3089,6 +3089,65 @@ class BazelLockfileTest(test_base.TestBase):
     self.assertIn('Fetching metadata for world...', stderr)
     self.assertIn('world: hash=drw', stderr)
 
+  def testMultipleExtensionsWithFacts(self):
+    """Test that multiple extensions with facts don't cause ClassCastException.
+
+    Regression test for the bug where ImmutableSortedMap.copyOf() was called
+    without a comparator on ModuleExtensionId keys. This would cause a
+    ClassCastException when there were multiple extensions with facts, as
+    ModuleExtensionId does not implement Comparable.
+    """
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'ext_a = use_extension("extension_a.bzl", "ext_a")',
+            'use_repo(ext_a, "repo_a")',
+            'ext_b = use_extension("extension_b.bzl", "ext_b")',
+            'use_repo(ext_b, "repo_b")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'extension_a.bzl',
+        [
+            'def impl(ctx):',
+            '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
+            'repo_rule = repository_rule(implementation = impl)',
+            'def _ext_a_impl(ctx):',
+            '    repo_rule(name = "repo_a")',
+            '    return ctx.extension_metadata(',
+            '        reproducible = False,',
+            '        facts = {"ext_a_fact": "value_a"},',
+            '    )',
+            'ext_a = module_extension(implementation = _ext_a_impl)',
+        ],
+    )
+    self.ScratchFile(
+        'extension_b.bzl',
+        [
+            'def impl(ctx):',
+            '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
+            'repo_rule = repository_rule(implementation = impl)',
+            'def _ext_b_impl(ctx):',
+            '    repo_rule(name = "repo_b")',
+            '    return ctx.extension_metadata(',
+            '        reproducible = False,',
+            '        facts = {"ext_b_fact": "value_b"},',
+            '    )',
+            'ext_b = module_extension(implementation = _ext_b_impl)',
+        ],
+    )
+
+    _, _, stderr = self.RunBazel(['build', '@repo_a//:all', '@repo_b//:all'])
+    stderr = ''.join(stderr)
+
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read().strip())
+
+    self.assertIn('facts', lockfile)
+    facts = lockfile['facts']
+    self.assertEqual(len(facts), 2)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
ModuleExtensionId is not comparable by itself and needs a comparator. Before this fix, I was able to crash Bazel with this message:

```
FATAL: bazel crashed due to an internal error. Printing stack trace: java.lang.ClassCastException: class com.google.devtools.build.lib.bazel.bzlmod.ModuleExtensionId cannot be cast to class java.lang.Comparable (com.google.devtools.build.lib.bazel.bzlmod.ModuleExtensionId is in unnamed module of loader 'app'; java.lang.Comparable is in module java.base of loader 'bootstrap')
        at com.google.common.collect.NaturalOrdering.compare(NaturalOrdering.java:29)
        at com.google.common.collect.ImmutableSortedMap.lambda$fromEntries$0(ImmutableSortedMap.java:536)
        at java.base/java.util.TimSort.countRunAndMakeAscending(Unknown Source)
        at java.base/java.util.TimSort.sort(Unknown Source)
        at java.base/java.util.Arrays.sort(Unknown Source)
        at com.google.common.collect.ImmutableSortedMap.fromEntries(ImmutableSortedMap.java:528)
        at com.google.common.collect.ImmutableSortedMap.fromEntries(ImmutableSortedMap.java:495)
        at com.google.common.collect.ImmutableSortedMap.copyOfInternal(ImmutableSortedMap.java:474)
        at com.google.common.collect.ImmutableSortedMap.copyOf(ImmutableSortedMap.java:372)
        at com.google.devtools.build.lib.bazel.bzlmod.BazelLockFileModule.afterCommand(BazelLockFileModule.java:135)
        at com.google.devtools.build.lib.runtime.BlazeRuntime.afterCommand(BlazeRuntime.java:734)
        at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.execExclusively(BlazeCommandDispatcher.java:711)
        at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.exec(BlazeCommandDispatcher.java:257)
        at com.google.devtools.build.lib.server.GrpcServerImpl.executeCommand(GrpcServerImpl.java:607)
        at com.google.devtools.build.lib.server.GrpcServerImpl.lambda$run$0(GrpcServerImpl.java:677)
        at io.grpc.Context$1.run(Context.java:566)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.base/java.lang.Thread.run(Unknown Source)
```

Fixes #27522

Closes #27816.

PiperOrigin-RevId: 840671327
Change-Id: Ia7eb05be4fd099f0e2711065faf4c344d45265b5

Commit https://github.com/bazelbuild/bazel/commit/b2587f641f08897e82043c5987a17ddeff944f1a