### PR TITLE
[8.6.0] Error on single_version_override patch with wrong patch_strip (https://github.com/bazelbuild/bazel/pull/28566)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
@@ -447,6 +447,8 @@ public class PatchUtil {
       throw new PatchFailedException("Cannot find patch file: " + patchFile.getPathString());
     }
 
+    String singleFileStr =
+        singleFile != null ? singleFile.relativeTo(outputDirectory).getPathString() : null;
     boolean isGitDiff = false;
     boolean hasRenameFrom = false;
     boolean hasRenameTo = false;
@@ -593,6 +595,16 @@ public class PatchUtil {
                 checkFilesStatusForRenaming(
                     oldFile, newFile, oldFileStr, newFileStr, patchStartLocation);
               }
+            }
+            if (singleFileStr != null
+                && strip == 0
+                && ("a/" + singleFileStr).equals(oldFileStr)
+                && ("b/" + singleFileStr).equals(newFileStr)) {
+              throw new PatchFailedException(
+                  String.format(
+                      "error at line %d: the patch file contains a/b prefixes, did you forget to"
+                          + " set patch_strip = 1?",
+                      patchStartLocation));
             }
 
             if (singleFile == null || (singleFile.equals(newFile) && singleFile.equals(oldFile))) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -1909,6 +1909,47 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
   }
 
   @Test
+  public void testSingleVersionOverridePatches_defaultPatchStripForGitPatch() throws Exception {
+    FakeRegistry registry = registryFactory.newFakeRegistry("/foo");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+    ModuleKey bbb = createModuleKey("bbb", "1.0");
+    registry.addModule(bbb, "module(name='bbb',version='1.0')");
+
+    scratch.file("BUILD");
+    scratch.file(
+        "patch.diff",
+        """
+        diff --git a/MODULE.bazel b/MODULE.bazel
+        --- a/MODULE.bazel
+        +++ b/MODULE.bazel
+        @@ -1,1 +1,1 @@
+        -module(name='bbb',version='1.0')
+        +module(name='bbb',version='1.0',bazel_compatibility=[">=7.0.0"])
+        """);
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        """
+        single_version_override(
+          module_name="bbb",
+          patches = [
+            "//:patch.diff",
+          ],
+        )
+        """);
+
+    var moduleFileKey = ModuleFileValue.key(bbb);
+    EvaluationResult<ModuleFileValue> result =
+        evaluator.evaluate(ImmutableList.of(moduleFileKey), evaluationContext);
+    assertThat(result.hasError()).isTrue();
+    assertThat(result.getError().getException())
+        .hasMessageThat()
+        .isEqualTo(
+            "error applying single_version_override patch /workspace/patch.diff to module file:"
+                + " error at line 2: the patch file contains a/b prefixes, did you forget to set"
+                + " patch_strip = 1?");
+  }
+
+  @Test
   public void testSingleVersionOverridePatches_failsOnRename() throws Exception {
     FakeRegistry registry = registryFactory.newFakeRegistry("/foo");
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));


### PR DESCRIPTION
Since diffs that don't apply to the MODULE.bazel file are silently skipped (see https://github.com/bazelbuild/bazel/commit/c413192fcf933e6a7a791c757618818219cfe005), this is needed to make users aware that their patch doesn't actually apply to the file.

Fixes #28560

Closes #28566.

PiperOrigin-RevId: 868458465
Change-Id: I78d4027c5e8e01c2f5297e679c271bd4dac7b724

Commit https://github.com/bazelbuild/bazel/commit/55312cc5edfbeab0df35c85ba9949d2b2293f650