### PR TITLE
[8.6.0] Add `short_uncached` and `detailed_uncached` options to `--test_summary`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestStrategy.java
@@ -19,8 +19,10 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
@@ -359,13 +361,18 @@ public abstract class TestStrategy implements TestActionContext {
     return digest.hexDigestAndReset().substring(0, 32);
   }
 
+  private static final ImmutableSet<ExecutionOptions.TestSummaryFormat> PARSE_TEST_RESULT_FORMATS =
+      Sets.immutableEnumSet(
+          ExecutionOptions.TestSummaryFormat.DETAILED,
+          ExecutionOptions.TestSummaryFormat.DETAILED_UNCACHED,
+          ExecutionOptions.TestSummaryFormat.TESTCASE);
+
   /** Parse a test result XML file into a {@link TestCase}. */
   @Nullable
   protected TestCase parseTestResult(Path resultFile) {
     /* xml files. We avoid parsing it unnecessarily, since test results can potentially consume
     a large amount of memory. */
-    if ((executionOptions.testSummary != ExecutionOptions.TestSummaryFormat.DETAILED)
-        && (executionOptions.testSummary != ExecutionOptions.TestSummaryFormat.TESTCASE)) {
+    if (!PARSE_TEST_RESULT_FORMATS.contains(executionOptions.testSummary)) {
       return null;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -254,11 +254,17 @@ public class ExecutionOptions extends OptionsBase {
         OptionEffectTag.EXECUTION
       },
       help =
-          "Specifies desired output mode. Valid values are 'summary' to output only test status "
-              + "summary, 'errors' to also print test logs for failed tests, 'all' to print logs "
-              + "for all tests and 'streamed' to output logs for all tests in real time "
-              + "(this will force tests to be executed locally one at a time regardless of "
-              + "--test_strategy value).")
+          """
+          Specifies desired output mode. Not to be confused with `--test_summary` which controls
+          the test summary printed on command completion.
+
+          Valid values are;
+          - `summary` (default) to print summaries for failed tests,
+          - `errors` to also print test logs for failed tests,
+          - `all` to print summaries and logs for all tests and
+          - `streamed` to output logs for all tests in real time (this will force tests to be
+            executed locally one at a time regardless of `--test_strategy` value).
+          """)
   public TestOutputFormat testOutput;
 
   @Option(
@@ -284,12 +290,18 @@ public class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
       help =
-          "Specifies the desired format of the test summary. Valid values are 'short' to print"
-              + " information only about tests executed, 'terse', to print information only about"
-              + " unsuccessful tests that were run, 'detailed' to print detailed information about"
-              + " failed test cases, 'testcase' to print summary in test case resolution, do not"
-              + " print detailed information about failed test cases and 'none' to omit the"
-              + " summary.")
+          """
+          Specifies the desired format of the test summary. Valid values are;
+          - `short` to list all tests that ran to completion.
+          - `short_uncached` to list tests that ran to completion, omitting cached tests.
+          - `terse` to list only failed and flaky tests.
+          - `detailed` to list tests that ran to completion and their test cases.
+          - `detailed_uncached` to list tests that ran to completion and their test cases,
+            omitting cached tests.
+          - `testcase` to print summary in test case resolution without detailed information about
+            failed test cases.
+          - `none` to omit the summary.
+          """)
   public TestSummaryFormat testSummary;
 
   @Option(
@@ -564,10 +576,19 @@ public class ExecutionOptions extends OptionsBase {
 
   /** An enum for specifying different formats of test output. */
   public enum TestOutputFormat {
-    SUMMARY, // Provide summary output only.
-    ERRORS, // Print output from failed tests to the stderr after the test failure.
-    ALL, // Print output from all tests to the stderr after the test completion.
-    STREAMED; // Stream output for each test.
+    /**
+     * Provide summary output only. NOTE: Functionally this is `NONE`, as `--test_summary` controls
+     * the summary output.
+     */
+    SUMMARY,
+    /** Print output from failed tests to the stderr after the test failure. */
+    ERRORS,
+    /** Print output from all tests to the stderr after the test completion. */
+    ALL,
+    /**
+     * Stream output from tests as they run. Forces tests to be executed sequentially and locally.
+     */
+    STREAMED;
 
     /** Converts to {@link TestOutputFormat}. */
     public static class Converter extends EnumConverter<TestOutputFormat> {
@@ -579,12 +600,23 @@ public class ExecutionOptions extends OptionsBase {
 
   /** An enum for specifying different formatting styles of test summaries. */
   public enum TestSummaryFormat {
-    SHORT, // Print information only about tests.
-    TERSE, // Like "SHORT", but even shorter: Do not print PASSED and NO STATUS tests.
-    DETAILED, // Print information only about failed test cases.
-    NONE, // Do not print summary.
-    TESTCASE; // Print summary in test case resolution, do not print detailed information about
-    // failed test cases.
+    /** Show all tests that can to completion, but not individual test cases. */
+    SHORT,
+    /** Like "SHORT", but do not show tests that were cached. */
+    SHORT_UNCACHED,
+    /** Like "SHORT", but even shorter: Only failed and flaky tests. */
+    TERSE,
+    /**
+     * Show all tests (including tests that failed to build), their test cases, and a summary of all
+     * test cases (passed, skipped, failing).
+     */
+    DETAILED,
+    /** Like "DETAILED", but only for tests that were not cached. */
+    DETAILED_UNCACHED,
+    /** Do not print summary. */
+    NONE,
+    /** Summarize all test cases (passed, skipped, failing). */
+    TESTCASE;
 
     /** Converts to {@link TestSummaryFormat}. */
     public static class Converter extends EnumConverter<TestSummaryFormat> {

--- a/src/main/java/com/google/devtools/build/lib/runtime/TestSummary.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/TestSummary.java
@@ -510,7 +510,7 @@ public class TestSummary implements Comparable<TestSummary>, BuildEventWithOrder
     return totalTestCases;
   }
 
-  public int getUnkownTestCases() {
+  public int getUnknownTestCases() {
     return totalUnknownTestCases;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/runtime/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BUILD
@@ -110,6 +110,7 @@ java_library(
         "//src/test/java/com/google/devtools/build/lib/testutil:TestUtils",
         "//src/test/java/com/google/devtools/build/lib/vfs/util",
         "//src/test/java/com/google/devtools/common/options:testutils",
+        "//third_party:auto_value",
         "//third_party:flogger",
         "//third_party:guava",
         "//third_party:guava-testlib",

--- a/src/test/java/com/google/devtools/build/lib/runtime/TerminalTestResultNotifierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/TerminalTestResultNotifierTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.auto.value.AutoBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
@@ -54,21 +55,18 @@ public final class TerminalTestResultNotifierTest {
   private final OptionsParsingResult optionsParsingResult = mock(OptionsParsingResult.class);
   private final AnsiTerminalPrinter ansiTerminalPrinter = mock(AnsiTerminalPrinter.class);
 
-  private BlazeTestStatus targetStatus;
-  private int numFailedTestCases;
-  private int numSkippedTestCases;
-  private int numUnknownTestCases;
-  private int numTotalTestCases;
-  private TestSummaryFormat testSummaryFormat;
-
   @Test
   public void testCaseOption_allPass() throws Exception {
-    testSummaryFormat = ExecutionOptions.TestSummaryFormat.TESTCASE;
-    numFailedTestCases = 0;
-    numTotalTestCases = 10;
-    targetStatus = BlazeTestStatus.PASSED;
-
-    printTestCaseSummary();
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.PASSED)
+            .setFailedTestCases(0)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.TESTCASE);
 
     String printed = getPrintedMessage();
     assertThat(printed).contains(info("10 passing"));
@@ -80,13 +78,16 @@ public final class TerminalTestResultNotifierTest {
 
   @Test
   public void testCaseOption_allPassButTargetFails() throws Exception {
-    testSummaryFormat = ExecutionOptions.TestSummaryFormat.TESTCASE;
-    numFailedTestCases = 0;
-    numUnknownTestCases = 10;
-    numTotalTestCases = 10;
-    targetStatus = BlazeTestStatus.FAILED;
-
-    printTestCaseSummary();
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.FAILED)
+            .setFailedTestCases(0)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(10)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.TESTCASE);
 
     String printed = getPrintedMessage();
     assertThat(printed).contains("0 passing");
@@ -98,13 +99,16 @@ public final class TerminalTestResultNotifierTest {
 
   @Test
   public void testCaseOption_someFail() throws Exception {
-    testSummaryFormat = ExecutionOptions.TestSummaryFormat.TESTCASE;
-    numFailedTestCases = 2;
-    numUnknownTestCases = 0;
-    numTotalTestCases = 10;
-    targetStatus = BlazeTestStatus.FAILED;
-
-    printTestCaseSummary();
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.FAILED)
+            .setFailedTestCases(2)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.TESTCASE);
 
     String printed = getPrintedMessage();
     assertThat(printed).contains(info("8 passing"));
@@ -115,14 +119,9 @@ public final class TerminalTestResultNotifierTest {
 
   @Test
   public void shortOption_someFailToBuild() throws Exception {
-    testSummaryFormat = ExecutionOptions.TestSummaryFormat.SHORT;
-    numFailedTestCases = 0;
     int numFailedToBuildTestCases = TerminalTestResultNotifier.NUM_FAILED_TO_BUILD + 1;
-    numUnknownTestCases = 0;
-    numTotalTestCases = 10;
-    targetStatus = BlazeTestStatus.FAILED_TO_BUILD;
 
-    printFailedToBuildSummaries();
+    printFailedToBuildSummaries(ExecutionOptions.TestSummaryFormat.SHORT);
 
     String skippedMessage = getPrintedMessage();
     assertThat(skippedMessage).isEqualTo("(Skipping other failed to build tests)");
@@ -143,14 +142,42 @@ public final class TerminalTestResultNotifierTest {
   }
 
   @Test
-  public void testCaseOption_allFail() throws Exception {
-    testSummaryFormat = ExecutionOptions.TestSummaryFormat.TESTCASE;
-    numFailedTestCases = 10;
-    numUnknownTestCases = 0;
-    numTotalTestCases = 10;
-    targetStatus = BlazeTestStatus.FAILED;
+  public void shortUncachedOption_someFailToBuild() throws Exception {
+    int numFailedToBuildTestCases = TerminalTestResultNotifier.NUM_FAILED_TO_BUILD + 1;
 
-    printTestCaseSummary();
+    printFailedToBuildSummaries(ExecutionOptions.TestSummaryFormat.SHORT_UNCACHED);
+
+    String skippedMessage = getPrintedMessage();
+    assertThat(skippedMessage).isEqualTo("(Skipping other failed to build tests)");
+
+    ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+    verify(ansiTerminalPrinter, times(numFailedToBuildTestCases))
+        .print(messageCaptor.capture()); // 1 but should all be printed
+    List<String> values = messageCaptor.getAllValues();
+
+    for (int i = 0; i < numFailedToBuildTestCases - 1; i++) {
+      String message = values.get(i);
+      assertThat(message).contains("//foo/bar:baz");
+      assertThat(message).contains(BlazeTestStatus.FAILED_TO_BUILD.toString().replace('_', ' '));
+    }
+
+    String last = values.get(numFailedToBuildTestCases - 1);
+    assertThat(last).contains("Executed 0 out of 6 tests");
+    assertThat(last).contains(numFailedToBuildTestCases + " fail to build");
+  }
+
+  @Test
+  public void testCaseOption_allFail() throws Exception {
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.FAILED)
+            .setFailedTestCases(10)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.TESTCASE);
 
     String printed = getPrintedMessage();
     assertThat(printed).contains("0 passing");
@@ -162,13 +189,60 @@ public final class TerminalTestResultNotifierTest {
 
   @Test
   public void detailedOption_allPass() throws Exception {
-    testSummaryFormat = ExecutionOptions.TestSummaryFormat.DETAILED;
-    numFailedTestCases = 0;
-    numUnknownTestCases = 0;
-    numTotalTestCases = 10;
-    targetStatus = BlazeTestStatus.PASSED;
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.PASSED)
+            .setFailedTestCases(0)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.DETAILED);
 
-    printTestCaseSummary();
+    String printed = getPrintedMessage();
+    assertThat(printed).contains(info("10 passing"));
+    assertThat(printed).contains("0 failing");
+    assertThat(printed).contains("0 skipped");
+    assertThat(printed).contains("out of 10 test cases");
+    assertThat(printed).doesNotContain(SOME_TARGETS_ARE_MISSING_TEST_CASES_DISCLAIMER);
+    assertThat(printed).doesNotContain(AnsiTerminalPrinter.Mode.ERROR.toString());
+  }
+
+  @Test
+  public void detailedUncachedOption_allPassUncached() throws Exception {
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.PASSED)
+            .setFailedTestCases(0)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.DETAILED_UNCACHED);
+
+    String printed = getPrintedMessage();
+    assertThat(printed).contains(info("10 passing"));
+    assertThat(printed).contains("0 failing");
+    assertThat(printed).contains("0 skipped");
+    assertThat(printed).contains("out of 10 test cases");
+    assertThat(printed).doesNotContain(SOME_TARGETS_ARE_MISSING_TEST_CASES_DISCLAIMER);
+    assertThat(printed).doesNotContain(AnsiTerminalPrinter.Mode.ERROR.toString());
+  }
+
+  @Test
+  public void detailedUncachedOption_allPassCached() throws Exception {
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.PASSED)
+            .setFailedTestCases(0)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(false)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.DETAILED_UNCACHED);
 
     String printed = getPrintedMessage();
     assertThat(printed).contains(info("10 passing"));
@@ -181,14 +255,60 @@ public final class TerminalTestResultNotifierTest {
 
   @Test
   public void detailedOption_allPassButSomeSkipped() throws Exception {
-    testSummaryFormat = ExecutionOptions.TestSummaryFormat.DETAILED;
-    numFailedTestCases = 0;
-    numUnknownTestCases = 0;
-    numTotalTestCases = 10;
-    numSkippedTestCases = 2;
-    targetStatus = BlazeTestStatus.PASSED;
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.PASSED)
+            .setFailedTestCases(0)
+            .setSkippedTestCases(2)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.DETAILED);
 
-    printTestCaseSummary();
+    String printed = getPrintedMessage();
+    assertThat(printed).contains(info("8 passing"));
+    assertThat(printed).contains("0 failing");
+    assertThat(printed).contains(warn("2 skipped"));
+    assertThat(printed).contains("out of 10 test cases");
+    assertThat(printed).doesNotContain(SOME_TARGETS_ARE_MISSING_TEST_CASES_DISCLAIMER);
+    assertThat(printed).doesNotContain(AnsiTerminalPrinter.Mode.ERROR.toString());
+  }
+
+  @Test
+  public void detailedUncachedOption_allPassUncachedButSomeSkipped() throws Exception {
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.PASSED)
+            .setFailedTestCases(0)
+            .setSkippedTestCases(2)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.DETAILED_UNCACHED);
+
+    String printed = getPrintedMessage();
+    assertThat(printed).contains(info("8 passing"));
+    assertThat(printed).contains("0 failing");
+    assertThat(printed).contains(warn("2 skipped"));
+    assertThat(printed).contains("out of 10 test cases");
+    assertThat(printed).doesNotContain(SOME_TARGETS_ARE_MISSING_TEST_CASES_DISCLAIMER);
+    assertThat(printed).doesNotContain(AnsiTerminalPrinter.Mode.ERROR.toString());
+  }
+
+  @Test
+  public void detailedUncachedOption_allPassCachedButSomeSkipped() throws Exception {
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.PASSED)
+            .setFailedTestCases(0)
+            .setSkippedTestCases(2)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(false)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.DETAILED_UNCACHED);
 
     String printed = getPrintedMessage();
     assertThat(printed).contains(info("8 passing"));
@@ -201,13 +321,37 @@ public final class TerminalTestResultNotifierTest {
 
   @Test
   public void detailedOption_allPassButTargetFails() throws Exception {
-    testSummaryFormat = ExecutionOptions.TestSummaryFormat.DETAILED;
-    numFailedTestCases = 0;
-    numUnknownTestCases = 10;
-    numTotalTestCases = 10;
-    targetStatus = BlazeTestStatus.FAILED;
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.FAILED)
+            .setFailedTestCases(0)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(10)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.DETAILED);
 
-    printTestCaseSummary();
+    String printed = getPrintedMessage();
+    assertThat(printed).contains("0 passing");
+    assertThat(printed).contains("0 failing");
+    assertThat(printed).contains("out of 10 test cases");
+    assertThat(printed).contains(SOME_TARGETS_ARE_MISSING_TEST_CASES_DISCLAIMER);
+    assertThat(printed).doesNotContain(AnsiTerminalPrinter.Mode.ERROR.toString());
+  }
+
+  @Test
+  public void detailedUncachedOption_allPassButTargetFails() throws Exception {
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.FAILED)
+            .setFailedTestCases(0)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(10)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.DETAILED_UNCACHED);
 
     String printed = getPrintedMessage();
     assertThat(printed).contains("0 passing");
@@ -219,13 +363,36 @@ public final class TerminalTestResultNotifierTest {
 
   @Test
   public void detailedOption_someFail() throws Exception {
-    testSummaryFormat = ExecutionOptions.TestSummaryFormat.DETAILED;
-    numFailedTestCases = 2;
-    numUnknownTestCases = 0;
-    numTotalTestCases = 10;
-    targetStatus = BlazeTestStatus.FAILED;
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.FAILED)
+            .setFailedTestCases(2)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.DETAILED);
 
-    printTestCaseSummary();
+    String printed = getPrintedMessage();
+    assertThat(printed).contains(info("8 passing"));
+    assertThat(printed).contains(error("2 failing"));
+    assertThat(printed).contains("out of 10 test cases");
+    assertThat(printed).doesNotContain(SOME_TARGETS_ARE_MISSING_TEST_CASES_DISCLAIMER);
+  }
+
+  @Test
+  public void detailedUncachedOption_someFail() throws Exception {
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.FAILED)
+            .setFailedTestCases(2)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.DETAILED_UNCACHED);
 
     String printed = getPrintedMessage();
     assertThat(printed).contains(info("8 passing"));
