### PR TITLE
Add platform check to installer script.

### DIFF
--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -88,7 +88,25 @@ genrule(
     cmd = """
         release_info="$$(cat $(location :README.md))"
         template="$$(cat $(location template_bin.sh))"
-        echo "$${template//%release_info%/$${release_info}}" >$@
+        target_os=""" + select({
+        "//src/conditions:darwin": "\"darwin\"",
+        "//src/conditions:freebsd": "\"freebsd\"",
+        "//src/conditions:openbsd": "\"openbsd\"",
+        "//conditions:default": "\"linux\"",
+    }) + """
+        target_arch=""" + select({
+        "//src/conditions:linux_x86_64": "\"x86_64\"",
+        "//src/conditions:linux_aarch64": "\"aarch64\"",
+        "//src/conditions:darwin_x86_64": "\"x86_64\"",
+        "//src/conditions:darwin_arm64": "\"arm64\"",
+        "//src/conditions:linux_arm": "\"arm\"",
+        "//src/conditions:linux_ppc": "\"ppc\"",
+        "//src/conditions:linux_s390x": "\"s390x\"",
+        "//conditions:default": "\"x86_64\"",  # Fallback
+    }) + """
+        template="$${template//%release_info%/$$release_info}"
+        template="$${template//%target_os%/$$target_os}"
+        echo "$${template//%target_arch%/$$target_arch}" >$@
         """,
 )
 

--- a/scripts/packages/template_bin.sh
+++ b/scripts/packages/template_bin.sh
@@ -23,6 +23,29 @@ install_prefix=${1:-"/usr/local"}
 
 progname="$0"
 
+skip_platform_check=false
+for opt in "${@}"; do
+  case $opt in
+    --skip-platform-check)
+      skip_platform_check=true
+      ;;
+  esac
+done
+
+if [ "$skip_platform_check" = false ]; then
+  actual_os="$(uname -s | tr 'A-Z' 'a-z')"
+  if [ "${actual_os}" != "%target_os%" ]; then
+    echo "The Bazel installer you are running is for %target_os%, but you are running on $(uname -s)." >&2
+    exit 1
+  fi
+
+  actual_arch="$(uname -m)"
+  if [ "${actual_arch}" != "%target_arch%" ]; then
+    echo "The Bazel installer you are running is for %target_arch%, but you are running on ${actual_arch}." >&2
+    exit 1
+  fi
+fi
+
 echo "Bazel installer"
 echo "---------------"
 echo
@@ -45,6 +68,7 @@ usage() {
   echo '      --bin=$HOME/bin --base=$HOME/.bazel' >&2
   echo "  --skip-uncompress skip uncompressing the base image until the" >&2
   echo "      first bazel invocation" >&2
+  echo "  --skip-platform-check skip the platform compatibility check" >&2
   exit 1
 }
 
@@ -70,6 +94,9 @@ for opt in "${@}"; do
       ;;
     --skip-uncompress)
       should_uncompress=false
+      ;;
+    --skip-platform-check)
+      # Already handled at the beginning of the script
       ;;
     *)
       usage


### PR DESCRIPTION
You can still work around this by passing `--skip-platform-check`.

Fixes #1858