### PR TITLE
[9.0.1] Update and minimize the JDK for Windows arm64 builds (https://github.com/bazelbuild/bazel/pull/28632)

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -370,7 +370,7 @@
   "moduleExtensions": {
     "//:repositories.bzl%async_profiler_repos": {
       "general": {
-        "bzlTransitiveDigest": "etFQVXOg/9s3aXoXLA2u/4Ehsh/uqT1G4bxKh8+oLPs=",
+        "bzlTransitiveDigest": "Ilg8GQT+f15+hygKAhbGD+qLdQhPyylJMENZ+S52+f8=",
         "usagesDigest": "OtEjntl27qRj/reKm6+KihKPMyBd4tlRLe6Q/xITqWk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -129,9 +129,13 @@ def embedded_jdk_repositories():
     )
     http_file(
         name = "openjdk_win_arm64_vanilla",
-        integrity = "sha256-X0R5KhKvIQC025tRIMJ8Qq+AgK1jvJ6q3JyiXlx91ZA=",
+        integrity = "sha256-zhWbTuPBCc1RNXrPhCZBQsHdsOGHjSBGbqxQsBU0cVQ=",
         downloaded_file_path = "zulu-win-arm64.zip",
-        url = "https://cdn.azul.com/zulu/bin/zulu25.32.17-ca-jdk25.0.2-win_aarch64.zip",
+        # Use an EA release of 25.0.3 here since versions <= 25.0.2 are affected by a severe JDK bug
+        # that causes virtual threads (and thus repo rules) to hang indefinitely on Windows ARM64.
+        # https://github.com/bazelbuild/bazel/issues/28520
+        # https://mail.openjdk.org/pipermail/loom-dev/2026-February/008286.html
+        url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B1-ea-beta/OpenJDK25U-jdk_aarch64_windows_hotspot_25.0.3_1-ea.zip",
     )
 
 def _async_profiler_repos(ctx):

--- a/src/BUILD
+++ b/src/BUILD
@@ -130,11 +130,7 @@ JAVA_TOOLS = [
     ],
 ) for suffix, jdk in {
     "_jdk_allmodules": [":embedded_jdk_allmodules"],
-    "_jdk_minimal": select({
-        # We cannot minimize the JDK during cross compiling for Windows arm64
-        "//src/conditions:windows_arm64": [":embedded_jdk_vanilla"],
-        "//conditions:default": [":embedded_jdk_minimal"],
-    }),
+    "_jdk_minimal": [":embedded_jdk_minimal"],
     "_nojdk": [],
 }.items()]
 


### PR DESCRIPTION
Fixes #28520

Closes #28632.

PiperOrigin-RevId: 872274729
Change-Id: Ib29a4b4c03582fc8cbf647d9cd3ddf7eb1547daa

Commit https://github.com/bazelbuild/bazel/commit/799c54fd605475845dcc4e1764b24fa54addd6d4