### PR TITLE
[9.0.0] Don't keep the journal of a PersistentMap open

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/BUILD
@@ -64,7 +64,6 @@ java_test(
     name = "RewindingTest",
     srcs = ["RewindingTest.java"],
     shard_count = 12,
-    tags = ["no_windows"],  # BuildIntegrationTestCase isn't fully compatible with Windows.
     deps = [
         ":rewinding_tests_helper",
         "//src/main/java/com/google/devtools/build/lib:runtime",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTest.java
@@ -83,6 +83,7 @@ public final class RewindingTest extends BuildIntegrationTestCase {
   protected void setupOptions() throws Exception {
     super.setupOptions();
     addOptions(
+        "--enable_runfiles",
         "--spawn_strategy=standalone",
         "--noexperimental_merged_skyframe_analysis_execution",
         "--rewind_lost_inputs",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
@@ -1812,6 +1812,7 @@ public class RewindingTestsHelper {
       HashSet<String> expectedRewoundGenrules =
           new HashSet<>(ImmutableList.of("//middle:gen1", "//middle:gen2"));
       int i = 0;
+      boolean sourceManifestActionSeen = false;
       while (i < 5) {
         assertThat(rewoundKeys.get(i)).isInstanceOf(ActionLookupData.class);
         ActionLookupData actionKey = (ActionLookupData) rewoundKeys.get(i);
@@ -1819,14 +1820,16 @@ public class RewindingTestsHelper {
         i++;
         if (actionLabel.equals("//middle:tool")) {
           switch (actionKey.getActionIndex()) {
-            case 0: // SymlinkAction
-              break;
-            case 1: // SourceManifestAction
-              assertActionKey(rewoundKeys.get(i), "//middle:tool", 2);
-              i++;
-              break;
-            default:
-              fail(String.format("Unexpected action index. actionKey: %s, i: %s", actionKey, i));
+            // SymlinkAction
+            case 0 -> {}
+            case 1 -> sourceManifestActionSeen = true;
+            // SymlinkTreeAction
+            case 2 -> assertThat(sourceManifestActionSeen).isTrue();
+            default ->
+                fail(
+                    String.format(
+                        "Unexpected action index. actionKey: %s, rewoundKeys: %s",
+                        actionKey, rewoundKeys));
           }
         } else {
           assertThat(expectedRewoundGenrules.remove(actionLabel)).isTrue();
@@ -1981,32 +1984,30 @@ public class RewindingTestsHelper {
 
     if (buildRunfileManifests()) {
       assertThat(rewoundKeys).hasSize(5);
-      int i = 0;
-      while (i < 4) {
+      boolean sourceManifestActionSeen = false;
+      for (int i = 0; i < 4; i++) {
         assertThat(rewoundKeys.get(i)).isInstanceOf(ActionLookupData.class);
         ActionLookupData actionKey = (ActionLookupData) rewoundKeys.get(i);
         String actionLabel = actionKey.getLabel().getCanonicalForm();
-        i++;
         if (actionLabel.equals("//test:tool")) {
           switch (actionKey.getActionIndex()) {
-            case 0: // SymlinkAction
-              break;
-            case 1: // SourceManifestAction
-              assertActionKey(rewoundKeys.get(i), "//test:tool", /* index= */ 2);
-              i++;
-              break;
-            default:
-              fail(
-                  String.format(
-                      "Unexpected action index. actionKey: %s, rewoundKeys: %s",
-                      actionKey, rewoundKeys));
+            // SymlinkAction
+            case 0 -> {}
+            case 1 -> sourceManifestActionSeen = true;
+            // SymlinkTreeAction
+            case 2 -> assertThat(sourceManifestActionSeen).isTrue();
+            default ->
+                fail(
+                    String.format(
+                        "Unexpected action index. actionKey: %s, rewoundKeys: %s",
+                        actionKey, rewoundKeys));
           }
         } else {
           assertThat(actionLabel).isEqualTo("//test:rule1");
         }
       }
 
-      assertActionKey(rewoundKeys.get(i++), "//test:tool", /* index= */ 3);
+      assertActionKey(rewoundKeys.get(4), "//test:tool", /* index= */ 3);
     } else {
       assertThat(rewoundKeys).hasSize(3);
       int i = 0;
@@ -2126,6 +2127,7 @@ public class RewindingTestsHelper {
     if (buildRunfileManifests()) {
       assertThat(rewoundKeys).hasSize(6);
       int i = 0;
+      boolean sourceManifestActionSeen = false;
       while (i < 5) {
         assertThat(rewoundKeys.get(i)).isInstanceOf(ActionLookupData.class);
         ActionLookupData actionKey = (ActionLookupData) rewoundKeys.get(i);
@@ -2133,14 +2135,16 @@ public class RewindingTestsHelper {
         i++;
         if (actionLabel.equals("//middle:tool")) {
           switch (actionKey.getActionIndex()) {
-            case 0: // SymlinkAction
-              break;
-            case 1: // SourceManifestAction
-              assertActionKey(rewoundKeys.get(i), "//middle:tool", 2);
-              i++;
-              break;
-            default:
-              fail(String.format("Unexpected action index. actionKey: %s", actionKey));
+            // SymlinkAction
+            case 0 -> {}
+            case 1 -> sourceManifestActionSeen = true;
+            // SymlinkTreeAction
+            case 2 -> assertThat(sourceManifestActionSeen).isTrue();
+            default ->
+                fail(
+                    String.format(
+                        "Unexpected action index. actionKey: %s, rewoundKeys: %s",
+                        actionKey, rewoundKeys));
           }
         } else {
           assertThat(actionLabel).isEqualTo("//middle:gen_tree");


### PR DESCRIPTION
This ensures that the journal file is not kept open after a build, which has been observed to cause `RewindingTest` to fail on Windows, which disallows deleting open files (in this case during test case cleanup).

Since the journal is written out at most every 3 seconds for all current usages of the `PersistentMap` class, the overhead of the additional `open` is negligible.

Also include small tweaks to `RewindingTest` so that it can be enabled on Windows. In particular, the order of `SymlinkAction` and `SourceManifestAction` being rewound doesn't seem to be fixed and can differ on Windows.

Closes #28108.

PiperOrigin-RevId: 855242645
Change-Id: Ic7434139b290c6b0e2061977f747e890c3c5ece6

Commit https://github.com/bazelbuild/bazel/commit/2be693e7badb63b5f12acd0c849b60fedd2aa513