### PR TITLE
[6.6.0] Add dummy //:maven-srcs target for 6.6.0 release

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,9 +1,9 @@
 # Bazel - Google's Build System
 
-load("//tools/distributions:distribution_rules.bzl", "distrib_jar_filegroup")
-load("//tools/python:private/defs.bzl", "py_binary")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//tools/distributions:distribution_rules.bzl", "distrib_jar_filegroup")
+load("//tools/python:private/defs.bzl", "py_binary")
 
 package(default_visibility = ["//scripts/release:__pkg__"])
 
@@ -36,10 +36,10 @@ filegroup(
         "//scripts:srcs",
         "//site:srcs",
         "//src:srcs",
-        "//tools:srcs",
-        "//third_party:srcs",
-        "//src/main/starlark/tests/builtins_bzl:srcs",
         "//src/main/java/com/google/devtools/build/docgen/release:srcs",
+        "//src/main/starlark/tests/builtins_bzl:srcs",
+        "//third_party:srcs",
+        "//tools:srcs",
     ] + glob([".bazelci/*"]) + [
         ".bazelrc",
         ".bazelversion",
@@ -155,6 +155,14 @@ pkg_tar(
     },
     strip_prefix = ".",
     # Public but bazel-only visibility.
+    visibility = ["//:__subpackages__"],
+)
+
+# https://github.com/bazelbuild/bazel/pull/27463#issuecomment-3730854621
+genrule(
+    name = "maven-srcs",
+    outs = ["maven-srcs.txt"],
+    cmd = "echo 'Dummy target to unblock the Bazel 6.6.0 release.' >$@",
     visibility = ["//:__subpackages__"],
 )
 


### PR DESCRIPTION
Fixes the following Rocky Linux 8 Bazel release job failure described in https://github.com/bazelbuild/bazel/pull/27463#issuecomment-3730668853:

```txt
ERROR: Skipping ':maven-srcs': no such target '//:maven-srcs':
  target 'maven-srcs' not declared in package ''
  defined by /workdir/BUILD
WARNING: Target pattern parsing failed.
ERROR: no such target '//:maven-srcs':
  target 'maven-srcs' not declared in package ''
  defined by /workdir/BUILD
```

Reproduced and confirmed the fix by executing the failing release job command locally:

```txt
./bazel-bin/src/bazel build --nobuild \
  :bazel-srcs :bootstrap-jars :maven-srcs //src:derived_java_srcs
```

Part of #28177.

---

Background from:

- https://github.com/bazelbuild/bazel/pull/27463#issuecomment-3730854621

`bazelbuild/continuous-integration/pipelines/bazel-release.yml` defines the failing Rocky Linux 8 job. (This was a CentOS 7 job prior to bazelbuild/continuous-integration#2281.)

- https://github.com/bazelbuild/continuous-integration/blob/agent-0.2.7/pipelines/bazel-release.yml#L85

bazelbuild/bazel@3d7937e329b5650fcc03e97b6f49e5deb4cadb9b introduced the `//:maven-srcs` target in Bazel 7.0.0. All the other targets in the failing `bazel build` invocation exist on the Bazel 6.6.0 branch.

bazelbuild/continuous-integration@14a03783d205697c7da49ae2c4294cbf1fa9aa9b added the `//:maven-srcs` target to this job as an attempt to fix `MODULE.bazel.lock` generation.

Neither the lock file nor the `//:maven-srcs` target itself should have any bearing on the Bazel 6.6.0 release. This dummy target fixes the build failure and allows the release to proceed.