### PR TITLE
fix: Fix coverage runfiles prefix to include workspace name

### DIFF
--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -110,7 +110,12 @@ public class TestCollatz {
 EOF
 
   bazel coverage --test_output=all //:test &>$TEST_log || fail "Coverage for //:test failed"
-  cat $TEST_log
+
+  # Regression test for https://github.com/bazelbuild/bazel/issues/28637
+  # Verifies that the coverage runtime classpath uses correct runfiles paths,
+  # i.e., workspace-local jars are found by singlejar without errors.
+  assert_not_contains "Cannot open input jar" "$TEST_log"
+
   local coverage_file_path="$( get_coverage_file_path_from_test_log )"
 
   local expected_result="SF:src/main/com/example/Collatz.java

--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -146,7 +146,7 @@ if [[ ! -z "${JAVA_RUNTIME_CLASSPATH_FOR_COVERAGE}" ]]; then
   # Append the runfiles prefix to all the relative paths found in
   # JAVA_RUNTIME_CLASSPATH_FOR_COVERAGE, to invoke SingleJar with the
   # absolute paths.
-  RUNFILES_PREFIX="$TEST_SRCDIR/"
+  RUNFILES_PREFIX="$TEST_SRCDIR/$TEST_WORKSPACE/"
   cat "$JAVA_RUNTIME_CLASSPATH_FOR_COVERAGE" | sed "s@^@$RUNFILES_PREFIX@" >> "$single_jar_params_file"
 
   # Invoke SingleJar. This will create JACOCO_METADATA_JAR.


### PR DESCRIPTION
## Description

`collect_coverage.sh` constructs absolute paths for the coverage runtime classpath by prepending `$TEST_SRCDIR/` to each entry from `JAVA_RUNTIME_CLASSPATH_FOR_COVERAGE`. However, workspace-local jar paths need `$TEST_WORKSPACE` included to resolve correctly under the runfiles tree.

Without this fix, singlejar fails with:
```
singlejar_local: src/tools/singlejar/input_jar.cc:28: Cannot open input jar
  .../MyTest.runfiles/path/to/MyTest.jar: No such file or directory
```

The correct path should be `.../MyTest.runfiles/_main/path/to/MyTest.jar`.

## Root cause

Line 149 of `collect_coverage.sh` sets:
```bash
RUNFILES_PREFIX="$TEST_SRCDIR/"
```

But workspace-local entries in the classpath file (e.g. `path/to/MyTest.jar`) need the workspace directory (`_main`) prepended. The fix changes this to:
```bash
RUNFILES_PREFIX="$TEST_SRCDIR/$TEST_WORKSPACE/"
```

Note that `$TEST_WORKSPACE` is already used for exactly this purpose on line 158:
```bash
cd "$TEST_SRCDIR/$TEST_WORKSPACE"
```

External dependency paths (prefixed with `../`) continue to resolve correctly since `_main/../ext_repo` resolves to the runfiles root level where external repos are located.

## Related issues

Fixes https://github.com/bazelbuild/bazel/issues/28637

Related:
- https://github.com/bazelbuild/bazel/issues/13358 — same class of bug for `JacocoCoverage_jarjar_deploy.jar` paths (fixed)
- https://github.com/bazelbuild/bazel/issues/13376 — same class of bug for external repository jar paths (fixed)