### PR TITLE
Fix `exec:--native_flag` scope handling

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
@@ -285,11 +285,17 @@ public final class FunctionTransitionUtil {
         if (starlarkOptions.containsKey(anotherFlag)) {
           ans.put(entry.getKey(), starlarkOptions.get(anotherFlag));
         } else {
+          // Native options (//command_line_option:*) are keyed by their short name (e.g.,
+          // "compilation_mode") in FragmentOptions.asMap(), not by their full canonical label form.
+          String nativeOptionKey =
+              anotherFlag.getPackageIdentifier().equals(COMMAND_LINE_OPTION_PACKAGE_IDENTIFIER)
+                  ? anotherFlag.getName()
+                  : anotherFlag.getUnambiguousCanonicalForm();
           boolean found = false;
           for (FragmentOptions fragment : options.getNativeOptions()) {
             Map<String, Object> nativeOptions = fragment.asMap();
-            if (nativeOptions.containsKey(anotherFlag.getUnambiguousCanonicalForm())) {
-              ans.put(entry.getKey(), nativeOptions.get(anotherFlag.getUnambiguousCanonicalForm()));
+            if (nativeOptions.containsKey(nativeOptionKey)) {
+              ans.put(entry.getKey(), nativeOptions.get(nativeOptionKey));
               found = true;
               break;
             }
@@ -299,8 +305,8 @@ public final class FunctionTransitionUtil {
             throw new IllegalStateException(
                 "Flag "
                     + anotherFlag
-                    + " is not found in the starlark options or native options. It should be one of"
-                    + " them.");
+                    + " is not found in the starlark options or native options. It should be one"
+                    + " of them.");
           }
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BuildOptionsScopeFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BuildOptionsScopeFunction.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.skyframe;
 
+import static com.google.devtools.build.lib.cmdline.LabelConstants.COMMAND_LINE_OPTION_PACKAGE_IDENTIFIER;
 import static com.google.devtools.build.lib.packages.RuleClass.Builder.STARLARK_BUILD_SETTING_DEFAULT_ATTR_NAME;
 import static com.google.devtools.build.lib.server.FailureDetails.TargetPatterns.Code.DEPENDENCY_NOT_FOUND;
 
@@ -91,18 +92,22 @@ public final class BuildOptionsScopeFunction implements SkyFunction {
         // have the --<another_flag_name> flag default value in the target config but also make sure
         // that it won't propagate to the exec config by setting the scope to "target".
         Label anotherFlag = Label.parseCanonicalUnchecked(scopeType.scopeType().substring(7));
-        Target anotherFlagTarget = getTarget(env, anotherFlag, scopedFlag.getPackageIdentifier());
-        if (anotherFlagTarget == null) {
-          return null;
-        }
+        // Native options (//command_line_option:*) are not build targets; their values are looked
+        // up directly from native options at transition time in FunctionTransitionUtil.
+        if (!anotherFlag.getPackageIdentifier().equals(COMMAND_LINE_OPTION_PACKAGE_IDENTIFIER)) {
+          Target anotherFlagTarget = getTarget(env, anotherFlag, scopedFlag.getPackageIdentifier());
+          if (anotherFlagTarget == null) {
+            return null;
+          }
 
-        if (!key.getBuildOptions().getStarlarkOptions().containsKey(anotherFlag)) {
-          fullyResolvedBuildOptionsBuilder =
-              fullyResolvedBuildOptionsBuilder.addStarlarkOption(
-                  anotherFlag,
-                  anotherFlagTarget
-                      .getAssociatedRule()
-                      .getAttr(STARLARK_BUILD_SETTING_DEFAULT_ATTR_NAME));
+          if (!key.getBuildOptions().getStarlarkOptions().containsKey(anotherFlag)) {
+            fullyResolvedBuildOptionsBuilder =
+                fullyResolvedBuildOptionsBuilder.addStarlarkOption(
+                    anotherFlag,
+                    anotherFlagTarget
+                        .getAssociatedRule()
+                        .getAttr(STARLARK_BUILD_SETTING_DEFAULT_ATTR_NAME));
+          }
         }
       }
     }

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValueTest.java
@@ -552,6 +552,42 @@ public final class BuildConfigurationValueTest extends ConfigurationTestCase {
   }
 
   @Test
+  public void starlarkFlagExecScopeReferencingNativeFlag() throws Exception {
+    scratch.file("my_starlark_flag/BUILD");
+    scratch.file(
+        "my_starlark_flag/rule_defs.bzl",
+        """
+        string_flag = rule(
+            implementation = lambda ctx: [],
+            build_setting = config.string(flag = True),
+            attrs = {"scope": attr.string(), "on_leave_scope": attr.string()},
+        )
+        """);
+    scratch.file(
+        "test/BUILD",
+        """
+        load("//my_starlark_flag:rule_defs.bzl", "string_flag")
+        string_flag(
+            name = "flag_following_compilation_mode",
+            build_setting_default = "default",
+            scope = "exec:--//command_line_option:compilation_mode",
+        )
+        """);
+
+    BuildConfigurationValue execConfig =
+        createExec(
+            ImmutableMap.of("//test:flag_following_compilation_mode", "target_value"),
+            "--compilation_mode=dbg",
+            "--experimental_exclude_starlark_flags_from_exec_config=true");
+
+    // The flag's value in exec config should match the target config's --compilation_mode value.
+    assertThat(execConfig.getOptions().getStarlarkOptions())
+        .containsExactly(
+            Label.parseCanonicalUnchecked("//test:flag_following_compilation_mode"),
+            CompilationMode.DBG);
+  }
+
+  @Test
   public void starlarkFlagExecScopes_take_precedence_over_custom_overrides() throws Exception {
     scratch.file("my_starlark_flag/BUILD");
     scratch.file(


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description


### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
