### PR TITLE
[9.0.0] Fix jvm_import_external in Bazel 9

### DIFF
--- a/tools/build_defs/repo/jvm.bzl
+++ b/tools/build_defs/repo/jvm.bzl
@@ -86,6 +86,7 @@ def _jvm_import_external(repository_ctx):
             srcpath = url[url.rindex("/") + 1:].replace("-sources.jar", "-src.jar")
             break
     lines = [_HEADER, ""]
+    lines.append("load(\"@rules_java//java:java_import.bzl\", \"java_import\")")
     if repository_ctx.attr.rule_load:
         lines.append(repository_ctx.attr.rule_load)
         lines.append("")


### PR DESCRIPTION
This PR contains 2 commit(s).

1)This attribute is no longer available by default and is breaking this rule at HEAD

Found via debugging Bazel 9 with https://github.com/bazeltools/bazel_jar_jar/blob/660b5517e56562af9e7d6168b45886b7d786da5f/test/deps.bzl#L4

RELNOTES: None
PiperOrigin-RevId: 842722721
Change-Id: I1959531b821121283fb476714e78fa3370d0a05a

Commit https://github.com/bazelbuild/bazel/commit/3f2295c341b61d7fd5032d2b840cdd9ac0db9111

2)RELNOTES: None
PiperOrigin-RevId: 843143069
Change-Id: Id849ec7e6490409781ccae9a0eccca2650028fee

Commit https://github.com/bazelbuild/bazel/commit/d9a9ffe2abf46f49decd2223b68495842b9d31f4

