### PR TITLE
[8.6.0] [Repository Downloader] Fail over immediately on TLS errors (https://github.com/bazelbuild/bazel/pull/28347)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
@@ -41,6 +41,7 @@ import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.WillClose;
+import javax.net.ssl.SSLException;
 
 /**
  * Class for establishing connections to HTTP servers for downloading files.
@@ -164,6 +165,22 @@ class HttpConnector {
           code = connection.getResponseCode();
         } catch (FileNotFoundException ignored) {
           code = connection.getResponseCode();
+        } catch (SSLException e) {
+          // Check if the exception is due to a permanent error, such as a certificate validation
+          // issue.
+          // These errors are unlikely to be resolved by retrying.
+          if (e.getMessage() != null
+              && (e.getMessage().contains("certificate")
+                  || e.getMessage().contains("CertPathValidatorException"))) {
+            String message = "TLS error: " + e.getMessage();
+            eventHandler.handle(Event.progress(message));
+            IOException httpException = new UnrecoverableHttpException(message);
+            httpException.addSuppressed(e);
+            throw httpException;
+          }
+          // Otherwise, treat it as a potentially transient network error and let it fall through
+          // to the standard IOException handler for retries.
+          throw e;
         } catch (UnknownHostException e) {
           String message = "Unknown host: " + e.getMessage();
           eventHandler.handle(Event.progress(message));

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -33,10 +33,10 @@ import com.google.devtools.build.lib.authandtls.StaticCredentials;
 import com.google.devtools.build.lib.bazel.repository.cache.DownloadCache;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.JavaIoFileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetAddress;
@@ -52,6 +52,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -130,7 +131,7 @@ public class HttpDownloaderTest {
               Collections.emptyMap(),
               "testRepo");
 
-      assertThat(new String(readFile(resultingFile), UTF_8)).isEqualTo("hello");
+      assertThat(new String(FileSystemUtils.readContent(resultingFile), UTF_8)).isEqualTo("hello");
     }
   }
 
@@ -170,7 +171,7 @@ public class HttpDownloaderTest {
               Collections.emptyMap(),
               "testRepo");
 
-      assertThat(new String(readFile(resultingFile), UTF_8)).isEqualTo("hello");
+      assertThat(new String(FileSystemUtils.readContent(resultingFile), UTF_8)).isEqualTo("hello");
       assertThat(resultingFile.asFragment().getFileExtension()).isEqualTo("zip");
       assertThat(resultingFile.asFragment().getBaseName()).doesNotContain(":");
     }
@@ -237,7 +238,8 @@ public class HttpDownloaderTest {
               Collections.emptyMap(),
               "testRepo");
 
-      assertThat(new String(readFile(resultingFile), UTF_8)).isEqualTo("content1");
+      assertThat(new String(FileSystemUtils.readContent(resultingFile), UTF_8))
+          .isEqualTo("content1");
     }
   }
 
@@ -305,7 +307,8 @@ public class HttpDownloaderTest {
               Collections.emptyMap(),
               "testRepo");
 
-      assertThat(new String(readFile(resultingFile), UTF_8)).isEqualTo("content2");
+      assertThat(new String(FileSystemUtils.readContent(resultingFile), UTF_8))
+          .isEqualTo("content2");
     }
   }
 
@@ -386,14 +389,67 @@ public class HttpDownloaderTest {
     }
   }
 
-  private static byte[] readFile(Path path) throws IOException {
-    final byte[] data = new byte[(int) path.getFileSize()];
+  @Test
+  public void downloadFrom2UrlsFirstTlsErrorSecondOk() throws IOException, InterruptedException {
+    try (ServerSocket server1 = new ServerSocket(0, 1, InetAddress.getByName(null));
+        ServerSocket server2 = new ServerSocket(0, 1, InetAddress.getByName(null))) {
+      Future<?> server1Future =
+          executor.submit(
+              () -> {
+                // Determine which port was assigned
+                try (Socket socket = server1.accept()) {
+                  // Write garbage to trigger SSL handshake failure on client
+                  socket.getOutputStream().write("Not SSL".getBytes(UTF_8));
+                }
+                return null;
+              });
 
-    try (DataInputStream stream = new DataInputStream(path.getInputStream())) {
-      stream.readFully(data);
+      Future<?> server2Future =
+          executor.submit(
+              () -> {
+                try (Socket socket = server2.accept()) {
+                  readHttpRequest(socket.getInputStream());
+                  sendLines(
+                      socket,
+                      "HTTP/1.1 200 OK",
+                      "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                      "Connection: close",
+                      "Content-Type: text/plain",
+                      "",
+                      "content2");
+                }
+                return null;
+              });
+
+      final List<URL> urls = new ArrayList<>(2);
+      // Use https for the first one to trigger SSL handshake
+      urls.add(new URL(String.format("https://localhost:%d/foo", server1.getLocalPort())));
+      urls.add(new URL(String.format("http://localhost:%d/foo", server2.getLocalPort())));
+
+      Path resultingFile = fs.getPath(workingDir.newFile().getAbsolutePath());
+
+      httpDownloader.download(
+          urls,
+          ImmutableMap.of(),
+          StaticCredentials.EMPTY,
+          Optional.empty(),
+          "testCanonicalId",
+          resultingFile,
+          eventHandler,
+          ImmutableMap.of(),
+          Optional.empty(),
+          "testRepo");
+
+      try {
+        server1Future.get();
+        server2Future.get();
+      } catch (ExecutionException e) {
+        throw new IOException(e.getCause());
+      }
+
+      assertThat(new String(FileSystemUtils.readContent(resultingFile), UTF_8))
+          .isEqualTo("content2");
     }
-
-    return data;
   }
 
   @Test
@@ -431,7 +487,7 @@ public class HttpDownloaderTest {
           Optional.empty(),
           "context");
 
-      assertThat(new String(readFile(destination), UTF_8)).isEqualTo("hello");
+      assertThat(new String(FileSystemUtils.readContent(destination), UTF_8)).isEqualTo("hello");
     }
   }
 
@@ -534,7 +590,7 @@ public class HttpDownloaderTest {
           Optional.empty(),
           "context");
 
-      assertThat(new String(readFile(destination), UTF_8)).isEqualTo("content2");
+      assertThat(new String(FileSystemUtils.readContent(destination), UTF_8)).isEqualTo("content2");
     }
   }
 


### PR DESCRIPTION
When a mirror URL fails with an SSLException (e.g. expired certificate), the downloader should fail over to the next mirror immediately instead of retrying the failing URL multiple times.

Fixes #28158

RELNOTES: Bazel now fails over immediately to mirror URLs if a TLS handshake error occurs.

CC @lberki @fmeum @wyv

Closes #28347.

PiperOrigin-RevId: 861936486
Change-Id: If40b966224c1e0687dd258adb2c03bbf055b8c40

Commit https://github.com/bazelbuild/bazel/commit/5594c2a6cdff8713476b531f603b3d0c841b2361