### PR TITLE
[8.7.0] Use the transitive bzl digest of the package BUILD file for `analysis_test` rule classes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/Package.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Package.java
@@ -50,6 +50,7 @@ import com.google.devtools.build.lib.skyframe.serialization.ObjectCodec;
 import com.google.devtools.build.lib.skyframe.serialization.SerializationContext;
 import com.google.devtools.build.lib.skyframe.serialization.SerializationException;
 import com.google.devtools.build.lib.util.DetailedExitCode;
+import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.util.StringUtil;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -1113,6 +1114,11 @@ public class Package {
     private final boolean precomputeTransitiveLoads;
     private final boolean noImplicitFileExport;
 
+    // The following field is populated by setLoads() and should be used only for analysis_test.
+    // TODO: b/291752414 - This should be serialized but only if needed for analysis_test;
+    // serializing unconditionally would interfere with lazy symbolic macro change pruning.
+    private byte[] transitiveBzlDigest = new byte[0];
+
     // The map from each repository to that repository's remappings map.
     // This is only used in the //external package, it is an empty map for all other packages.
     private final HashMap<RepositoryName, LinkedHashMap<String, RepositoryName>>
@@ -1465,7 +1471,17 @@ public class Package {
       } else {
         pkg.directLoads = ImmutableList.copyOf(directLoads);
       }
+      Fingerprint fp = new Fingerprint();
+      for (Module module : directLoads) {
+        fp.addBytes(BazelModuleContext.of(module).bzlTransitiveDigest());
+      }
+      this.transitiveBzlDigest = fp.digestAndReset();
       return this;
+    }
+
+    public byte[] getTransitiveBzlDigest() {
+      Preconditions.checkState(transitiveBzlDigest.length != 0);
+      return transitiveBzlDigest;
     }
 
     @CanIgnoreReturnValue

--- a/src/main/java/com/google/devtools/build/lib/rules/test/StarlarkTestingModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/test/StarlarkTestingModule.java
@@ -93,24 +93,19 @@ public class StarlarkTestingModule implements TestingModuleApi {
     // For normal Starlark-defined rule classes we're supposed to pass in the label of the bzl file
     // being initialized at the time the rule class is defined, as well as the transitive digest of
     // that bzl and all bzls it loads (for purposes of being sensitive to e.g. changes to the rule
-    // class's implementation function). For analysis_test this is currently infeasible because
-    // there is no such bzl file (since we're in a BUILD-evaluating thread) and we don't currently
-    // track the transitive digest of BUILD files and the bzls they load.
+    // class's implementation function).
     //
-    // In acknowledge of this infeasibility, we used to use a constant digest for all calls to
-    // analysis_test. This caused issues due to how the digest is used as part of the cache key of
-    // deserialized rule classes. To address that, we now use the combo of the package name and the
-    // target name (this works since we don't currently try to deserialize the same rule class
-    // produced at different source versions). See http://b/291752414#comment6.
-    //
-    // The digest is also used for purposes to detecting changes to a rule class across source
-    // versions; see blaze_query.Rule.skylark_environment_hash_code. So we're still incorrect there.
-    // See http://b/291752414#comment9 and http://b/291752414#comment10.
-    // TODO(b/291752414): Fix.
+    // We used to use a constant digest for all calls to analysis_test. This caused issues due to
+    // how the digest is used as part of the cache key of deserialized rule classes. To address
+    // that, we now use the combo of the package name and the target name (this works since we don't
+    // currently try to deserialize the same rule class produced at different source versions).
+    // See http://b/291752414#comment6.
     Label dummyBzlFile = Label.createUnvalidated(PackageIdentifier.EMPTY_PACKAGE_ID, "dummy_label");
     Fingerprint fingerprint = new Fingerprint();
     fingerprint.addString(pkgBuilder.getBuildFileLabel().getPackageName());
     fingerprint.addString(name);
+    // TODO: b/291752414 - also include the BUILD file digest
+    fingerprint.addBytes(pkgBuilder.getTransitiveBzlDigest());
     byte[] transitiveDigestToUse = fingerprint.digestAndReset();
 
     StarlarkRuleFunction starlarkRuleFunction =


### PR DESCRIPTION
PiperOrigin-RevId: 873913916
Change-Id: I672775ba892095dd9e323b306a56371c1d19e28b

(cherry picked from commit 8363d62b1c260c37f46a407432e99fa40d3a0750)