### PR TITLE
[9.1.0] Reduce Merkle tree footprint by referencing `FileArtifactValue` (http…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -13,15 +13,24 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.merkletree;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.devtools.build.lib.remote.util.DigestUtil.DIGEST_COMPARATOR;
+import static java.util.Comparator.comparing;
+
 import build.bazel.remote.execution.v2.Digest;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.primitives.UnsignedBytes;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
+import com.google.devtools.build.lib.remote.util.DigestUtil;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
@@ -77,12 +86,47 @@ public sealed interface MerkleTree {
    * A {@link MerkleTree} that retains all blobs that still need to be uploaded.
    *
    * <p>The empty blob doesn't have to be uploaded and is thus never included in the blobs map.
+   *
+   * <p>See {@link
+   * com.google.devtools.build.lib.remote.RemoteExecutionServiceTest#buildRemoteAction_goldenTest}
+   * for a test that verifies the memory footprint of this class. Since there can be thousands of
+   * inflight remote executions that may have to retain their blobs until all inputs have been
+   * uploaded, it's crucial to keep the memory footprint of this class as low as possible.
    */
   final class Uploadable implements MerkleTree {
+    private static final Comparator<FileArtifactValue> FILE_ARTIFACT_VALUE_COMPARATOR =
+        comparing(FileArtifactValue::getDigest, UnsignedBytes.lexicographicalComparator())
+            .thenComparing(FileArtifactValue::getSize);
+    static final Comparator<Object> DIGEST_AND_METADATA_COMPARATOR =
+        (o1, o2) ->
+            switch (o1) {
+              case Digest digest1 ->
+                  DIGEST_COMPARATOR.compare(
+                      digest1,
+                      switch (o2) {
+                        case Digest digest2 -> digest2;
+                        case FileArtifactValue metadata2 -> adaptToDigest(metadata2);
+                        default -> throw new IllegalStateException("Unexpected blob type: " + o2);
+                      });
+              case FileArtifactValue metadata1 ->
+                  switch (o2) {
+                    case FileArtifactValue metadata2 ->
+                        FILE_ARTIFACT_VALUE_COMPARATOR.compare(metadata1, metadata2);
+                    case Digest digest2 ->
+                        DIGEST_COMPARATOR.compare(adaptToDigest(metadata1), digest2);
+                    default -> throw new IllegalStateException("Unexpected blob type: " + o2);
+                  };
+              default -> throw new IllegalStateException("Unexpected blob type: " + o1);
+            };
     private final RootOnly.BlobsUploaded root;
-    private final ImmutableSortedMap<Digest, /* byte[] | ActionInput */ Object> blobs;
+    private final ImmutableSortedMap<
+            /* Digest | FileArtifactValue */ Object, /* byte[] | ActionInput */ Object>
+        blobs;
 
-    Uploadable(RootOnly.BlobsUploaded root, SortedMap<Digest, Object> blobs) {
+    Uploadable(
+        RootOnly.BlobsUploaded root,
+        SortedMap</* Digest | FileArtifactValue */ Object, /* byte[] | ActionInput */ Object>
+            blobs) {
       this.root = root;
       // A sorted map requires less memory than a regular hash map as it only stores two flat sorted
       // arrays. Access performance is not critical since it's only used to find missing blobs,
@@ -106,12 +150,13 @@ public sealed interface MerkleTree {
     }
 
     public Collection<Digest> allDigests() {
-      return blobs.keySet();
+      return Collections2.transform(blobs.keySet(), MerkleTree.Uploadable::adaptToDigest);
     }
 
     @VisibleForTesting
     public Map<Digest, Object> blobs() {
-      return blobs;
+      return blobs.entrySet().stream()
+          .collect(toImmutableMap(e -> adaptToDigest(e.getKey()), Map.Entry::getValue));
     }
 
     @Override
@@ -148,6 +193,15 @@ public sealed interface MerkleTree {
         }
         case null -> Optional.empty();
         default -> throw new IllegalStateException("Unexpected blob type: " + blobs.get(digest));
+      };
+    }
+
+    private static Digest adaptToDigest(Object key) {
+      return switch (key) {
+        case Digest digest -> digest;
+        case FileArtifactValue metadata ->
+            DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());
+        default -> throw new IllegalStateException("Unexpected blob type: " + key);
       };
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
@@ -23,7 +23,6 @@ import static com.google.common.util.concurrent.Futures.allAsList;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.Futures.transform;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-import static com.google.devtools.build.lib.remote.util.DigestUtil.DIGEST_COMPARATOR;
 import static com.google.devtools.build.lib.util.StringEncoding.internalToUnicode;
 import static com.google.devtools.build.lib.vfs.PathFragment.HIERARCHICAL_COMPARATOR;
 import static java.util.Comparator.comparing;
@@ -508,7 +507,10 @@ public final class MerkleTreeComputer {
     long inputFiles = 0;
     long inputBytes = 0;
     var blobs =
-        new TreeMap<Digest, /* byte[] | Path | VirtualActionInput */ Object>(DIGEST_COMPARATOR);
+        new TreeMap<
+            /* Digest | FileArtifactValue */ Object,
+            /* byte[] | Path | VirtualActionInput */ Object>(
+            MerkleTree.Uploadable.DIGEST_AND_METADATA_COMPARATOR);
     Deque<Directory.Builder> directoryStack = new ArrayDeque<>();
     directoryStack.push(Directory.newBuilder());
 
@@ -566,7 +568,7 @@ public final class MerkleTreeComputer {
           byte[] directoryBlob = directoryStack.pop().build().toByteArray();
           Digest directoryBlobDigest = digestUtil.compute(directoryBlob);
           if (blobPolicy != BlobPolicy.DISCARD && directoryBlobDigest.getSizeBytes() != 0) {
-            blobs.put(directoryBlobDigest, directoryBlob);
+            blobs.putIfAbsent(directoryBlobDigest, directoryBlob);
           }
           inputBytes += directoryBlobDigest.getSizeBytes();
           var topDirectory = directoryStack.peek();
@@ -659,7 +661,9 @@ public final class MerkleTreeComputer {
             var digest = DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());
             addFile(currentDirectory, name, digest, nodeProperties);
             if (blobPolicy != BlobPolicy.DISCARD && digest.getSizeBytes() != 0) {
-              blobs.put(digest, fileOrSourceDirectory);
+              // If there is both a Digest and a FileArtifactValue key for the same content, prefer
+              // the FileArtifactValue as it is retained anyway.
+              blobs.put(metadata, fileOrSourceDirectory);
             }
             inputFiles++;
             inputBytes += digest.getSizeBytes();
@@ -669,7 +673,7 @@ public final class MerkleTreeComputer {
           var digest = digestUtil.compute(virtualActionInput);
           addFile(currentDirectory, name, digest, nodeProperties);
           if (blobPolicy != BlobPolicy.DISCARD && digest.getSizeBytes() != 0) {
-            blobs.put(digest, virtualActionInput);
+            blobs.putIfAbsent(digest, virtualActionInput);
           }
           inputFiles++;
           inputBytes += digest.getSizeBytes();
@@ -688,7 +692,7 @@ public final class MerkleTreeComputer {
           var digest = digestUtil.compute(artifactPathResolver.toPath(input));
           addFile(currentDirectory, name, digest, nodeProperties);
           if (blobPolicy != BlobPolicy.DISCARD && digest.getSizeBytes() != 0) {
-            blobs.put(digest, input);
+            blobs.putIfAbsent(digest, input);
           }
           inputFiles++;
           inputBytes += digest.getSizeBytes();

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -839,8 +839,37 @@ public class RemoteExecutionServiceTest {
       var footprintOut =
           Paths.get(System.getenv("TEST_UNDECLARED_OUTPUTS_DIR"), "merkle_tree_footprint.txt");
       Files.writeString(footprintOut, merkleTreeUniqueRetention.toFootprint());
+      // Detailed footprint:
+      //     COUNT       AVG       SUM   DESCRIPTION
+      //        18       181      3264   [B
+      //         9        32       288   b.b.r.e.v2.Digest
+      //         2       112       224   [Ljava.lang.Object;
+      //         9        16       144   c.g.p.ByteString$LiteralByteString
+      //         1        40        40   c.g.c.c.ImmutableSortedMap
+      //         2        16        32   c.g.c.c.RegularImmutableList
+      //         1        32        32   c.g.d.b.l.r.m.MerkleTree$RootOnly$BlobsUploaded
+      //         1        24        24   c.g.c.c.RegularImmutableSortedSet
+      //         1        16        16   c.g.d.b.l.r.m.MerkleTree$Uploadable
+      //        44                4064   (total)
+      //
+      // Ignoring objects with constant count, the footprint is made up of:
+      // * the two Object arrays backing the ImmutableSortedMap that tracks a map from digest-like
+      //   object to their backing blob. Assuming that most of these objects are naturally retained
+      //   elsehwere, as is the case for regular files (which are represented as their
+      //   FileArtifactValue mapping to their Artifact), this representation is already optimal at
+      //   8 bytes per blob.
+      // * the Digest objects for non-regular file blobs, in particular Directory protos. These
+      //   could be represented more efficiently by storing their raw hash bytes and the size in a
+      //   a flat byte array, but savings aren't expected to be significant.
+      // * most importantly, the serialized Directory protos, which contain inlined Digest protos
+      //   as well as filenames for all files. This is where the largest gains can be made by
+      //   introducing a custom representation that is serialized on demand when actually uploading
+      //   to the remote. Such a representation could consist of a flat Object array containing
+      //   FileArtifactValues (to replace Digest protos), Artifacts (to retrieve the
+      //   basename for file nodes), and Integers (referencing intermediate segments of Artifact
+      //   exec paths for most directory nodes).
       // TODO: Get this number down.
-      assertThat(stableRetainedSize).isEqualTo(6112);
+      assertThat(stableRetainedSize).isEqualTo(4064);
     }
   }
 


### PR DESCRIPTION
…s://github.com/bazelbuild/bazel/pull/28739)

For regular files, use `FileArtifactValue`s instead of `Digest`s as the keys in the Merkle tree's blob map. The former are retained anyway, the latter are unique per tree.

Also describe the remaining footprint of `MerkleTree` and ideas for future improvements.

Work towards #20478
Work towards #28734

No

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES: None

Closes #28739.

PiperOrigin-RevId: 879654674
Change-Id: I87fc74392481a7409f3775c27d90eab8b5eb1b4b

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/bbdc0c30040e20d7969566481bfe407df3ddb675