### PR TITLE
Fix cross-compilation to Windows with clang MinGW

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ module(
 
 bazel_dep(name = "abseil-cpp", version = "20250814.1")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
-bazel_dep(name = "blake3", version = "1.8.2")
+bazel_dep(name = "blake3", version = "1.8.2.bcr.1")
 bazel_dep(name = "googleapis-grpc-java", version = "1.0.0")
 bazel_dep(name = "googleapis-java", version = "1.0.0")
 bazel_dep(name = "googleapis", version = "0.0.0-20250604-de157ca3")
@@ -42,7 +42,14 @@ bazel_dep(name = "zstd-jni", version = "1.5.6-9")
 # Depend on apple_support first and then rules_cc so that the Xcode toolchain
 # from apple_support wins over the generic Unix toolchain from rules_cc.
 bazel_dep(name = "apple_support", version = "1.24.5")
-bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "rules_cc")
+
+# rules_cc v0.2.17 is a transitive dependency, but causes Bazel tests to fail.
+# TODO: Remove this override when a fixed version of rules_cc is available.
+single_version_override(
+    module_name = "rules_cc",
+    version = "0.2.16",
+)
 
 # The starlark rules in @rules_cc are hidden behind macros but docgen needs to
 # load the rule class directly, so we need to expose the cc_compatibility_proxy

