### PR TITLE
Add the current skykey to the Thread name during skyframe execution.

### DIFF
--- a/src/main/java/com/google/devtools/build/skyframe/AbstractParallelEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/AbstractParallelEvaluator.java
@@ -466,10 +466,14 @@ abstract class AbstractParallelEvaluator {
         try (var s =
             Profiler.instance()
                 .profile(ProfilerTask.SKYFUNCTION, skyKey.functionName().getName())) {
+          String originalThreadName = Thread.currentThread().getName();
           try {
             evaluatorContext.getProgressReceiver().stateStarting(skyKey, NodeState.COMPUTE);
+            Thread.currentThread()
+                .setName(String.format("%s-%s", originalThreadName, skyKey.toString()));
             value = skyFunction.compute(skyKey, env);
           } finally {
+            Thread.currentThread().setName(originalThreadName);
             evaluatorContext.getProgressReceiver().stateEnding(skyKey, NodeState.COMPUTE);
           }
         } catch (SkyFunctionException builderException) {


### PR DESCRIPTION
This helps to read thread dumps and identify what specifically is being processed during Bazel hangs.

Part of debugging https://github.com/dzbarsky/rules_rs/issues/14.

Sample output:
```
"skyframe-evaluator-execution-0-ActionLookupData0{actionLookupKey=ConfiguredTargetKey{label=//:slow, config=BuildConfigurationKey[cfa90bf0cae8a315a4a62101a1b7f102a8b918ee45d01c8e303ddda756c1496d]}, actionIndex=0}" #234 [54421] daemon prio=5 os_prio=0 cpu=73.05ms elapsed=3.79s tid=0x0000775dd89611d0 nid=54421 waiting on condition  [0x0000775cd74fd000]
```

RELNOTES: None.