### PR TITLE
[8.5.1] Enable `--experimental_retain_test_configuration_across_testonly`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -183,7 +183,7 @@ public class TestConfiguration extends Fragment {
 
     @Option(
         name = "experimental_retain_test_configuration_across_testonly",
-        defaultValue = "false",
+        defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,
         effectTags = {
           OptionEffectTag.LOADING_AND_ANALYSIS,


### PR DESCRIPTION
This avoids action conflicts when `testonly` non-test targets depend on test targets.

Until `--incompatible_check_testonly_for_output_files` is flipped, it is still possible to get action conflicts when a non-`testonly` target depends on an output file of a test. Since this can be fixed by adding the missing `testonly` annotation, this is only a minor concern.

Fixes #28056

Closes #28073.

PiperOrigin-RevId: 847892897
Change-Id: I60e908a22b51c307306760aa054b3968cfbebac2

Commit https://github.com/bazelbuild/bazel/commit/bcd8bcb04f555edbecc48ec926fd37ba677bf1b0