### PR TITLE
Fix visibility for implicit deps of parent rules

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -580,6 +580,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/packages:package_specification",
         "//src/main/java/com/google/devtools/build/lib/skyframe:configured_target_and_data",
+        "//third_party:guava",
         "//third_party:jsr305",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/analysis/CommonPrerequisiteValidator.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/CommonPrerequisiteValidator.java
@@ -201,7 +201,14 @@ public abstract class CommonPrerequisiteValidator implements PrerequisiteValidat
       if (mainAspect != null) {
         state.owningAspect = ((StarlarkAspectClass) mainAspect.getAspectClass());
       } else {
-        state.owningRule = rule.getRuleClassObject();
+        // Rule extensions can't override private attributes, so we can just walk up the chain to
+        // find the rule class that actually introduced the attribute and thus its default.
+        var owningRule = rule.getRuleClassObject();
+        while (owningRule.getStarlarkParent() instanceof RuleClass parent
+            && parent.getAttributeProvider().getAttributeByNameMaybe(attrName) != null) {
+          owningRule = parent;
+        }
+        state.owningRule = owningRule;
       }
 
       if (!isVisibleToLocation(


### PR DESCRIPTION
The visibility of a default value of an implicit dep in an extended rule should be checked relative to the definition of the rule that introduced it, which may not be the child rule.

Fixes #28618