### PR TITLE
Support `{name}` and `{version}` placeholders in `use_repo`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
@@ -212,6 +212,8 @@ public abstract class InterimModule extends ModuleBase {
 
     abstract String getName();
 
+    abstract Version getVersion();
+
     abstract Optional<String> getRepoName();
 
     abstract InterimModule autoBuild();

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -673,9 +673,15 @@ public class ModuleFileGlobals {
     for (String arg : Sequence.cast(args, String.class, "args")) {
       extensionProxy.addImport(arg, arg, "by a use_repo() call", stack);
     }
+    String moduleName = context.getModuleBuilder().getName();
+    String moduleVersion = context.getModuleBuilder().getVersion().normalized();
     for (Map.Entry<String, String> entry :
         Dict.cast(kwargs, String.class, String.class, "kwargs").entrySet()) {
-      extensionProxy.addImport(entry.getKey(), entry.getValue(), "by a use_repo() call", stack);
+      extensionProxy.addImport(
+          entry.getKey(),
+          entry.getValue().replace("{name}", moduleName).replace("{version}", moduleVersion),
+          "by a use_repo() call",
+          stack);
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -88,6 +88,7 @@ java_library(
         "//third_party:jsr305",
         "//third_party:junit4",
         "//third_party:truth",
+        "@maven//:com_google_testparameterinjector_test_parameter_injector",
     ],
 )
 


### PR DESCRIPTION
This allows module extensions to reliably namespace repos created by individual modules, even in the presence of `multiple_version_override`, without causing additional churn for users during version bumps. In particular, projects with a publishing workflow that patches in the `version` attribute of the `module` function don't need to modify that workflow to e.g. patch a global constant or also search for the old version in `use_repo` call arguments.

Context: https://bazelbuild.slack.com/archives/C09E58X3AQ7/p1764934858912079

RELNOTES: The values of keyword arguments passed to `use_repo` can now contain the special substrings `{name}` and `{version}`, which are treated as equivalent to the corresponding attributes of the current module.