### PR TITLE
ijar: preserve multi-release status

### DIFF
--- a/third_party/ijar/ijar.cc
+++ b/third_party/ijar/ijar.cc
@@ -17,10 +17,10 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <memory>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <memory>
 
 #include "third_party/ijar/zip.h"
 
@@ -51,10 +51,11 @@ const char *MANIFEST_DIR_PATH = "META-INF/";
 const size_t MANIFEST_DIR_PATH_LENGTH = strlen(MANIFEST_DIR_PATH);
 const char *MANIFEST_PATH = "META-INF/MANIFEST.MF";
 const size_t MANIFEST_PATH_LENGTH = strlen(MANIFEST_PATH);
-const char *MANIFEST_HEADER =
-    "Manifest-Version: 1.0\r\n"
-    "Created-By: bazel\r\n";
+const char *MANIFEST_HEADER = "Manifest-Version: 1.0\r\n"
+                              "Created-By: bazel\r\n";
 const size_t MANIFEST_HEADER_LENGTH = strlen(MANIFEST_HEADER);
+const char *MULTI_RELEASE_TRUE_LINE = "Multi-Release: true\r\n";
+const size_t MULTI_RELEASE_TRUE_LINE_LENGTH = strlen(MULTI_RELEASE_TRUE_LINE);
 // These attributes are used by JavaBuilder, Turbine, and ijar.
 // They must all be kept in sync.
 const char *TARGET_LABEL_KEY = "Target-Label: ";
@@ -66,16 +67,36 @@ const size_t DUMMY_PATH_LENGTH = strlen(DUMMY_FILE);
 // The size of an output jar containing only an empty dummy file:
 const size_t JAR_WITH_DUMMY_FILE_SIZE = 98ull + 2 * DUMMY_PATH_LENGTH;
 
