### PR TITLE
[9.0.0] Classify UnknownHostException as retriable for repository

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -44,6 +44,7 @@ import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -381,7 +382,9 @@ public class DownloadManager {
   }
 
   private boolean isRetryableException(Throwable e) {
-    return e instanceof ContentLengthMismatchException || e instanceof SocketException;
+    return e instanceof ContentLengthMismatchException
+        || e instanceof SocketException
+        || e instanceof UnknownHostException;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
@@ -158,7 +158,9 @@ class HttpConnector {
         } catch (UnknownHostException e) {
           String message = "Unknown host: " + e.getMessage();
           eventHandler.handle(Event.progress(message));
-          throw new UnrecoverableHttpException(message);
+          IOException httpException = new UnrecoverableHttpException(message);
+          httpException.addSuppressed(e);
+          throw httpException;
         } catch (IllegalArgumentException e) {
           // This will happen if the user does something like specify a port greater than 2^16-1.
           throw new UnrecoverableHttpException(e.getMessage());


### PR DESCRIPTION
UnknownHostException can represent a transient failure in DNS.
Permit this exception to trigger the retry logic for the download loop.

Closes #28023.

PiperOrigin-RevId: 854154072
Change-Id: I84bca74b00af1bbbb322ecc3f8697ed252dbfe64

Commit https://github.com/bazelbuild/bazel/commit/8fe8d5556095f7ffd57b9555960e2fce8e264fc9