### PR TITLE
[8.6.0] zipper: handle empty filelist

### DIFF
--- a/third_party/ijar/test/zip_test.sh
+++ b/third_party/ijar/test/zip_test.sh
@@ -211,6 +211,13 @@ function test_zipper_permissions() {
   fi
 }
 
+function test_zipper_empty_file_list() {
+  local -r LOCAL_TEST_DIR="${TEST_TMPDIR}/${FUNCNAME[0]}"
+  mkdir -p ${LOCAL_TEST_DIR}/files
+  touch ${LOCAL_TEST_DIR}/empty_file_list.txt
+  ${ZIPPER} cC ${LOCAL_TEST_DIR}/output.zip @${LOCAL_TEST_DIR}/empty_file_list.txt
+}
+
 function test_unzipper_zip64_archive() {
   local -r test_dir="${TEST_TMPDIR}/${FUNCNAME[0]}"
   mkdir -p "${test_dir}"

--- a/third_party/ijar/zip_main.cc
+++ b/third_party/ijar/zip_main.cc
@@ -248,6 +248,12 @@ char **read_filelist(char *filename) {
     return NULL;
   }
 
+  if (file_stat.total_size == 0) {
+    char** filelist = static_cast<char**>(malloc(sizeof(char*)));
+    filelist[0] = NULL;
+    return filelist;
+  }
+
   char *data = static_cast<char *>(malloc(file_stat.total_size));
   if (!read_file(filename, data, file_stat.total_size)) {
     return NULL;


### PR DESCRIPTION
updates the zipper utility so it can handle empty filelists. previously this would fail with

```
File  does not seem to exist.
```

(note the double space)

rather than being treated as an empty list (`[]`), an empty filelist was being treated as a non-empty list of length one with the only element being an empty string (`['']`)

---

Why on earth do I want this? I have a rule that outputs a zip file that may or may not be empty. There is no easy way to tell ahead of time if there will be files. The output *could* be optional, but that would make my life harder for reasons that I can't be bothered explaining (feel free to push on this if it's important). `@bazel_tools//tools/zip:zipper` fails if the filelist is empty and I am working around this by manually creating an empty zip file using the EOCD record:

```js
if (files.length === 0) {
  fs.writeFileSync(zipFile, '\x50\x4b\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00');
}
```

it would be nice if I didn't have to do this :)

Closes #27008.

PiperOrigin-RevId: 812683346
Change-Id: Ifb7dc35b37ce9c07e53786206e90570da542fab7

Commit https://github.com/bazelbuild/bazel/commit/349f6fb7077a7406f7a1a9af697cfc2e44637e5d