### PR TITLE
Add deprecation warning to --build_python_zip.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -67,6 +67,9 @@ public final class BazelRulesModule extends BlazeModule {
         defaultValue = "auto",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
         effectTags = {OptionEffectTag.NO_OP},
+        deprecationWarning =
+            "The '--no' prefix is no longer supported for this flag. Please use"
+                + " --build_python_zip=false instead.",
         help = "Deprecated. No-op.")
     public TriState buildPythonZip;
 


### PR DESCRIPTION
There was an [issue](https://github.com/bazelbuild/bazel/issues/28348) surfaced where the native semantic `--nobuild_python_zip` had become a no-op due to the graveyarding/starlarkification of the option. The starlark flag version must use the `=` operator for assignment and can no longer work with the prefixed `no` option. This information was not surfaced in a great way causing confusion.