### PR TITLE
[9.0.0] Make it possible to use InputStream.transferTo() without having to handle ClosedByInterruptException correctly.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/util/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/util/BUILD
@@ -53,6 +53,15 @@ java_library(
 )
 
 java_library(
+    name = "file_channels",
+    srcs = ["FileChannels.java"],
+    add_exports = ["java.base/sun.nio.ch"],
+    deps = [
+        "//third_party:flogger",
+    ],
+)
+
+java_library(
     name = "process",
     srcs = ["ProcessUtils.java"],
     deps = [

--- a/src/main/java/com/google/devtools/build/lib/util/FileChannels.java
+++ b/src/main/java/com/google/devtools/build/lib/util/FileChannels.java
@@ -1,0 +1,66 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.util;
+
+import com.google.common.flogger.GoogleLogger;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.nio.channels.FileChannel;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** Utility methods for {@link FileChannel}. */
+public final class FileChannels {
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+  private static final AtomicBoolean alreadyLogged = new AtomicBoolean(false);
+
+  private static final MethodHandle SET_UNINTERRUPTIBLE;
+
+  static {
+    MethodHandle handle = null;
+    try {
+      handle =
+          MethodHandles.lookup()
+              .unreflect(
+                  Class.forName("sun.nio.ch.FileChannelImpl")
+                      .getDeclaredMethod("setUninterruptible"));
+    } catch (ReflectiveOperationException e) {
+      // Ignore: maybe we're using a JDK that doesn't provide this API.
+      logger.atWarning().withCause(e).log(
+          "Failed to obtain method handle for FileChannelImpl.setUninterruptible");
+    } finally {
+      SET_UNINTERRUPTIBLE = handle;
+    }
+  }
+
+  /**
+   * Makes the given channel uninterruptible.
+   *
+   * <p>This uses an internal OpenJDK API and may silently fail if it's not available.
+   */
+  public static void setUninterruptible(FileChannel channel) {
+    if (SET_UNINTERRUPTIBLE != null) {
+      try {
+        SET_UNINTERRUPTIBLE.invoke(channel);
+      } catch (Throwable e) {
+        // Ignore: maybe we're using a JDK that doesn't provide this API.
+        if (alreadyLogged.compareAndSet(false, true)) {
+          logger.atWarning().withCause(e).log(
+              "Failed to call FileChannelImpl.setUninterruptible (only logged once)");
+        }
+      }
+    }
+  }
+
+  private FileChannels() {}
+}

--- a/src/main/java/com/google/devtools/build/lib/vfs/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/vfs/BUILD
@@ -75,6 +75,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization:visible-for-serialization",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
+        "//src/main/java/com/google/devtools/build/lib/util:file_channels",
         "//src/main/java/com/google/devtools/build/lib/util:filetype",
         "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/util:string_encoding",

--- a/src/test/java/com/google/devtools/build/lib/unix/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/unix/BUILD
@@ -38,6 +38,7 @@ java_library(
         "//src/test/java/com/google/devtools/build/lib/vfs:FileSystemTest_lib",
         "//src/test/java/com/google/devtools/build/lib/vfs:SymlinkAwareFileSystemTest",
         "//src/test/java/com/google/devtools/build/lib/vfs/util",
+        "//third_party:guava",
         "//third_party:guava-testlib",
         "//third_party:junit4",
         "//third_party:mockito",


### PR DESCRIPTION
The comment in DiskBackedFileSystem explains why we're doing this and why this particular implementation was chosen.

PiperOrigin-RevId: 842191458
Change-Id: I5f722f388dbe747442beeb34bc7a9458e05d2ddf