### PR TITLE
Add Community Review Labeler GitHub Action

### DIFF
--- a/.github/config/trusted_contributors.yaml
+++ b/.github/config/trusted_contributors.yaml
@@ -1,0 +1,3 @@
+trusted_contributors:
+  - fmeum
+  - katre

--- a/.github/workflows/community-review-labeler.yml
+++ b/.github/workflows/community-review-labeler.yml
@@ -1,0 +1,52 @@
+name: Community Review Labeler
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label_community_reviewed:
+    # Only trigger if the review is an approval
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout master branch
+        # We checkout master to ensure we use the authoritative list of trusted contributors,
+        # preventing PR authors from adding themselves to the list in their own branch.
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Check if reviewer is trusted
+        id: check_reviewer
+        run: |
+          REVIEWER="${{ github.event.review.user.login }}"
+          echo "Reviewer: $REVIEWER"
+
+          # Check if the reviewer is in our trusted_contributors.yaml list
+          # We use yq to parse the YAML file and check for the reviewer
+          if yq e ".trusted_contributors | any_c(. == \"$REVIEWER\")" .github/config/trusted_contributors.yaml | grep -q "true"; then
+            echo "is_trusted=true" >> $GITHUB_OUTPUT
+            echo "Result: Reviewer is a trusted community contributor."
+          else
+            echo "is_trusted=false" >> $GITHUB_OUTPUT
+            echo "Result: Reviewer is not in the trusted list."
+          fi
+
+      - name: Add community-reviewed label
+        if: steps.check_reviewer.outputs.is_trusted == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.BAZEL_IO_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          echo "Adding 'community-reviewed' label to PR #$PR_NUMBER"
+          gh pr edit "$PR_NUMBER" --add-label "community-reviewed"


### PR DESCRIPTION
This PR implements a GitHub Action to automatically label PRs approved by trusted community contributors.
