### PR TITLE
[9.1.0] Add authenticated HTTP proxy support for Bazel downloads (https://github.com/bazelbuild/bazel/pull/28088)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
@@ -28,6 +28,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:os",
+        "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/net/starlark/java/syntax",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
@@ -14,6 +14,12 @@
 
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
+import static com.google.devtools.build.lib.util.StringEncoding.internalToUnicode;
+import static com.google.devtools.build.lib.util.StringEncoding.platformToInternal;
+import static com.google.devtools.build.lib.util.StringEncoding.unicodeToInternal;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import java.io.IOException;
 import java.net.Authenticator;
@@ -30,12 +36,23 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
-/**
- * Helper class for setting up a proxy server for network communication
- */
+/** Helper class for setting up a proxy server for network communication */
 public class ProxyHelper {
 
+  // Lock for thread-safe authenticator setup. The Authenticator is a JVM-wide singleton,
+  // so we use double-checked locking to ensure it's only set once.
+  private static final Object AUTHENTICATOR_LOCK = new Object();
+  private static volatile boolean authenticatorSet = false;
+
   private final Map<String, String> env;
+
+  /** Resets the static authenticator state. This is intended for testing only. */
+  static void resetAuthenticatorForTesting() {
+    synchronized (AUTHENTICATOR_LOCK) {
+      Authenticator.setDefault(null);
+      authenticatorSet = false;
+    }
+  }
 
   /**
    * Creates new instance.
@@ -52,9 +69,14 @@ public class ProxyHelper {
    * `https_proxy` and `http_proxy` system properties are set.
    *
    * @param requestedUrl remote resource that may need to be retrieved through a proxy
+   * @return ProxyInfo containing the proxy and optional credentials
    */
-  public Proxy createProxyIfNeeded(URL requestedUrl) throws IOException {
+  public ProxyInfo createProxyIfNeeded(URL requestedUrl) throws IOException {
     String proxyAddress = null;
+    String proxyUserProperty = null;
+    String proxyPasswordProperty = null;
+
+    // Check no_proxy/NO_PROXY environment variables
     String noProxyUrl = env.get("no_proxy");
     if (Strings.isNullOrEmpty(noProxyUrl)) {
       noProxyUrl = env.get("NO_PROXY");
@@ -66,17 +88,47 @@ public class ProxyHelper {
         if (noProxyUrlArray[i].startsWith(".")) {
           // This entry applies to sub-domains only.
           if (requestedHost.endsWith(noProxyUrlArray[i])) {
-            return Proxy.NO_PROXY;
+            return ProxyInfo.NO_PROXY;
           }
         } else {
           // This entry applies to the literal hostname and sub-domains.
           if (requestedHost.equals(noProxyUrlArray[i])
               || requestedHost.endsWith("." + noProxyUrlArray[i])) {
-            return Proxy.NO_PROXY;
+            return ProxyInfo.NO_PROXY;
           }
         }
       }
     }
+
+    // Check http.nonProxyHosts system property (Java standard, uses | separator and * wildcards)
+    String nonProxyHosts = System.getProperty("http.nonProxyHosts");
+    if (!Strings.isNullOrEmpty(nonProxyHosts)) {
+      nonProxyHosts = platformToInternal(nonProxyHosts);
+      String requestedHost = requestedUrl.getHost();
+      for (String pattern : Splitter.on('|').split(nonProxyHosts)) {
+        pattern = pattern.trim();
+        if (pattern.isEmpty()) {
+          continue;
+        }
+        if (pattern.startsWith("*")) {
+          // Wildcard at start: *.example.com matches foo.example.com
+          if (requestedHost.endsWith(pattern.substring(1))) {
+            return ProxyInfo.NO_PROXY;
+          }
+        } else if (pattern.endsWith("*")) {
+          // Wildcard at end: example.* matches example.com
+          if (requestedHost.startsWith(pattern.substring(0, pattern.length() - 1))) {
+            return ProxyInfo.NO_PROXY;
+          }
+        } else {
+          // Exact match
+          if (requestedHost.equals(pattern)) {
+            return ProxyInfo.NO_PROXY;
+          }
+        }
+      }
+    }
+
     if (HttpUtils.isProtocol(requestedUrl, "https")) {
       proxyAddress =
           Stream.of(
@@ -87,7 +139,11 @@ public class ProxyHelper {
                     if (host == null) {
                       return null;
                     }
+                    host = platformToInternal(host);
                     String port = System.getProperty("https.proxyPort");
+                    if (port != null) {
+                      port = platformToInternal(port);
+                    }
 
                     return String.format("%s%s", host, port == null ? "" : ":" + port);
                   })
@@ -95,6 +151,15 @@ public class ProxyHelper {
               .filter(Objects::nonNull)
               .findFirst()
               .orElse(null);
+      // Check for credentials in system properties
+      proxyUserProperty = System.getProperty("https.proxyUser");
+      if (proxyUserProperty != null) {
+        proxyUserProperty = platformToInternal(proxyUserProperty);
+      }
+      proxyPasswordProperty = System.getProperty("https.proxyPassword");
+      if (proxyPasswordProperty != null) {
+        proxyPasswordProperty = platformToInternal(proxyPasswordProperty);
+      }
     } else if (HttpUtils.isProtocol(requestedUrl, "http")) {
       proxyAddress =
           Stream.of(
@@ -105,7 +170,11 @@ public class ProxyHelper {
                     if (host == null) {
                       return null;
                     }
+                    host = platformToInternal(host);
                     String port = System.getProperty("http.proxyPort");
+                    if (port != null) {
+                      port = platformToInternal(port);
+                    }
 
                     return String.format("%s%s", host, port == null ? "" : ":" + port);
                   })
@@ -113,22 +182,52 @@ public class ProxyHelper {
               .filter(Objects::nonNull)
               .findFirst()
               .orElse(null);
+      // Check for credentials in system properties
+      proxyUserProperty = System.getProperty("http.proxyUser");
+      if (proxyUserProperty != null) {
+        proxyUserProperty = platformToInternal(proxyUserProperty);
+      }
+      proxyPasswordProperty = System.getProperty("http.proxyPassword");
+      if (proxyPasswordProperty != null) {
+        proxyPasswordProperty = platformToInternal(proxyPasswordProperty);
+      }
     }
-    return createProxy(proxyAddress);
+    return createProxyInfo(proxyAddress, proxyUserProperty, proxyPasswordProperty);
   }
 
   /**
-   * This method takes a proxyAddress as a String (ex.
-   * http://userId:password@proxyhost.domain.com:8000) and sets JVM arguments for http and https
-   * proxy as well as returns a java.net.Proxy object for optional use.
+   * This method takes a proxyAddress as a String (ex. {@code
+   * http://userId:password@proxyhost.domain.com:8000}) and returns a ProxyInfo containing the proxy
+   * configuration and optional authentication credentials.
    *
    * @param proxyAddress The fully qualified address of the proxy server
-   * @return Proxy
-   * @throws IOException
+   * @return ProxyInfo containing the proxy and optional credentials
+   * @throws IOException if the proxy address is invalid
    */
-  public static Proxy createProxy(@Nullable String proxyAddress) throws IOException {
+  public static ProxyInfo createProxy(@Nullable String proxyAddress) throws IOException {
+    return createProxyInfo(proxyAddress, null, null);
+  }
+
+  /**
+   * This method creates a ProxyInfo from either a proxy address URL (which may contain embedded
+   * credentials) or from separate credential parameters (typically from system properties).
+   *
+   * <p>Credentials in the proxy address URL take precedence over separately provided credentials.
+   *
+   * @param proxyAddress The proxy address, optionally containing embedded credentials
+   * @param systemPropertyUser Username from system property (http.proxyUser/https.proxyUser)
+   * @param systemPropertyPassword Password from system property
+   *     (http.proxyPassword/https.proxyPassword)
+   * @return ProxyInfo containing the proxy and optional credentials
+   * @throws IOException if the proxy address is invalid
+   */
+  public static ProxyInfo createProxyInfo(
+      @Nullable String proxyAddress,
+      @Nullable String systemPropertyUser,
+      @Nullable String systemPropertyPassword)
+      throws IOException {
     if (Strings.isNullOrEmpty(proxyAddress)) {
-      return Proxy.NO_PROXY;
+      return ProxyInfo.NO_PROXY;
     }
 
     // Here there be dragons.
@@ -141,8 +240,8 @@ public class ProxyHelper {
 
     final String protocol = matcher.group(1);
     final String idAndPassword = matcher.group(2);
-    final String username = matcher.group(3);
-    final String password = matcher.group(4);
+    final String urlUsername = matcher.group(3);
+    final String urlPassword = matcher.group(4);
     final String hostname = matcher.group(5);
     final String portRaw = matcher.group(6);
 
@@ -174,23 +273,99 @@ public class ProxyHelper {
       }
     }
 
+    Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(hostname, port));
+
+    // Determine credentials: URL credentials take precedence over system properties
+    String username = urlUsername;
+    String password = urlPassword;
+
     if (username != null) {
       if (password == null) {
         throw new IOException("No password given for proxy " + cleanProxyAddress);
       }
-
-      // We need to make sure the proxy password is not url encoded; some special characters in
+      // We need to make sure the proxy credentials are not url encoded; some special characters in
       // proxy passwords require url encoding for shells and other tools to properly consume.
-      final String decodedPassword = URLDecoder.decode(password, "UTF-8");
-      Authenticator.setDefault(
-          new Authenticator() {
-            @Override
-            public PasswordAuthentication getPasswordAuthentication() {
-              return new PasswordAuthentication(username, decodedPassword.toCharArray());
-            }
-          });
+      username = unicodeToInternal(URLDecoder.decode(internalToUnicode(username), UTF_8));
+      password = unicodeToInternal(URLDecoder.decode(internalToUnicode(password), UTF_8));
+    } else if (systemPropertyUser != null && systemPropertyPassword != null) {
+      // Fall back to system property credentials
+      username = systemPropertyUser;
+      password = systemPropertyPassword;
     }
 
-    return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(hostname, port));
+    // If credentials are provided, also set up Java's Authenticator for HTTPS proxy support.
+    // For HTTPS connections through HTTP proxies (CONNECT tunneling), Java's HttpURLConnection
+    // handles the CONNECT request internally and won't use Proxy-Authorization header we set.
+    // Instead, it uses the Authenticator mechanism. We also enable Basic auth tunneling by
+    // clearing the disabled schemes (by default, Basic auth is disabled for HTTPS tunneling).
+    if (username != null && password != null) {
+      // Use double-checked locking to ensure thread-safe, one-time setup of the global
+      // Authenticator. The first caller with credentials wins. This is safe because Bazel
+      // typically uses a single proxy configuration for all downloads.
+      if (!authenticatorSet) {
+        synchronized (AUTHENTICATOR_LOCK) {
+          if (!authenticatorSet) {
+            final String finalUsername = username;
+            final String finalPassword = password;
+            // Capture the previous authenticator to delegate non-proxy auth requests to it.
+            // This preserves existing behavior for server authentication (e.g., .netrc).
+            final Authenticator previousAuthenticator = Authenticator.getDefault();
+            Authenticator.setDefault(
+                new Authenticator() {
+                  @Nullable
+                  @Override
+                  public PasswordAuthentication getPasswordAuthentication() {
+                    // Only provide credentials for proxy authentication.
+                    if (getRequestorType() == RequestorType.PROXY) {
+                      return new PasswordAuthentication(
+                          internalToUnicode(finalUsername),
+                          internalToUnicode(finalPassword).toCharArray());
+                    }
+                    // Delegate non-proxy auth to previous authenticator (if any).
+                    // This preserves existing behavior for server authentication.
+                    if (previousAuthenticator != null) {
+                      return previousAuthenticator.requestPasswordAuthenticationInstance(
+                          getRequestingHost(),
+                          getRequestingSite(),
+                          getRequestingPort(),
+                          getRequestingProtocol(),
+                          getRequestingPrompt(),
+                          getRequestingScheme(),
+                          getRequestingURL(),
+                          getRequestorType());
+                    }
+                    return null;
+                  }
+                });
+            // Enable Basic authentication for HTTPS tunneling through HTTP proxies.
+            // By default, Java disables Basic auth for tunneling
+            // (jdk.http.auth.tunneling.disabledSchemes defaults to "Basic").
+            enableBasicAuthTunneling();
+            authenticatorSet = true;
+          }
+        }
+      }
+    }
+
+    return new ProxyInfo(proxy, username, password);
+  }
+
+  /**
+   * Enables Basic authentication for HTTPS tunneling through HTTP proxies.
+   *
+   * <p>By default, Java disables Basic authentication for HTTPS proxy tunneling for security
+   * reasons (the {@code jdk.http.auth.tunneling.disabledSchemes} system property defaults to
+   * "Basic"). This method clears that restriction to allow authenticated proxies to work with HTTPS
+   * URLs.
+   *
+   * <p>This is necessary because most enterprise proxies use Basic authentication, and without this
+   * setting, HTTPS downloads through authenticated proxies will fail with 407 errors.
+   *
+   * <p>Note: This modifies a JVM-wide setting. If the user has explicitly set this property, their
+   * setting will be preserved.
+   */
+  private static void enableBasicAuthTunneling() {
+    // Use putIfAbsent for thread-safe modification. Only modify if not already set by the user.
+    System.getProperties().putIfAbsent("jdk.http.auth.tunneling.disabledSchemes", "");
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyInfo.java
@@ -1,0 +1,67 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.downloader;
+
+import com.google.devtools.build.lib.authandtls.BasicHttpAuthenticationEncoder;
+import java.net.Proxy;
+import javax.annotation.Nullable;
+
+/**
+ * Container for proxy configuration including the proxy address and optional authentication
+ * credentials.
+ *
+ * <p>This class holds both the {@link Proxy} object for connection routing and the credentials
+ * needed for proxy authentication. The credentials are encoded as a Basic authentication header
+ * value suitable for use in the Proxy-Authorization HTTP header.
+ */
+public class ProxyInfo {
+
+  /** A ProxyInfo representing no proxy (direct connection). */
+  public static final ProxyInfo NO_PROXY = new ProxyInfo(Proxy.NO_PROXY, null, null);
+
+  private final Proxy proxy;
+  @Nullable private final String username;
+  @Nullable private final String password;
+
+  ProxyInfo(Proxy proxy, @Nullable String username, @Nullable String password) {
+    this.proxy = proxy;
+    this.username = username;
+    this.password = password;
+  }
+
+  /** Returns the proxy to use for connections, or {@link Proxy#NO_PROXY} for direct connections. */
+  public Proxy proxy() {
+    return proxy;
+  }
+
+  /** Returns true if this proxy requires authentication. */
+  public boolean hasCredentials() {
+    return username != null && password != null;
+  }
+
+  /**
+   * Returns the value for the Proxy-Authorization header, or null if no authentication is needed.
+   *
+   * <p>The returned value is Base64-encoded in the format required for HTTP Basic authentication
+   * (RFC 7617). Uses UTF-8 encoding to support international characters in credentials.
+   */
+  @Nullable
+  public String getProxyAuthorizationHeader() {
+    if (!hasCredentials()) {
+      return null;
+    }
+    return BasicHttpAuthenticationEncoder.encode(username, password);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerIntegrationTest.java
@@ -31,7 +31,6 @@ import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.util.Sleeper;
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.Proxy;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URL;
@@ -83,7 +82,7 @@ public class HttpConnectorMultiplexerIntegrationTest {
 
   @Before
   public void before() throws Exception {
-    when(proxyHelper.createProxyIfNeeded(any(URL.class))).thenReturn(Proxy.NO_PROXY);
+    when(proxyHelper.createProxyIfNeeded(any(URL.class))).thenReturn(ProxyInfo.NO_PROXY);
   }
 
   @After

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
@@ -41,7 +41,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.InetAddress;
-import java.net.Proxy;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
@@ -96,7 +95,7 @@ public class HttpConnectorTest {
 
   @Before
   public void before() throws Exception {
-    when(proxyHelper.createProxyIfNeeded(any(URL.class))).thenReturn(Proxy.NO_PROXY);
+    when(proxyHelper.createProxyIfNeeded(any(URL.class))).thenReturn(ProxyInfo.NO_PROXY);
   }
 
   @After

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelperTest.java
@@ -15,13 +15,18 @@
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.net.Proxy;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -32,32 +37,41 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ProxyHelperTest {
 
+  @Before
+  public void setUp() {
+    ProxyHelper.resetAuthenticatorForTesting();
+  }
+
   @Test
   public void testCreateIfNeededHttpLowerCase() throws Exception {
     ProxyHelper helper = new ProxyHelper(ImmutableMap.of("http_proxy", "http://my.example.com"));
-    Proxy proxy = helper.createProxyIfNeeded(new URL("http://www.something.com"));
-    assertThat(proxy.toString()).containsMatch("my\\.example\\.com(/<unresolved>)?:80$");
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("http://www.something.com"));
+    assertThat(proxyInfo.proxy().toString())
+        .containsMatch("my\\.example\\.com(/<unresolved>)?:80$");
   }
 
   @Test
   public void testCreateIfNeededHttpUpperCase() throws Exception {
     ProxyHelper helper = new ProxyHelper(ImmutableMap.of("HTTP_PROXY", "http://my.example.com"));
-    Proxy proxy = helper.createProxyIfNeeded(new URL("http://www.something.com"));
-    assertThat(proxy.toString()).containsMatch("my\\.example\\.com(/<unresolved>)?:80$");
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("http://www.something.com"));
+    assertThat(proxyInfo.proxy().toString())
+        .containsMatch("my\\.example\\.com(/<unresolved>)?:80$");
   }
 
   @Test
   public void testCreateIfNeededHttpsLowerCase() throws Exception {
     ProxyHelper helper = new ProxyHelper(ImmutableMap.of("https_proxy", "https://my.example.com"));
-    Proxy proxy = helper.createProxyIfNeeded(new URL("https://www.something.com"));
-    assertThat(proxy.toString()).containsMatch("my\\.example\\.com(/<unresolved>)?:443$");
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.something.com"));
+    assertThat(proxyInfo.proxy().toString())
+        .containsMatch("my\\.example\\.com(/<unresolved>)?:443$");
   }
 
   @Test
   public void testCreateIfNeededHttpsUpperCase() throws Exception {
     ProxyHelper helper = new ProxyHelper(ImmutableMap.of("HTTPS_PROXY", "https://my.example.com"));
-    Proxy proxy = helper.createProxyIfNeeded(new URL("https://www.something.com"));
-    assertThat(proxy.toString()).containsMatch("my\\.example\\.com(/<unresolved>)?:443$");
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.something.com"));
+    assertThat(proxyInfo.proxy().toString())
+        .containsMatch("my\\.example\\.com(/<unresolved>)?:443$");
   }
 
   @Test
@@ -69,8 +83,8 @@ public class ProxyHelperTest {
                 "something.com,example.com,localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    Proxy proxy = helper.createProxyIfNeeded(new URL("https://www.example.com"));
-    assertThat(proxy).isEqualTo(Proxy.NO_PROXY);
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.example.com"));
+    assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
   @Test
@@ -82,8 +96,8 @@ public class ProxyHelperTest {
                 "something.com,example.com,localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    Proxy proxy = helper.createProxyIfNeeded(new URL("https://www.example.com"));
-    assertThat(proxy).isEqualTo(Proxy.NO_PROXY);
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.example.com"));
+    assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
   @Test
@@ -95,8 +109,8 @@ public class ProxyHelperTest {
                 "something.com,example.com,localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    Proxy proxy = helper.createProxyIfNeeded(new URL("https://www.example.com"));
-    assertThat(proxy).isEqualTo(Proxy.NO_PROXY);
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.example.com"));
+    assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
   @Test
@@ -108,8 +122,8 @@ public class ProxyHelperTest {
                 "something.com,example.com,localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    Proxy proxy = helper.createProxyIfNeeded(new URL("https://www.example.com"));
-    assertThat(proxy).isEqualTo(Proxy.NO_PROXY);
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.example.com"));
+    assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
   @Test
@@ -121,14 +135,14 @@ public class ProxyHelperTest {
                 "something.com ,   example.com, localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    Proxy proxy = helper.createProxyIfNeeded(new URL("https://www.something.com"));
-    assertThat(proxy).isEqualTo(Proxy.NO_PROXY);
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.something.com"));
+    assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
 
-    Proxy proxy2 = helper.createProxyIfNeeded(new URL("https://www.example.com"));
-    assertThat(proxy2).isEqualTo(Proxy.NO_PROXY);
+    ProxyInfo proxyInfo2 = helper.createProxyIfNeeded(new URL("https://www.example.com"));
+    assertThat(proxyInfo2.proxy()).isEqualTo(Proxy.NO_PROXY);
 
-    Proxy proxy3 = helper.createProxyIfNeeded(new URL("https://localhost"));
-    assertThat(proxy3).isEqualTo(Proxy.NO_PROXY);
+    ProxyInfo proxyInfo3 = helper.createProxyIfNeeded(new URL("https://localhost"));
+    assertThat(proxyInfo3.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
   @Test
@@ -140,8 +154,9 @@ public class ProxyHelperTest {
                 "something.com,example.com,localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    Proxy proxy = helper.createProxyIfNeeded(new URL("https://www.not-example.com"));
-    assertThat(proxy.toString()).containsMatch("my\\.example\\.com(/<unresolved>)?:443$");
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.not-example.com"));
+    assertThat(proxyInfo.proxy().toString())
+        .containsMatch("my\\.example\\.com(/<unresolved>)?:443$");
   }
 
   @Test
@@ -153,8 +168,8 @@ public class ProxyHelperTest {
                 ".something.com,example.com,localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    Proxy proxy = helper.createProxyIfNeeded(new URL("https://www.my.something.com"));
-    assertThat(proxy).isEqualTo(Proxy.NO_PROXY);
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.my.something.com"));
+    assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
   @Test
@@ -166,52 +181,53 @@ public class ProxyHelperTest {
                 "something.com,example.com,localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    Proxy proxy = helper.createProxyIfNeeded(new URL("https://www.my.subdomain.something.com"));
-    assertThat(proxy).isEqualTo(Proxy.NO_PROXY);
+    ProxyInfo proxyInfo =
+        helper.createProxyIfNeeded(new URL("https://www.my.subdomain.something.com"));
+    assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
   @Test
   public void testNoProxy() throws Exception {
     // Empty address.
-    Proxy proxy = ProxyHelper.createProxy(null);
-    assertThat(proxy).isEqualTo(Proxy.NO_PROXY);
-    proxy = ProxyHelper.createProxy("");
-    assertThat(proxy).isEqualTo(Proxy.NO_PROXY);
+    ProxyInfo proxyInfo = ProxyHelper.createProxy(null);
+    assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
+    proxyInfo = ProxyHelper.createProxy("");
+    assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
     Map<String, String> env = ImmutableMap.of();
     ProxyHelper helper = new ProxyHelper(env);
-    proxy = helper.createProxyIfNeeded(new URL("https://www.something.com"));
-    assertThat(proxy).isEqualTo(Proxy.NO_PROXY);
+    proxyInfo = helper.createProxyIfNeeded(new URL("https://www.something.com"));
+    assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
   @Test
   public void testProxyDefaultPort() throws Exception {
-    Proxy proxy = ProxyHelper.createProxy("http://my.example.com");
-    assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
-    assertThat(proxy.toString()).endsWith(":80");
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("http://my.example.com");
+    assertThat(proxyInfo.proxy().type()).isEqualTo(Proxy.Type.HTTP);
+    assertThat(proxyInfo.proxy().toString()).endsWith(":80");
 
-    proxy = ProxyHelper.createProxy("https://my.example.com");
-    assertThat(proxy.toString()).endsWith(":443");
+    proxyInfo = ProxyHelper.createProxy("https://my.example.com");
+    assertThat(proxyInfo.proxy().toString()).endsWith(":443");
   }
 
   @Test
   public void testProxyExplicitPort() throws Exception {
-    Proxy proxy = ProxyHelper.createProxy("http://my.example.com:12345");
-    assertThat(proxy.toString()).endsWith(":12345");
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("http://my.example.com:12345");
+    assertThat(proxyInfo.proxy().toString()).endsWith(":12345");
 
-    proxy = ProxyHelper.createProxy("https://my.example.com:12345");
-    assertThat(proxy.toString()).endsWith(":12345");
+    proxyInfo = ProxyHelper.createProxy("https://my.example.com:12345");
+    assertThat(proxyInfo.proxy().toString()).endsWith(":12345");
   }
 
   @Test
   public void testProxyNoProtocol() throws Exception {
-    Proxy proxy = ProxyHelper.createProxy("my.example.com");
-    assertThat(proxy.toString()).endsWith(":80");
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("my.example.com");
+    assertThat(proxyInfo.proxy().toString()).endsWith(":80");
   }
 
   @Test
   public void testProxyNoProtocolWithPort() throws Exception {
-    Proxy proxy = ProxyHelper.createProxy("my.example.com:12345");
-    assertThat(proxy.toString()).endsWith(":12345");
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("my.example.com:12345");
+    assertThat(proxyInfo.proxy().toString()).endsWith(":12345");
   }
 
   @Test
@@ -225,19 +241,19 @@ public class ProxyHelperTest {
 
   @Test
   public void testProxyAuth() throws Exception {
-    Proxy proxy = ProxyHelper.createProxy("http://foo:barbaz@my.example.com");
-    assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
-    assertThat(proxy.toString()).endsWith(":80");
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("http://foo:barbaz@my.example.com");
+    assertThat(proxyInfo.proxy().type()).isEqualTo(Proxy.Type.HTTP);
+    assertThat(proxyInfo.proxy().toString()).endsWith(":80");
 
-    proxy = ProxyHelper.createProxy("https://biz:bat@my.example.com");
-    assertThat(proxy.toString()).endsWith(":443");
+    proxyInfo = ProxyHelper.createProxy("https://biz:bat@my.example.com");
+    assertThat(proxyInfo.proxy().toString()).endsWith(":443");
   }
 
   @Test
   public void testEncodedProxyAuth() throws Exception {
-    Proxy proxy = ProxyHelper.createProxy("http://foo:b%40rb%40z@my.example.com");
-    assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
-    assertThat(proxy.toString()).endsWith(":80");
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("http://foo:b%40rb%40z@my.example.com");
+    assertThat(proxyInfo.proxy().type()).isEqualTo(Proxy.Type.HTTP);
+    assertThat(proxyInfo.proxy().toString()).endsWith(":80");
   }
 
   @Test
@@ -249,15 +265,192 @@ public class ProxyHelperTest {
 
   @Test
   public void testNoProxyAuth() throws Exception {
-    Proxy proxy = ProxyHelper.createProxy("http://localhost:3128/");
-    assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
-    assertThat(proxy.toString()).endsWith(":3128");
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("http://localhost:3128/");
+    assertThat(proxyInfo.proxy().type()).isEqualTo(Proxy.Type.HTTP);
+    assertThat(proxyInfo.proxy().toString()).endsWith(":3128");
   }
 
   @Test
   public void testTrailingSlash() throws Exception {
-    Proxy proxy = ProxyHelper.createProxy("http://foo:bar@example.com:8000/");
-    assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
-    assertThat(proxy.toString()).endsWith(":8000");
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("http://foo:bar@example.com:8000/");
+    assertThat(proxyInfo.proxy().type()).isEqualTo(Proxy.Type.HTTP);
+    assertThat(proxyInfo.proxy().toString()).endsWith(":8000");
+  }
+
+  // Tests for ProxyInfo credentials
+
+  @Test
+  public void testProxyInfoWithCredentials() throws Exception {
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("http://myuser:mypass@proxy.example.com:8080");
+    assertThat(proxyInfo.hasCredentials()).isTrue();
+    assertThat(proxyInfo.getProxyAuthorizationHeader()).isNotNull();
+    // Verify it's a valid Basic auth header
+    assertThat(proxyInfo.getProxyAuthorizationHeader()).startsWith("Basic ");
+    // Decode and verify the credentials
+    String encoded = proxyInfo.getProxyAuthorizationHeader().substring("Basic ".length());
+    String decoded = new String(Base64.getDecoder().decode(encoded), UTF_8);
+    assertThat(decoded).isEqualTo("myuser:mypass");
+  }
+
+  @Test
+  public void testProxyInfoWithUrlEncodedCredentials() throws Exception {
+    // Password contains @ and : which are URL-encoded
+    ProxyInfo proxyInfo =
+        ProxyHelper.createProxy("http://user:p%40ss%3Aword@proxy.example.com:8080");
+    assertThat(proxyInfo.hasCredentials()).isTrue();
+    String encoded = proxyInfo.getProxyAuthorizationHeader().substring("Basic ".length());
+    String decoded = new String(Base64.getDecoder().decode(encoded), Charset.defaultCharset());
+    // URL-encoded characters should be decoded
+    assertThat(decoded).isEqualTo("user:p@ss:word");
+  }
+
+  @Test
+  public void testProxyInfoWithUrlEncodedUsername() throws Exception {
+    // Username contains @ which is URL-encoded
+    ProxyInfo proxyInfo =
+        ProxyHelper.createProxy("http://user%40domain:password@proxy.example.com:8080");
+    assertThat(proxyInfo.hasCredentials()).isTrue();
+    String encoded = proxyInfo.getProxyAuthorizationHeader().substring("Basic ".length());
+    String decoded = new String(Base64.getDecoder().decode(encoded), UTF_8);
+    // URL-encoded characters in username should be decoded
+    assertThat(decoded).isEqualTo("user@domain:password");
+  }
+
+  @Test
+  public void testProxyInfoWithUnicodeCredentials() throws Exception {
+    // Test Unicode characters in username and password
+    // Username: "用户" (Chinese for "user") = %E7%94%A8%E6%88%B7
+    // Password: "contraseña" (Spanish with ñ) = contrase%C3%B1a
+    ProxyInfo proxyInfo =
+        ProxyHelper.createProxy("http://%E7%94%A8%E6%88%B7:contrase%C3%B1a@proxy.example.com:8080");
+    assertThat(proxyInfo.hasCredentials()).isTrue();
+    String encoded = proxyInfo.getProxyAuthorizationHeader().substring("Basic ".length());
+    String decoded = new String(Base64.getDecoder().decode(encoded), StandardCharsets.UTF_8);
+    assertThat(decoded).isEqualTo("用户:contraseña");
+  }
+
+  @Test
+  public void testProxyInfoWithoutCredentials() throws Exception {
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("http://proxy.example.com:8080");
+    assertThat(proxyInfo.hasCredentials()).isFalse();
+    assertThat(proxyInfo.getProxyAuthorizationHeader()).isNull();
+  }
+
+  @Test
+  public void testProxyInfoNoProxyHasNoCredentials() throws Exception {
+    assertThat(ProxyInfo.NO_PROXY.hasCredentials()).isFalse();
+    assertThat(ProxyInfo.NO_PROXY.getProxyAuthorizationHeader()).isNull();
+    assertThat(ProxyInfo.NO_PROXY.proxy()).isEqualTo(Proxy.NO_PROXY);
+  }
+
+  @Test
+  public void testProxyInfoFromSystemProperties() throws Exception {
+    // Test that credentials can be provided via the systemPropertyUser/Password parameters
+    ProxyInfo proxyInfo =
+        ProxyHelper.createProxyInfo("http://proxy.example.com:8080", "sysuser", "syspass");
+    assertThat(proxyInfo.hasCredentials()).isTrue();
+    String encoded = proxyInfo.getProxyAuthorizationHeader().substring("Basic ".length());
+    String decoded = new String(Base64.getDecoder().decode(encoded), UTF_8);
+    assertThat(decoded).isEqualTo("sysuser:syspass");
+  }
+
+  @Test
+  public void testProxyInfoUrlCredentialsTakePrecedence() throws Exception {
+    // URL credentials should take precedence over system property credentials
+    ProxyInfo proxyInfo =
+        ProxyHelper.createProxyInfo(
+            "http://urluser:urlpass@proxy.example.com:8080", "sysuser", "syspass");
+    assertThat(proxyInfo.hasCredentials()).isTrue();
+    String encoded = proxyInfo.getProxyAuthorizationHeader().substring("Basic ".length());
+    String decoded = new String(Base64.getDecoder().decode(encoded), UTF_8);
+    assertThat(decoded).isEqualTo("urluser:urlpass");
+  }
+
+  @Test
+  public void testProxyInfoSystemPropertiesOnlyUserIgnored() throws Exception {
+    // If only username is provided via system properties (no password), credentials should not be
+    // set
+    ProxyInfo proxyInfo =
+        ProxyHelper.createProxyInfo("http://proxy.example.com:8080", "sysuser", null);
+    assertThat(proxyInfo.hasCredentials()).isFalse();
+  }
+
+  @Test
+  public void testProxyInfoSystemPropertiesOnlyPasswordIgnored() throws Exception {
+    // If only password is provided via system properties (no username), credentials should not be
+    // set
+    ProxyInfo proxyInfo =
+        ProxyHelper.createProxyInfo("http://proxy.example.com:8080", null, "syspass");
+    assertThat(proxyInfo.hasCredentials()).isFalse();
+  }
+
+  // Tests for http.nonProxyHosts system property
+
+  @Test
+  public void testNonProxyHostsExactMatch() throws Exception {
+    String oldValue = System.getProperty("http.nonProxyHosts");
+    try {
+      System.setProperty("http.nonProxyHosts", "localhost|example.com");
+      ProxyHelper helper = new ProxyHelper(ImmutableMap.of("http_proxy", "http://proxy:8080"));
+
+      // Exact match should bypass proxy
+      ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("http://example.com/foo"));
+      assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
+
+      // Non-match should use proxy
+      ProxyInfo proxyInfo2 = helper.createProxyIfNeeded(new URL("http://other.com/foo"));
+      assertThat(proxyInfo2.proxy()).isNotEqualTo(Proxy.NO_PROXY);
+    } finally {
+      if (oldValue != null) {
+        System.setProperty("http.nonProxyHosts", oldValue);
+      } else {
+        System.clearProperty("http.nonProxyHosts");
+      }
+    }
+  }
+
+  @Test
+  public void testNonProxyHostsWildcardPrefix() throws Exception {
+    String oldValue = System.getProperty("http.nonProxyHosts");
+    try {
+      System.setProperty("http.nonProxyHosts", "*.example.com");
+      ProxyHelper helper = new ProxyHelper(ImmutableMap.of("http_proxy", "http://proxy:8080"));
+
+      // Wildcard match should bypass proxy
+      ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("http://foo.example.com/bar"));
+      assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
+
+      // Non-match should use proxy
+      ProxyInfo proxyInfo2 = helper.createProxyIfNeeded(new URL("http://example.com/bar"));
+      assertThat(proxyInfo2.proxy()).isNotEqualTo(Proxy.NO_PROXY);
+    } finally {
+      if (oldValue != null) {
+        System.setProperty("http.nonProxyHosts", oldValue);
+      } else {
+        System.clearProperty("http.nonProxyHosts");
+      }
+    }
+  }
+
+  @Test
+  public void testNonProxyHostsWildcardSuffix() throws Exception {
+    String oldValue = System.getProperty("http.nonProxyHosts");
+    try {
+      System.setProperty("http.nonProxyHosts", "local*");
+      ProxyHelper helper = new ProxyHelper(ImmutableMap.of("http_proxy", "http://proxy:8080"));
+
+      // Wildcard match should bypass proxy
+      ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("http://localhost/bar"));
+      assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
+
+      ProxyInfo proxyInfo2 = helper.createProxyIfNeeded(new URL("http://localserver/bar"));
+      assertThat(proxyInfo2.proxy()).isEqualTo(Proxy.NO_PROXY);
+    } finally {
+      if (oldValue != null) {
+        System.setProperty("http.nonProxyHosts", oldValue);
+      } else {
+        System.clearProperty("http.nonProxyHosts");
+      }
+    }
   }
 }


### PR DESCRIPTION
This change enables Bazel to work with authenticated HTTP proxies by:

1. Reading proxy credentials from http.proxyUser/http.proxyPassword and https.proxyUser/https.proxyPassword system properties

2. Setting the Proxy-Authorization header directly on HTTP connections to ensure proper authentication with the proxy server

3. Automatically enabling Basic auth for HTTPS tunneling by clearing jdk.http.auth.tunneling.disabledSchemes (which defaults to "Basic")

4. Using Java's Authenticator mechanism for HTTPS CONNECT tunneling, with RequestorType.PROXY check to prevent credential leakage

The ProxyHelper now returns a ProxyInfo object that contains both the Proxy and optional authentication credentials, allowing HttpConnector to set appropriate headers.

Fixes https://github.com/bazelbuild/bazel/issues/14675
Fixes https://github.com/bazelbuild/bazel/issues/7487
Fixes https://github.com/bazelbuild/bazel/issues/6196
Fixes https://github.com/bazelbuild/bazel/issues/26674
Related to https://github.com/bazelbuild/bazel/issues/601
Related to https://github.com/bazelbuild/bazel/issues/587
Related to https://github.com/bazelbuild/bazel/issues/11374
Related to https://github.com/bazelbuild/bazel/issues/15740
Related to https://github.com/bazelbuild/bazel/issues/3993

Closes #28088.

PiperOrigin-RevId: 858722972
Change-Id: Iaaa556d3bb2ec6470bfafcb130432aada933cd33

Commit https://github.com/bazelbuild/bazel/commit/4a714d5e00888870e8ec8333095b65d17eedbe55