### PR TITLE
Remove unused variable

### DIFF
--- a/src/main/native/darwin/file_jni.cc
+++ b/src/main/native/darwin/file_jni.cc
@@ -28,8 +28,6 @@
 
 namespace blaze_jni {
 
-const int PATH_MAX2 = PATH_MAX * 2;
-
 using std::string;
 
 // See unix_jni.h.


### PR DESCRIPTION
The code cleanup in e348562a576e6b58a674d9c67a17a4d1b0bfb2e1 removed the function that made use of the PATH_MAX2 variable.  There are no uses of this variable and it can now be removed.

Avoids the compiler warning:

src/main/native/darwin/file_jni.cc:31:11: warning: unused variable 'PATH_MAX2' [-Wunused-const-variable]
   31 | const int PATH_MAX2 = PATH_MAX * 2;
      |           ^~~~~~~~~
1 warning generated.