### PR TITLE
[9.0.0] Verify Unicode environment variable name sorting in tests

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.when;
 import build.bazel.remote.execution.v2.ActionCacheUpdateCapabilities;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.CacheCapabilities;
+import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.DirectoryNode;
@@ -2906,6 +2907,10 @@ public class RemoteExecutionServiceTest {
             .withOutput(ActionsTestUtil.createArtifactWithExecPath(artifactRoot, twoF))
             .withOutput(ActionsTestUtil.createArtifactWithExecPath(artifactRoot, threeF))
             .withOutput(ActionsTestUtil.createArtifactWithExecPath(artifactRoot, fourF))
+            .withEnvironment(unicodeToInternal(one), "value1")
+            .withEnvironment(unicodeToInternal(two), "value2")
+            .withEnvironment(unicodeToInternal(three), "value3")
+            .withEnvironment(unicodeToInternal(four), "value4")
             .build();
     FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
     RemoteExecutionService service = newRemoteExecutionService();
@@ -2918,6 +2923,13 @@ public class RemoteExecutionServiceTest {
             execRoot.getRelative(two).getPathString(),
             execRoot.getRelative(three).getPathString(),
             execRoot.getRelative(four).getPathString())
+        .inOrder();
+    assertThat(remoteAction.getCommand().getEnvironmentVariablesList())
+        .containsExactly(
+            Command.EnvironmentVariable.newBuilder().setName(one).setValue("value1").build(),
+            Command.EnvironmentVariable.newBuilder().setName(two).setValue("value2").build(),
+            Command.EnvironmentVariable.newBuilder().setName(three).setValue("value3").build(),
+            Command.EnvironmentVariable.newBuilder().setName(four).setValue("value4").build())
         .inOrder();
   }
 


### PR DESCRIPTION
Related to #26745

Closes #28035.

PiperOrigin-RevId: 846391505
Change-Id: Ib414b80de550f9600d45c57f3eb8aba9c5ffea5c

Commit https://github.com/bazelbuild/bazel/commit/79b9a98e31d4ffab74fb61f736fec46ed639ccd3