### PR TITLE
[8.6.0] Don't repeatedly request QueryWriteStatus if the server doesn't support it (https://github.com/bazelbuild/bazel/pull/28235)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -50,6 +50,7 @@ import io.netty.util.ReferenceCounted;
 import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
 /**
@@ -67,6 +68,7 @@ final class ByteStreamUploader {
   private final long callTimeoutSecs;
   private final RemoteRetrier retrier;
   private final DigestFunction.Value digestFunction;
+  private final AtomicBoolean queryWriteStatusImplemented = new AtomicBoolean(true);
 
   @Nullable private final Semaphore openedFilePermits;
 
@@ -213,7 +215,7 @@ final class ByteStreamUploader {
     }
   }
 
-  private static final class AsyncUpload implements AsyncCallable<Long> {
+  private final class AsyncUpload implements AsyncCallable<Long> {
     private final RemoteActionExecutionContext context;
     private final ReferenceCountedChannel channel;
     private final CallCredentialsProvider callCredentialsProvider;
@@ -331,6 +333,11 @@ final class ByteStreamUploader {
     }
 
     private ListenableFuture<Long> query() {
+      if (!queryWriteStatusImplemented.get()) {
+        // Without server support for QueryWriteStatus, we have no choice but to restart the entire
+        // upload.
+        return Futures.immediateFuture(0L);
+      }
       ListenableFuture<Long> committedSizeFuture =
           Futures.transformAsync(
               channel.withChannelFuture(
@@ -351,8 +358,7 @@ final class ByteStreamUploader {
           (e) -> {
             Status status = Status.fromThrowable(e);
             if (status.getCode() == Code.UNIMPLEMENTED) {
-              // if the bytestream server does not implement the query, insist
-              // that we should reset the upload
+              queryWriteStatusImplemented.set(false);
               return Futures.immediateFuture(0L);
             }
             return Futures.immediateFailedFuture(e);


### PR DESCRIPTION
After the first time a `QueryWriteStatus` call fails with `UNIMPLEMENTED`, stop calling the method to avoid an additional roundtrip on every retry.

Closes #28235.

PiperOrigin-RevId: 861621112
Change-Id: Iedf106f771fe3105c4c9e8e7b44d14907bd4e835

Commit https://github.com/bazelbuild/bazel/commit/fb62559f37b143667689ab9506279853ab979dfc