### PR TITLE
Use more NIO on Windows

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/IncrementalPackageRoots.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/IncrementalPackageRoots.java
@@ -335,6 +335,7 @@ public class IncrementalPackageRoots implements PackageRoots {
   }
 
   private static void throwAbruptExitException(Exception e) throws AbruptExitException {
+    e.printStackTrace();
     throw new AbruptExitException(
         DetailedExitCode.of(
             FailureDetail.newBuilder()

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -217,7 +217,7 @@ public class JavaIoFileSystem extends DiskBackedFileSystem {
       return true;
     }
 
-    if (fileIsSymbolicLink(file)) {
+    if (fileIsSymbolicLink(file.toPath())) {
       throw new IOException(path + ERR_FILE_EXISTS);
     }
     if (file.isDirectory()) {
@@ -373,8 +373,8 @@ public class JavaIoFileSystem extends DiskBackedFileSystem {
     }
   }
 
-  protected boolean fileIsSymbolicLink(File file) {
-    return Files.isSymbolicLink(file.toPath());
+  protected boolean fileIsSymbolicLink(java.nio.file.Path file) {
+    return Files.isSymbolicLink(file);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -261,6 +261,9 @@ public class WindowsFileSystem extends JavaIoFileSystem {
         DosFileAttributes attributes, boolean followSymlinks, java.nio.file.Path nioPath) {
       this.attributes = attributes;
       this.followSymlinks = followSymlinks;
+      if (followSymlinks) {
+        isSymbolicLink = false;
+      }
       this.nioPath = nioPath;
     }
 
@@ -284,10 +287,12 @@ public class WindowsFileSystem extends JavaIoFileSystem {
 
     @Override
     public boolean isSymbolicLink() {
-      if (isSymbolicLink == null) {
-        isSymbolicLink = !followSymlinks && fileIsSymbolicLink(nioPath);
+      Boolean localIsSymbolicLink = isSymbolicLink;
+      if (localIsSymbolicLink == null) {
+        isSymbolicLink = fileIsSymbolicLink(nioPath);
+        localIsSymbolicLink = isSymbolicLink;
       }
-      return isSymbolicLink;
+      return localIsSymbolicLink;
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -245,13 +245,14 @@ public class WindowsFileSystem extends JavaIoFileSystem {
 
   @Override
   public void setWritable(PathFragment path, boolean writable) throws IOException {
-    // Windows does not have a notion of read-only directories.
-    // See https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants.
-    // JavaIoFileSystem#setWritable(dir, true) would throw, so reimplement it here as a no-op.
-    if (isDirectory(path, /* followSymlinks= */ true)) {
-      return;
+    // Windows does not have a notion of read-only directories, for which the readonly flag is
+    // ignored.
+    // https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants
+    try {
+      Files.setAttribute(getNioPath(path), "dos:readonly", writable);
+    } catch (IOException e) {
+      throw translateNioToIoException(path, e);
     }
-    super.setWritable(path, writable);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -164,7 +164,9 @@ public class WindowsFileSystem extends JavaIoFileSystem {
       }
       return new WindowsFileStatus(attributes, followSymlinks, nioPath);
     } catch (IOException e) {
-      // A parent of the path is not a directory, which means that the path doesn't exist.
+      // A parent of the path is not a directory, which means that the path doesn't exist - but the
+      // JDK reports this as a separate exception.
+      // https://bugs.openjdk.org/browse/JDK-8374441
       if (e instanceof FileSystemException fse && "Not a directory".equals(fse.getReason())) {
         return null;
       }
@@ -315,8 +317,9 @@ public class WindowsFileSystem extends JavaIoFileSystem {
 
     @Override
     public int getPermissions() {
-      // Files on Windows are implicitly readable and executable.
-      return 0555 | (attributes.isReadOnly() ? 0 : 0200);
+      // Files and directories on Windows are implicitly readable and executable, directories are
+      // also implicitly writable.
+      return 0555 | (attributes.isReadOnly() && !attributes.isDirectory() ? 0 : 0200);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -23,11 +23,11 @@ import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.JavaIoFileSystem;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.SymlinkTargetType;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.Path;
 import java.nio.file.attribute.DosFileAttributes;
 import javax.annotation.Nullable;
 
@@ -81,12 +81,12 @@ public class WindowsFileSystem extends JavaIoFileSystem {
     boolean existingDirectory = stat != null && stat.isDirectory();
 
     try {
-      File link = getIoFile(linkPath);
-      File target = getIoFile(targetPath);
+      Path link = getNioPath(linkPath);
+      Path target = getNioPath(targetPath);
 
       if (!createSymbolicLinks && existingFile) {
         // If symlinks aren't enabled and the target is an existing file, fall back to a copy.
-        Files.copy(target.toPath(), link.toPath());
+        Files.copy(target, link);
       } else if (createSymbolicLinks
           && (existingFile || (!existingDirectory && type != SymlinkTargetType.DIRECTORY))) {
         // If symlinks are enabled and the target is not an existing or future directory, create a
@@ -120,7 +120,7 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
-  protected boolean fileIsSymbolicLink(File file) {
+  protected boolean fileIsSymbolicLink(Path file) {
     try {
       if (isSymlinkOrJunction(file)) {
         return true;
@@ -137,7 +137,7 @@ public class WindowsFileSystem extends JavaIoFileSystem {
 
   @Override
   public FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
-    File file = getIoFile(path);
+    Path file = getNioPath(path);
     final DosFileAttributes attributes;
     try {
       attributes = getAttribs(file, followSymlinks);
@@ -214,14 +214,14 @@ public class WindowsFileSystem extends JavaIoFileSystem {
 
   @Override
   public boolean isSymbolicLink(PathFragment path) {
-    return fileIsSymbolicLink(getIoFile(path));
+    return fileIsSymbolicLink(getNioPath(path));
   }
 
   @Override
   public boolean isDirectory(PathFragment path, boolean followSymlinks) {
     if (!followSymlinks) {
       try {
-        if (isSymlinkOrJunction(getIoFile(path))) {
+        if (isSymlinkOrJunction(getNioPath(path))) {
           return false;
         }
       } catch (IOException e) {
@@ -274,13 +274,12 @@ public class WindowsFileSystem extends JavaIoFileSystem {
    * they are dangling), though only directory junctions and directory symlinks are useful.
    */
   @VisibleForTesting
-  static boolean isSymlinkOrJunction(File file) throws IOException {
-    return WindowsFileOperations.isSymlinkOrJunction(file.getPath());
+  static boolean isSymlinkOrJunction(Path file) throws IOException {
+    return WindowsFileOperations.isSymlinkOrJunction(file.toString());
   }
 
-  private static DosFileAttributes getAttribs(File file, boolean followSymlinks)
+  private static DosFileAttributes getAttribs(Path file, boolean followSymlinks)
       throws IOException {
-    return Files.readAttributes(
-        file.toPath(), DosFileAttributes.class, symlinkOpts(followSymlinks));
+    return Files.readAttributes(file, DosFileAttributes.class, symlinkOpts(followSymlinks));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
@@ -264,7 +264,7 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
             ctx.actions.run_shell(
                 inputs = [],
                 outputs = [out],
-                command = "ln -s hello $1",
+                command = "ln -s hello $1 && file $1 && ls -lah $1 && touch hello",
                 arguments = [out.path],
                 use_default_shell_env = True,
             )

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
@@ -1765,7 +1765,12 @@ public abstract class FileSystemTest {
   public void testSetExecutableOnDirectory() throws Exception {
     setExecutable(xNonEmptyDirectory, false);
 
-    IOException e = assertThrows(IOException.class, () -> xFileInNonEmptyDirectory.isWritable());
+    IOException e;
+    e = assertThrows(IOException.class, () -> xFileInNonEmptyDirectory.isWritable());
+    assertThat(e).hasMessageThat().endsWith(" (Permission denied)");
+    e = assertThrows(IOException.class, () -> xFileInNonEmptyDirectory.isReadable());
+    assertThat(e).hasMessageThat().endsWith(" (Permission denied)");
+    e = assertThrows(IOException.class, () -> xFileInNonEmptyDirectory.isExecutable());
     assertThat(e).hasMessageThat().endsWith(" (Permission denied)");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
@@ -1920,6 +1920,7 @@ public abstract class FileSystemTest {
     dir.getChild("dir_link").createSymbolicLink(dir.getChild("dir"));
     dir.getChild("looping_link").createSymbolicLink(dir.getChild("looping_link"));
     dir.getChild("dangling_link").createSymbolicLink(testFS.getPath("/does_not_exist"));
+    FileSystemUtils.createEmptyFile(dir.getChild("NUL"));
 
     assertThat(dir.getDirectoryEntries())
         .containsExactly(
@@ -1928,7 +1929,8 @@ public abstract class FileSystemTest {
             dir.getChild("file_link"),
             dir.getChild("dir_link"),
             dir.getChild("looping_link"),
-            dir.getChild("dangling_link"));
+            dir.getChild("dangling_link"),
+            dir.getChild("NUL"));
 
     assertThat(dir.readdir(Symlinks.NOFOLLOW))
         .containsExactly(
@@ -1937,7 +1939,8 @@ public abstract class FileSystemTest {
             new Dirent("file_link", Dirent.Type.SYMLINK),
             new Dirent("dir_link", Dirent.Type.SYMLINK),
             new Dirent("looping_link", Dirent.Type.SYMLINK),
-            new Dirent("dangling_link", Dirent.Type.SYMLINK));
+            new Dirent("dangling_link", Dirent.Type.SYMLINK),
+            new Dirent("NUL", Dirent.Type.FILE));
 
     assertThat(dir.readdir(Symlinks.FOLLOW))
         .containsExactly(
@@ -1946,7 +1949,8 @@ public abstract class FileSystemTest {
             new Dirent("file_link", Dirent.Type.FILE),
             new Dirent("dir_link", Dirent.Type.DIRECTORY),
             new Dirent("looping_link", Dirent.Type.UNKNOWN),
-            new Dirent("dangling_link", Dirent.Type.UNKNOWN));
+            new Dirent("dangling_link", Dirent.Type.UNKNOWN),
+            new Dirent("NUL", Dirent.Type.FILE));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
@@ -290,6 +290,13 @@ public abstract class FileSystemTest {
     assertThat(nonDir.getRelative("file").statIfFound()).isNull();
   }
 
+  @Test
+  public void testStatIfFoundReturnsNullForUnresolvedSymlink() throws Exception {
+    Path foo = absolutize("foo");
+    foo.createSymbolicLink(PathFragment.create("hi"));
+    assertThat(foo.statIfFound()).isNull();
+  }
+
   // The following tests check the handling of the current working directory.
   @Test
   public void testCreatePathRelativeToWorkingDirectory() {

--- a/src/test/java/com/google/devtools/build/lib/vfs/JavaIoFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/JavaIoFileSystemTest.java
@@ -46,12 +46,6 @@ public class JavaIoFileSystemTest extends SymlinkAwareFileSystemTest {
 
   // Tests are inherited from the FileSystemTest
 
-  // JavaIoFileSystem incorrectly throws a FileNotFoundException for all IO errors. This means that
-  // statIfFound incorrectly suppresses those errors.
-  @Override
-  @Test
-  public void testBadPermissionsThrowsExceptionOnStatIfFound() {}
-
   @Override
   protected boolean isHardLinked(Path a, Path b) throws IOException {
     return Files.readAttributes(

--- a/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
@@ -472,13 +472,13 @@ public class WindowsFileSystemTest {
 
     assertWritable(dir);
     dir.setWritable(false); // no-op
-    assertNotWritable(dir);
+    assertWritable(dir);
     dir.setWritable(true); // no-op
     assertWritable(dir);
 
     assertWritable(dirViaJunction);
     dirViaJunction.setWritable(false); // no-op
-    assertNotWritable(dirViaJunction);
+    assertWritable(dirViaJunction);
     dirViaJunction.setWritable(true); // no-op
     assertWritable(dirViaJunction);
 

--- a/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
@@ -150,34 +150,54 @@ public class WindowsFileSystemTest {
 
     testUtil.createJunctions(junctions);
 
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "shrtpath/a"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "shrtpath/b"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "shrtpath/c"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longlinkpath/a"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longlinkpath/b"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longlinkpath/c"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longli~1/a"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longli~1/b"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longli~1/c"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "abbreviated/a"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "abbreviated/b"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "abbreviated/c"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "abbrev~1/a"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "abbrev~1/b"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "abbrev~1/c"))).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "control/a"))).isFalse();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "control/b"))).isFalse();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "control/c"))).isFalse();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "shrttrgt/file1.txt")))
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "shrtpath/a").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "shrtpath/b").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "shrtpath/c").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longlinkpath/a").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longlinkpath/b").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longlinkpath/c").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longli~1/a").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longli~1/b").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longli~1/c").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "abbreviated/a").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "abbreviated/b").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "abbreviated/c").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "abbrev~1/a").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "abbrev~1/b").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "abbrev~1/c").toPath()))
+        .isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "control/a").toPath()))
         .isFalse();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longtargetpath/file2.txt")))
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "control/b").toPath()))
         .isFalse();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longta~1/file2.txt")))
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "control/c").toPath()))
+        .isFalse();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "shrttrgt/file1.txt").toPath()))
+        .isFalse();
+    assertThat(
+            WindowsFileSystem.isSymlinkOrJunction(
+                new File(root, "longtargetpath/file2.txt").toPath()))
+        .isFalse();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(new File(root, "longta~1/file2.txt").toPath()))
         .isFalse();
 
     assertThrows(
         FileNotFoundException.class,
-        () -> WindowsFileSystem.isSymlinkOrJunction(new File(root, "non-existent")));
+        () -> WindowsFileSystem.isSymlinkOrJunction(new File(root, "non-existent").toPath()));
 
     assertThat(Arrays.asList(new File(root + "/shrtpath/a").list())).containsExactly("file1.txt");
     assertThat(Arrays.asList(new File(root + "/shrtpath/b").list())).containsExactly("file2.txt");
