### PR TITLE
[9.0.0] Show stack traces in the remote repo contents cache with `--verbose_failures`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -803,7 +803,8 @@ public final class RemoteModule extends BlazeModule {
             env.getWorkspaceName(),
             remoteOptions.remoteInstanceName,
             remoteOptions.remoteAcceptCached,
-            remoteOptions.remoteUploadLocalResults));
+            remoteOptions.remoteUploadLocalResults,
+            verboseFailures));
     if (env.getDirectories().getOutputBase().getFileSystem()
         instanceof RemoteExternalOverlayFileSystem remoteFs) {
       remoteFs.beforeCommand(

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
@@ -24,6 +24,7 @@ import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.Tree;
 import com.google.common.base.Splitter;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
@@ -93,6 +94,7 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
   private final String commandId;
   private final boolean acceptCached;
   private final boolean uploadLocalResults;
+  private final boolean verboseFailures;
   private final DigestUtil digestUtil;
   private final Action baseAction;
 
@@ -101,12 +103,14 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
       String buildRequestId,
       String commandId,
       boolean acceptCached,
-      boolean uploadLocalResults) {
+      boolean uploadLocalResults,
+      boolean verboseFailures) {
     this.buildRequestId = buildRequestId;
     this.commandId = commandId;
     this.cache = cache;
     this.acceptCached = acceptCached;
     this.uploadLocalResults = uploadLocalResults;
+    this.verboseFailures = verboseFailures;
     this.digestUtil = cache.digestUtil;
     this.baseAction =
         Action.newBuilder()
@@ -142,7 +146,7 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
       reporter.handle(
           Event.warn(
               "Failed to read marker file repo %s, skipping: %s"
-                  .formatted(repoName, e.getMessage())));
+                  .formatted(repoName, maybeGetStackTrace(e))));
     }
     var action = buildAction(predeclaredInputHash);
     var actionKey = new ActionKey(digestUtil.compute(action));
@@ -168,12 +172,28 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
       reporter.handle(
           Event.warn(
               "Failed to upload repo contents to remote cache for repo %s: %s"
-                  .formatted(repoName, e.getMessage())));
+                  .formatted(repoName, maybeGetStackTrace(e))));
     }
   }
 
   @Override
   public boolean lookupCache(
+      RepositoryName repoName,
+      Path repoDir,
+      String predeclaredInputHash,
+      ExtendedEventHandler reporter)
+      throws IOException, InterruptedException {
+    try {
+      return doLookupCache(repoName, repoDir, predeclaredInputHash, reporter);
+    } catch (IOException e) {
+      throw new IOException(
+          "Failed to look up repo %s in the remote repo contents cache: %s"
+              .formatted(repoName, maybeGetStackTrace(e)),
+          e);
+    }
+  }
+
+  private boolean doLookupCache(
       RepositoryName repoName,
       Path repoDir,
       String predeclaredInputHash,
@@ -236,7 +256,8 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
       markerFileContent = new String(markerFileContentFuture.get(), StandardCharsets.ISO_8859_1);
       repoDirectoryContent = repoDirectoryContentFuture.get();
     } catch (ExecutionException e) {
-      throw new IllegalStateException("waitForBulkTransfer should have thrown", e);
+      throw new IllegalStateException(
+          "waitForBulkTransfer should have thrown: " + maybeGetStackTrace(e));
     }
     var markerFileLines =
         Splitter.on('\n')
@@ -283,6 +304,10 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
     return baseAction.toBuilder()
         .setSalt(ByteString.copyFrom(StringUnsafe.getByteArray(predeclaredInputHash)))
         .build();
+  }
+
+  private String maybeGetStackTrace(Exception e) {
+    return verboseFailures ? Throwables.getStackTraceAsString(e) : e.getMessage();
   }
 
   private record RepoRemotePathResolver(Path fetchedRepoMarkerFile, Path fetchedRepoDir)

--- a/src/main/java/com/google/devtools/build/lib/remote/RepositoryRemoteHelpersFactoryImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RepositoryRemoteHelpersFactoryImpl.java
@@ -31,6 +31,7 @@ class RepositoryRemoteHelpersFactoryImpl implements RepositoryRemoteHelpersFacto
   private final String remoteInstanceName;
   private final boolean acceptCached;
   private final boolean uploadLocalResults;
+  private final boolean verboseFailures;
 
   RepositoryRemoteHelpersFactoryImpl(
       CombinedCache cache,
@@ -40,7 +41,8 @@ class RepositoryRemoteHelpersFactoryImpl implements RepositoryRemoteHelpersFacto
       String workspaceName,
       String remoteInstanceName,
       boolean acceptCached,
-      boolean uploadLocalResults) {
+      boolean uploadLocalResults,
+      boolean verboseFailures) {
     this.cache = cache;
     this.remoteExecutor = remoteExecutor;
     this.buildRequestId = buildRequestId;
@@ -49,6 +51,7 @@ class RepositoryRemoteHelpersFactoryImpl implements RepositoryRemoteHelpersFacto
     this.remoteInstanceName = remoteInstanceName;
     this.acceptCached = acceptCached;
     this.uploadLocalResults = uploadLocalResults;
+    this.verboseFailures = verboseFailures;
   }
 
   @Nullable
@@ -72,6 +75,6 @@ class RepositoryRemoteHelpersFactoryImpl implements RepositoryRemoteHelpersFacto
   @Override
   public RemoteRepoContentsCache createRepoContentsCache() {
     return new RemoteRepoContentsCacheImpl(
-        cache, buildRequestId, commandId, acceptCached, uploadLocalResults);
+        cache, buildRequestId, commandId, acceptCached, uploadLocalResults, verboseFailures);
   }
 }


### PR DESCRIPTION
Makes it easier to debug issues with this experimental feature and also matches the behavior of remote execution/caching.

Work towards #27965

Closes #27970.

PiperOrigin-RevId: 853238791
Change-Id: Id46ccbb105d93fd17114fab13b086d0b46139fb4

Commit https://github.com/bazelbuild/bazel/commit/fc5f160593b5039f3cd10ae844e4eb7f5dce03b8