### PR TITLE
Docker build with symlinks

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
@@ -239,6 +239,7 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
         treeDeleter,
         /* sandboxDebugPath= */ null,
         statisticsPath,
+        /* successCallback = */ null,
         /* interactiveDebugArguments= */ null,
         spawn.getMnemonic(),
         spawn.getTargetLabel()) {

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DockerCommandLineBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DockerCommandLineBuilder.java
@@ -37,7 +37,6 @@ final class DockerCommandLineBuilder {
   private Path sandboxExecRoot;
   private Map<String, String> environmentVariables;
   private Duration timeout;
-  private boolean createNetworkNamespace;
   private UUID uuid;
   private int uid;
   private int gid;
@@ -45,6 +44,7 @@ final class DockerCommandLineBuilder {
   private boolean privileged;
   private Set<Path> writableFilesAndDirectories = ImmutableSet.of();
   private List<Map.Entry<String, String>> additionalMounts = ImmutableList.of();
+  private String networkMode;
 
   @CanIgnoreReturnValue
   public DockerCommandLineBuilder setProcessWrapper(ProcessWrapper processWrapper) {
@@ -86,12 +86,6 @@ final class DockerCommandLineBuilder {
   @CanIgnoreReturnValue
   public DockerCommandLineBuilder setTimeout(Duration timeout) {
     this.timeout = timeout;
-    return this;
-  }
-
-  @CanIgnoreReturnValue
-  public DockerCommandLineBuilder setCreateNetworkNamespace(boolean createNetworkNamespace) {
-    this.createNetworkNamespace = createNetworkNamespace;
     return this;
   }
 
@@ -139,21 +133,24 @@ final class DockerCommandLineBuilder {
     return this;
   }
 
+  @CanIgnoreReturnValue
+  public DockerCommandLineBuilder setNetworkMode(String networkMode) {
+    this.networkMode = networkMode;
+    return this;
+  }
+
   public ImmutableList<String> build() {
     Preconditions.checkNotNull(sandboxExecRoot, "sandboxExecRoot must be set");
     Preconditions.checkState(!imageName.isEmpty(), "imageName must be set");
     Preconditions.checkState(!commandArguments.isEmpty(), "commandArguments must be set");
+    Preconditions.checkState(networkMode != null, "networkMode must be set");
 
     ImmutableList.Builder<String> dockerCmdLine = ImmutableList.builder();
 
     dockerCmdLine.add(dockerClient.getPathString());
     dockerCmdLine.add("run");
     dockerCmdLine.add("--rm");
-    if (createNetworkNamespace) {
-      dockerCmdLine.add("--network=none");
-    } else {
-      dockerCmdLine.add("--network=host");
-    }
+    dockerCmdLine.add("--network=" + networkMode);
     if (privileged) {
       dockerCmdLine.add("--privileged");
     }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
@@ -252,10 +252,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
         .setWritableFilesAndDirectories(writableDirs)
         .setPrivileged(getSandboxOptions().getDockerPrivileged())
         .setEnvironmentVariables(environment)
-        .setCreateNetworkNamespace(
-            !(allowNetwork
-                || Spawns.requiresNetwork(
-                    spawn, getSandboxOptions().getDefaultSandboxAllowNetwork())))
+        .setNetworkMode(getNetworkMode(spawn))
         .setCommandId(commandId)
         .setUuid(uuid);
     // If uid / gid are -1, we are on an operating system that doesn't require us to set them on the
@@ -277,7 +274,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     // We register the container UUID for cleanup, but remove the UUID if the process ran
     // successfully.
     containersToCleanup.add(uuid);
-    if (cmdEnv.getOptions().getOptions(SandboxOptions.class).dockerSandboxUseSymlinks) {
+    if (cmdEnv.getOptions().getOptions(SandboxOptions.class).getDockerSandboxUseSymlinks()) {
       return new SymlinkedSandboxedSpawn(
               sandboxPath,
               sandboxExecRoot,
@@ -307,6 +304,15 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
               /* statisticsPath= */ null,
               () -> containersToCleanup.remove(uuid),
               spawn.getMnemonic());
+    }
+  }
+
+  private String getNetworkMode(Spawn spawn) {
+    var networkRequested = allowNetwork || Spawns.requiresNetwork(spawn, getSandboxOptions().getDefaultSandboxAllowNetwork());
+    if (networkRequested) {
+      return getSandboxOptions().getDockerSandboxNetworkConfig();
+    } else {
+      return "none";
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
@@ -281,7 +281,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
         sandboxPath,
         sandboxExecRoot,
         cmdLine.build(),
-        cmdEnv.getClientEnv(),
+        environment,
         inputs,
         outputs,
         writableDirs,

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
@@ -277,19 +277,37 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     // We register the container UUID for cleanup, but remove the UUID if the process ran
     // successfully.
     containersToCleanup.add(uuid);
-    return new CopyingSandboxedSpawn(
-        sandboxPath,
-        sandboxExecRoot,
-        cmdLine.build(),
-        environment,
-        inputs,
-        outputs,
-        writableDirs,
-        treeDeleter,
-        /* sandboxDebugPath= */ null,
-        /* statisticsPath= */ null,
-        () -> containersToCleanup.remove(uuid),
-        spawn.getMnemonic());
+    if (cmdEnv.getOptions().getOptions(SandboxOptions.class).dockerSandboxUseSymlinks) {
+      return new SymlinkedSandboxedSpawn(
+              sandboxPath,
+              sandboxExecRoot,
+              cmdLine.build(),
+              environment,
+              inputs,
+              outputs,
+              writableDirs,
+              treeDeleter,
+              /* sandboxDebugPath= */ null,
+              /* statisticsPath= */ null,
+              () -> containersToCleanup.remove(uuid),
+              null,
+              spawn.getMnemonic(),
+              spawn.getTargetLabel());
+    } else {
+      return new CopyingSandboxedSpawn(
+              sandboxPath,
+              sandboxExecRoot,
+              cmdLine.build(),
+              environment,
+              inputs,
+              outputs,
+              writableDirs,
+              treeDeleter,
+              /* sandboxDebugPath= */ null,
+              /* statisticsPath= */ null,
+              () -> containersToCleanup.remove(uuid),
+              spawn.getMnemonic());
+    }
   }
 
   private String getOrCreateCustomizedImage(String baseImage)

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
@@ -215,6 +215,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
     ImmutableMap<String, String> environment =
         localEnvProvider.rewriteLocalEnv(spawn.getEnvironment(), binTools, "/tmp");
+    ImmutableSet<Path> writableDirs = getWritableDirs(sandboxExecRoot, environment);
 
     SandboxInputs inputs =
         SandboxHelpers.processInputFiles(
@@ -248,6 +249,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
         .setCommandArguments(spawn.getArguments())
         .setSandboxExecRoot(sandboxExecRoot)
         .setAdditionalMounts(getSandboxOptions().getSandboxAdditionalMounts())
+        .setWritableFilesAndDirectories(writableDirs)
         .setPrivileged(getSandboxOptions().getDockerPrivileged())
         .setEnvironmentVariables(environment)
         .setCreateNetworkNamespace(
@@ -282,7 +284,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
         cmdEnv.getClientEnv(),
         inputs,
         outputs,
-        ImmutableSet.of(),
+        writableDirs,
         treeDeleter,
         /* sandboxDebugPath= */ null,
         /* statisticsPath= */ null,

--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -374,6 +374,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
           treeDeleter,
           sandboxDebugPath,
           statisticsPath,
+          /* successCallback = */ null,
           makeInteractiveDebugArguments(commandLineBuilder, sandboxOptions),
           spawn.getMnemonic(),
           spawn.getTargetLabel());

--- a/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
@@ -103,6 +103,7 @@ final class ProcessWrapperSandboxedSpawnRunner extends AbstractSandboxSpawnRunne
         treeDeleter,
         /* sandboxDebugPath= */ null,
         statisticsPath,
+        /* successCallback = */ null,
         /* interactiveDebugArguments= */ null,
         spawn.getMnemonic(),
         spawn.getTargetLabel());

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
@@ -365,6 +365,13 @@ public final class SandboxModule extends BlazeModule {
 
   @Nullable
   private static Path getPathToDockerClient(CommandEnvironment cmdEnv) {
+    SandboxOptions options = cmdEnv.getOptions().getOptions(SandboxOptions.class);
+    FileSystem fs = cmdEnv.getRuntime().getFileSystem();
+    Path sandboxExecutablePath = fs.getPath(options.getDockerSandboxExecutable());
+    if (sandboxExecutablePath.exists()) {
+      return sandboxExecutablePath;
+    }
+
     String path = cmdEnv.getClientEnv().getOrDefault("PATH", "");
 
     // TODO(philwo): Does this return the correct result if one of the elements intentionally ends
@@ -372,7 +379,6 @@ public final class SandboxModule extends BlazeModule {
     Splitter pathSplitter =
         Splitter.on(OS.getCurrent() == OS.WINDOWS ? ';' : ':').trimResults().omitEmptyStrings();
 
-    FileSystem fs = cmdEnv.getRuntime().getFileSystem();
 
     for (String pathElement : pathSplitter.split(path)) {
       // Sometimes the PATH contains the non-absolute entry "." - this resolves it against the
@@ -380,7 +386,7 @@ public final class SandboxModule extends BlazeModule {
       pathElement = new File(pathElement).getAbsolutePath();
       try {
         for (Path dentry : fs.getPath(pathElement).getDirectoryEntries()) {
-          if (dentry.getBaseName().replace(".exe", "").equals("docker")) {
+          if (dentry.getBaseName().replace(".exe", "").equals(options.getDockerSandboxExecutable())) {
             return dentry;
           }
         }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
@@ -248,6 +248,15 @@ public abstract class SandboxOptions extends OptionsBase {
   public abstract boolean getDockerSandboxUseSymlinks();
 
   @Option(
+          name = "experimental_docker_sandbox_executable",
+          defaultValue = "docker",
+          documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+          effectTags = {OptionEffectTag.EXECUTION},
+          help =
+                  "When Docker-based sandboxing is enabled, use the specified docker-cli compatible executable to run the containers.")
+  public abstract String getDockerSandboxExecutable();
+
+  @Option(
       name = "experimental_docker_image",
       defaultValue = "",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
@@ -248,6 +248,15 @@ public abstract class SandboxOptions extends OptionsBase {
   public abstract boolean getDockerSandboxUseSymlinks();
 
   @Option(
+      name = "experimental_docker_sandbox_network_config",
+      defaultValue = "host",
+      documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+      effectTags = {OptionEffectTag.EXECUTION},
+      help =
+          "When Docker-based sandboxing is enabled and the action has network access, specifies what to pass to --network")
+  public abstract String getDockerSandboxNetworkConfig();
+
+  @Option(
           name = "experimental_docker_sandbox_executable",
           defaultValue = "docker",
           documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
@@ -230,13 +230,22 @@ public abstract class SandboxOptions extends OptionsBase {
   }
 
   @Option(
-      name = "experimental_enable_docker_sandbox",
+          name = "experimental_enable_docker_sandbox",
+          defaultValue = "false",
+          documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+          effectTags = {OptionEffectTag.EXECUTION},
+          help =
+                  "Enable Docker-based sandboxing. This option has no effect if Docker is not installed.")
+  public abstract boolean getEnableDockerSandbox();
+
+  @Option(
+      name = "experimental_docker_sandbox_use_symlinks",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "Enable Docker-based sandboxing. This option has no effect if Docker is not installed.")
-  public abstract boolean getEnableDockerSandbox();
+          "When Docker-based sandboxing is enabled, input files will be symlinked to the sandbox instead of copied to the sandbox.")
+  public abstract boolean getDockerSandboxUseSymlinks();
 
   @Option(
       name = "experimental_docker_image",

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
@@ -42,6 +42,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
   private final String mnemonic;
 
   private final Label targetLabel;
+  private final Runnable successCallback;
 
   @Nullable private final ImmutableList<String> interactiveDebugArguments;
 
@@ -56,6 +57,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
       TreeDeleter treeDeleter,
       @Nullable Path sandboxDebugPath,
       @Nullable Path statisticsPath,
+      @Nullable Runnable successCallback,
       @Nullable ImmutableList<String> interactiveDebugArguments,
       String mnemonic,
       Label targetLabel) {
@@ -74,6 +76,15 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
     this.mnemonic = isNullOrEmpty(mnemonic) ? "_NoMnemonic_" : mnemonic;
     this.interactiveDebugArguments = interactiveDebugArguments;
     this.targetLabel = targetLabel;
+    this.successCallback = successCallback;
+  }
+
+  @Override
+  public void copyOutputs(Path execRoot) throws IOException, InterruptedException {
+    if (successCallback != null) {
+      successCallback.run();
+    }
+    super.copyOutputs(execRoot);
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawnTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawnTest.java
@@ -79,6 +79,7 @@ public class SymlinkedSandboxedSpawnTest {
             new SynchronousTreeDeleter(),
             /* sandboxDebugPath= */ null,
             /* statisticsPath= */ null,
+            /* successCallback = */ null,
             /* interactiveDebugArguments= */ null,
             "SomeMnemonic",
             /* targetLabel= */ null);
@@ -110,6 +111,7 @@ public class SymlinkedSandboxedSpawnTest {
             new SynchronousTreeDeleter(),
             /* sandboxDebugPath= */ null,
             /* statisticsPath= */ null,
+            /* successCallback = */ null,
             /* interactiveDebugArguments= */ null,
             "SomeMnemonic",
             /* targetLabel= */ null);

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -742,6 +742,20 @@ sh_test(
     tags = ["no_windows"],
 )
 
+sh_test(
+    name = "docker_sandboxing_test",
+    size = "large",
+    srcs = ["docker_sandboxing_test.sh"],
+    data = [
+        ":test-deps",
+    ],
+    shard_count = 4,
+    tags = [
+        "local",
+        "no_windows",
+    ],
+)
+
 package_group(
     name = "spend_cpu_time_users",
     packages = [

--- a/src/test/shell/integration/docker_sandboxing_test.sh
+++ b/src/test/shell/integration/docker_sandboxing_test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Test sandboxing spawn strategy
+#
+
+set -euo pipefail
+
+# Load the test setup defined in the parent directory
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CURRENT_DIR}/../integration_test_setup.sh" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+function set_up() {
+  echo -e "#!/bin/sh\necho success" > ${CURRENT_DIR}/fake_docker
+  chmod +x ${CURRENT_DIR}/fake_docker
+  add_to_bazelrc "build --experimental_enable_docker_sandbox"
+  add_to_bazelrc "build --experimental_docker_verbose"
+  add_to_bazelrc "build --experimental_docker_sandbox_use_symlinks"
+  add_to_bazelrc "build --experimental_docker_image=imagename"
+  add_to_bazelrc "build --experimental_docker_sandbox_executable=${CURRENT_DIR}/fake_docker"
+  add_to_bazelrc "build --spawn_strategy=docker"
+  add_to_bazelrc "build --genrule_strategy=docker"
+
+  # Enabled in testenv.sh.tmpl, but not in Bazel by default.
+  sed -i.bak '/sandbox_tmpfs_path/d' "$bazelrc"
+}
+
+function tear_down() {
+  bazel clean --expunge
+  bazel shutdown
+  rm -rf pkg
+}
+
+function test_sandbox_local_used_with_proper_strategy() {
+  mkdir pkg
+  cat >pkg/BUILD <<EOF
+genrule(name = "pkg", outs = ["pkg.out"], cmd = "pwd; echo >\$@",
+  tags = ["no-sandbox"])
+EOF
+
+  local output_base="$(bazel info output_base)"
+  local sandbox_base="${output_base}/sandbox"
+  rm -rf ${sandbox_base}
+
+  bazel build --genrule_strategy=sandboxed,standalone //pkg \
+    >"${TEST_log}" 2>&1 || fail "Expected build to succeed"
+
+  expect_not_log "${output_base}.*/sandbox/"
+}
+
+run_suite "sandboxing"


### PR DESCRIPTION
Hi all

I am currently testing out `--experimental_enable_docker_sandbox` to have better sandboxing than linux-sandbox. The performance is very slow because creating the sandbox directory takes much time. `docker_sandbox` does copy, `linux-sandbox` does symlinking. @fmeum suggested that ec90e05dee8690e89d925e59a590b51e9d6511f7 should improve the situation.

I tried it, but the performance is not much better. linux-sandbox with symlinking is way faster.

So I started this MR in the hopes to get it upstream.
A new option is introduced: `--experimental_enable_docker_sandbox_symlinked_spawn`.
When the option is active, then `docker-sandbox` uses `SymlinkedSandboxedSpawn`, just like `linux-sandbox` also does.

It is a bit imperfect, because not all necessary folders are mounted. In my case I need this command to have it running (the bazel root and the source tree need to be added as mount pair (readonly), so that the symlinks resolve correctly. I also tried to use the hardlinking style just like `--experimental_use_hermetic_linux_sandbox` does. But this is also very slow compared to the symlink case. I did not check, but I assume it is because symlinking can avoid traversing whole directories. Hardlinking may also be slower than symlinking when the bazel root and the source tree is not on the same filesystem of course.

I tried to use `--experimental_use_hermetic_linux_sandbox` for my needs, but I was never able to get it running. This solution with docker comes extremely near to a perfect sandbox in my opinion.

This is how it runs on my computer:
```
bazel test //... \
--experimental_enable_docker_sandbox \
--experimental_docker_verbose \
--experimental_enable_docker_sandbox_symlinked_spawn \
--experimental_docker_image=baseimage \
--define=EXECUTOR=remote \
--sandbox_add_mount_pair=/home/user/.cache/bazel \
--sandbox_add_mount_pair=/home/user/src
```




The timing is now quite near to linux-sandbox (it is a java build):

linux-sandbox
```
$ time /Work/bazel/bazel test //foo:bar --nocache_test_results
...
//foo:bar                                 PASSED in 0.6s
real    0m1.458s
user    0m0.014s
sys     0m0.016s
```

docker-sandbox (the existing, copying one)
```
$ time /Work/bazel/bazel test //foo:bar --nocache_test_results --experimental_enable_docker_sandbox
...
//foo:bar                                 PASSED in 0.9s
real    0m5.311s
user    0m0.016s
sys     0m0.021s
```

docker-sandbox (the new one from this PR)
```
$ time /Work/bazel/bazel test //foo:bar --nocache_test_results --experimental_enable_docker_sandbox --experimental_enable_docker_sandbox_symlinked_spawn
...
//foo:bar                                 PASSED in 0.7s
real    0m1.766s
user    0m0.010s
sys     0m0.018s

```