### PR TITLE
Fix missing opening bracket in visibility documentation

### DIFF
--- a/site/en/concepts/visibility.md
+++ b/site/en/concepts/visibility.md
@@ -7,7 +7,7 @@ Book: /_book.yaml
 
 This page covers Bazel's three visibility systems:
 [target visibility](#target-visibility),
-transitive visibility](#transitive-visibility) and
+[transitive visibility](#transitive-visibility) and
 [load visibility](#load-visibility).
 
 These types of visibility help other developers distinguish between your


### PR DESCRIPTION
## Summary

Fixed a formatting issue in `site/en/concepts/visibility.md` where the first sentence was missing an opening bracket `[` for the markdown link to "transitive visibility".

## Changes

- Added missing `[` before "transitive visibility" on line 10

**Before:**
```
transitive visibility](#transitive-visibility)
```

**After:**
```
[transitive visibility](#transitive-visibility)
```

This was causing a rendering issue on https://bazel.build/concepts/visibility where the link was not properly formatted.