### PR TITLE
Add exports_files in http_file BUILD.bazel

### DIFF
--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -195,7 +195,7 @@
   "moduleExtensions": {
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "2zypjdbXw56LJ6fX9Dc8/8VjOQ4CLOx5MPOfrNpfO84=",
+        "bzlTransitiveDigest": "q5WovbsuiZCto9a5UMikEQn6IbdHGSccgiKTJaq+ChQ=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
@@ -252,7 +252,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "xTQL2WwSnk5sODEM8aZ7ehfwglUBBCNKWIvS4z7M59w=",
+        "bzlTransitiveDigest": "PQM4M1U1YI3IMEJ5vxFEfZPNYOqCZrNL9Kzhr/u9LVE=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -224,9 +224,11 @@ def _http_archive_impl(ctx):
 _HTTP_FILE_BUILD = """\
 package(default_visibility = ["//visibility:public"])
 
+exports_files([{path}])
+
 filegroup(
     name = "file",
-    srcs = ["{}"],
+    srcs = [{path}],
 )
 """
 
@@ -256,7 +258,7 @@ def _http_file_impl(ctx):
         integrity = ctx.attr.integrity,
     )
     ctx.file("WORKSPACE", "workspace(name = \"{name}\")".format(name = ctx.name))
-    ctx.file("file/BUILD", _HTTP_FILE_BUILD.format(downloaded_file_path))
+    ctx.file("file/BUILD", _HTTP_FILE_BUILD.format(path = repr(downloaded_file_path)))
 
     return _update_integrity_attr(ctx, _http_file_attrs, download_info)
 


### PR DESCRIPTION
Without this, with `--incompatible_no_implicit_file_export` you are no
longer allowed to directly depend on the downloaded file. Directly
depending on the downloaded file is required if you want to use
`executable = True`, and then make that file runnable with `bazel run`
where that doesn't work if you attempt to run the `filegroup`.

Exporting this file seems pretty safe since the user can also control
its path.
