### PR TITLE
[9.1.0] Reduce lock contention in the loading phase (https://github.com/bazelbuild/bazel/pull/28665)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryDefinitionLocationEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryDefinitionLocationEvent.java
@@ -16,21 +16,5 @@ package com.google.devtools.build.lib.bazel.repository.starlark;
 import com.google.devtools.build.lib.events.ExtendedEventHandler.Postable;
 
 /** Event reporting about the place where a Starlark repository rule was defined. */
-public final class StarlarkRepositoryDefinitionLocationEvent implements Postable {
-
-  private final String name;
-  private final String definitionInformation;
-
-  public StarlarkRepositoryDefinitionLocationEvent(String name, String definitionInformation) {
-    this.name = name;
-    this.definitionInformation = definitionInformation;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public String getDefinitionInformation() {
-    return definitionInformation;
-  }
-}
+public record StarlarkRepositoryDefinitionLocationEvent(String name, String definitionInformation)
+    implements Postable {}


### PR DESCRIPTION
Profiling `bazel build //src:bazel-dev --nobuild` with `--experimental_command_profile=lock` revealed between 2.5s and 10s of total thread wait time in repo rule related event handling. #28661 already reduces that time by a fair amount and this PR makes the profile fully flat.

Benchmarks indicate a ~2-3% improvement in wall time:

```shell
$ hyperfine --prepare './{bazel} clean --expunge' './{bazel} build //src:bazel-dev --nobuild' --warmup 1 --runs 5 --parameter-list bazel bazel-after,bazel-before
Benchmark 1: ../bazel-truffle/bazel-after build //src:bazel-dev --nobuild
  Time (mean ± σ):      4.191 s ±  0.066 s    [User: 0.029 s, System: 0.026 s]
  Range (min … max):    4.109 s …  4.264 s    5 runs

Benchmark 2: ../bazel-truffle/bazel-before build //src:bazel-dev --nobuild
  Time (mean ± σ):      4.292 s ±  0.171 s    [User: 0.029 s, System: 0.025 s]
  Range (min … max):    4.124 s …  4.520 s    5 runs

Summary
  ../bazel-truffle/bazel-after build //src:bazel-dev --nobuild ran
    1.02 ± 0.04 times faster than ../bazel-truffle/bazel-before build //src:bazel-dev --nobuild
```

Closes #28665.

PiperOrigin-RevId: 875172188
Change-Id: I7305be6268486b509abbf78bbf86140ed16f473d

Commit https://github.com/bazelbuild/bazel/commit/20620cfafa7af436242bc757869c6592603ed069