+class ManifestLocator : public devtools_ijar::ZipExtractorProcessor {
+public:
+  ManifestLocator() : manifest_buf_(nullptr), manifest_size_(0) {}
+  virtual ~ManifestLocator() { free(manifest_buf_); }
+
+  u1 *manifest_buf_;
+  size_t manifest_size_;
+
+  virtual bool Accept(const char *filename, const u4 /*attr*/) {
+    return strcmp(filename, MANIFEST_PATH) == 0;
+  }
+
+  virtual void Process(const char * /*filename*/, const u4 /*attr*/,
+                       const u1 *data, const size_t size) {
+    manifest_buf_ = (u1 *)malloc(size);
+    memmove(manifest_buf_, data, size);
+    manifest_size_ = size;
+  }
+};
+
 class JarExtractorProcessor : public ZipExtractorProcessor {
- public:
+public:
   // Set the ZipBuilder to add the ijar class to the output zip file.
   // This pointer should not be deleted while this class is still in use and
   // it should be set before any call to the Process() method.
   void SetZipBuilder(ZipBuilder *builder) { this->builder_ = builder; }
-  virtual void WriteManifest(const char *target_label,
+  virtual void WriteManifest(const ManifestLocator &, const char *target_label,
                              const char *injecting_rule_kind) = 0;
 
- protected:
+protected:
   // Not owned by JarStripperProcessor, see SetZipBuilder().
   ZipBuilder *builder_;
 };
@@ -84,16 +105,16 @@ class JarExtractorProcessor : public ZipExtractorProcessor {
 // StripClass to generate an interface class, storing as a new file
 // in the specified ZipBuilder.
 class JarStripperProcessor : public JarExtractorProcessor {
- public:
+public:
   JarStripperProcessor() {}
   virtual ~JarStripperProcessor() {}
 
   virtual void Process(const char *filename, u4 attr, const u1 *data,
-                       size_t size);
-  virtual bool Accept(const char *filename, u4 attr);
+                       size_t size) override;
+  virtual bool Accept(const char *filename, u4 attr) override;
 
-  virtual void WriteManifest(const char *target_label,
-                             const char *injecting_rule_kind);
+  virtual void WriteManifest(const ManifestLocator &, const char *target_label,
+                             const char *injecting_rule_kind) override;
 };
 
 static bool StartsWith(const char *str, const size_t str_len,
@@ -196,18 +217,49 @@ static u1 *WriteManifestAttr(u1 *buf, const char *key, const char *val) {
   return buf;
 }
 
-void JarStripperProcessor::WriteManifest(const char *target_label,
-                                         const char *injecting_rule_kind) {
-  if (target_label == nullptr) {
+static bool IsMultiRelease(u1 *manifest_data, size_t manifest_size) {
+  static const char *enabled_line = "Multi-Release: true";
+  static const size_t enabled_length = strlen(enabled_line);
+  const char *line_start = (const char *)manifest_data;
+  const char *data_end = (const char *)manifest_data + manifest_size;
+  while (line_start < data_end) {
+    const char *line_end = strchr(line_start, '\n');
+    line_end = line_end != nullptr ? line_end + 1 : data_end;
+    size_t line_length = line_end - line_start;
+
+    if (line_length >= enabled_length &&
+        strncmp(line_start, enabled_line, enabled_length) == 0 &&
+        (line_length == enabled_length || line_start[enabled_length] == '\r' ||
+         line_start[enabled_length] == '\n')) {
+      return true;
+    }
+    line_start = line_end;
+  }
+  return false;
+}
+
+void JarStripperProcessor::WriteManifest(
+    const ManifestLocator &manifest_locator, const char *target_label,
+    const char *injecting_rule_kind) {
+  bool multi_release = manifest_locator.manifest_buf_ != nullptr &&
+                       IsMultiRelease(manifest_locator.manifest_buf_,
+                                      manifest_locator.manifest_size_);
+  if (target_label == nullptr && !multi_release) {
     return;
   }
   builder_->WriteEmptyFile(MANIFEST_DIR_PATH);
   u1 *start = builder_->NewFile(MANIFEST_PATH, 0);
   u1 *buf = start;
   buf = WriteStr(buf, MANIFEST_HEADER);
-  buf = WriteManifestAttr(buf, TARGET_LABEL_KEY, target_label);
-  if (injecting_rule_kind) {
-    buf = WriteManifestAttr(buf, INJECTING_RULE_KIND_KEY, injecting_rule_kind);
+  if (multi_release) {
+    buf = WriteStr(buf, MULTI_RELEASE_TRUE_LINE);
+  }
+  if (target_label != nullptr) {
+    buf = WriteManifestAttr(buf, TARGET_LABEL_KEY, target_label);
+    if (injecting_rule_kind) {
+      buf =
+          WriteManifestAttr(buf, INJECTING_RULE_KIND_KEY, injecting_rule_kind);
+    }
   }
   size_t total_len = buf - start;
   builder_->FinishFile(total_len, /* compress: */ false,
@@ -215,40 +267,18 @@ void JarStripperProcessor::WriteManifest(const char *target_label,
 }
 
 class JarCopierProcessor : public JarExtractorProcessor {
- public:
-  JarCopierProcessor(const char *jar) : jar_(jar) {}
+public:
+  JarCopierProcessor() {}
   virtual ~JarCopierProcessor() {}
 
   virtual void Process(const char *filename, u4 /*attr*/, const u1 *data,
-                       size_t size);
-  virtual bool Accept(const char *filename, u4 /*attr*/);
+                       size_t size) override;
+  virtual bool Accept(const char *filename, u4 /*attr*/) override;
 
-  virtual void WriteManifest(const char *target_label,
-                             const char *injecting_rule_kind);
+  virtual void WriteManifest(const ManifestLocator &, const char *target_label,
+                             const char *injecting_rule_kind) override;
 
- private:
-  class ManifestLocator : public ZipExtractorProcessor {
-   public:
-    ManifestLocator() : manifest_buf_(nullptr), manifest_size_(0) {}
-    virtual ~ManifestLocator() { free(manifest_buf_); }
-
-    u1 *manifest_buf_;
-    size_t manifest_size_;
-
-    virtual bool Accept(const char *filename, const u4 /*attr*/) {
-      return strcmp(filename, MANIFEST_PATH) == 0;
-    }
-
-    virtual void Process(const char * /*filename*/, const u4 /*attr*/,
-                         const u1 *data, const size_t size) {
-      manifest_buf_ = (u1 *)malloc(size);
-      memmove(manifest_buf_, data, size);
-      manifest_size_ = size;
-    }
-  };
-
-  const char *jar_;
-
+private:
   u1 *AppendTargetLabelToManifest(u1 *buf, const u1 *manifest_data, size_t size,
                                   const char *target_label,
                                   const char *injecting_rule_kind);
@@ -273,13 +303,9 @@ bool JarCopierProcessor::Accept(const char * /*filename*/, const u4 /*attr*/) {
   return true;
 }
 
-void JarCopierProcessor::WriteManifest(const char *target_label,
+void JarCopierProcessor::WriteManifest(const ManifestLocator &manifest_locator,
+                                       const char *target_label,
                                        const char *injecting_rule_kind) {
-  ManifestLocator manifest_locator;
-  std::unique_ptr<ZipExtractor> in(
-      ZipExtractor::Create(jar_, &manifest_locator));
-  in->ProcessAll();
-
   bool wants_manifest =
       manifest_locator.manifest_buf_ != nullptr || target_label != nullptr;
   if (wants_manifest) {
@@ -368,6 +394,7 @@ static size_t EstimateManifestOutputSize(const char *target_label,
 
   // manifest content
   length += MANIFEST_HEADER_LENGTH;
+  length += MULTI_RELEASE_TRUE_LINE_LENGTH;
   // target label manifest entry, including newline
   length += TARGET_LABEL_KEY_LENGTH + strlen(target_label) + 2;
   if (injecting_rule_kind) {
@@ -388,7 +415,7 @@ static void OpenFilesAndProcessJar(const char *file_out, const char *file_in,
         std::unique_ptr<JarExtractorProcessor>(new JarStripperProcessor());
   } else {
     processor =
-        std::unique_ptr<JarExtractorProcessor>(new JarCopierProcessor(file_in));
+        std::unique_ptr<JarExtractorProcessor>(new JarCopierProcessor());
   }
   std::unique_ptr<ZipExtractor> in(
       ZipExtractor::Create(file_in, processor.get()));
@@ -411,7 +438,14 @@ static void OpenFilesAndProcessJar(const char *file_out, const char *file_in,
     abort();
   }
   processor->SetZipBuilder(out.get());
-  processor->WriteManifest(target_label, injecting_rule_kind);
+  {
+    ManifestLocator manifest_locator;
+    std::unique_ptr<ZipExtractor> in(
+        ZipExtractor::Create(file_in, &manifest_locator));
+    in->ProcessAll();
+    processor->WriteManifest(manifest_locator, target_label,
+                             injecting_rule_kind);
+  }
 
   // Process all files in the zip
   if (in->ProcessAll() < 0) {
@@ -436,17 +470,16 @@ static void OpenFilesAndProcessJar(const char *file_out, const char *file_in,
             file_out, static_cast<int>(100.0 * out_length / in_length));
   }
 }
-}  // namespace devtools_ijar
+} // namespace devtools_ijar
 
 //
 // main method
 //
 static void usage() {
-  fprintf(stderr,
-          "Usage: ijar "
-          "[-v] [--[no]strip_jar] "
-          "[--target label label] [--injecting_rule_kind kind] "
-          "x.jar [x_interface.jar>]\n");
+  fprintf(stderr, "Usage: ijar "
+                  "[-v] [--[no]strip_jar] "
+                  "[--target label label] [--injecting_rule_kind kind] "
+                  "x.jar [x_interface.jar>]\n");
   fprintf(stderr, "Creates an interface jar from the specified jar file.\n");
   exit(1);
 }
@@ -497,9 +530,8 @@ int main(int argc, char **argv) {
       strcpy(filename_out_buf + len - 4, "-interface.jar");
       filename_out = filename_out_buf;
     } else {
-      fprintf(stderr,
-              "Can't determine output filename since input filename "
-              "doesn't end with '.jar'.\n");
+      fprintf(stderr, "Can't determine output filename since input filename "
+                      "doesn't end with '.jar'.\n");
       return 1;
     }
   }

--- a/third_party/ijar/test/BUILD
+++ b/third_party/ijar/test/BUILD
@@ -401,6 +401,26 @@ genrule(
     tools = ["//third_party/ijar"],
 )
 
+genrule(
+    name = "multirelease",
+    testonly = True,
+    srcs = ["Object.java"],
+    outs = ["multirelease.jar"],
+    cmd = "$(JAVABASE)/bin/jar --create --file $@ --release 9 $<",
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
+    ],
+)
+
+genrule(
+    name = "multirelease-interface",
+    testonly = True,
+    srcs = [":multirelease.jar"],
+    outs = ["multirelease-interface.jar"],
+    cmd = "$(location //third_party/ijar) $< $@",
+    tools = ["//third_party/ijar"],
+)
+
 java_test(
     name = "IjarTests",
     size = "small",
@@ -433,6 +453,7 @@ java_test(
         ":local_and_anonymous-interface.jar",
         ":meta_inf_transitive-interface",
         ":module_info-interface.jar",
+        ":multirelease-interface.jar",
         ":scala_tasty-interface.jar",
     ],
     tags = ["zip"],

--- a/third_party/ijar/test/IjarTests.java
+++ b/third_party/ijar/test/IjarTests.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.fail;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
-import org.objectweb.asm.Opcodes;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -57,6 +56,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Opcodes;
 
 /** JUnit tests for ijar tool. */
 @RunWith(JUnit4.class)
@@ -289,6 +289,13 @@ public class IjarTests {
     // ijar passes module-infos through unmodified, so it doesn't care that these ones are bogus
     assertThat(new String(lib.get("module-info.class"), UTF_8)).isEqualTo("hello");
     assertThat(new String(lib.get("foo/module-info.class"), UTF_8)).isEqualTo("goodbye");
+  }
+
+  @Test
+  public void multiReleasePreserved() throws Exception {
+    try (JarFile jf = new JarFile("third_party/ijar/test/multirelease-interface.jar")) {
+      assertThat(jf.isMultiRelease()).isTrue();
+    }
   }
 
   @Test


### PR DESCRIPTION
The output of ijar manifest now includes Multi-Release: true if the input jar manifest has it.

Fixes https://github.com/bazelbuild/bazel/issues/28316