### PR TITLE
[9.1.0] Only pass one `InputMetadataProvider` to `ImportantOutputHandler`.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ImportantOutputHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ImportantOutputHandler.java
@@ -37,6 +37,19 @@ public interface ImportantOutputHandler extends ActionContext {
   Duration LOG_THRESHOLD = Duration.ofMillis(100);
 
   /**
+   * Whether this handler requires metadata of top-level {@linkplain
+   * com.google.devtools.build.lib.analysis.OutputGroupInfo#HIDDEN_OUTPUT_GROUP_PREFIX hidden output
+   * groups} in {@link #processOutputsAndGetLostArtifacts}. Notably, this includes top-level
+   * runfiles trees.
+   *
+   * <p>If {@code false}, top-level runfiles may be handled in {@link
+   * #processRunfilesAndGetLostArtifacts}.
+   */
+  default boolean requiresHiddenOutputMetadata() {
+    return false;
+  }
+
+  /**
    * Informs this handler that top-level outputs have been built.
    *
    * <p>The handler may verify that remotely stored outputs are still available. Returns a map from
@@ -45,21 +58,17 @@ public interface ImportantOutputHandler extends ActionContext {
    * @param importantOutputs top-level outputs, excluding {@linkplain
    *     com.google.devtools.build.lib.analysis.OutputGroupInfo#HIDDEN_OUTPUT_GROUP_PREFIX hidden
    *     output groups}
-   * @param importantMetadataProvider provides metadata for artifacts in {@code importantOutputs}
-   *     and their expansions
-   * @param fullMetadataProvider like {@code importantMetadataProvider}, but additionally provides
-   *     metadata for artifacts in {@linkplain
+   * @param metadataProvider provides metadata for artifacts in {@code importantOutputs} and their
+   *     expansions; if {@link #requiresHiddenOutputMetadata}, additionally provides metadata for
+   *     artifacts in {@linkplain
    *     com.google.devtools.build.lib.analysis.OutputGroupInfo#HIDDEN_OUTPUT_GROUP_PREFIX hidden
    *     output groups} and their expansions
    * @return any artifacts that need to be regenerated via action rewinding
    * @throws ImportantOutputException for an issue processing the outputs, not including lost
    *     outputs which are reported in the returned {@link LostArtifacts}
    */
-  // TODO: jhorvitz - Find a cleaner way than passing two InputMetadataProviders.
   LostArtifacts processOutputsAndGetLostArtifacts(
-      Iterable<Artifact> importantOutputs,
-      InputMetadataProvider importantMetadataProvider,
-      InputMetadataProvider fullMetadataProvider)
+      Iterable<Artifact> importantOutputs, InputMetadataProvider metadataProvider)
       throws ImportantOutputException, InterruptedException;
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteImportantOutputHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteImportantOutputHandler.java
@@ -62,17 +62,20 @@ public final class RemoteImportantOutputHandler implements ImportantOutputHandle
   }
 
   @Override
