### PR TITLE
Update default OpenBSD JDK to 21

### DIFF
--- a/src/main/cpp/blaze_util_bsd.cc
+++ b/src/main/cpp/blaze_util_bsd.cc
@@ -16,7 +16,7 @@
 # define HAVE_PROCSTAT
 # define STANDARD_JAVABASE "/usr/local/openjdk8"
 #elif defined(__OpenBSD__)
-# define STANDARD_JAVABASE "/usr/local/jdk-17"
+# define STANDARD_JAVABASE "/usr/local/jdk-21"
 #else
 # error This BSD is not supported
 #endif


### PR DESCRIPTION
Same reasons as 7cccf1cb5f7:
* OpenJDK 21 is now the latest in the OpenBSD ports collection.
* Plus 21 is now required for bootstrapping.

As before, the FreeBSD macro is not touched, since that port patches it out anyway.

Closes #28149