### PR TITLE
[9.0.1] Fix clang warnings on Windows (https://github.com/bazelbuild/bazel/pull/28748)

### DIFF
--- a/src/main/cpp/util/errors_windows.cc
+++ b/src/main/cpp/util/errors_windows.cc
@@ -34,11 +34,10 @@ string GetLastErrorString() {
   }
 
   char* message_buffer;
-  size_t size = FormatMessageA(
-      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-          FORMAT_MESSAGE_IGNORE_INSERTS,
-      nullptr, last_error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-      (LPSTR)&message_buffer, 0, nullptr);
+  FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                     FORMAT_MESSAGE_IGNORE_INSERTS,
+                 nullptr, last_error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                 (LPSTR)&message_buffer, 0, nullptr);
 
   stringstream result;
   result << "(error: " << last_error << "): " << message_buffer;

--- a/src/main/native/windows/process.cc
+++ b/src/main/native/windows/process.cc
@@ -34,19 +34,6 @@ static std::wstring ToString(const T& e) {
   return s.str();
 }
 
-static bool DupeHandle(HANDLE h, AutoHandle* out, std::wstring* error) {
-  HANDLE dup;
-  if (!DuplicateHandle(GetCurrentProcess(), h, GetCurrentProcess(), &dup, 0,
-                       TRUE, DUPLICATE_SAME_ACCESS)) {
-    DWORD err = GetLastError();
-    *error =
-        MakeErrorMessage(WSTR(__FILE__), __LINE__, L"DupeHandle", L"", err);
-    return false;
-  }
-  *out = dup;
-  return true;
-}
-
 bool WaitableProcess::Create(const std::wstring& argv0,
                              const std::wstring& argv_rest, void* env,
                              const std::wstring& wcwd, std::wstring* error) {
@@ -113,7 +100,7 @@ bool WaitableProcess::Create(const std::wstring& argv0,
     return false;
   }
 
-  JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_info = {0};
+  JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_info = {};
   job_info.BasicLimitInformation.LimitFlags =
       JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
   if (!SetInformationJobObject(job_, JobObjectExtendedLimitInformation,

--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -278,7 +278,7 @@ class NativeProcess {
                                                   stdout_redirect, err_code);
         return false;
       }
-      if (!SetFilePointerEx(stdout_process, {0}, nullptr, FILE_END)) {
+      if (!SetFilePointerEx(stdout_process, {}, nullptr, FILE_END)) {
         DWORD err_code = GetLastError();
         error_ = bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
                                                   L"nativeCreateProcess",
@@ -339,7 +339,7 @@ class NativeProcess {
                                                   stderr_redirect, err_code);
         return false;
       }
-      if (!SetFilePointerEx(stderr_process, {0}, nullptr, FILE_END)) {
+      if (!SetFilePointerEx(stderr_process, {}, nullptr, FILE_END)) {
         DWORD err_code = GetLastError();
         error_ = bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
                                                   L"nativeCreateProcess",

--- a/src/tools/launcher/util/launcher_util.cc
+++ b/src/tools/launcher/util/launcher_util.cc
@@ -49,11 +49,10 @@ string GetLastErrorString() {
   }
 
   char* message_buffer;
-  size_t size = FormatMessageA(
-      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-          FORMAT_MESSAGE_IGNORE_INSERTS,
-      nullptr, last_error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-      (LPSTR)&message_buffer, 0, nullptr);
+  FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                     FORMAT_MESSAGE_IGNORE_INSERTS,
+                 nullptr, last_error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                 (LPSTR)&message_buffer, 0, nullptr);
 
   stringstream result;
   result << "(error: " << last_error << "): " << message_buffer;

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -921,7 +921,7 @@ bool AppendFileTo(const Path& file, const size_t total_size, HANDLE output) {
 // If the MIME type is unknown or an error occurs, the method returns
 // "application/octet-stream".
 std::string GetMimeType(const std::string& filename) {
-  static constexpr char* kDefaultMimeType = "application/octet-stream";
+  static constexpr const char* kDefaultMimeType = "application/octet-stream";
   std::string::size_type pos = filename.find_last_of('.');
   if (pos == std::string::npos) {
     return kDefaultMimeType;
@@ -1145,9 +1145,6 @@ bool PrintTestLogStartMarker() {
   return true;
 }
 
-inline bool GetWorkspaceName(std::wstring* result) {
-  return GetEnv(L"TEST_WORKSPACE", result) && !result->empty();
-}
 
 inline void ComputeRunfilePath(const std::wstring& test_workspace,
                                std::wstring* s) {
@@ -1232,24 +1229,6 @@ bool FindTestBinary(const Path& argv0, const Path& cwd, std::wstring test_path,
   return true;
 }
 
-bool CreateCommandLine(const Path& path, const std::wstring& args,
-                       std::unique_ptr<WCHAR[]>* result) {
-  // kMaxCmdline value: see lpCommandLine parameter of CreateProcessW.
-  static constexpr size_t kMaxCmdline = 32767;
-
-  if (path.Get().size() + args.size() > kMaxCmdline) {
-    LogErrorWithValue(__LINE__, L"Command is too long",
-                      path.Get().size() + args.size());
-    return false;
-  }
-
-  // Add an extra character for the final null-terminator.
-  result->reset(new WCHAR[path.Get().size() + args.size() + 1]);
-
-  wcsncpy(result->get(), path.Get().c_str(), path.Get().size());
-  wcsncpy(result->get() + path.Get().size(), args.c_str(), args.size() + 1);
-  return true;
-}
 
 bool StartSubprocess(const Path& path, const std::wstring& args,
                      const Path& outerr, std::unique_ptr<Tee>* tee,


### PR DESCRIPTION
### Description
Compiling with clang rather than MSVC generates more warnings on Windows, some of which point to legitimate logic bugs, memory safety issues or dead code.

### Motivation

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #28748.

PiperOrigin-RevId: 874450442
Change-Id: Ic3dd607333de761367d96950ad62a40479162a1b

Commit https://github.com/bazelbuild/bazel/commit/88b78b51af6c5eec32f62ebb1fcca0ea536ad25a