### PR TITLE
[6.6.0] Match postsubmit jobs with presubmit

### DIFF
--- a/.bazelci/build_bazel_binaries.yml
+++ b/.bazelci/build_bazel_binaries.yml
@@ -1,5 +1,6 @@
 ---
 platforms:
+  # This task actually runs Rocky Linux 8 (OpenJDK 11, gcc 10.2.1)
   centos7_java11_devtoolset10:
     build_targets:
       - "//src:bazel"
@@ -14,7 +15,7 @@ platforms:
     build_flags:
       - "-c"
       - "opt"
-  ubuntu2004:
+  ubuntu2004_java11:
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"
@@ -22,7 +23,7 @@ platforms:
       - "-c"
       - "opt"
   macos:
-    xcode_version: "13.0"
+    xcode_version: "16.2.0"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"
@@ -30,7 +31,7 @@ platforms:
       - "-c"
       - "opt"
   macos_arm64:
-    xcode_version: "13.0"
+    xcode_version: "16.2.0"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -1,10 +1,8 @@
 ---
 tasks:
+  # This task actually runs Rocky Linux 8 (OpenJDK 11, gcc 10.2.1)
   centos7_java11_devtoolset10:
     shell_commands:
-      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
-        android_ndk_repository/android_ndk_repository/' WORKSPACE
-      - rm -f WORKSPACE.bak
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
     build_flags:
@@ -20,6 +18,7 @@ tasks:
       - "//src:test_repos"
       - "//src/main/java/..."
     test_flags:
+      - "--test_output=errors"
       - "--sandbox_default_allow_network=false"
       - "--sandbox_writable_path=$HOME/bazeltest"
       - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
@@ -27,6 +26,7 @@ tasks:
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/..."
       - "//src/tools/execlog/..."
       - "//src/tools/singlejar/..."
@@ -43,14 +43,16 @@ tasks:
       - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_gcc"
       - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"
       - "-//src/test/shell/bazel:bazel_coverage_sh_test"
+      # The CI infrastructure no longer supports these tests.
+      - "-//src/test/shell/bazel/android/..."
+      - "-//src/test/java/com/google/devtools/build/android/..."
+      # https://github.com/bazelbuild/bazel/issues/16526#issuecomment-1415858550
+      - "-//src/test/shell/bazel:python_version_test"
     include_json_profile:
       - build
       - test
   ubuntu1804:
     shell_commands:
-      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
-        android_ndk_repository/android_ndk_repository/' WORKSPACE
-      - rm -f WORKSPACE.bak
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
     build_flags:
@@ -64,6 +66,7 @@ tasks:
       - "//src:test_repos"
       - "//src/main/java/..."
     test_flags:
+      - "--test_output=errors"
       - "--sandbox_default_allow_network=false"
       - "--sandbox_writable_path=$HOME/bazeltest"
       - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
@@ -73,6 +76,7 @@ tasks:
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/..."
       - "//src/tools/execlog/..."
       - "//src/tools/singlejar/..."
@@ -83,6 +87,9 @@ tasks:
       - "//tools/python/..."
       # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
       - "-//src/java_tools/import_deps_checker/..."
+      # The CI infrastructure no longer supports these tests.
+      - "-//src/test/shell/bazel/android/..."
+      - "-//src/test/java/com/google/devtools/build/android/..."
     include_json_profile:
       - build
       - test
@@ -93,9 +100,6 @@ tasks:
       CC_CONFIGURE_DEBUG: 1
     name: "Clang"
     shell_commands:
-      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
-        android_ndk_repository/android_ndk_repository/' WORKSPACE
-      - rm -f WORKSPACE.bak
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
     build_flags:
@@ -108,6 +112,7 @@ tasks:
       - "//src:test_repos"
       - "//src/main/java/..."
     test_flags:
+      - "--test_output=errors"
       - "--sandbox_default_allow_network=false"
       - "--sandbox_writable_path=$HOME/bazeltest"
       - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
