### PR TITLE
fix NPE in RuleTypeFilter with non-rule targets

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/pkgcache/FilteringPolicies.java
+++ b/src/main/java/com/google/devtools/build/lib/pkgcache/FilteringPolicies.java
@@ -117,7 +117,8 @@ public final class FilteringPolicies {
         return true;
       }
 
-      if (target.getAssociatedRule().getRuleClass().equals(ruleName())) {
+      var rule = target.getAssociatedRule();
+      if (rule != null && rule.getRuleClass().equals(ruleName())) {
         return true;
       }
 


### PR DESCRIPTION
When using wildcard patterns like `--extra_toolchains=//:*` on packages containing non-rule targets, Bazel would crash with a `NullPointerException`.

This fix adds a null check before accessing the rule, properly filtering out non-rule targets instead of crashing.

Fixes https://github.com/bazelbuild/bazel/issues/14801

RELNOTES: None
