### PR TITLE
[9.1.0] Fix NPE caused by --repo_env with no value set (https://github.com/bazelbuild/bazel/pull/28606)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -400,8 +400,11 @@ public class CommandEnvironment {
           nonstrictRepoEnvBuilder.put(name, value);
         }
         case Converters.EnvVar.Inherit(String name) -> {
-          repoEnvBuilder.put(name, clientEnv.get(name));
-          nonstrictRepoEnvBuilder.put(name, clientEnv.get(name));
+          String value = clientEnv.get(name);
+          if (value != null) {
+            repoEnvBuilder.put(name, value);
+            nonstrictRepoEnvBuilder.put(name, value);
+          }
         }
         case Converters.EnvVar.Unset(String name) -> {
           repoEnvBuilder.remove(name);

--- a/src/test/py/bazel/bazel_external_repository_test.py
+++ b/src/test/py/bazel/bazel_external_repository_test.py
@@ -535,6 +535,43 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     self.assertIn('FOO bar', os.linesep.join(stderr))
     self.assertNotIn('null value in entry: FOO=null', os.linesep.join(stderr))
 
+  def testRepoEnvMissingVariable(self):
+    # Test that --repo_env=VAR for a variable not set in the environment
+    # is silently ignored and doesn't crash (regression test for NPE fix).
+    # See https://github.com/bazelbuild/bazel/issues/28605
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'dump_env = use_repo_rule("//:main.bzl", "dump_env")',
+            'dump_env(',
+            '    name = "debug"',
+            ')',
+        ],
+    )
+    self.ScratchFile('BUILD')
+    self.ScratchFile(
+        'main.bzl',
+        [
+            'def _dump_env(ctx):',
+            '    val = ctx.os.environ.get("NONEXISTENT_VAR", "not_found")',
+            '    print("NONEXISTENT_VAR", val)',
+            '    ctx.file("BUILD")',
+            'dump_env = repository_rule(',
+            '    implementation = _dump_env,',
+            '    local = True,',
+            ')',
+        ],
+    )
+
+    _, _, stderr = self.RunBazel(
+        args=['build', '@debug//:all', '--repo_env=NONEXISTENT_VAR'],
+        env_remove=['NONEXISTENT_VAR'],
+    )
+    stderr_str = os.linesep.join(stderr)
+    self.assertNotIn('NullPointerException', stderr_str)
+    self.assertNotIn('null value in entry', stderr_str)
+    self.assertIn('NONEXISTENT_VAR not_found', stderr_str)
+
   def testRepoEnvUnset(self):
     self.ScratchFile(
         'MODULE.bazel',


### PR DESCRIPTION
This is to address #28605. bazel crashes with `NullPointerException` in case `--repo_env=NON_EXISTENT` is used with no value set in user's local environment. It worked in `8.5.1` but doesn't in `9.0.0` so it seems like a regression.

Closes #28606.

PiperOrigin-RevId: 868871905
Change-Id: I0ecd9a4b76b7795e1f00583050aaf343fe930832

Commit https://github.com/bazelbuild/bazel/commit/b55b69d65cb7dd249e1648cb3397ac0b4b0e2f59