### PR TITLE
[9.0.1] Support proto_library targets in @bazel_tools//src/main/protobuf (https://github.com/bazelbuild/bazel/pull/28428)

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -341,6 +341,7 @@ tasks:
       - "-//src/test/py/bazel:bazel_lockfile_test"
       - "-//src/test/py/bazel:bazel_overrides_test"
       - "-//src/test/py/bazel:bazel_repo_mapping_test"
+      - "-//src/test/py/bazel:bazel_tools_proto_test"
       - "-//src/test/py/bazel:bazel_yanked_versions_test"
       - "-//src/test/py/bazel:bzlmod_query_test"
       - "-//src/test/py/bazel:mod_command_test"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -349,6 +349,7 @@ tasks:
       - "-//src/test/py/bazel:bazel_lockfile_test"
       - "-//src/test/py/bazel:bazel_overrides_test"
       - "-//src/test/py/bazel:bazel_repo_mapping_test"
+      - "-//src/test/py/bazel:bazel_tools_proto_test"
       - "-//src/test/py/bazel:bazel_yanked_versions_test"
       - "-//src/test/py/bazel:bzlmod_query_test"
       - "-//src/test/py/bazel:mod_command_test"

--- a/src/main/protobuf/BUILD.tools
+++ b/src/main/protobuf/BUILD.tools
@@ -1,0 +1,175 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+FILES = [
+    "action_cache",
+    "bazel_flags",
+    "builtin",
+    "crash_debugging",
+    "crosstool_config",
+    "deps",
+    "desugar_deps",
+    "execution_statistics",
+    "extra_actions_base",
+    "java_compilation",
+    "memory_pressure",
+    "strategy_policy",
+    "test_status",
+    "worker_protocol",
+    "execution_graph",
+    "file_invalidation_data",
+]
+
+[proto_library(
+    name = s + "_proto",
+    srcs = [s + ".proto"],
+) for s in FILES]
+
+proto_library(
+    name = "build_proto",
+    srcs = ["build.proto"],
+    deps = [":stardoc_output_proto"],
+)
+
+proto_library(
+    name = "analysis_v2_proto",
+    srcs = ["analysis_v2.proto"],
+    deps = [":build_proto"],
+)
+
+proto_library(
+    name = "command_server_proto",
+    srcs = ["command_server.proto"],
+    deps = [
+        ":failure_details_proto",
+        "@com_google_protobuf//:any_proto",
+    ],
+)
+
+proto_library(
+    name = "failure_details_proto",
+    srcs = ["failure_details.proto"],
+    deps = ["@com_google_protobuf//:descriptor_proto"],
+)
+
+proto_library(
+    name = "invocation_policy_proto",
+    srcs = ["invocation_policy.proto"],
+    deps = [":strategy_policy_proto"],
+)
+
+proto_library(
+    name = "option_filters_proto",
+    srcs = ["option_filters.proto"],
+)
+
+proto_library(
+    name = "command_line_proto",
+    srcs = ["command_line.proto"],
+    deps = [":option_filters_proto"],
+)
+
+proto_library(
+    name = "cache_salt_proto",
+    srcs = ["cache_salt.proto"],
+)
+
+proto_library(
+    name = "remote_scrubbing_proto",
+    srcs = ["remote_scrubbing.proto"],
+)
+
+proto_library(
+    name = "spawn_proto",
+    srcs = ["spawn.proto"],
+    deps = [
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+proto_library(
+    name = "stardoc_output_proto",
+    srcs = ["stardoc_output.proto"],
+)
+
+proto_library(
+    name = "xcode_proto",
+    srcs = ["xcode_config.proto"],
+)
+
+# The following targets are not available in @bazel_tools
+# to give a clear error message if someone tries to use them.
+
+UNSUPPORTED_LANGUAGE_SPECIFIC_TARGETS = [
+    "build_java_proto",
+    "build_java_proto_srcs",
+    "analysis_v2_py_proto",
+    "analysis_v2_java_proto",
+    "analysis_v2_java_proto_srcs",
+    "any_java_proto",
+    "wrappers_java_proto",
+    "command_server_java_proto",
+    "command_server_java_proto_srcs",
+    "failure_details_java_proto",
+    "failure_details_java_proto_srcs",
+    "invocation_policy_java_proto",
+    "invocation_policy_java_proto_srcs",
+    "option_filters_java_proto",
+    "option_filters_java_proto_srcs",
+    "command_line_java_proto",
+    "command_line_java_proto_srcs",
+    "desugar_deps_cc_proto",
+    "worker_protocol_cc_proto",
+    "command_server_java_grpc",
+    "command_server_cc_proto",
+    "command_server_cc_grpc",
+    "build_pb_py",
+    "profile_java_proto_srcs",
+    "execution_statistics_cc_proto",
+    "remote_execution_log_proto",
+    "remote_execution_log_java_proto",
+    "remote_execution_log_java_proto_srcs",
+    "cache_salt_java_proto",
+    "cache_salt_java_proto_srcs",
+    "remote_scrubbing_java_proto",
+    "remote_scrubbing_java_proto_srcs",
+    "bazel_output_service_java_proto",
+    "bazel_output_service_java_proto_srcs",
+    "bazel_output_service_cc_proto",
+    "bazel_output_service_rev2_java_proto",
+    "bazel_output_service_rev2_java_proto_srcs",
+    "bazel_output_service_rev2_cc_proto",
+    "bazel_output_service_java_grpc",
+    "bazel_output_service_cc_grpc",
+    "spawn_java_proto",
+    "spawn_java_proto_srcs",
+    "stardoc_output_java_proto",
+    "stardoc_output_java_proto_srcs",
+    "xcode_java_proto",
+    "xcode_cc_proto",
+    "xcode_java_proto_srcs",
+]
+
+[alias(
+    name = s + "_java_proto",
+    actual = ":ERROR_language_specific_proto_library_is_unsupported_in_bazel_tools",
+) for s in FILES]
+
+[alias(
+    name = s + "_java_proto_srcs",
+    actual = ":ERROR_language_specific_proto_library_is_unsupported_in_bazel_tools",
+) for s in FILES]
+
+[alias(
+    name = name,
+    actual = ":ERROR_language_specific_proto_library_is_unsupported_in_bazel_tools",
+) for name in UNSUPPORTED_LANGUAGE_SPECIFIC_TARGETS]
+
+genrule(
+    name = "ERROR_language_specific_proto_library_is_unsupported_in_bazel_tools",
+    outs = ["unused.txt"],
+    cmd = "echo '\n\nLanguage specific proto targets are not available in @bazel_tools. Please use the proto_library and generate your own code.\n\n' >&2 && exit 1",
+)
+

--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -253,6 +253,13 @@ py_test(
     deps = [":test_base"],
 )
 
+py_test(
+    name = "bazel_tools_proto_test",
+    size = "medium",
+    srcs = ["bazel_tools_proto_test.py"],
+    deps = [":test_base"],
+)
+
 py_library(
     name = "bzlmod_test_utils",
     srcs = ["bzlmod/test_utils.py"],

--- a/src/test/py/bazel/bazel_tools_proto_test.py
+++ b/src/test/py/bazel/bazel_tools_proto_test.py
@@ -1,0 +1,83 @@
+# pylint: disable=g-bad-file-header
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from src.test.py.bazel import test_base
+
+
+class BazelToolsProtoTest(test_base.TestBase):
+
+  def testProtoLibraryInBazelTools(self):
+    self.AddBazelDep('protobuf')
+    self.ScratchFile(
+        'BUILD',
+        [
+            'load("@protobuf//bazel:proto_library.bzl", "proto_library")',
+            'proto_library(',
+            '    name = "my_proto",',
+            '    srcs = ["my.proto"],',
+            (
+                '    deps ='
+                ' ["@bazel_tools//src/main/protobuf:action_cache_proto"],'
+            ),
+            ')',
+        ],
+    )
+    self.ScratchFile(
+        'my.proto',
+        [
+            'syntax = "proto3";',
+            'import "src/main/protobuf/action_cache.proto";',
+            'package my;',
+            'message MyMessage {',
+            '  blaze.ActionCacheStatistics stats = 1;',
+            '}',
+        ],
+    )
+
+    # This should succeed because we fixed the visibility/load issues in
+    # @bazel_tools//src/main/protobuf:BUILD
+    self.RunBazel(['build', '//:my_proto'])
+
+  def testUnsupportedLanguageSpecificProtoTargets(self):
+    self.AddBazelDep('protobuf')
+    self.ScratchFile(
+        'BUILD',
+        [
+            'alias(',
+            '    name = "bad_alias",',
+            (
+                '    actual ='
+                ' "@bazel_tools//src/main/protobuf:action_cache_java_proto",'
+            ),
+            ')',
+        ],
+    )
+
+    exit_code, _, stderr = self.RunBazel(
+        ['build', '//:bad_alias'], allow_failure=True
+    )
+    self.AssertExitCode(exit_code, 1, stderr)
+    self.assertIn(
+        'Language specific proto targets are not available in @bazel_tools',
+        ''.join(stderr),
+    )
+    self.assertIn(
+        'Please use the proto_library and generate your own code',
+        ''.join(stderr),
+    )
+
+
+if __name__ == '__main__':
+  test_base.absltest.main()


### PR DESCRIPTION
This addresses https://github.com/bazelbuild/bazel/issues/28400.

Bazel 9 breaks usage of `proto_library` targets in `@bazel_tools//src/main/protobuf` because the `BUILD` file there loads rules and depends on repositories (like `@grpc-java`, `@com_github_grpc_grpc`, etc.) that are not visible from the `@bazel_tools` repository.

This change introduces `src/main/protobuf/BUILD.tools`, which will be used as the `BUILD` file for `@bazel_tools//src/main/protobuf`. This version:
1.  Only defines the `proto_library` targets, avoiding problematic loads and cross-repo dependencies.
2.  Adds `alias` targets for the language-specific targets (e.g., `_java_proto`) that were previously defined in the `BUILD` file.
3.  Points these aliases to a dedicated target that fails with a clear and helpful error message, explaining that language-specific proto targets are not available in `@bazel_tools` and users should generate their own code from the `proto_library`.

This ensures that users can still depend on the `proto_library` targets while providing a better experience for those attempting to use the unsupported language-specific targets.

Closes #28428.

PiperOrigin-RevId: 862360134
Change-Id: I55461f5bf08a4695f6148a5f8c0640e12d8d290e

Commit https://github.com/bazelbuild/bazel/commit/1d52819e40b1bcb76f8f02cff3edd4b972dd69b7