### PR TITLE
Allow `bazel run` to execute target if BES upload fails.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandResult.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandResult.java
@@ -148,4 +148,12 @@ public final class BlazeCommandResult {
     return new BlazeCommandResult(
         DetailedExitCode.success(), Preconditions.checkNotNull(execDescription), false);
   }
+
+  public static BlazeCommandResult execute(
+      ExecRequest execDescription, DetailedExitCode detailedExitCode) {
+    return new BlazeCommandResult(
+        Preconditions.checkNotNull(detailedExitCode),
+        Preconditions.checkNotNull(execDescription),
+        false);
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -814,7 +814,12 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
 
     BlazeCommandResult finalCommandResult;
     if (!commandResult.getExitCode().isInfrastructureFailure() && moduleExitCode != null) {
-      finalCommandResult = BlazeCommandResult.detailedExitCode(moduleExitCode);
+      if (commandResult.getExecRequest() != null) {
+        finalCommandResult =
+            BlazeCommandResult.execute(commandResult.getExecRequest(), moduleExitCode);
+      } else {
+        finalCommandResult = BlazeCommandResult.detailedExitCode(moduleExitCode);
+      }
     } else {
       finalCommandResult = commandResult;
     }

--- a/src/main/java/com/google/devtools/build/lib/server/CommandServer.java
+++ b/src/main/java/com/google/devtools/build/lib/server/CommandServer.java
@@ -545,8 +545,11 @@ public class CommandServer implements GrpcCommandServer.Callback {
             .setTerminationExpected(result.shutdown());
 
     if (result.getExecRequest() != null) {
-      response.setExitCode(0);
+      response.setExitCode(result.getExitCode().getNumericExitCode());
       response.setExecRequest(result.getExecRequest());
+      if (result.getFailureDetail() != null) {
+        response.setFailureDetail(result.getFailureDetail());
+      }
     } else {
       response.setExitCode(result.getExitCode().getNumericExitCode());
       if (result.getFailureDetail() != null) {

--- a/src/test/shell/integration/build_event_stream_test.sh
+++ b/src/test/shell/integration/build_event_stream_test.sh
@@ -1708,4 +1708,32 @@ function test_java_version_info_in_build_started() {
   fi
 }
 
+function test_bes_upload_failure_does_not_block_run() {
+  mkdir -p bes_run_fail
+  cat > bes_run_fail/hello.sh <<'EOF'
+#!/bin/bash
+echo "HELLO_FROM_BINARY"
+EOF
+  chmod +x bes_run_fail/hello.sh
+  cat > bes_run_fail/BUILD <<'EOF'
+genrule(
+    name = "hello",
+    srcs = ["hello.sh"],
+    outs = ["hello_bin.sh"],
+    cmd = "cp $< $@ && chmod +x $@",
+    executable = 1,
+)
+EOF
+
+  # Run with a bogus BES backend.
+  # We expect Bazel to report the error but still execute the binary.
+  bazel run //bes_run_fail:hello \
+      --bes_backend=localhost:1234 \
+      --bes_upload_mode=wait_for_upload_complete \
+      &> $TEST_log || fail "bazel run failed"
+
+  expect_log "The Build Event Protocol upload failed"
+  expect_log "HELLO_FROM_BINARY"
+}
+
 run_suite "Integration tests for the build event stream"


### PR DESCRIPTION
Fixes #28636.