### PR TITLE
[9.1.0] Use a virtual thread executor for the disk cache (https://github.com/bazelbuild/bazel/pull/28430)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
@@ -28,7 +28,6 @@ import com.google.devtools.build.lib.vfs.Path;
 import io.netty.channel.unix.DomainSocketAddress;
 import java.io.IOException;
 import java.net.URI;
-import java.util.concurrent.ExecutorService;
 import javax.annotation.Nullable;
 
 /** A factory class for providing a {@link CombinedCacheClient}. */
@@ -49,7 +48,6 @@ public final class CombinedCacheClientFactory {
       AuthAndTLSOptions authAndTlsOptions,
       Path workingDirectory,
       DigestUtil digestUtil,
-      ExecutorService executorService,
       RemoteRetrier retrier)
       throws IOException {
     Preconditions.checkNotNull(workingDirectory, "workingDirectory");
@@ -60,12 +58,7 @@ public final class CombinedCacheClientFactory {
     }
     if (isDiskCache(options)) {
       diskCacheClient =
-          createDiskCache(
-              workingDirectory,
-              options,
-              digestUtil,
-              executorService,
-              options.remoteVerifyDownloads);
+          createDiskCache(workingDirectory, options, digestUtil, options.remoteVerifyDownloads);
     }
     if (httpCacheClient == null && diskCacheClient == null) {
       throw new IllegalArgumentException(
@@ -127,14 +120,10 @@ public final class CombinedCacheClientFactory {
   }
 
   public static DiskCacheClient createDiskCache(
-      Path workingDirectory,
-      RemoteOptions options,
-      DigestUtil digestUtil,
-      ExecutorService executorService,
-      boolean verifyDownloads)
+      Path workingDirectory, RemoteOptions options, DigestUtil digestUtil, boolean verifyDownloads)
       throws IOException {
     Path cacheDir = workingDirectory.getRelative(Preconditions.checkNotNull(options.diskCache));
-    return new DiskCacheClient(cacheDir, digestUtil, executorService, verifyDownloads);
+    return new DiskCacheClient(cacheDir, digestUtil, verifyDownloads);
   }
 
   public static boolean isDiskCache(RemoteOptions options) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -269,8 +269,7 @@ public final class RemoteModule extends BlazeModule {
       Credentials credentials,
       AuthAndTLSOptions authAndTlsOptions,
       RemoteOptions remoteOptions,
-      DigestUtil digestUtil,
-      ExecutorService executorService) {
+      DigestUtil digestUtil) {
     CombinedCacheClient combinedCacheClient;
     Retrier.CircuitBreaker circuitBreaker =
         CircuitBreakerFactory.createCircuitBreaker(remoteOptions);
@@ -282,7 +281,6 @@ public final class RemoteModule extends BlazeModule {
               authAndTlsOptions,
               Preconditions.checkNotNull(env.getWorkingDirectory(), "workingDirectory"),
               digestUtil,
-              executorService,
               new RemoteRetrier(
                   remoteOptions, HTTP_RESULT_CLASSIFIER, retryScheduler, circuitBreaker));
     } catch (IOException e) {
@@ -609,8 +607,7 @@ public final class RemoteModule extends BlazeModule {
     }
 
     if ((enableHttpCache || enableDiskCache) && !enableGrpcCache) {
-      initHttpAndDiskCache(
-          env, credentials, authAndTlsOptions, remoteOptions, digestUtil, executorService);
+      initHttpAndDiskCache(env, credentials, authAndTlsOptions, remoteOptions, digestUtil);
       return;
     }
 
@@ -728,7 +725,6 @@ public final class RemoteModule extends BlazeModule {
                   env.getWorkingDirectory(),
                   remoteOptions,
                   digestUtil,
-                  executorService,
                   remoteOptions.remoteVerifyDownloads);
         } catch (Exception e) {
           handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
@@ -767,7 +763,6 @@ public final class RemoteModule extends BlazeModule {
                   env.getWorkingDirectory(),
                   remoteOptions,
                   digestUtil,
-                  executorService,
                   remoteOptions.remoteVerifyDownloads);
         } catch (Exception e) {
           handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -43,7 +43,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import javax.annotation.Nullable;
 
 /**
@@ -70,7 +70,13 @@ public class DiskCacheClient {
   private final ImmutableMap<Store, Path> storeRootMap;
   private final Path tmpRoot;
 
-  private final ListeningExecutorService executorService;
+  // Disk cache operations are almost entirely I/O-bound as digests are only computed as part of
+  // I/O operations, so using virtual threads is appropriate.
+  @SuppressWarnings("AllowVirtualThreads")
+  private final ListeningExecutorService executorService =
+      MoreExecutors.listeningDecorator(
+          Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("disk-cache-", 0).factory()));
+
   private final boolean verifyDownloads;
   private final DigestUtil digestUtil;
 
@@ -78,11 +84,9 @@ public class DiskCacheClient {
    * @param verifyDownloads whether verify the digest of downloaded content are the same as the
    *     digest used to index that file.
    */
-  public DiskCacheClient(
-      Path root, DigestUtil digestUtil, ExecutorService executorService, boolean verifyDownloads)
+  public DiskCacheClient(Path root, DigestUtil digestUtil, boolean verifyDownloads)
       throws IOException {
     this.digestUtil = digestUtil;
-    this.executorService = MoreExecutors.listeningDecorator(executorService);
     this.verifyDownloads = verifyDownloads;
 
     Path fnRoot =
@@ -262,7 +266,9 @@ public class DiskCacheClient {
         });
   }
 
-  public void close() {}
+  public void close() {
+    executorService.close();
+  }
 
   public ListenableFuture<Void> uploadFile(Digest digest, Path file) {
     return executorService.submit(

--- a/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactoryTest.java
@@ -82,7 +82,6 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            executorService,
             retrier);
 
     assertThat(blobStore.remoteCacheClient()).isInstanceOf(HttpCacheClient.class);
@@ -102,7 +101,6 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            executorService,
             retrier);
 
     assertThat(blobStore.remoteCacheClient()).isInstanceOf(HttpCacheClient.class);
@@ -125,7 +123,6 @@ public class CombinedCacheClientFactoryTest {
                 authAndTlsOptions,
                 /* workingDirectory= */ null,
                 digestUtil,
-                executorService,
                 retrier));
   }
 
@@ -144,7 +141,6 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            executorService,
             retrier);
 
     assertThat(blobStore.remoteCacheClient()).isInstanceOf(HttpCacheClient.class);
