### PR TITLE
[8.6.0] Add a `target_type` argument to `ctx.actions.symlink`.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -236,6 +236,21 @@ public interface StarlarkActionFactoryApi extends StarlarkValue {
                 "The exact path that the output symlink will point to. No normalization or other "
                     + "processing is applied."),
         @Param(
+            name = "target_type",
+            allowedTypes = {
+              @ParamType(type = String.class),
+              @ParamType(type = NoneType.class),
+            },
+            named = true,
+            positional = false,
+            defaultValue = "None",
+            doc =
+                "May only be used with <code>target_path</code>, not <code>target_file</code>. If"
+                    + " specified, it must be one of 'file' or 'directory', indicating the target"
+                    + " path's expected type.<p>On Windows, this determines which kind of"
+                    + " filesystem object to create (junction for a directory, symlink for a file)."
+                    + " It has no effect on other operating systems."),
+        @Param(
             name = "is_executable",
             named = true,
             positional = false,
@@ -270,6 +285,7 @@ public interface StarlarkActionFactoryApi extends StarlarkValue {
       FileApi output,
       Object targetFile,
       Object targetPath,
+      Object targetType,
       Boolean isExecutable,
       Object progressMessage,
       Object useExecRootForSourceObject,

--- a/src/main/java/com/google/devtools/build/lib/vfs/SymlinkTargetType.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/SymlinkTargetType.java
@@ -14,6 +14,8 @@
 //
 package com.google.devtools.build.lib.vfs;
 
+import com.google.devtools.build.lib.skyframe.serialization.EnumCodec;
+
 /**
  * Indicates the file type at the other end of a symlink.
  *
@@ -27,5 +29,19 @@ public enum SymlinkTargetType {
   /** The target is a regular file. */
   FILE,
   /** The target is a directory. */
-  DIRECTORY,
+  DIRECTORY;
+
+  /**
+   * Codec for {@link SymlinkTargetType}.
+   *
+   * <p>{@link com.google.devtools.build.lib.skyframe.serialization.AutoRegistry} excludes the
+   * entire com.google.devtools.build.lib.vfs java package from having DynamicCodec support.
+   * Therefore, we need to provide our own codec.
+   */
+  @SuppressWarnings("unused") // found by CLASSPATH-scanning magic
+  private static final class Codec extends EnumCodec<SymlinkTargetType> {
+    Codec() {
+      super(SymlinkTargetType.class);
+    }
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/UnresolvedSymlinkActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/UnresolvedSymlinkActionTest.java
@@ -40,6 +40,7 @@ import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
+import com.google.devtools.build.lib.vfs.SymlinkTargetType;
 import com.google.devtools.build.lib.vfs.SyscallCache;
 import org.junit.Before;
 import org.junit.Test;
@@ -71,6 +72,7 @@ public class UnresolvedSymlinkActionTest extends BuildViewTestCase {
             NULL_ACTION_OWNER,
             outputArtifact,
             "../some/relative/path",
+            SymlinkTargetType.UNSPECIFIED,
             "Creating unresolved symlink");
   }
 
@@ -88,12 +90,48 @@ public class UnresolvedSymlinkActionTest extends BuildViewTestCase {
   public void testTargetAffectsKey() {
     UnresolvedSymlinkAction action1 =
         UnresolvedSymlinkAction.create(
-            NULL_ACTION_OWNER, outputArtifact, "some/path", "Creating unresolved symlink");
+            NULL_ACTION_OWNER,
+            outputArtifact,
+            "some/path",
+            SymlinkTargetType.UNSPECIFIED,
+            "Creating unresolved symlink");
     UnresolvedSymlinkAction action2 =
         UnresolvedSymlinkAction.create(
-            NULL_ACTION_OWNER, outputArtifact, "some/other/path", "Creating unresolved symlink");
+            NULL_ACTION_OWNER,
+            outputArtifact,
+            "some/other/path",
+            SymlinkTargetType.UNSPECIFIED,
+            "Creating unresolved symlink");
 
     assertThat(computeKey(action1)).isNotEqualTo(computeKey(action2));
+  }
+
+  @Test
+  public void testTargetTypeAffectsKey() {
+    UnresolvedSymlinkAction action1 =
+        UnresolvedSymlinkAction.create(
+            NULL_ACTION_OWNER,
+            outputArtifact,
+            "some/path",
+            SymlinkTargetType.UNSPECIFIED,
+            "Creating unresolved symlink");
+    UnresolvedSymlinkAction action2 =
+        UnresolvedSymlinkAction.create(
+            NULL_ACTION_OWNER,
+            outputArtifact,
+            "some/path",
+            SymlinkTargetType.FILE,
+            "Creating unresolved symlink");
+    UnresolvedSymlinkAction action3 =
+        UnresolvedSymlinkAction.create(
+            NULL_ACTION_OWNER,
+            outputArtifact,
+            "some/path",
+            SymlinkTargetType.DIRECTORY,
+            "Creating unresolved symlink");
+
+    assertThat(computeKey(action1)).isNotEqualTo(computeKey(action2));
+    assertThat(computeKey(action2)).isNotEqualTo(computeKey(action3));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -216,9 +216,11 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/test/java/com/google/devtools/build/lib/buildtool/util",
+        "//src/test/java/com/google/devtools/build/lib/testutil:TestUtils",
         "//third_party:guava",
         "//third_party:junit4",
         "//third_party:truth",
+        "@maven//:com_google_testparameterinjector_test_parameter_injector",
     ],
 )
 
