### PR TITLE
[8.6.0] Fix --starlark_cpu_profile time misattribution.

### DIFF
--- a/src/main/java/net/starlark/java/eval/StarlarkThread.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkThread.java
@@ -243,6 +243,30 @@ public final class StarlarkThread {
 
   /** Pushes a function onto the call stack. */
   void push(StarlarkCallable fn) {
+    // Poll for newly installed CPU profiler.
+    if (profiler == null) {
+      this.profiler = CpuProfiler.get();
+      if (profiler != null) {
+        // Associated current Java thread with this StarlarkThread.
+        // (Save the previous association so we can restore it later.)
+        this.savedThread = CpuProfiler.setStarlarkThread(this);
+      }
+    }
+
+    if (profiler != null) {
+      if (callstack.isEmpty()) {
+        // If this is the top-level frame, reset the CPU tick counter.
+        cpuTicks.set(0);
+      } else {
+        // Record CPU ticks already accrued by the current frame, as otherwise they'd be
+        // misattributed to the next frame.
+        int ticks = cpuTicks.getAndSet(0);
+        if (ticks > 0) {
+          profiler.addEvent(ticks, getDebugCallStack());
+        }
+      }
+    }
+
     Frame fr = new Frame(this, fn);
     callstack.add(fr);
 
@@ -257,17 +281,6 @@ public final class StarlarkThread {
     CallProfiler callProfiler = StarlarkThread.callProfiler;
     if (callProfiler != null) {
       fr.profileStartTimeNanos = callProfiler.start();
-    }
-
-    // Poll for newly installed CPU profiler.
-    if (profiler == null) {
-      this.profiler = CpuProfiler.get();
-      if (profiler != null) {
-        cpuTicks.set(0);
-        // Associated current Java thread with this StarlarkThread.
-        // (Save the previous association so we can restore it later.)
-        this.savedThread = CpuProfiler.setStarlarkThread(this);
-      }
     }
   }
 


### PR DESCRIPTION
Previously, we flushed the per-thread tick counter when exiting a stack frame. This resulted in ticks already accrued by frame A before it calls frame B to be misattributed to B.

To fix it, also flush the counter when entering a stack frame.

The issue may be observed by profiling this rule:

```
def inner():
  x = 0
  for i in range(100000000):
    x += 1

def outer(ctx):
  x = 0
  for i in range(100000000):
    x += 1

  inner()

  x = 0
  for i in range(100000000):
    x += 1

  return DefaultInfo()

burn = rule(outer)
```

You'd expect one third of the time to be spent in `inner` and the remaining two thirds in `outer`. However, we currently report one third spent in `range`, one third in `inner`, and the final third in `DefaultInfo`.

PiperOrigin-RevId: 845199672
Change-Id: I5d9ffc2e5a779c96ce64c1bf77e8b84429c454e3