### PR TITLE
Remove --incompatible_lexicographical_output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOptions.java
@@ -19,7 +19,6 @@ import com.google.devtools.common.options.EnumConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
-import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.TriState;
 import java.util.Set;
 
@@ -119,10 +118,9 @@ public class QueryOptions extends CommonQueryOptions {
   @Option(
       name = "incompatible_lexicographical_output",
       defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.QUERY,
-      effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help = "If this option is set, sorts --order_output=auto output in lexicographical order.")
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {OptionEffectTag.NO_OP},
+      help = "No-op.")
   public boolean lexicographicalOutput;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOutputUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOutputUtils.java
@@ -37,9 +37,7 @@ public class QueryOutputUtils {
 
   public static boolean lexicographicallySortOutput(
       QueryOptions queryOptions, OutputFormatter formatter) {
-    return queryOptions.orderOutput == OrderOutput.AUTO
-        && queryOptions.lexicographicalOutput
-        && formatter instanceof StreamedFormatter;
+    return queryOptions.orderOutput == OrderOutput.AUTO && formatter instanceof StreamedFormatter;
   }
 
   public static boolean shouldStreamUnorderedOutput(

--- a/src/test/java/com/google/devtools/build/lib/buildtool/QueryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/QueryIntegrationTest.java
@@ -592,23 +592,6 @@ public class QueryIntegrationTest extends BuildIntegrationTestCase {
   }
 
   @Test
-  public void graphlessQueryWithLexicographicalOutput() throws Exception {
-    write(
-        "foo/BUILD",
-        "load('//test_defs:foo_library.bzl', 'foo_library')",
-        "foo_library(name='foo', srcs=['foo.sh'])");
-
-    QueryOutput result =
-        getQueryResult(
-            "//foo",
-            "--experimental_graphless_query",
-            "--order_output=auto",
-            "--incompatible_lexicographical_output");
-    assertSuccessfulExitCode(result);
-    assertThat(result.getStdout()).isNotEmpty();
-  }
-
-  @Test
   public void graphlessQueryRequiresStreamedFormatter() throws Exception {
     write(
         "foo/BUILD",


### PR DESCRIPTION
This flag was flipped in bazel 5.x or before.

Fixes https://github.com/bazelbuild/bazel/issues/12757
