### PR TITLE
Fix //src:bazel-dev misplacing the embedded JDK

### DIFF
--- a/src/create_embedded_tools.py
+++ b/src/create_embedded_tools.py
@@ -59,6 +59,8 @@ output_paths = [
     ('*openjdk_*/file/*.zip', lambda x: 'jdk.zip'),
     ('*src/minimal_jdk.tar.gz', lambda x: 'jdk.tar.gz'),
     ('*src/minimal_jdk.zip', lambda x: 'jdk.zip'),
+    ('*src/allmodules_jdk.tar.gz', lambda x: 'jdk.tar.gz'),
+    ('*src/allmodules_jdk.zip', lambda x: 'jdk.zip'),
     ('*.bzl.tools', lambda x: x[:-6]),
     ('*', lambda x: re.sub(r'^.*bazel-out/[^/]*/bin/', '', x, count=1)),
 ]


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description

Fixes a bug where the `//src:bazel-dev` target doesn't have the JDK at the correct location in the generated archive, causing the launcher to fall back to system java instead.

#### Before

(note I don't have `java` installed)

```
$ bazel build //src:bazel-dev
$ bazel-bin/src/bazel-dev
FATAL: Could not find system javabase. Ensure JAVA_HOME is set, or javac is on your PATH.
```

#### After

```
$ bazel build //src:bazel-dev
$ bazel-bin/src/bazel-dev
Starting local Bazel server (no_version) and connecting to it...
                                                     [bazel development version]
Usage: bazel <command> <options> ...

Available commands:
  aquery              Analyzes the given targets and queries the action graph.
  build               Builds the specified targets.
...
```


### Motivation

Bug fix

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
