### PR TITLE
[9.1.0] Fix `StarlarkBaseExternalContext#checkInOutputDirectory` (https://github.com/bazelbuild/bazel/pull/28581)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -314,7 +314,7 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
 
   protected void checkInOutputDirectory(String operation, StarlarkPath path)
       throws RepositoryFunctionException {
-    if (!path.getPath().getPathString().startsWith(workingDirectory.getPathString())) {
+    if (!path.getPath().startsWith(workingDirectory)) {
       throw new RepositoryFunctionException(
           Starlark.errorf(
               "Cannot %s outside of the repository directory for path %s", operation, path),

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.bazel.repository.starlark;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -292,6 +293,20 @@ public final class StarlarkRepositoryContextTest {
           .hasMessageThat()
           .isEqualTo("Cannot write outside of the repository directory for path /somepath");
     }
+    RepositoryFunctionException ex =
+        assertThrows(
+            RepositoryFunctionException.class,
+            () ->
+                context.createFile(
+                    Starlark.str(context.getPath(""), StarlarkSemantics.DEFAULT) + "_1",
+                    "",
+                    true,
+                    true,
+                    thread));
+    assertThat(ex)
+        .hasCauseThat()
+        .hasMessageThat()
+        .isEqualTo("Cannot write outside of the repository directory for path /outputDir_1");
   }
 
   @Test


### PR DESCRIPTION
Work towards #28575

Closes #28581.

PiperOrigin-RevId: 870851099
Change-Id: I806f709f8366d4c2d7cbe8dfc256b93795898e72

Commit https://github.com/bazelbuild/bazel/commit/726d5b3d31a57ee13e1a3cdc4607888368409bd1