### PR TITLE
list_source_repository: fix source not updating after deletion

### DIFF
--- a/src/test/shell/bazel/list_source_repository.bzl
+++ b/src/test/shell/bazel/list_source_repository.bzl
@@ -22,13 +22,6 @@ def _impl(rctx):
     workspace = rctx.path(Label("//:BUILD")).dirname
     srcs_excludes = "XXXXXXXXXXXXXX1268778dfsdf4"
 
-    # Depending in ~/.git/logs/HEAD is a trick to depends on something that
-    # change every time the workspace content change.
-    r = rctx.execute(["test", "-f", "%s/.git/logs/HEAD" % workspace])
-    if r.return_code == 0:
-        # We only add the dependency if it exists.
-        unused_var = rctx.path(Label("//:.git/logs/HEAD"))  # pylint: disable=unused-variable
-
     if "SRCS_EXCLUDES" in rctx.os.environ:
         srcs_excludes = rctx.os.environ["SRCS_EXCLUDES"]
     r = rctx.execute(["find", "-L", str(workspace), "-type", "f"])


### PR DESCRIPTION
Tell the repo rule to watch the workspace and rerun would be the best
way for us to get accurate data.

The repo rule is only used for //src/test/shell/bazel:srcs_test so users
who don't run this test would not have to re-run the repo rule for each
change.