@@ -166,7 +162,6 @@ public class CombinedCacheClientFactoryTest {
                         authAndTlsOptions,
                         workingDirectory,
                         digestUtil,
-                        executorService,
                         retrier)))
         .hasMessageThat()
         .contains("Remote cache proxy unsupported: bad-proxy");
@@ -183,7 +178,6 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            executorService,
             retrier);
 
     assertThat(blobStore.remoteCacheClient()).isInstanceOf(HttpCacheClient.class);
@@ -201,7 +195,6 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            executorService,
             retrier);
 
     assertThat(blobStore.remoteCacheClient()).isNull();

--- a/src/test/java/com/google/devtools/build/lib/remote/disk/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/disk/BUILD
@@ -16,6 +16,9 @@ filegroup(
 java_test(
     name = "disk",
     srcs = glob(["*.java"]),
+    jvm_flags = [
+        "-Djava.lang.Thread.allowVirtualThreads=true",
+    ],
     test_class = "com.google.devtools.build.lib.AllTests",
     deps = [
         "//src/main/java/com/google/devtools/build/lib/remote:store",

--- a/src/tools/remote/BUILD
+++ b/src/tools/remote/BUILD
@@ -19,6 +19,7 @@ java_binary(
     name = "worker",
     jvm_flags = [
         "--enable-native-access=ALL-UNNAMED",
+        "-Djava.lang.Thread.allowVirtualThreads=true",
     ],
     main_class = "com.google.devtools.build.remote.worker.RemoteWorker",
     visibility = ["//visibility:public"],

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
@@ -27,7 +27,6 @@ import build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy;
 import build.bazel.remote.execution.v2.SymlinkNode;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.remote.CombinedCache;
 import com.google.devtools.build.lib.remote.Store;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
@@ -39,13 +38,9 @@ import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 /** A {@link CombinedCache} backed by an {@link DiskCacheClient}. */
 class OnDiskBlobStoreCache extends CombinedCache {
-  private static final ExecutorService executorService =
-      MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1));
 
   private record DigestAndInvocation(Digest digest, String invocationId) {}
 
@@ -58,7 +53,7 @@ class OnDiskBlobStoreCache extends CombinedCache {
       throws IOException {
     super(
         /* remoteCacheClient= */ null,
-        new DiskCacheClient(cacheDir, digestUtil, executorService, /* verifyDownloads= */ true),
+        new DiskCacheClient(cacheDir, digestUtil, /* verifyDownloads= */ true),
         /* symlinkTemplate= */ null,
         digestUtil);
     this.remoteWorkerOptions = remoteWorkerOptions;


### PR DESCRIPTION
Individual disk cache operations are I/O-bound and not related to `--jobs` or remotely executing actions in any direct way, so it doesn't make sense to reuse the remote `ExecutorService` for them.

Closes #28430.

PiperOrigin-RevId: 862134357
Change-Id: I8e6c43649443179b9d73735a206fad04591fad2a

Commit https://github.com/bazelbuild/bazel/commit/81a74d21af5026799f669a4f8e0c4cedd03139a5