### PR TITLE
[8.6.0] Use a virtual thread executor for the disk cache (https://github.com/…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
@@ -28,7 +28,6 @@ import com.google.devtools.build.lib.vfs.Path;
 import io.netty.channel.unix.DomainSocketAddress;
 import java.io.IOException;
 import java.net.URI;
-import java.util.concurrent.ExecutorService;
 import javax.annotation.Nullable;
 
 /** A factory class for providing a {@link CombinedCacheClient}. */
@@ -49,7 +48,6 @@ public final class CombinedCacheClientFactory {
       AuthAndTLSOptions authAndTlsOptions,
       Path workingDirectory,
       DigestUtil digestUtil,
-      ExecutorService executorService,
       RemoteRetrier retrier)
       throws IOException {
     Preconditions.checkNotNull(workingDirectory, "workingDirectory");
@@ -60,12 +58,7 @@ public final class CombinedCacheClientFactory {
     }
     if (isDiskCache(options)) {
       diskCacheClient =
-          createDiskCache(
-              workingDirectory,
-              options,
-              digestUtil,
-              executorService,
-              options.remoteVerifyDownloads);
+          createDiskCache(workingDirectory, options, digestUtil, options.remoteVerifyDownloads);
     }
     if (httpCacheClient == null && diskCacheClient == null) {
       throw new IllegalArgumentException(
@@ -127,14 +120,10 @@ public final class CombinedCacheClientFactory {
   }
 
   public static DiskCacheClient createDiskCache(
-      Path workingDirectory,
-      RemoteOptions options,
-      DigestUtil digestUtil,
-      ExecutorService executorService,
-      boolean verifyDownloads)
+      Path workingDirectory, RemoteOptions options, DigestUtil digestUtil, boolean verifyDownloads)
       throws IOException {
     Path cacheDir = workingDirectory.getRelative(Preconditions.checkNotNull(options.diskCache));
-    return new DiskCacheClient(cacheDir, digestUtil, executorService, verifyDownloads);
+    return new DiskCacheClient(cacheDir, digestUtil, verifyDownloads);
   }
 
   public static boolean isDiskCache(RemoteOptions options) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -231,8 +231,7 @@ public final class RemoteModule extends BlazeModule {
       Credentials credentials,
       AuthAndTLSOptions authAndTlsOptions,
       RemoteOptions remoteOptions,
-      DigestUtil digestUtil,
-      ExecutorService executorService) {
+      DigestUtil digestUtil) {
     CombinedCacheClient combinedCacheClient;
     Retrier.CircuitBreaker circuitBreaker =
         CircuitBreakerFactory.createCircuitBreaker(remoteOptions);
@@ -244,7 +243,6 @@ public final class RemoteModule extends BlazeModule {
               authAndTlsOptions,
               Preconditions.checkNotNull(env.getWorkingDirectory(), "workingDirectory"),
               digestUtil,
-              executorService,
               new RemoteRetrier(
                   remoteOptions, RETRIABLE_HTTP_ERRORS, retryScheduler, circuitBreaker));
     } catch (IOException e) {
@@ -510,8 +508,7 @@ public final class RemoteModule extends BlazeModule {
     }
 
     if ((enableHttpCache || enableDiskCache) && !enableGrpcCache) {
-      initHttpAndDiskCache(
-          env, credentials, authAndTlsOptions, remoteOptions, digestUtil, executorService);
+      initHttpAndDiskCache(env, credentials, authAndTlsOptions, remoteOptions, digestUtil);
       return;
     }
 
@@ -629,7 +626,6 @@ public final class RemoteModule extends BlazeModule {
                   env.getWorkingDirectory(),
                   remoteOptions,
                   digestUtil,
-                  executorService,
                   remoteOptions.remoteVerifyDownloads);
         } catch (Exception e) {
           handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
@@ -689,7 +685,6 @@ public final class RemoteModule extends BlazeModule {
                   env.getWorkingDirectory(),
                   remoteOptions,
                   digestUtil,
-                  executorService,
                   remoteOptions.remoteVerifyDownloads);
         } catch (Exception e) {
           handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);

--- a/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactoryTest.java
@@ -79,7 +79,6 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            executorService,
             retrier);
 
     assertThat(blobStore.remoteCacheClient()).isInstanceOf(HttpCacheClient.class);
@@ -99,7 +98,6 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            executorService,
             retrier);
 
     assertThat(blobStore.remoteCacheClient()).isInstanceOf(HttpCacheClient.class);
@@ -122,7 +120,6 @@ public class CombinedCacheClientFactoryTest {
                 authAndTlsOptions,
                 /* workingDirectory= */ null,
                 digestUtil,
-                executorService,
                 retrier));
   }
 
