### PR TITLE
[8.6.0] Partially revert "Make download cache entries read-only"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCache.java
@@ -246,8 +246,6 @@ public class DownloadCache {
     Path tmpName = cacheEntry.getRelative(TMP_PREFIX + UUID.randomUUID());
     cacheEntry.createDirectoryAndParents();
     fileWriter.writeTo(tmpName);
-    // Avoid corruption to the cache entry in case it is hardlinked elsewhere.
-    tmpName.setWritable(false);
     try {
       tmpName.renameTo(cacheValue);
     } catch (FileAccessException e) {


### PR DESCRIPTION
This reverts commit 65fe46347318c30df4b9e49827d4439afa8349a7.

Breaks repo rules that hit a download cache entry and subsequently attempt to overwrite the file (e.g. http_archive's handling of remote module files).

Keeps the added test as it doesn't depend on the change.

Work towards #28031

Closes #28148.

PiperOrigin-RevId: 852373210
Change-Id: I9e5e9ae87696068fbcb41cfd4dc77c36fea8248b

Commit https://github.com/bazelbuild/bazel/commit/d5dba3f70370abd3f875e412e49c807bfc6bedb0