### PR TITLE
[9.0.0] Omit `run` args optional

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -192,6 +192,18 @@ public class RunCommand implements BlazeCommand {
             "If true, runs the target in the current working directory instead of the runfile"
                 + " tree.")
     public boolean runInCwd;
+
+    @Option(
+        name = "omit_run_args",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.LOGGING,
+        effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
+        help =
+            "Specifies whether the arguments passed to the runnable target will be omitted from the"
+                + " output for privacy reasons. If set to true, the output will not contain the"
+                + " arguments passed to the target. If set to false, the output will contain the"
+                + " arguments passed to the target.")
+    public boolean runOmitRunArgs;
   }
 
   private static final String NO_TARGET_MESSAGE = "No targets found to run";
@@ -354,7 +366,7 @@ public class RunCommand implements BlazeCommand {
               /* executionPlatformLabel= */ null,
               /* spawnRunner= */ null);
     } else {
-      commandDescription = runCommandLine.getPrettyArgs();
+      commandDescription = runCommandLine.getPrettyArgs(runOptions.runOmitRunArgs);
     }
 
     String prefix = runOptions.runBuiltTarget ? "Running" : "Runnable";

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommandLine.java
@@ -91,7 +91,7 @@ class RunCommandLine {
    * <p>Arguments from the {@code run} command line are omitted as to avoid possibly leaking
    * sensitive user-provided information in logging, BEP, etc.
    */
-  String getPrettyArgs() {
+  String getPrettyArgs(boolean runOmitRunArgs) {
     StringBuilder result = new StringBuilder();
     if (prettyRunUnderPrefix != null) {
       result.append(prettyRunUnderPrefix).append(" ");
@@ -103,7 +103,16 @@ class RunCommandLine {
       result.append(ShellEscaper.escapeString(prettyArgs.get(i)));
     }
     if (!residue.isEmpty()) {
-      result.append(" <args omitted>");
+      if (runOmitRunArgs) {
+        result.append(" <args omitted>");
+      } else {
+        for (int i = 0; i < residue.size(); i++) {
+          if (i < residue.size()) {
+            result.append(" ");
+          }
+          result.append(ShellEscaper.escapeString(residue.get(i)));
+        }
+      }
     }
     return result.toString();
   }


### PR DESCRIPTION
This is supposed to solve https://github.com/bazelbuild/bazel/issues/27221

Fixes https://github.com/bazelbuild/bazel/issues/27221

Closes #27222.

PiperOrigin-RevId: 836469388
Change-Id: I48ae9580db85a8e591c0f011423c77ae02ecb8b0

Commit https://github.com/bazelbuild/bazel/commit/08bc4d7bac30c36b67e4b48c0543aaf0d0b791c5