### PR TITLE
[9.1.0] Ensure that `rctx.symlink` invalidates correctly if it is a copy (https://github.com/bazelbuild/bazel/pull/28682)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -112,7 +112,7 @@ public class WindowsFileSystem extends JavaIoFileSystem {
 
   @Override
   public boolean supportsSymbolicLinksNatively(PathFragment path) {
-    return false;
+    return createSymbolicLinks;
   }
 
   @Override

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -219,13 +219,19 @@ class TestBase(absltest.TestCase):
 
   def AssertFileContentContains(self, file_path, entry):
     with open(file_path, 'r') as f:
-      if entry not in f.read():
-        self.fail('File "%s" does not contain "%s"' % (file_path, entry))
+      content = f.read()
+      if entry not in content:
+        self.fail(
+            'File "%s" does not contain "%s":\n%s' % (file_path, entry, content)
+        )
 
   def AssertFileContentNotContains(self, file_path, entry):
     with open(file_path, 'r') as f:
-      if entry in f.read():
-        self.fail('File "%s" does contain "%s"' % (file_path, entry))
+      content = f.read()
+      if entry in content:
+        self.fail(
+            'File "%s" does contain "%s":\n%s' % (file_path, entry, content)
+        )
 
   def AssertPathIsSymlink(self, path):
     if self.IsWindows():


### PR DESCRIPTION
### Description
When `rctx.symlink` is implemented as a copy (on Windows with default settings), the target is now watched so that modifications to it are still seen through the fake "symlink".
Motivation

### Build API Changes
No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes
RELNOTES: `rctx.symlink` now implicitly watches the target if it falls back to a copy.

Closes #28682.

PiperOrigin-RevId: 873775628
Change-Id: I6bd9d38e19b20e3342802ab4a11acd319b7ac52f

Commit https://github.com/bazelbuild/bazel/commit/6dd6396737cf953159079cee20355ba6123c934b