### PR TITLE
Don't unnecessarily read unresolved symlinks

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -137,7 +137,7 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
   }
 
   /**
-   * Returns the unresolved symlink target path.
+   * Returns the unresolved symlink target path, which is always normalized.
    *
    * @throws UnsupportedOperationException if the metadata is not of symlink file type.
    */

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
@@ -570,12 +570,14 @@ public final class MerkleTreeComputer {
           inputBytes += subTreeRoot.inputBytes();
         }
         case Artifact.SpecialArtifact symlink when symlink.isSymlink() -> {
-          Path symlinkPath = artifactPathResolver.toPath(symlink);
+          var metadata =
+              checkNotNull(
+                  metadataProvider.getInputMetadata(symlink), "missing metadata: %s", symlink);
           var builder =
               currentDirectory
                   .addSymlinksBuilder()
                   .setName(name)
-                  .setTarget(internalToUnicode(symlinkPath.readSymbolicLink().getPathString()));
+                  .setTarget(internalToUnicode(metadata.getUnresolvedSymlinkTarget()));
           if (nodeProperties != null) {
             builder.setNodeProperties(nodeProperties);
           }


### PR DESCRIPTION
Get the target path from the `InputMetadataProvider` instead and avoid I/O that way.