### PR TITLE
Avoid copying on disk cache hits if supported by the file system

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.exec.SpawnProgressEvent;
 import com.google.devtools.build.lib.remote.common.ActionKey;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.LazyFileOutputStream;
+import com.google.devtools.build.lib.remote.common.MaybePathBacked;
 import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.ProgressStatusListener;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
@@ -738,7 +739,7 @@ public class CombinedCache extends AbstractReferenceCounted {
    * An {@link OutputStream} that reports all the write operations with {@link
    * DownloadProgressReporter}.
    */
-  private static class ReportingOutputStream extends OutputStream {
+  private static class ReportingOutputStream extends OutputStream implements MaybePathBacked {
 
     private final OutputStream out;
     private final DownloadProgressReporter reporter;
@@ -774,6 +775,11 @@ public class CombinedCache extends AbstractReferenceCounted {
     @Override
     public void close() throws IOException {
       out.close();
+    }
+
+    @Override
+    public Path maybeGetPath() {
+      return out instanceof MaybePathBacked maybePathBacked ? maybePathBacked.maybeGetPath() : null;
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
@@ -119,8 +119,7 @@ public final class CombinedCacheClientFactory {
   }
 
   public static DiskCacheClient createDiskCache(
-      Path workingDirectory, RemoteOptions options, DigestUtil digestUtil, boolean verifyDownloads)
-      throws IOException {
+      Path workingDirectory, RemoteOptions options, DigestUtil digestUtil) throws IOException {
     Path cacheDir = workingDirectory.getRelative(Preconditions.checkNotNull(options.diskCache));
     return new DiskCacheClient(cacheDir, digestUtil);
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
@@ -57,8 +57,7 @@ public final class CombinedCacheClientFactory {
       httpCacheClient = createHttp(options, creds, authAndTlsOptions, digestUtil, retrier);
     }
     if (isDiskCache(options)) {
-      diskCacheClient =
-          createDiskCache(workingDirectory, options, digestUtil, options.remoteVerifyDownloads);
+      diskCacheClient = createDiskCache(workingDirectory, options, digestUtil);
     }
     if (httpCacheClient == null && diskCacheClient == null) {
       throw new IllegalArgumentException(
@@ -123,7 +122,7 @@ public final class CombinedCacheClientFactory {
       Path workingDirectory, RemoteOptions options, DigestUtil digestUtil, boolean verifyDownloads)
       throws IOException {
     Path cacheDir = workingDirectory.getRelative(Preconditions.checkNotNull(options.diskCache));
-    return new DiskCacheClient(cacheDir, digestUtil, verifyDownloads);
+    return new DiskCacheClient(cacheDir, digestUtil);
   }
 
   public static boolean isDiskCache(RemoteOptions options) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -724,10 +724,7 @@ public final class RemoteModule extends BlazeModule {
         try {
           diskCacheClient =
               CombinedCacheClientFactory.createDiskCache(
-                  env.getWorkingDirectory(),
-                  remoteOptions,
-                  digestUtil,
-                  remoteOptions.remoteVerifyDownloads);
+                  env.getWorkingDirectory(), remoteOptions, digestUtil);
         } catch (Exception e) {
           handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
           return;
@@ -762,10 +759,7 @@ public final class RemoteModule extends BlazeModule {
         try {
           diskCacheClient =
               CombinedCacheClientFactory.createDiskCache(
-                  env.getWorkingDirectory(),
-                  remoteOptions,
-                  digestUtil,
-                  remoteOptions.remoteVerifyDownloads);
+                  env.getWorkingDirectory(), remoteOptions, digestUtil);
         } catch (Exception e) {
           handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
           return;

--- a/src/main/java/com/google/devtools/build/lib/remote/common/LazyFileOutputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/LazyFileOutputStream.java
@@ -17,13 +17,14 @@ import com.google.devtools.build.lib.vfs.Path;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import javax.annotation.Nullable;
 
 /**
  * Creates an {@link OutputStream} backed by a file that isn't actually opened until the first data
  * is written. This is useful to only have as many open file descriptors as necessary at a time to
  * avoid running into system limits.
  */
-public class LazyFileOutputStream extends OutputStream {
+public class LazyFileOutputStream extends OutputStream implements MaybePathBacked {
 
   private final Path path;
   private OutputStream out;
@@ -52,8 +53,9 @@ public class LazyFileOutputStream extends OutputStream {
 
   @Override
   public void flush() throws IOException {
-    ensureOpen();
-    out.flush();
+    if (out != null) {
+      out.flush();
+    }
   }
 
   @Override
@@ -78,5 +80,11 @@ public class LazyFileOutputStream extends OutputStream {
     if (out == null) {
       out = path.getOutputStream();
     }
+  }
+
+  @Override
+  @Nullable
+  public Path maybeGetPath() {
+    return path;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/common/MaybePathBacked.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/MaybePathBacked.java
@@ -1,0 +1,27 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.common;
+
+import com.google.devtools.build.lib.vfs.Path;
+import javax.annotation.Nullable;
+
+/**
+ * An interface to mark {@link java.io.OutputStream} and {@link java.io.InputStream}s that may be
+ * known to write to an associated {@link Path}.
+ */
+public interface MaybePathBacked {
+  /** If this stream is backed by a Path, returns that Path. Otherwise, returns null. */
+  @Nullable
+  Path maybeGetPath();
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/common/MaybePathBacked.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/MaybePathBacked.java
@@ -17,8 +17,8 @@ import com.google.devtools.build.lib.vfs.Path;
 import javax.annotation.Nullable;
 
 /**
- * An interface to mark {@link java.io.OutputStream} and {@link java.io.InputStream}s that may be
- * known to write to an associated {@link Path}.
+ * An interface to mark {@link java.io.OutputStream}s that may be known to write to an associated
+ * {@link Path}.
  */
 public interface MaybePathBacked {
   /** If this stream is backed by a Path, returns that Path. Otherwise, returns null. */

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
@@ -17,6 +17,7 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/remote:store",
+        "//src/main/java/com/google/devtools/build/lib/remote/common",
         "//src/main/java/com/google/devtools/build/lib/remote/common:action_key",
         "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/options",

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -32,6 +32,8 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.remote.Store;
 import com.google.devtools.build.lib.remote.common.ActionKey;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
+import com.google.devtools.build.lib.remote.common.MaybePathBacked;
+import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
 import com.google.devtools.build.lib.remote.util.DigestOutputStream;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.Utils;
@@ -46,7 +48,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.UUID;
 import java.util.concurrent.Executors;
-import javax.annotation.Nullable;
 
 /**
  * An on-disk store for the remote action cache.
@@ -79,17 +80,10 @@ public class DiskCacheClient {
       MoreExecutors.listeningDecorator(
           Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("disk-cache-", 0).factory()));
 
-  private final boolean verifyDownloads;
   private final DigestUtil digestUtil;
 
-  /**
-   * @param verifyDownloads whether verify the digest of downloaded content are the same as the
-   *     digest used to index that file.
-   */
-  public DiskCacheClient(Path root, DigestUtil digestUtil, boolean verifyDownloads)
-      throws IOException {
+  public DiskCacheClient(Path root, DigestUtil digestUtil) throws IOException {
     this.digestUtil = digestUtil;
-    this.verifyDownloads = verifyDownloads;
 
     Path fnRoot =
         isOldStyleDigestFunction(digestUtil.getDigestFunction())
@@ -153,23 +147,25 @@ public class DiskCacheClient {
           if (!refresh(path)) {
             throw new CacheNotFoundException(digest);
           }
-          try (InputStream in = path.getInputStream()) {
-            ByteStreams.copy(in, out);
+          if (out instanceof MaybePathBacked maybePathBacked
+              && maybePathBacked.maybeGetPath() instanceof Path outPath) {
+            // If the output stream is path-backed, the filesystem may be able to avoid copying the
+            // file.
+            FileSystemUtils.copyFile(path, outPath);
+          } else {
+            try (InputStream in = path.getInputStream()) {
+              ByteStreams.copy(in, out);
+            }
           }
           return null;
         });
   }
 
   public ListenableFuture<Void> downloadBlob(Digest digest, OutputStream out) {
-    @Nullable
-    DigestOutputStream digestOut = verifyDownloads ? digestUtil.newDigestOutputStream(out) : null;
     return Futures.transformAsync(
-        download(digest, digestOut != null ? digestOut : out, Store.CAS),
+        download(digest, out, Store.CAS),
         (v) -> {
           try {
-            if (digestOut != null) {
-              Utils.verifyBlobContents(digest, digestOut.digest());
-            }
             out.flush();
             return immediateFuture(null);
           } catch (IOException e) {

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -33,8 +33,6 @@ import com.google.devtools.build.lib.remote.Store;
 import com.google.devtools.build.lib.remote.common.ActionKey;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.MaybePathBacked;
-import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
-import com.google.devtools.build.lib.remote.util.DigestOutputStream;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
@@ -80,11 +78,7 @@ public class DiskCacheClient {
       MoreExecutors.listeningDecorator(
           Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("disk-cache-", 0).factory()));
 
-  private final DigestUtil digestUtil;
-
   public DiskCacheClient(Path root, DigestUtil digestUtil) throws IOException {
-    this.digestUtil = digestUtil;
-
     Path fnRoot =
         isOldStyleDigestFunction(digestUtil.getDigestFunction())
             ? root

--- a/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
@@ -69,7 +69,7 @@ public class DiskCacheClientTest {
 
   @Before
   public void setUp() throws Exception {
-    client = new DiskCacheClient(root, DIGEST_UTIL, /* verifyDownloads= */ true);
+    client = new DiskCacheClient(root, DIGEST_UTIL);
   }
 
   @After
@@ -108,10 +108,7 @@ public class DiskCacheClientTest {
     assumeNotNull(BazelHashFunctions.BLAKE3); // BLAKE3 not available in Blaze.
 
     DiskCacheClient client =
-        new DiskCacheClient(
-            root,
-            new DigestUtil(SyscallCache.NO_CACHE, BazelHashFunctions.BLAKE3),
-            /* verifyDownloads= */ true);
+        new DiskCacheClient(root, new DigestUtil(SyscallCache.NO_CACHE, BazelHashFunctions.BLAKE3));
     Digest digest = Digest.newBuilder().setHash("0123456789abcdef").setSizeBytes(42).build();
     Path path = client.toPath(digest, Store.CAS);
 
@@ -123,10 +120,7 @@ public class DiskCacheClientTest {
     assumeNotNull(BazelHashFunctions.BLAKE3); // BLAKE3 not available in Blaze.
 
     DiskCacheClient client =
-        new DiskCacheClient(
-            root,
-            new DigestUtil(SyscallCache.NO_CACHE, BazelHashFunctions.BLAKE3),
-            /* verifyDownloads= */ true);
+        new DiskCacheClient(root, new DigestUtil(SyscallCache.NO_CACHE, BazelHashFunctions.BLAKE3));
     Digest digest = Digest.newBuilder().setHash("0123456789abcdef").setSizeBytes(42).build();
     Path path = client.toPath(digest, Store.AC);
 

--- a/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
@@ -226,17 +226,6 @@ public class DiskCacheClientTest {
   }
 
   @Test
-  public void downloadBlob_whenCorrupted_throwsOutputDigestMismatchException() throws Exception {
-    Digest digest = getDigest("contents");
-    populateCas(digest, "corrupted contents");
-    Path out = fs.getPath("/out");
-
-    assertThrows(
-        OutputDigestMismatchException.class,
-        () -> getFromFuture(client.downloadBlob(digest, out.getOutputStream())));
-  }
-
-  @Test
   public void downloadActionResult_whenPresent_returnsCachedActionResult() throws Exception {
     ActionKey actionKey = new ActionKey(getDigest("key"));
     ActionResult actionResult = ActionResult.newBuilder().setExitCode(42).build();

--- a/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.remote.Store;
 import com.google.devtools.build.lib.remote.common.ActionKey;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
-import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.testutil.TestUtils;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
@@ -341,8 +340,7 @@ public class DiskCacheClientTest {
   public void concurrentUploadDownload()
       throws IOException, ExecutionException, InterruptedException {
     var nativeDiskCacheDir = TestUtils.createUniqueTmpDir(FileSystems.getNativeFileSystem());
-    var nativeClient =
-        new DiskCacheClient(nativeDiskCacheDir, DIGEST_UTIL, /* verifyDownloads= */ false);
+    var nativeClient = new DiskCacheClient(nativeDiskCacheDir, DIGEST_UTIL);
     var tasks = new ArrayList<Future<?>>();
     // Use 1 MB blobs to increase the window for concurrent access during write/rename.
     var contentSize = 1024 * 1024;

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
@@ -53,7 +53,7 @@ class OnDiskBlobStoreCache extends CombinedCache {
       throws IOException {
     super(
         /* remoteCacheClient= */ null,
-        new DiskCacheClient(cacheDir, digestUtil, /* verifyDownloads= */ true),
+        new DiskCacheClient(cacheDir, digestUtil),
         /* symlinkTemplate= */ null,
         digestUtil);
     this.remoteWorkerOptions = remoteWorkerOptions;


### PR DESCRIPTION
RELNOTES: Bazel no longer verifies the digests of disk cache entries upon a cache hit. This honors the description but not the previous behavior of the `--remote_verify_downloads` flag, which in fact controlled digest verification for both remote and disk caches.

In the process, `LazyFileOutputStream#flush` had to be changed to not open the stream if not open yet, otherwise it would override the existing contents.

Tested manually by running a fully cached build of `//src:bazel` and then verifying that `du -kh bazel-bin/src/bazel` prints `0B` on macOS.