### PR TITLE
Use pretty aspect class names in errors

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/AspectKeyCreator.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/AspectKeyCreator.java
@@ -19,6 +19,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.actions.ActionLookupKey;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -44,7 +45,7 @@ public final class AspectKeyCreator {
   public static AspectKey createAspectKey(
       AspectDescriptor aspectDescriptor, ConfiguredTargetKey baseConfiguredTargetKey) {
     return createAspectKey(
-        aspectDescriptor, /*baseKeys=*/ ImmutableList.of(), baseConfiguredTargetKey);
+        aspectDescriptor, /* baseKeys= */ ImmutableList.of(), baseConfiguredTargetKey);
   }
 
   public static AspectKey createAspectKey(
@@ -375,7 +376,9 @@ public final class AspectKeyCreator {
     String getDescription() {
       return String.format(
           "%s with parameters %s on %s",
-          topLevelAspectsClasses, topLevelAspectsParameters, targetLabel);
+          Lists.transform(topLevelAspectsClasses, AspectClass::getName),
+          topLevelAspectsParameters,
+          targetLabel);
     }
 
     @Override


### PR DESCRIPTION
Previously, the default `toString()` implementation was used, printing the full class name and hash code.