@@ -117,11 +122,8 @@ tasks:
     include_json_profile:
       - build
       - test
-  ubuntu2004:
+  ubuntu2004_java11:
     shell_commands:
-      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
-        android_ndk_repository/android_ndk_repository/' WORKSPACE
-      - rm -f WORKSPACE.bak
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
     build_flags:
@@ -135,6 +137,7 @@ tasks:
       - "//src:test_repos"
       - "//src/main/java/..."
     test_flags:
+      - "--test_output=errors"
       - "--sandbox_default_allow_network=false"
       - "--sandbox_writable_path=$HOME/bazeltest"
       - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
@@ -144,6 +147,7 @@ tasks:
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/..."
       - "//src/tools/execlog/..."
       - "//src/tools/singlejar/..."
@@ -154,21 +158,20 @@ tasks:
       - "//tools/python/..."
       # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
       - "-//src/java_tools/import_deps_checker/..."
+      # The CI infrastructure no longer supports these tests.
+      - "-//src/test/shell/bazel/android/..."
+      - "-//src/test/java/com/google/devtools/build/android/..."
     include_json_profile:
       - build
       - test
   macos:
-    xcode_version: "14.2"
+    xcode_version: "16.2.0"
     shell_commands:
-      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
-        android_ndk_repository/android_ndk_repository/' WORKSPACE
-      - rm -f WORKSPACE.bak
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
       - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
     build_flags:
       - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
-      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
       - "--test_env=TEST_REPOSITORY_HOME=$HOME/bazeltest/external"
       - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
       - "--noremote_accept_cached"
@@ -178,7 +181,8 @@ tasks:
       - "//src:test_repos"
       - "//src/main/java/..."
     test_flags:
-      - "--sandbox_default_allow_network=false"
+      - "--test_output=errors"
+      - "--sandbox_default_allow_network=true"
       - "--sandbox_writable_path=$HOME/bazeltest"
       - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
       - "--test_env=TEST_REPOSITORY_HOME=$HOME/bazeltest/external"
@@ -188,6 +192,7 @@ tasks:
       - "--local_test_jobs=8"
     test_targets:
       - "//scripts/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/..."
       - "//src/tools/execlog/..."
       - "//src/tools/singlejar/..."
@@ -197,6 +202,9 @@ tasks:
       - "//tools/aquery_differ/..."
       - "//tools/osx/crosstool/..."
       - "//tools/python/..."
+      # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
+      - "-//src/java_tools/buildjar/..."
+      - "-//src/java_tools/import_deps_checker/..."
       # C++ coverage is not supported on macOS yet.
       - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
       # https://github.com/bazelbuild/bazel/issues/16526
@@ -208,9 +216,6 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/16526#issuecomment-1415858550
       - "-//src/test/shell/bazel:python_version_test"
       - "-//src/test/py/bazel:runfiles_test"
-      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
-      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_platforms"
       - "-//tools/python:pywrapper_test"
       # https://github.com/bazelbuild/bazel/issues/17410
       - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
@@ -223,12 +228,14 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/17457
       - "-//src/test/shell/bazel:jdeps_test"
       - "-//scripts/docs:rewriter_test"
+      # The CI infrastructure no longer supports these tests.
+      - "-//src/test/shell/bazel/android/..."
+      - "-//src/test/java/com/google/devtools/build/android/..."
     include_json_profile:
       - build
       - test
   windows:
     batch_commands:
-      - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
       - mkdir C:\b
       - mklink /J C:\b\bazeltest_external %OUTPUT_BASE:/=\%\external
     build_flags:
@@ -244,6 +251,7 @@ tasks:
       - "//src:test_repos"
       - "//src/main/java/..."
     test_flags:
+      - "--test_output=errors"
       - "--copt=-w"
       - "--host_copt=-w"
       - "--test_tag_filters=-no_windows,-slow"
