### PR TITLE
Fix off-by-one bug in `RunCommandLine`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommandLine.java
@@ -88,7 +88,7 @@ class RunCommandLine {
   /**
    * Returns a console-friendly (including relative paths) representation of the command line.
    *
-   * <p>Arguments from the {@code run} command line are omitted as to avoid possibly leaking
+   * <p>Arguments from the {@code run} command line can be omitted as to avoid possibly leaking
    * sensitive user-provided information in logging, BEP, etc.
    */
   String getPrettyArgs(boolean runOmitRunArgs) {
@@ -107,7 +107,7 @@ class RunCommandLine {
         result.append(" <args omitted>");
       } else {
         for (int i = 0; i < residue.size(); i++) {
-          if (i < residue.size()) {
+          if (i < residue.size() - 1) {
             result.append(" ");
           }
           result.append(ShellEscaper.escapeString(residue.get(i)));

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommandLine.java
@@ -106,12 +106,10 @@ class RunCommandLine {
       if (runOmitRunArgs) {
         result.append(" <args omitted>");
       } else {
-        for (int i = 0; i < residue.size(); i++) {
-          // Don't add a space after the last argument.
-          if (i < residue.size() - 1) {
-            result.append(" ");
-          }
-          result.append(ShellEscaper.escapeString(residue.get(i)));
+        for (String residueArg : residue) {
+          // Every residue argument is preceded by something: either an argument from the command
+          // line, or the executable itself.
+          result.append(" ").append(ShellEscaper.escapeString(residueArg));
         }
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommandLine.java
@@ -107,6 +107,7 @@ class RunCommandLine {
         result.append(" <args omitted>");
       } else {
         for (int i = 0; i < residue.size(); i++) {
+          // Don't add a space after the last argument.
           if (i < residue.size() - 1) {
             result.append(" ");
           }

--- a/src/test/java/com/google/devtools/build/lib/runtime/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BUILD
@@ -191,6 +191,8 @@ java_test(
     srcs = ["commands/RunCommandLineTest.java"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/runtime/commands",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs",
         "//third_party:guava",
         "//third_party:junit4",
         "//third_party:truth",

--- a/src/test/java/com/google/devtools/build/lib/runtime/commands/RunCommandLineTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/commands/RunCommandLineTest.java
@@ -20,12 +20,91 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public final class RunCommandLineTest {
+
+  private final Path workingDir =
+      new InMemoryFileSystem(DigestHashFunction.SHA256).getPath("/workspace");
+
+  private RunCommandLine.Builder builder() {
+    return new RunCommandLine.Builder(
+        /* runEnvironment= */ ImmutableSortedMap.of(),
+        /* environmentVariablesToClear= */ ImmutableSortedSet.of(),
+        workingDir,
+        /* isTestTarget= */ false);
+  }
+
+  @Test
+  public void getPrettyArgs_noResidue_returnsEscapedCommandLine() {
+    RunCommandLine underTest =
+        builder().addArgs(ImmutableList.of("executable", "argv1", "arg w spaces")).build();
+
+    assertThat(underTest.getPrettyArgs(/* runOmitRunArgs= */ false))
+        .isEqualTo("executable argv1 'arg w spaces'");
+  }
+
+  @Test
+  public void getPrettyArgs_withResidue_separatesAllArgsBySingleSpace() {
+    RunCommandLine underTest =
+        builder()
+            .addArgs(ImmutableList.of("executable", "argv1"))
+            .addArgsFromResidue(ImmutableList.of("residue1", "residue w spaces", "residue3"))
+            .build();
+
+    assertThat(underTest.getPrettyArgs(/* runOmitRunArgs= */ false))
+        .isEqualTo("executable argv1 residue1 'residue w spaces' residue3");
+  }
+
+  @Test
+  public void getPrettyArgs_singleResidueArg_separatesArgsBySingleSpace() {
+    RunCommandLine underTest =
+        builder()
+            .addArgs(ImmutableList.of("executable", "argv1"))
+            .addArgsFromResidue(ImmutableList.of("residue1"))
+            .build();
+
+    assertThat(underTest.getPrettyArgs(/* runOmitRunArgs= */ false))
+        .isEqualTo("executable argv1 residue1");
+  }
+
+  @Test
+  public void getPrettyArgs_runOmitRunArgs_omitsResidue() {
+    RunCommandLine underTest =
+        builder()
+            .addArgs(ImmutableList.of("executable", "argv1"))
+            .addArgsFromResidue(ImmutableList.of("residue1", "residue2"))
+            .build();
+
+    assertThat(underTest.getPrettyArgs(/* runOmitRunArgs= */ true))
+        .isEqualTo("executable argv1 <args omitted>");
+  }
+
+  @Test
+  public void getPrettyArgs_runOmitRunArgsWithoutResidue_doesNotMentionOmittedArgs() {
+    RunCommandLine underTest = builder().addArgs(ImmutableList.of("executable", "argv1")).build();
+
+    assertThat(underTest.getPrettyArgs(/* runOmitRunArgs= */ true)).isEqualTo("executable argv1");
+  }
+
+  @Test
+  public void getPrettyArgs_runUnderPrefix_prependedToCommandLine() {
+    RunCommandLine underTest =
+        builder()
+            .setRunUnderPrefix("unescaped run-under prefix &&")
+            .addArgs(ImmutableList.of("executable", "argv1"))
+            .addArgsFromResidue(ImmutableList.of("residue1", "residue2"))
+            .build();
+
+    assertThat(underTest.getPrettyArgs(/* runOmitRunArgs= */ false))
+        .isEqualTo("unescaped run-under prefix && executable argv1 residue1 residue2");
+  }
 
   @Test
   public void linuxFormatter_formatArgv_requiresShExecutable() {


### PR DESCRIPTION
This resulted in an extra space at the end of the command. Along the way update an outdated comment.