### PR TITLE
Document required flags for building bazel-dev with rules_cc

### DIFF
--- a/site/en/install/compile-source.md
+++ b/site/en/install/compile-source.md
@@ -37,7 +37,7 @@ To build Bazel from source, you can do one of the following:
 
     **Note:** Many rulesets rely on the Bazel version for feature detection.
     For this to work correctly, the version must be embedded in the binary.
-    Build `bazel-dev` in the **8.x–9.0** range with:
+    Build `bazel-dev` with:
 
     `bazel build --stamp --embed_label="X.Y.Z" //src:bazel-dev`
 


### PR DESCRIPTION
Related: #28230.

Add a note explaining that --stamp and --embed_label are required for development builds in the 8.x–9.0 range so that rules_cc resolves correctly.