### PR TITLE
docs: resolve duplicate anchor IDs

### DIFF
--- a/site/en/contribute/design-documents.md
+++ b/site/en/contribute/design-documents.md
@@ -200,7 +200,7 @@ A reviewer comments, reviews and approves design documents.
 You're responsible for reviewing design documents, asking for additional
 information if needed, and approving a design that passes the review process.
 
-#### When you receive a new proposal {:#new-proposal}
+#### When you receive a new proposal {:#receive-new-proposal}
 
 1.  Take a quick look at the document.
 1.  Comment if critical information is missing, or if the design doesn't fit

--- a/site/en/docs/bazel-and-java.md
+++ b/site/en/docs/bazel-and-java.md
@@ -280,7 +280,7 @@ Predefined configurations:
     built from sources (this may be useful on operating system with different
     libc)
 
-#### Configuring JVM and Java compiler flags {:#config-jvm}
+#### Configuring JVM and Java compiler flags {:#config-jvm-flags}
 
 You may configure JVM and javac flags either with flags or with
  `default_java_toolchain` attributes.

--- a/site/en/query/cquery.md
+++ b/site/en/query/cquery.md
@@ -405,7 +405,7 @@ all core Starlark
 plus a few cquery-specific ones described below, but not (for example) `glob`,
 `native`, or `rule`, and it does not support load statements.
 
-##### build_options(target) {:#build-options}
+##### build_options(target) {:#build-options-function}
 
 `build_options(target)` returns a map whose keys are build option identifiers
 (see [Configurations](/extending/config)) and whose values are their Starlark


### PR DESCRIPTION
### What does this PR do?

This PR fixes documentation pages that generate duplicate anchor IDs,
which can cause links to options or sections to resolve incorrectly.

The issue occurs when multiple headings or options produce the same
auto-generated anchor.

---

### What’s included?

- Updated affected documentation to ensure anchor IDs are unique
- Adjusted headings or anchor definitions where necessary
- No changes to documented behavior or content semantics

---

### Why is this useful?

Duplicate anchor IDs can break deep links and make it difficult to
reference specific options or sections in the documentation.

This change ensures links are stable and behave as expected.

---

### Verification

- Manually verified that affected pages no longer contain duplicate anchors
- Confirmed links resolve to the intended sections

---

Fixes #14822
