### PR TITLE
fix: remove unnecessary line breaks in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Build and test software of any size, quickly and reliably.
   * [Install Bazel](https://bazel.build/install)
   * [Get started with Bazel](https://bazel.build/start)
   * Follow our tutorials:
-
     - [Build C++](https://bazel.build/tutorials/cpp)
     - [Build Java](https://bazel.build/tutorials/java)
     - [Android](https://bazel.build/tutorials/android-app)


### PR DESCRIPTION
## Summary

Remove unnecessary line breaks that caused improper markdown rendering.

## Changes

- Removed redundant newlines in markdown content
- Fixed formatting inconsistencies

## Why

Extra line breaks were breaking the intended document structure and affecting readability.