### PR TITLE
Use the env trick for bash.

### DIFF
--- a/src/main/cpp/generate_jvm_module_options.sh
+++ b/src/main/cpp/generate_jvm_module_options.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 The Bazel Authors. All rights reserved.
 #


### PR DESCRIPTION
Other scripts in bazel do this properly. Not all systems install bash, and they may not be located at /bin.