### PR TITLE
Avoid repo mapping lookup to check builtin restrictions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleConfiguredTargetBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleConfiguredTargetBuilder.java
@@ -42,7 +42,6 @@ import com.google.devtools.build.lib.analysis.test.TestProvider;
 import com.google.devtools.build.lib.analysis.test.TestProvider.TestParams;
 import com.google.devtools.build.lib.analysis.test.TestTagsProvider;
 import com.google.devtools.build.lib.cmdline.Label;
-import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
@@ -372,8 +371,7 @@ public final class RuleConfiguredTargetBuilder {
       if (rdeLabel != null
           && BuiltinRestriction.isNotAllowed(
               rdeLabel,
-              RepositoryMapping.EMPTY,
-              BuiltinRestriction.INTERNAL_STARLARK_API_ALLOWLIST)) {
+          BuiltinRestriction.INTERNAL_STARLARK_API_ALLOWLIST)) {
         ruleContext.ruleError(rdeLabel + " cannot access the _transitive_validation private API");
         return;
       }

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -1836,9 +1836,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
               // allow setting private attributes from initializers in builtins
               Label definitionLabel = currentRuleClass.getRuleDefinitionEnvironmentLabel();
               BuiltinRestriction.failIfLabelOutsideAllowlist(
-                  definitionLabel,
-                  targetDefinitionContext.getMainRepoMapping(),
-                  ALLOWLIST_RULE_EXTENSION_API_EXPERIMENTAL);
+                  definitionLabel, ALLOWLIST_RULE_EXTENSION_API_EXPERIMENTAL);
             }
             String nativeName = arg.startsWith("_") ? "$" + arg.substring(1) : arg;
             Attribute attr =

--- a/src/main/java/com/google/devtools/build/lib/packages/BuiltinRestriction.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuiltinRestriction.java
@@ -17,7 +17,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.cmdline.BazelModuleContext;
 import com.google.devtools.build.lib.cmdline.Label;
-import com.google.devtools.build.lib.cmdline.RepositoryMapping;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.Collection;
 import net.starlark.java.eval.EvalException;
@@ -47,7 +47,6 @@ public final class BuiltinRestriction {
               BuiltinRestriction.allowlistEntry("", "tools/build_defs/android"),
               BuiltinRestriction.allowlistEntry("", "third_party/bazel_rules/rules_android"),
               BuiltinRestriction.allowlistEntry("rules_android", ""),
-              BuiltinRestriction.allowlistEntry("build_bazel_rules_android", ""),
 
               // Apple rules
               BuiltinRestriction.allowlistEntry("", "third_party/apple_crosstool"),
@@ -55,7 +54,6 @@ public final class BuiltinRestriction {
                   "", "third_party/cpptoolchains/portable_llvm/build_defs"),
               BuiltinRestriction.allowlistEntry("", "third_party/bazel_rules/rules_apple"),
               BuiltinRestriction.allowlistEntry("rules_apple", ""),
-              BuiltinRestriction.allowlistEntry("build_bazel_rules_apple", ""),
 
               // Cc rules
               BuiltinRestriction.allowlistEntry("", "third_party/bazel_rules/rules_cc"),
@@ -84,7 +82,6 @@ public final class BuiltinRestriction {
               // Proto rules
               BuiltinRestriction.allowlistEntry("", "third_party/protobuf"),
               BuiltinRestriction.allowlistEntry("protobuf", ""),
-              BuiltinRestriction.allowlistEntry("com_google_protobuf", ""),
 
               // Shell rules
               BuiltinRestriction.allowlistEntry("rules_shell", ""));
@@ -120,9 +117,24 @@ public final class BuiltinRestriction {
       return new AutoValue_BuiltinRestriction_AllowlistEntry(apparentRepoName, packagePrefix);
     }
 
-    final boolean allows(Label label, RepositoryMapping repoMapping) {
-      return label.getRepository().equals(repoMapping.get(apparentRepoName()))
+    final boolean allows(Label label) {
+      return reposMatch(apparentRepoName(), label.getRepository())
           && label.getPackageFragment().startsWith(packagePrefix());
+    }
+
+    private static boolean reposMatch(String allowedName, RepositoryName givenName) {
+      if (allowedName.equals(RepositoryName.MAIN.getName())) {
+        return givenName.equals(RepositoryName.MAIN);
+      }
+      if (allowedName.equals(RepositoryName.BAZEL_TOOLS.getName())) {
+        return givenName.equals(RepositoryName.BAZEL_TOOLS);
+      }
+      if (allowedName.equals(RepositoryName.BUILTINS.getName())) {
+        return givenName.equals(RepositoryName.BUILTINS);
+      }
+      // allowedName is a module name and givenName is a real canonical repo name, so it belongs to
+      // any version of that module if and only if it contains <allowedName>+ as a prefix.
+      return givenName.getName().startsWith(allowedName + "+");
     }
   }
 
@@ -165,17 +177,16 @@ public final class BuiltinRestriction {
    */
   public static void failIfModuleOutsideAllowlist(
       BazelModuleContext moduleContext, Collection<AllowlistEntry> allowlist) throws EvalException {
-    failIfLabelOutsideAllowlist(moduleContext.label(), moduleContext.repoMapping(), allowlist);
+    failIfLabelOutsideAllowlist(moduleContext.label(), allowlist);
   }
 
   /**
    * Throws {@code EvalException} if the given {@link Label} is not within either 1) the builtins
    * repository, or 2) a package or subpackage of an entry in the given allowlist.
    */
-  public static void failIfLabelOutsideAllowlist(
-      Label label, RepositoryMapping repoMapping, Collection<AllowlistEntry> allowlist)
+  public static void failIfLabelOutsideAllowlist(Label label, Collection<AllowlistEntry> allowlist)
       throws EvalException {
-    if (isNotAllowed(label, repoMapping, allowlist)) {
+    if (isNotAllowed(label, allowlist)) {
       throw Starlark.errorf("file '%s' cannot use private API", label.getCanonicalForm());
     }
   }
@@ -184,11 +195,10 @@ public final class BuiltinRestriction {
    * Returns true if the given {@link Label} is not within both 1) the builtins repository, or 2) a
    * package or subpackage of an entry in the given allowlist.
    */
-  public static boolean isNotAllowed(
-      Label label, RepositoryMapping repoMapping, Collection<AllowlistEntry> allowlist) {
+  public static boolean isNotAllowed(Label label, Collection<AllowlistEntry> allowlist) {
     if (label.getRepository().getName().equals("_builtins")) {
       return false;
     }
-    return allowlist.stream().noneMatch(e -> e.allows(label, repoMapping));
+    return allowlist.stream().noneMatch(e -> e.allows(label));
   }
 }


### PR DESCRIPTION
BuiltinRestriction currently accounts for 10-20% of the total CPU time for `bazel build --nobuild //src:bazel`. This is improved by avoiding the repeated creation of "non-visible" `RepositoryName` objects, which trigger a `SpellChecker` computation. Instead, the apparent repo names, which are in fact either module names or legacy WORKSPACE repo names that no longer matter in Bazel 9 and later, are turned into canonical repo name prefixes by appending a `+`.

Note that there is still overhead in the 2-3% range even after this change due to repeated linear searches as well as repeated recreations of allowlists in the `check_private_api` C++ Starlark API.

This PR also closes a loophole where a module could give itself a repo name of e.g. `bazel_build_rules_android` to then use private APIs.