### PR TITLE
[9.1.0] Reduce Merkle tree footprint by using an `ImmutableSortedMap` (https://github.com/bazelbuild/bazel/pull/28735)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.remote.util;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Comparator.comparing;
 
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.Digest;
@@ -31,13 +32,19 @@ import com.google.devtools.build.lib.vfs.DigestUtils;
 import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.XattrProvider;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.Comparator;
 
 /** Utility methods to work with {@link Digest}. */
 public class DigestUtil {
+  public static final Comparator<Digest> DIGEST_COMPARATOR =
+      comparing(Digest::getHashBytes, ByteString.unsignedLexicographicalComparator())
+          .thenComparing(Digest::getSizeBytes);
+
   private final XattrProvider xattrProvider;
   private final DigestHashFunction hashFn;
   private final DigestFunction.Value digestFunction;

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -806,46 +806,41 @@ public class RemoteExecutionServiceTest {
     // little memory as possible since they are kept in memory during the whole remote execution.
     // Memory usage isn't expected to differ by seed, so only check for one of them.
     if (seed == 1) {
-      var merkleTree =
-          service
-              .buildRemoteAction(spawn, context, MerkleTreeComputer.BlobPolicy.KEEP)
-              .getMerkleTree();
-      assertThat(merkleTree).isInstanceOf(MerkleTree.Uploadable.class);
-      // These are roots that are already retained while a remote action is being executed or are
-      // effectively global singletons.
-      var otherInput = ActionsTestUtil.createArtifact(artifactRoot, "some/other/input/file.txt");
-      fakeFileCache.createScratchInput(otherInput, "some other content");
-      var otherSpawn = new SpawnBuilder().withInput(otherInput).withOutput("foo").build();
-      var someOtherMerkleTree =
-          service.buildRemoteAction(otherSpawn, newSpawnExecutionContext(otherSpawn));
-
       // JOL tracks objects by their native address, so run GC to minimize noise from moved objects.
       System.gc();
-      var alreadyRetainedObjects =
-          GraphLayout.parseInstance(spawn, fakeFileCache, digestUtil, someOtherMerkleTree);
-      // This covers objects internal to JOL itself as well as metadata lazily attached to classes
-      // related to MerkleTree. Note that this has to be computed in a separate parseInstance call
-      // since the first call on someOtherMerkleTree may thus not have captured the metadata
-      // attached to the Class objects it references (e.g. cached field lists).
-      var jolInternalObjects =
-          GraphLayout.parseInstance(alreadyRetainedObjects, someOtherMerkleTree);
-      var merkleTreeTransitiveRetention = GraphLayout.parseInstance(merkleTree);
-
-      var merkleTreeOnlyRetention =
-          merkleTreeTransitiveRetention
-              .subtract(alreadyRetainedObjects)
-              .subtract(jolInternalObjects);
-      // Output the objects that are transitively retained by merkleTreeTransitiveRetention but
-      // neither by alreadyRetainedObjects nor jolInternalObjects for manual inspection.
+      // Keep building a Merkle tree and compute its retained size relative to all previous trees
+      // until the size stabilizes. The goal is to compute the size of the objects that are uniquely
+      // retained by the tree, as this is the effective overhead at runtime when building many trees
+      // in parallel. This is more delicate than it seems:
+      // 1. This has to be done in a loop since objects retain their respective Class and JOL's use
+      //    of reflection mutates the various caches in the Class objects in non-deterministic ways.
+      // 2. Subtracting previous trees is only correct under the assumption that the objects shared
+      //    with such trees would also be retained elsewhere (e.g. Artifact objects). If MerkleTree
+      //    ever uses techniques such as interning or weak caches, this strategy would have to be
+      //    revisited.
+      GraphLayout merkleTreeUniqueRetention;
+      var previousRoots = new ArrayList<>();
+      long stableRetainedSize = -1;
+      while (true) {
+        var merkleTree =
+            service
+                .buildRemoteAction(spawn, context, MerkleTreeComputer.BlobPolicy.KEEP)
+                .getMerkleTree();
+        assertThat(merkleTree).isInstanceOf(MerkleTree.Uploadable.class);
+        merkleTreeUniqueRetention =
+            GraphLayout.parseInstance(merkleTree)
+                .subtract(GraphLayout.parseInstance(previousRoots));
+        if (merkleTreeUniqueRetention.totalSize() == stableRetainedSize) {
+          break;
+        }
+        stableRetainedSize = merkleTreeUniqueRetention.totalSize();
+        previousRoots.add(merkleTree);
+      }
       var footprintOut =
           Paths.get(System.getenv("TEST_UNDECLARED_OUTPUTS_DIR"), "merkle_tree_footprint.txt");
-      Files.writeString(footprintOut, merkleTreeOnlyRetention.toFootprint());
+      Files.writeString(footprintOut, merkleTreeUniqueRetention.toFootprint());
       // TODO: Get this number down.
-      // TODO: Assert the size exactly after switching to an ImmutableSortedMap rather than an
-      //       ImmutableMap - proto messages don't have deterministic hash codes, which makes the
-      //       exact size vary slightly between runs.
-      assertThat(merkleTreeOnlyRetention.totalSize()).isAtLeast(8400);
-      assertThat(merkleTreeOnlyRetention.totalSize()).isAtMost(9500);
+      assertThat(stableRetainedSize).isEqualTo(7872);
     }
   }
 


### PR DESCRIPTION
### Description

An `ImmutableSortedMap` uses less memory than an `ImmutableMap` and access performance is masked by network I/O anyway. A secondary benefit is that memory usage becomes deterministic.

This includes pulling in a memory optimization to protobuf via a patch that is already active in the internal code base version, thereby reducing the instance size of `Digest` to 32 bytes.

### Motivation
Work towards #20478
Work towards #28734

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #28735.

PiperOrigin-RevId: 875593085
Change-Id: Id8b1304b6835024a36287a42f115c7ec47d3b99a

Commit https://github.com/bazelbuild/bazel/commit/0b59d801148d1423d590fc8a2534d4dd844859f6