### PR TITLE
docs: fix MDX parse error in query/quickstart

### DIFF
--- a/docs/query/quickstart.mdx
+++ b/docs/query/quickstart.mdx
@@ -257,7 +257,7 @@ This query returns all of the targets in the 'customers' package that have a tag
 Use this query to learn what Jenny wants to order.
 
 <Accordion title="Answer">
-  <p>Mac and Cheese</p>
+  Mac and Cheese
 </Accordion>
 
 ## Adding a new dependency
@@ -484,16 +484,15 @@ bazel-bin/src/main/java/com/example/reviews/review
 Going off Bazel queries only, try to find out who wrote the review, and what dish they were describing.
 
 <Accordion title="Hint">
-  <p>Check the tags and dependencies for useful information.</p>
+  Check the tags and dependencies for useful information.
 </Accordion>
 
 <Accordion title="Answer">
-  <p>This review was describing the Pizza and Amir was the reviewer. If you look at what dependencies that this rule had using
+  This review was describing the Pizza and Amir was the reviewer. If you look at what dependencies that this rule had using
   <code>bazel query --noimplicit\_deps 'deps(//src/main/java/com/example/reviews:review)'</code>
   The result of this command reveals that Amir is the reviewer!
   Next, since you know the reviewer is Amir, you can use the query function to seek which tag Amir has in the `BUILD` file to see what dish is there.
   The command <code>bazel query 'attr(tags, "pizza", //src/main/java/com/example/customers/...)'</code> output that Amir is the only customer that ordered a pizza and is the reviewer which gives us the answer.
-  </p>
 </Accordion>
 
 ## Wrapping up


### PR DESCRIPTION
## Problem

`docs/query/quickstart.mdx` fails to parse with Mintlify (and standard MDX parsers) due to multi-line `<p>` elements inside `<Accordion>` JSX components:

```
Expected a closing tag for `<p>` before the end of `paragraph`
```

In MDX, a `<p>` tag whose content wraps to the next line is treated as ending at the first line break, before the closing `</p>` tag is seen.

## Fix

Remove the `<p>` wrapper elements from the three `<Accordion>` blocks. MDX handles paragraph formatting automatically inside JSX components.