### PR TITLE
[9.0.1] Fix overflow in network metrics counters (https://github.com/bazelbuild/bazel/pull/28856)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/NetworkMetricsCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/NetworkMetricsCollector.java
@@ -160,6 +160,9 @@ public final class NetworkMetricsCollector {
   }
 
   private static long calcDelta(long prev, long next) {
+    if (Long.compareUnsigned(next, prev) < 0) {
+      return next;
+    }
     return next - prev;
   }
 


### PR DESCRIPTION
This was broken in d34d6389adb8848e55626b4b45667c3278772c51. On macOS
subsequent network updates can reset the counters, which resulted in
overflow. Now if the new value is lower we just replace it with that.
This should be harmless for the Linux use case where this should never
be the case.

Fixes https://github.com/bazelbuild/bazel/issues/28813

Closes #28856.

PiperOrigin-RevId: 877956215
Change-Id: Ic7667494c19fe854edcc7bc8df4b845214484086

Commit https://github.com/bazelbuild/bazel/commit/6ce906590c6009279539ea56f125514a3d18e12a