### PR TITLE
Add `execution_requirements` to `ctx.actions.write`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -373,8 +373,26 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             named = true,
             positional = false,
             doc = "A one-word description of the action, for example, CppCompile or GoLink."),
+        @Param(
+            name = "execution_requirements",
+            allowedTypes = {
+              @ParamType(type = Dict.class),
+              @ParamType(type = NoneType.class),
+            },
+            defaultValue = "None",
+            named = true,
+            positional = false,
+            doc =
+                "Information for scheduling the action. See "
+                    + "<a href=\"${link common-definitions#common.tags}\">tags</a> "
+                    + "for useful keys."),
       })
-  void write(FileApi output, Object content, Boolean isExecutable, Object mnemonicUnchecked)
+  void write(
+      FileApi output,
+      Object content,
+      Boolean isExecutable,
+      Object mnemonicUnchecked,
+      Object executionRequirementsUnchecked)
       throws EvalException, InterruptedException;
 
   @StarlarkMethod(


### PR DESCRIPTION
Since Bazel's only `FileWriteStrategy` doesn't execute a spawn, this can currently only affect the path mapping behavior of the action when supplying `Args` as content. This will make it possible to opt C++ rules into path mapping without any command line flags beyond `--experimental_output_paths=strip` in future PRs.

Work towards #27732
Work towards #27591