### PR TITLE
Add support for patches and overlays in Git repository specifications

### DIFF
--- a/site/en/external/registry.md
+++ b/site/en/external/registry.md
@@ -115,6 +115,19 @@ field, which defaults to `archive`.
         underlying `git_repository` repo rule: `remote`, `commit`,
         `shallow_since`, `tag`, `init_submodules`, `verbose`, and
         `strip_prefix`.
+    *   `patches`: A JSON object containing patch files to apply to the
+        cloned repository. The patch files are located under the
+        `/modules/$MODULE/$VERSION/patches` directory. The keys are the
+        patch file names, and the values are the integrity checksum of
+        the patch files. The patches are applied after cloning the repository.
+    *   `patch_strip`: A number; the same as the `--strip` argument of Unix
+        `patch`.
+    *   `overlay`: A JSON object containing overlay files to apply to the
+        cloned repository. The overlay files are located under the
+        `/modules/$MODULE/$VERSION/overlay` directory. The keys are the
+        relative paths where the files should be placed, and the values are
+        the integrity checksum of the overlay files. The overlays are applied
+        before the patch files.
 *   If `type` is `local_path`, this module version is backed by a
     [`local_repository`](/rules/lib/repo/local#local_repository) repo rule;
     it's symlinked to a directory on local disk. It supports the following

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
@@ -15,10 +15,13 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.List;
 import net.starlark.java.eval.Dict;
+import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.eval.StarlarkList;
 
 /**
@@ -78,6 +81,33 @@ public class GitRepoSpecBuilder {
       ArchiveRepoSpecBuilder.RemoteFile remoteModuleFile) {
     setAttr("remote_module_file_urls", remoteModuleFile.urls());
     setAttr("remote_module_file_integrity", remoteModuleFile.integrity());
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setPatches(ImmutableList<Label> patches) {
+    attrBuilder.put("patches", StarlarkList.immutableCopyOf(patches));
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setRemotePatches(ImmutableMap<String, String> remotePatches) {
+    attrBuilder.put("remote_patches", Dict.immutableCopyOf(remotePatches));
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setOverlay(ImmutableMap<String, ArchiveRepoSpecBuilder.RemoteFile> overlay) {
+    var remoteFiles = Maps.transformValues(overlay, rf -> StarlarkList.immutableCopyOf(rf.urls()));
+    var remoteFilesIntegrity = Maps.transformValues(overlay, ArchiveRepoSpecBuilder.RemoteFile::integrity);
+    attrBuilder.put("remote_file_urls", Dict.immutableCopyOf(remoteFiles));
+    attrBuilder.put("remote_file_integrity", Dict.immutableCopyOf(remoteFilesIntegrity));
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setRemotePatchStrip(int remotePatchStrip) {
+    attrBuilder.put("remote_patch_strip", StarlarkInt.of(remotePatchStrip));
     return this;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -292,6 +292,9 @@ public class IndexRegistry implements Registry {
     boolean initSubmodules;
     boolean verbose;
     String stripPrefix;
+    Map<String, String> patches;
+    Map<String, String> overlay;
+    int patchStrip;
   }
 
   /**
@@ -380,7 +383,7 @@ public class IndexRegistry implements Registry {
             parseJson(jsonString.get(), jsonUrl, GitRepoSourceJson.class);
         var moduleFileUrl = constructModuleFileUrl(key);
         var moduleFileChecksum = moduleFileHashes.get(moduleFileUrl).get();
-        return createGitRepoSpec(typedSourceJson, moduleFileUrl, moduleFileChecksum);
+        return createGitRepoSpec(typedSourceJson, moduleFileUrl, moduleFileChecksum, key);
       }
       default ->
           throw new IOException(
@@ -536,7 +539,44 @@ public class IndexRegistry implements Registry {
   }
 
   private RepoSpec createGitRepoSpec(
-      GitRepoSourceJson sourceJson, String moduleFileUrl, Checksum moduleFileChecksum) {
+      GitRepoSourceJson sourceJson, String moduleFileUrl, Checksum moduleFileChecksum, ModuleKey key)
+      throws IOException {
+    // Build remote patches as key-value pairs of "url" => "integrity".
+    ImmutableMap.Builder<String, String> remotePatches = new ImmutableMap.Builder<>();
+    if (sourceJson.patches != null) {
+      for (Map.Entry<String, String> entry : sourceJson.patches.entrySet()) {
+        remotePatches.put(
+            constructUrl(
+                getUrl(),
+                "modules",
+                key.name(),
+                key.version().toString(),
+                "patches",
+                entry.getKey()),
+            entry.getValue());
+      }
+    }
+
+    ImmutableMap<String, String> sourceJsonOverlay =
+        sourceJson.overlay != null ? ImmutableMap.copyOf(sourceJson.overlay) : ImmutableMap.of();
+    ImmutableMap<String, ArchiveRepoSpecBuilder.RemoteFile> overlay =
+        sourceJsonOverlay.entrySet().stream()
+            .collect(
+                toImmutableMap(
+                    Entry::getKey,
+                    entry ->
+                        new ArchiveRepoSpecBuilder.RemoteFile(
+                            entry.getValue(), // integrity
+                            // URLs in the registry itself are not mirrored.
+                            ImmutableList.of(
+                                constructUrl(
+                                    getUrl(),
+                                    "modules",
+                                    key.name(),
+                                    key.version().toString(),
+                                    "overlay",
+                                    entry.getKey())))));
+
     return new GitRepoSpecBuilder()
         .setRemote(sourceJson.remote)
         .setCommit(sourceJson.commit)
@@ -545,6 +585,9 @@ public class IndexRegistry implements Registry {
         .setInitSubmodules(sourceJson.initSubmodules)
         .setVerbose(sourceJson.verbose)
         .setStripPrefix(sourceJson.stripPrefix)
+        .setRemotePatches(remotePatches.buildOrThrow())
+        .setOverlay(overlay)
+        .setRemotePatchStrip(sourceJson.patchStrip)
         .setRemoteModuleFile(
             new RemoteFile(
                 moduleFileChecksum.toSubresourceIntegrity(), ImmutableList.of(moduleFileUrl)))

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -159,6 +159,22 @@ _common_attrs = {
         default = "",
         doc = "For internal use only.",
     ),
+    "remote_patches": attr.string_dict(
+        default = {},
+        doc = "For internal use only.",
+    ),
+    "remote_patch_strip": attr.int(
+        default = 0,
+        doc = "For internal use only.",
+    ),
+    "remote_file_urls": attr.string_list_dict(
+        default = {},
+        doc = "For internal use only.",
+    ),
+    "remote_file_integrity": attr.string_dict(
+        default = {},
+        doc = "For internal use only.",
+    ),
     "build_file": attr.label(
         allow_single_file = True,
         doc =


### PR DESCRIPTION
- Introduced `patches`, `overlay`, and `patch_strip` attributes in Git repository specifications.
- Updated `GitRepoSpecBuilder` to handle new attributes.
- Enhanced `IndexRegistry` to parse and apply patches and overlays from JSON.
- Added tests for retrieving Git repository specifications with patches.
- Modified utility functions to support creating Git repository modules with patches and overlays.