### PR TITLE
Remove hardcoded fastbuild copts for Objective-C

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcConfiguration.java
@@ -81,15 +81,7 @@ public class ObjcConfiguration extends Fragment implements ObjcConfigurationApi 
 
   @Override
   public ImmutableList<String> getCoptsForCompilationMode() {
-    switch (compilationMode) {
-      case DBG, OPT -> {
-        return ImmutableList.of();
-      }
-      case FASTBUILD -> {
-        return ImmutableList.of("-O0", "-DDEBUG=1");
-      }
-      default -> throw new AssertionError();
-    }
+    return ImmutableList.of();
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcStarlarkTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcStarlarkTest.java
@@ -664,7 +664,7 @@ swift_binary = rule(
 
     Object compilationModeCopts = myInfo.getValue("compilation_mode_copts");
 
-    assertThat((List<?>) compilationModeCopts).containsExactly("-O0", "-DDEBUG=1");
+    assertThat((List<?>) compilationModeCopts).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
These use to be controlled with the
`--experimental_objc_fastbuild_options` flag which was removed in
cb541be1eea5aafcce370ef8078b2e03537c0233, but the options still
remained. These should be configured via the crosstool, or by the user
passing `--objccopt`.

We should remove this starlark API as well in the future
