### PR TITLE
Fix grep for Unicode in invalid UTF-8

### DIFF
--- a/src/test/shell/integration/bazel_query_test.sh
+++ b/src/test/shell/integration/bazel_query_test.sh
@@ -1414,15 +1414,17 @@ EOF
   bazel query --output=proto //foo:without_select >& $TEST_log \
       || fail "Expected success"
 
+  # Force a C locale to ensure that grep matches the Unicode characters
+  # byte-by-byte even though the proto file is not valid UTF-8.
   for x in "${items[@]}"; do
-    grep -q "$x" $TEST_log || fail "Expected $x in query output for //foo:without_select"
+    LC_CTYPE=C grep -q "$x" $TEST_log || fail "Expected $x in query output for //foo:without_select"
   done
 
   bazel query --output=proto //foo:with_select >& $TEST_log \
       || fail "Expected success"
 
   for x in "${items[@]}"; do
-    grep -q "$x" $TEST_log || fail "Expected $x in query output for //foo:with_select"
+    LC_CTYPE=C grep -q "$x" $TEST_log || fail "Expected $x in query output for //foo:with_select"
   done
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
With `LC_CTYPE=C.UTF-8`, `grep` may silently stop matching if it encounters a file with invalid UTF-8 such as the raw proto output in `bazel_query_test`.


### Motivation
Fixes #28726

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
