### PR TITLE
Allow the use of the gRPC downloader for Bzlmod

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -270,10 +270,7 @@ public class BazelRepositoryModule extends BlazeModule {
   public void beforeCommand(CommandEnvironment env) throws AbruptExitException {
     DownloadManager downloadManager =
         new DownloadManager(
-            repositoryCache.getDownloadCache(),
-            env.getDownloaderDelegate(),
-            env.getHttpDownloader(),
-            env.getReporter());
+            repositoryCache.getDownloadCache(), env.getDownloaderDelegate(), env.getReporter());
     this.repositoryFetchFunction.setDownloadManager(downloadManager);
     this.moduleFileFunction.setDownloadManager(downloadManager);
     this.repoSpecFunction.setDownloadManager(downloadManager);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DelegatingDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DelegatingDownloader.java
@@ -16,8 +16,8 @@ package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import com.google.auth.Credentials;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
-import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +51,8 @@ public class DelegatingDownloader implements Downloader {
       Credentials credentials,
       Optional<Checksum> checksum,
       String canonicalId,
-      Path destination,
+      OutputStream out,
+      @Nullable String destinationPath,
       ExtendedEventHandler eventHandler,
       Map<String, String> clientEnv,
       Optional<String> type,
@@ -67,7 +68,8 @@ public class DelegatingDownloader implements Downloader {
         credentials,
         checksum,
         canonicalId,
-        destination,
+        out,
+        destinationPath,
         eventHandler,
         clientEnv,
         type,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -860,11 +860,11 @@ public class RemoteExecutionService {
     if (captureCorruptedOutputsDir != null) {
       if (e instanceof BulkTransferException) {
         for (Throwable suppressed : e.getSuppressed()) {
-          if (suppressed instanceof OutputDigestMismatchException) {
+          if (suppressed instanceof OutputDigestMismatchException outputDigestMismatchException) {
             // Capture corrupted outputs
             try {
-              String outputPath = ((OutputDigestMismatchException) suppressed).getOutputPath();
-              Path localPath = ((OutputDigestMismatchException) suppressed).getLocalPath();
+              String outputPath = outputDigestMismatchException.getOutputPath();
+              Path localPath = outputDigestMismatchException.getLocalPath();
               Path dst = captureCorruptedOutputsDir.getRelative(outputPath);
               dst.createDirectoryAndParents();
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoader.java
@@ -135,7 +135,6 @@ public class BazelPackageLoader extends AbstractPackageLoader {
           new DownloadManager(
               repositoryCache.getDownloadCache(),
               httpDownloader,
-              httpDownloader,
               // Only used in tests, so it's okay to miss download progress events.
               ExtendedEventHandler.NOOP);
       RegistryFactoryImpl registryFactory =

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -86,7 +86,7 @@ public class IndexRegistryTest extends FoundationTestCase {
     eventBus.register(eventRecorder);
     downloadCache = new DownloadCache();
     HttpDownloader httpDownloader = new HttpDownloader();
-    downloadManager = new DownloadManager(downloadCache, httpDownloader, httpDownloader, reporter);
+    downloadManager = new DownloadManager(downloadCache, httpDownloader, reporter);
     registryFactory = new RegistryFactoryImpl(Suppliers.ofInstance(ImmutableMap.of()));
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.hash.Hashing;
 import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.authandtls.StaticCredentials;
 import com.google.devtools.build.lib.bazel.repository.cache.DownloadCache;
@@ -80,7 +79,7 @@ public class HttpDownloaderTest {
   // Scale timeouts down to make test fast.
   private final HttpDownloader httpDownloader = new HttpDownloader(0, Duration.ZERO, 8, .1f);
   private final DownloadManager downloadManager =
-      new DownloadManager(downloadCache, httpDownloader, httpDownloader, eventHandler);
+      new DownloadManager(downloadCache, httpDownloader, eventHandler);
 
   private final ExecutorService executor = Executors.newFixedThreadPool(2);
   private final JavaIoFileSystem fs;
@@ -539,158 +538,9 @@ public class HttpDownloaderTest {
   }
 
   @Test
-  public void downloadAndReadOneUrl_ok() throws IOException, InterruptedException {
-    try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName(null))) {
-      @SuppressWarnings("unused")
-      Future<?> possiblyIgnoredError =
-          executor.submit(
-              () -> {
-                try (Socket socket = server.accept()) {
-                  readHttpRequest(socket.getInputStream());
-                  sendLines(
-                      socket,
-                      "HTTP/1.1 200 OK",
-                      "Date: Fri, 31 Dec 1999 23:59:59 GMT",
-                      "Connection: close",
-                      "Content-Type: text/plain",
-                      "Content-Length: 5",
-                      "",
-                      "hello");
-                }
-                return null;
-              });
-
-      assertThat(
-              new String(
-                  httpDownloader.downloadAndReadOneUrl(
-                      new URL(String.format("http://localhost:%d/foo", server.getLocalPort())),
-                      StaticCredentials.EMPTY,
-                      Optional.empty(),
-                      eventHandler,
-                      Collections.emptyMap()),
-                  UTF_8))
-          .isEqualTo("hello");
-    }
-  }
-
-  @Test
-  public void downloadAndReadOneUrl_notFound() throws IOException, InterruptedException {
-    try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName(null))) {
-      @SuppressWarnings("unused")
-      Future<?> possiblyIgnoredError =
-          executor.submit(
-              () -> {
-                try (Socket socket = server.accept()) {
-                  readHttpRequest(socket.getInputStream());
-                  sendLines(
-                      socket,
-                      "HTTP/1.1 404 Not Found",
-                      "Date: Fri, 31 Dec 1999 23:59:59 GMT",
-                      "Connection: close",
-                      "Content-Type: text/plain",
-                      "Content-Length: 5",
-                      "",
-                      "");
-                }
-                return null;
-              });
-
-      assertThrows(
-          IOException.class,
-          () ->
-              httpDownloader.downloadAndReadOneUrl(
-                  new URL(String.format("http://localhost:%d/foo", server.getLocalPort())),
-                  StaticCredentials.EMPTY,
-                  Optional.empty(),
-                  eventHandler,
-                  Collections.emptyMap()));
-    }
-  }
-
-  @Test
-  public void downloadAndReadOneUrl_checksumProvided()
-      throws IOException, Checksum.InvalidChecksumException, InterruptedException {
-    try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName(null))) {
-      @SuppressWarnings("unused")
-      Future<?> possiblyIgnoredError =
-          executor.submit(
-              () -> {
-                try (Socket socket = server.accept()) {
-                  readHttpRequest(socket.getInputStream());
-                  sendLines(
-                      socket,
-                      "HTTP/1.1 200 OK",
-                      "Date: Fri, 31 Dec 1999 23:59:59 GMT",
-                      "Connection: close",
-                      "Content-Type: text/plain",
-                      "Content-Length: 5",
-                      "",
-                      "hello");
-                }
-                return null;
-              });
-
-      assertThat(
-              new String(
-                  httpDownloader.downloadAndReadOneUrl(
-                      new URL(String.format("http://localhost:%d/foo", server.getLocalPort())),
-                      StaticCredentials.EMPTY,
-                      Optional.of(
-                          Checksum.fromString(
-                              DownloadCache.KeyType.SHA256,
-                              Hashing.sha256().hashString("hello", UTF_8).toString())),
-                      eventHandler,
-                      ImmutableMap.of()),
-                  UTF_8))
-          .isEqualTo("hello");
-    }
-  }
-
-  @Test
-  public void downloadAndReadOneUrl_checksumMismatch() throws IOException {
-    try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName(null))) {
-      @SuppressWarnings("unused")
-      Future<?> possiblyIgnoredError =
-          executor.submit(
-              () -> {
-                try (Socket socket = server.accept()) {
-                  readHttpRequest(socket.getInputStream());
-                  sendLines(
-                      socket,
-                      "HTTP/1.1 200 OK",
-                      "Date: Fri, 31 Dec 1999 23:59:59 GMT",
-                      "Connection: close",
-                      "Content-Type: text/plain",
-                      "Content-Length: 9",
-                      "",
-                      "malicious");
-                }
-                return null;
-              });
-
-      var e =
-          assertThrows(
-              UnrecoverableHttpException.class,
-              () ->
-                  httpDownloader.downloadAndReadOneUrl(
-                      new URL(String.format("http://localhost:%d/foo", server.getLocalPort())),
-                      StaticCredentials.EMPTY,
-                      Optional.of(
-                          Checksum.fromString(
-                              DownloadCache.KeyType.SHA256,
-                              Hashing.sha256().hashUnencodedChars("hello").toString())),
-                      eventHandler,
-                      ImmutableMap.of()));
-      assertThat(e).hasMessageThat().contains("Checksum was");
-    }
-  }
-
-  @Test
   public void download_contentLengthMismatch_propagateErrorIfNotRetry() throws Exception {
     Downloader downloader = mock(Downloader.class);
-    HttpDownloader httpDownloader = mock(HttpDownloader.class);
-    DownloadManager downloadManager =
-        new DownloadManager(downloadCache, downloader, httpDownloader, eventHandler);
+    DownloadManager downloadManager = new DownloadManager(downloadCache, downloader, eventHandler);
     // do not retry
     downloadManager.setRetries(0);
     AtomicInteger times = new AtomicInteger(0);
@@ -725,10 +575,8 @@ public class HttpDownloaderTest {
   @Test
   public void download_contentLengthMismatch_retries() throws Exception {
     Downloader downloader = mock(Downloader.class);
-    HttpDownloader httpDownloader = mock(HttpDownloader.class);
     int retries = 5;
-    DownloadManager downloadManager =
-        new DownloadManager(downloadCache, downloader, httpDownloader, eventHandler);
+    DownloadManager downloadManager = new DownloadManager(downloadCache, downloader, eventHandler);
     downloadManager.setRetries(retries);
     AtomicInteger times = new AtomicInteger(0);
     byte[] data = "content".getBytes(UTF_8);
@@ -769,10 +617,8 @@ public class HttpDownloaderTest {
   @Test
   public void download_contentLengthMismatchWithOtherErrors_retries() throws Exception {
     Downloader downloader = mock(Downloader.class);
-    HttpDownloader httpDownloader = mock(HttpDownloader.class);
     int retries = 5;
-    DownloadManager downloadManager =
-        new DownloadManager(downloadCache, downloader, httpDownloader, eventHandler);
+    DownloadManager downloadManager = new DownloadManager(downloadCache, downloader, eventHandler);
     downloadManager.setRetries(retries);
     AtomicInteger times = new AtomicInteger(0);
     byte[] data = "content".getBytes(UTF_8);
@@ -816,10 +662,8 @@ public class HttpDownloaderTest {
   @Test
   public void download_socketException_retries() throws Exception {
     Downloader downloader = mock(Downloader.class);
-    HttpDownloader httpDownloader = mock(HttpDownloader.class);
     int retries = 5;
-    DownloadManager downloadManager =
-        new DownloadManager(downloadCache, downloader, httpDownloader, eventHandler);
+    DownloadManager downloadManager = new DownloadManager(downloadCache, downloader, eventHandler);
     downloadManager.setRetries(retries);
     AtomicInteger times = new AtomicInteger(0);
     byte[] data = "content".getBytes(UTF_8);
@@ -860,10 +704,8 @@ public class HttpDownloaderTest {
   @Test
   public void download_socketExceptionWithOtherErrors_retries() throws Exception {
     Downloader downloader = mock(Downloader.class);
-    HttpDownloader httpDownloader = mock(HttpDownloader.class);
     int retries = 5;
-    DownloadManager downloadManager =
-        new DownloadManager(downloadCache, downloader, httpDownloader, eventHandler);
+    DownloadManager downloadManager = new DownloadManager(downloadCache, downloader, eventHandler);
     downloadManager.setRetries(retries);
     AtomicInteger times = new AtomicInteger(0);
     byte[] data = "content".getBytes(UTF_8);


### PR DESCRIPTION
This is enabled by a refactoring that lets Bzlmod fetches go through the `Downloader#download` function - by making the later consume an `OutputStream` rather than a `Path`.