@@ -253,8 +261,8 @@ tasks:
       - "--test_env=TEST_REPOSITORY_HOME=C:/b/bazeltest_external"
     test_targets:
       - "//src:embedded_tools_size_test"
+      - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/cpp/..."
-      - "//src/test/java/com/google/devtools/build/android/..."
       - "//src/test/java/com/google/devtools/build/lib/..."
       - "//src/test/java/com/google/devtools/build/skyframe/..."
       - "//src/test/java/com/google/devtools/common/options/..."
@@ -291,37 +299,40 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/remote:remote"
       - "-//src/test/shell/bazel/remote/..."
       - "-//tools/python:pywrapper_test"
+      # https://github.com/bazelbuild/bazel/issues/16526#issuecomment-1415858550
+      - "-//src/test/shell/bazel:python_version_test"
+      # The CI infrastructure no longer supports these tests.
+      - "-//src/test/shell/bazel/android/..."
+      - "-//src/test/java/com/google/devtools/build/android/..."
     include_json_profile:
       - build
       - test
   rbe_ubuntu1804:
     platform: ubuntu1804
-    shell_commands:
-      - sed -i.bak
-        -e 's/^# android_sdk_repository/android_sdk_repository/'
-        -e 's/^# android_ndk_repository/android_ndk_repository/' WORKSPACE
-      - rm -f WORKSPACE.bak
+    name: "RBE"
     build_flags:
       - "--config=ubuntu1804_java11"
       - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"
       - "--jobs=200"
-      - "--experimental_remote_download_outputs=minimal"
-      - "--experimental_inmemory_jdeps_files"
-      - "--experimental_inmemory_dotd_files"
+      - "--experimental_remote_cache_async"
+      - "--experimental_remote_merkle_tree_cache"
+      - "--remote_download_minimal"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src/main/java/..."
     test_flags:
+      - "--test_output=errors"
       - "--config=ubuntu1804_java11"
       - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"
       - "--jobs=200"
-      - "--experimental_remote_download_outputs=minimal"
-      - "--experimental_inmemory_jdeps_files"
-      - "--experimental_inmemory_dotd_files"
+      - "--experimental_remote_cache_async"
+      - "--experimental_remote_merkle_tree_cache"
+      - "--remote_download_minimal"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/..."
       - "//src/tools/execlog/..."
       - "//src/tools/singlejar/..."
@@ -347,16 +358,15 @@ tasks:
       - "-//src/test/py/bazel:bazel_yanked_versions_test"
       - "-//src/test/py/bazel:bzlmod_query_test"
       - "-//src/test/shell/bazel:verify_workspace"
+      # The CI infrastructure no longer supports these tests.
+      - "-//src/test/shell/bazel/android/..."
+      - "-//src/test/java/com/google/devtools/build/android/..."
     include_json_profile:
       - build
       - test
   kythe_ubuntu2004:
-    shell_commands:
-    - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/'
-      -e 's/^# android_ndk_repository/android_ndk_repository/' WORKSPACE
-    - rm -f WORKSPACE.bak
     index_flags:
-    - "--define=kythe_corpus=github.com/bazelbuild/bazel"
-    index_targets_query: "kind(\"cc_(binary|library|test|proto_library) rule\", ...) union kind(\"java_(binary|import|library|plugin|test|proto_library) rule\", ...) union kind(\"proto_library rule\", ...)"
+      - "--define=kythe_corpus=github.com/bazelbuild/bazel"
+    index_targets_query: 'kind("cc_(binary|library|test|proto_library) rule", ...) union kind("java_(binary|import|library|plugin|test|proto_library) rule", ...) union kind("proto_library rule", ...)'
     index_upload_policy: Always
     index_upload_gcs: True

--- a/.bazelci/postsubmit_bzlmod.yml
+++ b/.bazelci/postsubmit_bzlmod.yml
@@ -1,5 +1,6 @@
 ---
 tasks:
