### PR TITLE
[8.6.0] Fix crash when mixing `use_repo_rule` and `--inject_repository`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -651,8 +651,7 @@ public class ModuleFileFunction implements SkyFunction {
     }
     // Use the innate extension backing use_repo_rule.
     ModuleExtensionUsageBuilder usageBuilder =
-        new ModuleExtensionUsageBuilder(
-            context,
+        context.getOrCreateExtensionUsageBuilder(
             "//:MODULE.bazel",
             "@bazel_tools//tools/build_defs/repo:local.bzl local_repository",
             /* isolate= */ false);
@@ -679,7 +678,6 @@ public class ModuleFileFunction implements SkyFunction {
           "by --inject_repository",
           thread.getCallStack());
     }
-    context.getExtensionUsageBuilders().add(usageBuilder);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -468,27 +468,17 @@ public class ModuleFileGlobals {
             .setContainingModuleFilePath(context.getCurrentModuleFilePath());
 
     String extensionBzlFile = normalizeLabelString(context.getModuleBuilder(), rawExtensionBzlFile);
-    var newUsageBuilder =
-        new ModuleExtensionUsageBuilder(context, extensionBzlFile, extensionName, isolate);
 
     if (context.shouldIgnoreDevDeps() && devDependency) {
       // This is a no-op proxy.
-      return new ModuleExtensionProxy(newUsageBuilder, proxyBuilder);
+      return new ModuleExtensionProxy(
+          new ModuleExtensionUsageBuilder(context, extensionBzlFile, extensionName, isolate),
+          proxyBuilder);
     }
 
-    // Find an existing usage builder corresponding to this extension. Isolated usages need to get
-    // their own proxy.
-    if (!isolate) {
-      for (ModuleExtensionUsageBuilder usageBuilder : context.getExtensionUsageBuilders()) {
-        if (usageBuilder.isForExtension(extensionBzlFile, extensionName)) {
-          return new ModuleExtensionProxy(usageBuilder, proxyBuilder);
-        }
-      }
-    }
-
-    // If no such proxy exists, we can just use a new one.
-    context.getExtensionUsageBuilders().add(newUsageBuilder);
-    return new ModuleExtensionProxy(newUsageBuilder, proxyBuilder);
+    return new ModuleExtensionProxy(
+        context.getOrCreateExtensionUsageBuilder(extensionBzlFile, extensionName, isolate),
+        proxyBuilder);
   }
 
   private String normalizeLabelString(InterimModule.Builder module, String rawExtensionBzlFile)
@@ -820,16 +810,9 @@ public class ModuleFileGlobals {
     String extensionName = bzlFile + ' ' + ruleName;
     // Find or create the builder for the singular "innate" extension of this repo rule for this
     // module.
-    for (ModuleExtensionUsageBuilder usageBuilder : context.getExtensionUsageBuilders()) {
-      if (usageBuilder.isForExtension("//:MODULE.bazel", extensionName)) {
-        return new RepoRuleProxy(usageBuilder);
-      }
-    }
-    ModuleExtensionUsageBuilder newUsageBuilder =
-        new ModuleExtensionUsageBuilder(
-            context, "//:MODULE.bazel", extensionName, /* isolate= */ false);
-    context.getExtensionUsageBuilders().add(newUsageBuilder);
-    return new RepoRuleProxy(newUsageBuilder);
+    return new RepoRuleProxy(
+        context.getOrCreateExtensionUsageBuilder(
+            "//:MODULE.bazel", extensionName, /* isolate= */ false));
   }
 
   @StarlarkBuiltin(name = "repo_rule_proxy", documented = false)

--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -695,7 +695,7 @@ class BazelOverridesTest(test_base.TestBase):
     )
 
     # --inject_repository _must not_ affect `use_repo_rule` generated repo names
-    #.
+    # .
     _, stdout, _ = self.RunBazel([
         'mod',
         'dump_repo_mapping',
@@ -710,6 +710,28 @@ class BazelOverridesTest(test_base.TestBase):
         '"+_repo_rules2+injected_repo"',
         '\n'.join(stdout),
     )
+
+  def testInjectRepositoryAndLocalRepository(self):
+    # Regression test for https://github.com/bazelbuild/bazel/issues/27953
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            (
+                'local_repository ='
+                ' use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl",'
+                ' "local_repository")'
+            ),
+            'local_repository(name = "local_repo", path = "local_repo")',
+        ],
+    )
+    self.ScratchFile('local_repo/REPO.bazel')
+    self.ScratchFile('injected_repo/REPO.bazel')
+
+    self.RunBazel([
+        'mod',
+        'deps',
+        '--inject_repository=injected_repo=%workspace%/injected_repo',
+    ])
 
   def testOverrideRepositoryOnNonExistentRepo(self):
     self.ScratchFile('other_repo/REPO.bazel')


### PR DESCRIPTION
Bazel crashes at HEAD when `use_repo_rule` is used with `local_repository` while also using `--inject_repository`.

Make bugs like this less likely by extracting out a safe "get or create" helper for extension usages.

Fixes #27953

Closes #27967.

PiperOrigin-RevId: 844683022
Change-Id: I1edcf1e7c72ef8d46c67e51b4f9ffd6a6ce82ec8

Commit https://github.com/bazelbuild/bazel/commit/21d7fec5788413d002ac7ec65889730bcb4e4de1