### PR TITLE
docs: add missing load() statements in examples

### DIFF
--- a/site/en/docs/android-instrumentation-test.md
+++ b/site/en/docs/android-instrumentation-test.md
@@ -233,6 +233,7 @@ android_sdk_repository(
 
 # Android Test Support
 ATS_COMMIT = "$COMMIT_HASH"
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "android_test_support",
     strip_prefix = "android-test-%s" % ATS_COMMIT,

--- a/site/en/docs/configurable-attributes.md
+++ b/site/en/docs/configurable-attributes.md
@@ -937,6 +937,7 @@ You can even have a `bind()` target point to an `alias()`, if needed.
 $ cat WORKSPACE
 workspace(name = "myapp")
 bind(name = "openssl", actual = "//:ssl")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(name = "alternative", ...)
 http_archive(name = "boringssl", ...)
 


### PR DESCRIPTION
### What does this PR do?

This PR adds missing `load()` statements to documentation examples that reference
rules or symbols without showing how they are imported.

Several examples currently assume implicit knowledge of where rules are defined,
which can be confusing for new users.

---

### What’s included?

- Added the appropriate `load()` statements to affected examples
- No behavioral or semantic changes to the documented examples
- Improves copy-paste usability and clarity

---

### Why is this useful?

Without explicit `load()` statements, examples may not work as written and can
lead to confusion for users learning Bazel rules and macros.

This change makes the documentation more self-contained and accurate.

---

### Verification

- Manually reviewed updated examples for correctness and consistency
- Confirmed all added `load()` statements match the rules used in each example

---

Fixes #16001
