### PR TITLE
[8.6.0] Fix typo in SkyframeActionExecutor: Use lastEndTime instead of firstStartTime.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -1852,7 +1852,7 @@ public final class SkyframeActionExecutor {
             logs.build(),
             errorTiming,
             firstStartTime.equals(Instant.MAX) ? null : firstStartTime,
-            lastEndTime.equals(Instant.MIN) ? null : firstStartTime));
+            lastEndTime.equals(Instant.MIN) ? null : lastEndTime));
   }
 
   /**


### PR DESCRIPTION
Fixes #28370

PiperOrigin-RevId: 859588739
Change-Id: I3d18c96146f30325c76d229a7f241acc0581f520

Commit https://github.com/bazelbuild/bazel/commit/d9e434a4932e7eac1a94e7f65258a5cf6dbbdfc9