### PR TITLE
Conditionally download stdout and stderr of remotely executed actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutedEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutedEvent.java
@@ -51,7 +51,9 @@ public final class ActionExecutedEvent implements BuildEventWithConfiguration {
   private final Artifact outputArtifact;
   @Nullable private final FileArtifactValue primaryOutputMetadata;
   private final Path stdout;
+  @Nullable private final FileArtifactValue stdoutMetadata;
   private final Path stderr;
+  @Nullable private final FileArtifactValue stderrMetadata;
   private final ErrorTiming timing;
 
   /** Timestamp of the action starting; if no timestamp is available will be {@code null}. */
@@ -68,7 +70,9 @@ public final class ActionExecutedEvent implements BuildEventWithConfiguration {
       Artifact outputArtifact,
       @Nullable FileArtifactValue primaryOutputMetadata,
       Path stdout,
+      @Nullable FileArtifactValue stdoutMetadata,
       Path stderr,
+      @Nullable FileArtifactValue stderrMetadata,
       ErrorTiming timing,
       @Nullable Instant startTime,
       @Nullable Instant endTime) {
@@ -79,7 +83,9 @@ public final class ActionExecutedEvent implements BuildEventWithConfiguration {
     this.outputArtifact = outputArtifact;
     this.primaryOutputMetadata = primaryOutputMetadata;
     this.stdout = stdout;
+    this.stdoutMetadata = stdoutMetadata;
     this.stderr = stderr;
+    this.stderrMetadata = stderrMetadata;
     this.timing = timing;
     this.startTime = startTime;
     this.endTime = endTime;
@@ -156,10 +162,10 @@ public final class ActionExecutedEvent implements BuildEventWithConfiguration {
     ImmutableList.Builder<LocalFile> localFiles = ImmutableList.builder();
     // TODO(b/199940216): thread file metadata through here when possible.
     if (stdout != null) {
-      localFiles.add(new LocalFile(stdout, LocalFileType.STDOUT, /* artifactMetadata= */ null));
+      localFiles.add(new LocalFile(stdout, LocalFileType.STDOUT, stdoutMetadata));
     }
     if (stderr != null) {
-      localFiles.add(new LocalFile(stderr, LocalFileType.STDERR, /* artifactMetadata= */ null));
+      localFiles.add(new LocalFile(stderr, LocalFileType.STDERR, stderrMetadata));
     }
     if (exception == null) {
       localFiles.add(

--- a/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
@@ -280,6 +280,24 @@ public interface SpawnResult {
     return null;
   }
 
+  /**
+   * Returns metadata for the spawn's stdout if it was left in a remote CAS instead of being written
+   * to the local stdout file, otherwise null.
+   */
+  @Nullable
+  default FileArtifactValue getRemoteStdoutMetadata() {
+    return null;
+  }
+
+  /**
+   * Returns metadata for the spawn's stderr if it was left in a remote CAS instead of being written
+   * to the local stderr file, otherwise null.
+   */
+  @Nullable
+  default FileArtifactValue getRemoteStderrMetadata() {
+    return null;
+  }
+
   /** Basic implementation of {@link SpawnResult}. */
   @Immutable
   @ThreadSafe
@@ -308,6 +326,8 @@ public interface SpawnResult {
 
     private final boolean remote;
     @Nullable private final Digest digest;
+    @Nullable private final FileArtifactValue remoteStdoutMetadata;
+    @Nullable private final FileArtifactValue remoteStderrMetadata;
 
     SimpleSpawnResult(Builder builder) {
       this.exitCode = builder.exitCode;
@@ -338,6 +358,8 @@ public interface SpawnResult {
       this.inMemoryContents = builder.inMemoryContents;
       this.remote = builder.remote;
       this.digest = builder.digest;
+      this.remoteStdoutMetadata = builder.remoteStdoutMetadata;
+      this.remoteStderrMetadata = builder.remoteStderrMetadata;
     }
 
     @Override
@@ -472,6 +494,18 @@ public interface SpawnResult {
     @Override
     public Digest getDigest() {
       return digest;
+    }
+
+    @Override
+    @Nullable
+    public FileArtifactValue getRemoteStdoutMetadata() {
+      return remoteStdoutMetadata;
+    }
+
+    @Override
+    @Nullable
+    public FileArtifactValue getRemoteStderrMetadata() {
+      return remoteStderrMetadata;
     }
   }
 
@@ -610,6 +644,18 @@ public interface SpawnResult {
     public Digest getDigest() {
       return delegate.getDigest();
     }
+
+    @Override
+    @Nullable
+    public FileArtifactValue getRemoteStdoutMetadata() {
+      return delegate.getRemoteStdoutMetadata();
+    }
+
+    @Override
+    @Nullable
+    public FileArtifactValue getRemoteStderrMetadata() {
+      return delegate.getRemoteStderrMetadata();
+    }
   }
 
   /** Builder class for {@link SpawnResult}. */
@@ -638,6 +684,8 @@ public interface SpawnResult {
 
     private boolean remote;
     private Digest digest;
+    @Nullable private FileArtifactValue remoteStdoutMetadata;
+    @Nullable private FileArtifactValue remoteStderrMetadata;
 
     public SpawnResult build() {
       Preconditions.checkArgument(!runnerName.isEmpty());
@@ -788,6 +836,18 @@ public interface SpawnResult {
     @CanIgnoreReturnValue
     public Builder setDigest(Digest digest) {
       this.digest = digest;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder setRemoteStdoutMetadata(@Nullable FileArtifactValue metadata) {
+      this.remoteStdoutMetadata = metadata;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder setRemoteStderrMetadata(@Nullable FileArtifactValue metadata) {
+      this.remoteStderrMetadata = metadata;
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -109,12 +109,12 @@ import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTreeComputer;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOptions.ConcurrentChangesCheckLevel;
-import com.google.devtools.build.lib.remote.options.RemoteOutErrMode;
 import com.google.devtools.build.lib.remote.salt.CacheSalt;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.remote.util.Utils.InMemoryOutput;
+import com.google.devtools.build.lib.remote.util.Utils.UndownloadedOutErrMetadata;
 import com.google.devtools.build.lib.server.FailureDetails.RemoteExecution;
 import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.util.OS;
@@ -169,6 +169,9 @@ import javax.annotation.Nullable;
 public class RemoteExecutionService {
   private static final Comparator<String> PROTO_STRING_COMPARATOR =
       comparing(StringEncoding::unicodeToInternal);
+
+  // Mirrors TestRunnerAction.MNEMONIC, which isn't visible from this package.
+  private static final String TEST_RUNNER_MNEMONIC = "TestRunner";
 
   private final Reporter reporter;
   private final boolean verboseFailures;
@@ -1238,6 +1241,42 @@ public class RemoteExecutionService {
         files.buildOrThrow(), ImmutableMap.copyOf(symlinkMap), directories.buildOrThrow());
   }
 
+  private boolean shouldDownloadOutErr(RemoteAction action, RemoteActionResult result) {
+    if (TEST_RUNNER_MNEMONIC.equals(action.getSpawn().getMnemonic())) {
+      // Test actions always have their stdout and stderr downloaded (for `test.xml` generation).
+      return true;
+    }
+    if (!result.success()) {
+      // Failed actions always have their stdout and stderr downloaded.
+      return true;
+    }
+    return switch (remoteOptions.getRemoteOutErrMode()) {
+      case ALL -> true;
+      case UNCACHED -> !result.cacheHit();
+      case FAILED -> false;
+    };
+  }
+
+  /**
+   * Returns metadata for the stdout and stderr that {@link #downloadOutputs} left in the CAS, so
+   * that consumers such as the build event stream can still reference them.
+   */
+  public UndownloadedOutErrMetadata getUndownloadedOutErrMetadata(
+      RemoteAction action, RemoteActionResult result) {
+    if (shouldDownloadOutErr(action, result)) {
+      return UndownloadedOutErrMetadata.EMPTY;
+    }
+    ActionResult actionResult = result.actionResult;
+    return new UndownloadedOutErrMetadata(
+        actionResult.hasStdoutDigest() ? remoteFileMetadata(actionResult.getStdoutDigest()) : null,
+        actionResult.hasStderrDigest() ? remoteFileMetadata(actionResult.getStderrDigest()) : null);
+  }
+
+  private static FileArtifactValue remoteFileMetadata(Digest digest) {
+    return FileArtifactValue.createForRemoteFile(
+        DigestUtil.toBinaryDigest(digest), digest.getSizeBytes(), /* locationIndex= */ 0);
+  }
+
   /**
    * Downloads the outputs of a remotely executed action and injects their metadata.
    *
@@ -1388,23 +1427,7 @@ public class RemoteExecutionService {
     FileOutErr outErr = action.getSpawnExecutionContext().getFileOutErr();
     FileOutErr tmpOutErr = outErr.childOutErr();
 
-    boolean downloadOutErr = false;
-    if (remoteOptions.getRemoteOutErrMode() == RemoteOutErrMode.ALL) {
-      downloadOutErr = true;
-    } else if (!result.success()) {
-      // Failed actions always have their stdout and stderr downloaded
-      downloadOutErr = true;
-    } else if (remoteOptions.getRemoteOutErrMode() == RemoteOutErrMode.UNCACHED) {
-      if (!result.cacheHit()) {
-        downloadOutErr = true;
-      }
-    }
-    if ("TestRunner".equals(action.getSpawn().getMnemonic())) {
-      // Test actions always have their stdout and stderr downloaded (for `test.xml` generation)
-      downloadOutErr = true;
-    }
-
-    if (downloadOutErr) {
+    if (shouldDownloadOutErr(action, result)) {
       List<ListenableFuture<Void>> outErrDownloads =
           combinedCache.downloadOutErr(context, result.actionResult, tmpOutErr);
       for (ListenableFuture<Void> future : outErrDownloads) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -109,6 +109,7 @@ import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTreeComputer;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOptions.ConcurrentChangesCheckLevel;
+import com.google.devtools.build.lib.remote.options.RemoteOutErrMode;
 import com.google.devtools.build.lib.remote.salt.CacheSalt;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
@@ -1385,13 +1386,30 @@ public class RemoteExecutionService {
     }
 
     FileOutErr outErr = action.getSpawnExecutionContext().getFileOutErr();
-
-    // Always download the action stdout/stderr.
     FileOutErr tmpOutErr = outErr.childOutErr();
-    List<ListenableFuture<Void>> outErrDownloads =
-        combinedCache.downloadOutErr(context, result.actionResult, tmpOutErr);
-    for (ListenableFuture<Void> future : outErrDownloads) {
-      downloadsBuilder.add(transform(future, (v) -> null, directExecutor()));
+
+    boolean downloadOutErr = false;
+    if (remoteOptions.getRemoteOutErrMode() == RemoteOutErrMode.ALL) {
+      downloadOutErr = true;
+    } else if (!result.success()) {
+      // Failed actions always have their stdout and stderr downloaded
+      downloadOutErr = true;
+    } else if (remoteOptions.getRemoteOutErrMode() == RemoteOutErrMode.UNCACHED) {
+      if (!result.cacheHit()) {
+        downloadOutErr = true;
+      }
+    }
+    if ("TestRunner".equals(action.getSpawn().getMnemonic())) {
+      // Test actions always have their stdout and stderr downloaded (for `test.xml` generation)
+      downloadOutErr = true;
+    }
+
+    if (downloadOutErr) {
+      List<ListenableFuture<Void>> outErrDownloads =
+          combinedCache.downloadOutErr(context, result.actionResult, tmpOutErr);
+      for (ListenableFuture<Void> future : outErrDownloads) {
+        downloadsBuilder.add(transform(future, (v) -> null, directExecutor()));
+      }
     }
 
     ImmutableList<ListenableFuture<FileMetadata>> downloads = downloadsBuilder.build();

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -180,6 +180,7 @@ final class RemoteSpawnCache implements SpawnCache {
                     /* cacheHit= */ true,
                     result.cacheName(),
                     inMemoryOutput,
+                    remoteExecutionService.getUndownloadedOutErrMetadata(action, result),
                     result.getExecutionMetadata().getExecutionStartTimestamp(),
                     result.getExecutionMetadata().getExecutionCompletedTimestamp(),
                     spawnMetrics.build(),

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -508,6 +508,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
         cacheHit,
         cacheName,
         inMemoryOutput,
+        remoteExecutionService.getUndownloadedOutErrMetadata(action, result),
         result.getExecutionMetadata().getExecutionStartTimestamp(),
         result.getExecutionMetadata().getExecutionCompletedTimestamp(),
         spawnMetrics

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -619,11 +619,20 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       converter = RemoteOutputsStrategyConverter.class,
       help =
-          "If set to 'minimal' doesn't download any remote build outputs to the local machine, "
-              + "except the ones required by local actions. If set to 'toplevel' behaves like "
-              + "'minimal' except that it also downloads outputs of top level targets to the local "
-              + "machine. Both options can significantly reduce build times if network bandwidth "
-              + "is a bottleneck.")
+          """
+          Controls which remote build outputs are downloaded to the local machine.
+
+          - `minimal`: Don't download any remote outputs, except those required by local actions.
+          - `toplevel`: The default, like `minimal` except top level target outputs are also
+            downloaded.
+          - `all`: Download all remote outputs.
+
+          `minimal` and `toplevel` can significantly reduce build times if network bandwidth is a
+          bottleneck.
+
+          See also `--remote_download_stdouterr` which controls downloading of stdout and stderr for
+          remote actions.
+          """)
   public abstract RemoteOutputsMode getRemoteOutputsMode();
 
   public abstract void setRemoteOutputsMode(RemoteOutputsMode value);
@@ -672,6 +681,31 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
           "Downloads all remote outputs to the local machine. This flag is an alias for"
               + " --remote_download_outputs=all.")
   public abstract Void getRemoteOutputsAll();
+
+  @Option(
+      name = "remote_download_stdouterr",
+      defaultValue = "all",
+      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      converter = RemoteOutErrModeConverter.class,
+      help =
+          """
+          Controls downloading of stdout and stderr for non-test remote actions.
+
+          - `failed`: Only download if the action failed.
+          - `uncached`: Only download if the action was not cached.
+          - `all`: The default, always download.
+          """
+  )
+  public abstract RemoteOutErrMode getRemoteOutErrMode();
+
+  public abstract void setRemoteOutErrMode(RemoteOutErrMode value);
+
+  public static class RemoteOutErrModeConverter extends EnumConverter<RemoteOutErrMode> {
+    public RemoteOutErrModeConverter() {
+      super(RemoteOutErrMode.class, "remote stdout/stderr download mode");
+    }
+  }
 
   @Option(
       name = "remote_result_cache_priority",

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOutErrMode.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOutErrMode.java
@@ -1,0 +1,28 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote.options;
+
+/** Describes what action stdout and stderr should be downloaded. */
+public enum RemoteOutErrMode {
+
+  /** Download stdout and stderr of all actions. */
+  ALL,
+
+  /** Download stdout and stderr of uncached actions only. */
+  UNCACHED,
+
+  /** Download stdout and stderr of failed actions only. */
+  FAILED,
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/util/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/BUILD
@@ -50,6 +50,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:action_input",
         "//src/main/java/com/google/devtools/build/lib/actions:execution_requirements",
+        "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/authandtls:grpc",
         "//src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper",
         "//src/main/java/com/google/devtools/build/lib/remote:ExecutionStatusException",

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.Spawns;
@@ -130,6 +131,7 @@ public final class Utils {
       boolean cacheHit,
       String runnerName,
       @Nullable InMemoryOutput inMemoryOutput,
+      UndownloadedOutErrMetadata undownloadedOutErrMetadata,
       Timestamp executionStartTimestamp,
       Timestamp executionCompletedTimestamp,
       SpawnMetrics spawnMetrics,
@@ -150,7 +152,9 @@ public final class Utils {
                         .toMillis())
             .setSpawnMetrics(spawnMetrics)
             .setRemote(true)
-            .setDigest(digestUtil.asSpawnLogProto(actionKey));
+            .setDigest(digestUtil.asSpawnLogProto(actionKey))
+            .setRemoteStdoutMetadata(undownloadedOutErrMetadata.stdout())
+            .setRemoteStderrMetadata(undownloadedOutErrMetadata.stderr());
     if (exitCode != 0) {
       builder.setFailureDetail(
           FailureDetail.newBuilder()
@@ -453,6 +457,19 @@ public final class Utils {
     public ByteString getContents() {
       return contents;
     }
+  }
+
+  /**
+   * Metadata for an action's stdout and stderr that were left in the CAS because {@code
+   * --remote_download_stdouterr} suppressed their download.
+   *
+   * <p>A field is null if the corresponding stream was downloaded, was empty, or was inlined into
+   * the action result rather than stored in the CAS.
+   */
+  public record UndownloadedOutErrMetadata(
+      @Nullable FileArtifactValue stdout, @Nullable FileArtifactValue stderr) {
+    public static final UndownloadedOutErrMetadata EMPTY =
+        new UndownloadedOutErrMetadata(null, null);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -1953,16 +1953,30 @@ public final class SkyframeActionExecutor {
       ErrorTiming errorTiming) {
     Path stdout = null;
     Path stderr = null;
+    FileArtifactValue stdoutMetadata = null;
+    FileArtifactValue stderrMetadata = null;
 
-    if (outErr.hasRecordedStdout()) {
-      stdout = outErr.getOutputPath();
-    }
-    if (outErr.hasRecordedStderr()) {
-      stderr = outErr.getErrorPath();
-    }
     // Collect MetadataLogs and spawn start times/end times from the Action's SpawnResults.
     ImmutableList<SpawnResult> spawnResults =
         findSpawnResultsInActionResultAndException(actionResult, exception);
+
+    if (outErr.hasRecordedStdout()) {
+      stdout = outErr.getOutputPath();
+    } else {
+      stdoutMetadata = soleRemoteOutErrMetadata(spawnResults, SpawnResult::getRemoteStdoutMetadata);
+      if (stdoutMetadata != null) {
+        stdout = outErr.getOutputPath();
+      }
+    }
+    if (outErr.hasRecordedStderr()) {
+      stderr = outErr.getErrorPath();
+    } else {
+      stderrMetadata = soleRemoteOutErrMetadata(spawnResults, SpawnResult::getRemoteStderrMetadata);
+      if (stderrMetadata != null) {
+        stderr = outErr.getErrorPath();
+      }
+    }
+
     Instant firstStartTime = Instant.MAX;
     Instant lastEndTime = Instant.MIN;
     for (SpawnResult spawnResult : spawnResults) {
@@ -1983,10 +1997,34 @@ public final class SkyframeActionExecutor {
             action.getPrimaryOutput(),
             primaryOutputMetadata,
             stdout,
+            stdoutMetadata,
             stderr,
+            stderrMetadata,
             errorTiming,
             firstStartTime.equals(Instant.MAX) ? null : firstStartTime,
             lastEndTime.equals(Instant.MIN) ? null : lastEndTime));
+  }
+
+  /**
+   * Returns the remote stdout or stderr metadata of the only spawn that has it, or null if no or
+   * multiple spawns do, since a single path can't represent the output of multiple spawns.
+   */
+  @Nullable
+  private static FileArtifactValue soleRemoteOutErrMetadata(
+      ImmutableList<SpawnResult> spawnResults,
+      Function<SpawnResult, FileArtifactValue> extractor) {
+    FileArtifactValue found = null;
+    for (SpawnResult spawnResult : spawnResults) {
+      FileArtifactValue metadata = extractor.apply(spawnResult);
+      if (metadata == null) {
+        continue;
+      }
+      if (found != null) {
+        return null;
+      }
+      found = metadata;
+    }
+    return found;
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -116,6 +116,7 @@ import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTreeComputer;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOptions.ConcurrentChangesCheckLevel;
+import com.google.devtools.build.lib.remote.options.RemoteOutErrMode;
 import com.google.devtools.build.lib.remote.salt.CacheSalt;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.FakeSpawnExecutionContext;
@@ -123,6 +124,7 @@ import com.google.devtools.build.lib.remote.util.InMemoryCacheClient;
 import com.google.devtools.build.lib.remote.util.RxNoGlobalErrorsRule;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.remote.util.Utils.InMemoryOutput;
+import com.google.devtools.build.lib.remote.util.Utils.UndownloadedOutErrMetadata;
 import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
 import com.google.devtools.build.lib.testutil.TestConstants;
 import com.google.devtools.build.lib.util.Fingerprint;
@@ -1772,6 +1774,125 @@ public class RemoteExecutionServiceTest {
       throw new AssertionError("outErr should still be writable after download finished.", err);
     }
     assertThat(context.isLockOutputFilesCalled()).isTrue();
+  }
+
+  private ActionResult outErrActionResult(int exitCode, Digest stdout, Digest stderr) {
+    return ActionResult.newBuilder()
+        .setExitCode(exitCode)
+        .setStdoutDigest(stdout)
+        .setStderrDigest(stderr)
+        .build();
+  }
+
+  private static FileArtifactValue remoteFileMetadata(Digest digest) {
+    return FileArtifactValue.createForRemoteFile(
+        DigestUtil.toBinaryDigest(digest), digest.getSizeBytes(), /* locationIndex= */ 0);
+  }
+
+  private UndownloadedOutErrMetadata downloadOutputsWithOutErrMode(
+      RemoteOutErrMode mode, RemoteActionResult result) throws Exception {
+    remoteOptions.setRemoteOutErrMode(mode);
+    Spawn spawn = newSpawnFromResult(result);
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn, outErr);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    createOutputDirectories(spawn);
+    when(remoteOutputChecker.shouldDownloadOutput(ArgumentMatchers.<PathFragment>any(), any()))
+        .thenReturn(true);
+
+    service.downloadOutputs(action, result);
+
+    return service.getUndownloadedOutErrMetadata(action, result);
+  }
+
+  @Test
+  public void downloadOutputs_outErrModeFailed_skipsDownloadAndReportsCasMetadata()
+      throws Exception {
+    Digest digestStdout = cache.addContents(remoteActionExecutionContext, "stdout");
+    Digest digestStderr = cache.addContents(remoteActionExecutionContext, "stderr");
+    RemoteActionResult result =
+        RemoteActionResult.createFromCache(
+            CachedActionResult.remote(outErrActionResult(0, digestStdout, digestStderr)));
+
+    UndownloadedOutErrMetadata metadata =
+        downloadOutputsWithOutErrMode(RemoteOutErrMode.FAILED, result);
+
+    assertThat(outErr.getOutputPath().exists()).isFalse();
+    assertThat(outErr.getErrorPath().exists()).isFalse();
+    assertThat(metadata)
+        .isEqualTo(
+            new UndownloadedOutErrMetadata(
+                remoteFileMetadata(digestStdout), remoteFileMetadata(digestStderr)));
+  }
+
+  @Test
+  public void downloadOutputs_outErrModeUncachedWithCacheHit_skipsDownload() throws Exception {
+    Digest digestStdout = cache.addContents(remoteActionExecutionContext, "stdout");
+    Digest digestStderr = cache.addContents(remoteActionExecutionContext, "stderr");
+    RemoteActionResult result =
+        RemoteActionResult.createFromCache(
+            CachedActionResult.remote(outErrActionResult(0, digestStdout, digestStderr)));
+
+    UndownloadedOutErrMetadata metadata =
+        downloadOutputsWithOutErrMode(RemoteOutErrMode.UNCACHED, result);
+
+    assertThat(outErr.getOutputPath().exists()).isFalse();
+    assertThat(outErr.getErrorPath().exists()).isFalse();
+    assertThat(metadata)
+        .isEqualTo(
+            new UndownloadedOutErrMetadata(
+                remoteFileMetadata(digestStdout), remoteFileMetadata(digestStderr)));
+  }
+
+  @Test
+  public void downloadOutputs_outErrModeUncachedWithExecutedAction_downloads() throws Exception {
+    Digest digestStdout = cache.addContents(remoteActionExecutionContext, "stdout");
+    Digest digestStderr = cache.addContents(remoteActionExecutionContext, "stderr");
+    RemoteActionResult result =
+        RemoteActionResult.createFromResponse(
+            ExecuteResponse.newBuilder()
+                .setResult(outErrActionResult(0, digestStdout, digestStderr))
+                .setCachedResult(false)
+                .build());
+
+    UndownloadedOutErrMetadata metadata =
+        downloadOutputsWithOutErrMode(RemoteOutErrMode.UNCACHED, result);
+
+    assertThat(readContent(outErr.getOutputPath(), UTF_8)).isEqualTo("stdout");
+    assertThat(readContent(outErr.getErrorPath(), UTF_8)).isEqualTo("stderr");
+    assertThat(metadata).isEqualTo(UndownloadedOutErrMetadata.EMPTY);
+  }
+
+  @Test
+  public void downloadOutputs_outErrModeFailedWithFailedAction_downloads() throws Exception {
+    Digest digestStdout = cache.addContents(remoteActionExecutionContext, "stdout");
+    Digest digestStderr = cache.addContents(remoteActionExecutionContext, "stderr");
+    RemoteActionResult result =
+        RemoteActionResult.createFromCache(
+            CachedActionResult.remote(outErrActionResult(1, digestStdout, digestStderr)));
+
+    UndownloadedOutErrMetadata metadata =
+        downloadOutputsWithOutErrMode(RemoteOutErrMode.FAILED, result);
+
+    assertThat(readContent(outErr.getOutputPath(), UTF_8)).isEqualTo("stdout");
+    assertThat(readContent(outErr.getErrorPath(), UTF_8)).isEqualTo("stderr");
+    assertThat(metadata).isEqualTo(UndownloadedOutErrMetadata.EMPTY);
+  }
+
+  @Test
+  public void downloadOutputs_outErrModeAll_downloads() throws Exception {
+    Digest digestStdout = cache.addContents(remoteActionExecutionContext, "stdout");
+    Digest digestStderr = cache.addContents(remoteActionExecutionContext, "stderr");
+    RemoteActionResult result =
+        RemoteActionResult.createFromCache(
+            CachedActionResult.remote(outErrActionResult(0, digestStdout, digestStderr)));
+
+    UndownloadedOutErrMetadata metadata =
+        downloadOutputsWithOutErrMode(RemoteOutErrMode.ALL, result);
+
+    assertThat(readContent(outErr.getOutputPath(), UTF_8)).isEqualTo("stdout");
+    assertThat(readContent(outErr.getErrorPath(), UTF_8)).isEqualTo("stderr");
+    assertThat(metadata).isEqualTo(UndownloadedOutErrMetadata.EMPTY);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
@@ -126,7 +126,9 @@ public final class BuildEventStreamerTest extends BuildEventStreamerTestBase {
           ActionsTestUtil.DUMMY_ARTIFACT,
           FileArtifactValue.MISSING_FILE_MARKER,
           /* stdout= */ null,
+          /* stdoutMetadata= */ null,
           /* stderr= */ null,
+          /* stderrMetadata= */ null,
           ErrorTiming.NO_ERROR,
           /* startTime= */ null,
           /* endTime= */ null);
@@ -1424,7 +1426,9 @@ public final class BuildEventStreamerTest extends BuildEventStreamerTestBase {
             ActionsTestUtil.DUMMY_ARTIFACT,
             /* primaryOutputMetadata= */ null,
             /* stdout= */ null,
+            /* stdoutMetadata= */ null,
             /* stderr= */ null,
+            /* stderrMetadata= */ null,
             ErrorTiming.BEFORE_EXECUTION,
             /* startTime= */ null,
             /* endTime= */ null);
@@ -1469,7 +1473,9 @@ public final class BuildEventStreamerTest extends BuildEventStreamerTestBase {
             ActionsTestUtil.DUMMY_ARTIFACT,
             /* primaryOutputMetadata= */ null,
             /* stdout= */ null,
+            /* stdoutMetadata= */ null,
             /* stderr= */ null,
+            /* stderrMetadata= */ null,
             ErrorTiming.BEFORE_EXECUTION,
             /* startTime= */ null,
             /* endTime= */ null);

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -3258,4 +3258,88 @@ EOF
   done
 }
 
+function write_stdouterr_test_build_defs() {
+  add_rules_cc MODULE.bazel
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+genrule(
+  name = "foo",
+  srcs = [],
+  outs = ["foo.txt"],
+  cmd = """
+echo some_stdout
+echo some_stderr 1>&2
+touch $@
+""",
+)
+cc_test(
+  name = "test",
+  srcs = ["test.cc"],
+)
+EOF
+  cat > a/test.cc <<EOF
+#include <iostream>
+int main() { std::cout << "Hello test!" << std::endl; return 0; }
+EOF
+
+}
+
+function test_download_stdouterr_uncached() {
+  # Test that action stderr and stdout of cached actions are not downloaded with
+  # `--remote_download_stdouterr=uncached`.
+  write_stdouterr_test_build_defs
+  bazel test \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_download_stdouterr=uncached \
+    //a:all >& $TEST_log || fail "Failed to build+test //a:all"
+
+  expect_log "some_stdout"
+  expect_log "some_stderr"
+
+  # Ensure test.log exists and is populated
+  assert_exists bazel-testlogs/a/test/test.log
+  assert_contains "Hello test!" bazel-testlogs/a/test/test.log
+
+  bazel clean
+
+  bazel test \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_download_stdouterr=uncached \
+    //a:all >& $TEST_log || fail "Failed to build+test //a:all"
+
+  expect_not_log "some_stdout"
+  expect_not_log "some_stderr"
+
+  # Ensure test.log exists and is populated (no `--remote_download_minimal` so should be downloaded)
+  assert_exists bazel-testlogs/a/test/test.log
+  assert_contains "Hello test!" bazel-testlogs/a/test/test.log
+}
+
+function test_download_stdouterr_failed() {
+  # Test that action stderr and stdout of successful actions are not downloaded with
+  # `--remote_download_stdouterr=failed`.
+  write_stdouterr_test_build_defs
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_download_stdouterr=failed \
+    //a:foo >& $TEST_log || fail "Failed to build //a:foo"
+
+  expect_not_log "some_stdout"
+  expect_not_log "some_stderr"
+}
+
+function test_download_stdouterr_all() {
+  # Test that action stderr and stdout of all actions are downloaded with
+  # `--remote_download_stdouterr=all`.
+  write_stdouterr_test_build_defs
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_download_stdouterr=all \
+    //a:foo >& $TEST_log || fail "Failed to build //a:foo"
+
+  expect_log "some_stdout"
+  expect_log "some_stderr"
+}
+
 run_suite "Build without the Bytes tests"

--- a/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
+++ b/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
@@ -79,6 +79,41 @@ function expect_bes_file_not_uploaded() {
   fi
 }
 
+# Asserts that the ActionExecuted event for a remotely executed action references
+# the given stream ("stdout" or "stderr") by a bytestream:// URI whose digest
+# matches the expected contents and whose blob is present in the CAS.
+function expect_bes_action_stdouterr_in_cas() {
+  local stream=$1
+  local expected_contents=$2
+  local expected_hash
+  expected_hash="$(printf '%s\n' "$expected_contents" | sha256sum | cut -d ' ' -f 1)"
+
+  if [[ ! $(cat $BEP_JSON) =~ \"name\":\"${stream}\",\"uri\":\"bytestream://localhost:${worker_port}/blobs/([0-9a-f]+)/[0-9]+\" ]]; then
+    cat $BEP_JSON > $TEST_log
+    fail "BEP has no bytestream:// reference for action ${stream}"
+  fi
+  local actual_hash=${BASH_REMATCH[1]}
+  if [[ "$actual_hash" != "$expected_hash" ]]; then
+    cat $BEP_JSON > $TEST_log
+    fail "BEP ${stream} digest ${actual_hash} does not match expected ${expected_hash}"
+  fi
+  if ! remote_cas_file_exist "$actual_hash"; then
+    cat $BEP_JSON >> $TEST_log && append_remote_cas_files $TEST_log
+    fail "BEP ${stream} blob ${actual_hash} is not in the CAS"
+  fi
+}
+
+function write_stdouterr_genrule() {
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+genrule(
+  name = "foo",
+  outs = ["foo.txt"],
+  cmd = "echo some_stdout; echo some_stderr 1>&2; touch $@",
+)
+EOF
+}
+
 function test_upload_minimal_convert_paths_for_existed_blobs() {
   mkdir -p a
   cat > a/BUILD <<EOF
@@ -587,6 +622,93 @@ EOF
       //a:foo >& $TEST_log || fail "Failed to build"
 
   expect_bes_file_uploaded "command.profile.json"
+}
+
+function test_publish_all_actions_stdouterr_download_all() {
+  # Baseline: with the default --remote_download_stdouterr=all the action
+  # stdout/stderr are downloaded and still referenced by their CAS entries.
+  write_stdouterr_genrule
+
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_build_event_upload=minimal \
+      --remote_download_stdouterr=all \
+      --build_event_publish_all_actions \
+      --build_event_json_file=$BEP_JSON \
+      //a:foo >& $TEST_log || fail "Failed to build"
+
+  expect_log "some_stdout"
+  expect_log "some_stderr"
+  expect_bes_action_stdouterr_in_cas "stdout" "some_stdout"
+  expect_bes_action_stdouterr_in_cas "stderr" "some_stderr"
+}
+
+function test_publish_all_actions_stdouterr_download_failed() {
+  # --remote_download_stdouterr=failed skips the download for successful actions,
+  # but BEP must still reference the CAS entries.
+  write_stdouterr_genrule
+
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_build_event_upload=minimal \
+      --remote_download_stdouterr=failed \
+      --build_event_publish_all_actions \
+      --build_event_json_file=$BEP_JSON \
+      //a:foo >& $TEST_log || fail "Failed to build"
+
+  expect_not_log "some_stdout"
+  expect_not_log "some_stderr"
+  expect_bes_action_stdouterr_in_cas "stdout" "some_stdout"
+  expect_bes_action_stdouterr_in_cas "stderr" "some_stderr"
+}
+
+function test_publish_all_actions_stdouterr_download_uncached() {
+  # Same as above, but for a cache hit under --remote_download_stdouterr=uncached.
+  write_stdouterr_genrule
+
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_build_event_upload=minimal \
+      --remote_download_stdouterr=uncached \
+      --build_event_publish_all_actions \
+      --build_event_json_file=$BEP_JSON \
+      //a:foo >& $TEST_log || fail "Failed to build"
+
+  expect_log "some_stdout"
+  expect_log "some_stderr"
+
+  bazel clean >& $TEST_log || fail "Failed to clean"
+
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_build_event_upload=minimal \
+      --remote_download_stdouterr=uncached \
+      --build_event_publish_all_actions \
+      --build_event_json_file=$BEP_JSON \
+      //a:foo >& $TEST_log || fail "Failed to build"
+
+  expect_not_log "some_stdout"
+  expect_not_log "some_stderr"
+  expect_bes_action_stdouterr_in_cas "stdout" "some_stdout"
+  expect_bes_action_stdouterr_in_cas "stderr" "some_stderr"
+}
+
+function test_publish_all_actions_stdouterr_download_failed_upload_all() {
+  # --remote_build_event_upload=all must not try to upload the stdout/stderr that
+  # were never downloaded; they are already in the CAS.
+  write_stdouterr_genrule
+
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_build_event_upload=all \
+      --remote_download_stdouterr=failed \
+      --build_event_publish_all_actions \
+      --build_event_json_file=$BEP_JSON \
+      //a:foo >& $TEST_log || fail "Failed to build"
+
+  expect_not_log "Uploading BEP referenced local file"
+  expect_bes_action_stdouterr_in_cas "stdout" "some_stdout"
+  expect_bes_action_stdouterr_in_cas "stderr" "some_stderr"
 }
 
 run_suite "Remote build event uploader tests"


### PR DESCRIPTION
### Description
Adds a new flag `--remote_download_stdouterr` (`stdouterr` is to match `--experimental_ui_max_stdouterr_bytes`) to control downloading of action stdout and stderr.

To suite the various use cases, multiple options are available.
- `failed`: This is functionally a `none` option, as it matches the behavior of other action outputs under all configurations (barring usage of `--remote_download_symlink_template`) where outputs of failed actions are _always_ downloaded.
  - Fewest possible downloads when combined with `--remote_download_outputs=minimal`.
  - Implicitly reduces action log noise.
- `uncached`: Downloads stdout and stderr of all actions that actually ran. Implicitly includes failed actions (since failures are not cached).
  - An arbitrary split similar to `--test_summary=short_uncached|detailed_uncached`.
  - Number of downloads drops proportional to cache hit rate.
  - Implicitly reduces action log noise. May be useful for local development to put the focus on affected actions.
- `all`: The default and current behavior. All actions have their stdout and stderr downloaded.
  - Beyond being the default, keeping support for this is useful for integrations that require logs to be downloaded (none that I know of, but as the default I'm sure something is reliant on this).

A `toplevel` option was considered, but is more complicated to implement. Best implemented in a separate PR, if there is demand.

This does not affect the `test.log` (test action stdout/stderr) as it is required for generating `test.xml`. This limitation may be overcome with a refactor, however I am of the opinion that it would deserve it's own flag as `test.xml` and `test.log` are useful for integrating with existing test reporting systems, etc.

### Motivation
Ideally actions are silent, in practice however many log warnings (_very_ common for third party and even first-party C and C++).

In a CI setting this output is seldom viewed (mostly being regarded as log noise, which can be suppressed with UI filter flags), which makes the networking overhead hard to justify. This overhead can amount to significant load as the number of concurrent invocations increases (namely with `//...` builds).

Closes #19782

Note that a different take on this which modifies the behavior based on `--remote_download_outputs` has also been raised. #23223 This PR borrows the unit test implementation.

### Build API Changes

New command line flag `--remote_download_stdouterr` with options;
- `failed`
- `uncached`
- `all`

The flag itself has not been discussed, although the behavior (not downloading stdout and stderr of actions) has been discussed at #19782 and #23223.

Since the flag is not usable within builds (as part of a transition) it is backward compatible, although using the flag with older Bazel versions may result in an error (unrecognized flag).

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES[NEW]: Downloading of stdout and stderr of remotely executed non-test actions can now be disabled with `--remote_download_stdouterr`. Available options are `all` (default), `uncached` and `failed`.
