### PR TITLE
Allow a higher number of flaky test attempts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -579,7 +579,7 @@ public class ExecutionOptions extends OptionsBase {
   /** Converter for the --flaky_test_attempts option. */
   public static class TestAttemptsConverter extends PerLabelOptions.PerLabelOptionsConverter {
     private static final int MIN_VALUE = 1;
-    private static final int MAX_VALUE = 10;
+    private static final int MAX_VALUE = 1000;
 
     private void validateInput(String input) throws OptionsParsingException {
       if (!Objects.equals(input, "default")) {


### PR DESCRIPTION
I'm interested in having an always-flaky test to integration test our build tooling's handling of flaky test reporting.

Currently, there is no great way for a test to know that's it is a flaky re-run. Previously I saw the test drop a marker file in /tmp, fail, and then succeed on the retry when it detects the marker file.  However, this is incompatible with remote execution or hermetic /tmp.

It would be ideal to inject a flaky test attempt count via ENV var so we can deterministically know we are a retry (similar to how `--runs_per_test` is injected), but I can see that behavior being a little worrisome.

In the absence of that, we can fail the test with probability 7/8, which gives a ~15% false positive and false negative rate at 10 retries. Bumping the max retries to 1000 allows to fail the test with probability 199/200, which is roughly .5% false positive and false negative rate.

I know this is a bit of a weird use case, but hopefully this is a harmless-enough bump!