### PR TITLE
Fixed bug with cquery not returning error code on failure

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/PostAnalysisQueryProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/PostAnalysisQueryProcessor.java
@@ -237,8 +237,35 @@ public abstract class PostAnalysisQueryProcessor<T> implements BuildTool.Analysi
       env.getReporter().handle(Event.info("Empty query results"));
     }
     callback.start();
-    callback.process(aggregateResultsCallback.getResult());
-    callback.close(/* failFast= */ !result.getSuccess());
+    QueryException processQueryException = null;
+    InterruptedException processInterruptedException = null;
+    try {
+      callback.process(aggregateResultsCallback.getResult());
+    } catch (QueryException e) {
+      processQueryException = e;
+    } catch (InterruptedException e) {
+      processInterruptedException = e;
+    } finally {
+      try {
+        callback.close(/* failFast= */ !result.getSuccess());
+      } catch (InterruptedException | IOException closeException) {
+        if (processQueryException != null) {
+          processQueryException.addSuppressed(closeException);
+        } else if (processInterruptedException != null) {
+          processInterruptedException.addSuppressed(closeException);
+        } else if (closeException instanceof InterruptedException interruptedException) {
+          throw interruptedException;
+        } else {
+          throw (IOException) closeException;
+        }
+      }
+    }
+    if (processQueryException != null) {
+      throw processQueryException;
+    }
+    if (processInterruptedException != null) {
+      throw processInterruptedException;
+    }
 
     queryRuntimeHelper.afterQueryOutputIsWritten();
   }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
@@ -219,7 +219,21 @@ public class StarlarkOutputFormatterCallback extends CqueryThreadsafeCallback {
   }
 
   @Override
+  public void process(Iterable<CqueryNode> partialResult) throws QueryException, InterruptedException {
+    if (formatTargets(partialResult)) {
+      throw new QueryException(
+          "Starlark evaluation failed while formatting cquery results",
+          ConfigurableQuery.Code.STARLARK_EVAL_ERROR);
+    }
+  }
+
+  @Override
   public void processOutput(Iterable<CqueryNode> partialResult) throws InterruptedException {
+    formatTargets(partialResult);
+  }
+
+  private boolean formatTargets(Iterable<CqueryNode> partialResult) throws InterruptedException {
+    boolean sawEvaluationError = false;
     for (CqueryNode target : partialResult) {
       try {
         StarlarkThread thread =
@@ -237,8 +251,10 @@ public class StarlarkOutputFormatterCallback extends CqueryThreadsafeCallback {
                 String.format(
                     "Starlark evaluation error for %s: %s",
                     target.getOriginalLabel(), ex.getMessageWithStack())));
+        sawEvaluationError = true;
         continue;
       }
     }
