### PR TITLE
[8.5.1] Fix two incorrect usages of `SkyframeLookupResult`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/TestExpansionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/TestExpansionFunction.java
@@ -164,9 +164,11 @@ final class TestExpansionFunction implements SkyFunction {
     Map<PackageIdentifier, Package> packageMap = new HashMap<>();
     for (PackageIdentifier key : pkgIdentifiers) {
       try {
-        packageMap.put(
-            key,
-            ((PackageValue) packages.getOrThrow(key, NoSuchPackageException.class)).getPackage());
+        var packageValue = (PackageValue) packages.getOrThrow(key, NoSuchPackageException.class);
+        if (packageValue == null) {
+          return false;
+        }
+        packageMap.put(key, packageValue.getPackage());
       } catch (NoSuchPackageException e) {
         env.getListener().handle(Event.error(e.getMessage()));
         hasError = true;


### PR DESCRIPTION
All the values have to be checked for nullness individually.

Fixes the following two NPEs:
1. https://github.com/bazel-contrib/rules_go/pull/4531#discussion_r2594543426
```
java.lang.NullPointerException: Cannot invoke "com.google.devtools.build.lib.skyframe.PackageValue.getPackage()" because the return value of "com.google.devtools.build.skyframe.SkyframeLookupResult.getOrThrow(com.google.devtools.build.skyframe.SkyKey, java.lang.Class)" is null
	at com.google.devtools.build.lib.skyframe.TestExpansionFunction.getPrerequisites(TestExpansionFunction.java:169)
	at com.google.devtools.build.lib.skyframe.TestExpansionFunction.computeExpandedTests(TestExpansionFunction.java:85)
...
```
2. https://github.com/bazelbuild/bazel/issues/27942
```
java.lang.NullPointerException
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(Unknown Source)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline.collect(Unknown Source)
	at com.google.devtools.build.lib.skyframe.DirectoryTreeDigestFunction.getSubDirTreeDigests(DirectoryTreeDigestFunction.java:140)
	at com.google.devtools.build.lib.skyframe.DirectoryTreeDigestFunction.compute(DirectoryTreeDigestFunction.java:65)
```

Speculative fix for #27942

Closes #27959.

PiperOrigin-RevId: 843808256
Change-Id: I012756ec8a641c68bca31fe155d230caa00d8a3f

Commit https://github.com/bazelbuild/bazel/commit/1025821bb121d0ae85d0d91c5bc1482512e65121