--- a/src/BUILD
+++ b/src/BUILD
@@ -191,6 +191,11 @@ copy_file(
 cc_binary(
     name = "read_manifest",
     srcs = ["read_manifest.cc"],
+    linkopts = select({
+        # MinGW requires -municode when using wmain.
+        "@rules_cc//cc/compiler:clang": ["-municode"],
+        "//conditions:default": [],
+    }),
     tags = ["manual"],
     target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//src/java_tools:__subpackages__"],
@@ -200,6 +205,11 @@ cc_binary(
 cc_binary(
     name = "write_manifest",
     srcs = ["write_manifest.cc"],
+    linkopts = select({
+        # MinGW requires -municode when using wmain.
+        "@rules_cc//cc/compiler:clang": ["-municode"],
+        "//conditions:default": [],
+    }),
     tags = ["manual"],
     target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//src/java_tools:__subpackages__"],

--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -215,6 +215,27 @@ selects.config_setting_group(
 )
 
 config_setting(
+    name = "windows_clang_cl",
+    constraint_values = ["@platforms//os:windows"],
+    flag_values = {"@rules_cc//cc/compiler:compiler": "clang-cl"},
+)
+
+config_setting(
+    name = "windows_msvc_cl",
+    constraint_values = ["@platforms//os:windows"],
+    flag_values = {"@rules_cc//cc/compiler:compiler": "msvc-cl"},
+)
+
+selects.config_setting_group(
+    name = "windows_msvc_like",
+    match_any = [
+        ":windows_clang_cl",
+        ":windows_msvc_cl",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "arm",
     constraint_values = ["@platforms//cpu:arm"],
     visibility = ["//visibility:public"],

--- a/src/main/cpp/BUILD
+++ b/src/main/cpp/BUILD
@@ -106,7 +106,7 @@ cc_binary(
         "//conditions:default": [],
     }),
     copts = select({
-        "//src/conditions:windows": ["/wd4018"],
+        "//src/conditions:windows_msvc_like": ["/wd4018"],
         "//conditions:default": ["-Wno-sign-compare"],
     }),
     linkopts = select({
@@ -168,8 +168,11 @@ cc_library(
         # and the double % get reduced down to 1 by the compiler. A
         # forward slash is used because \b is a special character,
         # backspace.
-        "//src/conditions:windows": [
+        "//src/conditions:windows_msvc_like": [
             "/DBAZEL_SYSTEM_BAZELRC_PATH#\\\"%%ProgramData%%/bazel.bazelrc\\\"",
+        ],
+        "@platforms//os:windows": [
+            "-DBAZEL_SYSTEM_BAZELRC_PATH=\\\"%%ProgramData%%/bazel.bazelrc\\\"",
         ],
         # For posix platforms, this can include environment variables in the
         # form ${var_name}. Braces are required.

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/license/merge_licenses.bzl
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/license/merge_licenses.bzl
@@ -12,32 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A platform-independent build rule that merges license files."""
-
-def _windows_action(ctx, files):
-    cmd = "(FOR %F IN (%SRCS%) DO ((SET X=%F)&ECHO ===== !X:\\=/! =====&TYPE %F&ECHO.&ECHO.)) > %OUT%"
-    ctx.actions.run(
-        inputs = depset(direct = files),
-        outputs = [ctx.outputs.out],
-        executable = "cmd.exe",
-        arguments = ["/V:ON", "/E:ON", "/Q", "/C", cmd],
-        env = {
-            "OUT": ctx.outputs.out.path.replace("/", "\\"),
-            "SRCS": " ".join([f.path.replace("/", "\\") for f in files]),
-        },
-    )
-
-def _bash_action(ctx, files):
-    cmd = "for f in $SRCS; do echo ===== $f ===== && cat $f && echo && echo ; done > $OUT"
-    ctx.actions.run_shell(
-        inputs = depset(direct = files),
-        outputs = [ctx.outputs.out],
-        command = cmd,
-        env = {
-            "OUT": ctx.outputs.out.path,
-            "SRCS": " ".join([f.path for f in files]),
-        },
-    )
+"""A build rule that merges license files."""
 
 def _impl(ctx):
     files = []
@@ -48,30 +23,23 @@ def _impl(ctx):
                 break
     if not files:
         fail("expected some sources")
-    if ctx.attr.is_windows:
-        _windows_action(ctx, files)
-    else:
-        _bash_action(ctx, files)
 
+    cmd = "for f in $SRCS; do echo ===== $f ===== && cat $f && echo && echo ; done > $OUT"
+    ctx.actions.run_shell(
+        inputs = depset(direct = files),
+        outputs = [ctx.outputs.out],
+        command = cmd,
+        env = {
+            "OUT": ctx.outputs.out.path,
+            "SRCS": " ".join([f.path for f in files]),
+        },
+    )
     return [DefaultInfo(files = depset(direct = [ctx.outputs.out]))]
 
-_merge_licenses = rule(
+merge_licenses = rule(
     implementation = _impl,
     attrs = {
         "srcs": attr.label_list(allow_files = True, mandatory = True),
         "out": attr.output(mandatory = True),
-        "is_windows": attr.bool(mandatory = True),
     },
 )
-
-def merge_licenses(name, srcs, out, **kwargs):
-    _merge_licenses(
-        name = name,
-        srcs = srcs,
-        out = out,
-        is_windows = select({
-            "@bazel_tools//src/conditions:windows": True,
-            "//conditions:default": False,
-        }),
-        **kwargs
-    )

--- a/src/tools/launcher/util/launcher_util.cc
+++ b/src/tools/launcher/util/launcher_util.cc
@@ -17,8 +17,6 @@
 #endif
 #include <windows.h>
 
-// For rand_s function, https://msdn.microsoft.com/en-us/library/sxtz2fa8.aspx
-#define _CRT_RAND_S
 #include <fcntl.h>
 #include <io.h>
 #include <stdarg.h>
@@ -27,8 +25,10 @@
 #include <string.h>
 
 #include <algorithm>
+#include <random>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 #include "src/main/cpp/util/path_platform.h"
 #include "src/main/native/windows/file.h"
@@ -200,17 +200,17 @@ bool SetEnv(const wstring& env_name, const wstring& value) {
   return SetEnvironmentVariableW(env_name.c_str(), value.c_str());
 }
 
-wstring GetRandomStr(size_t len) {
-  static const wchar_t alphabet[] =
-      L"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  wstring rand_str;
-  rand_str.reserve(len);
-  unsigned int x;
-  for (size_t i = 0; i < len; i++) {
-    rand_s(&x);
-    rand_str += alphabet[x % wcslen(alphabet)];
-  }
-  return rand_str;
+std::wstring GetRandomStr(size_t len) {
+    static constexpr std::wstring_view alphabet =
+        L"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    std::random_device rd;
+    std::uniform_int_distribution<size_t> dist(0, alphabet.size() - 1);
+    std::wstring rand_str;
+    rand_str.reserve(len);
+    for (size_t i = 0; i < len; ++i) {
+        rand_str += alphabet[dist(rd)];
+    }
+    return rand_str;
 }
 
 bool NormalizePath(const wstring& path, wstring* result) {

--- a/third_party/ijar/common.h
+++ b/third_party/ijar/common.h
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #define PATH_MAX 4096
 typedef int mode_t;
 #endif  // _WIN32

--- a/tools/cpp/modules_tools/BUILD
+++ b/tools/cpp/modules_tools/BUILD
@@ -29,11 +29,6 @@ config_setting(
     constraint_values = ["@platforms//os:windows"],
 )
 
-COPTS = select({
-    ":windows": ["/std:c++17"],
-    "//conditions:default": ["-std=c++17"],
-})
-
 cc_library(
     name = "common",
     srcs = [
@@ -43,7 +38,6 @@ cc_library(
         "common/common.h",
         "common/json.hpp",
     ],
-    copts = COPTS,
     includes = ["."],
 )
 
@@ -51,14 +45,12 @@ cc_library(
     name = "aggregate-ddi-lib",
     srcs = ["aggregate-ddi/aggregate-ddi.cc"],
     hdrs = ["aggregate-ddi/aggregate-ddi.h"],
-    copts = COPTS,
     deps = [":common"],
 )
 
 cc_binary(
     name = "aggregate-ddi",
     srcs = ["aggregate-ddi/main.cc"],
-    copts = COPTS,
     deps = [
         ":aggregate-ddi-lib",
     ],
@@ -68,14 +60,12 @@ cc_library(
     name = "generate-modmap-lib",
     srcs = ["generate-modmap/generate-modmap.cc"],
     hdrs = ["generate-modmap/generate-modmap.h"],
-    copts = COPTS,
     deps = [":common"],
 )
 
 cc_binary(
     name = "generate-modmap",
     srcs = ["generate-modmap/main.cc"],
-    copts = COPTS,
     deps = [":generate-modmap-lib"],
 )
 
@@ -92,7 +82,6 @@ filegroup(
 cc_test(
     name = "generate-modmap_test",
     srcs = ["generate-modmap/generate-modmap_test.cc"],
-    copts = COPTS,
     deps = [
         ":generate-modmap-lib",
         "@com_google_googletest//:gtest_main",
@@ -102,7 +91,6 @@ cc_test(
 cc_test(
     name = "aggregate-ddi_test",
     srcs = ["aggregate-ddi/aggregate-ddi_test.cc"],
-    copts = COPTS,
     deps = [
         ":aggregate-ddi-lib",
         "@com_google_googletest//:gtest_main",
@@ -112,7 +100,6 @@ cc_test(
 cc_test(
     name = "common_test",
     srcs = ["common/common_test.cc"],
-    copts = COPTS,
     deps = [
         ":common",
         "@com_google_googletest//:gtest_main",
@@ -122,7 +109,6 @@ cc_test(
 cc_test(
     name = "json_test",
     srcs = ["common/json_test.cc"],
-    copts = COPTS,
     deps = [
         ":common",
         "@com_google_googletest//:gtest_main",

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -43,6 +43,11 @@ filegroup(
 cc_binary(
     name = "tw",
     srcs = ["windows/tw_main.cc"],
+    linkopts = select({
+        # MinGW requires -municode when using wmain.
+        "@rules_cc//cc/compiler:clang": ["-municode"],
+        "//conditions:default": [],
+    }),
     target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//visibility:private"],
     deps = [":tw_lib"],
@@ -51,6 +56,11 @@ cc_binary(
 cc_binary(
     name = "xml",
     srcs = ["windows/xml_main.cc"],
+    linkopts = select({
+        # MinGW requires -municode when using wmain.
+        "@rules_cc//cc/compiler:clang": ["-municode"],
+        "//conditions:default": [],
+    }),
     target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//visibility:private"],
     deps = [":tw_lib"],


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
* Replace `select`s on flags for Windows with the appropriate compiler constraints. Also update `blake3`, which contains the same type of fix in its most recent version.
* Ditch the `cmd.exe` implementation of `merge_licenses` that incorrectly matched on the target rather than the exec platform. Bash is already a requirement for Bazel at this point, so we might as well use it.
* Drop the explicit C++17 standard flags since this is already the default standard in Bazel@HEAD.


### Motivation
Get Bazel to build with `clang` (not `clang-cl`) on Windows and non-Windows platforms.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
