### PR TITLE
[9.0.0] Disallow type syntax in .scl files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -688,8 +688,11 @@ public final class BuildLanguageOptions extends OptionsBase {
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       metadataTags = {OptionMetadataTag.EXPERIMENTAL},
       help =
-          "Enables type annotations and related syntax. Locations of files where these are allowed "
-              + "is further restricted by `--experimental_starlark_types_allowed_paths`.")
+          """
+          Enables type annotations and related syntax in .bzl files. Locations of files where \
+          these are allowed is further restricted by `--experimental_starlark_types_allowed_paths`.
+          Type syntax is never permitted in .scl files regardless of this flag.
+          """)
   public boolean experimentalStarlarkTypeSyntax;
 
   @Option(

--- a/src/main/java/net/starlark/java/syntax/Parser.java
+++ b/src/main/java/net/starlark/java/syntax/Parser.java
@@ -1063,12 +1063,7 @@ final class Parser {
     if (options.allowTypeSyntax()) {
       return true;
     } else {
-      syntaxError(
-          offset,
-          tokenKind,
-          tokenValue,
-          "type annotations are disallowed. Enable them with --experimental_starlark_type_syntax "
-              + "and/or --experimental_starlark_types_allowed_paths.");
+      syntaxError(offset, tokenKind, tokenValue, "type annotations are disallowed");
       return false;
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkTypesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkTypesTest.java
@@ -13,9 +13,6 @@
 // limitations under the License.
 package com.google.devtools.build.lib.starlark;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
-
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,14 +52,25 @@ public class StarlarkTypesTest extends BuildViewTestCase {
         """);
     scratch.file("test/BUILD", "load(':foo.bzl', 'f')");
 
-    AssertionError e = assertThrows(AssertionError.class, () -> getTarget("//test:BUILD"));
-    assertThat(e)
-        .hasMessageThat()
-        .contains(
-            """
-            syntax error at ':': type annotations are disallowed. Enable them with \
-            --experimental_starlark_type_syntax and/or --experimental_starlark_types_allowed_paths.\
-            """);
+    checkLoadingPhaseError("//test:BUILD", "syntax error at ':': type annotations are disallowed");
+    assertContainsEvent(
+        "Type annotations syntax can be enabled with --experimental_starlark_type_syntax and/or"
+            + " --experimental_starlark_types_allowed_paths.");
+  }
+
+  @Test
+  public void experimentalStarlarkTypes_prohibitedInSclRegardlessOfFlag() throws Exception {
+    setBuildLanguageOptions("--experimental_starlark_type_syntax");
+    scratch.file(
+        "test/foo.scl",
+        """
+        def f(a: int):
+          pass\
+        """);
+    scratch.file("test/BUILD", "load(':foo.scl', 'f')");
+
+    checkLoadingPhaseError("//test:BUILD", "syntax error at ':': type annotations are disallowed");
+    assertContainsEvent("Type annotations are not permitted in .scl files.");
   }
 
   @Test
@@ -78,14 +86,10 @@ public class StarlarkTypesTest extends BuildViewTestCase {
         """);
     scratch.file("test/BUILD", "load(':foo.bzl', 'f')");
 
-    AssertionError e = assertThrows(AssertionError.class, () -> getTarget("//test:BUILD"));
-    assertThat(e)
-        .hasMessageThat()
-        .contains(
-            """
-            syntax error at ':': type annotations are disallowed. Enable them with \
-            --experimental_starlark_type_syntax and/or --experimental_starlark_types_allowed_paths.\
-            """);
+    checkLoadingPhaseError("//test:BUILD", "syntax error at ':': type annotations are disallowed");
+    assertContainsEvent(
+        "Type annotations syntax can be enabled with --experimental_starlark_type_syntax and/or"
+            + " --experimental_starlark_types_allowed_paths.");
   }
 
   @Test

--- a/src/test/java/net/starlark/java/syntax/ParserTest.java
+++ b/src/test/java/net/starlark/java/syntax/ParserTest.java
@@ -1557,10 +1557,10 @@ public final class ParserTest {
     setFileOptions(FileOptions.builder().allowTypeSyntax(false).build());
     setFailFast(false);
     parseStatement("def f(a: int): pass");
-    assertContainsError("syntax error at ':': type annotations are disallowed.");
+    assertContainsError("syntax error at ':': type annotations are disallowed");
     events.clear();
     parseStatement("def f[T](): pass");
-    assertContainsError("syntax error at '[': type annotations are disallowed.");
+    assertContainsError("syntax error at '[': type annotations are disallowed");
   }
 
   @Test


### PR DESCRIPTION
This merges the fix for #28042 into 9.0.0. Some minor merge conflicts were fixed.

Fixes #28057.