### PR TITLE
bzlmod: add experimental_remote_downloader_bzlmod

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BUILD
@@ -53,6 +53,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/pkgcache:package_options",
         "//src/main/java/com/google/devtools/build/lib/profiler",
+        "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/repository:repository_events",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/repository_directory_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:mutable_supplier",

--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -80,6 +80,7 @@ import com.google.devtools.build.lib.pkgcache.PackageOptions;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
+import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue;
 import com.google.devtools.build.lib.runtime.BlazeModule;
 import com.google.devtools.build.lib.runtime.BlazeRuntime;
@@ -292,6 +293,11 @@ public class BazelRepositoryModule extends BlazeModule {
     singleExtensionEvalFunction.setDownloadManager(downloadManager);
 
     RepositoryOptions repoOptions = env.getOptions().getOptions(RepositoryOptions.class);
+    RemoteOptions remoteOptions = env.getOptions().getOptions(RemoteOptions.class);
+    downloadManager.setBzlmodDownloadTempDir(env.getActionTempsDirectory().getChild("bzlmod"));
+    if (remoteOptions != null) {
+      downloadManager.setUseRemoteDownloaderForBzlmod(remoteOptions.remoteDownloaderBzlmod);
+    }
     if (repoOptions != null) {
       downloadManager.setDisableDownload(repoOptions.disableDownload);
       if (repoOptions.repositoryDownloaderRetries >= 0) {

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -153,6 +153,16 @@ public final class RemoteOptions extends CommonRemoteOptions {
   public String remoteDownloader;
 
   @Option(
+      name = "experimental_remote_downloader_bzlmod",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "Whether to use the remote downloader for bzlmod registry file downloads. This only"
+              + " has an effect when --experimental_remote_downloader is set.")
+  public boolean remoteDownloaderBzlmod;
+
+  @Option(
       name = "experimental_remote_downloader_local_fallback",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.REMOTE,


### PR DESCRIPTION
When this flag is enabled and a valid remote downloader was setup, Bazel
will attempt to download bzlmod data through the remote downloader grpc
endpoint.

The canonical ID of the download will be the original url of the bzlmod
data to help the remote downloader implement cache policy accordingly.