@@ -203,14 +223,14 @@ public class WindowsFileSystemTest {
 
     File linkPath = new File(helloPath.getParent().getParent().toFile(), "link");
     assertThat(Arrays.asList(linkPath.list())).containsExactly("hello.txt");
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(linkPath)).isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(linkPath.toPath())).isTrue();
 
     assertThat(helloPath.toFile().delete()).isTrue();
     assertThat(helloPath.getParent().toFile().delete()).isTrue();
     assertThat(helloPath.getParent().toFile().exists()).isFalse();
     assertThat(Arrays.asList(linkPath.getParentFile().list())).containsExactly("link");
 
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(linkPath)).isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(linkPath.toPath())).isTrue();
     assertThat(
             Files.exists(
                 linkPath.toPath(), WindowsFileSystem.symlinkOpts(/* followSymlinks */ false)))
@@ -226,18 +246,18 @@ public class WindowsFileSystemTest {
     File longPath =
         testUtil.scratchFile("target\\helloworld.txt", "hello").toAbsolutePath().toFile();
     File shortPath = new File(longPath.getParentFile(), "hellow~1.txt");
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(longPath)).isFalse();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(shortPath)).isFalse();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(longPath.toPath())).isFalse();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(shortPath.toPath())).isFalse();
 
     assertThat(longPath.delete()).isTrue();
     testUtil.createJunctions(ImmutableMap.of("target\\helloworld.txt", "target"));
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(longPath)).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(shortPath)).isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(longPath.toPath())).isTrue();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(shortPath.toPath())).isTrue();
 
     assertThat(longPath.delete()).isTrue();
     assertThat(longPath.mkdir()).isTrue();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(longPath)).isFalse();
