### PR TITLE
[9.0.0] Don't use the gRPC downloader for `file:` URLs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -851,10 +851,6 @@ public final class RemoteModule extends BlazeModule {
                 ServerCapabilitiesRequirement.NONE);
       }
 
-      Downloader fallbackDownloader = null;
-      if (remoteOptions.remoteDownloaderLocalFallback) {
-        fallbackDownloader = env.getHttpDownloader();
-      }
       remoteDownloader =
           new GrpcRemoteDownloader(
               buildRequestId,
@@ -866,7 +862,8 @@ public final class RemoteModule extends BlazeModule {
               digestUtil.getDigestFunction(),
               remoteOptions,
               verboseFailures,
-              fallbackDownloader);
+              env.getHttpDownloader(),
+              remoteOptions.remoteDownloaderLocalFallback);
       downloaderChannel.release();
       env.getDownloaderDelegate().setDelegate(remoteDownloader);
     }


### PR DESCRIPTION
Always use the HTTP downloader in this case as it supports these URLs.

Fixes #26810

Closes #27799.

PiperOrigin-RevId: 843590344
Change-Id: Ia28da102b29d828edd95ea0c1fb9f50ff70d3d85

Commit https://github.com/bazelbuild/bazel/commit/65574f3b6c8b9df93ecd9ee16c777d71bf8707ad