### PR TITLE
[9.1.0] Only use workspace facts for validation with --lockfile_mode=error (h…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -139,21 +139,26 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     // Check the lockfile first for that module extension
     LockfileMode lockfileMode = BazelLockFileFunction.LOCKFILE_MODE.get(env);
     Facts lockfileFacts = Facts.EMPTY;
+    // Store workspace lockfile facts separately for validation in ERROR mode
+    Facts workspaceLockfileFacts = Facts.EMPTY;
     if (!lockfileMode.equals(LockfileMode.OFF)) {
       var lockfiles =
           env.getValuesAndExceptions(
               ImmutableList.of(BazelLockFileValue.KEY, BazelLockFileValue.HIDDEN_KEY));
-      BazelLockFileValue lockfile = (BazelLockFileValue) lockfiles.get(BazelLockFileValue.KEY);
+      BazelLockFileValue workspaceLockfile =
+          (BazelLockFileValue) lockfiles.get(BazelLockFileValue.KEY);
       BazelLockFileValue hiddenLockfile =
           (BazelLockFileValue) lockfiles.get(BazelLockFileValue.HIDDEN_KEY);
-      if (lockfile == null || hiddenLockfile == null) {
+      if (workspaceLockfile == null || hiddenLockfile == null) {
         return null;
       }
-      lockfileFacts = lockfile.getFacts().get(extensionId);
+      workspaceLockfileFacts = workspaceLockfile.getFacts().get(extensionId);
+      lockfileFacts = workspaceLockfileFacts;
       if (lockfileFacts == null) {
         lockfileFacts = hiddenLockfile.getFacts().getOrDefault(extensionId, Facts.EMPTY);
+        workspaceLockfileFacts = Facts.EMPTY;
       }
-      var lockedExtensionMap = lockfile.getModuleExtensions().get(extensionId);
+      var lockedExtensionMap = workspaceLockfile.getModuleExtensions().get(extensionId);
       var lockedExtension =
           lockedExtensionMap == null ? null : lockedExtensionMap.get(extension.getEvalFactors());
       if (lockedExtension == null) {
@@ -238,13 +243,16 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                   : " for platform " + extension.getEvalFactors()));
     }
     var newFacts = moduleExtensionMetadata.getFacts();
-    if (lockfileMode.equals(LockfileMode.ERROR) && !newFacts.equals(lockfileFacts)) {
+    // In ERROR mode, validate facts only against the workspace lockfile, not the hidden lockfile.
+    // The hidden lockfile may contain stale facts from a different version (e.g., after a
+    // rollback), which would cause false-positive validation errors.
+    if (lockfileMode.equals(LockfileMode.ERROR) && !newFacts.equals(workspaceLockfileFacts)) {
       String reason =
           "the extension '%s' has changed its facts: %s != %s"
               .formatted(
                   extensionId,
                   Starlark.repr(newFacts.value()),
-                  Starlark.repr(lockfileFacts.value()));
+                  Starlark.repr(workspaceLockfileFacts.value()));
       throw createOutdatedLockfileException(reason);
     }
 


### PR DESCRIPTION
…ttps://github.com/bazelbuild/bazel/pull/28718)

When validating the facts in a lockfile with `--lockfile_mode=error`, only use the user-visible lockfile, not the hidden output root lockfile Fixes #28717

No

- [X] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES: Fix --lockfile_mode=error validation when rolling back changes to module extension facts

Closes #28718.

PiperOrigin-RevId: 874282163
Change-Id: I1479dcd6b756dc9d8b01183c4bfe15dd8700aeba

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/ce5f8ba8a7d3741c2e2fd3fe9a8b8aaa25de4ef6