@@ -236,13 +403,37 @@ public final class TerminalTestResultNotifierTest {
 
   @Test
   public void detailedOption_allFail() throws Exception {
-    testSummaryFormat = ExecutionOptions.TestSummaryFormat.DETAILED;
-    numFailedTestCases = 10;
-    numUnknownTestCases = 0;
-    numTotalTestCases = 10;
-    targetStatus = BlazeTestStatus.FAILED;
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.FAILED)
+            .setFailedTestCases(10)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.DETAILED);
 
-    printTestCaseSummary();
+    String printed = getPrintedMessage();
+    assertThat(printed).contains("0 passing");
+    assertThat(printed).contains(error("10 failing"));
+    assertThat(printed).contains("out of 10 test cases");
+    assertThat(printed).doesNotContain(SOME_TARGETS_ARE_MISSING_TEST_CASES_DISCLAIMER);
+    assertThat(printed).doesNotContain(AnsiTerminalPrinter.Mode.INFO.toString());
+  }
+
+  @Test
+  public void detailedUncachedOption_allFail() throws Exception {
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.FAILED)
+            .setFailedTestCases(10)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.DETAILED_UNCACHED);
 
     String printed = getPrintedMessage();
     assertThat(printed).contains("0 passing");
@@ -254,44 +445,137 @@ public final class TerminalTestResultNotifierTest {
 
   @Test
   public void shortOption_noSummaryPrinted() throws Exception {
-    testSummaryFormat = ExecutionOptions.TestSummaryFormat.SHORT;
-    numFailedTestCases = 2;
-    numUnknownTestCases = 0;
-    numTotalTestCases = 10;
-    targetStatus = BlazeTestStatus.FAILED;
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.FAILED)
+            .setFailedTestCases(2)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.SHORT);
 
