### PR TITLE
[9.0.0] Allow nonlocal tests with nobuild_runfile_manifests

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
@@ -441,10 +441,7 @@ public final class RunfilesSupport {
   /** Returns the root directory of the runfiles symlink farm; otherwise, returns null. */
   @Nullable
   public Path getRunfilesDirectory() {
-    if (runfilesInputManifest == null) {
-      return null;
-    }
-    return FileSystemUtils.replaceExtension(runfilesInputManifest.getPath(), RUNFILES_DIR_EXT);
+    return runfilesTreeArtifact.getPath();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -99,11 +99,6 @@ public class StandaloneTestStrategy extends TestStrategy {
   public TestRunnerSpawn createTestRunnerSpawn(
       TestRunnerAction action, ActionExecutionContext actionExecutionContext)
       throws ExecException, InterruptedException {
-    if (action.getExecutionSettings().getInputManifest() == null) {
-      throw createTestExecException(
-          TestAction.Code.LOCAL_TEST_PREREQ_UNMET,
-          "cannot run local tests with --nobuild_runfile_manifests");
-    }
     Map<String, String> testEnvironment =
         createEnvironment(actionExecutionContext, action, tmpDirRoot);
 

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -1113,8 +1113,11 @@ sh_test(
     srcs = ['test.sh'],
 )
 EOF
-  bazel test --nobuild_runfile_manifests //dir:test >& $TEST_log && fail "should have failed"
-  expect_log "cannot run local tests with --nobuild_runfile_manifests"
+  bazel test --nobuild_runfile_manifests --spawn_strategy=local --test_output=errors //dir:test >& $TEST_log && fail "should have failed"
+  expect_log "ERROR: RUNFILES_DIR does not exist. This can happen when using --nobuild_runfile_manifests with local execution."
+  bazel test --nobuild_runfile_manifests --spawn_strategy=standalone --test_output=errors //dir:test >& $TEST_log && fail "should have failed"
+  expect_log "ERROR: RUNFILES_DIR does not exist. This can happen when using --nobuild_runfile_manifests with local execution."
+  bazel test --nobuild_runfile_manifests --spawn_strategy=sandboxed //dir:test >& $TEST_log || fail "should have succeeded"
 }
 
 function test_test_with_reserved_env_variable() {

--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -80,6 +80,12 @@ fi
 
 is_absolute "$RUNFILES_DIR" || RUNFILES_DIR="$PWD/$RUNFILES_DIR"
 
+# Check that the runfiles directory exists
+if [[ ! -d "$RUNFILES_DIR" ]]; then
+    echo >&2 "ERROR: RUNFILES_DIR does not exist. This can happen when using --nobuild_runfile_manifests with local execution. Use a different execution strategy, or build with runfile manifests."
+    exit 1
+fi
+
 # TODO(ulfjack): Standardize on RUNFILES_DIR and remove the {JAVA,PYTHON}_RUNFILES vars.
 is_absolute "$JAVA_RUNFILES" || JAVA_RUNFILES="$PWD/$JAVA_RUNFILES"
 is_absolute "$PYTHON_RUNFILES" || PYTHON_RUNFILES="$PWD/$PYTHON_RUNFILES"


### PR DESCRIPTION
Addresses https://github.com/bazelbuild/bazel/issues/23980

When testing a large number of targets against a build farm, runfile manifests can start to pile up pretty quickly on the client, and take up a large amount of disk space. The runfile manifests are also unnecessary when performing tests with the sandboxed or remote spawn strategies, only (to my understanding) local or standalone.

This change modifies the test wrappers to error early if the runfile directory can't be found, and instructs the user to build with runfile manifests, or change their execution strategy.

We still need to be able to actually get the runfile directory when the input manifest isn't present. To address this, we also change the behavior of getRunfilesDirectory to just return the runfilesTreeArtifact's path.

Closes #27412.

PiperOrigin-RevId: 845855359
Change-Id: I761a79b1354879bce3622da4bacb3d5f04515a4f

Commit https://github.com/bazelbuild/bazel/commit/374f82f7a917021d7055ae532a03f77212a05e65