### PR TITLE
[8.6.0] Only use workspace facts for validation with --lockfile_mode=error (h…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -148,21 +148,26 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     // Check the lockfile first for that module extension
     LockfileMode lockfileMode = BazelLockFileFunction.LOCKFILE_MODE.get(env);
     Facts lockfileFacts = Facts.EMPTY;
+    // Store workspace lockfile facts separately for validation in ERROR mode
+    Facts workspaceLockfileFacts = Facts.EMPTY;
     if (!lockfileMode.equals(LockfileMode.OFF)) {
       var lockfiles =
           env.getValuesAndExceptions(
               ImmutableList.of(BazelLockFileValue.KEY, BazelLockFileValue.HIDDEN_KEY));
-      BazelLockFileValue lockfile = (BazelLockFileValue) lockfiles.get(BazelLockFileValue.KEY);
+      BazelLockFileValue workspaceLockfile =
+          (BazelLockFileValue) lockfiles.get(BazelLockFileValue.KEY);
       BazelLockFileValue hiddenLockfile =
           (BazelLockFileValue) lockfiles.get(BazelLockFileValue.HIDDEN_KEY);
-      if (lockfile == null || hiddenLockfile == null) {
+      if (workspaceLockfile == null || hiddenLockfile == null) {
         return null;
       }
-      lockfileFacts = lockfile.getFacts().get(extensionId);
+      workspaceLockfileFacts = workspaceLockfile.getFacts().get(extensionId);
+      lockfileFacts = workspaceLockfileFacts;
       if (lockfileFacts == null) {
         lockfileFacts = hiddenLockfile.getFacts().getOrDefault(extensionId, Facts.EMPTY);
+        workspaceLockfileFacts = Facts.EMPTY;
       }
-      var lockedExtensionMap = lockfile.getModuleExtensions().get(extensionId);
+      var lockedExtensionMap = workspaceLockfile.getModuleExtensions().get(extensionId);
       var lockedExtension =
           lockedExtensionMap == null ? null : lockedExtensionMap.get(extension.getEvalFactors());
       if (lockedExtension == null) {
@@ -242,13 +247,16 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                   : " for platform " + extension.getEvalFactors()));
     }
     var newFacts = moduleExtensionMetadata.getFacts();
-    if (lockfileMode.equals(LockfileMode.ERROR) && !newFacts.equals(lockfileFacts)) {
+    // In ERROR mode, validate facts only against the workspace lockfile, not the hidden lockfile.
+    // The hidden lockfile may contain stale facts from a different version (e.g., after a
+    // rollback), which would cause false-positive validation errors.
+    if (lockfileMode.equals(LockfileMode.ERROR) && !newFacts.equals(workspaceLockfileFacts)) {
       String reason =
           "The extension '%s' has changed its facts: %s != %s"
               .formatted(
                   extensionId,
                   Starlark.repr(newFacts.value()),
-                  Starlark.repr(lockfileFacts.value()));
+                  Starlark.repr(workspaceLockfileFacts.value()));
       throw createOutdatedLockfileException(reason);
     }
 

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -3148,6 +3148,106 @@ class BazelLockfileTest(test_base.TestBase):
     facts = lockfile['facts']
     self.assertEqual(len(facts), 2)
 
+  def testFactsWithLockfileModeErrorAfterRollback(self):
+    """Test that ERROR mode doesn't fail when rolling back to a version without facts.
+
+    Regression test for https://github.com/bazelbuild/bazel/issues/28717
+
+    Simulates the scenario:
+    1. Build with extension that produces facts (e.g., rules_go 0.60.0)
+    2. Rollback to older version without facts (e.g., rules_go 0.50.1)
+    3. Build with --lockfile_mode=error should succeed, not fail with
+       "extension has changed its facts" error
+    """
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'lockfile_ext = use_extension("extension.bzl", "lockfile_ext")',
+            'use_repo(lockfile_ext, "hello")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def impl(ctx):',
+            '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
+            'repo_rule = repository_rule(',
+            '    implementation = impl,',
+            '    attrs = {"hash": attr.string()},',
+            ')',
+            'def _mod_ext_impl(ctx):',
+            '    print("Extension with facts")',
+            '    metadata = {"hello": {"hash": "olleh"}}',
+            '    repo_rule(',
+            '        name = "hello",',
+            '        hash = metadata["hello"]["hash"],',
+            '    )',
+            '    return ctx.extension_metadata(',
+            '        reproducible = True,',
+            '        facts = metadata,',
+            '    )',
+            'lockfile_ext = module_extension(implementation = _mod_ext_impl)',
+        ],
+    )
+
+    # Initial build with facts - creates both workspace and hidden lockfiles
+    self.RunBazel(['build', '@hello//:all', '--lockfile_mode=update'])
+
+    # Verify facts are in the lockfile
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read().strip())
+    self.assertIn('facts', lockfile)
+    extension_id = '//:extension.bzl%lockfile_ext'
+    self.assertIn(extension_id, lockfile['facts'])
+
+    # Verify ERROR mode works with facts present
+    self.RunBazel(['build', '@hello//:all', '--lockfile_mode=error'])
+
+    # Simulate rollback: change extension to not produce facts
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def impl(ctx):',
+            '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
+            'repo_rule = repository_rule(',
+            '    implementation = impl,',
+            '    attrs = {"hash": attr.string()},',
+            ')',
+            'def _mod_ext_impl(ctx):',
+            '    print("Extension without facts")',
+            '    repo_rule(',
+            '        name = "hello",',
+            '        hash = "olleh",',
+            '    )',
+            '    return ctx.extension_metadata(',
+            '        reproducible = True,',
+            '    )',
+            'lockfile_ext = module_extension(implementation = _mod_ext_impl)',
+        ],
+    )
+
+    # Simulate rollback: manually remove facts from workspace lockfile
+    # (as would happen when checking out an older commit)
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read().strip())
+    if extension_id in lockfile['facts']:
+      del lockfile['facts'][extension_id]
+    with open(self.Path('MODULE.bazel.lock'), 'w') as f:
+      json.dump(lockfile, f, indent=2)
+
+    # This should succeed without "has changed its facts" error
+    # Before the fix, this would fail because the hidden lockfile still has
+    # facts from the previous build, causing a false-positive validation error
+    exit_code, stdout, stderr = self.RunBazel(
+        ['build', '@hello//:all', '--lockfile_mode=error'], allow_failure=True
+    )
+    stderr = ''.join(stderr)
+    # Should succeed (exit code 0)
+    self.AssertExitCode(exit_code, 0, stderr, stdout)
+    # Should not have "has changed its facts" error
+    self.assertNotIn('has changed its facts', stderr)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
…ttps://github.com/bazelbuild/bazel/pull/28718)

When validating the facts in a lockfile with `--lockfile_mode=error`, only use the user-visible lockfile, not the hidden output root lockfile Fixes #28717

No

- [X] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES: Fix --lockfile_mode=error validation when rolling back changes to module extension facts

Closes #28718.

PiperOrigin-RevId: 874282163
Change-Id: I1479dcd6b756dc9d8b01183c4bfe15dd8700aeba

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/ce5f8ba8a7d3741c2e2fd3fe9a8b8aaa25de4ef6