### PR TITLE
Allow more general exceptions in `getConfiguration`

### DIFF
--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -608,12 +608,10 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     self.ClearRemoteCache()
 
     # Build the other target: fails due to the lost input
-    # TODO: #26450 - Assert success and enable the checks below.
-    _, _, stderr = self.RunBazel(
-        ['build', '@my_repo//sub:sub'], allow_failure=True
-    )
+    _, _, stderr = self.RunBazel(['build', '@my_repo//sub:sub'])
+    # First restart recovers @my_repo, the next one recovers @platforms.
     self.assertEqual(
-        1,
+        2,
         stderr.count(
             'Found transient remote cache error, retrying the build...'
         ),


### PR DESCRIPTION
Fixes #27981

Fixes the following type of crash and, incidentally, a remote repo contents cache test that resulted in a related crash:
```
    FATAL: bazel crashed due to an internal error. Printing stack trace:
    java.lang.IllegalStateException: Unknown error during configuration creation evaluation
            at com.google.devtools.build.lib.skyframe.SkyframeExecutor.getConfiguration(SkyframeExecutor.java:2143)
            at com.google.devtools.build.lib.skyframe.SkyframeExecutor.createConfiguration(SkyframeExecutor.java:1876)
            at com.google.devtools.build.lib.analysis.BuildView.update(BuildView.java:281)
            at com.google.devtools.build.lib.buildtool.AnalysisPhaseRunner.runAnalysisPhase(AnalysisPhaseRunner.java:399)
            at com.google.devtools.build.lib.buildtool.AnalysisPhaseRunner.execute(AnalysisPhaseRunner.java:144)
            at com.google.devtools.build.lib.buildtool.BuildTool.buildTargetsWithoutMergedAnalysisExecution(BuildTool.java:512)
            at com.google.devtools.build.lib.buildtool.BuildTool.buildTargets(BuildTool.java:414)
            at com.google.devtools.build.lib.buildtool.BuildTool.processRequest(BuildTool.java:907)
            at com.google.devtools.build.lib.runtime.commands.CqueryCommand.exec(CqueryCommand.java:197)
            at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.execExclusively(BlazeCommandDispatcher.java:783)
            at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.exec(BlazeCommandDispatcher.java:266)
            at com.google.devtools.build.lib.server.GrpcServerImpl.executeCommand(GrpcServerImpl.java:608)
            at com.google.devtools.build.lib.server.GrpcServerImpl.lambda$run$0(GrpcServerImpl.java:679)
            at io.grpc.Context$1.run(Context.java:566)
            at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
            at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
            at java.base/java.lang.Thread.run(Unknown Source)
    Caused by: com.google.devtools.build.lib.skyframe.toolchains.PlatformLookupUtil$InvalidPlatformException: com.google.devtools.build.lib.packages.BuildFileNotFoundException: no such package '@@[unknown repo 'toolchains_llvm_boostrapped' requested from @@ (did you mean 'toolchains_llvm_bootstrapped'?)]//platforms': The repository '@@[unknown repo 'toolchains_llvm_boostrapped' requested from @@ (did you mean 'toolchains_llvm_bootstrapped'?)]' could not be resolved: No repository visible as '@toolchains_llvm_boostrapped' from main repository
            at com.google.devtools.build.lib.analysis.platform.PlatformFunction.compute(PlatformFunction.java:75)
            at com.google.devtools.build.lib.analysis.platform.PlatformFunction.compute(PlatformFunction.java:43)
            at com.google.devtools.build.skyframe.ParallelEvaluator.bubbleErrorUp(ParallelEvaluator.java:414)
            at com.google.devtools.build.skyframe.ParallelEvaluator.waitForCompletionAndConstructResult(ParallelEvaluator.java:207)
            at com.google.devtools.build.skyframe.ParallelEvaluator.doMutatingEvaluation(ParallelEvaluator.java:173)
            at com.google.devtools.build.skyframe.ParallelEvaluator.eval(ParallelEvaluator.java:672)
            at com.google.devtools.build.skyframe.AbstractInMemoryMemoizingEvaluator.evaluate(AbstractInMemoryMemoizingEvaluator.java:182)
            at com.google.devtools.build.lib.skyframe.SkyframeExecutor.evaluate(SkyframeExecutor.java:4279)
            at com.google.devtools.build.lib.skyframe.SkyframeExecutor.lambda$evaluateSkyKeys$0(SkyframeExecutor.java:2278)
            at com.google.devtools.build.lib.concurrent.Uninterruptibles.callUninterruptibly(Uninterruptibles.java:35)
            at com.google.devtools.build.lib.skyframe.SkyframeExecutor.evaluateSkyKeys(SkyframeExecutor.java:2274)
            at com.google.devtools.build.lib.skyframe.SkyframeExecutor.getConfiguration(SkyframeExecutor.java:2126)
            ... 16 more
```