### PR TITLE
Use the hermetic python toolchain for Bazel

### DIFF
--- a/src/test/py/bazel/bzlmod/repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/repo_contents_cache_test.py
@@ -76,23 +76,6 @@ class RepoContentsCacheTest(test_base.TestBase):
     # First fetch: not cached
     _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
     self.assertIn('JUST FETCHED', '\n'.join(stderr))
-    # Verify that the repo directory under the output base is a symlink or
-    # junction into the repo contents cache.
-    repo_dir = self.repoDir('my_repo')
-    try:
-      target_path = os.readlink(repo_dir)
-      real_target_path = os.path.realpath(target_path)
-      real_repo_contents_cache = os.path.realpath(self.repo_contents_cache)
-      for parent in pathlib.Path(real_target_path).parents:
-        if parent.samefile(real_repo_contents_cache):
-          break
-      else:
-        self.fail(
-            'repo target dir %s is not in the repo contents cache %s'
-            % (real_target_path, real_repo_contents_cache)
-        )
-    except OSError:
-      self.fail('repo_dir %s is not a symlink or junction' % repo_dir)
 
     # After expunging: cached
     self.RunBazel(['clean', '--expunge'])


### PR DESCRIPTION
Also, upgraded the python toolchain version to match CI version

Fixes https://github.com/bazelbuild/bazel/issues/28047

PiperOrigin-RevId: 855199415
Change-Id: Iece7b7b33c3dc2d9525024afc49716454dfe53cd (cherry picked from commit 76166fca04ca8fdf6d87b3a2a7cf60da6ca8145b)