### PR TITLE
[9.0.0] Use parseUnsignedLong for getNetIoCountersLinux

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/NetworkMetricsCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/NetworkMetricsCollector.java
@@ -160,12 +160,7 @@ public final class NetworkMetricsCollector {
   }
 
   private static long calcDelta(long prev, long next) {
-    // The next could wrap, and if that happens, assume prev is 0 (best effort).
-    if (next < prev) {
-      return next;
-    } else {
-      return next - prev;
-    }
+    return next - prev;
   }
 
   private static double calcValuePerSec(long deltaValue, double deltaNanos) {

--- a/src/main/java/com/google/devtools/build/lib/profiler/SystemNetworkStats.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/SystemNetworkStats.java
@@ -76,7 +76,10 @@ public class SystemNetworkStats {
       }
       String name = line.substring(0, colonAt).strip();
       long[] fields =
-          SPLITTER.splitToStream(line.substring(colonAt + 1)).mapToLong(Long::parseLong).toArray();
+          SPLITTER
+              .splitToStream(line.substring(colonAt + 1))
+              .mapToLong(Long::parseUnsignedLong)
+              .toArray();
       if (fields.length > 9) {
         long bytesRecv = fields[0];
         long packetsRecv = fields[1];


### PR DESCRIPTION
We had some users have this logic fail because of huge values in
`/proc/net/dev` like 10586847412485054478.

```
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.NumberFormatException: For input string: "10586847412485054478"
	at java.base/java.lang.NumberFormatException.forInputString(Unknown Source)
	at java.base/java.lang.Long.parseLong(Unknown Source)
	at java.base/java.lang.Long.parseLong(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$5$1.accept(Unknown Source)
	at java.base/java.util.Iterator.forEachRemaining(Unknown Source)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(Unknown Source)
	at java.base/java.util.stream.LongPipeline.toArray(Unknown Source)
	at com.google.devtools.build.lib.profiler.SystemNetworkStatsServiceImpl.getNetIoCountersLinux(SystemNetworkStatsServiceImpl.java:64)
	at com.google.devtools.build.lib.profiler.SystemNetworkStatsServiceImpl.getNetIoCounters(SystemNetworkStatsServiceImpl.java:43)
	at com.google.devtools.build.lib.profiler.NetworkMetricsCollector.collectSystemNetworkUsages(NetworkMetricsCollector.java:66)
	at com.google.devtools.build.lib.profiler.CollectLocalResourceUsage$SystemNetworkUsageCollector.collect(CollectLocalResourceUsage.java:489)
	at com.google.devtools.build.lib.profiler.CollectLocalResourceUsage$Collector.run(CollectLocalResourceUsage.java:200)
```

This is likely because we're using [RDMA over Converged
Ethernet](https://en.wikipedia.org/wiki/RDMA_over_Converged_Ethernet)
which massively inflates the transfer stats.

These values are u64s in the kernel so we should respect that
https://github.com/torvalds/linux/blob/187d0801404f415f22c0b31531982c7ea97fa341/include/uapi/linux/if_link.h#L219-L228

Closes #27966.

PiperOrigin-RevId: 856300911
Change-Id: Ic8a8373ac01b00084e33ba47565a6175010cf41f

Commit https://github.com/bazelbuild/bazel/commit/d34d6389adb8848e55626b4b45667c3278772c51