### PR TITLE
[9.0.1] Prevent a Blaze crash when an aspect uses a test's TestRunner action.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/standalone/StandaloneModule.java
+++ b/src/main/java/com/google/devtools/build/lib/standalone/StandaloneModule.java
@@ -58,6 +58,11 @@ public class StandaloneModule extends BlazeModule {
 
     ExecutionOptions executionOptions = env.getOptions().getOptions(ExecutionOptions.class);
     TestSummaryOptions testSummaryOptions = env.getOptions().getOptions(TestSummaryOptions.class);
+    if (testSummaryOptions == null) {
+      // It is possible, though unlikely, that the test summary options have not been set.
+      // This can happen if a test runner is being run without the test command having been used.
+      testSummaryOptions = TestSummaryOptions.DEFAULTS;
+    }
     Path testTmpRoot =
         TestStrategy.getTmpRoot(env.getWorkspace(), env.getExecRoot(), executionOptions);
     TestActionContext testStrategy =

--- a/src/test/shell/integration/test_test.sh
+++ b/src/test/shell/integration/test_test.sh
@@ -532,4 +532,57 @@ function test_executable_in_symlinks_only_stateless_runfiles() {
   run_test_executable_in_symlinks_only "runfiles"
 }
 
+function test_test_runner_does_not_crash_in_build_command() {
+  # ensure Bazel gracefully handles the test runner action failing even
+  # if it's not running via "bazel test".
+  # See https://github.com/bazelbuild/bazel/issues/28697
+  add_rules_shell "MODULE.bazel"
+  local -r pkg=$FUNCNAME
+  mkdir -p $pkg || fail "mkdir -p $pkg failed"
+
+  cat >$pkg/aspect.bzl <<'EOF'
+def _test_aspect_impl(target, ctx):
+    test_runner_action = [a for a in target.actions if a.mnemonic == "TestRunner"][0]
+    return [OutputGroupInfo(
+        test_files = test_runner_action.outputs,
+    )]
+
+test_aspect = aspect(
+    implementation = _test_aspect_impl,
+)
+EOF
+
+  cat >$pkg/BUILD <<'EOF'
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+sh_test(
+    name = "success",
+    srcs = ["success.sh"],
+)
+
+sh_test(
+    name = "fail",
+    srcs = ["fail.sh"],
+)
+EOF
+  cat >$pkg/success.sh <<'EOF'
+#!/bin/sh
+
+echo "success.sh is successful"
+exit 0
+EOF
+  chmod +x $pkg/success.sh
+
+  cat >$pkg/fail.sh <<'EOF'
+#!/bin/sh
+
+echo "fail.sh failed"
+exit 1
+EOF
+  chmod +x $pkg/fail.sh
+
+  bazel build --aspects //$pkg:aspect.bzl%test_aspect --output_groups=test_files //$pkg:all \
+      || fail "expected build to succeed"
+}
+
 run_suite "test tests"


### PR DESCRIPTION
A niche, maybe not supported but shouldn't crash, case is an aspect that wants
to inspect and depend on the outputs of the TestRunner action of a test
target. If the aspect is applied but the build was not triggered via
"blaze test" and the test fails, Blaze crashes with a NPE. This is because the
test summary options have not been configured - they are only provided via the
test command.

We fix this by providing the default options if they have not been otherwise
provided.

Fixes https://github.com/bazelbuild/bazel/issues/28697

PiperOrigin-RevId: 872795731
Change-Id: I505fa019e050467dae83cc79b2474bb96f3ebb3e

Commit https://github.com/bazelbuild/bazel/commit/d6ab1fcebdcfff15a76c59924f159e065a28157a