### PR TITLE
[8.6.0] Prevent `InvalidPathException` in `rctx.download_and_extract`

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -127,11 +127,52 @@ public class HttpDownloaderTest {
               "testCanonicalId",
               Optional.empty(),
               fs.getPath(workingDir.newFile().getAbsolutePath()),
-              eventHandler,
               Collections.emptyMap(),
               "testRepo");
 
       assertThat(new String(readFile(resultingFile), UTF_8)).isEqualTo("hello");
+    }
+  }
+
+  @Test
+  public void downloadFrom1UrlOk_specialCharInBasename() throws IOException, InterruptedException {
+    try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName(null))) {
+      @SuppressWarnings("unused")
+      Future<?> possiblyIgnoredError =
+          executor.submit(
+              () -> {
+                try (Socket socket = server.accept()) {
+                  readHttpRequest(socket.getInputStream());
+                  sendLines(
+                      socket,
+                      "HTTP/1.1 200 OK",
+                      "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                      "Connection: close",
+                      "Content-Type: text/plain",
+                      "Content-Length: 5",
+                      "",
+                      "hello");
+                }
+                return null;
+              });
+
+      Path resultingFile =
+          download(
+              downloadManager,
+              Collections.singletonList(
+                  new URL(String.format("http://localhost:%d/arch:ve.zip", server.getLocalPort()))),
+              Collections.emptyMap(),
+              Collections.emptyMap(),
+              Optional.empty(),
+              "testCanonicalId",
+              Optional.of("zip"),
+              fs.getPath(workingDir.newFolder().getAbsolutePath()),
+              Collections.emptyMap(),
+              "testRepo");
+
+      assertThat(new String(readFile(resultingFile), UTF_8)).isEqualTo("hello");
+      assertThat(resultingFile.asFragment().getFileExtension()).isEqualTo("zip");
+      assertThat(resultingFile.asFragment().getBaseName()).doesNotContain(":");
     }
   }
 
@@ -193,7 +234,6 @@ public class HttpDownloaderTest {
               "testCanonicalId",
               Optional.empty(),
               fs.getPath(workingDir.newFile().getAbsolutePath()),
-              eventHandler,
               Collections.emptyMap(),
               "testRepo");
 
@@ -262,7 +302,6 @@ public class HttpDownloaderTest {
               "testCanonicalId",
               Optional.empty(),
               fs.getPath(workingDir.newFile().getAbsolutePath()),
-              eventHandler,
               Collections.emptyMap(),
               "testRepo");
 
@@ -333,7 +372,6 @@ public class HttpDownloaderTest {
             "testCanonicalId",
             Optional.empty(),
             outputFile,
-            eventHandler,
             Collections.emptyMap(),
             "testRepo");
         fail("Should have thrown");
@@ -678,7 +716,6 @@ public class HttpDownloaderTest {
                 "testCanonicalId",
                 Optional.empty(),
                 fs.getPath(workingDir.newFile().getAbsolutePath()),
-                eventHandler,
                 ImmutableMap.of(),
                 "testRepo"));
 
@@ -721,7 +758,6 @@ public class HttpDownloaderTest {
             "testCanonicalId",
             Optional.empty(),
             fs.getPath(workingDir.newFile().getAbsolutePath()),
-            eventHandler,
             ImmutableMap.of(),
             "testRepo");
 
@@ -769,7 +805,6 @@ public class HttpDownloaderTest {
             "testCanonicalId",
             Optional.empty(),
             fs.getPath(workingDir.newFile().getAbsolutePath()),
-            eventHandler,
             ImmutableMap.of(),
             "testRepo");
 
@@ -814,7 +849,6 @@ public class HttpDownloaderTest {
             "testCanonicalId",
             Optional.empty(),
             fs.getPath(workingDir.newFile().getAbsolutePath()),
-            eventHandler,
             ImmutableMap.of(),
             "testRepo");
 
@@ -862,7 +896,6 @@ public class HttpDownloaderTest {
             "testCanonicalId",
             Optional.empty(),
             fs.getPath(workingDir.newFile().getAbsolutePath()),
-            eventHandler,
             ImmutableMap.of(),
             "testRepo");
 
@@ -880,7 +913,6 @@ public class HttpDownloaderTest {
       String canonicalId,
       Optional<String> type,
       Path output,
-      ExtendedEventHandler eventHandler,
       Map<String, String> clientEnv,
       String context)
       throws IOException, InterruptedException {


### PR DESCRIPTION
Fixes #28121

Closes #28128.

PiperOrigin-RevId: 852374394
Change-Id: I4390a6c0581cc955494bf3be549b0ca9efd48c7b

Commit https://github.com/bazelbuild/bazel/commit/5578c0010781b3d30bc6818f16cfb9d5f4fde01e