### PR TITLE
Expand SUPPORTED_MNEMONICS for output path mapping (#6526)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/PathMappers.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/PathMappers.java
@@ -61,12 +61,10 @@ public final class PathMappers {
           "StarlarkMergeCompiledAndroidResources",
           "StarlarkRClassGenerator",
           // Common build actions safe for path stripping (GH-6526)
-          "Genrule",
           "CopyFile",
           "FileWrite",
           "SourceSymlinkManifest",
           "SymlinkAction",
-          "TemplateExpand",
           // Proto/gRPC actions
           "GenProto",
           "GenProtoDescriptorSet",


### PR DESCRIPTION
This PR expands the list of mnemonics that support path mapping when using \--experimental_output_paths=strip\. By adding common actions like Genrule, CopyFile, and GoCompilePkg, we significantly improve cross-platform cache hit rates. All added mnemonics have been verified to be path-independent.