### PR TITLE
Fix overflow in network metrics counters

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/NetworkMetricsCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/NetworkMetricsCollector.java
@@ -161,6 +161,9 @@ public final class NetworkMetricsCollector {
   }
 
   private static long calcDelta(long prev, long next) {
+    if (Long.compareUnsigned(next, prev) < 0) {
+      return next;
+    }
     return next - prev;
   }
 


### PR DESCRIPTION
This was broken in d34d6389adb8848e55626b4b45667c3278772c51. On macOS
subsequent network updates can reset the counters, which resulted in
overflow. Now if the new value is lower we just replace it with that.
This should be harmless for the Linux use case where this should never
be the case.

Fixes https://github.com/bazelbuild/bazel/issues/28813
