### PR TITLE
[9.0.0] Fix repo mapping usage in `RuleConfiguredTargetBuilder.propagateTransitiveValidationOutputGroups`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleConfiguredTargetBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleConfiguredTargetBuilder.java
@@ -42,7 +42,6 @@ import com.google.devtools.build.lib.analysis.test.TestProvider;
 import com.google.devtools.build.lib.analysis.test.TestProvider.TestParams;
 import com.google.devtools.build.lib.analysis.test.TestTagsProvider;
 import com.google.devtools.build.lib.cmdline.Label;
-import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
@@ -364,7 +363,7 @@ public final class RuleConfiguredTargetBuilder {
    * <p>This is done within {@link RuleConfiguredTargetBuilder} so that every rule always and
    * automatically propagates the validation action output group.
    */
-  private void propagateTransitiveValidationOutputGroups() {
+  private void propagateTransitiveValidationOutputGroups() throws InterruptedException {
     if (outputGroupBuilders.containsKey(OutputGroupInfo.VALIDATION_TRANSITIVE)) {
       Label rdeLabel =
           ruleContext.getRule().getRuleClassObject().getRuleDefinitionEnvironmentLabel();
@@ -372,7 +371,7 @@ public final class RuleConfiguredTargetBuilder {
       if (rdeLabel != null
           && BuiltinRestriction.isNotAllowed(
               rdeLabel,
-              RepositoryMapping.EMPTY,
+              ruleContext.getAnalysisEnvironment().getMainRepoMapping(),
               BuiltinRestriction.INTERNAL_STARLARK_API_ALLOWLIST)) {
         ruleContext.ruleError(rdeLabel + " cannot access the _transitive_validation private API");
         return;


### PR DESCRIPTION
Work towards https://github.com/bazelbuild/rules_java/issues/342

Closes #28232.

PiperOrigin-RevId: 855228672
Change-Id: I7b3fcacd9d92e70b772bd06b274ce9459de9b68a

Commit https://github.com/bazelbuild/bazel/commit/893a75a68a6a4d42cda3e12e16b60bf93da19011