### PR TITLE
[9.1.0] Drop `memoizedIsInitialized` from Protobuf gencode (https://github.com/bazelbuild/bazel/pull/28776)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -104,6 +104,10 @@ single_version_override(
 # We need to package the lite runtime jar for Bazel's bootstrap build
 # 2. Partially revert of https://github.com/protocolbuffers/protobuf/commit/7ec5e19c0743b80c5097434a05cc0e972e7b4e7a
 # to support grpc
+# 3. Pull in the removal of the memoizedIsInitialized field for messages with no
+# required fields early. This reduces the memory usage of Bazel and avoids
+# spread in memory usage between Bazel and Blaze.
+# https://github.com/protocolbuffers/protobuf/blob/adf9e8b80fd10398b82e16c4ea72f2d2cffb0e9b/src/google/protobuf/compiler/java/full/message.cc#L884C1-L899C6
 single_version_override(
     module_name = "protobuf",
     patch_strip = 1,

--- a/third_party/protobuf.patch
+++ b/third_party/protobuf.patch
@@ -45,3 +45,34 @@ index 426bf9124..fd17ac96c 100644
  # Amalgamation #################################################################
  
  upb_amalgamation(
+diff --git a/src/google/protobuf/compiler/java/full/message.cc b/src/google/protobuf/compiler/java/full/message.cc
+index dd290f98c..1f100c568 100644
+--- a/src/google/protobuf/compiler/java/full/message.cc
++++ b/src/google/protobuf/compiler/java/full/message.cc
+@@ -842,7 +842,25 @@ void ImmutableMessageGenerator::GenerateIsInitialized(io::Printer* printer) {
+   // Memoizes whether the protocol buffer is fully initialized (has all
+   // required fields). -1 means not yet computed. 0 means false and 1 means
+   // true.
+-  printer->Print("private byte memoizedIsInitialized = -1;\n");
++
++  // If the message transitively has no required fields or extensions,
++  // isInitialized() is always true.
++  if (!HasRequiredFields(descriptor_)) {
++    printer->Print(
++        "/**\n"
++        "  * @deprecated This always returns true for this type as it \n"
++        "  *   does not transitively contain any required fields.\n"
++        "  */\n"
++        "@java.lang.Deprecated\n"
++        "@java.lang.Override\n"
++        "public final boolean isInitialized() {\n"
++        "  return true;\n"
++        "}\n"
++        "\n");
++    return;
++  }
++
++  printer->Print("private transient byte memoizedIsInitialized = -1;\n");
+   printer->Print(
+       "@java.lang.Override\n"
+       "public final boolean isInitialized() {\n");


### PR DESCRIPTION
### Description
This field is not relied on by Bazel and has been removed in Google's internal version of Protobuf. Since it reduces the instance size of heavily used messages such as `Digest` and is necessary to align memory usage tests between Bazel and Blaze, this change applies a patch to remove the field ahead of its upstream removal.

### Motivation

Work towards #20478
Work towards #28734

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #28776.

PiperOrigin-RevId: 875139304
Change-Id: If823229d41f493b38b2fb89f68ca0991754e898c

Commit https://github.com/bazelbuild/bazel/commit/67e6aa559f3fac6ae4215a5c2749df205721b1b8