### PR TITLE
[8.6.0] Print name of files that fail to upload with INVALID_ARGUMENT (https://github.com/bazelbuild/bazel/pull/28137)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * An interface for a remote caching protocol.
@@ -124,6 +125,12 @@ public interface RemoteCacheClient extends MissingDigestsFinder {
     /** Get an input stream for the blob's data. Can be called multiple times. */
     InputStream get() throws IOException;
 
+    /** An optional human-readable description of the blob's source. */
+    @Nullable
+    default String description() {
+      return null;
+    }
+
     @Override
     default void close() {}
   }
@@ -138,7 +145,20 @@ public interface RemoteCacheClient extends MissingDigestsFinder {
    */
   default ListenableFuture<Void> uploadFile(
       RemoteActionExecutionContext context, Digest digest, Path file) {
-    return uploadBlob(context, digest, () -> new LazyFileInputStream(file));
+    return uploadBlob(
+        context,
+        digest,
+        new Blob() {
+          @Override
+          public InputStream get() {
+            return new LazyFileInputStream(file);
+          }
+
+          @Override
+          public String description() {
+            return "file " + file;
+          }
+        });
   }
 
   /**


### PR DESCRIPTION
A major source of such failures are concurrent modifications, which are more easily debugged with the filename.

Work towards #28134

Closes #28137.

PiperOrigin-RevId: 855220277
Change-Id: I378f8bad0c94fc7328c4f74fbc6fa4ac26560a4d

Commit https://github.com/bazelbuild/bazel/commit/fcaf0ba1ee762c4ae898bc18c80d3893e48e965d