### PR TITLE
[9.0.0] Improve Bazel's analysis progress message style

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/AnalysisProgressReceiver.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/AnalysisProgressReceiver.java
@@ -66,19 +66,27 @@ public class AnalysisProgressReceiver {
    * targets and aspects configured so far.
    */
   public String getProgressString() {
-    String progress = "" + configuredTargetsCompleted + " ";
-    progress += (configuredTargetsCompleted.get() != 1) ? "targets" : "target";
-    if (configuredTargetsDownloaded.get() > 0) {
-      progress += " (" + configuredTargetsDownloaded + " remote cache hits)";
+    StringBuilder sb = new StringBuilder();
+
+    long targets = configuredTargetsCompleted.get();
+    sb.append(targets).append(targets == 1 ? " target" : " targets").append(" configured");
+
+    long downloadedTargets = configuredTargetsDownloaded.get();
+    if (downloadedTargets > 0) {
+      sb.append(" (").append(downloadedTargets).append(" remote cache hits)");
     }
-    if (configuredAspectsCompleted.get() > 0) {
-      progress += " and " + configuredAspectsCompleted + " ";
-      progress += (configuredAspectsCompleted.get() != 1) ? "aspects" : "aspect";
-      if (configuredAspectsDownloaded.get() > 0) {
-        progress += " (" + configuredAspectsDownloaded + " remote cache hits)";
+
+    long aspects = configuredAspectsCompleted.get();
+    if (aspects > 0) {
+      sb.append(", ")
+          .append(aspects)
+          .append(aspects == 1 ? " aspect application" : " aspect applications");
+      long downloadedAspects = configuredAspectsDownloaded.get();
+      if (downloadedAspects > 0) {
+        sb.append(" (").append(downloadedAspects).append(" remote cache hits)");
       }
     }
-    progress += " configured";
-    return progress;
+
+    return sb.toString();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/AnalysisProgressReceiverTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/AnalysisProgressReceiverTest.java
@@ -49,12 +49,12 @@ public class AnalysisProgressReceiverTest {
     progress.doneDownloadedConfiguredTarget();
     String progressString1 = progress.getProgressString();
 
-    assertThat(progressString1).contains("1 target (1 remote cache hits) configured");
+    assertThat(progressString1).contains("1 target configured (1 remote cache hits)");
 
     progress.doneConfigureTarget();
     String progressString2 = progress.getProgressString();
 
-    assertThat(progressString2).contains("2 targets (1 remote cache hits) configured");
+    assertThat(progressString2).contains("2 targets configured (1 remote cache hits)");
   }
 
   @Test
@@ -64,14 +64,14 @@ public class AnalysisProgressReceiverTest {
     String progressString1 = progress.getProgressString();
 
     assertWithMessage("One configured aspect should be visible in progress.")
-        .that(progressString1.contains("0 targets and 1 aspect configured"))
+        .that(progressString1.contains("0 targets configured, 1 aspect application"))
         .isTrue();
 
     progress.doneConfigureAspect();
     String progressString2 = progress.getProgressString();
 
     assertWithMessage("Two configured aspects should be visible in progress.")
-        .that(progressString2.contains("0 targets and 2 aspects configured"))
+        .that(progressString2.contains("0 targets configured, 2 aspect applications"))
         .isTrue();
   }
 
@@ -81,13 +81,14 @@ public class AnalysisProgressReceiverTest {
     progress.doneDownloadedConfiguredAspect();
     String progressString1 = progress.getProgressString();
 
-    assertThat(progressString1).contains("0 targets and 1 aspect (1 remote cache hits) configured");
+    assertThat(progressString1)
+        .contains("0 targets configured, 1 aspect application (1 remote cache hits)");
 
     progress.doneConfigureAspect();
     String progressString2 = progress.getProgressString();
 
     assertThat(progressString2)
-        .contains("0 targets and 2 aspects (1 remote cache hits) configured");
+        .contains("0 targets configured, 2 aspect applications (1 remote cache hits)");
   }
 
   @Test
@@ -104,7 +105,7 @@ public class AnalysisProgressReceiverTest {
     progress.doneConfigureAspect();
     String progressString3 = progress.getProgressString();
 
-    assertThat(progressString3).contains("1 target and 1 aspect configured");
+    assertThat(progressString3).contains("1 target configured, 1 aspect application");
   }
 
   @Test

--- a/src/test/shell/integration/nonincremental_builds_test.sh
+++ b/src/test/shell/integration/nonincremental_builds_test.sh
@@ -69,8 +69,8 @@ genrule(
     cmd = 'touch \$@'
 )
 EOF
-    INCREMENTAL_ANALYSIS_LOGLINE="Analy[sz]ed target //$pkg:top (0 packages loaded)"
-    NONINCREMENTAL_ANALYSIS_LOGLINE="Analy[sz]ed target //$pkg:top ([1-9][0-9]* packages loaded)"
+    INCREMENTAL_ANALYSIS_LOGLINE="Analy[sz]ed target //$pkg:top (0 packages loaded, [0-9]* targets configured)"
+    NONINCREMENTAL_ANALYSIS_LOGLINE="Analy[sz]ed target //$pkg:top ([1-9][0-9]* packages loaded, [0-9]* targets configured)"
 }
 
 # Test that the execution is not repeated, test to validate the test case


### PR DESCRIPTION
New style:
```
INFO: Analyzed 5 targets (2781 packages loaded, 280337 targets configured, 384 aspect applications)
```

Closes #28180.

PiperOrigin-RevId: 853783536
Change-Id: I45f4399a68c39933b7856bb40484515aeaab380f

Commit https://github.com/bazelbuild/bazel/commit/8f913cc270c30aeea70e3c430f0371445c028858