### PR TITLE
[rolling release 10.0.0-pre.20260112.1] Use the hermetic python toolchain for Bazel 

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -141,9 +141,9 @@ maven.install(
         # keep sorted
         "args4j:args4j:2.37",
         "com.beust:jcommander:1.82",
+        "com.dylibso.chicory:log:1.5.2",
         "com.dylibso.chicory:runtime:1.5.2",
         "com.dylibso.chicory:wasm:1.5.2",
-        "com.dylibso.chicory:log:1.5.2",
         "com.github.ben-manes.caffeine:caffeine:3.1.8",
         "com.github.stephenc.jcip:jcip-annotations:1.0-1",
         "com.google.api-client:google-api-client:1.35.2",
@@ -454,8 +454,6 @@ use_repo(remote_coverage_tools_extension, "remote_coverage_tools")
 # =========================================
 
 register_execution_platforms("//:default_host_platform")
-
-register_toolchains("@rules_python//python:autodetecting_toolchain")
 
 register_toolchains("@local_config_winsdk//:all")
 

--- a/src/test/py/bazel/bzlmod/repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/repo_contents_cache_test.py
@@ -93,18 +93,20 @@ class RepoContentsCacheTest(test_base.TestBase):
     # Verify that the repo directory under the output base is a symlink or
     # junction into the repo contents cache.
     repo_dir = self.repoDir('my_repo')
-    self.assertTrue(os.path.islink(repo_dir) or os.path.isjunction(repo_dir))
-    target_path = os.readlink(repo_dir)
-    real_target_path = os.path.realpath(target_path)
-    real_repo_contents_cache = os.path.realpath(self.repo_contents_cache)
-    for parent in pathlib.Path(real_target_path).parents:
-      if parent.samefile(real_repo_contents_cache):
-        break
-    else:
-      self.fail(
-          'repo target dir %s is not in the repo contents cache %s'
-          % (real_target_path, real_repo_contents_cache)
-      )
+    try:
+      target_path = os.readlink(repo_dir)
+      real_target_path = os.path.realpath(target_path)
+      real_repo_contents_cache = os.path.realpath(self.repo_contents_cache)
+      for parent in pathlib.Path(real_target_path).parents:
+        if parent.samefile(real_repo_contents_cache):
+          break
+      else:
+        self.fail(
+            'repo target dir %s is not in the repo contents cache %s'
+            % (real_target_path, real_repo_contents_cache)
+        )
+    except OSError:
+      self.fail('repo_dir %s is not a symlink or junction' % repo_dir)
 
     # After expunging: cached
     self.RunBazel(['clean', '--expunge'])


### PR DESCRIPTION
Also, upgraded the python toolchain version to match CI version

Fixes https://github.com/bazelbuild/bazel/issues/28047

PiperOrigin-RevId: 855199415
Change-Id: Iece7b7b33c3dc2d9525024afc49716454dfe53cd (cherry picked from commit 76166fca04ca8fdf6d87b3a2a7cf60da6ca8145b)