### PR TITLE
Print name of files that fail to upload with INVALID_ARGUMENT

### DIFF
--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3792,4 +3792,49 @@ EOF
   expect_log "The file type of '.*a/dir/symlink.txt' is not supported."
 }
 
+function do_test_concurrent_modification_during_upload() {
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+genrule(
+    name = "gen_and_overwrite",
+    srcs = ["in"],
+    outs = ["out"],
+    # Non-hermetically overwrite the source file.
+    cmd = """
+cat $< $< > $@
+echo -n "overwritten" > $<
+""",
+    tags = ["local"],
+)
+
+genrule(
+    name = "remote",
+    # Forced to run after gen_and_overwrite.
+    srcs = ["in", "out"],
+    outs = ["combined"],
+    cmd = "cat $(SRCS) > $@",
+)
+EOF
+  echo -n "$1" > a/in
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //a:remote >& $TEST_log && fail "build //a:remote should fail"
+  assert_contains "overwritten" a/in
+  expect_log "while uploading file .*/a/in:"
+  expect_log_n "a/in" 1
+}
+
+function test_concurrent_modification_during_upload_shorter() {
+  do_test_concurrent_modification_during_upload "very long content that will be overwritten"
+}
+
+function test_concurrent_modification_during_upload_longer() {
+  do_test_concurrent_modification_during_upload "short"
+}
+
+function test_concurrent_modification_during_upload_same_length() {
+  do_test_concurrent_modification_during_upload "same length"
+}
+
 run_suite "Remote execution and remote cache tests"


### PR DESCRIPTION
A major source of such failures are concurrent modifications, which are more easily debugged with the filename.

Work towards #28134