### PR TITLE
Use internal string encoding for Skycache keys

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/analysis/BUILD
@@ -208,6 +208,7 @@ java_library(
     name = "file_dependency_key_support",
     srcs = ["FileDependencyKeySupport.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/unsafe:string",
         "//src/main/java/com/google/devtools/build/lib/versioning:long_version_getter",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/protobuf:file_invalidation_data_java_proto",


### PR DESCRIPTION
All strings in Bazel are coded as raw bytes with a Latin1 coder. Taking advantage of this in `FileDependencyKeySupport#computeCacheKey` avoids double encoding and can avoid some buffer copies.