### PR TITLE
[9.0.0] Allow rewinding multiple artifacts with the same digest at the same time.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ImportantOutputHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ImportantOutputHandler.java
@@ -15,7 +15,7 @@ package com.google.devtools.build.lib.actions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.skyframe.DetailedException;
 import com.google.devtools.build.lib.skyframe.rewinding.LostInputOwners;
@@ -122,11 +122,11 @@ public interface ImportantOutputHandler extends ActionContext {
    * complete.
    */
   record LostArtifacts(
-      ImmutableMap<String, ActionInput> byDigest, Optional<LostInputOwners> owners) {
+      ImmutableSetMultimap<String, ActionInput> byDigest, Optional<LostInputOwners> owners) {
 
     /** An empty instance of {@link LostArtifacts}. */
     public static final LostArtifacts EMPTY =
-        new LostArtifacts(ImmutableMap.of(), Optional.of(new LostInputOwners()));
+        new LostArtifacts(ImmutableSetMultimap.of(), Optional.of(new LostInputOwners()));
 
     public LostArtifacts {
       checkNotNull(byDigest);

--- a/src/main/java/com/google/devtools/build/lib/actions/LostInputsActionExecutionException.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/LostInputsActionExecutionException.java
@@ -15,7 +15,7 @@
 package com.google.devtools.build.lib.actions;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.devtools.build.lib.skyframe.rewinding.LostInputOwners;
 import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.util.io.FileOutErr;
@@ -29,8 +29,8 @@ import javax.annotation.Nullable;
  */
 public final class LostInputsActionExecutionException extends ActionExecutionException {
 
-  /** Maps lost input digests to their {@link ActionInput}. */
-  private final ImmutableMap<String, ActionInput> lostInputs;
+  /** Maps lost input digests to their {@link ActionInput}s. */
+  private final ImmutableSetMultimap<String, ActionInput> lostInputs;
 
   /**
    * Optional mapping of lost inputs to their owning expansion artifacts (tree artifacts, filesets,
@@ -72,17 +72,17 @@ public final class LostInputsActionExecutionException extends ActionExecutionExc
 
   public LostInputsActionExecutionException(
       String message,
-      ImmutableMap<String, ActionInput> lostInputs,
+      ImmutableSetMultimap<String, ActionInput> lostInputs,
       Optional<LostInputOwners> owners,
       Action action,
       Exception cause,
       DetailedExitCode detailedExitCode) {
-    super(message, cause, action, /*catastrophe=*/ false, detailedExitCode);
+    super(message, cause, action, /* catastrophe= */ false, detailedExitCode);
     this.lostInputs = lostInputs;
     this.owners = owners;
   }
 
-  public ImmutableMap<String, ActionInput> getLostInputs() {
+  public ImmutableSetMultimap<String, ActionInput> getLostInputs() {
     return lostInputs;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/common/BulkTransferException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/BulkTransferException.java
@@ -16,7 +16,7 @@ package com.google.devtools.build.lib.remote.common;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ImportantOutputHandler.LostArtifacts;
@@ -87,7 +87,7 @@ public class BulkTransferException extends IOException {
       return LostArtifacts.EMPTY;
     }
 
-    var byDigestBuilder = ImmutableMap.<String, ActionInput>builder();
+    var byDigestBuilder = ImmutableSetMultimap.<String, ActionInput>builder();
     for (var suppressed : getSuppressed()) {
       CacheNotFoundException e = (CacheNotFoundException) suppressed;
       var missingDigest = e.getMissingDigest();
@@ -113,7 +113,7 @@ public class BulkTransferException extends IOException {
       }
       byDigestBuilder.put(DigestUtil.toString(missingDigest), actionInput);
     }
-    var byDigest = byDigestBuilder.buildKeepingLast();
+    var byDigest = byDigestBuilder.build();
     return new LostArtifacts(byDigest, Optional.empty());
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/rewinding/LostImportantOutputHandlerModule.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/rewinding/LostImportantOutputHandlerModule.java
@@ -20,7 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ConcurrentHashMultiset;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
@@ -129,7 +129,7 @@ public class LostImportantOutputHandlerModule extends BlazeModule {
 
     private LostArtifacts getLostOutputs(
         Iterable<Artifact> outputs, InputMetadataProvider metadataProvider) {
-      ImmutableMap.Builder<String, ActionInput> lost = ImmutableMap.builder();
+      ImmutableSetMultimap.Builder<String, ActionInput> lost = ImmutableSetMultimap.builder();
       LostInputOwners owners = new LostInputOwners();
       for (OutputAndOwner outputAndOwner : expand(outputs, metadataProvider)) {
         ActionInput output = outputAndOwner.output;
@@ -148,7 +148,7 @@ public class LostImportantOutputHandlerModule extends BlazeModule {
           owners.addOwner(output, owner);
         }
       }
-      return new LostArtifacts(lost.buildKeepingLast(), Optional.of(owners));
+      return new LostArtifacts(lost.build(), Optional.of(owners));
     }
 
     private static ImmutableList<OutputAndOwner> expand(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTest.java
@@ -286,6 +286,11 @@ public final class RewindingTest extends BuildIntegrationTestCase {
   }
 
   @Test
+  public void multipleLostInputsWithSameDigest_rewoundTogether() throws Exception {
+    helper.runMultipleLostInputsWithSameDigest_rewoundTogether();
+  }
+
+  @Test
   public void lostTopLevelOutputWithRewindingDisabled() throws Exception {
     helper.runLostTopLevelOutputWithRewindingDisabled();
   }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
@@ -29,8 +29,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.flogger.GoogleLogger;
@@ -248,11 +248,11 @@ public class RewindingTestsHelper {
 
   public final ExecResult createLostInputsExecException(
       ActionExecutionContext context, ImmutableList<ActionInput> lostInputs) throws IOException {
-    ImmutableMap.Builder<String, ActionInput> builder = ImmutableMap.builder();
+    ImmutableSetMultimap.Builder<String, ActionInput> builder = ImmutableSetMultimap.builder();
     for (ActionInput lostInput : lostInputs) {
       builder.put(getHexDigest(lostInput, context), lostInput);
     }
-    return ExecResult.ofException(new LostInputsExecException(builder.buildOrThrow()));
+    return ExecResult.ofException(new LostInputsExecException(builder.build()));
   }
 
   private String getHexDigest(ActionInput input, ActionExecutionContext context)
@@ -653,7 +653,8 @@ public class RewindingTestsHelper {
           (spawn, context) -> {
             intermediate.set(SpawnInputUtils.getInputWithName(spawn, "intermediate.txt"));
             return ExecResult.ofException(
-                new LostInputsExecException(ImmutableMap.of("fakedigest/10", intermediate.get())));
+                new LostInputsExecException(
+                    ImmutableSetMultimap.of("fakedigest/10", intermediate.get())));
           });
     }
 
@@ -763,13 +764,13 @@ public class RewindingTestsHelper {
       addSpawnShim(
           "Executing genrule //test:consume_" + target,
           (spawn, context) -> {
-            ImmutableMap.Builder<String, ActionInput> inputMapBuilder = ImmutableMap.builder();
+            ImmutableSetMultimap.Builder<String, ActionInput> inputMap =
+                ImmutableSetMultimap.builder();
             for (int e = 1; e <= target; e++) {
               ActionInput input = SpawnInputUtils.getInputWithName(spawn, "out_" + e + ".txt");
-              inputMapBuilder.put("fake_digest_" + target + "_" + e, input);
+              inputMap.put("fake_digest_" + target + "_" + e, input);
             }
-            ImmutableMap<String, ActionInput> inputMap = inputMapBuilder.buildOrThrow();
-            return ExecResult.ofException(new LostInputsExecException(inputMap));
+            return ExecResult.ofException(new LostInputsExecException(inputMap.build()));
           });
     }
     List<SkyKey> rewoundKeys = collectOrderedRewoundKeys();
@@ -2803,6 +2804,26 @@ public class RewindingTestsHelper {
     assertThat(rewoundKeys).containsExactly(Artifact.key(depPcm.get()));
     assertThat(ImmutableMultiset.copyOf(getExecutedSpawnDescriptions()))
         .hasCount("Compiling foo/dep.cppmap", 2);
+  }
+
+  public final void runMultipleLostInputsWithSameDigest_rewoundTogether() throws Exception {
+    testCase.write(
+        "foo/BUILD",
+        """
+        genrule(name = "top", srcs = [":dep1", ":dep2"], outs = ["top.out"], cmd = "echo top >$@")
+        genrule(name = "dep1", outs = ["dep1.out"], cmd = "echo dep > $@")
+        genrule(name = "dep2", outs = ["dep2.out"], cmd = "echo dep > $@")
+        """);
+    addSpawnShim(
+        "Executing genrule //foo:top",
+        (spawn, context) -> createLostInputsExecException(spawn, context, "dep1.out", "dep2.out"));
+    List<SkyKey> rewoundKeys = collectOrderedRewoundKeys();
+
+    testCase.buildTarget("//foo:top");
+
+    verifyAllSpawnShimsConsumed();
+    assertThat(rewoundArtifactOwnerLabels(rewoundKeys)).containsExactly("//foo:dep1", "//foo:dep2");
+    assertThat(recorder.getActionRewoundEvents()).hasSize(1);
   }
 
   public final void runLostTopLevelOutputWithRewindingDisabled() throws Exception {


### PR DESCRIPTION
This is actually pretty straightforward by refactoring from `ImmutableMap` to `ImmutableSetMultimap`.

PiperOrigin-RevId: 846739573
Change-Id: Id41e8a168ff90d9b73777a87e3fff75954bf31e1

Commit https://github.com/bazelbuild/bazel/commit/97e772078355009e24535cdf38f079767c7e3e50