@@ -138,7 +135,6 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            executorService,
             retrier);
 
     assertThat(blobStore.remoteCacheClient()).isInstanceOf(HttpCacheClient.class);
@@ -160,7 +156,6 @@ public class CombinedCacheClientFactoryTest {
                         authAndTlsOptions,
                         workingDirectory,
                         digestUtil,
-                        executorService,
                         retrier)))
         .hasMessageThat()
         .contains("Remote cache proxy unsupported: bad-proxy");
@@ -177,7 +172,6 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            executorService,
             retrier);
 
     assertThat(blobStore.remoteCacheClient()).isInstanceOf(HttpCacheClient.class);
@@ -195,7 +189,6 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            executorService,
             retrier);
 
     assertThat(blobStore.remoteCacheClient()).isNull();

--- a/src/test/java/com/google/devtools/build/lib/remote/disk/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/disk/BUILD
@@ -16,6 +16,9 @@ filegroup(
 java_test(
     name = "disk",
     srcs = glob(["*.java"]),
+    jvm_flags = [
+        "-Djava.lang.Thread.allowVirtualThreads=true",
+    ],
     test_class = "com.google.devtools.build.lib.AllTests",
     deps = [
         "//src/main/java/com/google/devtools/build/lib/remote:store",

--- a/src/tools/remote/BUILD
+++ b/src/tools/remote/BUILD
@@ -20,6 +20,7 @@ java_binary(
     jvm_flags = [
         # Disables functionality in StringUtil that relies on Bazel's own internal string representation.
         "-Dbazel.internal.UnicodeStrings=true",
+        "-Djava.lang.Thread.allowVirtualThreads=true",
     ],
     main_class = "com.google.devtools.build.remote.worker.RemoteWorker",
     visibility = ["//visibility:public"],

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
@@ -26,7 +26,6 @@ import build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy;
 import build.bazel.remote.execution.v2.SymlinkNode;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.remote.CombinedCache;
 import com.google.devtools.build.lib.remote.Store;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
@@ -38,13 +37,9 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 /** A {@link CombinedCache} backed by an {@link DiskCacheClient}. */
 class OnDiskBlobStoreCache extends CombinedCache {
-  private static final ExecutorService executorService =
-      MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1));
 
   private record DigestAndInvocation(Digest digest, String invocationId) {}
 
@@ -57,7 +52,7 @@ class OnDiskBlobStoreCache extends CombinedCache {
       throws IOException {
     super(
         /* remoteCacheClient= */ null,
-        new DiskCacheClient(cacheDir, digestUtil, executorService, /* verifyDownloads= */ true),
+        new DiskCacheClient(cacheDir, digestUtil, /* verifyDownloads= */ true),
         remoteOptions,
         digestUtil);
     this.remoteWorkerOptions = remoteWorkerOptions;


### PR DESCRIPTION
…bazelbuild/bazel/pull/28430)

Individual disk cache operations are I/O-bound and not related to `--jobs` or remotely executing actions in any direct way, so it doesn't make sense to reuse the remote `ExecutorService` for them.

Closes #28430.

PiperOrigin-RevId: 862134357
Change-Id: I8e6c43649443179b9d73735a206fad04591fad2a

Commit https://github.com/bazelbuild/bazel/commit/81a74d21af5026799f669a4f8e0c4cedd03139a5