### PR TITLE
Add `test` and `executable` to `Rule` protobuf message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/ProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/ProtoOutputFormatter.java
@@ -48,6 +48,7 @@ import com.google.devtools.build.lib.packages.PackageGroup;
 import com.google.devtools.build.lib.packages.ProtoUtils;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.Target;
+import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.packages.Types;
 import com.google.devtools.build.lib.query2.common.CommonQueryOptions;
@@ -196,7 +197,9 @@ public class ProtoOutputFormatter extends AbstractUnorderedFormatter {
       Build.Rule.Builder rulePb =
           Build.Rule.newBuilder()
               .setName(internalToUnicode(labelPrinter.toString(rule.getLabel())))
-              .setRuleClass(internalToUnicode(rule.getRuleClass()));
+              .setRuleClass(internalToUnicode(rule.getRuleClass()))
+              .setTest(TargetUtils.isTestRule(target))
+              .setExecutable(rule.isExecutable());
       if (includeLocations) {
         rulePb.setLocation(internalToUnicode(FormatUtils.getLocation(target, relativeLocations)));
       }

--- a/src/main/protobuf/build.proto
+++ b/src/main/protobuf/build.proto
@@ -359,6 +359,12 @@ message Rule {
   //
   // Requires --proto:rule_classes=true
   optional stardoc_output.RuleInfo rule_class_info = 17;
+
+  // The rule is a test.
+  optional bool test = 18;
+
+  // The rule is marked as executable or is a test.
+  optional bool executable = 19;
 }
 
 // Direct dependencies of a rule in <depLabel, depConfiguration> form.


### PR DESCRIPTION
This makes it possible to determine if a target is a test or is executable when using `bazel query`'s `proto`, `streamed_proto` and `streamed_jsonproto` output types.

Note that the `executable` property does _not_ match the behavior of the `executables` query function which excludes tests. These outputs are relatively low-level, so copying a deliberate high-level behavior did not make sense to me.

Also note that `test` detection is based on the rule name (ending with `_test`). This behavior is consistent within Bazel and the [invariant is enforced](https://github.com/bazelbuild/bazel/blob/6f283cf8519f4a561d65edc96b0803900ebc39e9/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java#L427).

e.g. `java_test`
```
❯ bazel query //src/test/java/com/google/devtools/build/lib/actions:ActionsTests --output streamed_jsonproto
{
    "type": "RULE",
    "rule": {
        "name": "//src/test/java/com/google/devtools/build/lib/actions:ActionsTests",
        ...
        "test": true,
        "executable": true
    }
}
```

e.g. `java_toolchain_alias`
```
❯ bazel query @rules_java//toolchains:current_java_toolchain --output streamed_jsonproto
{
    "type": "RULE",
    "rule": {
        "name": "@rules_java//toolchains:current_java_toolchain",
        ...
        "test": false,
        "executable": false
    }
}
```

e.g. `cc_binary`
```
❯ bazel query //src/test/native/windows:printarg --output streamed_jsonproto
{
    "type": "RULE",
    "rule": {
        "name": "//src/test/native/windows:printarg",
        ...
        "test": false,
        "executable": true
    }
}
```

The use case for this functionality is IDE integrations like [`BazelBuild.vscode-bazel`](https://github.com/bazel-contrib/vscode-bazel) for VSCode, where currently 3 queries would be necessary to collect the same information (at the cost of performance and implementation complexity);
1. `kind(rule, //foo:all)` for all targets in package.
2. `tests(//foo:all)` for all test targets in package.
3. `executables(//foo:all)` for all executable targets in package.