### PR TITLE
[9.0.0] Avoid deduplicating linkopts of cc_shared_library dependencies.

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
@@ -298,7 +298,7 @@ def _wrap_static_library_with_alwayslink(ctx, feature_configuration, cc_toolchai
     return cc_common.create_linker_input(
         owner = linker_input.owner,
         libraries = depset(direct = new_libraries_to_link),
-        user_link_flags = depset(direct = linker_input.user_link_flags),
+        user_link_flags = linker_input.user_link_flags,
         additional_inputs = depset(direct = linker_input.additional_inputs),
     )
 

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test5/BUILD.builtin_test
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test5/BUILD.builtin_test
@@ -1,0 +1,40 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+package(default_visibility = ["//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library:__subpackages__"])
+
+licenses(["notice"])
+
+cc_library(
+    name = "bar",
+    srcs = ["bar.cc"],
+    linkopts = select({
+        "@platforms//os:macos": ["-framework", "Security", "-framework", "IOKit"],
+        ":macos_arm64": ["-framework", "Security"],  # Seems there is no IOKit framework on arm64.
+        "//conditions:default": [],
+    }),
+)
+
+cc_shared_library(
+    name = "bar_so",
+    deps = [":bar"],
+)
+
+
+# This is not an actual test, we're just ensuring that this target builds.
+# And it needs to be cc_test rather than cc_binary because of the blaze test
+# command in src/main/starlark/tests/builtins_bzl/cc_builtin_tests.sh:65
+cc_test(
+    name = "cc_test",
+    srcs = ["main.cc"],
+    dynamic_deps = [":bar_so"],
+)
+
+config_setting(
+    name = "macos_arm64",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:macos",
+    ],
+)

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test5/bar.cc
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test5/bar.cc
@@ -1,0 +1,14 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+int bar() { return 42; }

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test5/main.cc
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test5/main.cc
@@ -1,0 +1,19 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <iostream>
+
+int main() {
+  std::cout << "hello, world!" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
Linker inputs for dependencies of `cc_shared_library` are currently passing their `linkopts` as a `depset`, which leads to deduplication of the flags thereby passed. Consequently, a sequence of well-formed flags like `-framework Security -framework IOKit` gets collapsed to `-framework Security IOKit`; the linker then interprets `IOKit` as an object file that it's unable to locate, which yields a malformed link line.

Passing `linkopts` directly rather than wrapping it in `depset` appears to resolve the issue. I've added a test that replicates the original issue; since `-framework` isn't meaningful on all platforms, I've only enabled it for MacOS.

Note that the tests in this repository utilize the `rules_cc` repository rather than the built-in rules; therefore, I don't think the new test can be expected to pass until the change has been propagated there, and the controlling [`MODULE.bazel.lock` entry](https://github.com/bazelbuild/bazel/blob/HEAD/src/test/tools/bzlmod/MODULE.bazel.lock#L113) has been updated. I've tested it locally by `cat`ing a `local_path_override` directive to the `MODULE.bazel` file that [gets synthesized](https://github.com/bazelbuild/bazel/blob/e887cfbfd641f57a3cdd950249daf9b568ebaeb5/src/main/starlark/tests/builtins_bzl/cc_builtin_tests.sh#L49) for these tests, in order to point the tests towards a local fork of `rules_cc` with this same change applied; under these conditions, the test passes.

Closes #27735.

Closes #27755.

PiperOrigin-RevId: 845984933
Change-Id: I5606b9f6f61e699f829d19bd34cb672026d50e50

Commit https://github.com/bazelbuild/bazel/commit/991d63860b8a2e5ad00c26ebe0632a06c18e9ee6