### PR TITLE
Drop `memoizedIsInitialized` from Protobuf gencode

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -105,6 +105,10 @@ single_version_override(
 # We need to package the lite runtime jar for Bazel's bootstrap build
 # 2. Partially revert of https://github.com/protocolbuffers/protobuf/commit/7ec5e19c0743b80c5097434a05cc0e972e7b4e7a
 # to support grpc
+# 3. Pull in the removal of the memoizedIsInitialized field for messages with no
+# required fields early. This reduces the memory usage of Bazel and avoids
+# spread in memory usage between Bazel and Blaze.
+# https://github.com/protocolbuffers/protobuf/blob/adf9e8b80fd10398b82e16c4ea72f2d2cffb0e9b/src/google/protobuf/compiler/java/full/message.cc#L884C1-L899C6
 single_version_override(
     module_name = "protobuf",
     patch_strip = 1,

--- a/third_party/protobuf.patch
+++ b/third_party/protobuf.patch
@@ -45,3 +45,34 @@ index 426bf9124..fd17ac96c 100644
  # Amalgamation #################################################################
  
  upb_amalgamation(
+diff --git a/src/google/protobuf/compiler/java/full/message.cc b/src/google/protobuf/compiler/java/full/message.cc
+index dd290f98c..1f100c568 100644
+--- a/src/google/protobuf/compiler/java/full/message.cc
++++ b/src/google/protobuf/compiler/java/full/message.cc
+@@ -842,7 +842,25 @@ void ImmutableMessageGenerator::GenerateIsInitialized(io::Printer* printer) {
+   // Memoizes whether the protocol buffer is fully initialized (has all
+   // required fields). -1 means not yet computed. 0 means false and 1 means
+   // true.
+-  printer->Print("private byte memoizedIsInitialized = -1;\n");
++
++  // If the message transitively has no required fields or extensions,
++  // isInitialized() is always true.
++  if (!HasRequiredFields(descriptor_)) {
++    printer->Print(
++        "/**\n"
++        "  * @deprecated This always returns true for this type as it \n"
++        "  *   does not transitively contain any required fields.\n"
++        "  */\n"
++        "@java.lang.Deprecated\n"
++        "@java.lang.Override\n"
++        "public final boolean isInitialized() {\n"
++        "  return true;\n"
++        "}\n"
++        "\n");
++    return;
++  }
++
++  printer->Print("private transient byte memoizedIsInitialized = -1;\n");
+   printer->Print(
+       "@java.lang.Override\n"
+       "public final boolean isInitialized() {\n");


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
This field is not relied on by Bazel and has been removed in the google3 version of Protobuf. Since it reduces the instance size of heavily used messages such as `Digest` and is necessary to align memory usage tests between OSS and google3 Bazel, this change applies a patch to remove the field ahead of its upstream removal.

### Motivation

Work towards #20478
Work towards #28734


### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