-    assertThat(WindowsFileSystem.isSymlinkOrJunction(shortPath)).isFalse();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(longPath.toPath())).isFalse();
+    assertThat(WindowsFileSystem.isSymlinkOrJunction(shortPath.toPath())).isFalse();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.windows;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.google.common.truth.TruthJUnit.assume;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeTrue;
@@ -30,6 +31,7 @@ import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem.NotASymlinkException;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.SymlinkTargetType;
 import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.windows.util.WindowsTestUtil;
@@ -518,6 +520,14 @@ public class WindowsFileSystemTest {
             .toLowerCase(Locale.ROOT);
     validateGetTypeConsistency(scratchRoot, entry, normalizedEntry);
     validateGetTypeConsistency(scratchRoot, normalizedEntry, entry);
+  }
+
+  @Test
+  public void testStatIfFoundOnUnresolvedSymlink() throws Exception {
+    Path foo = testUtil.createVfsPath(fs, "foo");
+    foo.createSymbolicLink(PathFragment.create("hi"));
+    assertThat(foo.statIfFound(Symlinks.NOFOLLOW)).isNotNull();
+    assertThat(foo.statIfFound(Symlinks.FOLLOW)).isNull();
   }
 
   private void validateGetTypeConsistency(Path baseDir, String entryToCreate, String entryToCheck)

