### PR TITLE
[9.0.0] Avoid undefined behavior in JStringLatin1Holder and its callers.

### DIFF
--- a/src/main/native/latin1_jni_path.h
+++ b/src/main/native/latin1_jni_path.h
@@ -29,7 +29,9 @@ jstring NewStringLatin1(JNIEnv* env, const char* str);
 // Any non-Latin1 characters are replaced with '?'.
 class JStringLatin1Holder {
  public:
-  // Constructs a JStringLatin1Holder.
+  // Constructs a JStringLatin1Holder for a Java String.
+  // If the Java String is null, a NullPointerException is thrown.
+  // Other errors might be thrown, e.g. OutOfMemoryError.
   // Callers must check env->ExceptionOccurred() before using this object.
   JStringLatin1Holder(JNIEnv* env, jstring string);
 


### PR DESCRIPTION
* If the String argument or its value field is null, throw a NullPointerException.
* If any of the class/field/method lookups fail, assert an error.

This way, failure to initialize a JStringLatin1Holder can always be detected by checking env->ExceptionOccurred(), which all callers already do.

PiperOrigin-RevId: 843645807
Change-Id: I907c2f7b27f3fa3be95a00270e40309f001e9178