### PR TITLE
Fix Unicode encoding of uploaded directories

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -445,7 +445,7 @@ public class UploadManifest {
           checkState(subdir.getParentDirectory().equals(dir));
           builder
               .addDirectoriesBuilder()
-              .setName(subdir.getBaseName())
+              .setName(internalToUnicode(subdir.getBaseName()))
               .setDigest(dirToDigest.get(subdir));
         }
         ByteString dirBlob = builder.build().toByteString();
@@ -533,7 +533,7 @@ public class UploadManifest {
       Digest digest = digestUtil.compute(path);
       FileNode node =
           FileNode.newBuilder()
-              .setName(path.getBaseName())
+              .setName(internalToUnicode(path.getBaseName()))
               .setDigest(digest)
               .setIsExecutable(!preserveExecutableBit || (stat.getPermissions() & 0100) != 0)
               .build();
@@ -544,7 +544,10 @@ public class UploadManifest {
     private void visitAsSymlink(Path path, PathFragment target) {
       Path parentPath = path.getParentDirectory();
       SymlinkNode node =
-          SymlinkNode.newBuilder().setName(path.getBaseName()).setTarget(target.toString()).build();
+          SymlinkNode.newBuilder()
+              .setName(internalToUnicode(path.getBaseName()))
+              .setTarget(internalToUnicode(target.toString()))
+              .build();
       dirToSymlinks.put(parentPath, node);
     }
   }


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
Reencode internal strings to Unicode strings.

### Motivation
`UploadManifest` got this right for files, but not for the contents of output directories.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