-    printTestCaseSummary();
+    verifyNoSummaryPrinted();
+  }
+
+  @Test
+  public void shortUncachedOption_noSummaryPrinted() throws Exception {
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.FAILED)
+            .setFailedTestCases(2)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.SHORT_UNCACHED);
 
     verifyNoSummaryPrinted();
   }
 
   @Test
   public void terseOption_noSummaryPrinted() throws Exception {
-    testSummaryFormat = ExecutionOptions.TestSummaryFormat.TERSE;
-    numFailedTestCases = 2;
-    numUnknownTestCases = 0;
-    numTotalTestCases = 10;
-    targetStatus = BlazeTestStatus.FAILED;
-
-    printTestCaseSummary();
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.FAILED)
+            .setFailedTestCases(2)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.TERSE);
 
     verifyNoSummaryPrinted();
   }
 
   @Test
   public void noneOption_noSummaryPrinted() throws Exception {
-    testSummaryFormat = ExecutionOptions.TestSummaryFormat.NONE;
-    numFailedTestCases = 2;
-    numUnknownTestCases = 0;
-    numTotalTestCases = 10;
-    targetStatus = BlazeTestStatus.FAILED;
-
-    printTestCaseSummary();
+    printTestCaseSummary(
+        TestSummarySpec.builder()
+            .setStatus(BlazeTestStatus.FAILED)
+            .setFailedTestCases(2)
+            .setSkippedTestCases(0)
+            .setUnknownTestCases(0)
+            .setTotalTestCases(10)
+            .setActionRan(true)
+            .build(),
+        ExecutionOptions.TestSummaryFormat.NONE);
 
     verifyNoSummaryPrinted();
   }
 
