### PR TITLE
[9.1.0] Fix Unicode encoding of uploaded directories (https://github.com/bazelbuild/bazel/pull/28684)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -447,7 +447,7 @@ public class UploadManifest {
           checkState(subdir.getParentDirectory().equals(dir));
           builder
               .addDirectoriesBuilder()
-              .setName(subdir.getBaseName())
+              .setName(internalToUnicode(subdir.getBaseName()))
               .setDigest(dirToDigest.get(subdir));
         }
         ByteString dirBlob = builder.build().toByteString();
@@ -535,7 +535,7 @@ public class UploadManifest {
       Digest digest = digestUtil.compute(path);
       FileNode node =
           FileNode.newBuilder()
-              .setName(path.getBaseName())
+              .setName(internalToUnicode(path.getBaseName()))
               .setDigest(digest)
               .setIsExecutable(!preserveExecutableBit || (stat.getPermissions() & 0100) != 0)
               .build();
@@ -546,7 +546,10 @@ public class UploadManifest {
     private void visitAsSymlink(Path path, PathFragment target) {
       Path parentPath = path.getParentDirectory();
       SymlinkNode node =
-          SymlinkNode.newBuilder().setName(path.getBaseName()).setTarget(target.toString()).build();
+          SymlinkNode.newBuilder()
+              .setName(internalToUnicode(path.getBaseName()))
+              .setTarget(internalToUnicode(target.toString()))
+              .build();
       dirToSymlinks.put(parentPath, node);
     }
   }


### PR DESCRIPTION
### Description
Reencode internal strings to Unicode strings.

### Motivation
`UploadManifest` got this right for files, but not for the contents of output directories.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

Closes #28684.

PiperOrigin-RevId: 871781011
Change-Id: Ia7aa2d746ea25ed47454797e62e68a93f4e575bc

Commit https://github.com/bazelbuild/bazel/commit/0449267b6aa781ca91dffe4a3c7e090a14278ffc