+    return sawEvaluationError;
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/BUILD
@@ -166,6 +166,29 @@ java_test(
 )
 
 java_test(
+    name = "StarlarkOutputFormatterCallbackTest",
+    size = "medium",
+    srcs = ["StarlarkOutputFormatterCallbackTest.java"],
+    jvm_flags = [
+        "-Djava.lang.Thread.allowVirtualThreads=true",
+    ],
+    shard_count = 4,
+    deps = [
+        ":configured_target_query_helper",
+        ":configured_target_query_test",
+        "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/query2",
+        "//src/main/java/com/google/devtools/build/lib/query2/common:cquery-node",
+        "//src/main/java/com/google/devtools/build/lib/query2/engine",
+        "//src/main/java/net/starlark/java/eval",
+        "//src/main/protobuf:failure_details_java_proto",
+        "//src/test/java/com/google/devtools/build/lib/analysis/util",
+        "//third_party:guava",
+        "//third_party:junit4",
+    ],
+)
+
+java_test(
     name = "TransitionsOutputFormatterTest",
     size = "medium",
     srcs = ["TransitionsOutputFormatterTest.java"],

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallbackTest.java
@@ -1,0 +1,78 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.query2.cquery;
+
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.eventbus.EventBus;
+import com.google.devtools.build.lib.events.Reporter;
+import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment;
+import com.google.devtools.build.lib.query2.common.CqueryNode;
+import com.google.devtools.build.lib.query2.engine.QueryExpression;
+import com.google.devtools.build.lib.query2.engine.QueryException;
+import com.google.devtools.build.lib.query2.engine.QueryParser;
+import com.google.devtools.build.lib.query2.engine.QueryUtil;
+import com.google.devtools.build.lib.query2.engine.QueryUtil.AggregateAllOutputFormatterCallback;
+import com.google.devtools.build.lib.server.FailureDetails.ConfigurableQuery.Code;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import net.starlark.java.eval.StarlarkSemantics;
+import org.junit.Test;
+
+/** Tests cquery's Starlark output formatter. */
+public final class StarlarkOutputFormatterCallbackTest extends ConfiguredTargetQueryTest {
+
+  @Test
+  public void evalErrorFailsQuery() throws Exception {
+    writeFile(
+        "test/BUILD",
+        """
+        filegroup(
+            name = "foo",
+            srcs = [],
+        )
+        """);
+
+    CqueryOptions options = new CqueryOptions();
+    options.file = "";
+    options.expr = "build_options()";
+
+    QueryExpression expression = QueryParser.parse("//test:foo", getDefaultFunctions());
+    Set<String> targetPatternSet = new LinkedHashSet<>();
+    expression.collectTargetPatterns(targetPatternSet);
+    PostAnalysisQueryEnvironment<CqueryNode> env =
+        ((ConfiguredTargetQueryHelper) helper).getPostAnalysisQueryEnvironment(targetPatternSet);
+
+    StarlarkOutputFormatterCallback callback =
+        new StarlarkOutputFormatterCallback(
+            new Reporter(new EventBus()),
+            options,
+            new PrintStream(new ByteArrayOutputStream()),
+            getHelper().getSkyframeExecutor(),
+            env.getAccessor(),
+            StarlarkSemantics.DEFAULT);
+
+    AggregateAllOutputFormatterCallback<CqueryNode, Set<CqueryNode>> aggregateResultsCallback =
+        QueryUtil.newOrderedAggregateAllOutputFormatterCallback(env);
+    env.evaluateQuery(expression, aggregateResultsCallback);
+
+    QueryException e =
+        assertThrows(
+            QueryException.class, () -> callback.process(aggregateResultsCallback.getResult()));
+    assertConfigurableQueryCode(e.getFailureDetail(), Code.STARLARK_EVAL_ERROR);
+  }
+}

--- a/src/test/shell/integration/configured_query_test.sh
+++ b/src/test/shell/integration/configured_query_test.sh
@@ -1259,17 +1259,17 @@ py_library(
 EOF
 
   bazel cquery "//$pkg:foo" --output=starlark \
-    --starlark:expr="build_options(False)" > output 2>"$TEST_log" || fail "Expected success"
+    --starlark:expr="build_options(False)" > output 2>"$TEST_log" && fail "Expected failure"
 
   assert_contains "Error in build_options: in call to build_options()" "$TEST_log"
 
   bazel cquery "//$pkg:foo" --output=starlark \
-    --starlark:expr="build_options()" > output 2>"$TEST_log" || fail "Expected success"
+    --starlark:expr="build_options()" > output 2>"$TEST_log" && fail "Expected failure"
 
   assert_contains "build_options() missing 1 required positional argument: target" "$TEST_log"
 
   bazel cquery "//$pkg:foo" --output=starlark \
-    --starlark:expr="build_options(target, 'blah')" > output 2>"$TEST_log" || fail "Expected success"
+    --starlark:expr="build_options(target, 'blah')" > output 2>"$TEST_log" && fail "Expected failure"
 
   assert_contains "build_options() accepts no more than 1 positional argument but got 2" "$TEST_log"
 }

--- a/src/test/shell/integration/configured_query_test.sh
+++ b/src/test/shell/integration/configured_query_test.sh
@@ -979,7 +979,7 @@ EOF
 
   bazel cquery "//$pkg:all" --output=starlark \
     --starlark:expr="str(target.label) + '%' + str(providers(target)['DefaultInfo'].files.to_list()[1].is_directory)" \
-    > output 2>"$TEST_log" || fail "Expected success"
+    > output 2>"$TEST_log" && fail "Expected failure"
 
   assert_contains "//$pkg:pylibtwo%False" output
   # pylib evaluation will fail, as it has only one output file.
@@ -1007,7 +1007,7 @@ def format(t):
 EOF
 
   bazel cquery "//$pkg:all" --output=starlark --starlark:file="$pkg/outfunc_isdir.bzl" \
-    >output 2>"$TEST_log" || fail "Expected success"
+    >output 2>"$TEST_log" && fail "Expected failure"
 
   assert_contains "//$pkg:pylibtwo%False" output
   # pylib evaluation will fail, as it has only one output file.


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
There is a bug in the cquery command where the command will exit with a 0 exit code even if the command fails at any step along the way (e.g. while fetching a dependency). In this PR, I override the `process` function to throw a clear starlark eval error.

### Motivation
Fixes #21466. This will fix a bug in the cquery command. Currently the only way to detect a failure of a cquery command that uses `starlark:expr` is by parsing the stdout of the command and search for errors, which can be quite flaky.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Fixes a bug in cquery where `starlark:expr` failures were being ignored for the status code
