### PR TITLE
[8.6.0] Add option to continue with local execution if remote cache is unavailable.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -189,10 +189,14 @@ final class RemoteSpawnCache implements SpawnCache {
           }
           throw createExecExceptionForCredentialHelperException(e);
         } catch (RemoteExecutionCapabilitiesException e) {
-          if (thisExecution != null) {
-            thisExecution.close();
+          boolean shouldLocalFallback =
+              options.remoteLocalFallbackForRemoteCache && options.remoteLocalFallback;
+          if (!shouldLocalFallback) {
+            if (thisExecution != null) {
+              thisExecution.close();
+            }
+            throw createExecExceptionFromRemoteExecutionCapabilitiesException(e);
           }
-          throw createExecExceptionFromRemoteExecutionCapabilitiesException(e);
         } catch (IOException e) {
           if (BulkTransferException.allCausedByCacheNotFoundException(e)) {
             // Intentionally left blank

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -292,6 +292,14 @@ public final class RemoteOptions extends CommonRemoteOptions {
           "Whether to fall back to standalone local execution strategy if remote execution fails.")
   public boolean remoteLocalFallback;
 
+  @Option(
+      name = "incompatible_remote_local_fallback_for_remote_cache",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "Whether --remote_local_fallback applies to --remote_cache.")
+  public boolean remoteLocalFallbackForRemoteCache;
+
   @Deprecated
   @Option(
       name = "remote_local_fallback_strategy",


### PR DESCRIPTION
Currently, if the endpoint specified by `--remote_cache` is not available at the start of the build, the build fails with a message saying that the remote cache is not available.

This change introduces a new flag `--incompatible_remote_local_fallback_for_remote_cache`, which when combined with `--remote_local_fallback`, allow build to continue build even if the remote cache is not available initially.

Fixes #27734, #25965.

Closes #27846.

PiperOrigin-RevId: 844783391
Change-Id: Id414458b27c2673318ac9767d07bd54887a74e45

Commit https://github.com/bazelbuild/bazel/commit/461c074e560f024fe533b538567ae8fa1ccbdeaf