### PR TITLE
Remove noisy warning recommending --test_verbose_timeout_warnings

### DIFF
--- a/docs/start/go.mdx
+++ b/docs/start/go.mdx
@@ -427,7 +427,6 @@ INFO: Build completed successfully, 1 total action
 //fortune:fortune_test                                          PASSED in 0.3s
 
 Executed 0 out of 1 test: 1 test passes.
-There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
 ```
 
 You can use the `...` wildcard to run all tests. Bazel will also build targets

--- a/site/en/start/go.md
+++ b/site/en/start/go.md
@@ -431,7 +431,6 @@ INFO: Build completed successfully, 1 total action
 //fortune:fortune_test                                          PASSED in 0.3s
 
 Executed 0 out of 1 test: 1 test passes.
-There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
 ```
 
 You can use the `...` wildcard to run all tests. Bazel will also build targets

--- a/src/main/java/com/google/devtools/build/lib/runtime/TerminalTestResultNotifier.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/TerminalTestResultNotifier.java
@@ -54,7 +54,6 @@ public class TerminalTestResultNotifier implements TestResultNotifier {
     int failedLocallyCount;
     int noStatusCount;
     int numberOfExecutedTargets;
-    boolean wasUnreportedWrongSize;
 
     int totalTestCases;
     int totalFailedTestCases;
@@ -189,10 +188,6 @@ public class TerminalTestResultNotifier implements TestResultNotifier {
         stats.failedLocallyCount++;
       }
 
-      if (summary.wasUnreportedWrongSize()) {
-        stats.wasUnreportedWrongSize = true;
-      }
-
       stats.totalTestCases += summary.getTotalTestCases();
       stats.totalUnknownTestCases += summary.getUnkownTestCases();
       stats.totalFailedTestCases += summary.getFailedTestCases().size();
@@ -323,11 +318,5 @@ public class TerminalTestResultNotifier implements TestResultNotifier {
           stats.noStatusCount,
           AnsiTerminalPrinter.Mode.DEFAULT));
     }
-
-    if (stats.wasUnreportedWrongSize) {
-       printer.print("There were tests whose specified size is too big. Use the "
-           + "--test_verbose_timeout_warnings command line option to see which "
-           + "ones these are.\n");
-     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/TestResultAggregator.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/TestResultAggregator.java
@@ -250,13 +250,12 @@ final class TestResultAggregator {
         .setRanRemotely(result.getData().getIsRemoteStrategy());
 
     List<String> warnings = new ArrayList<>();
-    if (status == BlazeTestStatus.PASSED
-        && shouldEmitTestSizeWarningInSummary(
-            policy.testVerboseTimeoutWarnings,
-            warnings,
-            result.getData().getTestProcessTimesList(),
-            target)) {
-      summary.setWasUnreportedWrongSize(true);
+    if (status == BlazeTestStatus.PASSED) {
+      shouldEmitTestSizeWarningInSummary(
+          policy.testVerboseTimeoutWarnings,
+          warnings,
+          result.getData().getTestProcessTimesList(),
+          target);
     }
 
     summary

--- a/src/main/java/com/google/devtools/build/lib/runtime/TestSummary.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/TestSummary.java
@@ -100,7 +100,6 @@ public class TestSummary implements Comparable<TestSummary>, BuildEventWithOrder
       setActionRan(existingSummary.actionRan);
       setNumCached(existingSummary.numCached);
       setRanRemotely(existingSummary.ranRemotely);
-      setWasUnreportedWrongSize(existingSummary.wasUnreportedWrongSize);
       mergeSystemFailure(existingSummary.getSystemFailure());
     }
 
@@ -319,13 +318,6 @@ public class TestSummary implements Comparable<TestSummary>, BuildEventWithOrder
     }
 
     @CanIgnoreReturnValue
-    public Builder setWasUnreportedWrongSize(boolean wasUnreportedWrongSize) {
-      checkMutation();
-      summary.wasUnreportedWrongSize = wasUnreportedWrongSize;
-      return this;
-    }
-
-    @CanIgnoreReturnValue
     public Builder mergeSystemFailure(@Nullable DetailedExitCode systemFailure) {
       checkMutation();
       summary.systemFailure =
@@ -403,7 +395,6 @@ public class TestSummary implements Comparable<TestSummary>, BuildEventWithOrder
   private int numLocalActionCached;
   private boolean actionRan;
   private boolean ranRemotely;
-  private boolean wasUnreportedWrongSize;
   private List<TestCase> failedTestCases = new ArrayList<>();
   private final List<TestCase> passedTestCases = new ArrayList<>();
   private final List<TestCase> skippedTestCases = new ArrayList<>();
@@ -500,10 +491,6 @@ public class TestSummary implements Comparable<TestSummary>, BuildEventWithOrder
 
   public boolean ranRemotely() {
     return ranRemotely;
-  }
-
-  public boolean wasUnreportedWrongSize() {
-    return wasUnreportedWrongSize;
   }
 
   public int getTotalTestCases() {

--- a/src/test/java/com/google/devtools/build/lib/runtime/TestSummaryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/TestSummaryTest.java
@@ -89,8 +89,7 @@ public class TestSummaryTest {
         .setStatus(BlazeTestStatus.PASSED)
         .setNumCached(NOT_CACHED)
         .setActionRan(true)
-        .setRanRemotely(false)
-        .setWasUnreportedWrongSize(false);
+        .setRanRemotely(false);
   }
 
   private List<Path> getPathList(String... names) {
@@ -705,7 +704,6 @@ public class TestSummaryTest {
         .setNumCached(numCached)
         .setActionRan(true)
         .setRanRemotely(false)
-        .setWasUnreportedWrongSize(false)
         .addFailedTestCases(emptyList, FailedTestCasesStatus.FULL)
         .addTestTimes(SMALL_TIMING)
         .build();


### PR DESCRIPTION
This warning seems to appear on almost every project I test things on,
implying that it's not very useful at driving any action, at the same
time it's noise that makes non-bazel-experts wonder if they're doing
something wrong, especially when they're adding a new test target.

Alternatively we could add yet another flag to disable this, but it
seems like it is fine to allow this flag to be one that is discovered
and passed manually when there is an issue.
