### PR TITLE
[9.0.0] Inject repositories after root module file processed

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -630,8 +630,8 @@ public class ModuleFileFunction implements SkyFunction {
             }
           });
 
-      injectRepos(injectedRepositories, context, thread);
       compiledRootModuleFile.runOnThread(thread);
+      injectRepos(injectedRepositories, context, thread);
     } catch (EvalException e) {
       eventHandler.handle(Event.error(e.getInnermostLocation(), e.getMessageWithStack()));
       throw errorf(Code.BAD_MODULE, "error executing MODULE.bazel file for %s", moduleKey);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
@@ -108,11 +108,12 @@ public class ModuleThreadContext extends StarlarkThreadContext {
   public void addRepoNameUsage(
       String repoName, String how, ImmutableList<StarlarkThread.CallStackEntry> stack)
       throws EvalException {
-    RepoNameUsage collision = repoNameUsages.put(repoName, new RepoNameUsage(how, stack));
+    RepoNameUsage incoming = new RepoNameUsage(how, stack);
+    RepoNameUsage collision = repoNameUsages.put(repoName, incoming);
     if (collision != null) {
       throw Starlark.errorf(
-          "The repo name '%s' is already being used %s at %s",
-          repoName, collision.how(), collision.location());
+          "The repo name '%s' cannot be defined %s at %s as it is already defined %s at %s",
+          repoName, incoming.how(), incoming.location(), collision.how(), collision.location());
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -522,7 +522,8 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
         evaluator.evaluate(
             ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
     assertThat(result.hasError()).isTrue();
-    assertContainsEvent("The repo name 'foo' is already being used");
+    assertContainsEvent("The repo name 'foo' cannot be defined");
+    assertContainsEvent("as it is already defined");
   }
 
   @Test
@@ -1144,8 +1145,8 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
     reporter.removeHandler(failFastHandler); // expect failures
     evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
 
-    assertContainsEvent(
-        "The repo name 'mymod' is already being used as the current module name at");
+    assertContainsEvent("The repo name 'mymod' cannot be defined");
+    assertContainsEvent("as it is already defined as the current module name");
   }
 
   @Test
@@ -1491,7 +1492,8 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
     reporter.removeHandler(failFastHandler); // expect failures
     evaluator.evaluate(ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
 
-    assertContainsEvent("The repo name 'bbb' is already being used as the module's own repo name");
+    assertContainsEvent("The repo name 'bbb' cannot be defined");
+    assertContainsEvent("as it is already defined as the module's own repo name");
   }
 
   @Test

--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -720,10 +720,65 @@ class BazelOverridesTest(test_base.TestBase):
         allow_failure=True,
     )
     self.AssertNotExitCode(exit_code, 0, stderr)
+    stderr = '\n'.join(stderr)
     self.assertIn(
-        "Error in use_repo: The repo name 'my_repo' is already being used by"
-        ' --inject_repository at <builtin>',
+        "ERROR: The repo name 'my_repo' cannot be defined by"
+        ' --inject_repository at <builtin> as it is already defined by'
+        ' a use_repo() call at',
         stderr,
+    )
+    self.assertIn(
+        'MODULE.bazel:2:9',
+        stderr,
+    )
+
+  def testInjectRepositoryRepoNameSideEffects(self):
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            (
+                'local_repository = use_repo_rule("@//:defs.bzl",'
+                ' "local_repository")'
+            ),
+            'local_repository(name = "repo")',
+        ],
+    )
+    self.ScratchFile(
+        'defs.bzl',
+        [
+            'def _impl(ctx):',
+            '  ctx.file("BUILD")',
+            # Deliberate collision with `@bazel_tools//tools/build_defs/repo:loc
+            # al.bzl%local_repository`
+            'local_repository = repository_rule(implementation=_impl)',
+        ],
+    )
+    self.ScratchFile('BUILD')
+
+    self.ScratchFile('other_module/REPO.bazel')
+    self.ScratchFile('other_repo/BUILD', ['filegroup(name="target")'])
+
+    _, stdout, _ = self.RunBazel(['mod', 'dump_repo_mapping', ''])
+    self.assertIn(
+        '"+local_repository+repo"',
+        '\n'.join(stdout),
+    )
+
+    # --inject_repository _must not_ affect `use_repo_rule` generated repo names
+    #.
+    _, stdout, _ = self.RunBazel([
+        'mod',
+        'dump_repo_mapping',
+        '',
+        '--inject_repository=injected_repo=%workspace%/other_repo',
+    ])
+    self.assertIn(
+        '"+local_repository+repo"',
+        '\n'.join(stdout),
+    )
+    self.assertIn(
+        '"+local_repository2+injected_repo"',
+        '\n'.join(stdout),
     )
 
   def testOverrideRepositoryOnNonExistentRepo(self):


### PR DESCRIPTION
This fixes an issue where repositories injected with `--inject_repository` can invalidate `MODULE.bazel.lock` by changing the order innate `use_repo_rule` extensions are registered.

For example;
```starlark
# //:MODULE.bazel
local_repository = use_repo_rule("@//:defs.bzl", "local_repository")
local_repository(name = "repo")
```
```shell
bazel mod dump_repo_mapping '' --inject_repository=my_repo=%workspace%/other_repo
# Bazel 9+
# {"my_repo":"+local_repository+my_repo","repo":"+local_repository2+repo",...}
# Bazel 8
# {"my_repo":"+_repo_rules+my_repo","repo":"+_repo_rules2+repo",...}
```

Handling repository injections later changes how collisions with apparent repository names from innate extensions (`use_repo_rule(...)(...)`) and module extensions (`use_extension(...).__(...)`) are reported. To permit debugging (and improve collision investigation in general) the error message now refers to the incoming and existing repo name definition.

For example;
```diff
-Error in use_repo: The repo name 'my_repo' is already being used by --inject_repository at <builtin>
+ERROR: The repo name 'my_repo' cannot be defined by --inject_repository at <builtin> as it is already defined by a use_repo() call at /___/MODULE.bazel:2:9
```

Closes #27795.

PiperOrigin-RevId: 841889374
Change-Id: I01a4500ae5580338f96d593323c1d680fdbb7672

Commit https://github.com/bazelbuild/bazel/commit/d564fc98a07af395463ba07ddc6ae5de884e39d2