### PR TITLE
Only upload shared subtrees to the remote cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
@@ -313,6 +313,8 @@ public final class MerkleTreeComputer {
             spawn,
             spawnExecutionContext,
             metadata,
+            // Inputs only have to be uploaded to and must be present in the remote cache for remote
+            // execution. For caching, inputs and Merkle trees are never uploaded anyway.
             CachePolicy.REMOTE_CACHE_ONLY,
             CachePolicy.NO_CACHE);
     Predicate<PathFragment> isToolInput;
@@ -897,10 +899,7 @@ public final class MerkleTreeComputer {
                   try {
                     if (merkleTreeUploader != null) {
                       merkleTreeUploader.ensureInputsPresent(
-                          // Inputs only have to be uploaded to and must be present in the remote
-                          // cache.
-                          remoteActionExecutionContext.withWriteCachePolicy(
-                              CachePolicy.REMOTE_CACHE_ONLY),
+                          remoteActionExecutionContext,
                           uploadable,
                           blobPolicy == BlobPolicy.KEEP_AND_REUPLOAD,
                           remotePathResolver);

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
@@ -897,7 +897,10 @@ public final class MerkleTreeComputer {
                   try {
                     if (merkleTreeUploader != null) {
                       merkleTreeUploader.ensureInputsPresent(
-                          remoteActionExecutionContext,
+                          // Inputs only have to be uploaded to and must be present in the remote
+                          // cache.
+                          remoteActionExecutionContext.withWriteCachePolicy(
+                              CachePolicy.REMOTE_CACHE_ONLY),
                           uploadable,
                           blobPolicy == BlobPolicy.KEEP_AND_REUPLOAD,
                           remotePathResolver);

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
@@ -1430,6 +1430,13 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
     buildTarget("//a:bar");
     assertOutputDoesNotExist("a/bar.out");
     getOutputBase().getRelative("action_cache").deleteTreesBelow();
+    if (useDiskCache) {
+      // Verify that no inputs have been uploaded to the disk cache yet.
+      assertThat(
+              getWorkspace().getRelative("disk_cache_dir").getDirectoryEntries().stream()
+                  .map(Path::getBaseName))
+          .containsExactly("ac", "tmp");
+    }
 
     // Evict blobs from remote cache
     evictAllBlobs();


### PR DESCRIPTION
Uploading inputs to the disk cache is wasteful and can also incorrectly report blobs as being present in the remote cache on `FindMissing` calls.

Speculatively fixes #27929