### PR TITLE
Allow exporting transitive module dependencies #28881

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ eclipse-*bin/
 # Bazelisk version file
 .bazelversion
 # User-specific .bazelrc
+issue.md
 user.bazelrc

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
@@ -113,10 +113,18 @@ final class Discovery {
     @Nullable
     Result run() throws InterruptedException, ExternalDepsException {
       SequencedMap<String, Optional<Checksum>> registryFileHashes = new LinkedHashMap<>();
-      depGraph.put(ModuleKey.ROOT, root.module().withDepsTransformed(this::applyOverrides));
+      InterimModule rootModule = root.module().withDepsTransformed(this::applyOverrides);
+      depGraph.put(ModuleKey.ROOT, rootModule);
       ImmutableSet<ModuleKey> horizon = ImmutableSet.of(ModuleKey.ROOT);
+      // Extra SkyKeys to fetch in the next iteration, added by export_repo processing.
+      Set<ModuleFileValue.Key> extraKeysToFetch = new HashSet<>();
       while (!horizon.isEmpty()) {
-        ImmutableSet<ModuleFileValue.Key> nextHorizonSkyKeys = advanceHorizon(horizon);
+        ImmutableSet<ModuleFileValue.Key> nextHorizonSkyKeys =
+            ImmutableSet.<ModuleFileValue.Key>builder()
+                .addAll(advanceHorizon(horizon))
+                .addAll(extraKeysToFetch)
+                .build();
+        extraKeysToFetch.clear();
         SkyframeLookupResult result = env.getValuesAndExceptions(nextHorizonSkyKeys);
         var nextHorizon = ImmutableSet.<ModuleKey>builder();
         for (ModuleFileValue.Key skyKey : nextHorizonSkyKeys) {
@@ -138,21 +146,32 @@ final class Discovery {
             nextHorizon.add(depKey);
           }
         }
+        // Process export_repo directives from the root module. For each discovered module that
+        // is referenced by an export_repo, look up the exported dep in that module's deps and
+        // add it as a direct dep of the root module. Any new modules that need fetching are
+        // added to extraKeysToFetch for the next iteration.
+        processExportedRepos(rootModule, extraKeysToFetch);
+
         horizon = nextHorizon.build();
+        // If we have extra keys to fetch but no regular horizon items, keep the loop going.
+        if (horizon.isEmpty() && !extraKeysToFetch.isEmpty()) {
+          horizon = ImmutableSet.of(ModuleKey.ROOT);
+        }
       }
       if (env.valuesMissing()) {
         return null;
       }
       // Remove all unfulfilled nodep edges from the dep graph. It should be just as if they never
       // existed.
-      var result = ImmutableMap.<ModuleKey, InterimModule>builderWithExpectedSize(depGraph.size());
+      var resultMap =
+          ImmutableMap.<ModuleKey, InterimModule>builderWithExpectedSize(depGraph.size());
       for (Map.Entry<ModuleKey, InterimModule> entry : depGraph.entrySet()) {
         InterimModule module = entry.getValue();
         if (module.getNodepDeps().stream()
             .allMatch(depSpec -> depGraph.containsKey(depSpec.toModuleKey()))) {
-          result.put(entry.getKey(), module);
+          resultMap.put(entry.getKey(), module);
         } else {
-          result.put(
+          resultMap.put(
               entry.getKey(),
               module.toBuilder()
                   .setNodepDeps(
@@ -162,7 +181,68 @@ final class Discovery {
                   .build());
         }
       }
-      return new Result(result.buildOrThrow(), ImmutableMap.copyOf(registryFileHashes));
+      return new Result(resultMap.buildOrThrow(), ImmutableMap.copyOf(registryFileHashes));
+    }
+
+    /**
+     * Processes export_repo directives from the root module. For each exported repo, finds the
+     * source module in the dep graph and looks up the named dep, then adds it as a direct dep
+     * of the root module. Any new modules to be fetched are added to extraKeysToFetch.
+     */
+    private void processExportedRepos(
+        InterimModule rootModule,
+        Set<ModuleFileValue.Key> extraKeysToFetch)
+        throws ExternalDepsException {
+      for (var exportedRepo : rootModule.getExportedRepos()) {
+        // Find the source module (the one referenced by module_name in export_repo)
+        DepSpec sourceDepSpec = rootModule.getDeps().get(exportedRepo.sourceModuleRepoName());
+        if (sourceDepSpec == null) {
+          // This should have been caught during MODULE.bazel evaluation, but check again
+          continue;
+        }
+        ModuleKey sourceKey = sourceDepSpec.toModuleKey();
+        InterimModule sourceModule = depGraph.get(sourceKey);
+        if (sourceModule == null) {
+          // Source module hasn't been discovered yet; it will be processed in a future round
+          continue;
+        }
+        // Look up the exported dep name in the source module's deps
+        DepSpec exportedDepSpec = null;
+        for (DepSpec dep : sourceModule.getDeps().values()) {
+          if (dep.name().equals(exportedRepo.exportedDepName())) {
+            exportedDepSpec = dep;
+            break;
+          }
+        }
+        if (exportedDepSpec == null) {
+          throw ExternalDepsException.withMessage(
+              FailureDetails.ExternalDeps.Code.BAD_MODULE,
+              "export_repo: module '%s' does not have a dependency named '%s'",
+              sourceDepSpec.name(),
+              exportedRepo.exportedDepName());
+        }
+        // Apply overrides to the exported dep
+        DepSpec resolvedDepSpec = applyOverrides(exportedDepSpec);
+        ModuleKey exportedKey = resolvedDepSpec.toModuleKey();
+
+        // Add as a direct dep of the root module (update the depGraph entry for ROOT)
+        InterimModule currentRoot = depGraph.get(ModuleKey.ROOT);
+        if (!currentRoot.getDeps().containsKey(exportedRepo.localRepoName())) {
+          var newDeps = new LinkedHashMap<>(currentRoot.getDeps());
+          newDeps.put(exportedRepo.localRepoName(), resolvedDepSpec);
+          depGraph.put(
+              ModuleKey.ROOT,
+              currentRoot.toBuilder()
+                  .setDeps(ImmutableMap.copyOf(newDeps))
+                  .setOriginalDeps(ImmutableMap.copyOf(newDeps))
+                  .build());
+        }
+        // Ensure the exported dep is scheduled for fetching if not already discovered
+        if (!depGraph.containsKey(exportedKey)) {
+          predecessors.putIfAbsent(exportedKey, ModuleKey.ROOT);
+          extraKeysToFetch.add(ModuleFileValue.key(exportedKey));
+        }
+      }
     }
 
     /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
@@ -81,6 +81,24 @@ public abstract class InterimModule extends ModuleBase {
   }
 
   /**
+   * Represents a request to export a transitive dependency from a named module. When the root
+   * module uses {@code export_repo(module_name = "foo", "bar")}, it means: look up module "foo"'s
+   * dependency named "bar" and add it as a direct dep of the root module.
+   *
+   * @param sourceModuleRepoName the repo name of the source module (from a bazel_dep)
+   * @param exportedDepName the name of the dep to export from the source module
+   * @param localRepoName the repo name under which the exported dep should be visible locally
+   */
+  public record ExportedRepo(
+      String sourceModuleRepoName, String exportedDepName, String localRepoName) {
+    public ExportedRepo {
+      requireNonNull(sourceModuleRepoName, "sourceModuleRepoName");
+      requireNonNull(exportedDepName, "exportedDepName");
+      requireNonNull(localRepoName, "localRepoName");
+    }
+  }
+
+  /**
    * The resolved direct dependencies of this module, which can be either the original ones,
    * overridden by a {@code single_version_override}, by a {@code multiple_version_override}, or by
    * a {@link NonRegistryOverride} (the version will be ""). The key type is the repo name of the
@@ -102,6 +120,12 @@ public abstract class InterimModule extends ModuleBase {
   public abstract ImmutableList<DepSpec> getNodepDeps();
 
   /**
+   * The list of exported repos requested by this module. Only meaningful for the root module.
+   * Each entry requests that a transitive dep of a named module be promoted to a direct dep.
+   */
+  public abstract ImmutableList<ExportedRepo> getExportedRepos();
+
+  /**
    * The registry where this module came from. Must be null iff the module has a {@link
    * NonRegistryOverride}.
    */
@@ -117,7 +141,8 @@ public abstract class InterimModule extends ModuleBase {
         .setName("")
         .setVersion(Version.EMPTY)
         .setKey(ModuleKey.ROOT)
-        .setCompatibilityLevel(0);
+        .setCompatibilityLevel(0)
+        .setExportedRepos(ImmutableList.of());
   }
 
   /**
@@ -195,6 +220,16 @@ public abstract class InterimModule extends ModuleBase {
     }
 
     public abstract Builder setNodepDeps(ImmutableList<DepSpec> value);
+
+    public abstract Builder setExportedRepos(ImmutableList<ExportedRepo> value);
+
+    abstract ImmutableList.Builder<ExportedRepo> exportedReposBuilder();
+
+    @CanIgnoreReturnValue
+    public final Builder addExportedRepo(ExportedRepo value) {
+      exportedReposBuilder().add(value);
+      return this;
+    }
 
     public abstract Builder setRegistry(Registry value);
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -319,6 +319,68 @@ public class ModuleFileGlobals {
   }
 
   @StarlarkMethod(
+      name = "export_repo",
+      doc =
+          """
+          Exports one or more transitive dependencies of a named module as direct dependencies of
+          the current module. This allows users to selectively expose deps from a "meta" module
+          without having to declare each one individually via <code>bazel_dep</code>.
+
+          <p>This directive only takes effect in the root module; in other words, if a module
+          is used as a dependency by others, its own export_repo directives are ignored.
+
+          <p>Example usage:
+          <pre>
+          bazel_dep(name = "ros", version = "rolling.2026-01-21")
+          export_repo(module_name = "ros", "sensor_msgs", "rclcpp")
+          </pre>
+
+          <p>After this, <code>@sensor_msgs</code> and <code>@rclcpp</code> are usable as if they
+          were declared with their own <code>bazel_dep</code> entries.\
+          """,
+      parameters = {
+        @Param(
+            name = "module_name",
+            doc =
+                "The repo name of an existing <code>bazel_dep</code> whose transitive dependencies"
+                    + " should be exported.",
+            named = true,
+            positional = false),
+        @Param(
+            name = "dev_dependency",
+            doc =
+                "If true, this export will be ignored if the current module is not the root"
+                    + " module or <code>--ignore_dev_dependency</code> is enabled.",
+            named = true,
+            positional = false,
+            defaultValue = "False"),
+      },
+      extraPositionals =
+          @Param(
+              name = "args",
+              doc =
+                  "The names of the modules to export from the named module's dependencies."
+                      + " Each name will also be used as the local repo name."),
+      useStarlarkThread = true)
+  public void exportRepo(
+      String moduleName,
+      boolean devDependency,
+      Tuple args,
+      StarlarkThread thread)
+      throws EvalException {
+    ModuleThreadContext context = ModuleThreadContext.fromOrFail(thread, "export_repo()");
+    context.setNonModuleCalled();
+    if (context.shouldIgnoreDevDeps() && devDependency) {
+      return;
+    }
+    ImmutableList<StarlarkThread.CallStackEntry> stack = thread.getCallStack();
+    for (String arg : Sequence.cast(args, String.class, "args")) {
+      validateModuleName(arg);
+      context.addExportedRepo(moduleName, arg, arg, stack);
+    }
+  }
+
+  @StarlarkMethod(
       name = "register_execution_platforms",
       doc =
           "Specifies already-defined execution platforms to be registered when this module is"

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.bazel.bzlmod.InterimModule.DepSpec;
+import com.google.devtools.build.lib.bazel.bzlmod.InterimModule.ExportedRepo;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -60,6 +61,7 @@ public class ModuleThreadContext extends StarlarkThreadContext {
 
   private final Map<String, RepoOverride> overriddenRepos = new HashMap<>();
   private final Map<String, RepoOverride> overridingRepos = new HashMap<>();
+  private final List<ExportedRepo> exportedRepos = new ArrayList<>();
 
   public static ModuleThreadContext fromOrFail(StarlarkThread thread, String what)
       throws EvalException {
@@ -159,6 +161,23 @@ public class ModuleThreadContext extends StarlarkThreadContext {
     } else {
       module.addNodepDep(depSpec);
     }
+  }
+
+  public void addExportedRepo(
+      String sourceModuleRepoName,
+      String exportedDepName,
+      String localRepoName,
+      ImmutableList<StarlarkThread.CallStackEntry> stack)
+      throws EvalException {
+    // Validate the source module repo name refers to an existing bazel_dep
+    if (!deps.containsKey(sourceModuleRepoName)) {
+      throw Starlark.errorf(
+          "export_repo() refers to module_name '%s', but no bazel_dep with that repo name exists",
+          sourceModuleRepoName);
+    }
+    // Register the local repo name usage for uniqueness
+    addRepoNameUsage(localRepoName, "by an export_repo", stack);
+    exportedRepos.add(new ExportedRepo(sourceModuleRepoName, exportedDepName, localRepoName));
   }
 
   ModuleExtensionUsageBuilder getOrCreateExtensionUsageBuilder(
@@ -410,6 +429,7 @@ public class ModuleThreadContext extends StarlarkThreadContext {
         .setDeps(ImmutableMap.copyOf(deps))
         .setOriginalDeps(ImmutableMap.copyOf(deps))
         .setExtensionUsages(extensionUsages.build())
+        .setExportedRepos(ImmutableList.copyOf(exportedRepos))
         .build();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
@@ -175,6 +175,14 @@ public final class BzlmodTestUtil {
       return this;
     }
 
+    @CanIgnoreReturnValue
+    public InterimModuleBuilder addExportedRepo(
+        String sourceModuleRepoName, String exportedDepName, String localRepoName) {
+      this.builder.addExportedRepo(
+          new InterimModule.ExportedRepo(sourceModuleRepoName, exportedDepName, localRepoName));
+      return this;
+    }
+
     public Map.Entry<ModuleKey, InterimModule> buildEntry() {
       InterimModule module = this.build();
       return new SimpleEntry<>(this.key, module);

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -2223,4 +2223,109 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
         to @my_repo directly.\
         """);
   }
+
+  @Test
+  public void testExportRepo_basic() throws Exception {
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa', version='0.1')",
+        "bazel_dep(name='bbb', version='1.0')",
+        "export_repo(module_name='bbb', 'ccc', 'ddd')");
+    FakeRegistry registry =
+        registryFactory
+            .newFakeRegistry("/foo")
+            .addModule(
+                createModuleKey("bbb", "1.0"),
+                "module(name='bbb', version='1.0')",
+                "bazel_dep(name='ccc', version='2.0')",
+                "bazel_dep(name='ddd', version='3.0')");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+
+    EvaluationResult<RootModuleFileValue> result =
+        evaluator.evaluate(
+            ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
+    if (result.hasError()) {
+      fail(result.getError().toString());
+    }
+    RootModuleFileValue rootModuleFileValue = result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE);
+    assertThat(rootModuleFileValue.module().getExportedRepos()).hasSize(2);
+    assertThat(rootModuleFileValue.module().getExportedRepos().get(0).sourceModuleRepoName())
+        .isEqualTo("bbb");
+    assertThat(rootModuleFileValue.module().getExportedRepos().get(0).exportedDepName())
+        .isEqualTo("ccc");
+    assertThat(rootModuleFileValue.module().getExportedRepos().get(0).localRepoName())
+        .isEqualTo("ccc");
+    assertThat(rootModuleFileValue.module().getExportedRepos().get(1).exportedDepName())
+        .isEqualTo("ddd");
+  }
+
+  @Test
+  public void testExportRepo_nonExistentModule() throws Exception {
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa', version='0.1')",
+        "export_repo(module_name='nonexistent', 'ccc')");
+    FakeRegistry registry = registryFactory.newFakeRegistry("/foo");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+
+    reporter.removeHandler(failFastHandler); // expect failures
+    EvaluationResult<RootModuleFileValue> result =
+        evaluator.evaluate(
+            ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
+    assertThat(result.hasError()).isTrue();
+    assertContainsEvent("no bazel_dep with that repo name exists");
+  }
+
+  @Test
+  public void testExportRepo_repoNameCollision() throws Exception {
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa', version='0.1')",
+        "bazel_dep(name='bbb', version='1.0')",
+        "bazel_dep(name='ccc', version='2.0')",
+        "export_repo(module_name='bbb', 'ccc')");
+    FakeRegistry registry =
+        registryFactory
+            .newFakeRegistry("/foo")
+            .addModule(
+                createModuleKey("bbb", "1.0"),
+                "module(name='bbb', version='1.0')",
+                "bazel_dep(name='ccc', version='2.0')");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+
+    reporter.removeHandler(failFastHandler); // expect failures
+    EvaluationResult<RootModuleFileValue> result =
+        evaluator.evaluate(
+            ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
+    assertThat(result.hasError()).isTrue();
+    assertContainsEvent("The repo name 'ccc' cannot be defined");
+  }
+
+  @Test
+  public void testExportRepo_devDependency() throws Exception {
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa', version='0.1')",
+        "bazel_dep(name='bbb', version='1.0')",
+        "export_repo(module_name='bbb', 'ccc', dev_dependency=True)");
+    FakeRegistry registry =
+        registryFactory
+            .newFakeRegistry("/foo")
+            .addModule(
+                createModuleKey("bbb", "1.0"),
+                "module(name='bbb', version='1.0')",
+                "bazel_dep(name='ccc', version='2.0')");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+    ModuleFileFunction.IGNORE_DEV_DEPS.set(differencer, true);
+
+    EvaluationResult<RootModuleFileValue> result =
+        evaluator.evaluate(
+            ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
+    if (result.hasError()) {
+      fail(result.getError().toString());
+    }
+    RootModuleFileValue rootModuleFileValue = result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE);
+    // Export should be ignored when dev deps are disabled
+    assertThat(rootModuleFileValue.module().getExportedRepos()).isEmpty();
+  }
 }


### PR DESCRIPTION
# Walkthrough: Implementing `export_repo` in Bazel

I have successfully implemented the `export_repo` directive in Bazel's [MODULE.bazel](file:///c:/Users/jayes/Downloads/bazel/MODULE.bazel) system. This feature allows a module (typically the root) to "re-export" transitive dependencies as direct dependencies, simplifying dependency management for large ecosystems.

## Changes Made

### Core API & Data Model

- **[InterimModule.java](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java)**
    - Added the [ExportedRepo](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java#92-100) record to store the source module repo name, exported dep name, and local repo name.
    - Updated the [InterimModule](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java#47-271) abstract class and its [Builder](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java#135-228) to support storing a list of [ExportedRepo](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java#92-100) requests.

- **[ModuleThreadContext.java](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java)**
    - Added an [exportedRepos](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java#226-227) list to accumulate requests during Starlark evaluation.
    - Implemented [addExportedRepo()](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java#166-182) with validation to ensure the source module exists as a `bazel_dep`.
    - Integrated with [buildModule()](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java#380-435) to transfer these requests to the [InterimModule](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java#47-271).

- **[ModuleFileGlobals.java](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java)**
    - Implemented the `export_repo` Starlark method. 
    - Added comprehensive docstrings and parameter handling (including `dev_dependency`).

### Discovery & Resolution Logic

- **[Discovery.java](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java)**
    - **Resolution Hook:** Modified the BFS loop in `DiscoveryRound.run()` to process `export_repo` directives after each round.
    - **Skyframe Integration:** Implemented [processExportedRepos()](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java#187-247) which promotes transitive deps to root deps. If the exported module hasn't been discovered yet, it's queued as a `ModuleFileValue.Key` to be fetched in the next BFS iteration.
    - **Stability:** Switched from `ImmutableSet.Builder` to a mutable `HashSet` for `extraKeysToFetch` to avoid "builder already built" errors during the loop's emptiness check.

### Test Infrastructure

- **[BzlmodTestUtil.java](file:///c:/Users/jayes/Downloads/bazel/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java)**
    - Added [addExportedRepo()](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java#166-182) to [InterimModuleBuilder](file:///c:/Users/jayes/Downloads/bazel/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java#69-206) for easier test setup.

## Verification Results

### [ModuleFileFunctionTest.java](file:///c:/Users/jayes/Downloads/bazel/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java)

I added 4 new test cases to verify the core functionality:

1.  **[testExportRepo_basic](file:///c:/Users/jayes/Downloads/bazel/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java#2227-2261)**: Verifies that `export_repo` correctly populates the [InterimModule](file:///c:/Users/jayes/Downloads/bazel/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java#47-271) with multiple exports.
2.  **[testExportRepo_nonExistentModule](file:///c:/Users/jayes/Downloads/bazel/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java#2262-2278)**: Ensures an error is thrown if the source module name doesn't match a `bazel_dep`.
3.  **[testExportRepo_repoNameCollision](file:///c:/Users/jayes/Downloads/bazel/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java#2279-2303)**: Ensures that exporting a repo under a name that is already used by a `bazel_dep` results in a collision error.
4.  **[testExportRepo_devDependency](file:///c:/Users/jayes/Downloads/bazel/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java#2304-2331)**: Verifies that `export_repo(..., dev_dependency=True)` is correctly ignored when `ignore_dev_dependency` is set.

---
**Status:** Ready for Review
