### PR TITLE
Fix more `grep`s in `bazel_query_test`

### DIFF
--- a/src/test/shell/integration/bazel_query_test.sh
+++ b/src/test/shell/integration/bazel_query_test.sh
@@ -590,7 +590,9 @@ py_binary(
 EOF
   touch foo/main.py || fail "Could not touch foo/main.py"
 
-  bazel query --output=proto \
+  # Force a C locale to ensure that grep matches the characters byte-by-byte
+  # even though the proto file is not valid UTF-8.
+  LC_CTYPE=C bazel query --output=proto \
     '//foo:main.py' >& $TEST_log || fail "Expected success"
 
   expect_log "${TEST_TMPDIR}/.*/foo/main.py:1:1" $TEST_log
@@ -1441,7 +1443,9 @@ EOF
   echo "//foo:äöüÄÖÜß🌱" > my_query || fail "Could not write my_query"
   # Check that the unicode characters are preserved in the output.
   bazel query --output=proto --query_file=my_query >& $TEST_log || fail "Expected success"
-  expect_log "//foo:äöüÄÖÜß🌱"
+  # Force a C locale to ensure that grep matches the characters byte-by-byte
+  # even though the proto file is not valid UTF-8.
+  LC_CTYPE=C grep -q "//foo:äöüÄÖÜß🌱" $TEST_log || fail "Expected Unicode target in query output"
 }
 
 run_suite "${PRODUCT_NAME} query tests"


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
Since proto output is not valid UTF-8, these `grep`s need to run in a C locale. This was missed in #28727.


### Motivation
Fixes #28726

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
