### PR TITLE
[9.1.0] Fix VirtualActionInput pipe thread naming (https://github.com/bazelbuild/bazel/pull/28414)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
@@ -227,7 +227,7 @@ public class RemoteExecutionCache extends CombinedCache implements MerkleTreeUpl
     @SuppressWarnings("AllowVirtualThreads")
     private static final ExecutorService VIRTUAL_ACTION_INPUT_PIPE_EXECUTOR =
         Executors.newThreadPerTaskExecutor(
-            Thread.ofVirtual().name("virtual-action-input-pipe-0").factory());
+            Thread.ofVirtual().name("virtual-action-input-pipe-", 0).factory());
 
     @Override
     public InputStream get() {


### PR DESCRIPTION
Closes #28414.

PiperOrigin-RevId: 861620869
Change-Id: I1eb4cfd4b74f85f047ee8f1b1e352d2ce4676af0

Commit https://github.com/bazelbuild/bazel/commit/21fcb6843885b845d4747771870d3dba55f8d635