### PR TITLE
Refactor flag aliases to be passed around as labels

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.analysis.config;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
@@ -939,11 +938,6 @@ public class BuildConfigurationValue
    */
   public List<Label> getTargetEnvironments() {
     return options.targetEnvironments;
-  }
-
-  public ImmutableMap<String, String> getCommandLineFlagAliases() {
-    return options.commandLineFlagAliases.stream()
-        .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   @Nullable

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/FragmentOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/FragmentOptions.java
@@ -97,10 +97,10 @@ public abstract class FragmentOptions extends OptionsBase implements Cloneable {
    * Helper method for subclasses to normalize list of map entries by keeping only the last entry
    * for each key. The order of the entries is preserved.
    */
-  protected static List<Map.Entry<String, String>> normalizeEntries(
-      List<Map.Entry<String, String>> entries) {
-    LinkedHashMap<String, String> normalizedEntries = new LinkedHashMap<>();
-    for (Map.Entry<String, String> entry : entries) {
+  protected static <V> List<Map.Entry<String, V>> normalizeEntries(
+      List<Map.Entry<String, V>> entries) {
+    LinkedHashMap<String, V> normalizedEntries = new LinkedHashMap<>();
+    for (Map.Entry<String, V> entry : entries) {
       normalizedEntries.put(entry.getKey(), entry.getValue());
     }
     // If we made no changes, return the same instance we got to reduce churn.

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkTransitionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkTransitionCache.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.analysis.config;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.config.StarlarkDefinedConfigTransition.Settings;
 import com.google.devtools.build.lib.analysis.config.transitions.ConfigurationTransition;
@@ -27,9 +28,7 @@ import com.google.devtools.build.lib.analysis.starlark.StarlarkTransition.Transi
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.events.StoredEventHandler;
-import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -75,7 +74,7 @@ public final class StarlarkTransitionCache {
    * flag mapped to this alias.
    */
   public ImmutableSet<Label> getAllStarlarkBuildSettings(
-      ConfigurationTransition root, List<Entry<String, String>> flagsAliases) {
+      ConfigurationTransition root, ImmutableMap<String, Label> flagsAliases) {
     var cachedValue = starlarkBuildSettingsCache.getIfPresent(root);
     if (cachedValue != null) {
       return cachedValue;
@@ -101,7 +100,7 @@ public final class StarlarkTransitionCache {
   /** Adds the default values for a transition's input build settings to its input build options. */
   private BuildOptions addDefaultStarlarkOptions(
       BuildOptions fromOptions,
-      List<Entry<String, String>> flagsAliases,
+      ImmutableMap<String, Label> flagsAliases,
       ConfigurationTransition transition,
       StarlarkBuildSettingsDetailsValue details) {
     if (details.buildSettingToDefault().isEmpty()) {
@@ -150,8 +149,8 @@ public final class StarlarkTransitionCache {
       return cachedResult.result;
     }
 
-    List<Entry<String, String>> flagsAliases =
-        fromOptions.get(CoreOptions.class).commandLineFlagAliases;
+    ImmutableMap<String, Label> flagsAliases =
+        fromOptions.get(CoreOptions.class).getCommandLineFlagAliases();
 
     // All code below here only executes on a cache miss and thus should rely only on values that
     // are part of the above cache key or constants that exist throughout the lifetime of the
@@ -231,6 +230,7 @@ public final class StarlarkTransitionCache {
 
   private static final class Value {
     private final Map<String, BuildOptions> result;
+
     /**
      * Stores events for successful transitions. Transitions that fail aren't added to the cache.
      * This is meant for non-error events like Starlark {@code print()} output. See {@link

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformValue.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.analysis.platform;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.skyframe.SkyFunctions;
 import com.google.devtools.build.lib.skyframe.config.ParsedFlagsValue;
@@ -48,7 +49,7 @@ public record PlatformValue(PlatformInfo platformInfo, Optional<ParsedFlagsValue
     return new PlatformValue(platformInfo, Optional.of(parsedFlags));
   }
 
-  public static Key key(Label platformLabel, List<Map.Entry<String, String>> flagAliasMappings) {
+  public static Key key(Label platformLabel, ImmutableMap<String, Label> flagAliasMappings) {
     return Key.create(platformLabel, flagAliasMappings);
   }
 
@@ -59,12 +60,11 @@ public record PlatformValue(PlatformInfo platformInfo, Optional<ParsedFlagsValue
    * @param flagAliasMappings {@code --flag_alias} maps that apply to this build.
    */
   @AutoCodec
-  public record Key(Label label, List<Map.Entry<String, String>> flagAliasMappings)
-      implements SkyKey {
+  public record Key(Label label, ImmutableMap<String, Label> flagAliasMappings) implements SkyKey {
     private static final SkyKeyInterner<Key> interner = new SkyKeyInterner<>();
 
     @AutoCodec.Instantiator
-    static Key create(Label label, List<Map.Entry<String, String>> flagAliasMappings) {
+    static Key create(Label label, ImmutableMap<String, Label> flagAliasMappings) {
       return interner.intern(new Key(label, flagAliasMappings));
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/BUILD
@@ -145,6 +145,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/skyframe",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//src/main/java/com/google/devtools/common/options",
+        "//third_party:guava",
         "//third_party:jsr305",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyProducer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyProducer.java
@@ -134,7 +134,7 @@ public final class BuildConfigurationKeyProducer<C>
       tasks.enqueue(
           new PlatformProducer(
               targetPlatforms.getFirst(),
-              options.get(CoreOptions.class).commandLineFlagAliases,
+              options.get(CoreOptions.class).getCommandLineFlagAliases(),
               this,
               this::checkTargetPlatformFlags));
       return runAfter;

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/DependencyContextProducerWithCompatibilityCheck.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/DependencyContextProducerWithCompatibilityCheck.java
@@ -104,7 +104,7 @@ public final class DependencyContextProducerWithCompatibilityCheck
             .getConfiguration()
             .getOptions()
             .get(CoreOptions.class)
-            .commandLineFlagAliases,
+            .getCommandLineFlagAliases(),
         (PlatformProducer.ResultSink) this,
         /* runAfter= */ this::computeConfigConditions);
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/PlatformProducer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/PlatformProducer.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.analysis.producers;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.platform.PlatformValue;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.skyframe.toolchains.PlatformLookupUtil.InvalidPlatformException;
@@ -20,8 +21,6 @@ import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.build.skyframe.state.StateMachine;
 import com.google.devtools.build.skyframe.state.StateMachine.ValueOrException2Sink;
 import com.google.devtools.common.options.OptionsParsingException;
-import java.util.List;
-import java.util.Map;
 import javax.annotation.Nullable;
 
 /** Retrieves {@link PlatformValue} for a given platform. */
@@ -39,7 +38,7 @@ final class PlatformProducer
 
   // -------------------- Input --------------------
   private final Label platformLabel;
-  private final List<Map.Entry<String, String>> flagAliasMappings;
+  private final ImmutableMap<String, Label> flagAliasMappings;
 
   // -------------------- Output --------------------
   private final ResultSink sink;
@@ -49,7 +48,7 @@ final class PlatformProducer
 
   PlatformProducer(
       Label platformLabel,
-      List<Map.Entry<String, String>> flagAliasMappings,
+      ImmutableMap<String, Label> flagAliasMappings,
       ResultSink sink,
       StateMachine runAfter) {
     this.platformLabel = platformLabel;

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/RuleTransitionApplier.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/RuleTransitionApplier.java
@@ -173,7 +173,7 @@ public class RuleTransitionApplier
                   .getConfigurationKey()
                   .getOptions()
                   .get(CoreOptions.class)
-                  .commandLineFlagAliases,
+                  .getCommandLineFlagAliases(),
               (PlatformProducer.ResultSink) this,
               this::computeConfigConditions));
     } else {

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/TransitionApplier.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/TransitionApplier.java
@@ -116,7 +116,7 @@ final class TransitionApplier
     ImmutableSet<Label> starlarkBuildSettings =
         transitionCache.getAllStarlarkBuildSettings(
             transition,
-            fromConfiguration.getOptions().get(CoreOptions.class).commandLineFlagAliases);
+            fromConfiguration.getOptions().get(CoreOptions.class).getCommandLineFlagAliases());
     if (starlarkBuildSettings.isEmpty()) {
       // Quick escape if transition doesn't use any Starlark build settings.
       buildSettingsDetailsValue = StarlarkBuildSettingsDetailsValue.EMPTY;

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleTransitionProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleTransitionProvider.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.analysis.starlark;
 import static com.google.devtools.build.lib.analysis.starlark.FunctionTransitionUtil.applyAndValidate;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -99,7 +100,7 @@ public final class StarlarkRuleTransitionProvider implements TransitionFactory<R
     RawAttributeMapper attributeMapper = RawAttributeMapper.of(rule);
     ConfiguredAttributeMapper configuredAttributeMapper =
         ConfiguredAttributeMapper.of(rule, configConditions, configHash, false);
-    ImmutableList<String> transitionOutputs = this.starlarkDefinedConfigTransition.getOutputs();
+    ImmutableCollection<String> transitionOutputs = this.starlarkDefinedConfigTransition.getOutputs();
 
     for (Attribute attribute : rule.getAttributes()) {
       // If the value is present, even if it is null, add to the attribute map.
@@ -148,7 +149,7 @@ public final class StarlarkRuleTransitionProvider implements TransitionFactory<R
   private Result handleConfiguredAttribute(
       @Nullable ImmutableMap<Label, ConfigMatchingProvider> configConditions,
       ConfiguredAttributeMapper configuredAttributeMapper,
-      ImmutableList<String> transitionOutputs,
+      ImmutableCollection<String> transitionOutputs,
       Attribute attribute,
       SelectorList<?> val) {
     // If there are no configConditions then nothing is resolvable.
@@ -173,7 +174,7 @@ public final class StarlarkRuleTransitionProvider implements TransitionFactory<R
 
   private boolean selectBranchesReferenceOutputs(
       ImmutableMap<Label, ConfigMatchingProvider> configConditions,
-      ImmutableList<String> transitionOutputs,
+      ImmutableCollection<String> transitionOutputs,
       SelectorList<?> val) {
     for (Object label : val.getKeyLabels()) {
       ConfigMatchingProvider configMatchingProvider = configConditions.get(label);
@@ -186,7 +187,7 @@ public final class StarlarkRuleTransitionProvider implements TransitionFactory<R
   }
 
   private boolean checkIfAttributeSelectOnAFlagTransitionChanges(
-      ConfigMatchingProvider configMatchingProvider, ImmutableList<String> transitionOutputs) {
+      ConfigMatchingProvider configMatchingProvider, ImmutableCollection<String> transitionOutputs) {
     // check settingMap
     Set<String> nativeFlagLabels = new HashSet<>();
     for (String key : configMatchingProvider.settingsMap().keySet()) {

--- a/src/main/java/com/google/devtools/build/lib/cmdline/LabelConstants.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/LabelConstants.java
@@ -63,4 +63,6 @@ public class LabelConstants {
   // $runfiles_root/$workspace_name/../$repo_name/<path>, i.e. $runfiles_root/$repo_name/<path>.
   public static final PathFragment EXTERNAL_RUNFILES_PATH_PREFIX = PathFragment.create("..");
   public static final String COMMAND_LINE_OPTION_PREFIX = "//command_line_option:";
+  public static final PackageIdentifier COMMAND_LINE_OPTION_PACKAGE_IDENTIFIER =
+      PackageIdentifier.createInMainRepo(PathFragment.create("command_line_option"));
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigRuleClasses.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.analysis.BaseRuleClasses;
 import com.google.devtools.build.lib.analysis.RuleDefinition;
 import com.google.devtools.build.lib.analysis.RuleDefinitionEnvironment;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.AllowlistChecker;
 import com.google.devtools.build.lib.packages.Attribute.LabelListLateBoundDefault;
@@ -50,9 +51,7 @@ public final class ConfigRuleClasses {
   private static final String NONCONFIGURABLE_ATTRIBUTE_REASON =
       "part of a rule class that *triggers* configurable behavior";
 
-  /**
-   * Common settings for all configurability rules.
-   */
+  /** Common settings for all configurability rules. */
   public static final class ConfigBaseRule implements RuleDefinition {
     @Override
     public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment env) {
@@ -139,10 +138,12 @@ public final class ConfigRuleClasses {
      */
     public static final String FLAG_ALIAS_SETTINGS_ATTRIBUTE = ":flag_alias_settings";
 
-    /** The name of the attribute that declares "--define foo=bar" flag bindings.*/
+    /** The name of the attribute that declares "--define foo=bar" flag bindings. */
     public static final String DEFINE_SETTINGS_ATTRIBUTE = "define_values";
+
     /** The name of the attribute that declares user-defined flag bindings. */
     public static final String FLAG_SETTINGS_ATTRIBUTE = "flag_values";
+
     /** The name of the attribute that declares constraint_values. */
     public static final String CONSTRAINT_VALUES_ATTRIBUTE = "constraint_values";
 
@@ -175,12 +176,12 @@ public final class ConfigRuleClasses {
                 return ImmutableList.of();
               }
               ImmutableList.Builder<Label> userDefinedFlags = ImmutableList.builder();
-              ImmutableMap<String, String> commandLineFlagAliases =
-                  configuration.getCommandLineFlagAliases();
+              ImmutableMap<String, Label> commandLineFlagAliases =
+                  configuration.getOptions().get(CoreOptions.class).getCommandLineFlagAliases();
               for (String flagName : attributes.get(SETTINGS_ATTRIBUTE, STRING_DICT).keySet()) {
-                String userDefinedFlag = commandLineFlagAliases.get(flagName);
+                Label userDefinedFlag = commandLineFlagAliases.get(flagName);
                 if (userDefinedFlag != null) {
-                  userDefinedFlags.add(Label.parseCanonicalUnchecked(userDefinedFlag));
+                  userDefinedFlags.add(userDefinedFlag);
                 }
               }
               return userDefinedFlags.build();
@@ -329,6 +330,7 @@ public final class ConfigRuleClasses {
           .build();
     }
   }
+
   /*<!-- #BLAZE_RULE (NAME = config_setting, FAMILY = General)[GENERIC_RULE] -->
 
   <p>

--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
@@ -191,14 +191,12 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
     // alias to "//bar". Since Bazel's options parsing replaces "--foo" with "//bar", we want to do
     // the same here to match the parsed options. Generally, all logic reading any user API that
     // sets "--foo" should do this.
-    ImmutableMap<String, String> commandLineFlagAliases =
+    ImmutableMap<String, Label> commandLineFlagAliases =
         ruleContext
             .getConfiguration()
             .getOptions()
             .get(CoreOptions.class)
-            .commandLineFlagAliases
-            .stream()
-            .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+            .getCommandLineFlagAliases();
 
     // Partition expected "--foo" settings (native flag style) by whether they're flag aliases.
     var nativeValuesParitionedByAlias =
@@ -224,13 +222,11 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
         attributes.get(
             ConfigSettingRule.FLAG_SETTINGS_ATTRIBUTE, BuildType.LABEL_KEYED_STRING_DICT));
     for (var flagAlias : nativeValuesParitionedByAlias.get(true)) {
-      try {
-        Label userDefinedFlag =
-            Label.parseCanonical(commandLineFlagAliases.get(flagAlias.getKey()));
-        String aliasValue = flagAlias.getValue();
-        String flagSettingsAttributeValue = userDefinedFlagSettings.get(userDefinedFlag);
-        if (flagSettingsAttributeValue != null && !flagSettingsAttributeValue.equals(aliasValue)) {
-          ruleContext.ruleError(
+      Label userDefinedFlag = commandLineFlagAliases.get(flagAlias.getKey());
+      String aliasValue = flagAlias.getValue();
+      String flagSettingsAttributeValue = userDefinedFlagSettings.get(userDefinedFlag);
+      if (flagSettingsAttributeValue != null && !flagSettingsAttributeValue.equals(aliasValue)) {
+        ruleContext.ruleError(
 """
 \nConflicting flag value expectations:
  - %s has '%s = {"%s": "%s"}'.
@@ -240,25 +236,22 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
 Either remove one of these settings or ensure they match the same value.
 
 """
-                  .formatted(
-                      ruleContext.getLabel(),
-                      ConfigRuleClasses.ConfigSettingRule.SETTINGS_ATTRIBUTE,
-                      flagAlias.getKey(),
-                      aliasValue,
-                      flagAlias.getKey(),
-                      userDefinedFlag,
-                      ConfigRuleClasses.ConfigSettingRule.FLAG_SETTINGS_ATTRIBUTE,
-                      userDefinedFlag,
-                      aliasValue,
-                      ruleContext.getLabel(),
-                      ConfigRuleClasses.ConfigSettingRule.FLAG_SETTINGS_ATTRIBUTE,
-                      userDefinedFlag,
-                      flagSettingsAttributeValue));
-        }
-        userDefinedFlagSettings.put(userDefinedFlag, aliasValue);
-      } catch (LabelSyntaxException e) {
-        ruleContext.ruleError("Cannot parse label: " + e.getMessage());
+                .formatted(
+                    ruleContext.getLabel(),
+                    ConfigRuleClasses.ConfigSettingRule.SETTINGS_ATTRIBUTE,
+                    flagAlias.getKey(),
+                    aliasValue,
+                    flagAlias.getKey(),
+                    userDefinedFlag,
+                    ConfigRuleClasses.ConfigSettingRule.FLAG_SETTINGS_ATTRIBUTE,
+                    userDefinedFlag,
+                    aliasValue,
+                    ruleContext.getLabel(),
+                    ConfigRuleClasses.ConfigSettingRule.FLAG_SETTINGS_ATTRIBUTE,
+                    userDefinedFlag,
+                    flagSettingsAttributeValue));
       }
+      userDefinedFlagSettings.put(userDefinedFlag, aliasValue);
     }
 
     // Collect platform constraint settings.

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -17,7 +17,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.devtools.build.lib.runtime.BlazeOptionHandler.BAD_OPTION_TAG;
 import static com.google.devtools.build.lib.runtime.BlazeOptionHandler.ERROR_SEPARATOR;
 import static com.google.devtools.build.lib.util.DetailedExitCode.DetailedExitCodeComparator.chooseMoreImportantWithFirstIfTie;
-import static com.google.devtools.common.options.Converters.BLAZE_ALIASING_FLAG;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -32,6 +31,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.io.Flushables;
 import com.google.devtools.build.lib.analysis.NoBuildEvent;
+import com.google.devtools.build.lib.analysis.config.CoreOptionConverters;
 import com.google.devtools.build.lib.bugreport.BugReporter;
 import com.google.devtools.build.lib.bugreport.Crash;
 import com.google.devtools.build.lib.bugreport.CrashContext;
@@ -939,7 +939,7 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
             .optionsData(optionsData)
             .skipStarlarkOptionPrefixes()
             .allowResidue(annotation.allowResidue())
-            .withAliasFlag(BLAZE_ALIASING_FLAG)
+            .withAliasFlag(CoreOptionConverters.BLAZE_ALIASING_FLAG)
             .build();
     return parser;
   }

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import com.google.common.flogger.GoogleLogger;
+import com.google.devtools.build.lib.analysis.config.CoreOptionConverters;
 import com.google.devtools.build.lib.cmdline.TargetParsingException;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
@@ -46,7 +47,6 @@ import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.skyframe.SkyFunction;
-import com.google.devtools.common.options.Converters;
 import com.google.devtools.common.options.InvocationPolicyEnforcer;
 import com.google.devtools.common.options.OptionAndRawValue;
 import com.google.devtools.common.options.OptionDefinition;
@@ -678,8 +678,8 @@ public final class BlazeOptionHandler {
       // The canonicalize-flags command only inherits bazelrc "build" commands. Not "test", not
       // "build:foo". Restrict --flag_alias accordingly to prevent building with flags that
       // canonicalize-flags can't recognize.
-      if ((override.option.startsWith("--" + Converters.BLAZE_ALIASING_FLAG + "=")
-              || override.option.equals("--" + Converters.BLAZE_ALIASING_FLAG))
+      if ((override.option.startsWith("--" + CoreOptionConverters.BLAZE_ALIASING_FLAG + "=")
+              || override.option.equals("--" + CoreOptionConverters.BLAZE_ALIASING_FLAG))
           && !BUILD_COMMAND_ANCESTORS.contains(override.command)) {
         throw new OptionsParsingException(
             String.format(
@@ -687,7 +687,7 @@ public final class BlazeOptionHandler {
                 rcFile,
                 override.command,
                 override.option,
-                Converters.BLAZE_ALIASING_FLAG,
+                CoreOptionConverters.BLAZE_ALIASING_FLAG,
                 String.join(", ", BUILD_COMMAND_ANCESTORS)));
       }
       String command = override.command;

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/BUILD
@@ -49,6 +49,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:print_action_visitor",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:build_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:build_options",
+        "//src/main/java/com/google/devtools/build/lib/analysis/config:core_option_converters",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:core_options",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:fragment",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:fragment_class_set",

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CanonicalizeCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CanonicalizeCommand.java
@@ -14,11 +14,12 @@
 package com.google.devtools.build.lib.runtime.commands;
 
 import static com.google.devtools.build.lib.runtime.Command.BuildPhase.NONE;
-import static com.google.devtools.common.options.Converters.BLAZE_ALIASING_FLAG;
+
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.analysis.config.CoreOptionConverters;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.pkgcache.PackageOptions;
@@ -187,7 +188,7 @@ public final class CanonicalizeCommand implements BlazeCommand {
             .optionsClasses(optionsClasses)
             .skipStarlarkOptionPrefixes()
             .allowResidue(true)
-            .withAliasFlag(BLAZE_ALIASING_FLAG)
+            .withAliasFlag(CoreOptionConverters.BLAZE_ALIASING_FLAG)
             .withAliases(options.getAliases())
             .withConversionContext(mainRepoMapping)
             .build();

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -1858,12 +1858,13 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     RepoContext mainRepoContext =
         RepoContext.of(RepositoryName.MAIN, mainRepositoryMappingValue.repositoryMapping());
 
-    ImmutableList<Entry<String, String>> flagAliasMappings =
+    ImmutableMap<String, Label> flagAliasMappings =
         args.stream()
             .filter(arg -> arg.startsWith("--flag_alias="))
             .map(arg -> arg.substring("--flag_alias=".length()).split("="))
-            .map(pair -> new SimpleImmutableEntry<>(pair[0], pair[1]))
-            .collect(toImmutableList());
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    pair -> pair[0], pair -> Label.parseCanonicalUnchecked(pair[1])));
     // Parse the options.
     PackageContext rootPackage = mainRepoContext.rootPackage();
     ParsedFlagsValue.Key parsedFlagsKey =

--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationFunction.java
@@ -110,7 +110,7 @@ public final class BuildConfigurationFunction implements SkyFunction {
 
     PlatformValue platformValue =
         (PlatformValue)
-            env.getValue(PlatformValue.key(platformLabel, coreOptions.commandLineFlagAliases));
+            env.getValue(PlatformValue.key(platformLabel, coreOptions.getCommandLineFlagAliases()));
     if (platformValue == null) {
       return null;
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/ParsedFlagsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/ParsedFlagsFunction.java
@@ -57,7 +57,7 @@ public final class ParsedFlagsFunction implements SkyFunction {
 
     ImmutableList.Builder<String> nativeFlags = ImmutableList.builder();
     ImmutableList.Builder<String> starlarkFlags = ImmutableList.builder();
-    ImmutableMap<String, String> flagAliasMappings = ImmutableMap.copyOf(key.flagAliasMappings());
+    ImmutableMap<String, Label> flagAliasMappings = key.flagAliasMappings();
     for (String flagSetting : key.rawFlags()) {
       if (!flagSetting.startsWith("--")) {
         // This is either something like "-c" or an invalid setting. Let options parsing handle it.
@@ -78,12 +78,14 @@ public final class ParsedFlagsFunction implements SkyFunction {
         flagName = flagSetting.substring(2); // --<flag>
       }
       // If --flag_alias=foo=//bar and we see --foo=1, use the canonical setting --//bar=1.
-      String actualFlag = flagAliasMappings.get(flagName);
+      Label actualFlag = flagAliasMappings.get(flagName);
       if (actualFlag != null) {
         flagSetting =
             "--%s%s%s"
                 .formatted(
-                    noPrefix ? "no" : "", actualFlag, delimiterIndex == -1 ? "" : "=" + flagValue);
+                    noPrefix ? "no" : "",
+                    actualFlag.getUnambiguousCanonicalForm(),
+                    delimiterIndex == -1 ? "" : "=" + flagValue);
       }
       if (STARLARK_SKIPPED_PREFIXES.stream().noneMatch(flagSetting::startsWith)) {
         nativeFlags.add(flagSetting);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/ParsedFlagsValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/ParsedFlagsValue.java
@@ -19,6 +19,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.FragmentOptions;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -35,7 +36,6 @@ import com.google.devtools.common.options.OptionDefinition;
 import com.google.devtools.common.options.OptionValueDescription;
 import com.google.devtools.common.options.OptionsParsingException;
 import com.google.devtools.common.options.OptionsParsingResult;
-import java.util.List;
 import java.util.Map;
 
 /** Stores the {@link OptionsParsingResult} from {@link ParsedFlagsFunction}. */
@@ -55,7 +55,7 @@ public final class ParsedFlagsValue implements SkyValue {
     public static Key create(
         ImmutableList<String> rawFlags,
         PackageContext packageContext,
-        List<Map.Entry<String, String>> flagAliasMappings) {
+        ImmutableMap<String, Label> flagAliasMappings) {
       return create(rawFlags, packageContext, /* includeDefaultValues= */ false, flagAliasMappings);
     }
 
@@ -68,7 +68,7 @@ public final class ParsedFlagsValue implements SkyValue {
         ImmutableList<String> rawFlags,
         PackageContext packageContext,
         boolean includeDefaultValues,
-        List<Map.Entry<String, String>> flagAliasMappings) {
+        ImmutableMap<String, Label> flagAliasMappings) {
       return interner.intern(
           new Key(rawFlags, packageContext, includeDefaultValues, flagAliasMappings));
     }
@@ -77,13 +77,13 @@ public final class ParsedFlagsValue implements SkyValue {
     private final PackageContext packageContext;
     private final boolean includeDefaultValues;
 
-    private final List<Map.Entry<String, String>> flagAliasMappings;
+    private final ImmutableMap<String, Label> flagAliasMappings;
 
     private Key(
         ImmutableList<String> rawFlags,
         PackageContext packageContext,
         boolean includeDefaultValues,
-        List<Map.Entry<String, String>> flagAliasMappings) {
+        ImmutableMap<String, Label> flagAliasMappings) {
       this.rawFlags = checkNotNull(rawFlags);
       this.packageContext = checkNotNull(packageContext);
       this.includeDefaultValues = includeDefaultValues;
@@ -102,7 +102,7 @@ public final class ParsedFlagsValue implements SkyValue {
       return includeDefaultValues;
     }
 
-    List<Map.Entry<String, String>> flagAliasMappings() {
+    ImmutableMap<String, Label> flagAliasMappings() {
       return flagAliasMappings;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/PlatformMappingFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/PlatformMappingFunction.java
@@ -215,7 +215,7 @@ public final class PlatformMappingFunction implements SkyFunction {
     // here unless a compelling case demands it.
     ParsedFlagsValue.Key parsedFlagsKey =
         ParsedFlagsValue.Key.create(
-            rawFlags, rootPackage, /* flagAliasMappings= */ ImmutableList.of());
+            rawFlags, rootPackage, /* flagAliasMappings= */ ImmutableMap.of());
     try {
       return (ParsedFlagsValue) env.getValueOrThrow(parsedFlagsKey, OptionsParsingException.class);
     } catch (OptionsParsingException e) {

--- a/src/main/java/com/google/devtools/common/options/Converters.java
+++ b/src/main/java/com/google/devtools/common/options/Converters.java
@@ -13,8 +13,6 @@
 // limitations under the License.
 package com.google.devtools.common.options;
 
-import static com.google.devtools.common.options.OptionsParser.STARLARK_SKIPPED_PREFIXES;
-
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
 import com.google.common.base.Ascii;
 import com.google.common.base.Splitter;
@@ -37,12 +35,6 @@ import javax.annotation.Nullable;
 
 /** Some convenient converters used by blaze. Note: These are specific to blaze. */
 public final class Converters {
-  /**
-   * The name of the flag used for shorthand aliasing in blaze. {@see
-   * com.google.devtools.build.lib.analysis.config.CoreOptions#commandLineFlagAliases} for the
-   * option definition.
-   */
-  public static final String BLAZE_ALIASING_FLAG = "flag_alias";
 
   private static final ImmutableSet<String> ENABLED_REPS =
       ImmutableSet.of("true", "1", "yes", "t", "y");
@@ -523,46 +515,6 @@ public final class Converters {
     @Override
     public String getTypeDescription() {
       return "a named float, 'name=value'";
-    }
-  }
-
-  /**
-   * A converter for command line flag aliases. It does additional validation on the name and value
-   * of the assignment to ensure they conform to the naming limitations.
-   */
-  public static class FlagAliasConverter extends AssignmentConverter {
-
-    @Override
-    public Map.Entry<String, String> convert(String input) throws OptionsParsingException {
-      Map.Entry<String, String> entry = super.convert(input);
-      String shortForm = entry.getKey();
-      String longForm = entry.getValue();
-
-      String cmdLineAlias = "--" + BLAZE_ALIASING_FLAG + "=" + input;
-
-      if (!Pattern.matches("([\\w])*", shortForm)) {
-        throw new OptionsParsingException(
-            shortForm + " should only consist of word characters to be a valid alias name.",
-            cmdLineAlias);
-      }
-      if (longForm.contains("=")) {
-        throw new OptionsParsingException(
-            "--" + BLAZE_ALIASING_FLAG + " does not support flag value assignment.", cmdLineAlias);
-      }
-
-      // Remove this check if native options are permitted to be aliased
-      longForm = "--" + longForm;
-      if (STARLARK_SKIPPED_PREFIXES.stream().noneMatch(longForm::startsWith)) {
-        throw new OptionsParsingException(
-            "--" + BLAZE_ALIASING_FLAG + " only supports Starlark build settings.", cmdLineAlias);
-      }
-
-      return entry;
-    }
-
-    @Override
-    public String getTypeDescription() {
-      return "a 'name=value' flag alias";
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/producers/PlatformProducerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/producers/PlatformProducerTest.java
@@ -16,14 +16,12 @@ package com.google.devtools.build.lib.analysis.producers;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.platform.PlatformValue;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.skyframe.toolchains.PlatformLookupUtil.InvalidPlatformException;
 import com.google.devtools.build.skyframe.state.StateMachine;
 import com.google.devtools.common.options.OptionsParsingException;
-import java.util.List;
-import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,7 +56,7 @@ public final class PlatformProducerTest extends ProducerTestCase {
         """);
 
     Label platformLabel = Label.parseCanonicalUnchecked("//lookup:basic");
-    PlatformValue result = fetch(platformLabel, /* flagAliasMappings= */ ImmutableList.of());
+    PlatformValue result = fetch(platformLabel, /* flagAliasMappings= */ ImmutableMap.of());
 
     assertThat(result).isNotNull();
     assertThat(result.platformInfo().label()).isEqualTo(platformLabel);
@@ -91,7 +89,7 @@ public final class PlatformProducerTest extends ProducerTestCase {
         """);
 
     Label platformLabel = Label.parseCanonicalUnchecked("//lookup:alias");
-    PlatformValue result = fetch(platformLabel, /* flagAliasMappings= */ ImmutableList.of());
+    PlatformValue result = fetch(platformLabel, /* flagAliasMappings= */ ImmutableMap.of());
 
     assertThat(result).isNotNull();
     assertThat(result.platformInfo().label())
@@ -113,7 +111,7 @@ public final class PlatformProducerTest extends ProducerTestCase {
     Label platformLabel = Label.parseCanonicalUnchecked("//lookup:basic");
     assertThrows(
         InvalidPlatformException.class,
-        () -> fetch(platformLabel, /* flagAliasMappings= */ ImmutableList.of()));
+        () -> fetch(platformLabel, /* flagAliasMappings= */ ImmutableMap.of()));
   }
 
   @Test
@@ -130,7 +128,7 @@ public final class PlatformProducerTest extends ProducerTestCase {
     Label platformLabel = Label.parseCanonicalUnchecked("//lookup:basic");
     assertThrows(
         OptionsParsingException.class,
-        () -> fetch(platformLabel, /* flagAliasMappings= */ ImmutableList.of()));
+        () -> fetch(platformLabel, /* flagAliasMappings= */ ImmutableMap.of()));
   }
 
   @Test
@@ -182,10 +180,10 @@ public final class PlatformProducerTest extends ProducerTestCase {
     PlatformValue result =
         fetch(
             Label.parseCanonicalUnchecked("//lookup:basic"),
-            /* flagAliasMappings= */ ImmutableList.of(
-                Map.entry("aliasname1", "//starlark:actual1"),
-                Map.entry("aliasname2", "//starlark:actual2"),
-                Map.entry("aliasname3", "//starlark:actual3")));
+            /* flagAliasMappings= */ ImmutableMap.of(
+                "aliasname1", Label.parseCanonicalUnchecked("//starlark:actual1"),
+                "aliasname2", Label.parseCanonicalUnchecked("//starlark:actual2"),
+                "aliasname3", Label.parseCanonicalUnchecked("//starlark:actual3")));
 
     // Native flags:
     assertThat(result.parsedFlags().get().parsingResult().canonicalize())
@@ -197,7 +195,7 @@ public final class PlatformProducerTest extends ProducerTestCase {
   }
 
   private PlatformValue fetch(
-      Label platformLabel, List<Map.Entry<String, String>> flagAliasMappings)
+      Label platformLabel, ImmutableMap<String, Label> flagAliasMappings)
       throws InvalidPlatformException, OptionsParsingException, InterruptedException {
     PlatformInfoSink sink = new PlatformInfoSink();
     PlatformProducer producer =

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTransitionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTransitionTest.java
@@ -164,7 +164,7 @@ public class StarlarkTransitionTest extends BuildViewTestCase {
 
     getConfiguredTarget("//test:arizona");
     assertContainsEvent(
-        "Transition declares duplicate build setting '@@//test:formation' in INPUTS");
+        "Transition declares duplicate build setting '//test:formation' in INPUTS");
   }
 
   @Test
@@ -213,7 +213,7 @@ public class StarlarkTransitionTest extends BuildViewTestCase {
     reporter.removeHandler(failFastHandler);
     getConfiguredTarget("//test:arizona");
     assertContainsEvent(
-        "Transition declares duplicate build setting '@@//test:formation' in OUTPUTS");
+        "Transition declares duplicate build setting '//test:formation' in OUTPUTS");
   }
 
   @Test
@@ -802,7 +802,7 @@ public class StarlarkTransitionTest extends BuildViewTestCase {
     getConfiguredTarget("//test:t1");
     assertContainsEvent(
         String.format(
-            "Starlark flag '@@//test:foo_starlark' and its alias '//command_line_option:%s'"
+            "Starlark flag '//test:foo_starlark' and its alias '//command_line_option:%s'"
                 + " have different values: 'val_for_starlark' and 'val_for_native'",
             nativeFlagName));
   }

--- a/src/test/java/com/google/devtools/build/lib/runtime/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BUILD
@@ -60,6 +60,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:test/test_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:build_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:build_options",
+        "//src/main/java/com/google/devtools/build/lib/analysis/config:core_option_converters",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:core_options",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:fragment_factory",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:fragment_options",

--- a/src/test/java/com/google/devtools/build/lib/runtime/FlagAliasTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/FlagAliasTest.java
@@ -15,9 +15,10 @@ package com.google.devtools.build.lib.runtime;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.runtime.BlazeOptionHandler.BAD_OPTION_TAG;
-import static com.google.devtools.common.options.Converters.BLAZE_ALIASING_FLAG;
+
 
 import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.analysis.config.CoreOptionConverters;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.StoredEventHandler;
@@ -48,7 +49,7 @@ public final class FlagAliasTest {
         new BlazeOptionHandlerTestHelper(
             optionsClasses,
             /* allowResidue= */ true,
-            /* aliasFlag= */ BLAZE_ALIASING_FLAG,
+            /* aliasFlag= */ CoreOptionConverters.BLAZE_ALIASING_FLAG,
             /* skipStarlarkPrefixes= */ true);
     eventHandler = helper.getEventHandler();
     parser = helper.getOptionsParser();
@@ -103,8 +104,8 @@ public final class FlagAliasTest {
     assertThat(eventHandler.getEvents())
         .contains(
             Event.error(
-                "While parsing option --flag_alias=foo: Variable definitions must be in"
-                    + " the form of a 'name=value' assignment"));
+                "While parsing option --flag_alias=foo: Flag alias definitions must be in"
+                    + " the form of a 'name=label' assignment"));
   }
 
   @Test

--- a/src/test/shell/integration/starlark_configurations_external_workspaces_test.sh
+++ b/src/test/shell/integration/starlark_configurations_external_workspaces_test.sh
@@ -330,11 +330,11 @@ EOF
   # This is important because select() and transitions read --flag_alias to
   # correctly map aliases.
   # This regex checks that the line starts with "flag_alias:" and contains
-  # both "compilation_mode=@//:my_flag" and "user_set=//:fake_flag" in any order.
+  # both "compilation_mode=//:my_flag" and "user_set=//:fake_flag" in any order.
   local flag_alias_regex="flag_alias:.*\\("
-  flag_alias_regex+="compilation_mode=@//:my_flag.*user_set=//:fake_flag"
+  flag_alias_regex+="compilation_mode=//:my_flag.*user_set=//:fake_flag"
   flag_alias_regex+="\\|"
-  flag_alias_regex+="user_set=//:fake_flag.*compilation_mode=@//:my_flag"
+  flag_alias_regex+="user_set=//:fake_flag.*compilation_mode=//:my_flag"
   flag_alias_regex+="\\)"
 
   expect_log "$flag_alias_regex" \


### PR DESCRIPTION
This avoids intermediate ad-hoc label parsing and stringification. It also makes it easier to reason about the involved types as they are no longer maps or pairs of `String`.

Also adds a test to verify that flag aliases pointing into external repos correctly parse apparent repo names.