### PR TITLE
[9.0.0] Speed up bazel_java_test.sh (https://github.com/bazelbuild/bazel/pull/28238)

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -315,7 +315,7 @@ JAVA_VERSIONS_COVERAGE = ("11", "17", "21")
             "@bazel_tools//tools/bash/runfiles",
         ],
         exec_compatible_with = ["//:highcpu_machine"],
-        shard_count = 2,
+        shard_count = 4,
         tags = [
             "requires-network",  # For Bzlmod
         ],

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -74,7 +74,6 @@ fi
 export TESTENV_DONT_BAZEL_CLEAN=1
 
 function tear_down() {
-  bazel shutdown
   rm -rf "$(bazel info bazel-bin)/java"
 }
 


### PR DESCRIPTION
According to some telemetry,
`//src/test/shell/bazel:bazel_java_test_jdk17_toolchain_head` took ~1500s at P90 on buildkite, so it is worth speeding it up.

Example run on my machine:
```
bazel test //src/test/shell/bazel:bazel_java_test_jdk17_toolchain_head                                                                                                                                                                                                              ─╯
INFO: Analyzed target //src/test/shell/bazel:bazel_java_test_jdk17_toolchain_head (1 packages loaded, 11 targets configured).
INFO: Found 1 test target...
Target //src/test/shell/bazel:bazel_java_test_jdk17_toolchain_head up-to-date:
  bazel-bin/src/test/shell/bazel/bazel_java_test_jdk17_toolchain_head
INFO: Elapsed time: 87.425s, Critical Path: 86.28s
INFO: 6 processes: 6 action cache hit, 2 internal, 4 linux-sandbox.
INFO: Build completed successfully, 6 total actions
//src/test/shell/bazel:bazel_java_test_jdk17_toolchain_head              PASSED in 86.2s
  Stats over 4 runs: max = 86.2s, min = 78.9s, avg = 82.8s, dev = 2.7s
```

Closes #28238.

PiperOrigin-RevId: 855220439
Change-Id: I37117549a7ed310c6e3de5af6273795e25f4147b

Commit https://github.com/bazelbuild/bazel/commit/6ba259585efb6e242393443acf4ae4614d18c065