### PR TITLE
Remove incompatible_enable_cc_toolchain_resolution and crosstool_top

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,7 +13,6 @@ common:remote_shared --jobs=100
 common:remote_shared --action_env=PATH=/bin:/usr/bin:/usr/local/bin
 
 # Configuration to build and test Bazel on RBE on Ubuntu 20.04
-common:ubuntu2004 --crosstool_top=@rbe_ubuntu2004//cc:toolchain
 common:ubuntu2004 --extra_toolchains=@rbe_ubuntu2004//config:cc-toolchain
 common:ubuntu2004 --extra_execution_platforms=//:rbe_ubuntu2004_platform,//:rbe_ubuntu2004_highcpu_platform
 common:ubuntu2004 --host_platform=//:rbe_ubuntu2004_platform

--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigGlobalLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigGlobalLibrary.java
@@ -196,8 +196,7 @@ public class ConfigGlobalLibrary implements ConfigGlobalLibraryApi {
       return false;
     }
 
-    if (optionName.equals("incompatible_enable_cc_toolchain_resolution")
-        || optionName.equals("incompatible_enable_apple_toolchain_resolution")) {
+    if (optionName.equals("incompatible_enable_apple_toolchain_resolution")) {
       // This is specifically allowed.
       return true;
     } else if (optionName.startsWith("incompatible_")) {

--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
@@ -95,7 +95,7 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
 
   /** Flags we'd like to remove once there are no more repo references. */
   private static final ImmutableSet<String> DEPRECATED_PRE_PLATFORMS_FLAGS =
-      ImmutableSet.of("cpu", "host_cpu", "crosstool_top");
+      ImmutableSet.of("cpu", "host_cpu");
 
   /**
    * The settings this {@code config_setting} expects.

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -100,17 +100,6 @@ public class CppOptions extends FragmentOptions {
   }
 
   @Option(
-      name = "crosstool_top",
-      defaultValue = "@bazel_tools//tools/cpp:toolchain",
-      converter = LabelConverter.class,
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {
-        OptionEffectTag.NO_OP,
-      },
-      help = "No-op flag. Will be removed in a future release.")
-  public Label crosstoolTop;
-
-  @Option(
       name = "compiler",
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
@@ -806,15 +795,6 @@ public class CppOptions extends FragmentOptions {
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
       help = "No-op flag. Will be removed in a future release.")
   public boolean disableLegacyCcProvider;
-
-  @Option(
-      name = "incompatible_enable_cc_toolchain_resolution",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help = "No-op flag. Will be removed in a future release.")
-  public boolean enableCcToolchainResolutionNoOp;
 
   @Option(
       name = "experimental_save_feature_state",

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -290,7 +290,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:start_end_lib",
         "//command_line_option:experimental_inmemory_dotd_files",
         "//command_line_option:incompatible_disable_legacy_cc_provider",
-        "//command_line_option:incompatible_enable_cc_toolchain_resolution",
         "//command_line_option:incompatible_remove_legacy_whole_archive",
         "//command_line_option:incompatible_dont_enable_host_nonhost_crosstool_features",
         "//command_line_option:incompatible_require_ctx_in_configure_features",

--- a/src/test/java/com/google/devtools/build/lib/analysis/AutoExecGroupsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/AutoExecGroupsTest.java
@@ -239,8 +239,7 @@ public class AutoExecGroupsTest extends BuildViewTestCase {
     String[] flags = {
       "--extra_toolchains=//toolchain:foo_toolchain,//toolchain:bar_toolchain,//toolchain:baz_toolchain,//toolchain:quz_toolchain,toolchain:qux_toolchain",
       "--platforms=//platforms:platform_1",
-      "--extra_execution_platforms=//platforms:platform_1,//platforms:platform_2,//platforms:platform_3,//platforms:platform_4",
-      "--incompatible_enable_cc_toolchain_resolution"
+      "--extra_execution_platforms=//platforms:platform_1,//platforms:platform_2,//platforms:platform_3,//platforms:platform_4"
     };
 
     super.useConfiguration(ObjectArrays.concat(flags, args, String.class));

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrTransitionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrTransitionProviderTest.java
@@ -3080,11 +3080,6 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
     // TODO(waltl): check that dynamic_mode is parsed properly.
   }
 
-  @Test
-  public void testOptionConversionCrosstoolTop() throws Exception {
-    // TODO(waltl): check that crosstool_top is parsed properly.
-  }
-
   /**
    * Changing --cpu implicitly changes the target platform. Test that the old value of --platforms
    * gets cleared out (platform mappings can then kick in to set --platforms correctly).

--- a/src/test/java/com/google/devtools/build/lib/rules/ToolchainTypeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/ToolchainTypeTest.java
@@ -66,7 +66,6 @@ public class ToolchainTypeTest extends BuildViewTestCase {
 
     scratch.file("a/cc_toolchain_config.bzl", MockCcSupport.EMPTY_CC_TOOLCHAIN);
     useConfiguration(
-        "--incompatible_enable_cc_toolchain_resolution",
         "--experimental_platforms=//a:mock-platform",
         "--extra_toolchains=//a:toolchain_b");
 

--- a/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
@@ -3007,7 +3007,7 @@ public final class ConfigSettingTest extends BuildViewTestCase {
   }
 
   @Test
-  @TestParameters({"{flag: cpu}", "{flag: host_cpu}", "{flag: crosstool_top}"})
+  @TestParameters({"{flag: cpu}", "{flag: host_cpu}"})
   public void selectOnDeprecatedFlagEmitsWarning(String flag) throws Exception {
     scratch.file(
         "test/BUILD",
@@ -3028,7 +3028,7 @@ public final class ConfigSettingTest extends BuildViewTestCase {
   }
 
   @Test
-  @TestParameters({"{flag: cpu}", "{flag: host_cpu}", "{flag: crosstool_top}"})
+  @TestParameters({"{flag: cpu}", "{flag: host_cpu}"})
   public void selectOnDisabledFlagFails(String flag) throws Exception {
     scratch.file(
         "test/BUILD",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcImportBaseConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcImportBaseConfiguredTargetTest.java
@@ -162,8 +162,7 @@ public abstract class CcImportBaseConfiguredTargetTest extends BuildViewTestCase
   @Test
   public void testCcImportWithSharedLibrary() throws Exception {
     useConfiguration(
-        "--platforms=" + TestConstants.PLATFORM_LABEL,
-        "--noincompatible_enable_cc_toolchain_resolution");
+        "--platforms=" + TestConstants.PLATFORM_LABEL);
     ConfiguredTarget target =
         scratchConfiguredTarget(
             "a",
@@ -189,8 +188,7 @@ public abstract class CcImportBaseConfiguredTargetTest extends BuildViewTestCase
   @Test
   public void testCcImportWithVersionedSharedLibrary() throws Exception {
     useConfiguration(
-        "--platforms=" + TestConstants.PLATFORM_LABEL,
-        "--noincompatible_enable_cc_toolchain_resolution");
+        "--platforms=" + TestConstants.PLATFORM_LABEL);
     ConfiguredTarget target =
         scratchConfiguredTarget(
             "a",
@@ -216,8 +214,7 @@ public abstract class CcImportBaseConfiguredTargetTest extends BuildViewTestCase
   @Test
   public void testCcImportWithVersionedSharedLibraryWithDotInTheName() throws Exception {
     useConfiguration(
-        "--platforms=" + TestConstants.PLATFORM_LABEL,
-        "--noincompatible_enable_cc_toolchain_resolution");
+        "--platforms=" + TestConstants.PLATFORM_LABEL);
 
     ConfiguredTarget target =
         scratchConfiguredTarget(
@@ -271,8 +268,7 @@ public abstract class CcImportBaseConfiguredTargetTest extends BuildViewTestCase
   @Test
   public void testCcImportWithInterfaceSharedLibrary() throws Exception {
     useConfiguration(
-        "--platforms=" + TestConstants.PLATFORM_LABEL,
-        "--noincompatible_enable_cc_toolchain_resolution");
+        "--platforms=" + TestConstants.PLATFORM_LABEL);
     ConfiguredTarget target =
         scratchConfiguredTarget(
             "b",
@@ -299,8 +295,7 @@ public abstract class CcImportBaseConfiguredTargetTest extends BuildViewTestCase
   @Test
   public void testCcImportWithBothStaticAndSharedLibraries() throws Exception {
     useConfiguration(
-        "--platforms=" + TestConstants.PLATFORM_LABEL,
-        "--noincompatible_enable_cc_toolchain_resolution");
+        "--platforms=" + TestConstants.PLATFORM_LABEL);
     ConfiguredTarget target =
         scratchConfiguredTarget(
             "a",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainSelectionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainSelectionTest.java
@@ -45,7 +45,6 @@ public class CcToolchainSelectionTest extends BuildViewTestCase {
   @Test
   public void testResolvedCcToolchain() throws Exception {
     useConfiguration(
-        "--incompatible_enable_cc_toolchain_resolution",
         "--experimental_platforms=//mock_platform:mock-k8-platform",
         "--extra_toolchains=//mock_platform:toolchain_cc-compiler-k8");
     ConfiguredTarget target =
@@ -66,7 +65,6 @@ public class CcToolchainSelectionTest extends BuildViewTestCase {
   @Test
   public void testToolchainSelectionWithPlatforms() throws Exception {
     useConfiguration(
-        "--incompatible_enable_cc_toolchain_resolution",
         "--experimental_platforms=//mock_platform:mock-k8-platform",
         "--extra_toolchains=//mock_platform:toolchain_cc-compiler-k8");
     ConfiguredTarget target =
@@ -110,7 +108,6 @@ public class CcToolchainSelectionTest extends BuildViewTestCase {
     mockToolsConfig.append("mock_platform/BUILD", "platform(name = 'mock-piii-platform')");
 
     useConfiguration(
-        "--incompatible_enable_cc_toolchain_resolution",
         "--experimental_platforms=//mock_platform:mock-piii-platform",
         "--extra_toolchains=//incomplete_toolchain:incomplete_toolchain_cc-compiler-piii");
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariablesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariablesTest.java
@@ -230,8 +230,7 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
   public void testTargetSysrootWithoutPlatforms() throws Exception {
     useConfiguration(
         "--grte_top=//target_libc",
-        "--host_grte_top=//host_libc",
-        "--noincompatible_enable_cc_toolchain_resolution");
+        "--host_grte_top=//host_libc");
 
     scratch.file(
         "x/BUILD",
@@ -254,7 +253,6 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
     useConfiguration(
         "--experimental_platforms=//mock_platform:mock-k8-platform",
         "--extra_toolchains=//mock_platform:toolchain_cc-compiler-k8",
-        "--incompatible_enable_cc_toolchain_resolution",
         "--grte_top=//target_libc",
         "--host_grte_top=//host_libc");
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollectorTest.java
@@ -119,7 +119,6 @@ public final class LibrariesToLinkCollectorTest extends BuildViewTestCase {
     useConfiguration(
         "--extra_toolchains=//toolchain:toolchain",
         "--dynamic_mode=fully",
-        "--incompatible_enable_cc_toolchain_resolution",
         "--platforms=" + TestConstants.PLATFORM_LABEL,
         "--experimental_platform_in_output_dir",
         String.format(
@@ -233,7 +232,6 @@ public final class LibrariesToLinkCollectorTest extends BuildViewTestCase {
     useConfiguration(
         "--extra_toolchains=@@toolchain+//:toolchain",
         "--dynamic_mode=fully",
-        "--incompatible_enable_cc_toolchain_resolution",
         "--platforms=" + TestConstants.PLATFORM_LABEL,
         "--experimental_platform_in_output_dir",
         String.format(

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkAspectsToolchainPropagationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkAspectsToolchainPropagationTest.java
@@ -1965,8 +1965,7 @@ public final class StarlarkAspectsToolchainPropagationTest extends AnalysisTestC
     useConfiguration(
         "--extra_toolchains=//toolchain:foo_toolchain_exec_1,//toolchain:foo_toolchain_exec_2",
         "--extra_execution_platforms=//platforms:platform_1,//platforms:platform_2",
-        "--incompatible_auto_exec_groups=True",
-        "--incompatible_enable_cc_toolchain_resolution");
+        "--incompatible_auto_exec_groups=True");
 
     var analysisResult = update(ImmutableList.of("//test:defs.bzl%my_aspect"), "//test:t1");
 
@@ -2043,8 +2042,7 @@ public final class StarlarkAspectsToolchainPropagationTest extends AnalysisTestC
     useConfiguration(
         "--extra_toolchains=//toolchain:foo_toolchain_exec_1,//toolchain:foo_toolchain_exec_2",
         "--extra_execution_platforms=//platforms:platform_1,//platforms:platform_2",
-        "--incompatible_auto_exec_groups=False",
-        "--incompatible_enable_cc_toolchain_resolution");
+        "--incompatible_auto_exec_groups=False");
 
     var analysisResult = update(ImmutableList.of("//test:defs.bzl%my_aspect"), "//test:t1");
 
@@ -2122,8 +2120,7 @@ public final class StarlarkAspectsToolchainPropagationTest extends AnalysisTestC
     useConfiguration(
         "--extra_toolchains=//toolchain:foo_toolchain_exec_1,//toolchain:foo_toolchain_exec_2",
         "--extra_execution_platforms=//platforms:platform_1,//platforms:platform_2",
-        "--incompatible_auto_exec_groups=" + autoExecGroups,
-        "--incompatible_enable_cc_toolchain_resolution");
+        "--incompatible_auto_exec_groups=" + autoExecGroups);
 
     var analysisResult = update(ImmutableList.of("//test:defs.bzl%my_aspect"), "//test:t1");
 
@@ -2205,8 +2202,7 @@ public final class StarlarkAspectsToolchainPropagationTest extends AnalysisTestC
     useConfiguration(
         "--extra_toolchains=//toolchain:foo_toolchain",
         "--extra_execution_platforms=//platforms:platform_1,//platforms:platform_2",
-        "--incompatible_auto_exec_groups=" + autoExecGroups,
-        "--incompatible_enable_cc_toolchain_resolution");
+        "--incompatible_auto_exec_groups=" + autoExecGroups);
 
     var unused = update(ImmutableList.of("//test:defs.bzl%toolchain_aspect"), "//test:t1");
 

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkDefinedAspectsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkDefinedAspectsTest.java
@@ -403,8 +403,7 @@ MyAspect = aspect(
   @Test
   public void aspectsPropagatingForDefaultAndImplicit() throws Exception {
     useConfiguration(
-        "--experimental_builtins_injection_override=+cc_library",
-        "--incompatible_enable_cc_toolchain_resolution");
+        "--experimental_builtins_injection_override=+cc_library");
     scratch.file(
         "test/aspect.bzl",
         """

--- a/src/test/java/com/google/devtools/build/lib/testutil/TestConstants.java
+++ b/src/test/java/com/google/devtools/build/lib/testutil/TestConstants.java
@@ -156,7 +156,7 @@ public class TestConstants {
           "--host_platform=@platforms//host",
           // TODO(#7849): Remove after flag flip.
           "--incompatible_use_toolchain_resolution_for_java_rules",
-          "--incompatible_disable_select_on=cpu,crosstool_top,host_cpu");
+          "--incompatible_disable_select_on=cpu,host_cpu");
 
   public static final ImmutableList<String> PRODUCT_SPECIFIC_BUILD_LANG_OPTIONS =
       ImmutableList.of();

--- a/src/test/shell/bazel/bazel_proto_library_test.sh
+++ b/src/test/shell/bazel/bazel_proto_library_test.sh
@@ -562,7 +562,7 @@ void f() {
 }
 EOF
 
-  bazel build --incompatible_enable_cc_toolchain_resolution //a:c || fail "build failed"
+  bazel build //a:c || fail "build failed"
 }
 
 function test_cc_proto_library_import_prefix_stripping() {

--- a/src/test/shell/bazel/bazel_windows_example_test.sh
+++ b/src/test/shell/bazel/bazel_windows_example_test.sh
@@ -133,8 +133,8 @@ function test_cpp_with_msys_gcc() {
   ./bazel-bin/${cpp_pkg}/hello-world foo >& $TEST_log \
     || fail "./bazel-bin/${cpp_pkg}/hello-world foo execution failed"
   expect_log "Hello foo"
-  assert_test_ok "//examples/cpp:hello-success_test" --compiler=msys-gcc --noincompatible_enable_cc_toolchain_resolution
-  assert_test_fails "//examples/cpp:hello-fail_test" --compiler=msys-gcc --noincompatible_enable_cc_toolchain_resolution
+  assert_test_ok "//examples/cpp:hello-success_test" --compiler=msys-gcc
+  assert_test_fails "//examples/cpp:hello-fail_test" --compiler=msys-gcc
 }
 
 function test_cpp_with_mingw_gcc() {

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1985,7 +1985,7 @@ EOF
 function test_find_optional_cpp_toolchain_present_without_toolchain_resolution() {
   setup_find_optional_cpp_toolchain
 
-  bazel build //pkg:my_rule --noincompatible_enable_cc_toolchain_resolution \
+  bazel build //pkg:my_rule \
     &> "$TEST_log" || fail "Build failed"
   assert_contains "Toolchain found" bazel-bin/pkg/my_rule
 }
@@ -1993,7 +1993,7 @@ function test_find_optional_cpp_toolchain_present_without_toolchain_resolution()
 function test_find_optional_cpp_toolchain_present_with_toolchain_resolution() {
   setup_find_optional_cpp_toolchain
 
-  bazel build //pkg:my_rule --incompatible_enable_cc_toolchain_resolution \
+  bazel build //pkg:my_rule \
     &> "$TEST_log" || fail "Build failed"
   assert_contains "Toolchain found" bazel-bin/pkg/my_rule
 }
@@ -2001,7 +2001,7 @@ function test_find_optional_cpp_toolchain_present_with_toolchain_resolution() {
 function test_find_optional_cpp_toolchain_not_present_with_toolchain_resolution() {
   setup_find_optional_cpp_toolchain
 
-  bazel build //pkg:my_rule --incompatible_enable_cc_toolchain_resolution \
+  bazel build //pkg:my_rule \
     --platforms=//pkg:exotic_platform &> "$TEST_log" || fail "Build failed"
   assert_contains "Toolchain not found" bazel-bin/pkg/my_rule
 }


### PR DESCRIPTION
This flags have been a no-op in Bazel 8 and Bazel 9. Removing them reduces the confusion that can bring to users when it comes to toolchains for C++.