### PR TITLE
Consistently use regular inheritance in StarlarkInt

### DIFF
--- a/src/main/java/net/starlark/java/eval/StarlarkInt.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkInt.java
@@ -34,7 +34,7 @@ import net.starlark.java.types.Types;
             + "100 % -7  # -5 (unlike in some other languages)\n"
             + "int(\"18\")\n"
             + "</pre>")
-public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkInt> {
+public abstract sealed class StarlarkInt implements StarlarkValue, Comparable<StarlarkInt> {
   @Override
   public StarlarkType getStarlarkType() {
     return Types.INT;
@@ -183,17 +183,32 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
 
     @Override
     public long toLong(String what) {
-      return (long) v;
+      return v;
     }
 
     @Override
     protected long toLongFast() {
-      return (long) v;
+      return v;
+    }
+
+    @Override
+    public double toDouble() {
+      return v;
     }
 
     @Override
     public BigInteger toBigInteger() {
       return BigInteger.valueOf(v);
+    }
+
+    @Override
+    public int toIntUnchecked() {
+      return v;
+    }
+
+    @Override
+    public int truncateToInt() {
+      return v;
     }
 
     @Override
@@ -218,8 +233,13 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
 
     @Override
     public boolean equals(Object that) {
-      return (that instanceof Int32 && this.v == ((Int32) that).v)
-          || (that instanceof StarlarkFloat && intEqualsFloat(this, (StarlarkFloat) that));
+      return (that instanceof Int32 int32 && this.v == int32.v)
+          || (that instanceof StarlarkFloat starlarkFloat && intEqualsFloat(this, starlarkFloat));
+    }
+
+    @Override
+    public String toString() {
+      return Integer.toString(v);
     }
   }
 
@@ -242,8 +262,18 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
     }
 
     @Override
+    public double toDouble() {
+      return v;
+    }
+
+    @Override
     public BigInteger toBigInteger() {
       return BigInteger.valueOf(v);
+    }
+
+    @Override
+    public int truncateToInt() {
+      return (int) v;
     }
 
     @Override
@@ -268,8 +298,13 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
 
     @Override
     public boolean equals(Object that) {
-      return (that instanceof Int64 && this.v == ((Int64) that).v)
-          || (that instanceof StarlarkFloat && intEqualsFloat(this, (StarlarkFloat) that));
+      return (that instanceof Int64 int64 && this.v == int64.v)
+          || (that instanceof StarlarkFloat starlarkFloat && intEqualsFloat(this, starlarkFloat));
+    }
+
+    @Override
+    public String toString() {
+      return Long.toString(v);
     }
   }
 
@@ -282,8 +317,18 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
     }
 
     @Override
+    public double toDouble() {
+      return v.doubleValue();
+    }
+
+    @Override
     public BigInteger toBigInteger() {
       return v;
+    }
+
+    @Override
+    public int truncateToInt() {
+      return v.intValue();
     }
 
     @Override
@@ -308,8 +353,13 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
 
     @Override
     public boolean equals(Object that) {
-      return (that instanceof Big && this.v.equals(((Big) that).v))
-          || (that instanceof StarlarkFloat && intEqualsFloat(this, (StarlarkFloat) that));
+      return (that instanceof Big big && this.v.equals(big.v))
+          || (that instanceof StarlarkFloat starlarkFloat && intEqualsFloat(this, starlarkFloat));
+    }
+
+    @Override
+    public String toString() {
+      return v.toString();
     }
   }
 
@@ -321,15 +371,7 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
 
   /** Returns this StarlarkInt as a string of decimal digits. */
   @Override
-  public String toString() {
-    if (this instanceof Int32) {
-      return Integer.toString(((Int32) this).v);
-    } else if (this instanceof Int64) {
-      return Long.toString(((Int64) this).v);
-    } else {
-      return toBigInteger().toString();
-    }
-  }
+  public abstract String toString();
 
   @Override
   public abstract void repr(Printer printer);
@@ -358,22 +400,14 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
   }
 
   /** Returns the nearest IEEE-754 double-precision value closest to this int, which may be ±Inf. */
-  public double toDouble() {
-    if (this instanceof Int32) {
-      return ((Int32) this).v;
-    } else if (this instanceof Int64) {
-      return ((Int64) this).v;
-    } else {
-      return toBigInteger().doubleValue(); // may be ±Inf
-    }
-  }
+  public abstract double toDouble();
 
   /**
    * Returns the nearest IEEE-754 double-precision value closest to this int.
    *
    * @throws EvalException is the int is to large to represent as a finite float value.
    */
-  public double toFiniteDouble() throws EvalException {
+  public final double toFiniteDouble() throws EvalException {
     double d = toDouble();
     if (!Double.isFinite(d)) {
       throw Starlark.errorf("int too large to convert to float");
@@ -389,25 +423,14 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
    *
    * @throws IllegalArgumentException if this int is not in that value range.
    */
-  public final int toIntUnchecked() throws IllegalArgumentException {
-    if (this instanceof Int32) {
-      return ((Int32) this).v;
-    }
+  public int toIntUnchecked() throws IllegalArgumentException {
     // This operator is provided for fast access and case discrimination.
     // Use toInt(String) for user-visible errors.
     throw new IllegalArgumentException("not a signed 32-bit value");
   }
 
   /** Returns the result of truncating this value into the signed 32-bit range. */
-  public int truncateToInt() {
-    if (this instanceof Int32) {
-      return ((Int32) this).v;
-    } else if (this instanceof Int64) {
-      return (int) ((Int64) this).v;
-    } else {
-      return toBigInteger().intValue();
-    }
-  }
+  public abstract int truncateToInt();
 
   @Override
   public boolean isImmutable() {


### PR DESCRIPTION
Previously this class mixed regular method overrides with manual `instanceof` dispatch, which resulted in a number of redundant `toBigInteger()` calls and generally made it harder to follow the different cases.