### PR TITLE
[9.0.1] Introduce RunfilesProxyArtifactValue.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/RunfilesArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/RunfilesArtifactValue.java
@@ -81,7 +81,7 @@ public final class RunfilesArtifactValue implements RichArtifactData {
 
     // Compute the digest of this runfiles tree by combining its layout and the digests of every
     // artifact it references.
-    this.metadata = FileArtifactValue.createProxy(computeDigest());
+    this.metadata = FileArtifactValue.createRunfilesProxy(computeDigest());
   }
 
   private byte[] computeDigest() {

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerFilesHashTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerFilesHashTest.java
@@ -92,14 +92,24 @@ public final class WorkerFilesHashTest {
 
     TreeArtifactValue treeArtifactValue =
         TreeArtifactValue.newBuilder(tree)
-            .putChild(child1, FileArtifactValue.createProxy(child1Digest))
-            .putChild(child2, FileArtifactValue.createProxy(child2Digest))
+            .putChild(
+                child1,
+                FileArtifactValue.createForNormalFile(
+                    child1Digest, /* proxy= */ null, /* size= */ 123))
+            .putChild(
+                child2,
+                FileArtifactValue.createForNormalFile(
+                    child2Digest, /* proxy= */ null, /* size= */ 456))
             .build();
 
     FakeActionInputFileCache fakeActionInputFileCache = new FakeActionInputFileCache();
     fakeActionInputFileCache.putTreeArtifact(tree, treeArtifactValue);
-    fakeActionInputFileCache.put(child1, FileArtifactValue.createProxy(child1Digest));
-    fakeActionInputFileCache.put(child2, FileArtifactValue.createProxy(child2Digest));
+    fakeActionInputFileCache.put(
+        child1,
+        FileArtifactValue.createForNormalFile(child1Digest, /* proxy= */ null, /* size= */ 123));
+    fakeActionInputFileCache.put(
+        child2,
+        FileArtifactValue.createForNormalFile(child2Digest, /* proxy= */ null, /* size= */ 456));
     SortedMap<PathFragment, byte[]> filesWithDigests =
         WorkerFilesHash.getWorkerFilesWithDigests(spawn, fakeActionInputFileCache);
 


### PR DESCRIPTION
This specialization of FileArtifactValue is now returned by RunfilesArtifactValue.getMetadata(), thereby ensuring that the metadata is of directory type. This is required for it to be handled correctly by the BEP.

This is intended to be a low-risk targeted fix to be cherry-picked into 9.x. It leaves a couple of open questions to be addressed:

* Should RunfilesArtifactValue itself implement FileArtifactValue and avoid the extra indirection? (The impact on memory usage is unclear.)

* Should the SpecialArtifact for a runfiles tree also return true from isDirectory()? (It may require fixing callers that only expect it to return true for tree artifacts and filesets.)

Fixes #28330.

PiperOrigin-RevId: 865346372
Change-Id: I49c897ca444547b077c1d471b7ac670bd83bae34

Commit https://github.com/bazelbuild/bazel/commit/952aabb464d25b87828927121911db1f03ad1df3