### PR TITLE
[9.1.0] Add `execution_requirements` to `ctx.actions.write`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -373,8 +373,26 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             named = true,
             positional = false,
             doc = "A one-word description of the action, for example, CppCompile or GoLink."),
+        @Param(
+            name = "execution_requirements",
+            allowedTypes = {
+              @ParamType(type = Dict.class),
+              @ParamType(type = NoneType.class),
+            },
+            defaultValue = "None",
+            named = true,
+            positional = false,
+            doc =
+                "Information for scheduling the action. See "
+                    + "<a href=\"${link common-definitions#common.tags}\">tags</a> "
+                    + "for useful keys."),
       })
-  void write(FileApi output, Object content, Boolean isExecutable, Object mnemonicUnchecked)
+  void write(
+      FileApi output,
+      Object content,
+      Boolean isExecutable,
+      Object mnemonicUnchecked,
+      Object executionRequirementsUnchecked)
       throws EvalException, InterruptedException;
 
   @StarlarkMethod(

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.ActionAnalysisMetadata;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.CommandLine;
@@ -3122,6 +3123,33 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
 
     assertThat(ev.eval("type(action)")).isEqualTo("Action");
     assertThat(ev.eval("action.mnemonic")).isEqualTo("MyWrite");
+
+    Object contentUnchecked = ev.eval("action.content");
+    assertThat(contentUnchecked).isInstanceOf(String.class);
+    // Args content ends the file with a newline
+    assertThat(contentUnchecked).isEqualTo("foo123\n");
+  }
+
+  @Test
+  public void testFileWriteActionInterfaceWithArgsAndSupportsPathMapping() throws Exception {
+    useConfiguration("--experimental_output_paths=strip");
+    scratch.file(
+        "test/rules.bzl",
+        getSimpleUnderTestDefinition(
+            "args = ctx.actions.args()",
+            "args.add('foo123')",
+            "ctx.actions.write(output=out, content=args,"
+                + " execution_requirements={'supports-path-mapping': ''})"),
+        testingRuleDefinition);
+    scratch.file("test/BUILD", simpleBuildDefinition);
+    StarlarkRuleContext ruleContext = createRuleContext("//test:testing");
+    setRuleContext(ruleContext);
+    ev.update("file", ev.eval("ruleContext.attr.dep[DefaultInfo].files.to_list()[0]"));
+    var action = (Action) ev.eval("ruleContext.attr.dep[Actions].by_file[file]");
+    ev.update("action", action);
+
+    assertThat(ev.eval("type(action)")).isEqualTo("Action");
+    assertThat(action.getExecutionInfo()).containsEntry("supports-path-mapping", "");
 
     Object contentUnchecked = ev.eval("action.content");
     assertThat(contentUnchecked).isInstanceOf(String.class);


### PR DESCRIPTION
Since Bazel's only `FileWriteStrategy` doesn't execute a spawn, this can currently only affect the path mapping behavior of the action when supplying `Args` as content. This will make it possible to opt C++ rules into path mapping without any command line flags beyond `--experimental_output_paths=strip` in future PRs.

Work towards #27732
Work towards #27591

Closes #28335.

PiperOrigin-RevId: 859069420
Change-Id: I73db26fb1f37303f49931ab19cd12575536607fb

Commit https://github.com/bazelbuild/bazel/commit/2e4abf8b2252512947298300a03750574f050ce6