### PR TITLE
Document behavior of `execution_requirements` vs. `exec_properties`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionAnalysisMetadata.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionAnalysisMetadata.java
@@ -242,8 +242,8 @@ public interface ActionAnalysisMetadata {
   PlatformInfo getExecutionPlatform();
 
   /**
-   * Returns the execution requirements for this action, or an empty map if the action type does not
-   * have access to execution requirements.
+   * Returns the execution properties for this action, or an empty map if the action type does not
+   * have access to execution properties.
    */
   default ImmutableMap<String, String> getExecutionInfo() {
     return getExecProperties();

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -113,6 +113,17 @@ arguments:
 
 This function must be top-level, i.e. lambdas and nested functions are not allowed.
 """;
+    static final String EXECUTION_REQUIREMENTS_DOC =
+"""
+Information for scheduling the action. See <a href="${link common-definitions#common.tags}">tags</a>
+for useful keys.
+
+<p><code>execution_requirements</code> is not to be confused with the
+<a href="${link common-definitions#common.exec_properties}"><code>exec_properties</code></a>
+rule attribute. Values will not be merged into the platform's execution properties, meaning they
+will only influnce spawn behavior. They will not be visible to remote executors.
+</p>
+""";
 
   @StarlarkMethod(
       name = "declare_file",
@@ -382,10 +393,7 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             defaultValue = "None",
             named = true,
             positional = false,
-            doc =
-                "Information for scheduling the action. See "
-                    + "<a href=\"${link common-definitions#common.tags}\">tags</a> "
-                    + "for useful keys."),
+            doc = EXECUTION_REQUIREMENTS_DOC),
       })
   void write(
       FileApi output,
@@ -529,10 +537,7 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             defaultValue = "None",
             named = true,
             positional = false,
-            doc =
-                "Information for scheduling the action. See "
-                    + "<a href=\"${link common-definitions#common.tags}\">tags</a> "
-                    + "for useful keys."),
+            doc = EXECUTION_REQUIREMENTS_DOC),
         @Param(
             // TODO(bazel-team): The name here isn't accurate anymore.
             // This is technically experimental, so folks shouldn't be too attached,
@@ -783,10 +788,7 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             defaultValue = "None",
             named = true,
             positional = false,
-            doc =
-                "Information for scheduling the action. See "
-                    + "<a href=\"${link common-definitions#common.tags}\">tags</a> "
-                    + "for useful keys."),
+            doc = EXECUTION_REQUIREMENTS_DOC),
         @Param(
             // TODO(bazel-team): The name here isn't accurate anymore.
             // This is technically experimental, so folks shouldn't be too attached,
@@ -961,10 +963,7 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             defaultValue = "None",
             named = true,
             positional = false,
-            doc =
-                "Information for scheduling the created actions. See "
-                    + "<a href=\"${link common-definitions#common.tags}\">tags</a> "
-                    + "for useful keys."),
+            doc = EXECUTION_REQUIREMENTS_DOC),
         @Param(
             name = "exec_group",
             allowedTypes = {

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -121,7 +121,7 @@ for useful keys.
 <p><code>execution_requirements</code> is not to be confused with the
 <a href="${link common-definitions#common.exec_properties}"><code>exec_properties</code></a>
 rule attribute. Values will not be merged into the platform's execution properties, meaning they
-will only influnce spawn behavior. They will not be visible to remote executors.
+will only influence spawn behavior. They will not be visible to remote executors.
 </p>
 """;
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleContextApi.java
@@ -624,9 +624,17 @@ public interface StarlarkRuleContextApi<ConstraintValueT extends ConstraintValue
             named = true,
             positional = false,
             doc =
-                "Information for scheduling the action to resolve this command. See "
-                    + "<a href=\"${link common-definitions#common.tags}\">tags</a> "
-                    + "for useful keys."),
+                """
+                Information for scheduling execution of command resolution. See
+                <a href="${link common-definitions#common.tags}">tags</a> for useful keys.
+
+                <p><code>execution_requirements</code> is not to be confused with the
+                <a href="${link common-definitions#common.exec_properties}"><code>exec_properties</code></a>
+                rule attribute. Values will not be merged into the platform's execution properties,
+                meaning they will only influnce spawn behavior. They will not be visible to remote
+                executors.
+                </p>
+                """),
       },
       useStarlarkThread = true)
   Tuple resolveCommand(

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleContextApi.java
@@ -625,15 +625,8 @@ public interface StarlarkRuleContextApi<ConstraintValueT extends ConstraintValue
             positional = false,
             doc =
                 """
-                Information for scheduling execution of command resolution. See
+                Information to correctly resolve the command for the target action. See
                 <a href="${link common-definitions#common.tags}">tags</a> for useful keys.
-
-                <p><code>execution_requirements</code> is not to be confused with the
-                <a href="${link common-definitions#common.exec_properties}"><code>exec_properties</code></a>
-                rule attribute. Values will not be merged into the platform's execution properties,
-                meaning they will only influnce spawn behavior. They will not be visible to remote
-                executors.
-                </p>
                 """),
       },
       useStarlarkThread = true)


### PR DESCRIPTION
### Description

Expands documentation of `execution_requirements` to disambiguate it from `exec_properties`, clarifying that it only influences spawn behavior and that values will not be forward to remote executors.

### Motivation

The behavior of `execution_requirements` is often confused with `exec_properties`. Namely, `execution_requirements` values are not passed along to remote executors. This results in missing remote configuration (e.g. `container-image` and `Pool` in the case of EngFlow).

As unknown keys are silently ignored by `execution_requirements`, clear documentation is the first and only defense against these kinds of mistakes.

The current lack of clarity also makes intended behavior unclear, resulting in issues like #24616 needing more investigation to be properly triaged (e.g. https://github.com/bazelbuild/bazel/issues/24616#issuecomment-2539551125).

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any). - NA
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
