### PR TITLE
[9.0.0] Make overlaid files executable in `http_archive`

### DIFF
--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -189,7 +189,7 @@
   "moduleExtensions": {
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "GgIiVlvZqoYAjWaH9VUtDRf8f5X9Napi9dGAVJQhrzU=",
+        "bzlTransitiveDigest": "06cynZ1bCvvy8zHPrrDlXq+Z68xmjctHpfFxi+zEpJY=",
         "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
         "recordedInputs": [
           "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
@@ -211,7 +211,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "pbmJxEwJzfXQAt1h4//1aJNFbUurmReKAVNAgucRSuA=",
+        "bzlTransitiveDigest": "ABI1D/sbS1ovwaW/kHDoj8nnXjQ0oKU9fzmzEG4iT8o=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
@@ -268,7 +268,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "UU21jeC2Pw1VvcZk7WvUdCqZHiLX7oKNiFLS/SPaXr8=",
+        "bzlTransitiveDigest": "2hLgIvNVTLgxus0ZuXtleBe70intCfo0cHs8qvt6cdM=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
@@ -436,7 +436,7 @@
     },
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
-        "bzlTransitiveDigest": "zyNsrbgVKwpA0B3zI84imAfuC424VSzYNPgjr/HJy5M=",
+        "bzlTransitiveDigest": "ijW9KS7qsIY+yBVvJ+Nr1mzwQox09j13DnE3iIwaeTM=",
         "usagesDigest": "H8dQoNZcoqP+Mu0tHZTi4KHATzvNkM5ePuEqoQdklIU=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -107,6 +107,8 @@ def download_remote_files(ctx, auth = None):
             auth = get_auth(ctx, remote_file_urls) if auth == None else auth,
             integrity = ctx.attr.remote_file_integrity.get(path, ""),
             block = False,
+            # Overlaid files may be shell scripts.
+            executable = True,
         )
         for path, remote_file_urls in ctx.attr.remote_file_urls.items()
     }


### PR DESCRIPTION
This makes it possible to use registry overlays to add shell scripts.

Context: https://bazelbuild.slack.com/archives/C014RARENH0/p1767975320777969

Closes #28202.

PiperOrigin-RevId: 855699722
Change-Id: I65891a0cb6d7e99d70ab33c8b38f1c7da943fc09

Commit https://github.com/bazelbuild/bazel/commit/3efde5a407e00044c8ca0cbaaf3423f37813b7f9