### PR TITLE
[9.1.0] Support external repository labels in package_group (https://github.com/bazelbuild/bazel/pull/28811)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/BazelBuildApiGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/BazelBuildApiGlobals.java
@@ -15,6 +15,8 @@
 package com.google.devtools.build.lib.analysis.starlark;
 
 import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.cmdline.BazelModuleContext;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.packages.BzlInitThreadContext;
 import com.google.devtools.build.lib.packages.BzlVisibility;
@@ -63,12 +65,16 @@ public class BazelBuildApiGlobals implements StarlarkBuildApiGlobals {
       throw Starlark.errorf("load visibility may not be set more than once");
     }
 
+    BazelModuleContext moduleContext = BazelModuleContext.ofInnermostBzlOrThrow(thread);
+    RepositoryMapping repoMapping = moduleContext.repoMapping();
+
     RepositoryName repo = context.getBzlFile().getRepository();
     ImmutableList<PackageSpecification> specs;
     if (value instanceof String) {
       // `visibility("public")`, `visibility("private")`, visibility("//pkg")
       specs =
-          ImmutableList.of(PackageSpecification.fromStringForBzlVisibility(repo, (String) value));
+          ImmutableList.of(
+              PackageSpecification.fromStringForBzlVisibility(repoMapping, repo, (String) value));
     } else if (value instanceof StarlarkList) {
       // `visibility(["//pkg1", "//pkg2", ...])`
       List<String> specStrings = Sequence.cast(value, String.class, "visibility list");
@@ -76,7 +82,7 @@ public class BazelBuildApiGlobals implements StarlarkBuildApiGlobals {
           ImmutableList.builderWithExpectedSize(specStrings.size());
       for (String specString : specStrings) {
         PackageSpecification spec =
-            PackageSpecification.fromStringForBzlVisibility(repo, specString);
+            PackageSpecification.fromStringForBzlVisibility(repoMapping, repo, specString);
         specsBuilder.add(spec);
       }
       specs = specsBuilder.build();

--- a/src/main/java/com/google/devtools/build/lib/packages/PackageGroup.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/PackageGroup.java
@@ -61,6 +61,7 @@ public class PackageGroup implements Target {
       try {
         specification =
             PackageSpecification.fromString(
+                pkg.getMetadata().repositoryMapping(),
                 label.getRepository(),
                 packageSpecification,
                 allowPublicPrivate,

--- a/src/main/java/com/google/devtools/build/lib/packages/PackageSpecification.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/PackageSpecification.java
@@ -14,12 +14,12 @@
 package com.google.devtools.build.lib.packages;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerialization;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.SerializationConstant;
@@ -122,6 +122,7 @@ public abstract class PackageSpecification {
   // TODO(#16365): Remove allowPublicPrivate.
   // TODO(#16324): Remove legacy behavior and repoRootMeansCurrentRepo param.
   public static PackageSpecification fromString(
+      RepositoryMapping repositoryMapping,
       RepositoryName repositoryName,
       String spec,
       boolean allowPublicPrivate,
@@ -151,22 +152,38 @@ public abstract class PackageSpecification {
       }
     }
     PackageSpecification packageSpecification =
-        fromStringPositive(repositoryName, spec, repoRootMeansCurrentRepo);
+        fromStringPositive(repositoryMapping, repositoryName, spec, repoRootMeansCurrentRepo);
     return negative ? new NegativePackageSpecification(packageSpecification) : packageSpecification;
   }
 
   private static PackageSpecification fromStringPositive(
-      RepositoryName repositoryName, String spec, boolean repoRootMeansCurrentRepo)
+      RepositoryMapping repositoryMapping,
+      RepositoryName repositoryName,
+      String spec,
+      boolean repoRootMeansCurrentRepo)
       throws InvalidPackageSpecificationException {
     if (spec.equals(PUBLIC_VISIBILITY)) {
       return AllPackages.INSTANCE;
     } else if (spec.equals(PRIVATE_VISIBILITY)) {
       return NoPackages.INSTANCE;
     }
-    if (!spec.startsWith("//")) {
+
+    if (!spec.startsWith("//") && !spec.startsWith("@")) {
       throw new InvalidPackageSpecificationException(
           String.format(
-              "invalid package name '%s': must start with '//' or be 'public' or 'private'", spec));
+              "invalid package name '%s': must start with '//', '@', or be 'public' or 'private'",
+              spec));
+    }
+
+    try {
+      Label label =
+          Label.parseWithRepoContext(spec, Label.RepoContext.of(repositoryName, repositoryMapping));
+      PackageSpecification mappedSpec = fromLabel(label);
+      if (mappedSpec != null) {
+        return mappedSpec;
+      }
+    } catch (LabelSyntaxException e) {
+      // Fall through to parse as a package path (e.g. //foo/...)
     }
 
     String pkgPath;
@@ -182,22 +199,24 @@ public abstract class PackageSpecification {
           // Legacy behavior: //... is "public".
           return AllPackages.INSTANCE;
         }
+      } else if (spec.endsWith("//...")) {
+        // spec was "@repo//..."
+        pkgPath += "/";
       }
     } else {
       pkgPath = spec;
     }
 
-    PackageIdentifier unqualifiedPkgId;
+    PackageIdentifier pkgId;
     try {
-      unqualifiedPkgId = PackageIdentifier.parse(pkgPath);
+      pkgId =
+          Label.parseWithRepoContext(
+                  pkgPath + ":__pkg__", Label.RepoContext.of(repositoryName, repositoryMapping))
+              .getPackageIdentifier();
     } catch (LabelSyntaxException e) {
       throw new InvalidPackageSpecificationException(
           String.format("invalid package name '%s': %s", spec, e.getMessage()));
     }
-    Verify.verify(unqualifiedPkgId.getRepository().isMain());
-
-    PackageIdentifier pkgId =
-        PackageIdentifier.create(repositoryName, unqualifiedPkgId.getPackageFragment());
     return allBeneath ? new AllPackagesBeneath(pkgId) : new SinglePackage(pkgId);
   }
 
@@ -212,15 +231,17 @@ public abstract class PackageSpecification {
    * --incompatible_fix_package_group_reporoot_syntax} are enabled.
    */
   public static PackageSpecification fromStringForBzlVisibility(
-      RepositoryName repositoryName, String spec) throws EvalException {
+      RepositoryMapping repoMapping, RepositoryName repositoryName, String spec)
+      throws EvalException {
     PackageSpecification result;
     try {
       result =
           fromString(
+              repoMapping,
               repositoryName,
               spec,
-              /*allowPublicPrivate=*/ true,
-              /*repoRootMeansCurrentRepo=*/ true);
+              /* allowPublicPrivate= */ true,
+              /* repoRootMeansCurrentRepo= */ true);
     } catch (InvalidPackageSpecificationException e) {
       throw new EvalException(e.getMessage());
     }

--- a/src/test/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/BUILD
@@ -724,8 +724,11 @@ java_test(
     srcs = ["PackageGroupBuildViewTest.java"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
+        "//src/test/java/com/google/devtools/build/lib/bazel/bzlmod:util",
         "//third_party:junit4",
+        "//third_party:truth",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/PackageGroupBuildViewTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/PackageGroupBuildViewTest.java
@@ -13,8 +13,12 @@
 // limitations under the License.
 package com.google.devtools.build.lib.analysis;
 
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.createModuleKey;
+
 import com.google.devtools.build.lib.analysis.configuredtargets.PackageGroupConfiguredTarget;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.cmdline.Label;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -24,6 +28,11 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public final class PackageGroupBuildViewTest extends BuildViewTestCase {
+  @Override
+  protected boolean allowExternalRepositories() {
+    return true;
+  }
+
   /** Regression test for bug #3445835. */
   @Test
   public void testPackageGroupInDeps() throws Exception {
@@ -47,5 +56,48 @@ public final class PackageGroupBuildViewTest extends BuildViewTestCase {
         "package_group(name = 'foo', packages = ['//none'])",
         "load('@rules_cc//cc:cc_library.bzl', 'cc_library')",
         "cc_library(name = 'bar', data = [':foo'])");
+  }
+
+  @Test
+  public void testPackageGroupWithAllPackagesInMainRepository() throws Exception {
+    scratch.file(
+        "fruits/BUILD", "package_group(", "    name = 'apple',", "    packages = ['@//...'],", ")");
+
+    PackageGroupConfiguredTarget pg =
+        (PackageGroupConfiguredTarget) getConfiguredTarget("//fruits:apple");
+    PackageSpecificationProvider provider = pg.getProvider(PackageSpecificationProvider.class);
+    assertThat(provider.targetInAllowlist(Label.parseCanonical("//any/pkg:target"))).isTrue();
+  }
+
+  @Test
+  public void testPackageGroupWithRepoMapping() throws Exception {
+    registry.addModule(createModuleKey("veggies", "1.0"), "module(name='veggies', version='1.0')");
+
+    scratch.overwriteFile(
+        "MODULE.bazel",
+        "module(name='main', version='1.0')",
+        "bazel_dep(name='veggies', version='1.0', repo_name='my_veggies')");
+
+    invalidatePackages();
+
+    scratch.file(
+        "fruits/BUILD",
+        "package_group(",
+        "    name = 'banana',",
+        "    packages = ['@my_veggies//cucumber'],",
+        ")");
+
+    PackageGroupConfiguredTarget pg =
+        (PackageGroupConfiguredTarget) getConfiguredTarget("//fruits:banana");
+    PackageSpecificationProvider provider = pg.getProvider(PackageSpecificationProvider.class);
+
+    assertThat(
+            provider.targetInAllowlist(
+                Label.parseWithRepoContext(
+                    "@my_veggies//cucumber:something",
+                    Label.RepoContext.of(
+                        pg.getLabel().getRepository(),
+                        skyframeExecutor.getMainRepoMapping(reporter)))))
+        .isTrue();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/packages/PackageGroupStaticInitializationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/PackageGroupStaticInitializationTest.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.packages;
 
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.packages.util.PackageLoadingTestCase;
 import com.google.devtools.build.lib.testutil.TestThread;
@@ -45,6 +46,7 @@ public class PackageGroupStaticInitializationTest extends PackageLoadingTestCase
                     Label.parseCanonicalUnchecked("//context").getRepository();
                 groupQueue.put(
                     PackageSpecification.fromString(
+                        RepositoryMapping.EMPTY,
                         defaultRepoName,
                         "//fruits/...",
                         /* allowPublicPrivate= */ true,

--- a/src/test/java/com/google/devtools/build/lib/packages/PackageGroupTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/PackageGroupTest.java
@@ -18,6 +18,7 @@ import static com.google.devtools.build.lib.packages.util.TargetDataSubject.asse
 
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.packages.PackageSpecification.PackageGroupContents;
 import com.google.devtools.build.lib.packages.util.PackageLoadingTestCase;
@@ -95,23 +96,22 @@ public class PackageGroupTest extends PackageLoadingTestCase {
   }
 
   @Test
-  public void testPackagesWithRepositoryDoNotWork() throws Exception {
+  public void testPackagesWithRepositoryWorks() throws Exception {
     scratch.file(
         "fruits/BUILD",
         """
         package_group(
             name = "banana",
-            packages = ["@veggies//:cucumber"],
+            packages = ["@@veggies//cucumber"],
         )
         """);
 
-    reporter.removeHandler(failFastHandler);
-    getPackageGroup("fruits", "banana");
-    assertContainsEvent("invalid package name '@veggies//:cucumber'");
+    PackageGroup grp = getPackageGroup("fruits", "banana");
+    assertThat(grp.contains(pkgId("veggies", "cucumber"))).isTrue();
   }
 
   @Test
-  public void testAllPackagesInMainRepositoryDoesNotWork() throws Exception {
+  public void testAllPackagesInMainRepositoryWorks() throws Exception {
     scratch.file(
         "fruits/BUILD",
         """
@@ -121,9 +121,8 @@ public class PackageGroupTest extends PackageLoadingTestCase {
         )
         """);
 
-    reporter.removeHandler(failFastHandler);
-    getPackageGroup("fruits", "apple");
-    assertContainsEvent("invalid package name '@//...'");
+    PackageGroup grp = getPackageGroup("fruits", "apple");
+    assertThat(grp.contains(pkgId("anything"))).isTrue();
   }
 
   // TODO(brandjon): It'd be nice to include a test here that you can cross repositories via
@@ -546,7 +545,11 @@ public class PackageGroupTest extends PackageLoadingTestCase {
   /** Convenience method for obtaining a PackageSpecification. */
   private PackageSpecification pkgSpec(RepositoryName repository, String spec) throws Exception {
     return PackageSpecification.fromString(
-        repository, spec, /*allowPublicPrivate=*/ true, /*repoRootMeansCurrentRepo=*/ true);
+        RepositoryMapping.EMPTY,
+        repository,
+        spec,
+        /* allowPublicPrivate= */ true,
+        /* repoRootMeansCurrentRepo= */ true);
   }
 
   /** Convenience method for obtaining a PackageIdentifier. */

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadFunctionTest.java
@@ -973,7 +973,7 @@ public class BzlLoadFunctionTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testBzlVisibility_invalid_packageOutsideRepo() throws Exception {
+  public void testBzlVisibility_packageWithRepoWorks() throws Exception {
     setBuildLanguageOptions("--experimental_bzl_visibility=true");
 
     scratch.file("a/BUILD");
@@ -981,9 +981,7 @@ public class BzlLoadFunctionTest extends BuildViewTestCase {
         "a/foo.bzl", //
         "visibility([\"@repo//b\"])");
 
-    reporter.removeHandler(failFastHandler);
-    checkFailingLookup("//a:foo.bzl", "initialization of module 'a/foo.bzl' failed");
-    assertContainsEvent("invalid package name '@repo//b': must start with '//'");
+    checkSuccessfulLookup("//a:foo.bzl");
   }
 
   @Test


### PR DESCRIPTION
### Description

This PR enables `package_group` to correctly interpret labels that include external repositories (e.g., `@module//...` or `@module//:__subpackages__`).

### Motivation

Previously, `PackageSpecification.java` strictly required package names to start with `//`, failing on labels with repository prefixes. This made it impossible to define a `package_group` that includes packages from other Bzlmod modules. This change leverages `Label.parseWithRepoContext` to correctly resolve repository mapping and validate package specifications within the context of the repository where the `package_group` is defined.

Fixes an issue where bazel build would fail when a `package_group` referenced an external repository in its `packages` attribute.

### Build API Changes

Yes. This change affects the behavior of the `package_group` rule and the `visibility()` function in `.bzl` files.

1. Has this been discussed in a design doc or issue? No, but the change and impact should be straightforward to understand.
2. Is the change backward compatible? Yes, it relaxes a restriction that previously caused errors.
3. If it's a breaking change, what is the migration plan? N/A

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: `package_group` now supports labels with external repositories in the `packages` attribute.

Closes #28811.

PiperOrigin-RevId: 878957471
Change-Id: Ic84df870374fb8c6f6f24d6fdff388d909750469

Commit https://github.com/bazelbuild/bazel/commit/dfe9326d719de997c110bc2f4fc2eadd16b2909e