### PR TITLE
Optimize coverage executions

### DIFF
--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovMergerFlags.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovMergerFlags.java
@@ -26,7 +26,10 @@ import javax.annotation.Nullable;
 @Parameters(separators = "= ")
 class LcovMergerFlags {
   private static final Logger logger = Logger.getLogger(LcovMergerFlags.class.getName());
-  private static final int DEFAULT_PARSE_FILE_PARALLELISM = 4;
+  // Use available processors for better parallelism on modern machines.
+  // Minimum of 4 to ensure reasonable performance even on small machines.
+  private static final int DEFAULT_PARSE_FILE_PARALLELISM =
+      Math.max(4, Runtime.getRuntime().availableProcessors());
 
   @Parameter(names = "--coverage_dir")
   private String coverageDir;


### PR DESCRIPTION
- Replaces hard-coded 4 threads to 16 for coverage file parsing parallelism.
- Realized that forkjoinpool resource was not properly cleaned up.
- Parsed different file types in parallel rather than sequential.
- Optimized directory walking.