### PR TITLE
[8.6.0] Make -s apply to 'bazel run' command

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/BUILD
@@ -101,6 +101,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/lib/util:command",
+        "//src/main/java/com/google/devtools/build/lib/util:command_failure_utils",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
         "//src/main/java/com/google/devtools/build/lib/util:exit_code",
         "//src/main/java/com/google/devtools/build/lib/util:interrupted_failure_details",

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.actions.ActionEnvironment;
+import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.CommandLine;
@@ -86,6 +87,8 @@ import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.Interrupted;
 import com.google.devtools.build.lib.server.FailureDetails.RunCommand.Code;
+import com.google.devtools.build.lib.util.CommandDescriptionForm;
+import com.google.devtools.build.lib.util.CommandFailureUtils;
 import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.util.ExitCode;
 import com.google.devtools.build.lib.util.InterruptedFailureDetails;
@@ -327,13 +330,42 @@ public class RunCommand implements BlazeCommand {
     if (runOptions.scriptPath != null) {
       return handleScriptPath(runOptions, execRequest, runCommandLine, env, builtTargets);
     }
-    if (runOptions.runBuiltTarget) {
-      env.getReporter()
-          .handle(Event.info(null, "Running command line: " + runCommandLine.getPrettyArgs()));
+
+    ExecutionOptions executionOptions = options.getOptions(ExecutionOptions.class);
+    ActionExecutionContext.ShowSubcommands showSubcommands = executionOptions.showSubcommands;
+
+    String commandDescription;
+    if (showSubcommands != ActionExecutionContext.ShowSubcommands.FALSE) {
+      String shExecutable = null;
+      if (runCommandLine.requiresShExecutable()) {
+        try {
+          shExecutable =
+              getShellExecutableOrThrow(env, builtTargets.configuration, "", builtTargets.stopTime);
+        } catch (RunCommandException e) {
+          return e.result;
+        }
+      }
+      ImmutableList<String> args = runCommandLine.getArgs(shExecutable);
+      commandDescription =
+          CommandFailureUtils.describeCommand(
+              CommandDescriptionForm.COMPLETE,
+              showSubcommands == ActionExecutionContext.ShowSubcommands.PRETTY_PRINT,
+              args,
+              finalRunEnv,
+              ImmutableList.copyOf(runCommandLine.getEnvironmentVariablesToClear()),
+              runCommandLine.getWorkingDir().getPathString(),
+              /* configurationChecksum= */ null,
+              /* executionPlatformLabel= */ null,
+              /* spawnRunner= */ null);
     } else {
-      env.getReporter()
-          .handle(Event.info(null, "Runnable command line: " + runCommandLine.getPrettyArgs()));
+      commandDescription = runCommandLine.getPrettyArgs();
     }
+
+    String prefix = runOptions.runBuiltTarget ? "Running" : "Runnable";
+    String separator =
+        showSubcommands != ActionExecutionContext.ShowSubcommands.FALSE ? ":\n" : ": ";
+    env.getReporter()
+        .handle(Event.info(null, prefix + " command line" + separator + commandDescription));
 
     try {
       env.getReporter()

--- a/src/test/shell/bazel/run_test.sh
+++ b/src/test/shell/bazel/run_test.sh
@@ -206,4 +206,47 @@ EOF
   true
 }
 
+function test_run_subcommands_flag() {
+  add_rules_shell "MODULE.bazel"
+  local -r pkg="pkg${LINENO}"
+  mkdir $pkg
+  cat >$pkg/BUILD <<EOF
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+sh_binary(
+    name = "hello",
+    srcs = ["hello.sh"],
+)
+EOF
+
+  cat >$pkg/hello.sh <<'EOF'
+#!/bin/bash
+echo "Hello from test script!"
+echo "BUILD_WORKING_DIRECTORY: \${BUILD_WORKING_DIRECTORY:-NOT SET}"
+echo "CUSTOM_VAR: \${CUSTOM_VAR:-NOT SET}"
+EOF
+  chmod +x $pkg/hello.sh
+
+  bazel run //$pkg:hello --run_env=CUSTOM_VAR=test_value >&$TEST_log 2>&1 \
+    || fail "Expected bazel run to succeed"
+  expect_log "Running command line:"
+  if is_windows; then
+    expect_not_log "cd /d"
+  else
+    expect_not_log "exec env"
+  fi
+
+  bazel run -s //$pkg:hello --run_env=CUSTOM_VAR=test_value >&$TEST_log 2>&1 \
+    || fail "Expected bazel run -s to succeed"
+  expect_log "Running command line:"
+  if is_windows; then
+    expect_log "cd /d"
+    expect_log "SET BUILD_WORKSPACE_DIRECTORY="
+    expect_log "SET CUSTOM_VAR=test_value"
+  else
+    expect_log "exec env"
+    expect_log "BUILD_WORKING_DIRECTORY="
+    expect_log "CUSTOM_VAR=test_value"
+  fi
+}
+
 run_suite "run_under_tests"


### PR DESCRIPTION
When passing `-s` 'bazel run' now prints the variables that bazel
manipulates and the actual command it runs:

```
(cd /home/ubuntu/.cache/bazel/_bazel_ubuntu/849dbde84a22ddb2fb36884b9d5c6317/execroot/_main/bazel-out/aarch64-fastbuild/bin/main.runfiles/_main && \
  exec env - \
    -u JAVA_RUNFILES \
    -u RUNFILES_DIR \
    -u RUNFILES_MANIFEST_FILE \
    -u RUNFILES_MANIFEST_ONLY \
    -u TEST_SRCDIR \
    BUILD_EXECROOT=/home/ubuntu/.cache/bazel/_bazel_ubuntu/849dbde84a22ddb2fb36884b9d5c6317/execroot/_main \
    BUILD_ID=5b02eb3b-c5d7-4bb9-81eb-bdb8e8d2a6ff \
    BUILD_WORKING_DIRECTORY=/tmp/foobar \
    BUILD_WORKSPACE_DIRECTORY=/tmp/foobar \
  /bin/bash -c /home/ubuntu/.cache/bazel/_bazel_ubuntu/849dbde84a22ddb2fb36884b9d5c6317/execroot/_main/bazel-out/aarch64-fastbuild/bin/main)
```

Closes #27057.

PiperOrigin-RevId: 825578273
Change-Id: I9655cae9569d82fa8e4761677c02c5ed4cee68c3

Commit https://github.com/bazelbuild/bazel/commit/9789bbda782adb8b2cac51fe30a85f186efd1dd7