### PR TITLE
[8.5.1] Update skyframe error checking in case the second skyframe lookup in

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainTypeLookupUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainTypeLookupUtil.java
@@ -70,6 +70,11 @@ public class ToolchainTypeLookupUtil {
       Label originalLabel = key.getLabel();
       Optional<ToolchainTypeInfo> toolchainTypeInfo =
           findToolchainTypeInfo(toolchainTypeRequirement, key, values);
+      if (toolchainTypeInfo == null) {
+        // Continue processing to find errors, but note that we didn't succeed.
+        valuesMissing = true;
+        continue;
+      }
       if (!valuesMissing) {
         toolchainTypeInfo.ifPresent(
             info -> {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainTypeLookupUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainTypeLookupUtilTest.java
@@ -179,6 +179,8 @@ public class ToolchainTypeLookupUtilTest extends ToolchainTestCase {
     assertContainsEvent("no such package 'fake': BUILD file not found");
   }
 
+  // TODO: b/381396141 - Add a regression test for failure to find the second Skyframe value.
+
   // Calls ToolchainTypeLookupUtil.getToolchainTypeInfo.
   private static final SkyFunctionName GET_TOOLCHAIN_TYPE_INFO_FUNCTION =
       SkyFunctionName.createHermetic("GET_TOOLCHAIN_TYPE_INFO_FUNCTION");


### PR DESCRIPTION
ToolchainTypeUtils is incomplete.

PiperOrigin-RevId: 702010313
Change-Id: I24983bd2a1c708f7f8f63ee87273e22ecddb3a72

Commit https://github.com/bazelbuild/bazel/commit/7e4fb4111ef6fdee56966a04ec1dfb9f9d044409