### PR TITLE
[9.1.0] Fix cross-platform `launcher_maker` actions (https://github.com/bazelbuild/bazel/pull/28746)

### DIFF
--- a/tools/build_defs.bzl
+++ b/tools/build_defs.bzl
@@ -31,6 +31,7 @@ _single_binary_toolchain_rule = rule(
     implementation = _single_binary_toolchain_rule_impl,
     attrs = {
         "binary": attr.label(
+            cfg = "exec",
             allow_single_file = True,
             mandatory = True,
         ),


### PR DESCRIPTION
### Description
The `launcher_maker` binary should be built for the exec platform when using the from-source toolchain.

### Motivation
Fixing Unix-to-Windows cross-platform builds.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #28746.

PiperOrigin-RevId: 874445666
Change-Id: I4cfe6133a442432b04bd701afe253b6cf2b49250

Commit https://github.com/bazelbuild/bazel/commit/aabad1a89a42837ff2e2e0284113314b99369ee2