### PR TITLE
[9.0.0] Make --incompatible_enable_proto_toolchain_resolution default to true in Bazel

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -643,7 +643,7 @@ public final class BuildLanguageOptions extends OptionsBase {
   // Flip when dependencies to rules_* repos are upgraded and protobuf registers toolchains
   @Option(
       name = "incompatible_enable_proto_toolchain_resolution",
-      defaultValue = "false",
+      defaultValue = FlagConstants.DEFAULT_INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION,
       documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
@@ -1109,7 +1109,7 @@ public final class BuildLanguageOptions extends OptionsBase {
   public static final String INCOMPATIBLE_FAIL_ON_UNKNOWN_ATTRIBUTES =
       "+incompatible_fail_on_unknown_attributes";
   public static final String INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION =
-      "-incompatible_enable_proto_toolchain_resolution";
+      FlagConstants.DEFAULT_INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION_NAME;
   public static final String INCOMPATIBLE_DISABLE_NON_EXECUTABLE_JAVA_BINARY =
       "-incompatible_disable_non_executable_java_binary";
   public static final String INCOMPATIBLE_DISABLE_TARGET_DEFAULT_PROVIDER_FIELDS =

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/FlagConstants.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/FlagConstants.java
@@ -44,4 +44,8 @@ class FlagConstants {
       "+incompatible_package_group_has_public_syntax";
   public static final String INCOMPATIBLE_FIX_PACKAGE_GROUP_REPOROOT_SYNTAX =
       "+incompatible_fix_package_group_reporoot_syntax";
+
+  public static final String DEFAULT_INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION = "true";
+  public static final String DEFAULT_INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION_NAME =
+      "+incompatible_enable_proto_toolchain_resolution";
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/java/proto/StarlarkJavaLiteProtoLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/proto/StarlarkJavaLiteProtoLibraryTest.java
@@ -58,6 +58,7 @@ public class StarlarkJavaLiteProtoLibraryTest extends BuildViewTestCase {
 
   @Before
   public final void setUpMocks() throws Exception {
+    setBuildLanguageOptions("--incompatible_enable_proto_toolchain_resolution=false");
     useConfiguration(
         "--proto_compiler=//proto:compiler",
         "--proto_toolchain_for_javalite=//tools/proto/toolchains:javalite");


### PR DESCRIPTION
This change updates the default value of the --incompatible_enable_proto_toolchain_resolution flag to true for Bazel builds.

This is essentially an internal flag flip, coordinated with the protobuf upgrade in Bazel 9. Users are not expected to have to perform any migration.