### PR TITLE
Fix COVERAGE_DIR permissions for split coverage post-processing

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -764,6 +764,15 @@ public class StandaloneTestStrategy extends TestStrategy {
               .add(testAction.getCoverageDirectoryTreeArtifact())
               .build();
 
+      // Make coverage directory writable for post-processing.
+      // The directory may have been made read-only after the test action completed.
+      Path coverageDirPath =
+          actionExecutionContext.getInputPath(testAction.getCoverageDirectoryTreeArtifact());
+      coverageDirPath.setWritable(true);
+      for (Artifact artifact : expandedCoverageDir) {
+        actionExecutionContext.getInputPath(artifact).setWritable(true);
+      }
+
       Spawn coveragePostProcessingSpawn =
           createCoveragePostProcessingSpawn(
               actionExecutionContext,

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -769,9 +769,6 @@ public class StandaloneTestStrategy extends TestStrategy {
       Path coverageDirPath =
           actionExecutionContext.getInputPath(testAction.getCoverageDirectoryTreeArtifact());
       coverageDirPath.setWritable(true);
-      for (Artifact artifact : expandedCoverageDir) {
-        actionExecutionContext.getInputPath(artifact).setWritable(true);
-      }
 
       Spawn coveragePostProcessingSpawn =
           createCoveragePostProcessingSpawn(


### PR DESCRIPTION
When --experimental_split_coverage_postprocessing is enabled, coverage post-processing runs as a separate spawn after the test action completes. However, Bazel makes test outputs (including COVERAGE_DIR) read-only after the test action, causing the coverage collection script to fail with "Permission denied" errors when trying to write coverage data.

This change makes the coverage directory and its contents writable before executing the coverage post-processing spawn.

Fixes: https://github.com/bazelbuild/bazel/issues/28310