### PR TITLE
Fix crash when mixing `use_repo_rule` and `--inject_repository`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -658,8 +658,7 @@ public class ModuleFileFunction implements SkyFunction {
     }
     // Use the innate extension backing use_repo_rule.
     ModuleExtensionUsageBuilder usageBuilder =
-        new ModuleExtensionUsageBuilder(
-            context,
+        context.getOrCreateExtensionUsageBuilder(
             "//:MODULE.bazel",
             "@bazel_tools//tools/build_defs/repo:local.bzl local_repository",
             /* isolate= */ false);
@@ -686,7 +685,6 @@ public class ModuleFileFunction implements SkyFunction {
           "by --inject_repository",
           thread.getCallStack());
     }
-    context.getExtensionUsageBuilders().add(usageBuilder);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -468,27 +468,17 @@ public class ModuleFileGlobals {
             .setContainingModuleFilePath(context.getCurrentModuleFilePath());
 
     String extensionBzlFile = normalizeLabelString(context.getModuleBuilder(), rawExtensionBzlFile);
-    var newUsageBuilder =
-        new ModuleExtensionUsageBuilder(context, extensionBzlFile, extensionName, isolate);
 
     if (context.shouldIgnoreDevDeps() && devDependency) {
       // This is a no-op proxy.
-      return new ModuleExtensionProxy(newUsageBuilder, proxyBuilder);
+      return new ModuleExtensionProxy(
+          new ModuleExtensionUsageBuilder(context, extensionBzlFile, extensionName, isolate),
+          proxyBuilder);
     }
 
-    // Find an existing usage builder corresponding to this extension. Isolated usages need to get
-    // their own proxy.
-    if (!isolate) {
-      for (ModuleExtensionUsageBuilder usageBuilder : context.getExtensionUsageBuilders()) {
-        if (usageBuilder.isForExtension(extensionBzlFile, extensionName)) {
-          return new ModuleExtensionProxy(usageBuilder, proxyBuilder);
-        }
-      }
-    }
-
-    // If no such proxy exists, we can just use a new one.
-    context.getExtensionUsageBuilders().add(newUsageBuilder);
-    return new ModuleExtensionProxy(newUsageBuilder, proxyBuilder);
+    return new ModuleExtensionProxy(
+        context.getOrCreateExtensionUsageBuilder(extensionBzlFile, extensionName, isolate),
+        proxyBuilder);
   }
 
   private String normalizeLabelString(InterimModule.Builder module, String rawExtensionBzlFile)
@@ -826,16 +816,9 @@ public class ModuleFileGlobals {
     String extensionName = bzlFile + ' ' + ruleName;
     // Find or create the builder for the singular "innate" extension of this repo rule for this
     // module.
-    for (ModuleExtensionUsageBuilder usageBuilder : context.getExtensionUsageBuilders()) {
-      if (usageBuilder.isForExtension("//:MODULE.bazel", extensionName)) {
-        return new RepoRuleProxy(usageBuilder);
-      }
-    }
-    ModuleExtensionUsageBuilder newUsageBuilder =
-        new ModuleExtensionUsageBuilder(
-            context, "//:MODULE.bazel", extensionName, /* isolate= */ false);
-    context.getExtensionUsageBuilders().add(newUsageBuilder);
-    return new RepoRuleProxy(newUsageBuilder);
+    return new RepoRuleProxy(
+        context.getOrCreateExtensionUsageBuilder(
+            "//:MODULE.bazel", extensionName, /* isolate= */ false));
   }
 
   @StarlarkBuiltin(name = "repo_rule_proxy", documented = false)

--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -816,6 +816,22 @@ class BazelOverridesTest(test_base.TestBase):
         '\n'.join(stdout),
     )
 
+  def testInjectRepositoryAndLocalRepository(self):
+    # Regression test for https://github.com/bazelbuild/bazel/issues/27953
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
+            'local_repository(name = "local_repo", path = "local_repo")'
+        ],
+    )
+    self.ScratchFile("local_repo/REPO.bazel")
+    self.ScratchFile("injected_repo/REPO.bazel")
+
+    self.RunBazel([
+      'mod', 'deps', '--inject_repository=injected_repo=%workspace%/injected_repo'
+    ])
+
   def testOverrideRepositoryOnNonExistentRepo(self):
     self.ScratchFile('other_repo/REPO.bazel')
     self.ScratchFile('other_repo/BUILD', ['filegroup(name="target")'])


### PR DESCRIPTION
Bazel crashes at HEAD when `use_repo_rule` is used with `local_repository` while also using `--inject_repository`.

Make bugs like this less likely by extracting out a safe "get or create" helper for extension usages.

Fixes #27953