### PR TITLE
[9.0.1] Fix visibility for implicit deps of parent rules (https://github.com/bazelbuild/bazel/pull/28627)

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -5700,6 +5700,64 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
   }
 
   @Test
+  public void extendRule_parentPrivateAttrDefault_visibilityCheckedAgainstParent()
+      throws Exception {
+    scratch.file(
+        "extend_rule_testing/parent/BUILD",
+        """
+        exports_files(
+            ["parent_tool.txt"],
+            visibility = ["//extend_rule_testing/parent:__pkg__"],
+        )
+        """);
+    scratch.file("extend_rule_testing/parent/parent_tool.txt");
+    scratch.file(
+        "extend_rule_testing/parent/parent.bzl",
+        """
+        def _impl(ctx):
+            return []
+
+        parent_library = rule(
+            implementation = _impl,
+            extendable = True,
+            attrs = {
+                "_tool": attr.label(
+                    allow_single_file = True,
+                    default = "//extend_rule_testing/parent:parent_tool.txt",
+                ),
+            },
+        )
+        """);
+    scratch.file(
+        "extend_rule_testing/child.bzl",
+        """
+        load("//extend_rule_testing/parent:parent.bzl", "parent_library")
+
+        def _impl(ctx):
+            return ctx.super()
+
+        my_library = rule(
+            implementation = _impl,
+            parent = parent_library,
+        )
+        """);
+    scratch.file(
+        "extend_rule_testing/BUILD",
+        """
+        load(":child.bzl", "my_library")
+
+        my_library(name = "my_target")
+        """);
+
+    // This should succeed because the visibility of the parent's private attribute default should
+    // be checked against the parent rule's package, not the child rule's package.
+    // See https://github.com/bazelbuild/bazel/issues/28618
+    getConfiguredTarget("//extend_rule_testing:my_target");
+
+    assertNoEvents();
+  }
+
+  @Test
   public void extendRule_attributeOverrideDefault() throws Exception {
     scratch.file("extend_rule_testing/parent/BUILD");
     scratch.file(


### PR DESCRIPTION
The visibility of a default value of an implicit dep in an extended rule should be checked relative to the definition of the rule that introduced it, which may not be the child rule.

Fixes #28618

Closes #28627.

PiperOrigin-RevId: 871303947
Change-Id: I0027e277dc9f01396fa4674297d2a73e1e9d257e

Commit https://github.com/bazelbuild/bazel/commit/a16489f96bb436b6e6abc350a4f38070bc7f1a6e