--- a/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
@@ -472,13 +472,13 @@ public class WindowsFileSystemTest {
 
     assertWritable(dir);
     dir.setWritable(false); // no-op
-    assertWritable(dir);
+    assertNotWritable(dir);
     dir.setWritable(true); // no-op
     assertWritable(dir);
 
     assertWritable(dirViaJunction);
     dirViaJunction.setWritable(false); // no-op
-    assertWritable(dirViaJunction);
+    assertNotWritable(dirViaJunction);
     dirViaJunction.setWritable(true); // no-op
     assertWritable(dirViaJunction);
 

--- a/src/test/shell/bazel/bazel_windows_example_test.sh
+++ b/src/test/shell/bazel/bazel_windows_example_test.sh
@@ -232,7 +232,7 @@ function create_tmp_drive() {
   for X in {A..Z}
   do
     TMP_DRIVE=${X}
-    subst ${TMP_DRIVE}: ${TMP_DRIVE_PATH} >NUL || TMP_DRIVE=""
+    subst ${TMP_DRIVE}: ${TMP_DRIVE_PATH} >/dev/null || TMP_DRIVE=""
     if [ -n "${TMP_DRIVE}" ]; then
       break
     fi

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
@@ -210,6 +210,7 @@ final class ExecutionServer extends ExecutionImplBase {
               resp =
                   ExecuteResponse.newBuilder()
                       .setStatus(StatusUtils.internalErrorStatus(e))
+                      .setMessage(Throwables.getStackTraceAsString(e))
                       .build();
             }
             responseObserver.onNext(
@@ -428,7 +429,7 @@ final class ExecutionServer extends ExecutionImplBase {
           errStatus =
               Status.newBuilder()
                   .setCode(Code.FAILED_PRECONDITION.getNumber())
-                  .setMessage(e.getMessage())
+                  .setMessage(Throwables.getStackTraceAsString(e))
                   .build();
         }
       }


### PR DESCRIPTION
* Using `Files.list` in `readdir` avoids an extra stat per file on Windows.
* Use `checkAccess` directly in the `is{Readable,Writable,Executable}` methods to make it more obvious that they distinguish between failure to get the metadata and the file not being accessible. This is what `File.is*` does under the hood anyway. Also ensure that non-executable parent directories are handled correctly for all methods and avoid an extra stat in case the file exists and has the queried property.
* Overriding `setWritable` avoids another stat.

Related to #23729 since it removes some usages of `getIoFile()`.