### PR TITLE
docs: add reference for label_flag and label_setting rules

### DIFF
--- a/site/en/extending/config.md
+++ b/site/en/extending/config.md
@@ -335,7 +335,7 @@ the [`configuration_field`](/rules/lib/globals/bzl#configuration_field)
 
 #### `label_flag` and `label_setting` {:#label-flag-setting}
 
-These rules serve as label-typed build settings used for transitions and command-line configuration. They function as aliases that can be redirected by the configuration.
+These rules are label-typed build settings. `label_flag` can be set on the command line, while `label_setting` is for internal configuration (e.g. via transitions). Both function as aliases that can be redirected by the configuration.
 
 **Attributes:**
 

--- a/site/en/extending/config.md
+++ b/site/en/extending/config.md
@@ -333,6 +333,39 @@ final values can be affected by configuration. In Starlark, this will replace
 the [`configuration_field`](/rules/lib/globals/bzl#configuration_field)
  API.
 
+#### `label_flag` and `label_setting` {:#label-flag-setting}
+
+These rules serve as label-typed build settings used for transitions and command-line configuration. They function as aliases that can be redirected by the configuration.
+
+**Attributes:**
+
+*   `name`: (required) A unique name for this target.
+*   `build_setting_default`: (required) The default label this alias points to.
+*   `visibility`: (optional) Standard visibility attribute.
+
+**Example:**
+
+```python
+# //example/BUILD
+label_flag(
+    name = "my_flag",
+    build_setting_default = ":default_target",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "default_target",
+    srcs = ["default.cc"],
+)
+```
+
+You can then override this flag on the command line:
+
+```shell
+$ bazel build //my:target --//example:my_flag=//other:target
+```
+
+
 ```python
 # example/rules.bzl
 MyProvider = provider(fields = ["my_field"])

--- a/site/en/extending/config.md
+++ b/site/en/extending/config.md
@@ -320,51 +320,20 @@ in a `.bazelrc` reduces command line clutter.
 [End to end example](https://github.com/bazelbuild/examples/tree/HEAD/configurations/label_typed_build_setting){: .external}
 
 Unlike other build settings, label-typed settings cannot be defined using the
-`build_setting` rule parameter. Instead, bazel has two built-in rules:
-`label_flag` and `label_setting`. These rules forward the providers of the
-actual target to which the build setting is set. `label_flag` and
-`label_setting` can be read/written by transitions and `label_flag` can be set
-by the user like other `build_setting` rules can. Their only difference is they
-can't customely defined.
+`build_setting` rule parameter. Instead, Bazel has two built-in rules:
+[`label_flag`](/reference/be/general#label_flag) and
+[`label_setting`](/reference/be/general#label_setting). These
+[language-agnostic native rules](/reference/be/overview#language-agnostic-native-rules)
+forward the providers of the actual target to which the build setting is set.
+Both can be read and written by transitions. `label_flag` can also be set by
+the user on the command line, while `label_setting` is intended for internal
+configuration. They cannot be user-defined.
 
 Label-typed settings will eventually replace the functionality of late-bound
 defaults. Late-bound default attributes are Label-typed attributes whose
 final values can be affected by configuration. In Starlark, this will replace
 the [`configuration_field`](/rules/lib/globals/bzl#configuration_field)
  API.
-
-#### `label_flag` and `label_setting` {:#label-flag-setting}
-
-These rules are label-typed build settings. `label_flag` can be set on the command line, while `label_setting` is for internal configuration (e.g. via transitions). Both function as aliases that can be redirected by the configuration.
-
-**Attributes:**
-
-*   `name`: (required) A unique name for this target.
-*   `build_setting_default`: (required) The default label this alias points to.
-*   `visibility`: (optional) Standard visibility attribute.
-
-**Example:**
-
-```python
-# //example/BUILD
-label_flag(
-    name = "my_flag",
-    build_setting_default = ":default_target",
-    visibility = ["//visibility:public"],
-)
-
-cc_library(
-    name = "default_target",
-    srcs = ["default.cc"],
-)
-```
-
-You can then override this flag on the command line:
-
-```shell
-$ bazel build //my:target --//example:my_flag=//other:target
-```
-
 
 ```python
 # example/rules.bzl
@@ -393,6 +362,7 @@ parent_rule = rule(
 load("//example:rules.bzl", "dep_rule", "parent_rule")
 
 dep_rule(name = "dep")
+dep_rule(name = "other_dep")
 
 parent_rule(name = "parent", my_field_provider = ":my_field_provider")
 
@@ -400,6 +370,12 @@ label_flag(
     name = "my_field_provider",
     build_setting_default = ":dep"
 )
+```
+
+You can override a `label_flag` on the command line:
+
+```shell
+$ bazel build //example:parent --//example:my_field_provider=//example:other_dep
 ```
 
 ### Build settings and select() {:#build-settings-and-select}

--- a/src/main/java/com/google/devtools/build/lib/rules/LabelBuildSettings.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/LabelBuildSettings.java
@@ -92,6 +92,15 @@ public final class LabelBuildSettings {
                 .value("universal")
                 .nonconfigurable(NONCONFIGURABLE_ATTRIBUTE_REASON))
         .add(attr("on_leave_scope", NODEP_LABEL).nonconfigurable(NONCONFIGURABLE_ATTRIBUTE_REASON))
+        /* <!-- #BLAZE_RULE(label_flag).ATTRIBUTE(build_setting_default) -->
+        The default label for this build setting's value. The providers of the referenced target
+        are forwarded by the <code>label_flag</code> until the value is changed by the command line
+        or by a transition.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        /* <!-- #BLAZE_RULE(label_setting).ATTRIBUTE(build_setting_default) -->
+        The default label for this build setting's value. The providers of the referenced target
+        are forwarded by the <code>label_setting</code> until the value is changed by a transition.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .setBuildSetting(BuildSetting.create(flag, NODEP_LABEL))
         .canHaveAnyProvider()
         .toolchainResolutionMode(ToolchainResolutionMode.DISABLED)
@@ -126,3 +135,69 @@ public final class LabelBuildSettings {
 
   private LabelBuildSettings() {}
 }
+
+/*<!-- #BLAZE_RULE (NAME = label_flag, FAMILY = General)[GENERIC_RULE] -->
+
+<p>
+  A <code>label_flag</code> is a label-typed build setting that forwards the providers of the
+  target referenced by its current value.
+</p>
+
+<p>
+  Use <code>label_flag</code> when you want a label-typed build setting that can be changed by
+  transitions and by users at the command line.
+</p>
+
+<h4 id="label_flag_examples">Example</h4>
+
+<pre class="code">
+label_flag(
+    name = "my_flag",
+    build_setting_default = ":default_target",
+)
+
+cc_library(
+    name = "default_target",
+    srcs = ["default.cc"],
+)
+
+cc_library(
+    name = "other_target",
+    srcs = ["other.cc"],
+)
+</pre>
+
+<p>
+  Users can override this with a command like
+  <code>bazel build //example:target --//example:my_flag=//example:other_target</code>.
+</p>
+
+<!-- #END_BLAZE_RULE -->*/
+
+/*<!-- #BLAZE_RULE (NAME = label_setting, FAMILY = General)[GENERIC_RULE] -->
+
+<p>
+  A <code>label_setting</code> is a label-typed build setting that forwards the providers of the
+  target referenced by its current value.
+</p>
+
+<p>
+  Use <code>label_setting</code> for internal configuration that should be changed by transitions
+  but not set directly by users on the command line.
+</p>
+
+<h4 id="label_setting_examples">Example</h4>
+
+<pre class="code">
+label_setting(
+    name = "current_tool",
+    build_setting_default = ":default_tool",
+)
+
+filegroup(
+    name = "default_tool",
+    srcs = ["tool.txt"],
+)
+</pre>
+
+<!-- #END_BLAZE_RULE -->*/


### PR DESCRIPTION
### What does this PR do?

This PR adds missing reference documentation for the `label_flag` and `label_setting`
rules in `site/en/extending/config.md`.

These rules are currently mentioned in the documentation, but do not have a
clear description of their purpose, attributes, or usage.

---

### What’s included?

- Expanded documentation in the **Label-typed build settings** section
- Clear explanations of:
  - `label_flag`
  - `label_setting`
- A description of how these rules are used for configuration and transitions
- A list of supported attributes:
  - `name`
  - `build_setting_default`
  - `visibility`
- A minimal example showing how to define and reference them

---

### Why is this useful?

Users encountering `label_flag` and `label_setting` currently need to inspect
rule definitions or source code to understand how they work.

This change provides a concise reference-style explanation consistent with
other build setting documentation and improves discoverability for users
extending Bazel configuration.

---

### Verification

- Manually reviewed the updated documentation for clarity and consistency
  with existing sections
- Verified that examples follow current Bazel syntax and documentation style

---

Fixes #16128
