### PR TITLE
Cleaning up `SpawnStrategyRegistry`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/SpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SpawnStrategy.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableList;
 // TODO(blaze-team): If possible, merge this with AbstractSpawnStrategy and SpawnRunner. The former
 //  because (almost?) all implementations of this interface extend it; the latter because it forms
 //  a shadow hierarchy graph that looks like that of the corresponding strategies.
-public interface SpawnStrategy {
+public interface SpawnStrategy extends Comparable<SpawnStrategy> {
 
   /**
    * Executes the given spawn and returns metadata about the execution. Implementations must
@@ -49,4 +49,15 @@ public interface SpawnStrategy {
   // TODO(katre): Remove once strategies are only instantiated if used, the callback can then be
   //  done upon construction.
   default void usedContext(ActionContext.ActionContextRegistry actionContextRegistry) {}
+
+  @Override
+  default int compareTo(SpawnStrategy other) {
+    if (this == other) {
+      return 0;
+    }
+
+    // Most implementations override toString to provide their name (e.g. `standalone`).
+    // To maintain `a.compareTo(b) == 0` and `a.equals(b)` consistency, `hashCode` is appended.
+    return (this.toString() + this.hashCode()).compareTo(other.toString() + other.hashCode());
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/actions/SpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SpawnStrategy.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableList;
 // TODO(blaze-team): If possible, merge this with AbstractSpawnStrategy and SpawnRunner. The former
 //  because (almost?) all implementations of this interface extend it; the latter because it forms
 //  a shadow hierarchy graph that looks like that of the corresponding strategies.
-public interface SpawnStrategy extends Comparable<SpawnStrategy> {
+public interface SpawnStrategy {
 
   /**
    * Executes the given spawn and returns metadata about the execution. Implementations must
@@ -49,15 +49,4 @@ public interface SpawnStrategy extends Comparable<SpawnStrategy> {
   // TODO(katre): Remove once strategies are only instantiated if used, the callback can then be
   //  done upon construction.
   default void usedContext(ActionContext.ActionContextRegistry actionContextRegistry) {}
-
-  @Override
-  default int compareTo(SpawnStrategy other) {
-    if (this == other) {
-      return 0;
-    }
-
-    // Most implementations override toString to provide their name (e.g. `standalone`).
-    // To maintain `a.compareTo(b) == 0` and `a.equals(b)` consistency, `hashCode` is appended.
-    return (this.toString() + this.hashCode()).compareTo(other.toString() + other.hashCode());
-  }
 }

--- a/src/main/java/com/google/devtools/build/lib/collect/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/collect/BUILD
@@ -70,6 +70,14 @@ java_library(
 )
 
 java_library(
+    name = "recency_map",
+    srcs = ["RecencyMap.java"],
+    deps = [
+        "//third_party:jsr305",
+    ],
+)
+
+java_library(
     name = "iterable_codecs",
     srcs = ["IterableCodecs.java"],
     deps = [

--- a/src/main/java/com/google/devtools/build/lib/collect/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/collect/BUILD
@@ -73,6 +73,7 @@ java_library(
     name = "recency_map",
     srcs = ["RecencyMap.java"],
     deps = [
+        "//third_party:guava",
         "//third_party:jsr305",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/collect/RecencyMap.java
+++ b/src/main/java/com/google/devtools/build/lib/collect/RecencyMap.java
@@ -1,0 +1,91 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.collect;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A map that orders entries by recency of insertion or update.
+ */
+public class RecencyMap<K, V> implements Map<K, V> {
+  private final Map<K, V> backingMap = new LinkedHashMap<>();
+  
+  @Override
+  public int size() {
+    return backingMap.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return backingMap.isEmpty();
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return backingMap.containsKey(key);
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return backingMap.containsValue(value);
+  }
+
+  @Override
+  public V get(Object key) {
+    return backingMap.get(key);
+  }
+
+  @Override
+  public V put(K k, V v) {
+    if (backingMap.containsKey(k)) {
+      backingMap.remove(k);
+    }
+    return backingMap.put(k, v);
+  }
+
+  @Override
+  public V remove(Object key) {
+    return backingMap.remove(key);
+  }
+
+  @Override
+  public void putAll(Map<? extends K, ? extends V> m) {
+    for (Map.Entry<? extends K, ? extends V> entry : m.entrySet()) {
+      put(entry.getKey(), entry.getValue());
+    }
+  }
+
+  @Override
+  public void clear() {
+    backingMap.clear();
+  }
+
+  @Override
+  public Set<K> keySet() {
+    return backingMap.keySet();
+  }
+
+  @Override
+  public Collection<V> values() {
+    return backingMap.values();
+  }
+
+  @Override
+  public Set<Entry<K, V>> entrySet() {
+    return backingMap.entrySet();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/collect/RecencyMap.java
+++ b/src/main/java/com/google/devtools/build/lib/collect/RecencyMap.java
@@ -13,79 +13,43 @@
 // limitations under the License.
 package com.google.devtools.build.lib.collect;
 
-import java.util.Collection;
+import com.google.common.collect.ForwardingMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
- * A map that orders entries by recency of insertion or update.
+ * A {@link Map} whose iteration order is the order in which entries were last inserted or updated.
+ *
+ * <p>This differs from {@link LinkedHashMap}, which keeps a re-inserted key at the position of its
+ * original insertion. Use this when the last occurrence of a key (e.g. on the command line) should
+ * also determine where that key is ordered relative to other keys.
+ *
+ * <p>The views returned by {@link #keySet}, {@link #values} and {@link #entrySet} are live views of
+ * the underlying map. Updating a value through {@link Map.Entry#setValue} does not refresh the
+ * entry's position.
  */
-public class RecencyMap<K, V> implements Map<K, V> {
-  private final Map<K, V> backingMap = new LinkedHashMap<>();
-  
+public final class RecencyMap<K, V> extends ForwardingMap<K, V> {
+  private final Map<K, V> delegate = new LinkedHashMap<>();
+
   @Override
-  public int size() {
-    return backingMap.size();
+  protected Map<K, V> delegate() {
+    return delegate;
   }
 
   @Override
-  public boolean isEmpty() {
-    return backingMap.isEmpty();
-  }
-
-  @Override
-  public boolean containsKey(Object key) {
-    return backingMap.containsKey(key);
-  }
-
-  @Override
-  public boolean containsValue(Object value) {
-    return backingMap.containsValue(value);
-  }
-
-  @Override
-  public V get(Object key) {
-    return backingMap.get(key);
-  }
-
-  @Override
-  public V put(K k, V v) {
-    if (backingMap.containsKey(k)) {
-      backingMap.remove(k);
+  @Nullable
+  public V put(K key, V value) {
+    if (delegate.containsKey(key)) {
+      V previous = delegate.remove(key);
+      delegate.put(key, value);
+      return previous;
     }
-    return backingMap.put(k, v);
+    return delegate.put(key, value);
   }
 
   @Override
-  public V remove(Object key) {
-    return backingMap.remove(key);
-  }
-
-  @Override
-  public void putAll(Map<? extends K, ? extends V> m) {
-    for (Map.Entry<? extends K, ? extends V> entry : m.entrySet()) {
-      put(entry.getKey(), entry.getValue());
-    }
-  }
-
-  @Override
-  public void clear() {
-    backingMap.clear();
-  }
-
-  @Override
-  public Set<K> keySet() {
-    return backingMap.keySet();
-  }
-
-  @Override
-  public Collection<V> values() {
-    return backingMap.values();
-  }
-
-  @Override
-  public Set<Entry<K, V>> entrySet() {
-    return backingMap.entrySet();
+  public void putAll(Map<? extends K, ? extends V> map) {
+    standardPutAll(map);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/dynamic/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/dynamic/BUILD
@@ -19,6 +19,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:localhost_capacity",
         "//src/main/java/com/google/devtools/build/lib/buildtool:build_request_options",
+        "//src/main/java/com/google/devtools/build/lib/collect:recency_map",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
         "//src/main/java/com/google/devtools/build/lib/events",

--- a/src/main/java/com/google/devtools/build/lib/dynamic/DynamicExecutionModule.java
+++ b/src/main/java/com/google/devtools/build/lib/dynamic/DynamicExecutionModule.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnStrategy;
 import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.buildtool.BuildRequestOptions;
+import com.google.devtools.build.lib.collect.RecencyMap;
 import com.google.devtools.build.lib.concurrent.ExecutorUtil;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.Reporter;
@@ -42,7 +43,6 @@ import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.common.options.OptionsBase;
 import com.google.errorprone.annotations.ForOverride;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -117,6 +117,9 @@ public class DynamicExecutionModule extends BlazeModule {
     }
     localAndWorkerStrategies.put("", defaultLocalStrategies.build());
 
+    // this is not inserting in expected order
+    // also apparently no builtin java class uses the last insertion (which to be fair, is terrible
+    // for performance)
     for (Map.Entry<String, List<String>> entry : options.getDynamicLocalStrategy()) {
       localAndWorkerStrategies.put(entry);
       throwIfContainsDynamic(entry.getValue(), "--dynamic_local_strategy");
@@ -126,7 +129,7 @@ public class DynamicExecutionModule extends BlazeModule {
 
   private ImmutableMap<String, List<String>> getRemoteStrategies(DynamicExecutionOptions options)
       throws AbruptExitException {
-    Map<String, List<String>> strategies = new HashMap<>(); // Needed to dedup
+    RecencyMap<String, List<String>> strategies = new RecencyMap<>(); // Needed to dedup
     for (Map.Entry<String, List<String>> e : options.getDynamicRemoteStrategy()) {
       throwIfContainsDynamic(e.getValue(), "--dynamic_remote_strategy");
       strategies.put(e.getKey(), e.getValue());

--- a/src/main/java/com/google/devtools/build/lib/dynamic/DynamicExecutionModule.java
+++ b/src/main/java/com/google/devtools/build/lib/dynamic/DynamicExecutionModule.java
@@ -105,7 +105,7 @@ public class DynamicExecutionModule extends BlazeModule {
       DynamicExecutionOptions options, boolean sandboxingSupported) throws AbruptExitException {
     // Options that set "allowMultiple" to true ignore the default value, so we replicate that
     // functionality here.
-    ImmutableMap.Builder<String, List<String>> localAndWorkerStrategies = ImmutableMap.builder();
+    RecencyMap<String, List<String>> localAndWorkerStrategies = new RecencyMap<>();
     ImmutableList.Builder<String> defaultLocalStrategies = ImmutableList.builder();
     defaultLocalStrategies.add("worker");
     if (sandboxingSupported) {
@@ -117,14 +117,11 @@ public class DynamicExecutionModule extends BlazeModule {
     }
     localAndWorkerStrategies.put("", defaultLocalStrategies.build());
 
-    // this is not inserting in expected order
-    // also apparently no builtin java class uses the last insertion (which to be fair, is terrible
-    // for performance)
     for (Map.Entry<String, List<String>> entry : options.getDynamicLocalStrategy()) {
-      localAndWorkerStrategies.put(entry);
+      localAndWorkerStrategies.put(entry.getKey(), entry.getValue());
       throwIfContainsDynamic(entry.getValue(), "--dynamic_local_strategy");
     }
-    return localAndWorkerStrategies.buildKeepingLast();
+    return ImmutableMap.copyOf(localAndWorkerStrategies);
   }
 
   private ImmutableMap<String, List<String>> getRemoteStrategies(DynamicExecutionOptions options)

--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -363,6 +363,7 @@ java_library(
         ":spawn_strategy_policy",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/collect:recency_map",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -111,16 +111,32 @@ public abstract class ExecutionOptions extends OptionsBase {
       effectTags = {OptionEffectTag.EXECUTION},
       defaultValue = "null",
       help =
-          "Override which spawn strategy should be used to execute spawn actions that have "
-              + "descriptions matching a certain regex_filter. See --per_file_copt for details on "
-              + "regex_filter matching. "
-              + "The last regex_filter that matches the description is used. "
-              + "This option overrides other flags for specifying strategy. "
-              + "Example: --strategy_regexp=//foo.*\\.cc,-//foo/bar=local means to run actions "
-              + "using local strategy if their descriptions match //foo.*.cc but not //foo/bar. "
-              + "Example: --strategy_regexp='Compiling.*/bar=local "
-              + " --strategy_regexp=Compiling=sandboxed will run 'Compiling //foo/bar/baz' with "
-              + "the 'local' strategy, but reversing the order would run it with 'sandboxed'. ")
+          """
+          Override which spawn strategy should be used to execute spawn actions that have
+          descriptions matching a certain `regex_filter`.
+          The last `regex_filter` that matches the description is used.
+
+          Note that `--spawn_strategy` (defaults) and `--strategy` (mnemonic-targeted overrides)
+          still apply. If a strategy is listed that contradicts those flags, it will be ignored.
+
+          See `--per_file_copt` for details on `regex_filter` matching.
+
+          Example:
+          ```
+          common --strategy_regexp=//foo.*\\.cc,-//foo/bar=local
+          ```
+          With the above option, actions with descriptions matching `//foo.*\\.cc` but not
+          `//foo/bar` will have their strategies filtered to only `local`.
+
+          Example:
+          ```
+          common --strategy_regexp='Compiling.*/bar=local
+          common --strategy_regexp=Compiling=sandboxed
+          ```
+          With the above options, an action with description `Compiling //foo/bar/baz` will have
+          its strategies filtered to only `local`, while an action with description
+          `Compiling //foo/baz` will have its strategies filtered to only `sandboxed`.
+          """)
   public abstract List<Map.Entry<RegexFilter, List<String>>> getStrategyByRegexp();
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -112,12 +112,13 @@ public abstract class ExecutionOptions extends OptionsBase {
       defaultValue = "null",
       help =
           """
-          Override which spawn strategy should be used to execute spawn actions that have
-          descriptions matching a certain `regex_filter`.
+          Override which spawn strategy should be used to execute spawn actions
+          whose descriptions match a certain `regex_filter`.
           The last `regex_filter` that matches the description is used.
 
-          Note that `--spawn_strategy` (defaults) and `--strategy` (mnemonic-targeted overrides)
-          still apply. If a strategy is listed that contradicts those flags, it will be ignored.
+          Note that `--spawn_strategy` (defaults) and `--strategy` (mnemonic
+          overrides) still apply. If a strategy is listed that contradicts
+          those flags, it will be ignored.
 
           See `--per_file_copt` for details on `regex_filter` matching.
 
@@ -125,17 +126,19 @@ public abstract class ExecutionOptions extends OptionsBase {
           ```
           common --strategy_regexp=//foo.*\\.cc,-//foo/bar=local
           ```
-          With the above option, actions with descriptions matching `//foo.*\\.cc` but not
-          `//foo/bar` will have their strategies filtered to only `local`.
+          With the above option, actions with descriptions matching
+          `//foo.*\\.cc` but not `//foo/bar` will have their strategies
+          filtered to only `local`.
 
           Example:
           ```
-          common --strategy_regexp='Compiling.*/bar=local
+          common --strategy_regexp='Compiling.*/bar=local'
           common --strategy_regexp=Compiling=sandboxed
           ```
-          With the above options, an action with description `Compiling //foo/bar/baz` will have
-          its strategies filtered to only `local`, while an action with description
-          `Compiling //foo/baz` will have its strategies filtered to only `sandboxed`.
+          With the above options, an action with description
+          `Compiling //foo/bar/baz` matches both filters, so the last one
+          specified wins and its strategies are filtered to only `sandboxed`.
+          Reversing the order of the two options filters them to only `local`.
           """)
   public abstract List<Map.Entry<RegexFilter, List<String>>> getStrategyByRegexp();
 

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistry.java
@@ -19,15 +19,12 @@ import static java.util.stream.Collectors.joining;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Multimaps;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.actions.ActionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
@@ -53,7 +50,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 import javax.annotation.Nullable;
 
 /**
@@ -74,8 +70,10 @@ public final class SpawnStrategyRegistry
   private final StrategyRegexFilter strategyRegexFilter;
   private final StrategyPlatformFilter strategyPlatformFilter;
   private final ImmutableList<? extends SpawnStrategy> defaultStrategies;
-  private final ImmutableMultimap<String, SandboxedSpawnStrategy> mnemonicToRemoteDynamicStrategies;
-  private final ImmutableMultimap<String, SandboxedSpawnStrategy> mnemonicToLocalDynamicStrategies;
+  private final ImmutableListMultimap<String, SandboxedSpawnStrategy>
+      mnemonicToRemoteDynamicStrategies;
+  private final ImmutableListMultimap<String, SandboxedSpawnStrategy>
+      mnemonicToLocalDynamicStrategies;
   @Nullable private final AbstractSpawnStrategy remoteLocalFallbackStrategy;
 
   private SpawnStrategyRegistry(
@@ -83,8 +81,8 @@ public final class SpawnStrategyRegistry
       StrategyRegexFilter strategyRegexFilter,
       StrategyPlatformFilter strategyPlatformFilter,
       ImmutableList<? extends SpawnStrategy> defaultStrategies,
-      ImmutableMultimap<String, SandboxedSpawnStrategy> mnemonicToRemoteDynamicStrategies,
-      ImmutableMultimap<String, SandboxedSpawnStrategy> mnemonicToLocalDynamicStrategies,
+      ImmutableListMultimap<String, SandboxedSpawnStrategy> mnemonicToRemoteDynamicStrategies,
+      ImmutableListMultimap<String, SandboxedSpawnStrategy> mnemonicToLocalDynamicStrategies,
       @Nullable AbstractSpawnStrategy remoteLocalFallbackStrategy) {
     this.mnemonicToStrategies = mnemonicToStrategies;
     this.strategyRegexFilter = strategyRegexFilter;
@@ -111,7 +109,8 @@ public final class SpawnStrategyRegistry
    * <p>If the reason for selecting the context is worth mentioning to the user, logs a message
    * using the given {@link Reporter}.
    */
-  public List<? extends SpawnStrategy> getStrategies(Spawn spawn, @Nullable EventHandler reporter) {
+  public ImmutableList<? extends SpawnStrategy> getStrategies(
+      Spawn spawn, @Nullable EventHandler reporter) {
     return strategyPlatformFilter.getStrategies(
         spawn, getStrategies(spawn.getResourceOwner(), spawn.getMnemonic(), reporter));
   }
@@ -127,7 +126,7 @@ public final class SpawnStrategyRegistry
    *
    * <p>NOTE: This method is public for Blaze, Bazel must use `getStrategies(Spawn, EventHandler)`.
    */
-  public List<? extends SpawnStrategy> getStrategies(
+  public ImmutableList<? extends SpawnStrategy> getStrategies(
       ActionExecutionMetadata resourceOwner, String mnemonic, @Nullable EventHandler reporter) {
     if (resourceOwner.allowsStrategyRegexpMatching()) {
       String description = resourceOwner.getProgressMessage();
@@ -156,9 +155,9 @@ public final class SpawnStrategyRegistry
   }
 
   @Override
-  public ImmutableCollection<SandboxedSpawnStrategy> getDynamicSpawnActionContexts(
+  public ImmutableList<SandboxedSpawnStrategy> getDynamicSpawnActionContexts(
       Spawn spawn, DynamicMode dynamicMode) {
-    ImmutableMultimap<String, SandboxedSpawnStrategy> mnemonicToDynamicStrategies =
+    ImmutableListMultimap<String, SandboxedSpawnStrategy> mnemonicToDynamicStrategies =
         dynamicMode == DynamicStrategyRegistry.DynamicMode.REMOTE
             ? mnemonicToRemoteDynamicStrategies
             : mnemonicToLocalDynamicStrategies;
@@ -175,9 +174,12 @@ public final class SpawnStrategyRegistry
   @Nullable
   @Override
   public AbstractSpawnStrategy getRemoteLocalFallbackStrategy(Spawn spawn) {
+    if (remoteLocalFallbackStrategy == null) {
+      return null;
+    }
     var strategies =
         strategyPlatformFilter.getStrategies(
-            spawn, Lists.newArrayList(remoteLocalFallbackStrategy));
+            spawn, ImmutableList.of(remoteLocalFallbackStrategy));
     if (strategies.isEmpty()) {
       return null;
     }
@@ -211,7 +213,7 @@ public final class SpawnStrategyRegistry
     for (Map.Entry<String, Collection<SpawnStrategy>> entry :
         mnemonicToStrategies.asMap().entrySet()) {
       logger.atInfo().log(
-          "MnemonicToStrategyImplementations: \"%s\" = [%s]",
+        "MnemonicToStrategyImplementations: \"%s\" = [%s]",
           entry.getKey(), toImplementationNames(entry.getValue()));
     }
 
@@ -254,7 +256,7 @@ public final class SpawnStrategyRegistry
     }
   }
 
-  private static String toImplementationNames(Collection<?> strategies) {
+  private static String toImplementationNames(Collection<? extends SpawnStrategy> strategies) {
     return strategies.stream()
         .map(strategy -> strategy.getClass().getSimpleName())
         .collect(joining(", "));
@@ -462,20 +464,22 @@ public final class SpawnStrategyRegistry
     public SpawnStrategyRegistry build() throws AbruptExitException {
       List<FilterAndIdentifiers> orderedFilterAndIdentifiers = Lists.reverse(filterAndIdentifiers);
 
-      ListMultimap<RegexFilter, String> filterToIdentifiers = LinkedListMultimap.create();
+      ListMultimap<RegexFilter, String> filterToStrategyIdentifiers = LinkedListMultimap.create();
       ListMultimap<RegexFilter, SpawnStrategy> filterToStrategies = LinkedListMultimap.create();
       for (FilterAndIdentifiers filterAndIdentifier : orderedFilterAndIdentifiers) {
         RegexFilter filter = filterAndIdentifier.filter();
-        if (!filterToIdentifiers.containsKey(filter)) {
-          filterToIdentifiers.putAll(filter, filterAndIdentifier.identifiers());
+        if (!filterToStrategyIdentifiers.containsKey(filter)) {
+          filterToStrategyIdentifiers.putAll(filter, filterAndIdentifier.identifiers());
           filterToStrategies.putAll(
               filter,
               strategyMapper.toStrategies(filterAndIdentifier.identifiers(), "filter " + filter));
         }
       }
 
-      ImmutableSetMultimap.Builder<Label, SpawnStrategy> platformToStrategies =
-          ImmutableSetMultimap.builder();
+      var platformToStrategies =
+          new ImmutableSetMultimap.Builder<Label, SpawnStrategy>()
+          .orderKeysBy(Label::compareTo)
+          .orderValuesBy(SpawnStrategy::compareTo);
       for (Map.Entry<Label, List<String>> entry : execPlatformFilters.entrySet()) {
         Label platform = entry.getKey();
         platformToStrategies.putAll(
@@ -484,8 +488,9 @@ public final class SpawnStrategyRegistry
                 entry.getValue(), "platform " + platform.getCanonicalForm()));
       }
 
-      ImmutableListMultimap.Builder<String, SpawnStrategy> mnemonicToStrategies =
-          new ImmutableListMultimap.Builder<>();
+      var mnemonicToStrategies =
+          new ImmutableListMultimap.Builder<String, SpawnStrategy>()
+          .orderKeysBy(String::compareTo);
       for (Map.Entry<String, List<String>> entry : mnemonicToIdentifiers.entrySet()) {
         String mnemonic = entry.getKey();
         ImmutableList<String> sanitizedStrategies =
@@ -494,8 +499,9 @@ public final class SpawnStrategyRegistry
             mnemonic, strategyMapper.toStrategies(sanitizedStrategies, "mnemonic " + mnemonic));
       }
 
-      ImmutableListMultimap.Builder<String, SandboxedSpawnStrategy> mnemonicToLocalStrategies =
-          new ImmutableListMultimap.Builder<>();
+      var mnemonicToLocalStrategies =
+          new ImmutableListMultimap.Builder<String, SandboxedSpawnStrategy>()
+          .orderKeysBy(String::compareTo);
       for (Map.Entry<String, List<String>> entry : mnemonicToLocalDynamicIdentifiers.entrySet()) {
         String mnemonic = entry.getKey();
         ImmutableList<String> sanitizedStrategies =
@@ -506,8 +512,9 @@ public final class SpawnStrategyRegistry
                 sanitizedStrategies, "local mnemonic " + mnemonic));
       }
 
-      ImmutableListMultimap.Builder<String, SandboxedSpawnStrategy> mnemonicToRemoteStrategies =
-          new ImmutableListMultimap.Builder<>();
+      var mnemonicToRemoteStrategies =
+          new ImmutableListMultimap.Builder<String, SandboxedSpawnStrategy>()
+          .orderKeysBy(String::compareTo);
       for (Map.Entry<String, List<String>> entry : mnemonicToRemoteDynamicIdentifiers.entrySet()) {
         String mnemonic = entry.getKey();
         ImmutableList<String> sanitizedStrategies =
@@ -553,7 +560,10 @@ public final class SpawnStrategyRegistry
       return new SpawnStrategyRegistry(
           mnemonicToStrategies.build(),
           new StrategyRegexFilter(
-              strategyMapper, strategyPolicy, filterToIdentifiers, filterToStrategies),
+              strategyMapper,
+              strategyPolicy,
+              ImmutableListMultimap.copyOf(filterToStrategyIdentifiers),
+              ImmutableListMultimap.copyOf(filterToStrategies)),
           new StrategyPlatformFilter(platformToStrategies.build()),
           defaultStrategies,
           mnemonicToRemoteStrategies.build(),
@@ -562,47 +572,47 @@ public final class SpawnStrategyRegistry
     }
 
     @VisibleForTesting
-    public SpawnStrategy toStrategy(String identifier, Object requestName)
+    public SpawnStrategy toStrategy(String identifier, String requestName)
         throws AbruptExitException {
       return strategyMapper.toStrategy(identifier, requestName);
     }
   }
 
-  /** Filter that applies strategy_regexp while respecting the command's strategy-policy. */
+  /** Override that applies `--strategy_regexp` while respecting the command's strategy-policy. */
   private static class StrategyRegexFilter {
     private final SpawnStrategyPolicy strategyPolicy;
-    private final ListMultimap<RegexFilter, String> filterToIdentifiers;
-    private final ListMultimap<RegexFilter, SpawnStrategy> filterToStrategies;
+    private final ImmutableListMultimap<RegexFilter, String> filterToStrategyIdentifiers;
+    private final ImmutableListMultimap<RegexFilter, SpawnStrategy> filterToStrategies;
     private final StrategyMapper strategyMapper;
 
     public StrategyRegexFilter(
         StrategyMapper strategyMapper,
         SpawnStrategyPolicy strategyPolicy,
-        ListMultimap<RegexFilter, String> filterToIdentifiers,
-        ListMultimap<RegexFilter, SpawnStrategy> filterToStrategies) {
+        ImmutableListMultimap<RegexFilter, String> filterToStrategyIdentifiers,
+        ImmutableListMultimap<RegexFilter, SpawnStrategy> filterToStrategies) {
       this.strategyPolicy = strategyPolicy;
-      this.filterToIdentifiers = filterToIdentifiers;
+      this.filterToStrategyIdentifiers = filterToStrategyIdentifiers;
       this.filterToStrategies = filterToStrategies;
       this.strategyMapper = strategyMapper;
     }
 
     public ImmutableList<? extends SpawnStrategy> getStrategies(
         String mnemonic, String description, @Nullable EventHandler reporter) {
-      for (Map.Entry<RegexFilter, List<String>> filterToIdentifiers :
-          Multimaps.asMap(filterToIdentifiers).entrySet()) {
-        if (filterToIdentifiers.getKey().isIncluded(description)) {
+      for (RegexFilter filter : filterToStrategyIdentifiers.keySet()) {
+        if (filter.isIncluded(description)) {
+          ImmutableList<String> strategyIdentifiers = filterToStrategyIdentifiers.get(filter);
           if (reporter != null) {
             // TODO(schmitt): Why is this done here and not after running canExec?
             reporter.handle(
-                Event.progress(description + " with context " + filterToIdentifiers.getValue()));
+                Event.progress(description + " with context " + strategyIdentifiers));
           }
           // Apply the policy to the identifiers.
           ImmutableList<String> sanitizedStrategies =
-              strategyPolicy.apply(mnemonic, filterToIdentifiers.getValue());
+              strategyPolicy.apply(mnemonic, strategyIdentifiers);
           try {
             ImmutableList<? extends SpawnStrategy> strategies =
                 strategyMapper.toStrategies(
-                    sanitizedStrategies, "filter " + filterToIdentifiers.getKey());
+                    sanitizedStrategies, "filter " + filter);
             if (strategies.isEmpty()) {
               // If after sanitizing we get the empty list of strategies, we should return null
               // to indicate that default strategies should be used.
@@ -616,7 +626,7 @@ public final class SpawnStrategyRegistry
                 String.format(
                     "Failed to apply policy for to strategies that were already applied for"
                         + " mnemonic %s and filter %s",
-                    mnemonic, filterToIdentifiers.getKey()),
+                    mnemonic, filter),
                 e);
           }
         }
@@ -626,7 +636,7 @@ public final class SpawnStrategyRegistry
       return ImmutableList.of();
     }
 
-    ListMultimap<RegexFilter, SpawnStrategy> getFilterToStrategies() {
+    ImmutableListMultimap<RegexFilter, SpawnStrategy> getFilterToStrategies() {
       return filterToStrategies;
     }
 
@@ -636,6 +646,7 @@ public final class SpawnStrategyRegistry
     }
   }
 
+  /** Applies filter `--allowed_strategies_by_exec_platform` with respect to provided candidates. */
   private static class StrategyPlatformFilter {
     private final ImmutableSetMultimap<Label, SpawnStrategy> platformToStrategies;
 
@@ -657,29 +668,24 @@ public final class SpawnStrategyRegistry
      *     platform or all if no restrictions are in place. Order from {@code candidateStrategies}
      *     is preserved.
      */
-    <T extends SpawnStrategy> List<T> getStrategies(Spawn spawn, List<T> candidateStrategies) {
+    <T extends SpawnStrategy> ImmutableList<T> getStrategies(
+        Spawn spawn, ImmutableList<T> candidateStrategies) {
       var platformLabel = spawn.getExecutionPlatformLabel();
       Preconditions.checkNotNull(
           platformLabel, "Attempting to spawn action without an execution platform.");
 
       if (platformToStrategies.containsKey(platformLabel)) {
         var allowedStrategies = platformToStrategies.get(platformLabel);
-        List<T> filteredStrategies = new ArrayList<>();
+        var filteredStrategies = ImmutableList.<T>builder();
         for (var strategy : candidateStrategies) {
           if (allowedStrategies.contains(strategy)) {
             filteredStrategies.add(strategy);
           }
         }
-        return filteredStrategies;
+        return filteredStrategies.build();
       }
 
       return candidateStrategies;
-    }
-
-    <T extends SpawnStrategy> ImmutableCollection<T> getStrategies(
-        Spawn spawn, ImmutableCollection<T> candidateStrategies) {
-      return ImmutableList.copyOf(
-          getStrategies(spawn, new CopyOnWriteArrayList<>(candidateStrategies)));
     }
 
     ImmutableSetMultimap<Label, SpawnStrategy> getFilterToStrategies() {
@@ -703,7 +709,7 @@ public final class SpawnStrategyRegistry
       identifierToStrategy.put(identifier, strategy);
     }
 
-    ImmutableList<SpawnStrategy> toStrategies(List<String> identifiers, Object requestName)
+    ImmutableList<SpawnStrategy> toStrategies(List<String> identifiers, String requestName)
         throws AbruptExitException {
       ImmutableList.Builder<SpawnStrategy> strategies = ImmutableList.builder();
       for (String identifier : identifiers) {
@@ -715,7 +721,7 @@ public final class SpawnStrategyRegistry
       return strategies.build();
     }
 
-    SpawnStrategy toStrategy(String identifier, Object requestName) throws AbruptExitException {
+    SpawnStrategy toStrategy(String identifier, String requestName) throws AbruptExitException {
       SpawnStrategy strategy = identifierToStrategy.get(identifier);
       if (strategy == null) {
         throw createExitException(
@@ -729,7 +735,7 @@ public final class SpawnStrategyRegistry
     }
 
     Iterable<? extends SandboxedSpawnStrategy> toSandboxedStrategies(
-        List<String> identifiers, Object requestName) throws AbruptExitException {
+        List<String> identifiers, String requestName) throws AbruptExitException {
       Iterable<? extends SpawnStrategy> strategies = toStrategies(identifiers, requestName);
       for (SpawnStrategy strategy : strategies) {
         if (!(strategy instanceof SandboxedSpawnStrategy)) {

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistry.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.actions.SandboxedSpawnStrategy;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnStrategy;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.collect.RecencyMap;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.events.Reporter;
@@ -308,11 +309,10 @@ public final class SpawnStrategyRegistry
     private final List<FilterAndIdentifiers> filterAndIdentifiers = new ArrayList<>();
     // Using List values here rather than multimaps as there is no need for the latter's
     // functionality: The values are always replaced as a whole, no adding/creation required.
-    private final HashMap<String, List<String>> mnemonicToIdentifiers = new HashMap<>();
-    private final HashMap<String, List<String>> mnemonicToRemoteDynamicIdentifiers =
-        new HashMap<>();
-    private final HashMap<String, List<String>> mnemonicToLocalDynamicIdentifiers = new HashMap<>();
-    private final HashMap<Label, List<String>> execPlatformFilters = new HashMap<>();
+    private final RecencyMap<String, List<String>> mnemonicToIdentifiers = new RecencyMap<>();
+    private final RecencyMap<String, List<String>> mnemonicToRemoteDynamicIdentifiers = new RecencyMap<>();
+    private final RecencyMap<String, List<String>> mnemonicToLocalDynamicIdentifiers = new RecencyMap<>();
+    private final RecencyMap<Label, List<String>> execPlatformFilters = new RecencyMap<>();
 
     @Nullable private String remoteLocalFallbackStrategyIdentifier;
 
@@ -476,10 +476,8 @@ public final class SpawnStrategyRegistry
         }
       }
 
-      var platformToStrategies =
-          new ImmutableSetMultimap.Builder<Label, SpawnStrategy>()
-          .orderKeysBy(Label::compareTo)
-          .orderValuesBy(SpawnStrategy::compareTo);
+       ImmutableSetMultimap.Builder<Label, SpawnStrategy> platformToStrategies =
+          ImmutableSetMultimap.builder();
       for (Map.Entry<Label, List<String>> entry : execPlatformFilters.entrySet()) {
         Label platform = entry.getKey();
         platformToStrategies.putAll(
@@ -488,9 +486,8 @@ public final class SpawnStrategyRegistry
                 entry.getValue(), "platform " + platform.getCanonicalForm()));
       }
 
-      var mnemonicToStrategies =
-          new ImmutableListMultimap.Builder<String, SpawnStrategy>()
-          .orderKeysBy(String::compareTo);
+      ImmutableListMultimap.Builder<String, SpawnStrategy> mnemonicToStrategies =
+          ImmutableListMultimap.builder();
       for (Map.Entry<String, List<String>> entry : mnemonicToIdentifiers.entrySet()) {
         String mnemonic = entry.getKey();
         ImmutableList<String> sanitizedStrategies =
@@ -499,9 +496,8 @@ public final class SpawnStrategyRegistry
             mnemonic, strategyMapper.toStrategies(sanitizedStrategies, "mnemonic " + mnemonic));
       }
 
-      var mnemonicToLocalStrategies =
-          new ImmutableListMultimap.Builder<String, SandboxedSpawnStrategy>()
-          .orderKeysBy(String::compareTo);
+      ImmutableListMultimap.Builder<String, SandboxedSpawnStrategy> mnemonicToLocalStrategies =
+          ImmutableListMultimap.builder();
       for (Map.Entry<String, List<String>> entry : mnemonicToLocalDynamicIdentifiers.entrySet()) {
         String mnemonic = entry.getKey();
         ImmutableList<String> sanitizedStrategies =
@@ -512,9 +508,8 @@ public final class SpawnStrategyRegistry
                 sanitizedStrategies, "local mnemonic " + mnemonic));
       }
 
-      var mnemonicToRemoteStrategies =
-          new ImmutableListMultimap.Builder<String, SandboxedSpawnStrategy>()
-          .orderKeysBy(String::compareTo);
+      ImmutableListMultimap.Builder<String, SandboxedSpawnStrategy> mnemonicToRemoteStrategies =
+          ImmutableListMultimap.builder();
       for (Map.Entry<String, List<String>> entry : mnemonicToRemoteDynamicIdentifiers.entrySet()) {
         String mnemonic = entry.getKey();
         ImmutableList<String> sanitizedStrategies =

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistry.java
@@ -48,7 +48,7 @@ import com.google.devtools.build.lib.util.RegexFilter;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -214,7 +214,7 @@ public final class SpawnStrategyRegistry
     for (Map.Entry<String, Collection<SpawnStrategy>> entry :
         mnemonicToStrategies.asMap().entrySet()) {
       logger.atInfo().log(
-        "MnemonicToStrategyImplementations: \"%s\" = [%s]",
+          "MnemonicToStrategyImplementations: \"%s\" = [%s]",
           entry.getKey(), toImplementationNames(entry.getValue()));
     }
 
@@ -310,8 +310,10 @@ public final class SpawnStrategyRegistry
     // Using List values here rather than multimaps as there is no need for the latter's
     // functionality: The values are always replaced as a whole, no adding/creation required.
     private final RecencyMap<String, List<String>> mnemonicToIdentifiers = new RecencyMap<>();
-    private final RecencyMap<String, List<String>> mnemonicToRemoteDynamicIdentifiers = new RecencyMap<>();
-    private final RecencyMap<String, List<String>> mnemonicToLocalDynamicIdentifiers = new RecencyMap<>();
+    private final RecencyMap<String, List<String>> mnemonicToRemoteDynamicIdentifiers =
+        new RecencyMap<>();
+    private final RecencyMap<String, List<String>> mnemonicToLocalDynamicIdentifiers =
+        new RecencyMap<>();
     private final RecencyMap<Label, List<String>> execPlatformFilters = new RecencyMap<>();
 
     @Nullable private String remoteLocalFallbackStrategyIdentifier;
@@ -476,7 +478,7 @@ public final class SpawnStrategyRegistry
         }
       }
 
-       ImmutableSetMultimap.Builder<Label, SpawnStrategy> platformToStrategies =
+      ImmutableSetMultimap.Builder<Label, SpawnStrategy> platformToStrategies =
           ImmutableSetMultimap.builder();
       for (Map.Entry<Label, List<String>> entry : execPlatformFilters.entrySet()) {
         Label platform = entry.getKey();
@@ -598,8 +600,7 @@ public final class SpawnStrategyRegistry
           ImmutableList<String> strategyIdentifiers = filterToStrategyIdentifiers.get(filter);
           if (reporter != null) {
             // TODO(schmitt): Why is this done here and not after running canExec?
-            reporter.handle(
-                Event.progress(description + " with context " + strategyIdentifiers));
+            reporter.handle(Event.progress(description + " with context " + strategyIdentifiers));
           }
           // Apply the policy to the identifiers.
           ImmutableList<String> sanitizedStrategies =
@@ -696,7 +697,7 @@ public final class SpawnStrategyRegistry
   /* Maps the strategy identifier (e.g. "local", "worker"..) to the real strategy. */
   private static class StrategyMapper {
 
-    private final Map<String, SpawnStrategy> identifierToStrategy = new HashMap<>();
+    private final Map<String, SpawnStrategy> identifierToStrategy = new LinkedHashMap<>();
 
     StrategyMapper() {}
 
@@ -729,11 +730,11 @@ public final class SpawnStrategyRegistry
       return strategy;
     }
 
-    Iterable<? extends SandboxedSpawnStrategy> toSandboxedStrategies(
+    ImmutableList<SandboxedSpawnStrategy> toSandboxedStrategies(
         List<String> identifiers, String requestName) throws AbruptExitException {
-      Iterable<? extends SpawnStrategy> strategies = toStrategies(identifiers, requestName);
-      for (SpawnStrategy strategy : strategies) {
-        if (!(strategy instanceof SandboxedSpawnStrategy)) {
+      ImmutableList.Builder<SandboxedSpawnStrategy> sandboxedStrategies = ImmutableList.builder();
+      for (SpawnStrategy strategy : toStrategies(identifiers, requestName)) {
+        if (!(strategy instanceof SandboxedSpawnStrategy sandboxedStrategy)) {
           throw createExitException(
               String.format(
                   "'%s' was requested for %s but is not a sandboxed strategy (which is required for"
@@ -741,12 +742,9 @@ public final class SpawnStrategyRegistry
                   strategy.getClass().getSimpleName(), requestName),
               Code.DYNAMIC_STRATEGY_NOT_SANDBOXED);
         }
+        sandboxedStrategies.add(sandboxedStrategy);
       }
-
-      @SuppressWarnings("unchecked") // Each element of the iterable was checked to fulfil this.
-      Iterable<? extends SandboxedSpawnStrategy> sandboxedStrategies =
-          (Iterable<? extends SandboxedSpawnStrategy>) strategies;
-      return sandboxedStrategies;
+      return sandboxedStrategies.build();
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/collect/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/collect/BUILD
@@ -87,6 +87,17 @@ java_test(
 )
 
 java_test(
+    name = "RecencyMapTest",
+    srcs = ["RecencyMapTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/collect:recency_map",
+        "//third_party:guava",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
+java_test(
     name = "SimpleTargetPatternMatcherTest",
     srcs = ["SimpleTargetPatternMatcherTest.java"],
     deps = [

--- a/src/test/java/com/google/devtools/build/lib/collect/RecencyMapTest.java
+++ b/src/test/java/com/google/devtools/build/lib/collect/RecencyMapTest.java
@@ -1,0 +1,92 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.collect;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link RecencyMap}. */
+@RunWith(JUnit4.class)
+public final class RecencyMapTest {
+
+  @Test
+  public void put_newKeys_preservesInsertionOrder() {
+    RecencyMap<String, Integer> map = new RecencyMap<>();
+    map.put("a", 1);
+    map.put("b", 2);
+    map.put("c", 3);
+
+    assertThat(map).containsExactly("a", 1, "b", 2, "c", 3).inOrder();
+  }
+
+  @Test
+  public void put_existingKey_movesKeyToEnd() {
+    RecencyMap<String, Integer> map = new RecencyMap<>();
+    map.put("a", 1);
+    map.put("b", 2);
+    map.put("c", 3);
+    map.put("a", 4);
+
+    assertThat(map).containsExactly("b", 2, "c", 3, "a", 4).inOrder();
+  }
+
+  @Test
+  public void put_existingKey_returnsPreviousValue() {
+    RecencyMap<String, Integer> map = new RecencyMap<>();
+    map.put("a", 1);
+
+    assertThat(map.put("a", 2)).isEqualTo(1);
+    assertThat(map.put("b", 3)).isNull();
+  }
+
+  @Test
+  public void putAll_existingKeys_movesKeysToEnd() {
+    RecencyMap<String, Integer> map = new RecencyMap<>();
+    map.put("a", 1);
+    map.put("b", 2);
+    map.put("c", 3);
+
+    map.putAll(ImmutableMap.of("b", 4, "d", 5));
+
+    assertThat(map).containsExactly("a", 1, "c", 3, "b", 4, "d", 5).inOrder();
+  }
+
+  @Test
+  public void remove_thenPut_appendsKeyAtEnd() {
+    RecencyMap<String, Integer> map = new RecencyMap<>();
+    map.put("a", 1);
+    map.put("b", 2);
+
+    assertThat(map.remove("a")).isEqualTo(1);
+    map.put("a", 3);
+
+    assertThat(map).containsExactly("b", 2, "a", 3).inOrder();
+  }
+
+  @Test
+  public void equalsAndHashCode_matchEquivalentMap() {
+    RecencyMap<String, Integer> map = new RecencyMap<>();
+    map.put("a", 1);
+    map.put("b", 2);
+    map.put("a", 3);
+
+    ImmutableMap<String, Integer> expected = ImmutableMap.of("b", 2, "a", 3);
+    assertThat(map).isEqualTo(expected);
+    assertThat(map.hashCode()).isEqualTo(expected.hashCode());
+  }
+}

--- a/src/test/shell/integration/execution_strategies_test.sh
+++ b/src/test/shell/integration/execution_strategies_test.sh
@@ -44,6 +44,11 @@ fi
 source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
+tear_down() {
+  # Rollover to a new server log by shutting down the Bazel server.
+  bazel shutdown
+}
+
 # Helper function to assert that one pattern appears before another in a file.
 # Usage: assert_line_order <pattern1> <pattern2> <file>
 # Verifies that pattern1 appears on an earlier line than pattern2.

--- a/src/test/shell/integration/execution_strategies_test.sh
+++ b/src/test/shell/integration/execution_strategies_test.sh
@@ -100,60 +100,60 @@ function test_spawn_strategy_order() {
   bazel build \
     --spawn_strategy=worker,local \
     --genrule_strategy=local \
-    --strategy=LOREM=sandboxed,worker \
-    --strategy=IPSUM=worker,sandboxed \
-    --strategy_regexp='//bar=sandboxed,local' \
-    --strategy_regexp='//foo.*\.cc,-//foo/bar=local,sandboxed' \
+    --strategy=LOREM=local,worker \
+    --strategy=IPSUM=worker,local \
+    --strategy_regexp='//bar=local,worker' \
+    --strategy_regexp='//foo.*\.cc,-//foo/bar=worker,local' \
     --strategy_regexp='//buzz=local' \
-    --dynamic_local_strategy==sandboxed \
-    --dynamic_local_strategy=FOO=worker,sandboxed \
-    --dynamic_local_strategy=BAR=sandboxed,worker \
+    --dynamic_local_strategy==local \
+    --dynamic_local_strategy=FOO=worker,local \
+    --dynamic_local_strategy=BAR=local,worker \
     --dynamic_remote_strategy==remote \
-    --dynamic_remote_strategy=BETA=sandboxed,remote \
-    --dynamic_remote_strategy=ALPHA=remote,sandboxed \
-    --remote_local_fallback_strategy=sandboxed \
-    --allowed_strategies_by_exec_platform=@platforms//host:host=local,sandboxed,worker \
-    --allowed_strategies_by_exec_platform=//:foo_platform=worker,sandboxed \
+    --dynamic_remote_strategy=BETA=local,remote \
+    --dynamic_remote_strategy=ALPHA=remote,local \
+    --remote_local_fallback_strategy=local \
+    --allowed_strategies_by_exec_platform=@platforms//host:host=local,worker \
+    --allowed_strategies_by_exec_platform=//:foo_platform=worker,local \
     || fail
 
   assert_contains 'DefaultStrategyImplementations: \[WorkerSpawnStrategy, StandaloneSpawnStrategy\]' "$SERVER_LOG"
-  assert_contains 'RemoteLocalFallbackImplementation: \[.*SandboxedStrategy\]' "$SERVER_LOG"
+  assert_contains 'RemoteLocalFallbackImplementation: \[StandaloneSpawnStrategy\]' "$SERVER_LOG"
 
   # Keys (regex filters) in reverse specified order, values in specified order
   assert_line_order \
-    'FilterDescriptionToStrategyImplementations: "(?:(?>//foo.*\.cc)),-(?:(?>//foo/bar))" = \[StandaloneSpawnStrategy, .*SandboxedStrategy\]' \
-    'FilterDescriptionToStrategyImplementations: "(?:(?>//bar))" = \[.*SandboxedStrategy, StandaloneSpawnStrategy\]' \
+    'FilterDescriptionToStrategyImplementations: "(?:(?>//foo.*\.cc)),-(?:(?>//foo/bar))" = \[WorkerSpawnStrategy, StandaloneSpawnStrategy\]' \
+    'FilterDescriptionToStrategyImplementations: "(?:(?>//bar))" = \[StandaloneSpawnStrategy, WorkerSpawnStrategy\]' \
     "$SERVER_LOG"
   assert_line_order \
     'FilterDescriptionToStrategyImplementations: "(?:(?>//buzz))" = \[StandaloneSpawnStrategy\]' \
-    'FilterDescriptionToStrategyImplementations: "(?:(?>//foo.*\.cc)),-(?:(?>//foo/bar))" = \[StandaloneSpawnStrategy, .*SandboxedStrategy\]' \
+    'FilterDescriptionToStrategyImplementations: "(?:(?>//foo.*\.cc)),-(?:(?>//foo/bar))" = \[WorkerSpawnStrategy, StandaloneSpawnStrategy\]' \
     "$SERVER_LOG"
 
   # Keys (mnemonics) in lexical order, values in specified order
   assert_contains 'MnemonicToStrategyImplementations: "Genrule" = \[StandaloneSpawnStrategy\]' "$SERVER_LOG"
   assert_line_order \
-    'MnemonicToStrategyImplementations: "IPSUM" = \[WorkerSpawnStrategy, .*SandboxedStrategy\]' \
-    'MnemonicToStrategyImplementations: "LOREM" = \[.*SandboxedStrategy, WorkerSpawnStrategy\]' \
+    'MnemonicToStrategyImplementations: "IPSUM" = \[WorkerSpawnStrategy, StandaloneSpawnStrategy\]' \
+    'MnemonicToStrategyImplementations: "LOREM" = \[StandaloneSpawnStrategy, WorkerSpawnStrategy\]' \
     "$SERVER_LOG"
 
   # Keys (mnemonics) in lexical order, values in specified order
-  assert_contains 'MnemonicToLocalDynamicStrategyImplementations: "" = \[.*SandboxedStrategy\]' "$SERVER_LOG"
+  assert_contains 'MnemonicToLocalDynamicStrategyImplementations: "" = \[StandaloneSpawnStrategy\]' "$SERVER_LOG"
   assert_line_order \
-    'MnemonicToLocalDynamicStrategyImplementations: "BAR" = \[.*SandboxedStrategy, WorkerSpawnStrategy\]' \
-    'MnemonicToLocalDynamicStrategyImplementations: "FOO" = \[WorkerSpawnStrategy, .*SandboxedStrategy\]' \
+    'MnemonicToLocalDynamicStrategyImplementations: "BAR" = \[StandaloneSpawnStrategy, WorkerSpawnStrategy\]' \
+    'MnemonicToLocalDynamicStrategyImplementations: "FOO" = \[WorkerSpawnStrategy, StandaloneSpawnStrategy\]' \
     "$SERVER_LOG"
 
   # Keys (mnemonics) in lexical order, values in specified order
   assert_contains 'MnemonicToRemoteDynamicStrategyImplementations: "" = \[RemoteSpawnStrategy\]' "$SERVER_LOG"
   assert_line_order \
-    'MnemonicToRemoteDynamicStrategyImplementations: "ALPHA" = \[RemoteSpawnStrategy, .*SandboxedStrategy\]' \
-    'MnemonicToRemoteDynamicStrategyImplementations: "BETA" = \[.*SandboxedStrategy, RemoteSpawnStrategy\]' \
+    'MnemonicToRemoteDynamicStrategyImplementations: "ALPHA" = \[RemoteSpawnStrategy, StandaloneSpawnStrategy\]' \
+    'MnemonicToRemoteDynamicStrategyImplementations: "BETA" = \[StandaloneSpawnStrategy, RemoteSpawnStrategy\]' \
     "$SERVER_LOG"
 
   # Keys (platform labels) and values in lexical order
   assert_line_order \
-    'FilterPlatformToStrategyImplementations: "//:foo_platform" = \[.*SandboxedStrategy, WorkerSpawnStrategy\]' \
-    'FilterPlatformToStrategyImplementations: "@@platforms//host:host" = \[.*SandboxedStrategy, StandaloneSpawnStrategy, WorkerSpawnStrategy\]' \
+    'FilterPlatformToStrategyImplementations: "//:foo_platform" = \[StandaloneSpawnStrategy, WorkerSpawnStrategy\]' \
+    'FilterPlatformToStrategyImplementations: "@@platforms//host:host" = \[StandaloneSpawnStrategy, WorkerSpawnStrategy\]' \
     "$SERVER_LOG"
 }
 

--- a/src/test/shell/integration/execution_strategies_test.sh
+++ b/src/test/shell/integration/execution_strategies_test.sh
@@ -44,6 +44,36 @@ fi
 source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
+# Helper function to assert that one pattern appears before another in a file.
+# Usage: assert_line_order <pattern1> <pattern2> <file>
+# Verifies that pattern1 appears on an earlier line than pattern2.
+function assert_line_order() {
+  local pattern1=$1
+  local pattern2=$2
+  local file=$3
+  local message="Expected '$pattern1' to appear before '$pattern2' in '$file'"
+  
+  local line1=$(grep -n "$pattern1" "$file" | head -1 | cut -d: -f1)
+  local line2=$(grep -n "$pattern2" "$file" | head -1 | cut -d: -f1)
+  
+  if [[ -z "$line1" ]]; then
+    fail "Pattern '$pattern1' not found in '$file'" $(__copy_to_undeclared_outputs "$file")
+    return 1
+  fi
+  
+  if [[ -z "$line2" ]]; then
+    fail "Pattern '$pattern2' not found in '$file'" $(__copy_to_undeclared_outputs "$file")
+    return 1
+  fi
+  
+  if [[ "$line1" -lt "$line2" ]]; then
+    return 0
+  else
+    fail "$message (line $line1 >= line $line2)" $(__copy_to_undeclared_outputs "$file")
+    return 1
+  fi
+}
+
 # Tests that you can set the spawn strategy flags to a list of strategies.
 function test_multiple_strategies() {
   SERVER_LOG=$(bazel info server_log)
@@ -61,6 +91,70 @@ function test_no_worker_defaults() {
   assert_not_contains "\"Closure\"" "$SERVER_LOG"
   assert_not_contains "\"DexBuilder\"" "$SERVER_LOG"
   assert_not_contains "\"Javac\"" "$SERVER_LOG"
+}
+
+# Tests that spawn strategy data structures are populated in the expected order and that it is
+# reflected in the server log.
+function test_spawn_strategy_order() {
+  SERVER_LOG=$(bazel info server_log)
+  bazel build \
+    --spawn_strategy=worker,local \
+    --genrule_strategy=local \
+    --strategy=LOREM=sandboxed,worker \
+    --strategy=IPSUM=worker,sandboxed \
+    --strategy_regexp='//bar=sandboxed,local' \
+    --strategy_regexp='//foo.*\.cc,-//foo/bar=local,sandboxed' \
+    --strategy_regexp='//buzz=local' \
+    --dynamic_local_strategy==sandboxed \
+    --dynamic_local_strategy=FOO=worker,sandboxed \
+    --dynamic_local_strategy=BAR=sandboxed,worker \
+    --dynamic_remote_strategy==remote \
+    --dynamic_remote_strategy=BETA=sandboxed,remote \
+    --dynamic_remote_strategy=ALPHA=remote,sandboxed \
+    --remote_local_fallback_strategy=sandboxed \
+    --allowed_strategies_by_exec_platform=@platforms//host:host=local,sandboxed,worker \
+    --allowed_strategies_by_exec_platform=//:foo_platform=worker,sandboxed \
+    || fail
+
+  assert_contains 'DefaultStrategyImplementations: \[WorkerSpawnStrategy, StandaloneSpawnStrategy\]' "$SERVER_LOG"
+  assert_contains 'RemoteLocalFallbackImplementation: \[.*SandboxedStrategy\]' "$SERVER_LOG"
+
+  # Keys (regex filters) in reverse specified order, values in specified order
+  assert_line_order \
+    'FilterDescriptionToStrategyImplementations: "(?:(?>//foo.*\.cc)),-(?:(?>//foo/bar))" = \[StandaloneSpawnStrategy, .*SandboxedStrategy\]' \
+    'FilterDescriptionToStrategyImplementations: "(?:(?>//bar))" = \[.*SandboxedStrategy, StandaloneSpawnStrategy\]' \
+    "$SERVER_LOG"
+  assert_line_order \
+    'FilterDescriptionToStrategyImplementations: "(?:(?>//buzz))" = \[StandaloneSpawnStrategy\]' \
+    'FilterDescriptionToStrategyImplementations: "(?:(?>//foo.*\.cc)),-(?:(?>//foo/bar))" = \[StandaloneSpawnStrategy, .*SandboxedStrategy\]' \
+    "$SERVER_LOG"
+
+  # Keys (mnemonics) in lexical order, values in specified order
+  assert_contains 'MnemonicToStrategyImplementations: "Genrule" = \[StandaloneSpawnStrategy\]' "$SERVER_LOG"
+  assert_line_order \
+    'MnemonicToStrategyImplementations: "IPSUM" = \[WorkerSpawnStrategy, .*SandboxedStrategy\]' \
+    'MnemonicToStrategyImplementations: "LOREM" = \[.*SandboxedStrategy, WorkerSpawnStrategy\]' \
+    "$SERVER_LOG"
+
+  # Keys (mnemonics) in lexical order, values in specified order
+  assert_contains 'MnemonicToLocalDynamicStrategyImplementations: "" = \[.*SandboxedStrategy\]' "$SERVER_LOG"
+  assert_line_order \
+    'MnemonicToLocalDynamicStrategyImplementations: "BAR" = \[.*SandboxedStrategy, WorkerSpawnStrategy\]' \
+    'MnemonicToLocalDynamicStrategyImplementations: "FOO" = \[WorkerSpawnStrategy, .*SandboxedStrategy\]' \
+    "$SERVER_LOG"
+
+  # Keys (mnemonics) in lexical order, values in specified order
+  assert_contains 'MnemonicToRemoteDynamicStrategyImplementations: "" = \[RemoteSpawnStrategy\]' "$SERVER_LOG"
+  assert_line_order \
+    'MnemonicToRemoteDynamicStrategyImplementations: "ALPHA" = \[RemoteSpawnStrategy, .*SandboxedStrategy\]' \
+    'MnemonicToRemoteDynamicStrategyImplementations: "BETA" = \[.*SandboxedStrategy, RemoteSpawnStrategy\]' \
+    "$SERVER_LOG"
+
+  # Keys (platform labels) and values in lexical order
+  assert_line_order \
+    'FilterPlatformToStrategyImplementations: "//:foo_platform" = \[.*SandboxedStrategy, WorkerSpawnStrategy\]' \
+    'FilterPlatformToStrategyImplementations: "@@platforms//host:host" = \[.*SandboxedStrategy, StandaloneSpawnStrategy, WorkerSpawnStrategy\]' \
+    "$SERVER_LOG"
 }
 
 # Tests that Bazel catches an invalid strategy list that has an empty string as an element.

--- a/src/test/shell/integration/execution_strategies_test.sh
+++ b/src/test/shell/integration/execution_strategies_test.sh
@@ -44,12 +44,8 @@ fi
 source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-function testenv_set_up() {
-  echo 'startup --quiet' > .bazelrc
-}
-
-tear_down() {
-  # Rollover to a new server log by shutting down the Bazel server.
+function tear_down() {
+  # Roll over to a new server log so that assertions don't see the previous test's output.
   bazel shutdown
 }
 
@@ -61,20 +57,20 @@ function assert_line_order() {
   local pattern2=$2
   local file=$3
   local message="Expected '$pattern1' to appear before '$pattern2' in '$file'"
-  
+
   local line1=$(grep -n "$pattern1" "$file" | head -1 | cut -d: -f1)
   local line2=$(grep -n "$pattern2" "$file" | head -1 | cut -d: -f1)
-  
+
   if [[ -z "$line1" ]]; then
     fail "Pattern '$pattern1' not found in '$file'" $(__copy_to_undeclared_outputs "$file")
     return 1
   fi
-  
+
   if [[ -z "$line2" ]]; then
     fail "Pattern '$pattern2' not found in '$file'" $(__copy_to_undeclared_outputs "$file")
     return 1
   fi
-  
+
   if [[ "$line1" -lt "$line2" ]]; then
     return 0
   else
@@ -341,7 +337,7 @@ genrule(
 
 EOF
 
-  bazel --noquiet build --internal_spawn_scheduler --genrule_strategy=dynamic \
+  bazel build --internal_spawn_scheduler --genrule_strategy=dynamic \
     --dynamic_remote_strategy=sandboxed \
     --dynamic_local_strategy=standalone \
     --sandbox_add_mount_pair=/tmp \


### PR DESCRIPTION
This is a follow up to #24265 addressing feedback which was too invasive to do at the time.

Changes include;
- Using immutable collection types where possible.
- Favoring `ImmutableList` and `ImmutableSet` over `ImmutableCollection`, as recommended in docs (for the well-defined `Object.equals(Object)` behavior
- Mappings and sets which are order insensitive (platform labels, mnemonics, strategy allowlists) are now sorted to prevent order-sensitive behaviors from being unintentionally introduced.
- Thanks to the latter, `logSpawnStrategies` now logs order insensitive map keys (like with `MnemonicToStrategyImplementations`) with sorting applied.
- `--strategy_regexp` flag documentation updated to cover interaction with `--spawn_strategy` and `--strategy`.
- Test coverage for strategy logging (in server log) and ordering variations for order insensitive collections.