### PR TITLE
[9.0.0] fix error message for experimental API flag

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -1043,7 +1043,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
     if (!getRuleContext().getConfiguration().allowMapDirectory()) {
       throw Starlark.errorf(
           "actions.map_directory() is an experimental API and is subjected to change. "
-              + "Please set the flag --experimental_starlark_action_templates_api to enable it.");
+              + "Please set the flag --experimental_allow_map_directory to enable it.");
     }
     context.checkMutable("actions.map_directory");
 


### PR DESCRIPTION
experimental_allow_map_directory is the new name, this was renamed after landing in dcc3f29361b3a29766081828107bdfb1f8f4079d

Closes #28094.

PiperOrigin-RevId: 852759958
Change-Id: I3a326daa2d8166fac92f234ac2618fa361bda276

Commit https://github.com/bazelbuild/bazel/commit/d563497764229a2055b7968b1d304ef4f35a4623