### PR TITLE
[9.1.0] Communicate persistent worker protocol to remote execution service (https://github.com/bazelbuild/bazel/pull/28489)

### DIFF
--- a/docs/remote/persistent.mdx
+++ b/docs/remote/persistent.mdx
@@ -205,8 +205,11 @@ JSON, `requires-worker-protocol` would be set to `proto`, like this:
   }
 ```
 
-If you do not include `requires-worker-protocol` in the execution requirements,
-Bazel will default the worker communication to use protobuf.
+Setting `requires-worker-protocol` also ensures that the selected protocol is
+forwarded to any remote execution server via the `persistentWorkerProtocol`
+platform property. If you do not include `requires-worker-protocol` in the
+execution requirements, Bazel will default the worker communication to use
+protobuf.
 
 Bazel derives the `WorkerKey` from the mnemonic and the shared flags, so if this
 configuration allowed changing the `max_mem` parameter, a separate worker would

--- a/site/en/remote/persistent.md
+++ b/site/en/remote/persistent.md
@@ -208,8 +208,11 @@ JSON, `requires-worker-protocol` would be set to `proto`, like this:
   }
 ```
 
-If you do not include `requires-worker-protocol` in the execution requirements,
-Bazel will default the worker communication to use protobuf.
+Setting `requires-worker-protocol` also ensures that the selected protocol is
+forwarded to any remote execution server via the `persistentWorkerProtocol`
+platform property. If you do not include `requires-worker-protocol` in the
+execution requirements, Bazel will default the worker communication to use
+protobuf.
 
 Bazel derives the `WorkerKey` from the mnemonic and the shared flags, so if this
 configuration allowed changing the `max_mem` parameter, a separate worker would

--- a/src/main/java/com/google/devtools/build/lib/remote/PlatformProperties.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/PlatformProperties.java
@@ -1,0 +1,46 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote;
+
+/**
+ * Strings used to communicate properties through the Remote Execution API.
+ *
+ * <p>While these can interact with {@link
+ * com.google.devtools.build.lib.actions.ExecutionRequirements}, platform properties specifically
+ * refer Property entries inserted into build.bazel.remote.execution.v2.Platform remote execution
+ * messages. This allows Bazel to communicate per-action requirements to a remote execution service.
+ *
+ * <p>Prefer formally introducing new platform properties to the Remote Execution API before adding
+ * them here.
+ */
+public class PlatformProperties {
+  /**
+   * (nonstandard) A unique identifier used to group identical build actions.
+   *
+   * <p>The value of this string indicates which persistent worker should handle incoming work
+   * associated with the action this key is bound to.
+   */
+  public static final String PERSISTENT_WORKER_KEY = "persistentWorkerKey";
+
+  /**
+   * (nonstandard) The required protocol for remote persistent workers.
+   *
+   * <p>This communicates to the remote execution server which protocol a persistent worker is
+   * expecting for the action this platform property is bound to.
+   *
+   * <p>Supported values: json, protobuf.
+   */
+  public static final String PERSISTENT_WORKER_PROTOCOL = "persistentWorkerProtocol";
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -528,13 +528,18 @@ public class RemoteExecutionService {
 
       // Get the remote platform properties.
       Platform platform;
+      ImmutableMap.Builder<String, String> additionalPropertiesBuilder = ImmutableMap.builder();
       if (toolSignature != null) {
-        platform =
-            PlatformUtils.getPlatformProto(
-                spawn, remoteOptions, ImmutableMap.of("persistentWorkerKey", toolSignature.key));
-      } else {
-        platform = PlatformUtils.getPlatformProto(spawn, remoteOptions);
+        additionalPropertiesBuilder.put(
+            PlatformProperties.PERSISTENT_WORKER_KEY, toolSignature.key);
       }
+      if (spawn.getExecutionInfo().containsKey(ExecutionRequirements.REQUIRES_WORKER_PROTOCOL)) {
+        additionalPropertiesBuilder.put(
+            PlatformProperties.PERSISTENT_WORKER_PROTOCOL,
+            spawn.getExecutionInfo().get(ExecutionRequirements.REQUIRES_WORKER_PROTOCOL));
+      }
+      platform =
+          PlatformUtils.getPlatformProto(spawn, remoteOptions, additionalPropertiesBuilder.build());
 
       SpawnScrubber spawnScrubber = scrubber != null ? scrubber.forSpawn(spawn) : null;
       Command command =

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -2636,6 +2636,7 @@ public class RemoteExecutionServiceTest {
     Spawn spawn =
         new SpawnBuilder("@flagfile")
             .withExecutionInfo(ExecutionRequirements.SUPPORTS_WORKERS, "1")
+            .withExecutionInfo(ExecutionRequirements.REQUIRES_WORKER_PROTOCOL, "json")
             .withInputs(input, toolInput, runfilesArtifact)
             .withTools(toolInput, runfilesArtifact)
             .setPathMapper(
@@ -2726,9 +2727,15 @@ public class RemoteExecutionServiceTest {
                 (byte[]) merkleTree.blobs().get(merkleTree.digest()),
                 ExtensionRegistry.getEmptyRegistry()))
         .isEqualTo(rootDirectory);
-    assertThat(remoteAction1.getAction().getPlatform().getPropertiesList()).hasSize(1);
+    assertThat(remoteAction1.getAction().getPlatform().getPropertiesList()).hasSize(2);
     assertThat(remoteAction1.getAction().getPlatform().getProperties(0).getName())
         .isEqualTo("persistentWorkerKey");
+
+    // Ensure the worker protocol is communicated.
+    assertThat(remoteAction1.getAction().getPlatform().getProperties(1).getName())
+        .isEqualTo("persistentWorkerProtocol");
+    assertThat(remoteAction1.getAction().getPlatform().getProperties(1).getValue())
+        .isEqualTo("json");
 
     // Check that if a non-tool input changes, the persistent worker key does not change.
     fakeFileCache.createScratchInput(input, "value2");
@@ -2739,7 +2746,7 @@ public class RemoteExecutionServiceTest {
     // Check that if a tool input changes, the persistent worker key changes.
     fakeFileCache.createScratchInput(toolInput, "worker value2");
     var remoteAction3 = service.buildRemoteAction(spawn, context);
-    assertThat(remoteAction3.getAction().getPlatform().getPropertiesList()).hasSize(1);
+    assertThat(remoteAction3.getAction().getPlatform().getPropertiesList()).hasSize(2);
     assertThat(remoteAction3.getAction().getPlatform().getProperties(0).getName())
         .isEqualTo("persistentWorkerKey");
     assertThat(remoteAction3.getAction().getPlatform().getProperties(0).getValue())


### PR DESCRIPTION
This gives remote execution services the information required to correctly handle remote persistent workers that do not use the default protocol.

Closes #28405.

RELNOTES: The `requires-worker-protocol` execution requirement is now forwarded to remote execution services as a platform property (`persistentWorkerProtocol`) to support intermixing JSON and Proto remote persistent worker protocols across a build.

Closes #28489.

PiperOrigin-RevId: 871888051
Change-Id: I3ed4a1d7e13e3fe81da0a75c0c13bcde65f94787

Commit https://github.com/bazelbuild/bazel/commit/120d4e75ec27f26b8121f3dd15d81af15d7696cb