### PR TITLE
Migrate from URL to URI

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/CacheHitReportingModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/CacheHitReportingModule.java
@@ -22,7 +22,7 @@ import com.google.devtools.build.lib.repository.RepositoryFetchProgress;
 import com.google.devtools.build.lib.runtime.BlazeModule;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.util.Pair;
-import java.net.URL;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -31,7 +31,7 @@ import java.util.Set;
 /** Module reporting about cache hits in external repositories in case of failures */
 public final class CacheHitReportingModule extends BlazeModule {
   private Reporter reporter;
-  private Map<String, Set<Pair<String, URL>>> cacheHitsByContext;
+  private Map<String, Set<Pair<String, URI>>> cacheHitsByContext;
 
   @Override
   public void beforeCommand(CommandEnvironment env) {
@@ -49,22 +49,22 @@ public final class CacheHitReportingModule extends BlazeModule {
   @Subscribe
   public synchronized void cacheHit(DownloadCacheHitEvent event) {
     cacheHitsByContext
-        .computeIfAbsent(event.getContext(), k -> new HashSet<>())
-        .add(Pair.of(event.getFileHash(), event.getUrl()));
+        .computeIfAbsent(event.context(), k -> new HashSet<>())
+        .add(Pair.of(event.fileHash(), event.uri()));
   }
 
   @Subscribe
   public void failed(RepositoryFailedEvent event) {
     // TODO(wyv): add an event for the failure of a module extension too
     String context = RepositoryFetchProgress.repositoryFetchContextString(event.getRepo());
-    Set<Pair<String, URL>> cacheHits = cacheHitsByContext.get(context);
+    Set<Pair<String, URI>> cacheHits = cacheHitsByContext.get(context);
     if (cacheHits != null && !cacheHits.isEmpty()) {
       StringBuilder info = new StringBuilder();
 
       info.append(context)
           .append(
               "' used the following cache hits instead of downloading the corresponding file.\n");
-      for (Pair<String, URL> hit : cacheHits) {
+      for (Pair<String, URI> hit : cacheHits) {
         info.append(" * Hash '")
             .append(hit.getFirst())
             .append("' for ")

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -44,9 +44,8 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -207,7 +206,7 @@ public class IndexRegistry implements Registry {
               + "report at https://github.com/bazelbuild/bazel/issues/new/choose.");
     }
 
-    URL url = URI.create(rawUrl).toURL();
+    URI url = URI.create(rawUrl);
     // Don't read the registry URL from the vendor directory in the following cases:
     // 1. vendorUtil is null, which means vendor mode is disabled.
     // 2. The checksum is not present, which means the URL is not vendored or the vendored content
@@ -216,7 +215,7 @@ public class IndexRegistry implements Registry {
     // 4. The vendor path doesn't exist, which means the URL is not vendored.
     if (vendorManager != null
         && checksum.isPresent()
-        && !url.getProtocol().equals("file")
+        && !"file".equals(url.getScheme())
         && vendorManager.isUrlVendored(url)) {
       try {
         return vendorManager.readRegistryUrl(url, checksum.get());
@@ -268,7 +267,7 @@ public class IndexRegistry implements Registry {
 
   /** Represents fields in {@code source.json} for each archive-type version of a module. */
   private static class ArchiveSourceJson {
-    URL url;
+    URI url;
     List<String> mirrorUrls;
     String integrity;
     String stripPrefix;
@@ -450,7 +449,7 @@ public class IndexRegistry implements Registry {
       Optional<BazelRegistryJson> bazelRegistryJson,
       ModuleKey key)
       throws IOException {
-    URL sourceUrl = sourceJson.url;
+    URI sourceUrl = sourceJson.url;
     if (sourceUrl == null) {
       throw new IOException(String.format("Missing source URL for module %s", key));
     }
@@ -470,12 +469,16 @@ public class IndexRegistry implements Registry {
     // URL concatenated with the source URL.
     for (String mirror : allMirrors) {
       try {
-        var unused = new URL(mirror);
-      } catch (MalformedURLException e) {
-        throw new IOException("Malformed mirror URL", e);
+        var unused = new URI(mirror);
+      } catch (URISyntaxException e) {
+        throw new IOException("Malformed mirror URL specified in bazel_registry.json of " + uri, e);
       }
-
-      urls.add(constructUrl(mirror, sourceUrl.getAuthority(), sourceUrl.getFile()));
+      String authority = sourceUrl.getAuthority();
+      String path = sourceUrl.getPath();
+      String query = sourceUrl.getQuery();
+      urls.add(
+          constructUrl(mirror, authority != null ? authority : "", path != null ? path : "")
+              + (query != null ? "?" + query : ""));
     }
     // Add the original source URL itself.
     urls.add(sourceUrl.toString());

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -473,9 +473,9 @@ public class IndexRegistry implements Registry {
       } catch (URISyntaxException e) {
         throw new IOException("Malformed mirror URL specified in bazel_registry.json of " + uri, e);
       }
-      String authority = sourceUrl.getAuthority();
-      String path = sourceUrl.getPath();
-      String query = sourceUrl.getQuery();
+      String authority = sourceUrl.getRawAuthority();
+      String path = sourceUrl.getRawPath();
+      String query = sourceUrl.getRawQuery();
       urls.add(
           constructUrl(mirror, authority != null ? authority : "", path != null ? path : "")
               + (query != null ? "?" + query : ""));

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorManager.java
@@ -30,7 +30,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URL;
+import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.file.Files;
 import java.util.Collection;
@@ -184,7 +184,7 @@ public class VendorManager {
    * @return true if the URL is vendored, false otherwise.
    * @throws UnsupportedEncodingException if the URL decoding fails.
    */
-  public boolean isUrlVendored(URL url) throws UnsupportedEncodingException {
+  public boolean isUrlVendored(URI url) throws UnsupportedEncodingException {
     return getVendorPathForUrl(url).isFile();
   }
 
@@ -195,7 +195,7 @@ public class VendorManager {
    * @param content The content to write.
    * @throws IOException if an I/O error occurs.
    */
-  public void vendorRegistryUrl(URL url, byte[] content) throws IOException {
+  public void vendorRegistryUrl(URI url, byte[] content) throws IOException {
     Path outputPath = getVendorPathForUrl(url);
     Objects.requireNonNull(outputPath.getParentDirectory()).createDirectoryAndParents();
     FileSystemUtils.writeContent(outputPath, content);
@@ -209,7 +209,7 @@ public class VendorManager {
    * @return The content of the registry URL.
    * @throws IOException if an I/O error occurs or the checksum verification fails.
    */
-  public byte[] readRegistryUrl(URL url, Checksum checksum) throws IOException {
+  public byte[] readRegistryUrl(URI url, Checksum checksum) throws IOException {
     byte[] content = FileSystemUtils.readContent(getVendorPathForUrl(url));
     Hasher hasher = checksum.getKeyType().newHasher();
     hasher.putBytes(content);
@@ -259,7 +259,7 @@ public class VendorManager {
    * @return The vendor path.
    * @throws UnsupportedEncodingException if the URL decoding fails.
    */
-  public Path getVendorPathForUrl(URL url) throws UnsupportedEncodingException {
+  public Path getVendorPathForUrl(URI url) throws UnsupportedEncodingException {
     String host = url.getHost().toLowerCase(Locale.ROOT); // Host names are case-insensitive
     String path = url.getPath();
     path = URLDecoder.decode(path, "UTF-8");

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
@@ -67,7 +67,6 @@ import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.OptionsParsingResult;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -351,8 +350,8 @@ public final class VendorCommand implements BlazeCommand {
     // The user has to update the Bazel registries this if such conflicts occur.
     Map<String, String> vendorPathToUrl = new HashMap<>();
     for (Entry<String, Optional<Checksum>> entry : registryFiles.entrySet()) {
-      URL url = URI.create(entry.getKey()).toURL();
-      if (url.getProtocol().equals("file")) {
+      URI url = URI.create(entry.getKey());
+      if ("file".equals(url.getScheme())) {
         continue;
       }
 
@@ -369,7 +368,7 @@ public final class VendorCommand implements BlazeCommand {
                     + " cause conflict on case insensitive file systems, please fix by changing the"
                     + " registry URLs!",
                 previousUrl,
-                vendorManager.getVendorPathForUrl(URI.create(previousUrl).toURL()).getPathString(),
+                vendorManager.getVendorPathForUrl(URI.create(previousUrl)).getPathString(),
                 entry.getKey(),
                 outputPath));
       }

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -25,7 +25,7 @@ import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.Templa
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.WhichEvent;
 import com.google.devtools.build.lib.events.ExtendedEventHandler.Postable;
 import com.google.protobuf.ByteString;
-import java.net.URL;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import net.starlark.java.syntax.Location;
@@ -83,7 +83,7 @@ public final class WorkspaceRuleEvent implements Postable {
 
   /** Creates a new WorkspaceRuleEvent for a download event. */
   public static WorkspaceRuleEvent newDownloadEvent(
-      List<URL> urls,
+      List<URI> urls,
       String output,
       String sha256,
       String integrity,
@@ -96,7 +96,7 @@ public final class WorkspaceRuleEvent implements Postable {
             .setSha256(sha256)
             .setIntegrity(integrity)
             .setExecutable(executable);
-    for (URL u : urls) {
+    for (URI u : urls) {
       e.addUrl(u.toString());
     }
 
@@ -142,7 +142,7 @@ public final class WorkspaceRuleEvent implements Postable {
 
   /** Creates a new WorkspaceRuleEvent for a download and extract event. */
   public static WorkspaceRuleEvent newDownloadAndExtractEvent(
-      List<URL> urls,
+      List<URI> urls,
       String output,
       String sha256,
       String integrity,
@@ -159,7 +159,7 @@ public final class WorkspaceRuleEvent implements Postable {
             .setType(type)
             .setStripPrefix(stripPrefix)
             .putAllRenameFiles(renameFiles);
-    for (URL u : urls) {
+    for (URI u : urls) {
       e.addUrl(u.toString());
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCacheHitEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCacheHitEvent.java
@@ -15,29 +15,7 @@
 package com.google.devtools.build.lib.bazel.repository.cache;
 
 import com.google.devtools.build.lib.events.ExtendedEventHandler.Postable;
-import java.net.URL;
+import java.net.URI;
 
 /** Event reporting about cache hits for download requests. */
-public final class DownloadCacheHitEvent implements Postable {
-  private final String context;
-  private final String hash;
-  private final URL url;
-
-  public DownloadCacheHitEvent(String context, String hash, URL url) {
-    this.context = context;
-    this.hash = hash;
-    this.url = url;
-  }
-
-  public String getContext() {
-    return context;
-  }
-
-  public URL getUrl() {
-    return url;
-  }
-
-  public String getFileHash() {
-    return hash;
-  }
-}
+public record DownloadCacheHitEvent(String context, String fileHash, URI uri) implements Postable {}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DelegatingDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DelegatingDownloader.java
@@ -18,7 +18,7 @@ import com.google.auth.Credentials;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -46,7 +46,7 @@ public class DelegatingDownloader implements Downloader {
 
   @Override
   public void download(
-      List<URL> urls,
+      List<URI> urls,
       Map<String, List<String>> headers,
       Credentials credentials,
       Optional<Checksum> checksum,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadProgressEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadProgressEvent.java
@@ -16,7 +16,7 @@ package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.remote.util.Utils;
-import java.net.URL;
+import java.net.URI;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
@@ -27,14 +27,14 @@ import java.util.OptionalLong;
  * being downloaded and the number of bytes read so far.
  */
 public class DownloadProgressEvent implements ExtendedEventHandler.FetchProgress {
-  private final URL originalUrl;
-  private final URL actualUrl;
+  private final URI originalUrl;
+  private final URI actualUrl;
   private final long bytesRead;
   private final OptionalLong totalBytes;
   private final boolean downloadFinished;
 
   public DownloadProgressEvent(
-      URL originalUrl, URL actualUrl, long bytesRead, OptionalLong totalBytes, boolean finished) {
+      URI originalUrl, URI actualUrl, long bytesRead, OptionalLong totalBytes, boolean finished) {
     this.originalUrl = originalUrl;
     this.actualUrl = actualUrl;
     this.bytesRead = bytesRead;
@@ -42,19 +42,19 @@ public class DownloadProgressEvent implements ExtendedEventHandler.FetchProgress
     this.downloadFinished = finished;
   }
 
-  public DownloadProgressEvent(URL originalUrl, long bytesRead, boolean finished) {
+  public DownloadProgressEvent(URI originalUrl, long bytesRead, boolean finished) {
     this(originalUrl, null, bytesRead, OptionalLong.empty(), finished);
   }
 
-  public DownloadProgressEvent(URL url, long bytesRead) {
+  public DownloadProgressEvent(URI url, long bytesRead) {
     this(url, bytesRead, false);
   }
 
-  public DownloadProgressEvent(URL url) {
+  public DownloadProgressEvent(URI url) {
     this(url, 0);
   }
 
-  public URL getOriginalUrl() {
+  public URI getOriginalUrl() {
     return originalUrl;
   }
 
@@ -63,7 +63,7 @@ public class DownloadProgressEvent implements ExtendedEventHandler.FetchProgress
     return originalUrl.toString();
   }
 
-  public URL getActualUrl() {
+  public URI getActualUrl() {
     return actualUrl;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Downloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Downloader.java
@@ -18,7 +18,7 @@ import com.google.auth.Credentials;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -42,7 +42,7 @@ public interface Downloader {
    * @throws InterruptedException if this thread is being cast into oblivion
    */
   void download(
-      List<URL> urls,
+      List<URI> urls,
       Map<String, List<String>> headers,
       Credentials credentials,
       Optional<Checksum> checksum,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
-import java.net.URL;
+import java.net.URI;
 import java.net.URLConnection;
 import java.net.UnknownHostException;
 import java.time.Duration;
@@ -108,15 +108,15 @@ class HttpConnector {
   }
 
   URLConnection connect(
-      URL originalUrl, Function<URL, ImmutableMap<String, List<String>>> requestHeaders)
+      URI originalUrl, Function<URI, ImmutableMap<String, List<String>>> requestHeaders)
       throws IOException {
 
     if (Thread.interrupted()) {
       throw new InterruptedIOException();
     }
-    URL url = originalUrl;
+    URI url = originalUrl;
     if (HttpUtils.isProtocol(url, "file")) {
-      return url.openConnection();
+      return url.toURL().openConnection();
     }
     List<Throwable> suppressions = new ArrayList<>();
     int retries = 0;
@@ -126,7 +126,7 @@ class HttpConnector {
       HttpURLConnection connection = null;
       try {
         ProxyInfo proxyInfo = proxyHelper.createProxyIfNeeded(url);
-        connection = (HttpURLConnection) url.openConnection(proxyInfo.proxy());
+        connection = (HttpURLConnection) url.toURL().openConnection(proxyInfo.proxy());
         // For HTTP connections through authenticated proxies, set the Proxy-Authorization header.
         // For HTTPS, Java's HttpURLConnection handles CONNECT tunneling internally using the
         // Authenticator we set in ProxyHelper.

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
@@ -28,8 +28,7 @@ import com.google.devtools.build.lib.events.EventHandler;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
-import java.net.URISyntaxException;
-import java.net.URL;
+import java.net.URI;
 import java.net.URLConnection;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +72,7 @@ final class HttpConnectorMultiplexer {
     this.httpStreamFactory = httpStreamFactory;
   }
 
-  public HttpStream connect(URL url, Optional<Checksum> checksum) throws IOException {
+  public HttpStream connect(URI url, Optional<Checksum> checksum) throws IOException {
     return connect(url, checksum, ImmutableMap.of(), StaticCredentials.EMPTY, Optional.empty());
   }
 
@@ -85,7 +84,7 @@ final class HttpConnectorMultiplexer {
    * uncompressed files. It reports download progress. It enforces a SHA-256 checksum which
    * continues to be enforced even after this method returns.
    *
-   * @param url the URL to conenct to. can be: file, http, or https
+   * @param url the URI to connect to. can be: file, http, or https
    * @param checksum checksum lazily checked on entire payload, or empty to disable
    * @param credentials the credentials
    * @param type extension, e.g. "tar.gz" to force on downloaded filename, or empty to not do this
@@ -95,7 +94,7 @@ final class HttpConnectorMultiplexer {
    * @throws IllegalArgumentException if {@code urls} is empty or has an unsupported protocol
    */
   public HttpStream connect(
-      URL url,
+      URI url,
       Optional<Checksum> checksum,
       Map<String, List<String>> headers,
       Credentials credentials,
@@ -110,7 +109,7 @@ final class HttpConnectorMultiplexer {
     // REQUEST_HEADERS should not be overridable by user provided headers
     baseHeaders.putAll(REQUEST_HEADERS);
 
-    Function<URL, ImmutableMap<String, List<String>>> headerFunction =
+    Function<URI, ImmutableMap<String, List<String>>> headerFunction =
         getHeaderFunction(baseHeaders.buildKeepingLast(), credentials, eventHandler);
     URLConnection connection = connector.connect(url, headerFunction);
     return httpStreamFactory.create(
@@ -121,7 +120,7 @@ final class HttpConnectorMultiplexer {
           eventHandler.handle(
               Event.progress(String.format("Lost connection for %s due to %s", url, cause)));
           return connector.connect(
-              connection.getURL(),
+              HttpUtils.toURI(connection),
               newUrl ->
                   new ImmutableMap.Builder<String, List<String>>()
                       .putAll(headerFunction.apply(newUrl))
@@ -132,7 +131,7 @@ final class HttpConnectorMultiplexer {
   }
 
   @VisibleForTesting
-  static Function<URL, ImmutableMap<String, List<String>>> getHeaderFunction(
+  static Function<URI, ImmutableMap<String, List<String>>> getHeaderFunction(
       Map<String, List<String>> baseHeaders, Credentials credentials, EventHandler eventHandler) {
     Preconditions.checkNotNull(baseHeaders);
     Preconditions.checkNotNull(credentials);
@@ -141,10 +140,9 @@ final class HttpConnectorMultiplexer {
       ImmutableMap.Builder<String, List<String>> headers = new ImmutableMap.Builder<>();
       headers.putAll(baseHeaders);
       try {
-        headers.putAll(credentials.getRequestMetadata(url.toURI()));
-      } catch (URISyntaxException | IOException e) {
-        // If we can't convert the URL to a URI (because it is syntactically malformed), or fetching
-        // credentials fails for any other reason, still try to do the connection, not adding
+        headers.putAll(credentials.getRequestMetadata(url));
+      } catch (IOException e) {
+        // If fetching credentials fails for any reason, still try to do the connection, not adding
         // authentication information as we cannot look it up.
         eventHandler.handle(
             Event.warn("Error retrieving auth headers, continuing without: " + e.getMessage()));

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.net.SocketTimeoutException;
-import java.net.URL;
+import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -74,7 +74,7 @@ public class HttpDownloader implements Downloader {
 
   @Override
   public void download(
-      List<URL> urls,
+      List<URI> urls,
       Map<String, List<String>> headers,
       Credentials credentials,
       Optional<Checksum> checksum,
@@ -93,7 +93,7 @@ public class HttpDownloader implements Downloader {
 
     List<IOException> ioExceptions = ImmutableList.of();
 
-    for (URL url : urls) {
+    for (URI url : urls) {
       semaphore.acquire();
 
       try (HttpStream payload = multiplexer.connect(url, checksum, headers, credentials, type);
@@ -145,7 +145,7 @@ public class HttpDownloader implements Downloader {
 
   /** Downloads the contents of one URL and reads it into a byte array. */
   public byte[] downloadAndReadOneUrl(
-      URL url,
+      URI url,
       Credentials credentials,
       Optional<Checksum> checksum,
       ExtendedEventHandler eventHandler,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpUtils.java
@@ -19,34 +19,34 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
+import java.net.URLConnection;
 import java.util.Collection;
+import java.util.Objects;
 
 /** HTTP utilities. */
 public final class HttpUtils {
 
-  /** Returns {@code true} if {@code url} is supported by {@link HttpDownloader}. */
-  public static boolean isUrlSupportedByDownloader(URL url) {
-    return isHttp(url) || isProtocol(url, "file");
+  /** Returns {@code true} if {@code uri} is supported by {@link HttpDownloader}. */
+  public static boolean isUrlSupportedByDownloader(URI uri) {
+    return isHttp(uri) || isProtocol(uri, "file");
   }
 
-  static boolean isHttp(URL url) {
-    return isProtocol(url, "http") || isProtocol(url, "https");
+  static boolean isHttp(URI uri) {
+    return isProtocol(uri, "http") || isProtocol(uri, "https");
   }
 
-  static boolean isProtocol(URL url, String protocol) {
+  static boolean isProtocol(URI uri, String protocol) {
     // An implementation should accept uppercase letters as equivalent to lowercase in scheme names
     // (e.g., allow "HTTP" as well as "http") for the sake of robustness. Quoth RFC3986 § 3.1
-    return Ascii.equalsIgnoreCase(protocol, url.getProtocol());
+    return Ascii.equalsIgnoreCase(protocol, uri.getScheme());
   }
 
-  static void checkUrlsArgument(Collection<URL> urls) {
-    Preconditions.checkArgument(!urls.isEmpty(), "urls list empty");
-    for (URL url : urls) {
-      Preconditions.checkArgument(isUrlSupportedByDownloader(url), "unsupported protocol: %s", url);
+  static void checkUrlsArgument(Collection<URI> uris) {
+    Preconditions.checkArgument(!uris.isEmpty(), "urls list empty");
+    for (URI uri : uris) {
+      Preconditions.checkArgument(isUrlSupportedByDownloader(uri), "unsupported protocol: %s", uri);
     }
   }
 
@@ -58,37 +58,42 @@ public final class HttpUtils {
     return Ascii.toLowerCase(path.substring(index + 1));
   }
 
-  static URL getLocation(HttpURLConnection connection) throws IOException {
+  static URI getLocation(HttpURLConnection connection) throws IOException {
     String newLocation = connection.getHeaderField("Location");
     if (newLocation == null) {
       throw new IOException("Remote redirect missing Location.");
     }
-    URL result = mergeUrls(URI.create(newLocation), connection.getURL());
+    URI result = mergeUrls(URI.create(newLocation), toURI(connection));
     if (!isHttp(result)) {
       throw new IOException("Bad Location: " + newLocation);
     }
     return result;
   }
 
-  private static URL mergeUrls(URI preferred, URL original) throws IOException {
-    // Try to short cut to preferred.toURL() to preserve the original presentation of the
-    // quoting (as a call to the structed URI constructor puts quoting into a canocial form).
+  private static URI mergeUrls(URI preferred, URI original) throws IOException {
+    // Try to short cut to preferred to preserve the original presentation of the
+    // quoting (as a call to the structured URI constructor puts quoting into a canonical form).
     // This is necessary as some sites rely on the precise presentation for the authentication
     // scheme of their redirect URLs.
     if (preferred.getHost() != null
         && preferred.getScheme() != null
-        && (preferred.getFragment() != null || original.getRef() == null)) {
+        && (preferred.getFragment() != null || original.getFragment() == null)
+        // Forward user info to the same origin.
+        && (preferred.getUserInfo() != null
+            || original.getUserInfo() == null
+            || !(Objects.equals(preferred.getHost(), original.getHost())
+                && preferred.getPort() == original.getPort()))) {
       // In this case we obviously do not inherit anything from the original URL, as all inheritable
       // fields are either set explicitly or not present in the original either. Therefore, it is
       // safe to short cut.
-      return preferred.toURL();
+      return preferred;
     }
 
     // If the Location value provided in a 3xx (Redirection) response does not have a fragment
     // component, a user agent MUST process the redirection as if the value inherits the fragment
     // component of the URI reference used to generate the request target (i.e., the redirection
     // inherits the original reference's fragment, if any). Quoth RFC7231 § 7.1.2
-    String protocol = MoreObjects.firstNonNull(preferred.getScheme(), original.getProtocol());
+    String protocol = MoreObjects.firstNonNull(preferred.getScheme(), original.getScheme());
     String userInfo = preferred.getUserInfo();
     String host = preferred.getHost();
     int port;
@@ -98,9 +103,7 @@ public final class HttpUtils {
       userInfo = original.getUserInfo();
     } else {
       port = preferred.getPort();
-      if (userInfo == null
-          && host.equals(original.getHost())
-          && port == original.getPort()) {
+      if (userInfo == null && host.equals(original.getHost()) && port == original.getPort()) {
         userInfo = original.getUserInfo();
       }
     }
@@ -108,15 +111,27 @@ public final class HttpUtils {
     String query = preferred.getQuery();
     String fragment = preferred.getFragment();
     if (fragment == null) {
-      fragment = original.getRef();
+      fragment = original.getFragment();
     }
-    URL result;
+    URI result;
     try {
-      result = new URI(protocol, userInfo, host, port, path, query, fragment).toURL();
-    } catch (URISyntaxException | MalformedURLException e) {
+      result = new URI(protocol, userInfo, host, port, path, query, fragment);
+    } catch (URISyntaxException e) {
       throw new IOException("Could not merge " + preferred + " into " + original, e);
     }
     return result;
+  }
+
+  /**
+   * Converts a {@link URLConnection}'s URL to a {@link URI}. Since the URL comes from an active
+   * connection, it should always be a valid URI.
+   */
+  static URI toURI(URLConnection connection) {
+    try {
+      return connection.getURL().toURI();
+    } catch (URISyntaxException e) {
+      throw new IllegalStateException("Invalid URI from connection URL: " + connection.getURL(), e);
+    }
   }
 
   private HttpUtils() {}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProgressInputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProgressInputStream.java
@@ -22,7 +22,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
+import java.net.URI;
 import java.util.Locale;
 import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicLong;
@@ -53,8 +53,8 @@ final class ProgressInputStream extends InputStream {
 
     InputStream create(
         @WillCloseWhenClosed InputStream delegate,
-        URL url,
-        URL originalUrl,
+        URI url,
+        URI originalUrl,
         OptionalLong totalBytes) {
       return new ProgressInputStream(
           locale,
@@ -73,8 +73,8 @@ final class ProgressInputStream extends InputStream {
   private final ExtendedEventHandler eventHandler;
   private final InputStream delegate;
   private final long intervalMs;
-  private final URL url;
-  private final URL originalUrl;
+  private final URI url;
+  private final URI originalUrl;
   private final OptionalLong totalBytes;
   private final AtomicLong toto = new AtomicLong();
   private final AtomicLong nextEvent;
@@ -85,8 +85,8 @@ final class ProgressInputStream extends InputStream {
       ExtendedEventHandler eventHandler,
       long intervalMs,
       InputStream delegate,
-      URL url,
-      URL originalUrl,
+      URI url,
+      URI originalUrl,
       OptionalLong totalBytes) {
     Preconditions.checkArgument(intervalMs >= 0);
     this.locale = locale;

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
@@ -26,7 +26,7 @@ import java.net.Authenticator;
 import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
-import java.net.URL;
+import java.net.URI;
 import java.net.URLDecoder;
 import java.util.Map;
 import java.util.Objects;
@@ -71,7 +71,7 @@ public class ProxyHelper {
    * @param requestedUrl remote resource that may need to be retrieved through a proxy
    * @return ProxyInfo containing the proxy and optional credentials
    */
-  public ProxyInfo createProxyIfNeeded(URL requestedUrl) throws IOException {
+  public ProxyInfo createProxyIfNeeded(URI requestedUrl) throws IOException {
     String proxyAddress = null;
     String proxyUserProperty = null;
     String proxyPasswordProperty = null;

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
@@ -37,10 +37,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
@@ -144,7 +141,7 @@ public class UrlRewriter {
    * @param urls The input list of {@link URL}s. May be empty.
    * @return The amended lists of URLs.
    */
-  public ImmutableList<RewrittenURL> amend(List<URL> urls) {
+  public ImmutableList<RewrittenURL> amend(List<URI> urls) {
     Objects.requireNonNull(urls, "URLS to check must be set but may be empty");
 
     return urls.stream().map(this::rewrite).flatMap(Collection::stream).collect(toImmutableList());
@@ -174,18 +171,14 @@ public class UrlRewriter {
 
       String userInfo = url.url().getUserInfo();
       if (userInfo != null) {
-        try {
-          String token =
-              "Basic " + Base64.getEncoder().encodeToString(userInfo.getBytes(ISO_8859_1));
-          updatedAuthHeaders.put(
-              url.url().toURI(), ImmutableMap.of("Authorization", ImmutableList.of(token)));
-        } catch (URISyntaxException e) {
-          // If the credentials extraction failed, we're letting bazel try without credentials.
-        }
+        String token =
+            "Basic " + Base64.getEncoder().encodeToString(userInfo.getBytes(ISO_8859_1));
+        updatedAuthHeaders.put(
+            url.url(), ImmutableMap.of("Authorization", ImmutableList.of(token)));
       } else if (netrcCreds != null) {
         try {
           Map<String, List<String>> urlAuthHeaders =
-              netrcCreds.getRequestMetadata(url.url().toURI());
+              netrcCreds.getRequestMetadata(url.url());
           if (urlAuthHeaders == null || urlAuthHeaders.isEmpty()) {
             continue;
           }
@@ -194,11 +187,11 @@ public class UrlRewriter {
               urlAuthHeaders.entrySet().stream().findFirst().get();
           if (firstAuthHeader.getValue() != null && !firstAuthHeader.getValue().isEmpty()) {
             updatedAuthHeaders.put(
-                url.url().toURI(),
+                url.url(),
                 ImmutableMap.of(
                     firstAuthHeader.getKey(), ImmutableList.of(firstAuthHeader.getValue().get(0))));
           }
-        } catch (URISyntaxException | IOException e) {
+        } catch (IOException e) {
           // If the credentials extraction failed, we're letting bazel try without credentials.
         }
       }
@@ -207,12 +200,12 @@ public class UrlRewriter {
     return ImmutableMap.copyOf(updatedAuthHeaders);
   }
 
-  private ImmutableList<RewrittenURL> rewrite(URL url) {
+  private ImmutableList<RewrittenURL> rewrite(URI url) {
     Preconditions.checkNotNull(url);
 
     // Cowardly refuse to rewrite non-HTTP(S) urls
     if (REWRITABLE_SCHEMES.stream()
-        .noneMatch(scheme -> Ascii.equalsIgnoreCase(scheme, url.getProtocol()))) {
+        .noneMatch(scheme -> Ascii.equalsIgnoreCase(scheme, url.getScheme()))) {
       return ImmutableList.of(RewrittenURL.create(url, false));
     }
 
@@ -236,7 +229,7 @@ public class UrlRewriter {
     return toReturn.build();
   }
 
-  private boolean isAllowMatched(URL url) {
+  private boolean isAllowMatched(URI url) {
     for (String host : config.getAllowList()) {
       if (isMatchingHostName(url, host)) {
         return true;
@@ -245,7 +238,7 @@ public class UrlRewriter {
     return false;
   }
 
-  private boolean isBlockMatched(URL url) {
+  private boolean isBlockMatched(URI url) {
     for (String host : config.getBlockList()) {
       // Allow a wild-card block
       if ("*".equals(host)) {
@@ -259,12 +252,12 @@ public class UrlRewriter {
     return false;
   }
 
-  private static boolean isMatchingHostName(URL url, String host) {
+  private static boolean isMatchingHostName(URI url, String host) {
     return host.equals(url.getHost()) || url.getHost().endsWith("." + host);
   }
 
-  private ImmutableList<RewrittenURL> applyRewriteRules(URL url) {
-    String withoutScheme = url.toString().substring(url.getProtocol().length() + 3);
+  private ImmutableList<RewrittenURL> applyRewriteRules(URI url) {
+    String withoutScheme = url.toString().substring(url.getScheme().length() + 3);
 
     ImmutableSet.Builder<String> rewrittenUrls = ImmutableSet.builder();
 
@@ -285,23 +278,19 @@ public class UrlRewriter {
     }
 
     return rewrittenUrls.build().stream()
-        .map(urlString -> prefixWithProtocol(urlString, url.getProtocol()))
+        .map(urlString -> prefixWithProtocol(urlString, url.getScheme()))
         .map(plainUrl -> RewrittenURL.create(plainUrl, true))
         .collect(toImmutableList());
   }
 
   /** Prefixes url with protocol if not already prefixed by {@link #REWRITABLE_SCHEMES} */
-  private static URL prefixWithProtocol(String url, String protocol) {
-    try {
-      for (String schemaPrefix : REWRITABLE_SCHEMES) {
-        if (url.startsWith(schemaPrefix + "://")) {
-          return new URL(url);
-        }
+  private static URI prefixWithProtocol(String url, String protocol) {
+    for (String schemaPrefix : REWRITABLE_SCHEMES) {
+      if (url.startsWith(schemaPrefix + "://")) {
+        return URI.create(url);
       }
-      return new URL(protocol + "://" + url);
-    } catch (MalformedURLException e) {
-      throw new IllegalStateException(e);
     }
+    return URI.create(protocol + "://" + url);
   }
 
   /**
@@ -363,11 +352,11 @@ public class UrlRewriter {
   /** Holds the URL along with meta-info, such as whether URL was re-written or not. */
   @AutoValue
   public abstract static class RewrittenURL {
-    static RewrittenURL create(URL url, boolean rewritten) {
+    static RewrittenURL create(URI url, boolean rewritten) {
       return new AutoValue_UrlRewriter_RewrittenURL(url, rewritten);
     }
 
-    abstract URL url();
+    abstract URI url();
 
     abstract boolean rewritten();
   }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/TestHttpServer.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/TestHttpServer.java
@@ -21,8 +21,7 @@ import com.google.common.base.Joiner;
 import com.sun.net.httpserver.HttpServer;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.util.List;
 import org.junit.rules.ExternalResource;
 
@@ -82,7 +81,9 @@ public class TestHttpServer extends ExternalResource {
     server.removeContext(path);
   }
 
-  public String getUrl() throws MalformedURLException {
-    return new URL("http", "[::1]", server.getAddress().getPort(), "").toString();
+  public String getUrl() {
+    return URI.create(
+            "http://[::1]:" + server.getAddress().getPort())
+        .toString();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloaderTestUtils.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloaderTestUtils.java
@@ -20,20 +20,10 @@ import com.google.common.base.Joiner;
 import com.google.common.io.ByteStreams;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.Socket;
-import java.net.URL;
 import javax.annotation.WillNotClose;
 
 final class DownloaderTestUtils {
-
-  static URL makeUrl(String url) {
-    try {
-      return new URL(url);
-    } catch (MalformedURLException e) {
-      throw new RuntimeException(e);
-    }
-  }
 
   static void sendLines(@WillNotClose Socket socket, String... data) throws IOException {
     ByteStreams.copy(

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerIntegrationTest.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.URL;
+import java.net.URI;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CyclicBarrier;
@@ -82,7 +82,7 @@ public class HttpConnectorMultiplexerIntegrationTest {
 
   @Before
   public void before() throws Exception {
-    when(proxyHelper.createProxyIfNeeded(any(URL.class))).thenReturn(ProxyInfo.NO_PROXY);
+    when(proxyHelper.createProxyIfNeeded(any(URI.class))).thenReturn(ProxyInfo.NO_PROXY);
   }
 
   @After
@@ -116,7 +116,7 @@ public class HttpConnectorMultiplexerIntegrationTest {
       barrier.await();
       try (HttpStream stream =
           multiplexer.connect(
-              new URL(String.format("http://localhost:%d", server.getLocalPort())), HELLO_SHA256)) {
+              URI.create(String.format("http://localhost:%d", server.getLocalPort())), HELLO_SHA256)) {
         assertThat(toByteArray(stream)).isEqualTo("hello".getBytes(US_ASCII));
       }
     }
@@ -149,7 +149,7 @@ public class HttpConnectorMultiplexerIntegrationTest {
               IOException.class,
               () ->
                   multiplexer.connect(
-                      new URL(String.format("http://localhost:%d", server.getLocalPort())),
+                      URI.create(String.format("http://localhost:%d", server.getLocalPort())),
                       HELLO_SHA256));
       assertThat(e).hasMessageThat().containsMatch("Checksum was .+ but wanted");
     }
@@ -183,7 +183,7 @@ public class HttpConnectorMultiplexerIntegrationTest {
               IOException.class,
               () ->
                   multiplexer.connect(
-                      new URL(String.format("http://localhost:%d", server.getLocalPort())),
+                      URI.create(String.format("http://localhost:%d", server.getLocalPort())),
                       HELLO_SHA256));
       assertThat(e).hasMessageThat().contains("GET returned 503 MELTDOWN");
     }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
@@ -44,7 +44,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
-import java.net.URL;
+import java.net.URI;
 import java.net.URLConnection;
 import java.util.List;
 import java.util.Locale;
@@ -95,7 +95,7 @@ public class HttpConnectorTest {
 
   @Before
   public void before() throws Exception {
-    when(proxyHelper.createProxyIfNeeded(any(URL.class))).thenReturn(ProxyInfo.NO_PROXY);
+    when(proxyHelper.createProxyIfNeeded(any(URI.class))).thenReturn(ProxyInfo.NO_PROXY);
   }
 
   @After
@@ -109,7 +109,7 @@ public class HttpConnectorTest {
     assertThat(
             ByteStreams.toByteArray(
                 connector
-                    .connect(createTempFile(fileContents).toURI().toURL(), url -> ImmutableMap.of())
+                    .connect(createTempFile(fileContents).toURI(), url -> ImmutableMap.of())
                     .getInputStream()))
         .isEqualTo(fileContents);
   }
@@ -118,7 +118,7 @@ public class HttpConnectorTest {
   public void badHost_throwsIOException() throws Exception {
     thrown.expect(IOException.class);
     thrown.expectMessage("Unknown host: bad.example");
-    connector.connect(new URL("http://bad.example"), url -> ImmutableMap.of());
+    connector.connect(URI.create("http://bad.example"), url -> ImmutableMap.of());
   }
 
   @Test
@@ -150,7 +150,7 @@ public class HttpConnectorTest {
           new InputStreamReader(
               connector
                   .connect(
-                      new URL(String.format("http://localhost:%d/boo", server.getLocalPort())),
+                      URI.create(String.format("http://localhost:%d/boo", server.getLocalPort())),
                       url -> ImmutableMap.of("Content-Encoding", ImmutableList.of("gzip")))
                   .getInputStream(),
               ISO_8859_1)) {
@@ -202,7 +202,7 @@ public class HttpConnectorTest {
           new InputStreamReader(
               connector
                   .connect(
-                      new URL(String.format("http://localhost:%d", server.getLocalPort())),
+                      URI.create(String.format("http://localhost:%d", server.getLocalPort())),
                       url -> ImmutableMap.of())
                   .getInputStream(),
               ISO_8859_1)) {
@@ -262,7 +262,7 @@ public class HttpConnectorTest {
           new InputStreamReader(
               connector
                   .connect(
-                      new URL(String.format("http://localhost:%d", port)), url -> ImmutableMap.of())
+                      URI.create(String.format("http://localhost:%d", port)), url -> ImmutableMap.of())
                   .getInputStream(),
               ISO_8859_1)) {
         assertThat(CharStreams.toString(payload)).isEqualTo("hello");
@@ -321,7 +321,7 @@ public class HttpConnectorTest {
           new InputStreamReader(
               connector
                   .connect(
-                      new URL(String.format("http://localhost:%d", server.getLocalPort())),
+                      URI.create(String.format("http://localhost:%d", server.getLocalPort())),
                       url -> ImmutableMap.of())
                   .getInputStream(),
               ISO_8859_1)) {
@@ -354,7 +354,7 @@ public class HttpConnectorTest {
           new InputStreamReader(
               connector
                   .connect(
-                      new URL(String.format("http://localhost:%d", server.getLocalPort())),
+                      URI.create(String.format("http://localhost:%d", server.getLocalPort())),
                       url -> ImmutableMap.of())
                   .getInputStream(),
               ISO_8859_1)) {
@@ -408,7 +408,7 @@ public class HttpConnectorTest {
       thrown.expect(IOException.class);
       thrown.expectMessage("401 Unauthorized");
       connector.connect(
-          new URL(String.format("http://localhost:%d", server.getLocalPort())),
+          URI.create(String.format("http://localhost:%d", server.getLocalPort())),
           url -> ImmutableMap.of());
     }
   }
@@ -440,7 +440,7 @@ public class HttpConnectorTest {
       thrown.expect(FileNotFoundException.class);
       thrown.expectMessage("404 Not Found");
       connector.connect(
-          new URL(String.format("http://localhost:%d", server.getLocalPort())),
+          URI.create(String.format("http://localhost:%d", server.getLocalPort())),
           url -> ImmutableMap.of());
     }
   }
@@ -475,7 +475,7 @@ public class HttpConnectorTest {
                 }
               });
       connector.connect(
-          new URL(String.format("http://localhost:%d", server.getLocalPort())),
+          URI.create(String.format("http://localhost:%d", server.getLocalPort())),
           url -> ImmutableMap.of());
       fail();
     } catch (IOException ignored) {
@@ -518,7 +518,7 @@ public class HttpConnectorTest {
       thrown.expectMessage("500 Oh My");
       try {
         connector.connect(
-            new URL(String.format("http://localhost:%d", server.getLocalPort())),
+            URI.create(String.format("http://localhost:%d", server.getLocalPort())),
             url -> ImmutableMap.of());
       } finally {
         assertThat(tries.get()).isGreaterThan(2);
@@ -557,7 +557,7 @@ public class HttpConnectorTest {
       thrown.expectMessage("403 Forbidden");
       try {
         connector.connect(
-            new URL(String.format("http://localhost:%d", server.getLocalPort())),
+            URI.create(String.format("http://localhost:%d", server.getLocalPort())),
             url -> ImmutableMap.of());
       } finally {
         assertThat(tries.get()).isGreaterThan(2);
@@ -628,10 +628,10 @@ public class HttpConnectorTest {
               });
       URLConnection connection =
           connector.connect(
-              new URL(String.format("http://localhost:%d", server.getLocalPort())),
+              URI.create(String.format("http://localhost:%d", server.getLocalPort())),
               url -> ImmutableMap.of());
       assertThat(connection.getURL()).isEqualTo(
-          new URL(String.format("http://localhost:%d/doodle.tar.gz", server.getLocalPort())));
+          URI.create(String.format("http://localhost:%d/doodle.tar.gz", server.getLocalPort())).toURL());
       try (InputStream input = connection.getInputStream()) {
         assertThat(ByteStreams.toByteArray(input)).isEmpty();
       }
@@ -693,10 +693,10 @@ public class HttpConnectorTest {
               });
       // Header function that provides different auth headers for
       // the two servers.
-      Function<URL, ImmutableMap<String, List<String>>> authHeaders =
+      Function<URI, ImmutableMap<String, List<String>>> authHeaders =
           new Function<>() {
             @Override
-            public ImmutableMap<String, List<String>> apply(URL url) {
+            public ImmutableMap<String, List<String>> apply(URI url) {
               if (url.getPort() == server1.getLocalPort()) {
                 return ImmutableMap.of("Authentication", ImmutableList.of(basic1));
               } else if (url.getPort() == server2.getLocalPort()) {
@@ -708,9 +708,9 @@ public class HttpConnectorTest {
           };
       URLConnection connection =
           connector.connect(
-              new URL(String.format("http://localhost:%d", server1.getLocalPort())), authHeaders);
+              URI.create(String.format("http://localhost:%d", server1.getLocalPort())), authHeaders);
       assertThat(connection.getURL()).isEqualTo(
-          new URL(String.format("http://localhost:%d/doodle.tar.gz", server2.getLocalPort())));
+          URI.create(String.format("http://localhost:%d/doodle.tar.gz", server2.getLocalPort())).toURL());
       try (InputStream input = connection.getInputStream()) {
         assertThat(ByteStreams.toByteArray(input)).isEqualTo("hello".getBytes(US_ASCII));
       }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -45,7 +45,6 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
-import java.net.URL;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -121,7 +120,7 @@ public class HttpDownloaderTest {
           download(
               downloadManager,
               Collections.singletonList(
-                  new URL(String.format("http://localhost:%d/foo", server.getLocalPort()))),
+                  URI.create(String.format("http://localhost:%d/foo", server.getLocalPort()))),
               Collections.emptyMap(),
               Collections.emptyMap(),
               Optional.empty(),
@@ -161,7 +160,7 @@ public class HttpDownloaderTest {
           download(
               downloadManager,
               Collections.singletonList(
-                  new URL(String.format("http://localhost:%d/arch:ve.zip", server.getLocalPort()))),
+                  URI.create(String.format("http://localhost:%d/arch:ve.zip", server.getLocalPort()))),
               Collections.emptyMap(),
               Collections.emptyMap(),
               Optional.empty(),
@@ -221,9 +220,9 @@ public class HttpDownloaderTest {
                 return null;
               });
 
-      final List<URL> urls = new ArrayList<>(2);
-      urls.add(new URL(String.format("http://localhost:%d/foo", server1.getLocalPort())));
-      urls.add(new URL(String.format("http://localhost:%d/foo", server2.getLocalPort())));
+      final List<URI> urls = new ArrayList<>(2);
+      urls.add(URI.create(String.format("http://localhost:%d/foo", server1.getLocalPort())));
+      urls.add(URI.create(String.format("http://localhost:%d/foo", server2.getLocalPort())));
 
       Path resultingFile =
           download(
@@ -290,9 +289,9 @@ public class HttpDownloaderTest {
                 return null;
               });
 
-      final List<URL> urls = new ArrayList<>(2);
-      urls.add(new URL(String.format("http://localhost:%d/foo", server1.getLocalPort())));
-      urls.add(new URL(String.format("http://localhost:%d/foo", server2.getLocalPort())));
+      final List<URI> urls = new ArrayList<>(2);
+      urls.add(URI.create(String.format("http://localhost:%d/foo", server1.getLocalPort())));
+      urls.add(URI.create(String.format("http://localhost:%d/foo", server2.getLocalPort())));
 
       Path resultingFile =
           download(
@@ -360,9 +359,9 @@ public class HttpDownloaderTest {
                 return null;
               });
 
-      final List<URL> urls = new ArrayList<>(2);
-      urls.add(new URL(String.format("http://localhost:%d/foo", server1.getLocalPort())));
-      urls.add(new URL(String.format("http://localhost:%d/foo", server2.getLocalPort())));
+      final List<URI> urls = new ArrayList<>(2);
+      urls.add(URI.create(String.format("http://localhost:%d/foo", server1.getLocalPort())));
+      urls.add(URI.create(String.format("http://localhost:%d/foo", server2.getLocalPort())));
 
       Path outputFile = fs.getPath(workingDir.newFile().getAbsolutePath());
       try {
@@ -421,10 +420,10 @@ public class HttpDownloaderTest {
                 return null;
               });
 
-      final List<URL> urls = new ArrayList<>(2);
+      final List<URI> urls = new ArrayList<>(2);
       // Use https for the first one to trigger SSL handshake
-      urls.add(new URL(String.format("https://localhost:%d/foo", server1.getLocalPort())));
-      urls.add(new URL(String.format("http://localhost:%d/foo", server2.getLocalPort())));
+      urls.add(URI.create(String.format("https://localhost:%d/foo", server1.getLocalPort())));
+      urls.add(URI.create(String.format("http://localhost:%d/foo", server2.getLocalPort())));
 
       Path resultingFile = fs.getPath(workingDir.newFile().getAbsolutePath());
 
@@ -476,7 +475,7 @@ public class HttpDownloaderTest {
       Path destination = fs.getPath(workingDir.newFile().getAbsolutePath());
       httpDownloader.download(
           Collections.singletonList(
-              new URL(String.format("http://localhost:%d/foo", server.getLocalPort()))),
+              URI.create(String.format("http://localhost:%d/foo", server.getLocalPort()))),
           Collections.emptyMap(),
           StaticCredentials.EMPTY,
           Optional.empty(),
@@ -517,7 +516,7 @@ public class HttpDownloaderTest {
           () ->
               httpDownloader.download(
                   Collections.singletonList(
-                      new URL(String.format("http://localhost:%d/foo", server.getLocalPort()))),
+                      URI.create(String.format("http://localhost:%d/foo", server.getLocalPort()))),
                   Collections.emptyMap(),
                   StaticCredentials.EMPTY,
                   Optional.empty(),
@@ -573,9 +572,9 @@ public class HttpDownloaderTest {
                 return null;
               });
 
-      final List<URL> urls = new ArrayList<>(2);
-      urls.add(new URL(String.format("http://localhost:%d/foo", server1.getLocalPort())));
-      urls.add(new URL(String.format("http://localhost:%d/foo", server2.getLocalPort())));
+      final List<URI> urls = new ArrayList<>(2);
+      urls.add(URI.create(String.format("http://localhost:%d/foo", server1.getLocalPort())));
+      urls.add(URI.create(String.format("http://localhost:%d/foo", server2.getLocalPort())));
 
       Path destination = fs.getPath(workingDir.newFile().getAbsolutePath());
       httpDownloader.download(
@@ -619,7 +618,7 @@ public class HttpDownloaderTest {
       assertThat(
               new String(
                   httpDownloader.downloadAndReadOneUrl(
-                      new URL(String.format("http://localhost:%d/foo", server.getLocalPort())),
+                      URI.create(String.format("http://localhost:%d/foo", server.getLocalPort())),
                       StaticCredentials.EMPTY,
                       Optional.empty(),
                       eventHandler,
@@ -655,7 +654,7 @@ public class HttpDownloaderTest {
           IOException.class,
           () ->
               httpDownloader.downloadAndReadOneUrl(
-                  new URL(String.format("http://localhost:%d/foo", server.getLocalPort())),
+                  URI.create(String.format("http://localhost:%d/foo", server.getLocalPort())),
                   StaticCredentials.EMPTY,
                   Optional.empty(),
                   eventHandler,
@@ -689,7 +688,7 @@ public class HttpDownloaderTest {
       assertThat(
               new String(
                   httpDownloader.downloadAndReadOneUrl(
-                      new URL(String.format("http://localhost:%d/foo", server.getLocalPort())),
+                      URI.create(String.format("http://localhost:%d/foo", server.getLocalPort())),
                       StaticCredentials.EMPTY,
                       Optional.of(
                           Checksum.fromString(
@@ -729,7 +728,7 @@ public class HttpDownloaderTest {
               UnrecoverableHttpException.class,
               () ->
                   httpDownloader.downloadAndReadOneUrl(
-                      new URL(String.format("http://localhost:%d/foo", server.getLocalPort())),
+                      URI.create(String.format("http://localhost:%d/foo", server.getLocalPort())),
                       StaticCredentials.EMPTY,
                       Optional.of(
                           Checksum.fromString(
@@ -765,7 +764,7 @@ public class HttpDownloaderTest {
         () ->
             download(
                 downloadManager,
-                ImmutableList.of(new URL("http://localhost")),
+                ImmutableList.of(URI.create("http://localhost")),
                 Collections.emptyMap(),
                 ImmutableMap.of(),
                 Optional.empty(),
@@ -807,7 +806,7 @@ public class HttpDownloaderTest {
     Path result =
         download(
             downloadManager,
-            ImmutableList.of(new URL("http://localhost")),
+            ImmutableList.of(URI.create("http://localhost")),
             ImmutableMap.of(),
             ImmutableMap.of(),
             Optional.empty(),
@@ -854,7 +853,7 @@ public class HttpDownloaderTest {
     Path result =
         download(
             downloadManager,
-            ImmutableList.of(new URL("http://localhost")),
+            ImmutableList.of(URI.create("http://localhost")),
             ImmutableMap.of(),
             ImmutableMap.of(),
             Optional.empty(),
@@ -898,7 +897,7 @@ public class HttpDownloaderTest {
     Path result =
         download(
             downloadManager,
-            ImmutableList.of(new URL("http://localhost")),
+            ImmutableList.of(URI.create("http://localhost")),
             ImmutableMap.of(),
             ImmutableMap.of(),
             Optional.empty(),
@@ -945,7 +944,7 @@ public class HttpDownloaderTest {
     Path result =
         download(
             downloadManager,
-            ImmutableList.of(new URL("http://localhost")),
+            ImmutableList.of(URI.create("http://localhost")),
             ImmutableMap.of(),
             ImmutableMap.of(),
             Optional.empty(),
@@ -962,7 +961,7 @@ public class HttpDownloaderTest {
 
   public Path download(
       DownloadManager downloadManager,
-      List<URL> originalUrls,
+      List<URI> originalUrls,
       Map<String, List<String>> headers,
       Map<URI, Map<String, List<String>>> authHeaders,
       Optional<Checksum> checksum,

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpUtilsTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
-import java.net.URL;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -50,84 +49,84 @@ public class HttpUtilsTest {
   @Test
   public void getLocation_missingInRedirect_throwsIOException() throws Exception {
     thrown.expect(IOException.class);
-    when(connection.getURL()).thenReturn(new URL("http://lol.example"));
+    when(connection.getURL()).thenReturn(URI.create("http://lol.example").toURL());
     HttpUtils.getLocation(connection);
   }
 
   @Test
   public void getLocation_absoluteInRedirect_returnsNewUrl() throws Exception {
-    when(connection.getURL()).thenReturn(new URL("http://lol.example"));
+    when(connection.getURL()).thenReturn(URI.create("http://lol.example").toURL());
     when(connection.getHeaderField("Location")).thenReturn("http://new.example/hi");
-    assertThat(HttpUtils.getLocation(connection)).isEqualTo(new URL("http://new.example/hi"));
+    assertThat(HttpUtils.getLocation(connection)).isEqualTo(URI.create("http://new.example/hi"));
   }
 
   @Test
   public void getLocation_redirectOnlyHasPath_mergesHostFromOriginalUrl() throws Exception {
-    when(connection.getURL()).thenReturn(new URL("http://lol.example"));
+    when(connection.getURL()).thenReturn(URI.create("http://lol.example").toURL());
     when(connection.getHeaderField("Location")).thenReturn("/hi");
-    assertThat(HttpUtils.getLocation(connection)).isEqualTo(new URL("http://lol.example/hi"));
+    assertThat(HttpUtils.getLocation(connection)).isEqualTo(URI.create("http://lol.example/hi"));
   }
 
   @Test
   public void getLocation_onlyHasPathWithoutSlash_failsToMerge() throws Exception {
     thrown.expect(IOException.class);
     thrown.expectMessage("Could not merge");
-    when(connection.getURL()).thenReturn(new URL("http://lol.example"));
+    when(connection.getURL()).thenReturn(URI.create("http://lol.example").toURL());
     when(connection.getHeaderField("Location")).thenReturn("omg");
     HttpUtils.getLocation(connection);
   }
 
   @Test
   public void getLocation_hasFragment_prefersNewFragment() throws Exception {
-    when(connection.getURL()).thenReturn(new URL("http://lol.example#a"));
+    when(connection.getURL()).thenReturn(URI.create("http://lol.example#a").toURL());
     when(connection.getHeaderField("Location")).thenReturn("http://new.example/hi#b");
-    assertThat(HttpUtils.getLocation(connection)).isEqualTo(new URL("http://new.example/hi#b"));
+    assertThat(HttpUtils.getLocation(connection)).isEqualTo(URI.create("http://new.example/hi#b"));
   }
 
   @Test
   public void getLocation_hasNoFragmentButOriginalDoes_mergesOldFragment() throws Exception {
-    when(connection.getURL()).thenReturn(new URL("http://lol.example#a"));
+    when(connection.getURL()).thenReturn(URI.create("http://lol.example#a").toURL());
     when(connection.getHeaderField("Location")).thenReturn("http://new.example/hi");
-    assertThat(HttpUtils.getLocation(connection)).isEqualTo(new URL("http://new.example/hi#a"));
+    assertThat(HttpUtils.getLocation(connection)).isEqualTo(URI.create("http://new.example/hi#a"));
   }
 
   @Test
   public void getLocation_oldUrlHasPassRedirectingToSameDomain_mergesPassword() throws Exception {
-    when(connection.getURL()).thenReturn(new URL("http://a:b@lol.example"));
+    when(connection.getURL()).thenReturn(URI.create("http://a:b@lol.example").toURL());
     when(connection.getHeaderField("Location")).thenReturn("http://lol.example/hi");
     assertThat(HttpUtils.getLocation(connection))
-        .isEqualTo(new URL("http://a:b@lol.example/hi"));
-    when(connection.getURL()).thenReturn(new URL("http://a:b@lol.example"));
+        .isEqualTo(URI.create("http://a:b@lol.example/hi"));
+    when(connection.getURL()).thenReturn(URI.create("http://a:b@lol.example").toURL());
     when(connection.getHeaderField("Location")).thenReturn("/hi");
     assertThat(HttpUtils.getLocation(connection))
-        .isEqualTo(new URL("http://a:b@lol.example/hi"));
+        .isEqualTo(URI.create("http://a:b@lol.example/hi"));
   }
 
   @Test
   public void getLocation_oldUrlHasPasswordRedirectingToNewServer_doesntMerge() throws Exception {
-    when(connection.getURL()).thenReturn(new URL("http://a:b@lol.example"));
+    when(connection.getURL()).thenReturn(URI.create("http://a:b@lol.example").toURL());
     when(connection.getHeaderField("Location")).thenReturn("http://new.example/hi");
-    assertThat(HttpUtils.getLocation(connection)).isEqualTo(new URL("http://new.example/hi"));
-    when(connection.getURL()).thenReturn(new URL("http://a:b@lol.example"));
+    assertThat(HttpUtils.getLocation(connection)).isEqualTo(URI.create("http://new.example/hi"));
+    when(connection.getURL()).thenReturn(URI.create("http://a:b@lol.example").toURL());
     when(connection.getHeaderField("Location")).thenReturn("http://lol.example:81/hi");
     assertThat(HttpUtils.getLocation(connection))
-        .isEqualTo(new URL("http://lol.example:81/hi"));
+        .isEqualTo(URI.create("http://lol.example:81/hi"));
   }
 
   @Test
   public void getLocation_redirectToFtp_throwsIOException() throws Exception {
     thrown.expect(IOException.class);
     thrown.expectMessage("Bad Location");
-    when(connection.getURL()).thenReturn(new URL("http://lol.example"));
+    when(connection.getURL()).thenReturn(URI.create("http://lol.example").toURL());
     when(connection.getHeaderField("Location")).thenReturn("ftp://lol.example");
     HttpUtils.getLocation(connection);
   }
 
   @Test
   public void getLocation_redirectToHttps_works() throws Exception {
-    when(connection.getURL()).thenReturn(new URL("http://lol.example"));
+    when(connection.getURL()).thenReturn(URI.create("http://lol.example").toURL());
     when(connection.getHeaderField("Location")).thenReturn("https://lol.example");
-    assertThat(HttpUtils.getLocation(connection)).isEqualTo(new URL("https://lol.example"));
+    assertThat(HttpUtils.getLocation(connection)).isEqualTo(URI.create("https://lol.example"));
   }
 
   @Test
@@ -135,9 +134,9 @@ public class HttpUtilsTest {
     String redirect =
         "http://redirected.example.org/foo?"
             + "response-content-disposition=attachment%3Bfilename%3D%22bar.tar.gz%22";
-    when(connection.getURL()).thenReturn(new URL("http://original.example.org"));
+    when(connection.getURL()).thenReturn(URI.create("http://original.example.org").toURL());
     when(connection.getHeaderField("Location")).thenReturn(redirect);
-    assertThat(HttpUtils.getLocation(connection)).isEqualTo(URI.create(redirect).toURL());
+    assertThat(HttpUtils.getLocation(connection)).isEqualTo(URI.create(redirect));
   }
 
   @Test
@@ -145,8 +144,8 @@ public class HttpUtilsTest {
     String redirect =
         "http://redirected.example.org/foo?"
             + "response-content-disposition=attachment%3Bfilename%3D%22bar.tar.gz%22";
-    when(connection.getURL()).thenReturn(new URL("http://a:b@original.example.org"));
+    when(connection.getURL()).thenReturn(URI.create("http://a:b@original.example.org").toURL());
     when(connection.getHeaderField("Location")).thenReturn(redirect);
-    assertThat(HttpUtils.getLocation(connection)).isEqualTo(URI.create(redirect).toURL());
+    assertThat(HttpUtils.getLocation(connection)).isEqualTo(URI.create(redirect));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProgressInputStreamTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProgressInputStreamTest.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.devtools.build.lib.bazel.repository.downloader.DownloaderTestUtils.makeUrl;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -35,7 +34,7 @@ import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.testutil.ManualClock;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
+import java.net.URI;
 import java.util.Locale;
 import java.util.OptionalLong;
 import org.junit.After;
@@ -52,7 +51,7 @@ public class ProgressInputStreamTest {
   private final ExtendedEventHandler extendedEventHandler =
       new Reporter(new EventBus(), eventHandler);
   private final InputStream delegate = mock(InputStream.class);
-  private final URL url = makeUrl("http://lol.example");
+  private final URI url = URI.create("http://lol.example");
   private ProgressInputStream stream =
       new ProgressInputStream(
           Locale.US, clock, extendedEventHandler, 1, delegate, url, url, OptionalLong.empty());
@@ -154,7 +153,7 @@ public class ProgressInputStreamTest {
             extendedEventHandler,
             1,
             delegate,
-            new URL("http://cdn.example/foo"),
+            URI.create("http://cdn.example/foo"),
             url,
             OptionalLong.empty());
     when(delegate.read()).thenReturn(42);

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelperTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.net.Proxy;
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -45,7 +45,7 @@ public class ProxyHelperTest {
   @Test
   public void testCreateIfNeededHttpLowerCase() throws Exception {
     ProxyHelper helper = new ProxyHelper(ImmutableMap.of("http_proxy", "http://my.example.com"));
-    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("http://www.something.com"));
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("http://www.something.com"));
     assertThat(proxyInfo.proxy().toString())
         .containsMatch("my\\.example\\.com(/<unresolved>)?:80$");
   }
@@ -53,7 +53,7 @@ public class ProxyHelperTest {
   @Test
   public void testCreateIfNeededHttpUpperCase() throws Exception {
     ProxyHelper helper = new ProxyHelper(ImmutableMap.of("HTTP_PROXY", "http://my.example.com"));
-    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("http://www.something.com"));
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("http://www.something.com"));
     assertThat(proxyInfo.proxy().toString())
         .containsMatch("my\\.example\\.com(/<unresolved>)?:80$");
   }
@@ -61,7 +61,7 @@ public class ProxyHelperTest {
   @Test
   public void testCreateIfNeededHttpsLowerCase() throws Exception {
     ProxyHelper helper = new ProxyHelper(ImmutableMap.of("https_proxy", "https://my.example.com"));
-    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.something.com"));
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("https://www.something.com"));
     assertThat(proxyInfo.proxy().toString())
         .containsMatch("my\\.example\\.com(/<unresolved>)?:443$");
   }
@@ -69,7 +69,7 @@ public class ProxyHelperTest {
   @Test
   public void testCreateIfNeededHttpsUpperCase() throws Exception {
     ProxyHelper helper = new ProxyHelper(ImmutableMap.of("HTTPS_PROXY", "https://my.example.com"));
-    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.something.com"));
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("https://www.something.com"));
     assertThat(proxyInfo.proxy().toString())
         .containsMatch("my\\.example\\.com(/<unresolved>)?:443$");
   }
@@ -83,7 +83,7 @@ public class ProxyHelperTest {
                 "something.com,example.com,localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.example.com"));
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("https://www.example.com"));
     assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
@@ -96,7 +96,7 @@ public class ProxyHelperTest {
                 "something.com,example.com,localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.example.com"));
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("https://www.example.com"));
     assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
@@ -109,7 +109,7 @@ public class ProxyHelperTest {
                 "something.com,example.com,localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.example.com"));
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("https://www.example.com"));
     assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
@@ -122,7 +122,7 @@ public class ProxyHelperTest {
                 "something.com,example.com,localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.example.com"));
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("https://www.example.com"));
     assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
@@ -135,13 +135,13 @@ public class ProxyHelperTest {
                 "something.com ,   example.com, localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.something.com"));
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("https://www.something.com"));
     assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
 
-    ProxyInfo proxyInfo2 = helper.createProxyIfNeeded(new URL("https://www.example.com"));
+    ProxyInfo proxyInfo2 = helper.createProxyIfNeeded(URI.create("https://www.example.com"));
     assertThat(proxyInfo2.proxy()).isEqualTo(Proxy.NO_PROXY);
 
-    ProxyInfo proxyInfo3 = helper.createProxyIfNeeded(new URL("https://localhost"));
+    ProxyInfo proxyInfo3 = helper.createProxyIfNeeded(URI.create("https://localhost"));
     assertThat(proxyInfo3.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
@@ -154,7 +154,7 @@ public class ProxyHelperTest {
                 "something.com,example.com,localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.not-example.com"));
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("https://www.not-example.com"));
     assertThat(proxyInfo.proxy().toString())
         .containsMatch("my\\.example\\.com(/<unresolved>)?:443$");
   }
@@ -168,7 +168,7 @@ public class ProxyHelperTest {
                 ".something.com,example.com,localhost",
                 "HTTPS_PROXY",
                 "https://my.example.com"));
-    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.my.something.com"));
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("https://www.my.something.com"));
     assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
@@ -182,7 +182,7 @@ public class ProxyHelperTest {
                 "HTTPS_PROXY",
                 "https://my.example.com"));
     ProxyInfo proxyInfo =
-        helper.createProxyIfNeeded(new URL("https://www.my.subdomain.something.com"));
+        helper.createProxyIfNeeded(URI.create("https://www.my.subdomain.something.com"));
     assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
@@ -195,7 +195,7 @@ public class ProxyHelperTest {
     assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
     Map<String, String> env = ImmutableMap.of();
     ProxyHelper helper = new ProxyHelper(env);
-    proxyInfo = helper.createProxyIfNeeded(new URL("https://www.something.com"));
+    proxyInfo = helper.createProxyIfNeeded(URI.create("https://www.something.com"));
     assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
   }
 
@@ -394,11 +394,11 @@ public class ProxyHelperTest {
       ProxyHelper helper = new ProxyHelper(ImmutableMap.of("http_proxy", "http://proxy:8080"));
 
       // Exact match should bypass proxy
-      ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("http://example.com/foo"));
+      ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("http://example.com/foo"));
       assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
 
       // Non-match should use proxy
-      ProxyInfo proxyInfo2 = helper.createProxyIfNeeded(new URL("http://other.com/foo"));
+      ProxyInfo proxyInfo2 = helper.createProxyIfNeeded(URI.create("http://other.com/foo"));
       assertThat(proxyInfo2.proxy()).isNotEqualTo(Proxy.NO_PROXY);
     } finally {
       if (oldValue != null) {
@@ -417,11 +417,11 @@ public class ProxyHelperTest {
       ProxyHelper helper = new ProxyHelper(ImmutableMap.of("http_proxy", "http://proxy:8080"));
 
       // Wildcard match should bypass proxy
-      ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("http://foo.example.com/bar"));
+      ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("http://foo.example.com/bar"));
       assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
 
       // Non-match should use proxy
-      ProxyInfo proxyInfo2 = helper.createProxyIfNeeded(new URL("http://example.com/bar"));
+      ProxyInfo proxyInfo2 = helper.createProxyIfNeeded(URI.create("http://example.com/bar"));
       assertThat(proxyInfo2.proxy()).isNotEqualTo(Proxy.NO_PROXY);
     } finally {
       if (oldValue != null) {
@@ -440,10 +440,10 @@ public class ProxyHelperTest {
       ProxyHelper helper = new ProxyHelper(ImmutableMap.of("http_proxy", "http://proxy:8080"));
 
       // Wildcard match should bypass proxy
-      ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("http://localhost/bar"));
+      ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("http://localhost/bar"));
       assertThat(proxyInfo.proxy()).isEqualTo(Proxy.NO_PROXY);
 
-      ProxyInfo proxyInfo2 = helper.createProxyIfNeeded(new URL("http://localserver/bar"));
+      ProxyInfo proxyInfo2 = helper.createProxyIfNeeded(URI.create("http://localserver/bar"));
       assertThat(proxyInfo2.proxy()).isEqualTo(Proxy.NO_PROXY);
     } finally {
       if (oldValue != null) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.net.URI;
-import java.net.URL;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -56,8 +55,8 @@ public class UrlRewriterTest {
   public void byDefaultTheUrlRewriterDoesNothing() throws Exception {
     UrlRewriter munger = testUrlRewriter("/dev/null", new StringReader(""));
 
-    List<URL> urls = ImmutableList.of(new URL("http://example.com"));
-    ImmutableList<URL> amended =
+    List<URI> urls = ImmutableList.of(URI.create("http://example.com"));
+    ImmutableList<URI> amended =
         munger.amend(urls).stream().map(url -> url.url()).collect(toImmutableList());
 
     assertThat(amended).isEqualTo(urls);
@@ -85,15 +84,15 @@ public class UrlRewriterTest {
     String config = "block example.com";
     UrlRewriter munger = testUrlRewriter("/dev/null", new StringReader(config));
 
-    List<URL> urls =
+    List<URI> urls =
         ImmutableList.of(
-            new URL("http://example.com"),
-            new URL("https://example.com"),
-            new URL("http://localhost"));
-    ImmutableList<URL> amended =
+            URI.create("http://example.com"),
+            URI.create("https://example.com"),
+            URI.create("http://localhost"));
+    ImmutableList<URI> amended =
         munger.amend(urls).stream().map(url -> url.url()).collect(toImmutableList());
 
-    assertThat(amended).containsExactly(new URL("http://localhost"));
+    assertThat(amended).containsExactly(URI.create("http://localhost"));
   }
 
   @Test
@@ -101,11 +100,11 @@ public class UrlRewriterTest {
     String config = "rewrite example.com/foo/(.*) mycorp.com/$1/foo";
     UrlRewriter munger = testUrlRewriter("/dev/null", new StringReader(config));
 
-    List<URL> urls = ImmutableList.of(new URL("https://example.com/foo/bar"));
-    ImmutableList<URL> amended =
+    List<URI> urls = ImmutableList.of(URI.create("https://example.com/foo/bar"));
+    ImmutableList<URI> amended =
         munger.amend(urls).stream().map(url -> url.url()).collect(toImmutableList());
 
-    assertThat(amended).containsExactly(new URL("https://mycorp.com/bar/foo"));
+    assertThat(amended).containsExactly(URI.create("https://mycorp.com/bar/foo"));
   }
 
   @Test
@@ -115,13 +114,13 @@ public class UrlRewriterTest {
             + "rewrite example.com/foo/(.*) mycorp.com/$1/elsewhere";
     UrlRewriter munger = testUrlRewriter("/dev/null", new StringReader(config));
 
-    List<URL> urls = ImmutableList.of(new URL("https://example.com/foo/bar"));
-    ImmutableList<URL> amended =
+    List<URI> urls = ImmutableList.of(URI.create("https://example.com/foo/bar"));
+    ImmutableList<URI> amended =
         munger.amend(urls).stream().map(url -> url.url()).collect(toImmutableList());
 
     // There's no guarantee about the ordering of the rewrites
-    assertThat(amended).contains(new URL("https://mycorp.com/bar/somewhere"));
-    assertThat(amended).contains(new URL("https://mycorp.com/bar/elsewhere"));
+    assertThat(amended).contains(URI.create("https://mycorp.com/bar/somewhere"));
+    assertThat(amended).contains(URI.create("https://mycorp.com/bar/elsewhere"));
   }
 
   /** Same as {@link #rewritesCanExpandToMoreThanOneUrl()} but spread across two config files. */
@@ -134,13 +133,13 @@ public class UrlRewriterTest {
             ImmutableList.of("/dev/null", "/dev/null"),
             ImmutableList.of(new StringReader(config), new StringReader(config2)));
 
-    List<URL> urls = ImmutableList.of(new URL("https://example.com/foo/bar"));
-    ImmutableList<URL> amended =
+    List<URI> urls = ImmutableList.of(URI.create("https://example.com/foo/bar"));
+    ImmutableList<URI> amended =
         munger.amend(urls).stream().map(url -> url.url()).collect(toImmutableList());
 
     // There's no guarantee about the ordering of the rewrites
-    assertThat(amended).contains(new URL("https://mycorp.com/bar/somewhere"));
-    assertThat(amended).contains(new URL("https://mycorp.com/bar/elsewhere"));
+    assertThat(amended).contains(URI.create("https://mycorp.com/bar/somewhere"));
+    assertThat(amended).contains(URI.create("https://mycorp.com/bar/elsewhere"));
   }
 
   @Test
@@ -149,17 +148,17 @@ public class UrlRewriterTest {
 
     UrlRewriter munger = testUrlRewriter("/dev/null", new StringReader(config));
 
-    List<URL> urls =
+    List<URI> urls =
         ImmutableList.of(
-            new URL("https://foo.com"),
-            new URL("https://example.com/foo/bar"),
-            new URL("https://subdomain.example.com/qux"));
-    ImmutableList<URL> amended =
+            URI.create("https://foo.com"),
+            URI.create("https://example.com/foo/bar"),
+            URI.create("https://subdomain.example.com/qux"));
+    ImmutableList<URI> amended =
         munger.amend(urls).stream().map(url -> url.url()).collect(toImmutableList());
 
     assertThat(amended)
         .containsExactly(
-            new URL("https://example.com/foo/bar"), new URL("https://subdomain.example.com/qux"));
+            URI.create("https://example.com/foo/bar"), URI.create("https://subdomain.example.com/qux"));
   }
 
   @Test
@@ -173,11 +172,11 @@ public class UrlRewriterTest {
 
     UrlRewriter munger = testUrlRewriter("/dev/null", new StringReader(config));
 
-    List<URL> urls = ImmutableList.of(new URL("https://foo.com"), new URL("https://example.com"));
-    ImmutableList<URL> amended =
+    List<URI> urls = ImmutableList.of(URI.create("https://foo.com"), URI.create("https://example.com"));
+    ImmutableList<URI> amended =
         munger.amend(urls).stream().map(url -> url.url()).collect(toImmutableList());
 
-    assertThat(amended).containsExactly(new URL("https://example.com"));
+    assertThat(amended).containsExactly(URI.create("https://example.com"));
   }
 
   @Test
@@ -186,12 +185,12 @@ public class UrlRewriterTest {
 
     UrlRewriter munger = testUrlRewriter("/dev/null", new StringReader(config));
 
-    ImmutableList<URL> amended =
-        munger.amend(ImmutableList.of(new URL("https://subdomain.example.com"))).stream()
+    ImmutableList<URI> amended =
+        munger.amend(ImmutableList.of(URI.create("https://subdomain.example.com"))).stream()
             .map(url -> url.url())
             .collect(toImmutableList());
 
-    assertThat(amended).containsExactly(new URL("https://subdomain.example.com"));
+    assertThat(amended).containsExactly(URI.create("https://subdomain.example.com"));
   }
 
   @Test
@@ -200,8 +199,8 @@ public class UrlRewriterTest {
 
     UrlRewriter munger = testUrlRewriter("/dev/null", new StringReader(config));
 
-    ImmutableList<URL> amended =
-        munger.amend(ImmutableList.of(new URL("https://subdomain.example.com"))).stream()
+    ImmutableList<URI> amended =
+        munger.amend(ImmutableList.of(URI.create("https://subdomain.example.com"))).stream()
             .map(url -> url.url())
             .collect(toImmutableList());
 
@@ -214,12 +213,12 @@ public class UrlRewriterTest {
 
     UrlRewriter munger = testUrlRewriter("/dev/null", new StringReader(config));
 
-    ImmutableList<URL> amended =
-        munger.amend(ImmutableList.of(new URL("https://subdomain.example.com"))).stream()
+    ImmutableList<URI> amended =
+        munger.amend(ImmutableList.of(URI.create("https://subdomain.example.com"))).stream()
             .map(url -> url.url())
             .collect(toImmutableList());
 
-    assertThat(amended).containsExactly(new URL("https://subdomain.example.com"));
+    assertThat(amended).containsExactly(URI.create("https://subdomain.example.com"));
   }
 
   @Test
@@ -228,16 +227,16 @@ public class UrlRewriterTest {
 
     UrlRewriter munger = testUrlRewriter("/dev/null", new StringReader(config));
 
-    List<URL> amended =
+    List<URI> amended =
         munger
             .amend(
                 ImmutableList.of(
-                    new URL("https://www.bad.com"), new URL("https://bad.com/foo/bar")))
+                    URI.create("https://www.bad.com"), URI.create("https://bad.com/foo/bar")))
             .stream()
             .map(url -> url.url())
             .collect(toImmutableList());
 
-    assertThat(amended).containsExactly(new URL("https://mycorp.com/bar"));
+    assertThat(amended).containsExactly(URI.create("https://mycorp.com/bar"));
   }
 
   @Test
@@ -247,16 +246,16 @@ public class UrlRewriterTest {
 
     UrlRewriter munger = testUrlRewriter("/dev/null", new StringReader(config));
 
-    List<URL> amended =
+    List<URI> amended =
         munger
             .amend(
                 ImmutableList.of(
-                    new URL("https://www.bad.com"), new URL("https://bad.com/foo/bar")))
+                    URI.create("https://www.bad.com"), URI.create("https://bad.com/foo/bar")))
             .stream()
             .map(url -> url.url())
             .collect(toImmutableList());
 
-    assertThat(amended).containsExactly(new URL("https://mycorp.com/bar"));
+    assertThat(amended).containsExactly(URI.create("https://mycorp.com/bar"));
   }
 
   @Test
@@ -309,20 +308,20 @@ public class UrlRewriterTest {
 
     UrlRewriter munger = testUrlRewriter("/dev/null", new StringReader(config));
 
-    List<URL> amended =
+    List<URI> amended =
         munger
             .amend(
                 ImmutableList.of(
-                    new URL("https://www.bad.com"),
-                    new URL("https://bad.com/foo/bar"),
-                    new URL("http://bad.com/bar/xyz")))
+                    URI.create("https://www.bad.com"),
+                    URI.create("https://bad.com/foo/bar"),
+                    URI.create("http://bad.com/bar/xyz")))
             .stream()
             .map(url -> url.url())
             .collect(toImmutableList());
 
     assertThat(amended)
         .containsExactly(
-            new URL("http://mycorp.com/bar"), new URL("https://othercorp.com/bar/xyz"));
+            URI.create("http://mycorp.com/bar"), URI.create("https://othercorp.com/bar/xyz"));
   }
 
   @Test
@@ -356,11 +355,11 @@ public class UrlRewriterTest {
     ImmutableList<UrlRewriter.RewrittenURL> amended =
         munger.amend(
             ImmutableList.of(
-                new URL("https://my.example.com/foo/bar"),
-                new URL("https://my.example.com/from_netrc/bar"),
-                new URL("https://my.example.com/from_other_netrc_entry/bar"),
-                new URL("https://my.example.com/no_creds/bar"),
-                new URL("https://should-not-be-overridden.com/")));
+                URI.create("https://my.example.com/foo/bar"),
+                URI.create("https://my.example.com/from_netrc/bar"),
+                URI.create("https://my.example.com/from_other_netrc_entry/bar"),
+                URI.create("https://my.example.com/no_creds/bar"),
+                URI.create("https://should-not-be-overridden.com/")));
     Map<URI, Map<String, List<String>>> updatedAuthHeaders =
         munger.updateAuthHeaders(amended, ImmutableMap.of(), netrc);
 
@@ -383,13 +382,13 @@ public class UrlRewriterTest {
     assertThat(amended)
         .containsExactly(
             UrlRewriter.RewrittenURL.create(
-                new URL("https://user:password@mycorp.com/foo/bar"), true),
-            UrlRewriter.RewrittenURL.create(new URL("https://mycorp.com/from_netrc/bar"), true),
+                URI.create("https://user:password@mycorp.com/foo/bar"), true),
+            UrlRewriter.RewrittenURL.create(URI.create("https://mycorp.com/from_netrc/bar"), true),
             UrlRewriter.RewrittenURL.create(
-                new URL("https://myothercorp.com/from_netrc/bar"), true),
-            UrlRewriter.RewrittenURL.create(new URL("https://myopencorp.com/no_creds/bar"), true),
+                URI.create("https://myothercorp.com/from_netrc/bar"), true),
+            UrlRewriter.RewrittenURL.create(URI.create("https://myopencorp.com/no_creds/bar"), true),
             UrlRewriter.RewrittenURL.create(
-                new URL("https://should-not-be-overridden.com/"), false));
+                URI.create("https://should-not-be-overridden.com/"), false));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/runtime/UiStateTrackerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/UiStateTrackerTest.java
@@ -84,7 +84,7 @@ import com.google.devtools.build.lib.view.test.TestStatus.BlazeTestStatus;
 import com.google.testing.junit.testparameterinjector.TestParameter;
 import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
@@ -1294,7 +1294,7 @@ public class UiStateTrackerTest extends FoundationTestCase {
     clock.advance(Duration.ofSeconds(1234));
     UiStateTracker stateTracker = getUiStateTracker(clock, /* targetWidth= */ 80);
 
-    URL url = new URL("http://example.org/first/dep");
+    URI url = URI.create("http://example.org/first/dep");
 
     stateTracker.buildStarted();
     stateTracker.downloadProgress(new DownloadProgressEvent(url));
@@ -1336,7 +1336,7 @@ public class UiStateTrackerTest extends FoundationTestCase {
     clock.advance(Duration.ofSeconds(1234));
     UiStateTracker stateTracker = getUiStateTracker(clock, /* targetWidth= */ 80);
 
-    URL url = new URL("http://example.org/first/dep");
+    URI url = URI.create("http://example.org/first/dep");
 
     stateTracker.mainRepoMappingComputationStarted();
     stateTracker.downloadProgress(new DownloadProgressEvent(url));
@@ -1379,7 +1379,7 @@ public class UiStateTrackerTest extends FoundationTestCase {
     ManualClock clock = new ManualClock();
     clock.advanceMillis(TimeUnit.SECONDS.toMillis(1234));
     UiStateTracker stateTracker = getUiStateTracker(clock, /* targetWidth= */ 60);
-    URL url = new URL("http://example.org/some/really/very/very/long/path/filename.tar.gz");
+    URI url = URI.create("http://example.org/some/really/very/very/long/path/filename.tar.gz");
 
     stateTracker.buildStarted();
     stateTracker.downloadProgress(new DownloadProgressEvent(url));
@@ -1387,7 +1387,7 @@ public class UiStateTrackerTest extends FoundationTestCase {
     for (int i = 0; i < 10; i++) {
       stateTracker.downloadProgress(
           new DownloadProgressEvent(
-              new URL(
+              URI.create(
                   "http://otherhost.example/another/also/length/path/to/another/download"
                       + i
                       + ".zip")));


### PR DESCRIPTION
The `URL` class is a legacy concept and a performance footgun as its `equals`/`hashCode` methods call out to the network. This affected the event subscriber `CacheHitReportingModule`, which stored `URL`s in a Set and thus triggered DNS resolution, even if all downloads hit the cache.

While most of this change is not expected to cause any change in behavior, it has to fix a regression introduced by 8cefb8bed4ac82df8640682517372a9249732352: As of that commit, user info has no longer been forwarded to the new location requested by a redirect if the host and port stay the same. This was masked by insufficient test cases that relied on `URL#equals`, which ignores user info.

Work towards #25068