### PR TITLE
[8.6.0] Don't use the gRPC downloader for `file:` URLs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -748,10 +748,6 @@ public final class RemoteModule extends BlazeModule {
                 ServerCapabilitiesRequirement.NONE);
       }
 
-      Downloader fallbackDownloader = null;
-      if (remoteOptions.remoteDownloaderLocalFallback) {
-        fallbackDownloader = env.getHttpDownloader();
-      }
       remoteDownloader =
           new GrpcRemoteDownloader(
               buildRequestId,
@@ -763,7 +759,8 @@ public final class RemoteModule extends BlazeModule {
               digestUtil.getDigestFunction(),
               remoteOptions,
               verboseFailures,
-              fallbackDownloader);
+              env.getHttpDownloader(),
+              remoteOptions.remoteDownloaderLocalFallback);
       downloaderChannel.release();
       env.getDownloaderDelegate().setDelegate(remoteDownloader);
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -86,7 +86,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -104,6 +103,7 @@ public class GrpcRemoteDownloaderTest {
 
   private final MutableHandlerRegistry serviceRegistry = new MutableHandlerRegistry();
   private final String fakeServerName = "fake server for " + getClass();
+  private final RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
   private Server fakeServer;
   private RemoteActionExecutionContext context;
   private ListeningScheduledExecutorService retryService;
@@ -141,12 +141,11 @@ public class GrpcRemoteDownloaderTest {
   }
 
   private GrpcRemoteDownloader newDownloader(RemoteCacheClient cacheClient) throws IOException {
-    return newDownloader(cacheClient, /* fallbackDownloader= */ null);
+    return newDownloader(cacheClient, mock(Downloader.class)/* allowFallback= */ );
   }
 
   private GrpcRemoteDownloader newDownloader(
-      RemoteCacheClient cacheClient, @Nullable Downloader fallbackDownloader) throws IOException {
-    final RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+      RemoteCacheClient cacheClient, Downloader httpDownloader) throws IOException {
     final RemoteRetrier retrier =
         TestUtils.newRemoteRetrier(
             () -> new ExponentialBackoff(remoteOptions),
@@ -179,7 +178,8 @@ public class GrpcRemoteDownloaderTest {
         DIGEST_UTIL.getDigestFunction(),
         remoteOptions,
         /* verboseFailures= */ false,
-        fallbackDownloader);
+        httpDownloader,
+        remoteOptions.remoteDownloaderLocalFallback);
   }
 
   private static byte[] downloadBlob(
@@ -247,6 +247,7 @@ public class GrpcRemoteDownloaderTest {
 
   @Test
   public void testDownloadFallback() throws Exception {
+    remoteOptions.remoteDownloaderLocalFallback = true;
     final byte[] content = "example content".getBytes(UTF_8);
     serviceRegistry.addService(
         new FetchImplBase() {
@@ -279,6 +280,39 @@ public class GrpcRemoteDownloaderTest {
   }
 
   @Test
+  public void testFileUrl() throws Exception {
+    var fileUrl = new URL("file:///my/local/file");
+    byte[] content = "example content".getBytes(UTF_8);
+    serviceRegistry.addService(
+        new FetchImplBase() {
+          @Override
+          public void fetchBlob(
+              FetchBlobRequest request, StreamObserver<FetchBlobResponse> responseObserver) {
+            responseObserver.onError(new IOException("io error"));
+          }
+        });
+    var cacheClient = new InMemoryCacheClient();
+    var fallbackDownloader = mock(Downloader.class);
+    doAnswer(
+            invocation -> {
+              List<URL> urls = invocation.getArgument(0);
+              if (urls.equals(ImmutableList.of(fileUrl))) {
+                Path output = invocation.getArgument(5);
+                FileSystemUtils.writeContent(output, content);
+              }
+              return null;
+            })
+        .when(fallbackDownloader)
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq("context"));
+    GrpcRemoteDownloader downloader = newDownloader(cacheClient, fallbackDownloader);
+
+    byte[] downloaded = downloadBlob(downloader, fileUrl, Optional.empty());
+
+    assertThat(downloaded).isEqualTo(content);
+    assertThat(eventHandler.getPosts()).isEmpty();
+  }
+
+  @Test
   public void testStatusHandling() throws Exception {
     serviceRegistry.addService(
         new FetchImplBase() {
@@ -306,8 +340,7 @@ public class GrpcRemoteDownloaderTest {
           }
         });
     final RemoteCacheClient cacheClient = new InMemoryCacheClient();
-    final GrpcRemoteDownloader downloader =
-        newDownloader(cacheClient, /* fallbackDownloader= */ null);
+    final GrpcRemoteDownloader downloader = newDownloader(cacheClient, /* httpDownloader= */ null);
     // Add a cache entry for the empty Digest to verify that the implementation checks the status
     // before fetching the digest.
     getFromFuture(cacheClient.uploadBlob(context, Digest.getDefaultInstance(), ByteString.EMPTY));


### PR DESCRIPTION
Always use the HTTP downloader in this case as it supports these URLs.

Fixes #26810

Closes #27799.

PiperOrigin-RevId: 843590344
Change-Id: Ia28da102b29d828edd95ea0c1fb9f50ff70d3d85

Commit https://github.com/bazelbuild/bazel/commit/65574f3b6c8b9df93ecd9ee16c777d71bf8707ad