### PR TITLE
Update ProcessWrapperSandboxedSpawnRunner to print sandbox debug directions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
@@ -124,7 +124,7 @@ public abstract class AbstractContainerizingSandboxedSpawn implements SandboxedS
           inputsToCreate,
           dirsToCreate,
           Iterables.concat(
-              ImmutableSet.of(), inputs.getFiles().keySet(), inputs.getSymlinks().keySet()),
+              inputs.getFiles().keySet(), inputs.getSymlinks().keySet()),
           outputs);
     }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
@@ -177,6 +177,7 @@ java_library(
     deps = [
         ":abstract_sandbox_spawn_runner",
         ":sandbox_helpers",
+        ":sandbox_options",
         ":sandboxed_spawns",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/exec:abstract_spawn_strategy",

--- a/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.sandbox;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.exec.TreeDeleter;
@@ -25,6 +26,7 @@ import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+
 import java.io.IOException;
 import java.time.Duration;
 
@@ -92,10 +94,11 @@ final class ProcessWrapperSandboxedSpawnRunner extends AbstractSandboxSpawnRunne
             execRoot);
     SandboxOutputs outputs = SandboxHelpers.getOutputs(spawn);
 
+    ImmutableList<String> commandLine = commandLineBuilder.build();
     return new SymlinkedSandboxedSpawn(
         sandboxPath,
         sandboxExecRoot,
-        commandLineBuilder.build(),
+        commandLine,
         environment,
         inputs,
         outputs,
@@ -103,7 +106,7 @@ final class ProcessWrapperSandboxedSpawnRunner extends AbstractSandboxSpawnRunne
         treeDeleter,
         /* sandboxDebugPath= */ null,
         statisticsPath,
-        /* interactiveDebugArguments= */ null,
+        getSandboxOptions().sandboxDebug ? commandLine : null,
         spawn.getMnemonic(),
         spawn.getTargetLabel());
   }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
@@ -26,9 +26,9 @@ import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-
 import java.io.IOException;
 import java.time.Duration;
+import javax.annotation.Nullable;
 
 /** Strategy that uses sandboxing to execute a process. */
 final class ProcessWrapperSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
@@ -106,7 +106,7 @@ final class ProcessWrapperSandboxedSpawnRunner extends AbstractSandboxSpawnRunne
         treeDeleter,
         /* sandboxDebugPath= */ null,
         statisticsPath,
-        getSandboxOptions().sandboxDebug ? commandLine : null,
+        makeInteractiveDebugArguments(commandLine, getSandboxOptions()),
         spawn.getMnemonic(),
         spawn.getTargetLabel());
   }
@@ -114,5 +114,14 @@ final class ProcessWrapperSandboxedSpawnRunner extends AbstractSandboxSpawnRunne
   @Override
   public String getName() {
     return "processwrapper-sandbox";
+  }
+
+  @Nullable
+  private ImmutableList<String> makeInteractiveDebugArguments(
+      ImmutableList<String> commandLine, SandboxOptions sandboxOptions) {
+    if (!sandboxOptions.sandboxDebug) {
+      return null;
+    }
+    return new ImmutableList.Builder<String>().add("/bin/sh").add("-i").addAll(commandLine).build();
   }
 }


### PR DESCRIPTION
Before this commit, note that `--sandbox_debug` is present but no debug message is given:
```
$ bazel build --spawn_strategy=processwrapper-sandbox --sandbox_debug -- //:demo
INFO: Analyzed target //:demo (5 packages loaded, 9 targets configured).
INFO: Found 1 target...
Target //:demo up-to-date:
  bazel-bin/demo.log
INFO: Elapsed time: 0.792s, Critical Path: 0.03s
INFO: 2 processes: 1 internal, 1 processwrapper-sandbox.
INFO: Build completed successfully, 2 total actions
```

After this commit:
```
$ bazel-dev build --spawn_strategy=processwrapper-sandbox --sandbox_debug -- //:demo
INFO: Analyzed target //:demo (6 packages loaded, 9 targets configured).
DEBUG: Sandbox debug output for Genrule //:demo:
Run this command to start an interactive shell in an identical sandboxed environment:
(cd /home/jcater/.cache/bazel/_bazel_jcater/9e3cdd9e1a0472143f50dde6dd8d0dbd/sandbox/processwrapper-sandbox/1/execroot/_main && \
  exec env - \
    LC_CTYPE=C.UTF-8 \
    PATH=/bin:/usr/bin:/usr/local/bin \
    TMPDIR=/tmp \
  /home/jcater/.cache/bazel/_bazel_jcater/install/a4cb4b763f743b55e3a49f4ec323167e/process-wrapper '--timeout=0' '--kill_delay=15' '--stats=/home/jcater/.cache/bazel/_bazel_jcater/9e3cdd9e1a0472143f50dde6dd8d0dbd/sandbox/processwrapper-sandbox/1/stats.out' /bin/bash -c 'source external/bazel_tools/tools/genrule/genrule-setup.sh; echo '\''not dbg'\'' > bazel-out/k8-fastbuild/bin/demo.log')
INFO: Found 1 target...
Target //:demo up-to-date:
  bazel-bin/demo.log
INFO: Elapsed time: 4.490s, Critical Path: 0.04s
INFO: 2 processes: 1 internal, 1 processwrapper-sandbox.
INFO: Build completed successfully, 2 total actions
```

Also includes a drive-by fix to remove an unneeded `ImmutableSet` instance.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
