### PR TITLE
[9.1.0] Reduce Merkle tree footprint by lazily converting to `Path`s (https:/…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -17,10 +17,10 @@ import build.bazel.remote.execution.v2.Digest;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
-import com.google.devtools.build.lib.vfs.Path;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -80,7 +80,7 @@ public sealed interface MerkleTree {
    */
   final class Uploadable implements MerkleTree {
     private final RootOnly.BlobsUploaded root;
-    private final ImmutableSortedMap<Digest, /* byte[] | Path | VirtualActionInput */ Object> blobs;
+    private final ImmutableSortedMap<Digest, /* byte[] | ActionInput */ Object> blobs;
 
     Uploadable(RootOnly.BlobsUploaded root, SortedMap<Digest, Object> blobs) {
       this.root = root;
@@ -130,10 +130,22 @@ public sealed interface MerkleTree {
         Digest digest) {
       return switch (blobs.get(digest)) {
         case byte[] data -> Optional.of(uploader.uploadBlob(context, digest, data));
-        case Path path ->
-            Optional.of(uploader.uploadFile(context, remotePathResolver, digest, path));
         case VirtualActionInput virtualActionInput ->
             Optional.of(uploader.uploadVirtualActionInput(context, digest, virtualActionInput));
+        case ActionInput actionInput -> {
+          var spawnExecutionContext = context.getSpawnExecutionContext();
+          var pathResolver =
+              // This can only be null when uploading a tree created by
+              // MerkleTreeComputer#buildForFiles, which only happens for remote repo execution and
+              // tests. Only the latter actually reach this code path since remote repo execution
+              // doesn't upload any inputs.
+              spawnExecutionContext != null
+                  ? spawnExecutionContext.getPathResolver()
+                  : MerkleTreeComputer.PATH_ACTION_INPUT_RESOLVER;
+          yield Optional.of(
+              uploader.uploadFile(
+                  context, remotePathResolver, digest, pathResolver.toPath(actionInput)));
+        }
         case null -> Optional.empty();
         default -> throw new IllegalStateException("Unexpected blob type: " + blobs.get(digest));
       };

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -840,7 +840,7 @@ public class RemoteExecutionServiceTest {
           Paths.get(System.getenv("TEST_UNDECLARED_OUTPUTS_DIR"), "merkle_tree_footprint.txt");
       Files.writeString(footprintOut, merkleTreeUniqueRetention.toFootprint());
       // TODO: Get this number down.
-      assertThat(stableRetainedSize).isEqualTo(7872);
+      assertThat(stableRetainedSize).isEqualTo(6112);
     }
   }
 


### PR DESCRIPTION
…/github.com/bazelbuild/bazel/pull/28737)

`Path`s of `ActionInput`s are typically not retained, which means that keeping them in memory as part of a Merkle tree is wasteful. Instead, retain the inputs and lazily convert to `Path` when uploading using the `ArtifactPathResolver` anyway retained by `SpawnExecutionContext`.

Work towards #20478
Work towards #28734

No

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES: None

Closes #28737.

PiperOrigin-RevId: 876039610
Change-Id: Id4af6af2daf7ef72e8a8e3da35f00e2dccd81bd0

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/21ac6c147f3c0dd7a02f85d71578525fd29b58f1