### PR TITLE
[9.0.0] Expand `FileRoot` to its exec path in command lines

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactRoot.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactRoot.java
@@ -90,8 +90,9 @@ import net.starlark.java.eval.Printer;
  */
 @AutoCodec
 @Immutable
-public final class ArtifactRoot implements Comparable<ArtifactRoot>, FileRootApi {
+public final class ArtifactRoot implements Comparable<ArtifactRoot>, FileRootApi, CommandLineItem {
   private static final Interner<ArtifactRoot> INTERNER = Interners.newWeakInterner();
+
   /**
    * Do not use except in tests and in {@link
    * com.google.devtools.build.lib.skyframe.SkyframeExecutor}.
@@ -300,5 +301,10 @@ public final class ArtifactRoot implements Comparable<ArtifactRoot>, FileRootApi
   @Override
   public void repr(Printer printer) {
     printer.append(isSourceRoot() ? "<source root>" : "<derived root>");
+  }
+
+  @Override
+  public String expandToCommandLine() {
+    return getExecPathString();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/BUILD
@@ -96,6 +96,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/testutils:round-tripping",
+        "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",


### PR DESCRIPTION
Before this commit, `FileRoot` objects were stringified to their absolute (!) path with a `derived/source` suffix, which is neither hermetic nor useful.

In the future, when path mapping is restricted to path stripping, which can be applied to prefixes of full exec paths without knowing the full path, `FileRoot` objects can be path mapped automatically. Even before that happens, allowing users to e.g. do `args.add(ctx.bin_dir)` avoids a gotcha and makes it easier to write code that can be path mapped in the future.

Along the way improve test coverage by parametrizing tests in the choice of `NestedSet` vs. list.

Closes #28074.

PiperOrigin-RevId: 852347380
Change-Id: I7949849eb0aa6c69a946a3a9b38ad4cd8687ac27

Commit https://github.com/bazelbuild/bazel/commit/4db316592872e7550af933150c3c2c8c57da8188