### PR TITLE
[9.1.0] Support `patches` in `git_repository` registry sources (https://github.com/bazelbuild/bazel/pull/28597)

### DIFF
--- a/docs/external/registry.mdx
+++ b/docs/external/registry.mdx
@@ -111,7 +111,13 @@ field, which defaults to `archive`.
     *   The following fields are supported, and are directly forwarded to the
         underlying `git_repository` repo rule: `remote`, `commit`,
         `shallow_since`, `tag`, `init_submodules`, `verbose`, and
-        `strip_prefix`.
+        `strip_prefix`, `patch_strip`.
+    *   `patches`: A JSON object containing patch files to apply to the
+        cloned repository. The patch files are located under the
+        `/modules/$MODULE/$VERSION/patches` directory. The keys are the
+        patch file names, and the values are the integrity checksum of
+        the patch files. The patches are applied in the order they appear in
+        `patches`.
 *   If `type` is `local_path`, this module version is backed by a
     [`local_repository`](/rules/lib/repo/local#local_repository) repo rule;
     it's symlinked to a directory on local disk. It supports the following

--- a/site/en/external/registry.md
+++ b/site/en/external/registry.md
@@ -114,7 +114,13 @@ field, which defaults to `archive`.
     *   The following fields are supported, and are directly forwarded to the
         underlying `git_repository` repo rule: `remote`, `commit`,
         `shallow_since`, `tag`, `init_submodules`, `verbose`, and
-        `strip_prefix`.
+        `strip_prefix`, `patch_strip`.
+    *   `patches`: A JSON object containing patch files to apply to the
+        cloned repository. The patch files are located under the
+        `/modules/$MODULE/$VERSION/patches` directory. The keys are the
+        patch file names, and the values are the integrity checksum of
+        the patch files. The patches are applied in the order they appear in
+        `patches`.
 *   If `type` is `local_path`, this module version is backed by a
     [`local_repository`](/rules/lib/repo/local#local_repository) repo rule;
     it's symlinked to a directory on local disk. It supports the following

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
@@ -15,10 +15,12 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.List;
 import net.starlark.java.eval.Dict;
+import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.eval.StarlarkList;
 
 /**
@@ -74,11 +76,21 @@ public class GitRepoSpecBuilder {
   }
 
   @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setRemotePatches(ImmutableMap<String, String> remotePatches) {
+    return setAttr("remote_patches", remotePatches);
+  }
+
+  @CanIgnoreReturnValue
   public GitRepoSpecBuilder setRemoteModuleFile(
       ArchiveRepoSpecBuilder.RemoteFile remoteModuleFile) {
     setAttr("remote_module_file_urls", remoteModuleFile.urls());
     setAttr("remote_module_file_integrity", remoteModuleFile.integrity());
     return this;
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setRemotePatchStrip(int remotePatchStrip) {
+    return setAttr("remote_patch_strip", remotePatchStrip);
   }
 
   public RepoSpec build() {
@@ -104,6 +116,20 @@ public class GitRepoSpecBuilder {
     if (value != null && !value.isEmpty()) {
       attrBuilder.put(name, StarlarkList.immutableCopyOf(value));
     }
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  private GitRepoSpecBuilder setAttr(String name, ImmutableMap<?, ?> value) {
+    if (value != null && !value.isEmpty()) {
+      attrBuilder.put(name, Dict.immutableCopyOf(value));
+    }
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  private GitRepoSpecBuilder setAttr(String name, int value) {
+    attrBuilder.put(name, StarlarkInt.of(value));
     return this;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -291,6 +291,8 @@ public class IndexRegistry implements Registry {
     String tag;
     boolean initSubmodules;
     boolean verbose;
+    Map<String, String> patches;
+    int patchStrip;
     String stripPrefix;
   }
 
@@ -380,7 +382,7 @@ public class IndexRegistry implements Registry {
             parseJson(jsonString.get(), jsonUrl, GitRepoSourceJson.class);
         var moduleFileUrl = constructModuleFileUrl(key);
         var moduleFileChecksum = moduleFileHashes.get(moduleFileUrl).get();
-        return createGitRepoSpec(typedSourceJson, moduleFileUrl, moduleFileChecksum);
+        return createGitRepoSpec(typedSourceJson, moduleFileUrl, moduleFileChecksum, key);
       }
       default ->
           throw new IOException(
@@ -525,7 +527,7 @@ public class IndexRegistry implements Registry {
         .setUrls(urls.build())
         .setIntegrity(sourceJson.integrity)
         .setStripPrefix(Strings.nullToEmpty(sourceJson.stripPrefix))
-        .setRemotePatches(remotePatches.buildOrThrow())
+        .setRemotePatches(remotePatches.buildKeepingLast())
         .setOverlay(overlay)
         .setRemoteModuleFile(
             new RemoteFile(
@@ -536,7 +538,26 @@ public class IndexRegistry implements Registry {
   }
 
   private RepoSpec createGitRepoSpec(
-      GitRepoSourceJson sourceJson, String moduleFileUrl, Checksum moduleFileChecksum) {
+      GitRepoSourceJson sourceJson,
+      String moduleFileUrl,
+      Checksum moduleFileChecksum,
+      ModuleKey key) {
+    // Build remote patches as key-value pairs of "url" => "integrity".
+    ImmutableMap.Builder<String, String> remotePatches = new ImmutableMap.Builder<>();
+    if (sourceJson.patches != null) {
+      for (Map.Entry<String, String> entry : sourceJson.patches.entrySet()) {
+        remotePatches.put(
+            constructUrl(
+                getUrl(),
+                "modules",
+                key.name(),
+                key.version().toString(),
+                "patches",
+                entry.getKey()),
+            entry.getValue());
+      }
+    }
+
     return new GitRepoSpecBuilder()
         .setRemote(sourceJson.remote)
         .setCommit(sourceJson.commit)
@@ -548,6 +569,8 @@ public class IndexRegistry implements Registry {
         .setRemoteModuleFile(
             new RemoteFile(
                 moduleFileChecksum.toSubresourceIntegrity(), ImmutableList.of(moduleFileUrl)))
+        .setRemotePatches(remotePatches.buildKeepingLast())
+        .setRemotePatchStrip(sourceJson.patchStrip)
         .build();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -333,7 +333,11 @@ public class IndexRegistryTest extends FoundationTestCase {
         {
             "type": "git_repository",
             "remote": "https://github.com/raspberrypi/pico-sdk.git",
-            "commit": "4b6e647590213f253f2789ad9026df1d00f38c5d"
+            "commit": "4b6e647590213f253f2789ad9026df1d00f38c5d",
+            "patches": {
+                "foo.patch": "sha256-totallyarealhash"
+            },
+            "patch_strip": 1
         }
         """);
     server.serve("/modules/foo/1.0/MODULE.bazel", "module(name = \"foo\", version = \"1.0\")");
@@ -365,6 +369,11 @@ public class IndexRegistryTest extends FoundationTestCase {
                         sha256("module(name = \"foo\", version = \"1.0\")")
                             .toSubresourceIntegrity(),
                         ImmutableList.of(server.getUrl() + "/modules/foo/1.0/MODULE.bazel")))
+                .setRemotePatches(
+                    ImmutableMap.of(
+                        server.getUrl() + "/modules/foo/1.0/patches/foo.patch",
+                        "sha256-totallyarealhash"))
+                .setRemotePatchStrip(1)
                 .build());
   }
 


### PR DESCRIPTION
Closes #22857.

Closes #28597.

PiperOrigin-RevId: 874069887
Change-Id: I518fae15e9d099425ae24f90a10fa1ee5c2bc909

Commit https://github.com/bazelbuild/bazel/commit/f12c6cec35c3864738dc7c49e03083b059ee6c06