-  private void printFailedToBuildSummaries() throws LabelSyntaxException {
+  // A helper that creates `TestSummary` mocks for testing.
+  static class TestSummarySpec {
+    private final BlazeTestStatus status;
+    private final int failedTestCases;
+    private final int skippedTestCases;
+    private final int unknownTestCases;
+    private final int totalTestCases;
+    private final boolean actionRan;
+
+    TestSummarySpec(
+        BlazeTestStatus status,
+        int failedTestCases,
+        int skippedTestCases,
+        int unknownTestCases,
+        int totalTestCases,
+        boolean actionRan) {
+      this.status = status;
+      this.failedTestCases = failedTestCases;
+      this.skippedTestCases = skippedTestCases;
+      this.unknownTestCases = unknownTestCases;
+      this.totalTestCases = totalTestCases;
+      this.actionRan = actionRan;
+    }
+
+    static Builder builder() {
+      return new AutoBuilder_TerminalTestResultNotifierTest_TestSummarySpec_Builder();
+    }
+
+    TestSummary build() throws LabelSyntaxException {
+      TestSummary testSummary = mock(TestSummary.class);
+      when(testSummary.getTotalTestCases()).thenReturn(totalTestCases);
+      when(testSummary.getUnknownTestCases()).thenReturn(unknownTestCases);
+      when(testSummary.getStatus()).thenReturn(status);
+      when(testSummary.actionRan()).thenReturn(actionRan);
+
+      TestCase failedTestCase = TestCase.newBuilder().setStatus(Status.FAILED).build();
+      List<TestCase> failedTestCasesList = Collections.nCopies(failedTestCases, failedTestCase);
+      when(testSummary.getFailedTestCases()).thenReturn(failedTestCasesList);
+
+      TestCase skippedTestCase = TestCase.newBuilder().setStatus(Status.SKIPPED).build();
+      List<TestCase> skippedTestCasesList = Collections.nCopies(skippedTestCases, skippedTestCase);
+      when(testSummary.getSkippedTestCases()).thenReturn(skippedTestCasesList);
+
+      Label label = Label.parseCanonical("//foo:bar");
+      when(testSummary.getLabel()).thenReturn(label);
+
+      return testSummary;
+    }
+
+    @AutoBuilder(ofClass = TestSummarySpec.class)
+    abstract static class Builder {
+      abstract Builder setStatus(BlazeTestStatus status);
+
+      abstract Builder setFailedTestCases(int failedTestCases);
+
+      abstract Builder setSkippedTestCases(int skippedTestCases);
+
+      abstract Builder setUnknownTestCases(int unknownTestCases);
+
+      abstract Builder setTotalTestCases(int totalTestCases);
+
+      abstract Builder setActionRan(boolean actionRan);
+
+      abstract TestSummarySpec build();
+    }
+  }
+
+  private void printFailedToBuildSummaries(TestSummaryFormat testSummaryFormat)
+      throws LabelSyntaxException {
     ExecutionOptions executionOptions = ExecutionOptions.DEFAULTS;
     executionOptions.testSummary = testSummaryFormat;
     when(optionsParsingResult.getOptions(ExecutionOptions.class)).thenReturn(executionOptions);
@@ -308,6 +592,7 @@ public final class TerminalTestResultNotifierTest {
       Label labelA = Label.parseCanonical("//foo/bar:baz" + i);
       when(testSummary.getFailedTestCases()).thenReturn(ImmutableList.of());
       when(testSummary.getStatus()).thenReturn(BlazeTestStatus.FAILED_TO_BUILD);
+      when(testSummary.actionRan()).thenReturn(false);
       when(testSummary.getLabel()).thenReturn(labelA);
 
       builder.add(testSummary);
@@ -322,7 +607,9 @@ public final class TerminalTestResultNotifierTest {
     terminalTestResultNotifier.notify(builder.build(), 0);
   }
 
-  private void printTestCaseSummary() throws LabelSyntaxException {
+  private void printTestCaseSummary(
+      TestSummarySpec testSummarySpec, TestSummaryFormat testSummaryFormat)
+      throws LabelSyntaxException {
     ExecutionOptions executionOptions = ExecutionOptions.DEFAULTS;
     executionOptions.testSummary = testSummaryFormat;
     when(optionsParsingResult.getOptions(ExecutionOptions.class)).thenReturn(executionOptions);
@@ -330,27 +617,13 @@ public final class TerminalTestResultNotifierTest {
     testSummaryOptions.verboseSummary = true;
     when(optionsParsingResult.getOptions(TestSummaryOptions.class)).thenReturn(testSummaryOptions);
 
-    TestSummary testSummary = mock(TestSummary.class);
-    when(testSummary.getTotalTestCases()).thenReturn(numTotalTestCases);
-    when(testSummary.getUnkownTestCases()).thenReturn(numUnknownTestCases);
-    TestCase failedTestCase = TestCase.newBuilder().setStatus(Status.FAILED).build();
-    List<TestCase> failedTestCases = Collections.nCopies(numFailedTestCases, failedTestCase);
-    TestCase skippedTestCase = TestCase.newBuilder().setStatus(Status.SKIPPED).build();
-    List<TestCase> skippedTestCases = Collections.nCopies(numSkippedTestCases, skippedTestCase);
-
-    Label labelA = Label.parseCanonical("//foo/bar:baz");
-    when(testSummary.getFailedTestCases()).thenReturn(failedTestCases);
-    when(testSummary.getSkippedTestCases()).thenReturn(skippedTestCases);
-    when(testSummary.getStatus()).thenReturn(targetStatus);
-    when(testSummary.getLabel()).thenReturn(labelA);
-
     TerminalTestResultNotifier terminalTestResultNotifier =
         new TerminalTestResultNotifier(
             ansiTerminalPrinter,
             Path::getPathString,
             optionsParsingResult,
             RepositoryMapping.ALWAYS_FALLBACK);
-    terminalTestResultNotifier.notify(ImmutableSet.of(testSummary), 1);
+    terminalTestResultNotifier.notify(ImmutableSet.of(testSummarySpec.build()), 1);
   }
 
   private String getPrintedMessage() {

--- a/src/test/java/com/google/devtools/build/lib/runtime/TestSummaryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/TestSummaryTest.java
@@ -610,7 +610,7 @@ public class TestSummaryTest {
         getTemplateBuilder().collectTestCases(null).setStatus(BlazeTestStatus.FAILED).build();
 
     assertThat(summary.getTotalTestCases()).isEqualTo(1);
-    assertThat(summary.getUnkownTestCases()).isEqualTo(1);
+    assertThat(summary.getUnknownTestCases()).isEqualTo(1);
   }
 
   @Test
@@ -628,7 +628,7 @@ public class TestSummaryTest {
         getTemplateBuilder().collectTestCases(a).setStatus(BlazeTestStatus.FAILED).build();
 
     assertThat(summary.getTotalTestCases()).isEqualTo(2);
-    assertThat(summary.getUnkownTestCases()).isEqualTo(0);
+    assertThat(summary.getUnknownTestCases()).isEqualTo(0);
     assertThat(summary.getFailedTestCases()).isEmpty();
   }
 

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -763,6 +763,50 @@ function test_detailed_test_summary_for_passed_test() {
   expect_log 'PASSED.*com\.example\.myproject\.TestHello\.testWithArgument'
 }
 
+function test_detailed_uncached_test_summary() {
+  copy_examples
+  add_rules_cc "MODULE.bazel"
+  add_rules_java "MODULE.bazel"
+  setup_javatest_support
+
+  local cc_test="//examples/cpp:hello-success_test"
+  local java_test="//examples/java-native/src/test/java/com/example/myproject:hello"
+
+  # Partially warm cache by running only the C++ test.
+  bazel test --test_summary=detailed_uncached "${cc_test}" >& $TEST_log \
+    || fail "expected success"
+  expect_log "${cc_test}.*PASSED in .*s"
+
+  # Now run both tests and expect only the Java test to be reported.
+  bazel test --test_summary=detailed_uncached "${cc_test}" "${java_test}" >& $TEST_log \
+    || fail "expected success"
+  expect_not_log "${cc_test}.*PASSED in .*s"
+  expect_log "${java_test}.*PASSED in .*s"
+  expect_log 'PASSED.*com\.example\.myproject\.TestHello\.testNoArgument'
+  expect_log 'PASSED.*com\.example\.myproject\.TestHello\.testWithArgument'
+}
+
+function test_short_uncached_test_summary() {
+  copy_examples
+  add_rules_cc "MODULE.bazel"
+  add_rules_java "MODULE.bazel"
+  setup_javatest_support
+
+  local cc_test="//examples/cpp:hello-success_test"
+  local java_test="//examples/java-native/src/test/java/com/example/myproject:hello"
+
+  # Partially warm cache by running only the C++ test.
+  bazel test --test_summary=short_uncached "${cc_test}" >& $TEST_log \
+    || fail "expected success"
+  expect_log "${cc_test}.*PASSED in .*s"
+
+  # Now run both tests and expect only the Java test to be reported.
+  bazel test --test_summary=short_uncached "${cc_test}" "${java_test}" >& $TEST_log \
+    || fail "expected success"
+  expect_not_log "${cc_test}.*PASSED in .*s"
+  expect_log "${java_test}.*PASSED in .*s"
+}
+
 # This test uses "--ignore_all_rc_files" since outside .bazelrc files can pollute
 # this environment. Just "--bazelrc=/dev/null" is not sufficient to fix.
 function test_flaky_test() {


### PR DESCRIPTION
These options exclude cached test results from the summary.

With `short` (default)
```
vscode ➜ /workspaces/bazel/bazel (uncached-test-summary-options) $ bazel-bin/src/bazel test //src/test/java/com/google/devtools/build/lib/runtime:RuntimeTests --test_filter=shortUncachedOption_allPassed
INFO: Analyzed target //src/test/java/com/google/devtools/build/lib/runtime:RuntimeTests (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //src/test/java/com/google/devtools/build/lib/runtime:RuntimeTests up-to-date:
  bazel-bin/src/test/java/com/google/devtools/build/lib/runtime/RuntimeTests
  bazel-bin/src/test/java/com/google/devtools/build/lib/runtime/RuntimeTests.jar
INFO: Elapsed time: 0.770s, Critical Path: 0.00s
INFO: 1 process: 1 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
//src/test/java/com/google/devtools/build/lib/runtime:RuntimeTests (cached) PASSED in 2.8s

Executed 0 out of 1 test: 1 test passes.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```

With `short_uncached`
```
vscode ➜ /workspaces/bazel/bazel (uncached-test-summary-options) $ bazel-bin/src/bazel test //src/test/java/com/google/devtools/build/lib/runtime:RuntimeTests --test_filter=shortUncachedOption_allPassed --test_summary=short_uncached
INFO: Analyzed target //src/test/java/com/google/devtools/build/lib/runtime:RuntimeTests (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //src/test/java/com/google/devtools/build/lib/runtime:RuntimeTests up-to-date:
  bazel-bin/src/test/java/com/google/devtools/build/lib/runtime/RuntimeTests
  bazel-bin/src/test/java/com/google/devtools/build/lib/runtime/RuntimeTests.jar
INFO: Elapsed time: 0.264s, Critical Path: 0.00s
INFO: 1 process: 1 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action

Executed 0 out of 1 test: 1 test passes.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```

Resolves #28062

RELNOTES: Reporting of cached test results can now be suppressed with `--test_summary=short_uncached` or `--test_summary=detailed_uncached`.

Backport of #28290.