@@ -248,6 +250,7 @@ java_test(
         "//third_party:guava",
         "//third_party:junit4",
         "//third_party:truth",
+        "@maven//:com_google_testparameterinjector_test_parameter_injector",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
@@ -39,15 +39,15 @@ import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Symlinks;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.io.IOException;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /** Integration tests for Build without the Bytes. */
-@RunWith(JUnit4.class)
+@RunWith(TestParameterInjector.class)
 public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesIntegrationTestBase {
   @ClassRule @Rule public static final WorkerInstance worker = IntegrationTestUtils.createWorker();
 

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -34,12 +34,15 @@ import com.google.devtools.build.lib.analysis.TargetCompleteEvent;
 import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
 import com.google.devtools.build.lib.skyframe.ActionExecutionValue;
 import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
+import com.google.devtools.build.lib.testutil.TestUtils;
 import com.google.devtools.build.lib.util.CommandBuilder;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.io.RecordingOutErr;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.SymlinkTargetType;
+import com.google.testing.junit.testparameterinjector.TestParameter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -1032,29 +1035,55 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
   }
 
   @Test
-  public void downloadToplevel_unresolvedSymlink() throws Exception {
-    // Dangling symlink would require developer mode to be enabled in the CI environment.
+  public void downloadToplevel_unresolvedSymlink(@TestParameter SymlinkTargetType targetType)
+      throws Exception {
     assumeFalse(OS.getCurrent() == OS.WINDOWS);
+
+    Path targetPath = TestUtils.createUniqueTmpDir(null).getChild("target");
+
+    String targetPathArg = targetPath.getPathString();
+    String targetTypeArg =
+        switch (targetType) {
+          case FILE -> "file";
+          case DIRECTORY -> "directory";
+          case UNSPECIFIED -> "";
+        };
 
     setDownloadToplevel();
     writeSymlinkRule();
     write(
         "BUILD",
-        "load(':symlink.bzl', 'symlink')",
-        "symlink(",
-        "  name = 'foo-link',",
-        "  target_path = '/some/path',",
-        ")");
+        """
+        load(':symlink.bzl', 'symlink')
+        symlink(
+          name = 'foo-link',
+          target_path = '%s',
+          target_type = '%s',
+        )
+        """
+            .formatted(targetPathArg, targetTypeArg));
 
     buildTarget("//:foo-link");
 
-    assertSymlink("foo-link", PathFragment.create("/some/path"));
+    assertSymlink("foo-link", targetPath.asFragment());
 
     // Delete link, re-plant symlink
     getOutputPath("foo-link").delete();
     buildTarget("//:foo-link");
 
-    assertSymlink("foo-link", PathFragment.create("/some/path"));
+    assertSymlink("foo-link", targetPath.asFragment());
+
+    // Assert that the symlink works after planting the target.
+    if (targetType == SymlinkTargetType.FILE) {
+      FileSystemUtils.writeContent(targetPath, UTF_8, "hello world");
+      assertThat(FileSystemUtils.readContent(getOutputPath("foo-link"), UTF_8))
+          .isEqualTo("hello world");
+    } else if (targetType == SymlinkTargetType.DIRECTORY) {
+      targetPath.createDirectory();
+      FileSystemUtils.writeContent(targetPath.getChild("file.txt"), UTF_8, "hello world");
+      assertThat(FileSystemUtils.readContent(getOutputPath("foo-link/file.txt"), UTF_8))
+          .isEqualTo("hello world");
+    }
   }
 
   @Test
@@ -2043,7 +2072,11 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
                 ctx.actions.symlink(output = link, target_file = ctx.file.target_artifact)
             elif ctx.attr.target_path and not ctx.file.target_artifact:
                 link = ctx.actions.declare_symlink(ctx.attr.name)
-                ctx.actions.symlink(output = link, target_path = ctx.attr.target_path)
+                ctx.actions.symlink(
+                    output = link,
+                    target_path = ctx.attr.target_path,
+                    target_type = ctx.attr.target_type or None,
+                )
             else:
                 fail("exactly one of target_artifact or target_path must be set")
 
@@ -2054,6 +2087,7 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
             attrs = {
                 "target_artifact": attr.label(allow_single_file = True),
                 "target_path": attr.string(),
+                "target_type": attr.string(),
             },
         )
         """);


### PR DESCRIPTION
This is necessary to create the right kind of filesystem object on Windows (junction for directories, symlink for files) when the target does not yet exist.

This argument is only allowed in conjunction with `target_path`. For `target_file`, I have a different plan (infer the type from the artifact) which will be implemented separately.

Fixes #26701.

Progress on #21747.

RELNOTES: `ctx.actions.symlink` now accepts a `target_type` argument.
PiperOrigin-RevId: 820670309
Change-Id: I2f29adfd074c404a0b15be369a97fcdfb84fbdad