### PR TITLE
Delete obsolete constraints from `@bazel_tools`

### DIFF
--- a/src/conditions/BUILD.tools
+++ b/src/conditions/BUILD.tools
@@ -144,35 +144,6 @@ config_setting(
 )
 
 config_setting(
-    name = "host_windows_x64_constraint",
-    deprecation = "No longer used by Bazel and will be removed in the future. Migrate to toolchains or define your own version of this setting.",
-    values = {"host_cpu": "x64_windows"},
-)
-
-config_setting(
-    name = "host_windows_arm64_constraint",
-    deprecation = "No longer used by Bazel and will be removed in the future. Migrate to toolchains or define your own version of this setting.",
-    values = {"host_cpu": "arm64_windows"},
-)
-
-alias(
-    name = "host_windows",
-    actual = select({
-        ":host_windows_arm64_constraint": ":host_windows_arm64_constraint",
-        "//conditions:default": ":host_windows_x64_constraint",
-    }),
-    deprecation = "No longer used by Bazel and will be removed in the future. Migrate to toolchains or define your own version of this setting.",
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "remote",
-    deprecation = "No longer used by Bazel and will be removed in the future. Migrate to toolchains or define your own version of this setting.",
-    values = {"define": "EXECUTOR=remote"},
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
     name = "debian_build",
     values = {
         "define": "distribution=debian",


### PR DESCRIPTION
These constraints had been deprecated for Bazel 9 and can now be removed. 

While they can trivially be copied into any rulesets that may still want to use them, toolchains are a superior replacement and hard-coded assumptions about the host or execution platform should generally be avoided.

RELNOTES[INC]: The `config_setting`s `@bazel_tools//src/conditions:{host_windows,remote}` have been removed. Toolchains are usually a better fit as they don't depend on the configuration of the host machine running Bazel and/or fixed execution modes.