### PR TITLE
Add --test_sharding_strategy=only=N to run single shard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -2060,6 +2060,7 @@ java_library(
         "test/TestShardingStrategy.java",
         "test/TestShardingStrategyForced.java",
         "test/TestShardingStrategyNotForced.java",
+        "test/TestShardingStrategyOnly.java",
     ],
     deps = [
         "//src/main/java/com/google/devtools/common/options",

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -52,6 +52,7 @@ import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.TreeMap;
 import javax.annotation.Nullable;
 
@@ -237,6 +238,27 @@ public final class TestActionBuilder {
     int runsPerTest = getRunsPerTest(ruleContext);
     int shardCount = getShardCount(ruleContext);
 
+    OptionalInt onlyShardIndex =
+        testConfiguration.testShardingStrategy().getOnlyShardIndex();
+    if (onlyShardIndex.isPresent()) {
+      int onlyShardDisplay = onlyShardIndex.getAsInt() + 1;
+      if (shardCount == 0) {
+        ruleContext.ruleError(
+            "--test_sharding_strategy=only="
+                + onlyShardDisplay
+                + " requires a sharded test (set shard_count in the BUILD file)");
+      } else if (onlyShardIndex.getAsInt() >= shardCount) {
+        ruleContext.ruleError(
+            "--test_sharding_strategy=only="
+                + onlyShardDisplay
+                + " is out of range: test only has "
+                + shardCount
+                + " shard(s) (valid range: 1 to "
+                + shardCount
+                + ")");
+      }
+    }
+
     NestedSet<Artifact> lcovMergerFilesToRun = NestedSetBuilder.emptySet(Order.STABLE_ORDER);
 
     TestTargetExecutionSettings executionSettings;
@@ -342,13 +364,17 @@ public final class TestActionBuilder {
 
     NestedSet<Artifact> inputs = inputsBuilder.build();
     int shardRuns = (shardCount > 0 ? shardCount : 1);
+    int expectedActions = onlyShardIndex.isPresent() ? runsPerTest : runsPerTest * shardRuns;
     List<Artifact.DerivedArtifact> results =
-        Lists.newArrayListWithCapacity(runsPerTest * shardRuns);
+        Lists.newArrayListWithCapacity(expectedActions);
     ImmutableList.Builder<Artifact> coverageArtifacts = ImmutableList.builder();
     ImmutableList.Builder<ActionInput> testOutputs = ImmutableList.builder();
 
     // Use 1-based indices for user friendliness.
     for (int shard = 0; shard < shardRuns; shard++) {
+      if (onlyShardIndex.isPresent() && shard != onlyShardIndex.getAsInt()) {
+        continue;
+      }
       String shardDir =
           shardRuns > 1 ? String.format("shard_%d_of_%d", shard + 1, shardCount) : null;
       for (int run = 0; run < runsPerTest; run++) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -254,6 +254,9 @@ public class TestConfiguration extends Fragment {
             - `disabled` to never use test sharding.
             - `forced=k` to enforce `k` shards for testing regardless of the `shard_count` `BUILD`
               attribute.
+            - `only=k` to run only shard `k` (1-based) of a sharded test. The test must have a
+              `shard_count` set and `k` must be in range. `TEST_TOTAL_SHARDS` is preserved so
+              the test framework partitions tests correctly.
             """)
     public TestShardingStrategy testShardingStrategy;
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestShardingStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestShardingStrategy.java
@@ -17,18 +17,26 @@ import com.google.common.base.Ascii;
 import com.google.devtools.common.options.Converter;
 import com.google.devtools.common.options.Converters.IntegerConverter;
 import com.google.devtools.common.options.OptionsParsingException;
+import java.util.OptionalInt;
 
 /** A strategy for running the same tests in many processes. */
 interface TestShardingStrategy {
   int getNumberOfShards(int shardCountFromAttr);
 
+  /** Returns the single shard index to run, if this strategy selects only one shard. */
+  default OptionalInt getOnlyShardIndex() {
+    return OptionalInt.empty();
+  }
+
   /** Converts to {@link TestShardingStrategy}. */
   final class ShardingStrategyConverter extends Converter.Contextless<TestShardingStrategy> {
     private static final String FORCED_PREFIX = "forced=";
+    private static final String ONLY_PREFIX = "only=";
 
     @Override
     public String getTypeDescription() {
-      return "explicit, disabled or forced=k where k is the number of shards to enforce";
+      return "explicit, disabled, forced=k where k is the number of shards to enforce, or only=k"
+          + " where k is the 1-based shard index to run";
     }
 
     @Override
@@ -47,6 +55,17 @@ interface TestShardingStrategy {
         }
 
         return new TestShardingStrategyForced(forcedShardsCount);
+      }
+
+      if (Ascii.toLowerCase(input).startsWith(ONLY_PREFIX)) {
+        int onlyShardIndex =
+            new IntegerConverter().convert(input.substring(ONLY_PREFIX.length()));
+        if (onlyShardIndex < 1) {
+          throw new OptionsParsingException("Shard index for only= must be at least 1.");
+        }
+
+        // Convert from 1-based (user-facing) to 0-based (internal).
+        return new TestShardingStrategyOnly(onlyShardIndex - 1);
       }
 
       throw new OptionsParsingException(

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestShardingStrategyOnly.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestShardingStrategyOnly.java
@@ -1,0 +1,42 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.analysis.test;
+
+import static java.lang.Math.max;
+
+import java.util.OptionalInt;
+
+final class TestShardingStrategyOnly implements TestShardingStrategy {
+  private final int onlyShardIndex;
+
+  TestShardingStrategyOnly(int onlyShardIndex) {
+    this.onlyShardIndex = onlyShardIndex;
+  }
+
+  @Override
+  public int getNumberOfShards(int shardCountFromAttr) {
+    return max(shardCountFromAttr, 0);
+  }
+
+  @Override
+  public OptionalInt getOnlyShardIndex() {
+    return OptionalInt.of(onlyShardIndex);
+  }
+
+  @Override
+  public String toString() {
+    return "only=" + (onlyShardIndex + 1);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
@@ -280,6 +280,82 @@ public class TestActionBuilderTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testShardingOnly() throws Exception {
+    useConfiguration("--test_sharding_strategy=only=5");
+    writeJavaTests();
+    ConfiguredTarget target = getConfiguredTarget("//javatests/jt:RGT_many");
+    ImmutableList<Artifact.DerivedArtifact> testStatusList = getTestStatusArtifacts(target);
+    assertThat(testStatusList).hasSize(1);
+    TestRunnerAction action =
+        (TestRunnerAction) getGeneratingAction(testStatusList.get(0));
+    assertThat(action.getShardNum()).isEqualTo(4);
+    assertThat(action.getExecutionSettings().getTotalShards()).isEqualTo(33);
+    assertThat(action.isSharded()).isTrue();
+  }
+
+  @Test
+  public void testShardingOnly_indexOutOfRange() throws Exception {
+    useConfiguration("--test_sharding_strategy=only=75");
+    writeJavaTests();
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//javatests/jt:RGT_many");
+    assertContainsEvent("--test_sharding_strategy=only=75 is out of range");
+  }
+
+  @Test
+  public void testShardingOnly_notSharded() throws Exception {
+    useConfiguration("--test_sharding_strategy=only=4");
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//tests:small_test_1");
+    assertContainsEvent("requires a sharded test");
+  }
+
+  @Test
+  public void testShardingOnly_withRunsPerTest() throws Exception {
+    useConfiguration("--test_sharding_strategy=only=3", "--runs_per_test=2");
+    writeJavaTests();
+    ConfiguredTarget target = getConfiguredTarget("//javatests/jt:RGT_many");
+    ImmutableList<Artifact.DerivedArtifact> testStatusList = getTestStatusArtifacts(target);
+    assertThat(testStatusList).hasSize(2);
+    for (Artifact.DerivedArtifact testStatus : testStatusList) {
+      TestRunnerAction action = (TestRunnerAction) getGeneratingAction(testStatus);
+      assertThat(action.getShardNum()).isEqualTo(2);
+      assertThat(action.getExecutionSettings().getTotalShards()).isEqualTo(33);
+      assertThat(action.isSharded()).isTrue();
+    }
+    assertThat(testStatusList.get(0).getRootRelativePath().getPathString())
+        .contains("shard_3_of_33_run_1_of_2");
+    assertThat(testStatusList.get(1).getRootRelativePath().getPathString())
+        .contains("shard_3_of_33_run_2_of_2");
+  }
+
+  @Test
+  public void testShardingOnly_equalValue_equalChecksum() throws Exception {
+    useConfiguration("--test_sharding_strategy=only=2");
+    var config1 = getTargetConfiguration();
+
+    initializeSkyframeExecutor();
+
+    useConfiguration("--test_sharding_strategy=only=2");
+    var config2 = getTargetConfiguration();
+
+    assertThat(config2).isEqualTo(config1);
+  }
+
+  @Test
+  public void testShardingOnly_differentValue_differentChecksum() throws Exception {
+    useConfiguration("--test_sharding_strategy=only=2");
+    var config1 = getTargetConfiguration();
+
+    initializeSkyframeExecutor();
+
+    useConfiguration("--test_sharding_strategy=only=3");
+    var config2 = getTargetConfiguration();
+
+    assertThat(config2).isNotEqualTo(config1);
+  }
+
+  @Test
   public void testFlakyAttributeValidation() throws Exception {
     scratch.file(
         "flaky/BUILD",


### PR DESCRIPTION
If you are iterating on a sharded test, when a single shard fails it can
be useful to rerun only that shard over and over while you fix the test.
This allows you to do that. It is indexed on the same numbers users see
in the UI.

Fixes https://github.com/bazelbuild/bazel/issues/28819
