### PR TITLE
[9.1.0] Error on single_version_override patch with wrong patch_strip (https://github.com/bazelbuild/bazel/pull/28566)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/PatchUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/PatchUtil.java
@@ -447,6 +447,8 @@ public class PatchUtil {
       throw new PatchFailedException("Cannot find patch file: " + patchFile.getPathString());
     }
 
+    String singleFileStr =
+        singleFile != null ? singleFile.relativeTo(outputDirectory).getPathString() : null;
     boolean isGitDiff = false;
     boolean hasRenameFrom = false;
     boolean hasRenameTo = false;
@@ -593,6 +595,16 @@ public class PatchUtil {
                 checkFilesStatusForRenaming(
                     oldFile, newFile, oldFileStr, newFileStr, patchStartLocation);
               }
+            }
+            if (singleFileStr != null
+                && strip == 0
+                && ("a/" + singleFileStr).equals(oldFileStr)
+                && ("b/" + singleFileStr).equals(newFileStr)) {
+              throw new PatchFailedException(
+                  String.format(
+                      "error at line %d: the patch file contains a/b prefixes, did you forget to"
+                          + " set patch_strip = 1?",
+                      patchStartLocation));
             }
 
             if (singleFile == null || (singleFile.equals(newFile) && singleFile.equals(oldFile))) {


### PR DESCRIPTION
Since diffs that don't apply to the MODULE.bazel file are silently skipped (see https://github.com/bazelbuild/bazel/commit/c413192fcf933e6a7a791c757618818219cfe005), this is needed to make users aware that their patch doesn't actually apply to the file.

Fixes #28560

Closes #28566.

PiperOrigin-RevId: 868458465
Change-Id: I78d4027c5e8e01c2f5297e679c271bd4dac7b724

Commit https://github.com/bazelbuild/bazel/commit/55312cc5edfbeab0df35c85ba9949d2b2293f650