### PR TITLE
[9.0.0] Implement a more general mechanism to invalidate action execution.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
@@ -183,7 +183,7 @@ public class ActionCacheChecker {
    *     outputMetadataStore}.
    * @param outputChecker used to check whether remote metadata should be trusted.
    * @param effectiveEnvironment the effective client environment for the action.
-   * @param effectiveExecProperties the effective exec properties for the action.
+   * @param actionExecutionSalt the action execution salt
    * @param outputPermissions the requested output permissions
    * @param useArchivedTreeArtifacts whether archived tree artifacts are enabled.
    * @return whether the action cache entry is valid.
@@ -199,7 +199,7 @@ public class ActionCacheChecker {
       @Nullable CachedOutputMetadata cachedOutputMetadata,
       @Nullable OutputChecker outputChecker,
       ImmutableMap<String, String> effectiveEnvironment,
-      ImmutableMap<String, String> effectiveExecProperties,
+      String actionExecutionSalt,
       OutputPermissions outputPermissions,
       boolean useArchivedTreeArtifacts)
       throws InterruptedException {
@@ -208,7 +208,7 @@ public class ActionCacheChecker {
             actionKey,
             action.discoversInputs(),
             effectiveEnvironment,
-            effectiveExecProperties,
+            actionExecutionSalt,
             outputPermissions,
             useArchivedTreeArtifacts,
             mandatoryInputsDigest);
@@ -288,13 +288,6 @@ public class ActionCacheChecker {
 
   private boolean unconditionalExecution(Action action) {
     return !isActionExecutionProhibited(action) && action.executeUnconditionally();
-  }
-
-  private static ImmutableMap<String, String> computeEffectiveExecProperties(
-      Action action, ImmutableMap<String, String> defaultExecProperties) {
-    return action.getExecProperties().isEmpty()
-        ? defaultExecProperties
-        : action.getExecProperties();
   }
 
   private static ImmutableMap<String, String> computeEffectiveEnvironment(
@@ -467,7 +460,7 @@ public class ActionCacheChecker {
       EventHandler handler,
       InputMetadataProvider inputMetadataProvider,
       OutputMetadataStore outputMetadataStore,
-      ImmutableMap<String, String> remoteDefaultExecProperties,
+      String actionExecutionSalt,
       @Nullable OutputChecker outputChecker,
       boolean useArchivedTreeArtifacts)
       throws InterruptedException {
@@ -517,7 +510,7 @@ public class ActionCacheChecker {
         actionInputs,
         clientEnv,
         outputPermissions,
-        remoteDefaultExecProperties,
+        actionExecutionSalt,
         mandatoryInputsDigest,
         cachedOutputMetadata,
         outputChecker,
@@ -551,7 +544,7 @@ public class ActionCacheChecker {
       NestedSet<Artifact> actionInputs,
       Map<String, String> clientEnv,
       OutputPermissions outputPermissions,
-      ImmutableMap<String, String> remoteDefaultExecProperties,
+      String actionExecutionSalt,
       @Nullable byte[] mandatoryInputsDigest,
       @Nullable CachedOutputMetadata cachedOutputMetadata,
       @Nullable OutputChecker outputChecker,
@@ -582,8 +575,6 @@ public class ActionCacheChecker {
 
     ImmutableMap<String, String> effectiveEnvironment =
         computeEffectiveEnvironment(action, clientEnv);
-    ImmutableMap<String, String> effectiveExecProperties =
-        computeEffectiveExecProperties(action, remoteDefaultExecProperties);
 
     if (!isUpToDate(
         entry,
@@ -596,7 +587,7 @@ public class ActionCacheChecker {
         cachedOutputMetadata,
         outputChecker,
         effectiveEnvironment,
-        effectiveExecProperties,
+        actionExecutionSalt,
         outputPermissions,
         useArchivedTreeArtifacts)) {
       reportDigestMismatch(handler, action);
@@ -670,7 +661,7 @@ public class ActionCacheChecker {
       OutputMetadataStore outputMetadataStore,
       Map<String, String> clientEnv,
       OutputPermissions outputPermissions,
-      ImmutableMap<String, String> remoteDefaultExecProperties,
+      String actionExecutionSalt,
       boolean useArchivedTreeArtifacts,
       @Nullable byte[] mandatoryInputsDigest)
       throws IOException, InterruptedException {
@@ -683,8 +674,6 @@ public class ActionCacheChecker {
     }
     ImmutableMap<String, String> effectiveEnvironment =
         computeEffectiveEnvironment(action, clientEnv);
-    ImmutableMap<String, String> effectiveExecProperties =
-        computeEffectiveExecProperties(action, remoteDefaultExecProperties);
 
     // We may already have the action key stored in the token if there was a previous (but out of
     // date) cache entry for this action. If not, there's no need to store the action key in the
@@ -699,7 +688,7 @@ public class ActionCacheChecker {
             actionKey,
             action.discoversInputs(),
             effectiveEnvironment,
-            effectiveExecProperties,
+            actionExecutionSalt,
             outputPermissions,
             useArchivedTreeArtifacts,
             mandatoryInputsDigest);
@@ -832,7 +821,7 @@ public class ActionCacheChecker {
       EventHandler handler,
       InputMetadataProvider inputMetadataProvider,
       OutputMetadataStore outputMetadataStore,
-      ImmutableMap<String, String> remoteDefaultExecProperties,
+      String actionExecutionSalt,
       @Nullable OutputChecker outputChecker,
       boolean useArchivedTreeArtifacts)
       throws InterruptedException {
@@ -848,7 +837,7 @@ public class ActionCacheChecker {
         handler,
         inputMetadataProvider,
         outputMetadataStore,
-        remoteDefaultExecProperties,
+        actionExecutionSalt,
         outputChecker,
         useArchivedTreeArtifacts);
   }

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/ActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/ActionCache.java
@@ -287,7 +287,8 @@ public interface ActionCache {
       private final HashMap<String, FileArtifactValue> metadataMap = new HashMap<>();
 
       private final ImmutableMap<String, String> clientEnv;
-      private final ImmutableMap<String, String> execProperties;
+
+      private final String actionExecutionSalt;
 
       // Discovered inputs.
       // Null if the action does not discover inputs.
@@ -318,13 +319,13 @@ public interface ActionCache {
           String actionKey,
           boolean discoversInputs,
           ImmutableMap<String, String> clientEnv,
-          ImmutableMap<String, String> execProperties,
+          String actionExecutionSalt,
           OutputPermissions outputPermissions,
           boolean useArchivedTreeArtifacts,
           @Nullable byte[] mandatoryInputsDigest) {
         this.actionKey = actionKey;
         this.clientEnv = clientEnv;
-        this.execProperties = execProperties;
+        this.actionExecutionSalt = actionExecutionSalt;
         this.discoveredInputPaths = discoversInputs ? ImmutableList.builder() : null;
         this.outputPermissions = outputPermissions;
         this.useArchivedTreeArtifacts = useArchivedTreeArtifacts;
@@ -412,7 +413,7 @@ public interface ActionCache {
                 discoveredInputPaths != null,
                 metadataMap,
                 clientEnv,
-                execProperties,
+                actionExecutionSalt,
                 outputPermissions,
                 useArchivedTreeArtifacts),
             mandatoryInputsDigest,
@@ -427,7 +428,7 @@ public interface ActionCache {
           boolean discoversInputs,
           Map<String, FileArtifactValue> metadataMap,
           Map<String, String> clientEnv,
-          Map<String, String> execProperties,
+          String actionExecutionSalt,
           OutputPermissions outputPermissions,
           boolean useArchivedTreeArtifacts) {
         Fingerprint fp = new Fingerprint();
@@ -435,7 +436,7 @@ public interface ActionCache {
         fp.addBoolean(discoversInputs);
         fp.addBytes(MetadataDigestUtils.fromMetadata(metadataMap));
         fp.addBytes(computeMapDigest(clientEnv));
-        fp.addBytes(computeMapDigest(execProperties));
+        fp.addString(actionExecutionSalt);
         fp.addInt(outputPermissions.getPermissionsMode());
         fp.addBoolean(useArchivedTreeArtifacts);
         return fp.digestAndReset();

--- a/src/main/java/com/google/devtools/build/lib/buildtool/SkyframeBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/SkyframeBuilder.java
@@ -66,6 +66,7 @@ import javax.annotation.Nullable;
 public class SkyframeBuilder implements Builder {
   private final ResourceManager resourceManager;
   private final SkyframeExecutor skyframeExecutor;
+  private final String actionExecutionSalt;
   private final ModifiedFileSet modifiedOutputFiles;
   private final InputMetadataProvider fileCache;
   private final ActionInputPrefetcher actionInputPrefetcher;
@@ -78,6 +79,7 @@ public class SkyframeBuilder implements Builder {
       SkyframeExecutor skyframeExecutor,
       ResourceManager resourceManager,
       ActionCacheChecker actionCacheChecker,
+      String actionExecutionSalt,
       ModifiedFileSet modifiedOutputFiles,
       InputMetadataProvider fileCache,
       ActionInputPrefetcher actionInputPrefetcher,
@@ -86,6 +88,7 @@ public class SkyframeBuilder implements Builder {
     this.resourceManager = resourceManager;
     this.skyframeExecutor = skyframeExecutor;
     this.actionCacheChecker = actionCacheChecker;
+    this.actionExecutionSalt = actionExecutionSalt;
     this.modifiedOutputFiles = modifiedOutputFiles;
     this.fileCache = fileCache;
     this.actionInputPrefetcher = actionInputPrefetcher;
@@ -117,7 +120,8 @@ public class SkyframeBuilder implements Builder {
     skyframeExecutor.detectModifiedOutputFiles(
         modifiedOutputFiles, lastExecutionTimeRange, outputChecker, fsvcThreads);
     try (SilentCloseable c = Profiler.instance().profile("configureActionExecutor")) {
-      skyframeExecutor.configureActionExecutor(fileCache, actionInputPrefetcher);
+      skyframeExecutor.configureActionExecutor(
+          fileCache, actionInputPrefetcher, actionExecutionSalt);
     }
     // Note that executionProgressReceiver accesses builtTargets concurrently (after wrapping in a
     // synchronized collection), so unsynchronized access to this variable is unsafe while it runs.

--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -115,7 +115,9 @@ java_library(
     deps = [
         ":executor_lifecycle_listener",
         "//src/main/java/com/google/devtools/build/lib/actions",
+        "//third_party:error_prone_annotations",
         "//third_party:guava",
+        "//third_party:jsr305",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -99,6 +100,7 @@ import com.google.devtools.build.lib.skyframe.SkyframeExecutorWrappingWalkableGr
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.util.ExitCode;
+import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.util.TempPathGenerator;
 import com.google.devtools.build.lib.util.io.AsynchronousMessageOutputStream;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
@@ -1162,6 +1164,30 @@ public final class RemoteModule extends BlazeModule {
         env.getEventBus().register(outputService);
       }
     }
+
+    builder.setActionExecutionSalt(computeActionExecutionSalt(remoteOptions));
+  }
+
+  private static String computeActionExecutionSalt(RemoteOptions remoteOptions) {
+    Fingerprint fp = new Fingerprint();
+
+    // When building without a remote cache following a build with one, cached actions may reference
+    // remotely stored files which cannot be downloaded. For simplicity we also invalidate in the
+    // reverse situation (building with a remote cache after building without one) even though
+    // cached local actions don't need it.
+    // TODO(chiwang): Solve this with build/action rewinding instead. The main difficulty is that if
+    // no remote options are set, we lack a prefetcher and cannot trigger rewinding.
+    fp.addBoolean(remoteOptions != null && remoteOptions.isRemoteCacheEnabled());
+
+    // The default exec properties may affect how a spawn is remotely executed without affecting the
+    // action key. In practice, only spawns with no execution platform or whose execution platform
+    // has no exec properties are affected, but we don't have access to this information at the
+    // time we're computing the action key, so we unconditionally include the defaults. This
+    // shouldn't be too bad, as we don't expect the defaults to change very often.
+    fp.addStringMap(
+        remoteOptions != null ? remoteOptions.getRemoteDefaultExecProperties() : ImmutableMap.of());
+
+    return fp.hexDigestAndReset();
   }
 
   @Override

--- a/src/main/native/latin1_jni_path.h
+++ b/src/main/native/latin1_jni_path.h
@@ -29,7 +29,9 @@ jstring NewStringLatin1(JNIEnv* env, const char* str);
 // Any non-Latin1 characters are replaced with '?'.
 class JStringLatin1Holder {
  public:
-  // Constructs a JStringLatin1Holder.
+  // Constructs a JStringLatin1Holder for a Java String.
+  // If the Java String is null, a NullPointerException is thrown.
+  // Other errors might be thrown, e.g. OutOfMemoryError.
   // Callers must check env->ExceptionOccurred() before using this object.
   JStringLatin1Holder(JNIEnv* env, jstring string);
 

--- a/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
@@ -769,7 +769,7 @@ public class CompactPersistentActionCacheTest {
         actionKey,
         discoversInputs,
         /* clientEnv= */ ImmutableMap.of(),
-        /* execProperties= */ ImmutableMap.of(),
+        /* actionExecutionSalt= */ "",
         OutputPermissions.READONLY,
         /* useArchivedTreeArtifacts= */ false,
         discoversInputs ? new byte[DigestUtils.ESTIMATED_SIZE] : null);

--- a/src/test/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutorTest.java
@@ -862,7 +862,8 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
     Action action2 =
         new MissingOutputAction(NestedSetBuilder.emptySet(Order.STABLE_ORDER), output2);
     ActionLookupValue ctValue2 = createActionLookupValue(action2, lc2);
-    skyframeExecutor.configureActionExecutor(/* fileCache= */ null, ActionInputPrefetcher.NONE);
+    skyframeExecutor.configureActionExecutor(
+        /* fileCache= */ null, ActionInputPrefetcher.NONE, /* actionExecutionSalt= */ "");
     // Inject the "configured targets" into the graph.
     skyframeExecutor
         .getDifferencerForTesting()
@@ -943,7 +944,8 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
     // is running. This way, both actions will check the action cache beforehand and try to update
     // the action cache post-build.
     final CountDownLatch inputsRequested = new CountDownLatch(2);
-    skyframeExecutor.configureActionExecutor(/* fileCache= */ null, ActionInputPrefetcher.NONE);
+    skyframeExecutor.configureActionExecutor(
+        /* fileCache= */ null, ActionInputPrefetcher.NONE, /* actionExecutionSalt= */ "");
     skyframeExecutor
         .getEvaluator()
         .injectGraphTransformerForTesting(
@@ -1073,7 +1075,8 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
 
     Thread mainThread = Thread.currentThread();
     CountDownLatch cStarted = new CountDownLatch(1);
-    skyframeExecutor.configureActionExecutor(/* fileCache= */ null, ActionInputPrefetcher.NONE);
+    skyframeExecutor.configureActionExecutor(
+        /* fileCache= */ null, ActionInputPrefetcher.NONE, /* actionExecutionSalt= */ "");
     skyframeExecutor
         .getEvaluator()
         .injectGraphTransformerForTesting(
@@ -1209,7 +1212,8 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
     Action action2 =
         new TreeArtifactAction(NestedSetBuilder.emptySet(Order.STABLE_ORDER), output2, children);
     ActionLookupValue ctValue2 = createActionLookupValue(action2, lc2);
-    skyframeExecutor.configureActionExecutor(/* fileCache= */ null, ActionInputPrefetcher.NONE);
+    skyframeExecutor.configureActionExecutor(
+        /* fileCache= */ null, ActionInputPrefetcher.NONE, /* actionExecutionSalt= */ "");
     // Inject the "configured targets" into the graph.
     skyframeExecutor
         .getDifferencerForTesting()
@@ -1323,7 +1327,8 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
     ActionTemplate<DummyAction> template2 =
         new DummyActionTemplate(baseOutput, sharedOutput2, ActionOwner.SYSTEM_ACTION_OWNER);
     ActionLookupValue shared2Ct = createActionLookupValue(template2, shared2);
-    skyframeExecutor.configureActionExecutor(/* fileCache= */ null, ActionInputPrefetcher.NONE);
+    skyframeExecutor.configureActionExecutor(
+        /* fileCache= */ null, ActionInputPrefetcher.NONE, /* actionExecutionSalt= */ "");
     // Inject the "configured targets" into the graph.
     skyframeExecutor
         .getDifferencerForTesting()
@@ -1650,7 +1655,8 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
             createActionLookupValue(slowAction, lc2),
             null,
             NestedSetBuilder.emptySet(Order.STABLE_ORDER));
-    skyframeExecutor.configureActionExecutor(/* fileCache= */ null, ActionInputPrefetcher.NONE);
+    skyframeExecutor.configureActionExecutor(
+        /* fileCache= */ null, ActionInputPrefetcher.NONE, /* actionExecutionSalt= */ "");
     skyframeExecutor
         .getEvaluator()
         .injectGraphTransformerForTesting(
@@ -1781,7 +1787,8 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
             createActionLookupValue(action2, lc2),
             null,
             NestedSetBuilder.create(Order.STABLE_ORDER, Event.warn("analysis warning 2")));
-    skyframeExecutor.configureActionExecutor(/* fileCache= */ null, ActionInputPrefetcher.NONE);
+    skyframeExecutor.configureActionExecutor(
+        /* fileCache= */ null, ActionInputPrefetcher.NONE, /* actionExecutionSalt= */ "");
     skyframeExecutor
         .getDifferencerForTesting()
         .inject(ImmutableMap.of(lc1, Delta.justNew(ctValue1), lc2, Delta.justNew(ctValue2)));
@@ -1981,6 +1988,7 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
             skyframeExecutor,
             new ResourceManager(),
             NULL_CHECKER,
+            /* actionExecutionSalt= */ "",
             ModifiedFileSet.EVERYTHING_MODIFIED,
             /* fileCache= */ null,
             ActionInputPrefetcher.NONE,
@@ -2121,6 +2129,7 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
             skyframeExecutor,
             new ResourceManager(),
             NULL_CHECKER,
+            /* actionExecutionSalt= */ "",
             ModifiedFileSet.EVERYTHING_MODIFIED,
             /* fileCache= */ null,
             ActionInputPrefetcher.NONE,
@@ -2245,6 +2254,7 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
             skyframeExecutor,
             new ResourceManager(),
             NULL_CHECKER,
+            /* actionExecutionSalt= */ "",
             ModifiedFileSet.EVERYTHING_MODIFIED,
             /* fileCache= */ null,
             ActionInputPrefetcher.NONE,
@@ -2366,6 +2376,7 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
             skyframeExecutor,
             new ResourceManager(),
             NULL_CHECKER,
+            /* actionExecutionSalt= */ "",
             ModifiedFileSet.EVERYTHING_MODIFIED,
             /* fileCache= */ null,
             ActionInputPrefetcher.NONE,
@@ -2477,6 +2488,7 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
             skyframeExecutor,
             new ResourceManager(),
             NULL_CHECKER,
+            /* actionExecutionSalt= */ "",
             ModifiedFileSet.EVERYTHING_MODIFIED,
             /* fileCache= */ null,
             ActionInputPrefetcher.NONE,
@@ -2574,6 +2586,7 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
             skyframeExecutor,
             new ResourceManager(),
             NULL_CHECKER,
+            /* actionExecutionSalt= */ "",
             ModifiedFileSet.EVERYTHING_MODIFIED,
             /* fileCache= */ null,
             ActionInputPrefetcher.NONE,
@@ -2656,6 +2669,7 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
             skyframeExecutor,
             new ResourceManager(),
             NULL_CHECKER,
+            /* actionExecutionSalt= */ "",
             ModifiedFileSet.EVERYTHING_MODIFIED,
             /* fileCache= */ null,
             ActionInputPrefetcher.NONE,

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TimestampBuilderTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TimestampBuilderTestCase.java
@@ -244,7 +244,10 @@ public abstract class TimestampBuilderTestCase extends FoundationTestCase {
             scratch.getFileSystem(),
             SyscallCache.NO_CACHE);
     skyframeActionExecutor.configure(
-        cache, ActionInputPrefetcher.NONE, DiscoveredModulesPruner.DEFAULT);
+        cache,
+        ActionInputPrefetcher.NONE,
+        DiscoveredModulesPruner.DEFAULT,
+        /* actionExecutionSalt= */ "");
 
     InMemoryMemoizingEvaluator evaluator =
         new InMemoryMemoizingEvaluator(

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1240,8 +1240,7 @@ EOF
 }
 
 function test_remote_default_exec_properties_invalidation() {
-  # Test that when changing values of --remote_default_exec_properties all actions are
-  # invalidated if no platform is used.
+  # Test that changing --remote_default_exec_properties invalidates actions,
   mkdir -p test
   cat > test/BUILD << 'EOF'
 genrule(
@@ -1264,8 +1263,7 @@ EOF
     --remote_default_exec_properties="build=88888" \
     //test:test >& $TEST_log || fail "Failed to build //test:test"
 
-  # Changing --remote_default_exec_properties value should invalidate SkyFrames in-memory
-  # caching and make it re-run the action.
+  # Changing --remote_default_exec_properties value should invalidate Skyframe.
   expect_log "2 processes: 1 internal, 1 remote"
 
   bazel build \
@@ -1273,8 +1271,7 @@ EOF
     --remote_default_exec_properties="build=88888" \
     //test:test >& $TEST_log || fail "Failed to build //test:test"
 
-  # The same value of --remote_default_exec_properties should NOT invalidate SkyFrames in-memory cache
-  #  and make the action should not be re-run.
+  # Unchanging --remote_default_exec_properties should NOT invalidate Skyframe.
   expect_log "1 process: 1 internal"
 
   bazel shutdown
@@ -1284,14 +1281,13 @@ EOF
     --remote_default_exec_properties="build=88888" \
     //test:test >& $TEST_log || fail "Failed to build //test:test"
 
-  # The same value of --remote_default_exec_properties should NOT invalidate SkyFrames on-disk cache
-  #  and the action should not be re-run.
+  # Unchanging --remote_default_exec_properties should NOT invalidate Skyframe.
   expect_log "1 process: .*1 internal"
 }
 
 function test_remote_default_exec_properties_invalidation_with_platform_exec_properties() {
-  # Test that when changing values of --remote_default_exec_properties all actions are
-  # invalidated.
+  # Test that changing --remote_default_exec_properties invalidates actions,
+  # even if an exec platform with exec properties is set.
   mkdir -p test
   cat > test/BUILD << 'EOF'
 platform(
@@ -1323,9 +1319,10 @@ EOF
     --remote_default_exec_properties="build=88888" \
     //test:test >& $TEST_log || fail "Failed to build //test:test"
 
-  # Changing --remote_default_exec_properties value does not invalidate SkyFrames
-  # given it is superseded by the platform exec_properties.
-  expect_log "1 process: .*1 internal."
+  # Changing --remote_default_exec_properties value invalidates Skyframe, but
+  # it doesn't affect the spawn's platform properties, so we still get a remote
+  # cache hit.
+  expect_log "2 processes: 1 remote cache hit, 1 internal"
 }
 
 function test_platform_default_properties_invalidation_with_platform_remote_execution_properties() {


### PR DESCRIPTION
An opaque "action execution salt" may be provided by at most one module during executor initialization. Skyframe keeps track of the last known value and invalidates all action executions when it changes. The persistent action cache incorporates it into the cache key. This generalizes preexisting Bazel-only cache-busting logic, making it possible for Blaze to reuse it.

PiperOrigin-RevId: 840516116
Change-Id: I6a80b8b85abb221d0c1595586e3a9a03128803ef