+  # This task actually runs Rocky Linux 8 (OpenJDK 11, gcc 10.2.1)
   centos7_java11_devtoolset10:
     build_flags:
       - "--config=bzlmod"
@@ -20,13 +21,13 @@ tasks:
       - "--config=bzlmod"
     build_targets:
       - "//src:bazel_nojdk"
-  ubuntu2004:
+  ubuntu2004_java11:
     build_flags:
       - "--config=bzlmod"
     build_targets:
       - "//src:bazel_nojdk"
   macos:
-    xcode_version: "13.0"
+    xcode_version: "16.2.0"
     build_flags:
       - "--config=bzlmod"
     build_targets:
@@ -35,4 +36,4 @@ tasks:
     build_flags:
       - "--config=bzlmod"
     build_targets:
-      - "//src:bazel_nojdk"
+      - "//src:bazel_nojdk.exe"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -221,7 +221,6 @@ tasks:
       # The CI infrastructure no longer supports these tests.
       - "-//src/test/shell/bazel/android/..."
       - "-//src/test/java/com/google/devtools/build/android/..."
-      
   windows:
     shards: 4
     batch_commands:
@@ -251,7 +250,6 @@ tasks:
       - "//src:embedded_tools_size_test"
       - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/cpp/..."
-      - "//src/test/java/com/google/devtools/build/android/..."
       - "//src/test/java/com/google/devtools/build/lib/..."
       - "//src/test/java/com/google/devtools/build/skyframe/..."
       - "//src/test/java/com/google/devtools/common/options/..."
@@ -293,7 +291,6 @@ tasks:
       # The CI infrastructure no longer supports these tests.
       - "-//src/test/shell/bazel/android/..."
       - "-//src/test/java/com/google/devtools/build/android/..."
-
   rbe_ubuntu1804:
     platform: ubuntu1804
     name: "RBE"
@@ -348,11 +345,10 @@ tasks:
       # The CI infrastructure no longer supports these tests.
       - "-//src/test/shell/bazel/android/..."
       - "-//src/test/java/com/google/devtools/build/android/..."
-
   kythe_ubuntu2004:
     index_flags:
-    - "--define=kythe_corpus=github.com/bazelbuild/bazel"
-    index_targets_query: "kind(\"cc_(binary|library|test|proto_library) rule\", ...) union kind(\"java_(binary|import|library|plugin|test|proto_library) rule\", ...) union kind(\"proto_library rule\", ...)"
+      - "--define=kythe_corpus=github.com/bazelbuild/bazel"
+    index_targets_query: 'kind("cc_(binary|library|test|proto_library) rule", ...) union kind("java_(binary|import|library|plugin|test|proto_library) rule", ...) union kind("proto_library rule", ...)'
     index_upload_policy: Always
     index_upload_gcs: False
   docs_ubuntu1804:


### PR DESCRIPTION
Fixes postsubmit job failures after merging #27463 by aligning the `.bazelci` postsubmit jobs with `.bazelci/presubmit.yml`. Specifically:

- Disabled Android setup and test targets due to infrastructure changes (including but not limited to bazelbuild/continuous-integration#2408).

- Updated the `ubuntu2004` jobs to `ubuntu2004_java11` (not that it should matter after the `*_for_testing` repo fix from #27463).

- Updated the `xcode_version` of `macos` jobs.

Contains other touch-ups to synchronize build images, build flags, test flags, and test targets, as well as to make minor formatting changes.

Produced most changes via: `vimdiff .bazelci/p{re,ost}submit.yml`. The remaining differences are:

- No sharding in postsubmit jobs.

- Setting `--noremote_accept_cached` in postsubmit jobs

- Including `include_json_profile` blocks in postsubmit jobs.

- The `kythe_ubuntu2004` job sets `index_upload_gcs` to `False` in presubmit and `True` in postsubmit.

- The `docs_ubuntu1804` job only exists in presubmit.

Part of #28177.