### PR TITLE
[9.0.0] Delete --remote_default_platform_properties.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
@@ -464,7 +464,7 @@ public class ActionCacheChecker {
       EventHandler handler,
       InputMetadataProvider inputMetadataProvider,
       OutputMetadataStore outputMetadataStore,
-      ImmutableMap<String, String> remoteDefaultPlatformProperties,
+      ImmutableMap<String, String> remoteDefaultExecProperties,
       @Nullable OutputChecker outputChecker,
       boolean useArchivedTreeArtifacts)
       throws InterruptedException {
@@ -514,7 +514,7 @@ public class ActionCacheChecker {
         actionInputs,
         clientEnv,
         outputPermissions,
-        remoteDefaultPlatformProperties,
+        remoteDefaultExecProperties,
         cachedOutputMetadata,
         outputChecker,
         useArchivedTreeArtifacts)) {
@@ -547,7 +547,7 @@ public class ActionCacheChecker {
       NestedSet<Artifact> actionInputs,
       Map<String, String> clientEnv,
       OutputPermissions outputPermissions,
-      ImmutableMap<String, String> remoteDefaultPlatformProperties,
+      ImmutableMap<String, String> remoteDefaultExecProperties,
       @Nullable CachedOutputMetadata cachedOutputMetadata,
       @Nullable OutputChecker outputChecker,
       boolean useArchivedTreeArtifacts)
@@ -578,7 +578,7 @@ public class ActionCacheChecker {
     ImmutableMap<String, String> effectiveEnvironment =
         computeEffectiveEnvironment(action, clientEnv);
     ImmutableMap<String, String> effectiveExecProperties =
-        computeEffectiveExecProperties(action, remoteDefaultPlatformProperties);
+        computeEffectiveExecProperties(action, remoteDefaultExecProperties);
 
     if (!isUpToDate(
         entry,
@@ -664,7 +664,7 @@ public class ActionCacheChecker {
       OutputMetadataStore outputMetadataStore,
       Map<String, String> clientEnv,
       OutputPermissions outputPermissions,
-      ImmutableMap<String, String> remoteDefaultPlatformProperties,
+      ImmutableMap<String, String> remoteDefaultExecProperties,
       boolean useArchivedTreeArtifacts)
       throws IOException, InterruptedException {
     checkState(cacheConfig.enabled(), "cache unexpectedly disabled, action: %s", action);
@@ -677,7 +677,7 @@ public class ActionCacheChecker {
     ImmutableMap<String, String> effectiveEnvironment =
         computeEffectiveEnvironment(action, clientEnv);
     ImmutableMap<String, String> effectiveExecProperties =
-        computeEffectiveExecProperties(action, remoteDefaultPlatformProperties);
+        computeEffectiveExecProperties(action, remoteDefaultExecProperties);
 
     // We may already have the action key stored in the token if there was a previous (but out of
     // date) cache entry for this action. If not, there's no need to store the action key in the
@@ -815,7 +815,7 @@ public class ActionCacheChecker {
       EventHandler handler,
       InputMetadataProvider inputMetadataProvider,
       OutputMetadataStore outputMetadataStore,
-      ImmutableMap<String, String> remoteDefaultPlatformProperties,
+      ImmutableMap<String, String> remoteDefaultExecProperties,
       @Nullable OutputChecker outputChecker,
       boolean useArchivedTreeArtifacts)
       throws InterruptedException {
@@ -830,7 +830,7 @@ public class ActionCacheChecker {
         handler,
         inputMetadataProvider,
         outputMetadataStore,
-        remoteDefaultPlatformProperties,
+        remoteDefaultExecProperties,
         outputChecker,
         useArchivedTreeArtifacts);
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -14,18 +14,9 @@
 
 package com.google.devtools.build.lib.remote.options;
 
-import static com.google.devtools.build.lib.util.StringEncoding.internalToUnicode;
-import static com.google.devtools.build.lib.util.StringEncoding.unicodeToInternal;
-
-import build.bazel.remote.execution.v2.Platform;
-import build.bazel.remote.execution.v2.Platform.Property;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.remote.Scrubber;
-import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
-import com.google.devtools.build.lib.server.FailureDetails.RemoteExecution;
-import com.google.devtools.build.lib.server.FailureDetails.RemoteExecution.Code;
 import com.google.devtools.build.lib.util.OptionsUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.common.options.BoolOrEnumConverter;
@@ -41,8 +32,6 @@ import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
 import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.OptionsParsingException;
-import com.google.protobuf.TextFormat;
-import com.google.protobuf.TextFormat.ParseException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -572,22 +561,6 @@ public final class RemoteOptions extends CommonRemoteOptions {
   public int remoteExecutionPriority;
 
   @Option(
-      name = "remote_default_platform_properties",
-      oldName = "host_platform_remote_properties_override",
-      defaultValue = "",
-      documentationCategory = OptionDocumentationCategory.REMOTE,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      deprecationWarning =
-          "--remote_default_platform_properties has been deprecated in favor of"
-              + " --remote_default_exec_properties.",
-      help =
-          "Set the default platform properties to be set for the remote execution API, "
-              + "if the execution platform does not already set remote_execution_properties. "
-              + "This value will also be used if the host platform is selected as the execution "
-              + "platform for remote execution.")
-  public String remoteDefaultPlatformProperties;
-
-  @Option(
       name = "remote_default_exec_properties",
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.REMOTE,
@@ -816,55 +789,12 @@ public final class RemoteOptions extends CommonRemoteOptions {
 
   /**
    * Returns the default exec properties specified by the user or an empty map if nothing was
-   * specified. Use this method instead of directly accessing the fields.
+   * specified. Use this method instead of directly accessing the field.
    */
-  public ImmutableSortedMap<String, String> getRemoteDefaultExecProperties()
-      throws UserExecException {
-    boolean hasExecProperties = !remoteDefaultExecProperties.isEmpty();
-    boolean hasPlatformProperties = !remoteDefaultPlatformProperties.isEmpty();
-
-    if (hasExecProperties && hasPlatformProperties) {
-      throw new UserExecException(
-          createFailureDetail(
-              "Setting both --remote_default_platform_properties and "
-                  + "--remote_default_exec_properties is not allowed. Prefer setting "
-                  + "--remote_default_exec_properties.",
-              Code.INVALID_EXEC_AND_PLATFORM_PROPERTIES));
-    }
-
-    if (hasExecProperties) {
-      return ImmutableSortedMap.copyOf(remoteDefaultExecProperties);
-    }
-    if (hasPlatformProperties) {
-      // Try and use the provided default value.
-      final Platform platform;
-      try {
-        Platform.Builder builder = Platform.newBuilder();
-        TextFormat.getParser().merge(internalToUnicode(remoteDefaultPlatformProperties), builder);
-        platform = builder.build();
-      } catch (ParseException e) {
-        String message =
-            "Failed to parse --remote_default_platform_properties "
-                + remoteDefaultPlatformProperties;
-        throw new UserExecException(
-            e, createFailureDetail(message, Code.REMOTE_DEFAULT_PLATFORM_PROPERTIES_PARSE_FAILURE));
-      }
-
-      ImmutableSortedMap.Builder<String, String> builder = ImmutableSortedMap.naturalOrder();
-      for (Property property : platform.getPropertiesList()) {
-        builder.put(unicodeToInternal(property.getName()), unicodeToInternal(property.getValue()));
-      }
-      return builder.buildOrThrow();
-    }
-
-    return ImmutableSortedMap.of();
-  }
-
-  private static FailureDetail createFailureDetail(String message, Code detailedCode) {
-    return FailureDetail.newBuilder()
-        .setMessage(message)
-        .setRemoteExecution(RemoteExecution.newBuilder().setCode(detailedCode))
-        .build();
+  public ImmutableSortedMap<String, String> getRemoteDefaultExecProperties() {
+    return remoteDefaultExecProperties != null
+        ? ImmutableSortedMap.copyOf(remoteDefaultExecProperties)
+        : ImmutableSortedMap.of();
   }
 
   /** An enum for specifying different modes for printing remote execution messages. */

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -80,7 +80,6 @@ import com.google.devtools.build.lib.actions.SpawnActionExecutionException;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.StoppedScanningActionEvent;
 import com.google.devtools.build.lib.actions.ThreadStateReceiver;
-import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.actions.cache.OutputMetadataStore;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.bugreport.BugReport;
@@ -831,8 +830,6 @@ public final class SkyframeActionExecutor {
                   action, inputMetadataProvider, actionStartTime, BlazeClock.nanoTime()));
         }
       }
-    } catch (UserExecException e) {
-      throw ActionExecutionException.fromExecException(e, action);
     } finally {
       if (cacheHitSemaphore != null) {
         cacheHitSemaphore.release();
@@ -851,16 +848,12 @@ public final class SkyframeActionExecutor {
     if (!actionCacheChecker.enabled()) {
       return;
     }
-    ImmutableSortedMap<String, String> remoteDefaultProperties;
-    try {
-      RemoteOptions remoteOptions = this.options.getOptions(RemoteOptions.class);
-      remoteDefaultProperties =
-          remoteOptions != null
-              ? remoteOptions.getRemoteDefaultExecProperties()
-              : ImmutableSortedMap.of();
-    } catch (UserExecException e) {
-      throw ActionExecutionException.fromExecException(e, action);
-    }
+
+    RemoteOptions remoteOptions = this.options.getOptions(RemoteOptions.class);
+    ImmutableSortedMap<String, String> remoteDefaultProperties =
+        remoteOptions != null
+            ? remoteOptions.getRemoteDefaultExecProperties()
+            : ImmutableSortedMap.of();
 
     try {
       actionCacheChecker.updateActionCache(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -85,7 +85,6 @@ import com.google.devtools.build.lib.actions.OutputChecker;
 import com.google.devtools.build.lib.actions.PackageRoots;
 import com.google.devtools.build.lib.actions.ResourceManager;
 import com.google.devtools.build.lib.actions.ThreadStateReceiver;
-import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.actions.cache.ActionCache;
 import com.google.devtools.build.lib.analysis.AnalysisOptions;
 import com.google.devtools.build.lib.analysis.AspectConfiguredEvent;
@@ -2036,26 +2035,8 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
   public void deleteActionsIfRemoteOptionsChanged(OptionsProvider options)
       throws AbruptExitException {
     RemoteOptions remoteOptions = options.getOptions(RemoteOptions.class);
-    Map<String, String> remoteDefaultExecProperties;
-    try {
-      remoteDefaultExecProperties =
-          remoteOptions != null
-              ? remoteOptions.getRemoteDefaultExecProperties()
-              : ImmutableMap.of();
-    } catch (UserExecException e) {
-      throw new AbruptExitException(
-          DetailedExitCode.of(
-              FailureDetail.newBuilder()
-                  .setMessage(e.getMessage())
-                  .setRemoteOptions(
-                      FailureDetails.RemoteOptions.newBuilder()
-                          .setCode(
-                              FailureDetails.RemoteOptions.Code
-                                  .REMOTE_DEFAULT_EXEC_PROPERTIES_LOGIC_ERROR)
-                          .build())
-                  .build()),
-          e);
-    }
+    Map<String, String> remoteDefaultExecProperties =
+        remoteOptions != null ? remoteOptions.getRemoteDefaultExecProperties() : ImmutableMap.of();
     boolean needsDeletion =
         lastRemoteDefaultExecProperties != null
             && !remoteDefaultExecProperties.equals(lastRemoteDefaultExecProperties);

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -501,7 +501,7 @@ public final class ActionCacheCheckerTest {
                 /* handler= */ null,
                 fakeMetadataHandler,
                 fakeMetadataHandler,
-                /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+                /* remoteDefaultExecProperties= */ ImmutableMap.of(),
                 OutputChecker.TRUST_ALL,
                 /* useArchivedTreeArtifacts= */ false))
         .isNotNull();
@@ -654,7 +654,7 @@ public final class ActionCacheCheckerTest {
             /* handler= */ null,
             metadataHandler,
             metadataHandler,
-            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            /* remoteDefaultExecProperties= */ ImmutableMap.of(),
             OutputChecker.TRUST_ALL,
             /* useArchivedTreeArtifacts= */ false);
 
@@ -688,7 +688,7 @@ public final class ActionCacheCheckerTest {
             /* handler= */ null,
             metadataHandler,
             metadataHandler,
-            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            /* remoteDefaultExecProperties= */ ImmutableMap.of(),
             CHECK_TTL,
             /* useArchivedTreeArtifacts= */ false);
 
@@ -717,7 +717,7 @@ public final class ActionCacheCheckerTest {
             /* handler= */ null,
             metadataHandler,
             metadataHandler,
-            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            /* remoteDefaultExecProperties= */ ImmutableMap.of(),
             /* outputChecker= */ null,
             /* useArchivedTreeArtifacts= */ false);
 
@@ -778,7 +778,7 @@ public final class ActionCacheCheckerTest {
             /* handler= */ null,
             metadataHandler,
             metadataHandler,
-            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            /* remoteDefaultExecProperties= */ ImmutableMap.of(),
             outputChecker,
             /* useArchivedTreeArtifacts= */ false);
     verify(outputChecker)
@@ -974,7 +974,7 @@ public final class ActionCacheCheckerTest {
             /* handler= */ null,
             metadataHandler,
             metadataHandler,
-            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            /* remoteDefaultExecProperties= */ ImmutableMap.of(),
             OutputChecker.TRUST_ALL,
             /* useArchivedTreeArtifacts= */ false);
 
@@ -1079,7 +1079,7 @@ public final class ActionCacheCheckerTest {
             /* handler= */ null,
             metadataHandler,
             metadataHandler,
-            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            /* remoteDefaultExecProperties= */ ImmutableMap.of(),
             OutputChecker.TRUST_ALL,
             /* useArchivedTreeArtifacts= */ false);
 
@@ -1139,7 +1139,7 @@ public final class ActionCacheCheckerTest {
             /* handler= */ null,
             metadataHandler,
             metadataHandler,
-            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            /* remoteDefaultExecProperties= */ ImmutableMap.of(),
             outputChecker,
             /* useArchivedTreeArtifacts= */ false);
     verify(outputChecker)
@@ -1212,7 +1212,7 @@ public final class ActionCacheCheckerTest {
             /* handler= */ null,
             metadataHandler,
             metadataHandler,
-            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            /* remoteDefaultExecProperties= */ ImmutableMap.of(),
             outputChecker,
             /* useArchivedTreeArtifacts= */ false);
     when(outputChecker.shouldTrustMetadata(any(), any())).thenReturn(true);
@@ -1277,7 +1277,7 @@ public final class ActionCacheCheckerTest {
             /* handler= */ null,
             metadataHandler,
             metadataHandler,
-            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            /* remoteDefaultExecProperties= */ ImmutableMap.of(),
             CHECK_TTL,
             /* useArchivedTreeArtifacts= */ false);
 
@@ -1321,7 +1321,7 @@ public final class ActionCacheCheckerTest {
             /* handler= */ null,
             metadataHandler,
             metadataHandler,
-            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            /* remoteDefaultExecProperties= */ ImmutableMap.of(),
             CHECK_TTL,
             /* useArchivedTreeArtifacts= */ false);
 
@@ -1373,7 +1373,7 @@ public final class ActionCacheCheckerTest {
             /* handler= */ null,
             metadataHandler,
             metadataHandler,
-            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            /* remoteDefaultExecProperties= */ ImmutableMap.of(),
             CHECK_TTL,
             !initiallyEnabled);
 
@@ -1417,7 +1417,7 @@ public final class ActionCacheCheckerTest {
             /* handler= */ null,
             metadataHandler,
             metadataHandler,
-            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            /* remoteDefaultExecProperties= */ ImmutableMap.of(),
             OutputChecker.TRUST_ALL,
             /* useArchivedTreeArtifacts= */ false);
 

--- a/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
-import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.common.options.Options;
 import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.OptionsParsingException;
@@ -48,31 +47,6 @@ public class RemoteOptionsTest {
 
     SortedMap<String, String> properties = options.getRemoteDefaultExecProperties();
     assertThat(properties).isEqualTo(ImmutableSortedMap.of("OSFamily", "linux", "ISA", "x86-64"));
-  }
-
-  @Test
-  public void testRemoteDefaultPlatformProperties() throws Exception {
-    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
-    options.remoteDefaultPlatformProperties =
-        "properties:{name:\"ISA\" value:\"x86-64\"} properties:{name:\"OSFamily\" value:\"linux\"}";
-
-    SortedMap<String, String> properties = options.getRemoteDefaultExecProperties();
-    assertThat(properties).isEqualTo(ImmutableSortedMap.of("OSFamily", "linux", "ISA", "x86-64"));
-  }
-
-  @Test
-  public void testConflictingRemotePlatformAndExecProperties() {
-    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
-    options.remoteDefaultExecProperties = Arrays.asList(Maps.immutableEntry("ISA", "x86-64"));
-    options.remoteDefaultPlatformProperties = "properties:{name:\"OSFamily\" value:\"linux\"}";
-
-    // TODO(buchgr): Use assertThrows once Bazel starts using junit > 4.13
-    try {
-      options.getRemoteDefaultExecProperties();
-      fail();
-    } catch (UserExecException e) {
-      // Intentionally left empty.
-    }
   }
 
   @Test

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -964,7 +964,7 @@ EOF
            || fail "Failed to run //a:starlark_output_dir_test with remote execution"
 }
 
-function test_remote_exec_properties() {
+function test_remote_default_exec_properties() {
   # Test that setting remote exec properties works.
   mkdir -p a
   cat > a/BUILD <<'EOF'
@@ -1239,8 +1239,8 @@ EOF
   [[ ! -f bazel-bin/test.runfiles/MANIFEST ]] || fail "expected output manifest to exist"
 }
 
-function test_platform_default_properties_invalidation() {
-  # Test that when changing values of --remote_default_platform_properties all actions are
+function test_remote_default_exec_properties_invalidation() {
+  # Test that when changing values of --remote_default_exec_properties all actions are
   # invalidated if no platform is used.
   mkdir -p test
   cat > test/BUILD << 'EOF'
@@ -1264,7 +1264,7 @@ EOF
     --remote_default_exec_properties="build=88888" \
     //test:test >& $TEST_log || fail "Failed to build //test:test"
 
-  # Changing --remote_default_platform_properties value should invalidate SkyFrames in-memory
+  # Changing --remote_default_exec_properties value should invalidate SkyFrames in-memory
   # caching and make it re-run the action.
   expect_log "2 processes: 1 internal, 1 remote"
 
@@ -1273,7 +1273,7 @@ EOF
     --remote_default_exec_properties="build=88888" \
     //test:test >& $TEST_log || fail "Failed to build //test:test"
 
-  # The same value of --remote_default_platform_properties should NOT invalidate SkyFrames in-memory cache
+  # The same value of --remote_default_exec_properties should NOT invalidate SkyFrames in-memory cache
   #  and make the action should not be re-run.
   expect_log "1 process: 1 internal"
 
@@ -1284,24 +1284,13 @@ EOF
     --remote_default_exec_properties="build=88888" \
     //test:test >& $TEST_log || fail "Failed to build //test:test"
 
-  # The same value of --remote_default_platform_properties should NOT invalidate SkyFrames on-disk cache
+  # The same value of --remote_default_exec_properties should NOT invalidate SkyFrames on-disk cache
   #  and the action should not be re-run.
   expect_log "1 process: .*1 internal"
-
-  bazel build \
-    --remote_executor=grpc://localhost:${worker_port} \
-    --remote_default_exec_properties="build=88888" \
-    --remote_default_platform_properties='properties:{name:"build" value:"1234"}' \
-    //test:test >& $TEST_log && fail "Should fail" || true
-
-  # Build should fail with a proper error message if both
-  # --remote_default_platform_properties and --remote_default_exec_properties
-  # are provided via command line
-  expect_log "Setting both --remote_default_platform_properties and --remote_default_exec_properties is not allowed"
 }
 
-function test_platform_default_properties_invalidation_with_platform_exec_properties() {
-  # Test that when changing values of --remote_default_platform_properties all actions are
+function test_remote_default_exec_properties_invalidation_with_platform_exec_properties() {
+  # Test that when changing values of --remote_default_exec_properties all actions are
   # invalidated.
   mkdir -p test
   cat > test/BUILD << 'EOF'
@@ -1334,8 +1323,8 @@ EOF
     --remote_default_exec_properties="build=88888" \
     //test:test >& $TEST_log || fail "Failed to build //test:test"
 
-  # Changing --remote_default_platform_properties value does not invalidate SkyFrames
-  # given its is superseded by the platform exec_properties.
+  # Changing --remote_default_exec_properties value does not invalidate SkyFrames
+  # given it is superseded by the platform exec_properties.
   expect_log "1 process: .*1 internal."
 }
 


### PR DESCRIPTION
It has been deprecated in favor of --remote_default_exec_properties since 2019.

PiperOrigin-RevId: 837080711
Change-Id: I30d3350cd425711093dcec5c38b0e75cd7d75956