### PR TITLE
Get the Java runtime tools to run on the minimum supported JDK

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -66,6 +66,8 @@ common --tool_java_runtime_version=remotejdk_25
 # TODO: Remove this after migrating more code to use VarHandles.
 common --javacopt=-Xlint:-removal
 common --host_javacopt=-Xlint:-removal
+# Use a bootclasspath version matching the language version.
+common --@rules_java//toolchains:incompatible_language_version_bootclasspath
 
 # Fail if a classpath contains different versions of the same class
 common --experimental_one_version_enforcement=ERROR

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/BazelTestRunner.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/BazelTestRunner.java
@@ -26,7 +26,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.junit.runner.Result;
 import sun.misc.Signal;
 
@@ -210,10 +210,10 @@ public class BazelTestRunner {
                     final List<Thread> nonDaemonAliveThreads =
                         Thread.getAllStackTraces().keySet().stream()
                             .filter(Thread::isAlive)
-                            .filter(Predicate.not(Thread::isDaemon))
-                            .filter(t -> t.threadId() != currentThread.threadId())
-                            .filter(t -> t.threadId() != mainThread.threadId())
-                            .toList();
+                            .filter(thread -> !thread.isDaemon())
+                            .filter(t -> t.getId() != currentThread.getId())
+                            .filter(t -> t.getId() != mainThread.getId())
+                            .collect(Collectors.toList());
 
                     if (nonDaemonAliveThreads.isEmpty()) {
                       return;

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/internal/StackTraces.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/internal/StackTraces.java
@@ -109,14 +109,14 @@ public class StackTraces {
                         && m.getParameterTypes()[0] == String.class
                         && m.getParameterTypes()[1].isEnum())
             .findFirst();
-    if (dumpThreadsMethod.isEmpty()) {
+    if (!dumpThreadsMethod.isPresent()) {
       return;
     }
     Optional<?> threadDumpFormatJson =
         Arrays.stream(dumpThreadsMethod.get().getParameterTypes()[1].getEnumConstants())
             .filter(e -> e.toString().equalsIgnoreCase("JSON"))
             .findFirst();
-    if (threadDumpFormatJson.isEmpty()) {
+    if (!threadDumpFormatJson.isPresent()) {
       return;
     }
     HotSpotDiagnosticMXBean diagnosticBean =

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BranchCoverage.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BranchCoverage.java
@@ -15,10 +15,10 @@
 package com.google.devtools.coverageoutputgenerator;
 
 import com.google.common.collect.ImmutableList;
+import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -343,7 +343,7 @@ final class BranchCoverage implements Iterable<Entry<BranchCoverageKey, BranchCo
         throw new NoSuchElementException();
       }
       Entry<BranchCoverageKey, BranchCoverageItem> result =
-          Map.entry(
+          new AbstractMap.SimpleImmutableEntry<>(
               BranchCoverageKey.create(
                   lineNumberKeyData[idx], blockIdKeyData[idx], branchIdKeyData[idx]),
               BranchCoverageItem.create(

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LineCoverage.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LineCoverage.java
@@ -16,6 +16,7 @@ package com.google.devtools.coverageoutputgenerator;
 
 import static java.lang.Math.max;
 
+import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Iterator;
@@ -120,7 +121,8 @@ final class LineCoverage implements Iterable<Entry<Integer, Long>> {
       if (!hasNext()) {
         throw new NoSuchElementException();
       }
-      Entry<Integer, Long> result = Map.entry(idx, lineExecutions[idx]);
+      Entry<Integer, Long> result =
+          new AbstractMap.SimpleImmutableEntry<>(idx, lineExecutions[idx]);
       advanceToNextInstrumentedLine();
       return result;
     }


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
The verification afforded by the `minimum_java_runtime_*` rules doesn't extend to the bootclasspath version without the incompatible flag, which masked this regression.


### Motivation
Observed that `bazel coverage` fails with a JDK 8 runtime with recent versions of rules_java.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
