### PR TITLE
starlark interpreter: Fix string.splitlines() incorrectly splitting UTF8 characters

### DIFF
--- a/src/main/java/net/starlark/java/eval/StringModule.java
+++ b/src/main/java/net/starlark/java/eval/StringModule.java
@@ -589,7 +589,7 @@ final class StringModule implements StarlarkValue {
   }
 
   private static final Pattern SPLIT_LINES_PATTERN =
-      Pattern.compile("(?<line>.*)(?<break>(\\r\\n|\\r|\\n)?)");
+      Pattern.compile("(?<line>[^\\r\\n]*)(?<break>(\\r\\n|\\r|\\n)?)");
 
   @StarlarkMethod(
       name = "rfind",

--- a/src/test/java/net/starlark/java/eval/testdata/string_splitlines.star
+++ b/src/test/java/net/starlark/java/eval/testdata/string_splitlines.star
@@ -20,6 +20,12 @@ assert_eq("\r\n\r\n\r\n".splitlines(), ["", "", ""])
 # Escaped sequences
 assert_eq("\n\\n\\\n".splitlines(), ["", "\\n\\"])
 
+# UTF-8 characters with \u0085 in it
+# "包" is U+5305. UTF-8 is E5 8C 85.
+# If Starlark treats each byte as a Latin1 char, then 85 is \u0085 (NEL).
+# Java's Pattern.compile(".*") stops at \u0085.
+assert_eq("abc包def".splitlines(), ["abc包def"])
+
 # KeepEnds
 assert_eq("".splitlines(True), [])
 assert_eq("\n".splitlines(True), ["\n"])


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description

string.splitlines() should not split on u+0085 (NEL) in UTF-8 as byte array mode.

<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation

Fixes #28885 
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

- Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
  - Yes. starlark API string.splitlines() has changed. #28885

- Is the change backward compatible?
  - No.

- If it's a breaking change, what is the migration plan?
  - This specific case could be an exception where no migration plan is needed. Since:
    - 1. previous behavior on a UTF-8 file is clearly a bug.
    - 2. it should be pretty rare for this to affect other encodings as well.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES[INC]: string.splitlines() no longer treat u+0085 as a newline character when internal_starlark_utf_8_byte_strings is set (which defaults to true)
