### PR TITLE
ensure shutdown of the symlink planting pool

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -147,6 +147,7 @@ public class ExecutionTool {
   private final String actionExecutionSalt;
 
   private boolean informedOutputServiceToStartTheBuild = false;
+  private IncrementalPackageRoots incrementalPackageRoots;
 
   ExecutionTool(CommandEnvironment env, BuildRequest request)
       throws AbruptExitException, InterruptedException {
@@ -268,7 +269,7 @@ public class ExecutionTool {
     SkyframeExecutor skyframeExecutor = env.getSkyframeExecutor();
 
     try (SilentCloseable c = Profiler.instance().profile("preparingExecroot")) {
-      IncrementalPackageRoots incrementalPackageRoots =
+      incrementalPackageRoots =
           IncrementalPackageRoots.createAndRegisterToEventBus(
               getExecRoot(),
               // Single package path is a Skymeld prerequisite.
@@ -611,6 +612,9 @@ public class ExecutionTool {
     // These may flush logs, which may help if there is a catastrophic failure.
     for (ExecutorLifecycleListener executorLifecycleListener : executorLifecycleListeners) {
       executorLifecycleListener.executionPhaseEnding();
+    }
+    if (incrementalPackageRoots != null) {
+      incrementalPackageRoots.shutdown();
     }
 
     // Handlers process these events and others (e.g. CommandCompleteEvent), even in the event of


### PR DESCRIPTION
I was iteratively fixing some build failures with bazel and realized bazel was becoming more and more sluggish. Taking a thread dump, I observed way too many symlink planting threads:
```
$ grep -c 'Non-eager Symlink planter ' stacks.txt
36800
```

Try harder to ensure the symlink planting thread pool is released after the build is done.