+  public boolean requiresHiddenOutputMetadata() {
+    // We want to process top-level runfiles in processOutputsAndGetLostArtifacts.
+    return true;
+  }
+
+  @Override
   public LostArtifacts processOutputsAndGetLostArtifacts(
-      Iterable<Artifact> importantOutputs,
-      InputMetadataProvider importantMetadataProvider,
-      InputMetadataProvider fullMetadataProvider)
+      Iterable<Artifact> importantOutputs, InputMetadataProvider metadataProvider)
       throws ImportantOutputException, InterruptedException {
-    // Use the full metadata provider since we want to include runfiles trees.
     try {
-      ensureToplevelArtifacts(importantOutputs, fullMetadataProvider);
+      ensureToplevelArtifacts(importantOutputs, metadataProvider);
     } catch (IOException e) {
       if (e instanceof BulkTransferException bulkTransferException) {
-        var lostArtifacts = bulkTransferException.getLostArtifacts(fullMetadataProvider::getInput);
+        var lostArtifacts = bulkTransferException.getLostArtifacts(metadataProvider::getInput);
         if (!lostArtifacts.isEmpty()) {
           return lostArtifacts;
         }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/CompletionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/CompletionFunction.java
@@ -401,7 +401,11 @@ public final class CompletionFunction<
     }
 
     Label label = key.actionLookupKey().getLabel();
-    InputMetadataProvider fullMetadataProvider = new ActionInputMetadataProvider(inputMap);
+    InputMetadataProvider metadataProvider =
+        new ActionInputMetadataProvider(
+            importantOutputHandler.requiresHiddenOutputMetadata()
+                ? inputMap
+                : ctx.getImportantInputMap());
     try {
       LostArtifacts lostOutputs;
       try (var ignored =
@@ -414,8 +418,7 @@ public final class CompletionFunction<
                 key.topLevelArtifactContext().expandFilesets()
                     ? importantArtifacts
                     : Iterables.filter(importantArtifacts, artifact -> !artifact.isFileset()),
-                new ActionInputMetadataProvider(ctx.getImportantInputMap()),
-                fullMetadataProvider);
+                metadataProvider);
       }
       if (lostOutputs.isEmpty()) {
         return null;
@@ -427,7 +430,7 @@ public final class CompletionFunction<
               .orElseGet(
                   () ->
                       ActionRewindStrategy.calculateLostInputOwners(
-                          lostOutputs.byDigest().values(), fullMetadataProvider));
+                          lostOutputs.byDigest().values(), metadataProvider));
       // Filter out lost outputs from the set of built artifacts so that they are not reported. If
       // rewinding is successful, we'll report them later on.
       for (ActionInput lostOutput : lostOutputs.byDigest().values()) {
@@ -436,14 +439,14 @@ public final class CompletionFunction<
       }
 
       Iterable<Artifact> artifactsRelevantForRewinding = importantArtifacts;
-      // Runfiles are not considered important outputs, but can arise as dep keys to which lost
-      // outputs are attributed in Bazel (but not Blaze).
-      var hiddenTopLevelArtifacts =
-          artifactsToBuild.getAllArtifactsByOutputGroup().get(OutputGroupInfo.HIDDEN_TOP_LEVEL);
-      if (hiddenTopLevelArtifacts != null) {
-        artifactsRelevantForRewinding =
-            Iterables.concat(
-                artifactsRelevantForRewinding, hiddenTopLevelArtifacts.getArtifacts().toList());
+      if (importantOutputHandler.requiresHiddenOutputMetadata()) {
+        var hiddenTopLevelArtifacts =
+            artifactsToBuild.getAllArtifactsByOutputGroup().get(OutputGroupInfo.HIDDEN_TOP_LEVEL);
+        if (hiddenTopLevelArtifacts != null) {
+          artifactsRelevantForRewinding =
+              Iterables.concat(
+                  artifactsRelevantForRewinding, hiddenTopLevelArtifacts.getArtifacts().toList());
+        }
       }
 
       return actionRewindStrategy.prepareRewindPlanForLostTopLevelOutputs(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/rewinding/LostImportantOutputHandlerModule.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/rewinding/LostImportantOutputHandlerModule.java
@@ -102,10 +102,8 @@ public class LostImportantOutputHandlerModule extends BlazeModule {
 
     @Override
     public LostArtifacts processOutputsAndGetLostArtifacts(
-        Iterable<Artifact> importantOutputs,
-        InputMetadataProvider importantMetadataProvider,
-        InputMetadataProvider fullMetadataProvider) {
-      return getLostOutputs(importantOutputs, importantMetadataProvider);
+        Iterable<Artifact> importantOutputs, InputMetadataProvider metadataProvider) {
+      return getLostOutputs(importantOutputs, metadataProvider);
     }
 
     @Override


### PR DESCRIPTION
Blaze's `ImportantOutputHandler` only needs important output metadata because it processes top-level runfiles separately. Bazel's `RemoteImportantOutputHandler` needs (hidden) top-level runfiles trees in addition to important outputs.

Instead of passing two metadata providers (important only and full), ask the `ImportantOutputHandler` which it needs.

This is a step towards moving ownership tracking completely into `ActionRewindStrategy`.

PiperOrigin-RevId: 877593911
Change-Id: I1ad1474a5cec900187ac0ae053e3275629d55b39

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/b005ba93a4cc2eeff9de231ffbd7c4e9747df881