### PR TITLE
[9.1.0] Add exports_files in http_file BUILD.bazel (https://github.com/bazelbuild/bazel/pull/28859)

### DIFF
--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -190,7 +190,7 @@
   "moduleExtensions": {
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "06cynZ1bCvvy8zHPrrDlXq+Z68xmjctHpfFxi+zEpJY=",
+        "bzlTransitiveDigest": "SvNI34rEx++n9ZTIMzQTBWWQs+1CiNwjSPy+OwPTYlk=",
         "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
         "recordedInputs": [
           "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
@@ -212,7 +212,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "ABI1D/sbS1ovwaW/kHDoj8nnXjQ0oKU9fzmzEG4iT8o=",
+        "bzlTransitiveDigest": "WiOgCmUiJHUupCXKVmOZW10bk9qT79K0EeMPkDk0OeU=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
@@ -269,7 +269,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "2hLgIvNVTLgxus0ZuXtleBe70intCfo0cHs8qvt6cdM=",
+        "bzlTransitiveDigest": "Wn+HROYr8hNtwzKSnbzCyruVFyjCGMF94mKODrecSFA=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -224,9 +224,11 @@ def _http_archive_impl(ctx):
 _HTTP_FILE_BUILD = """\
 package(default_visibility = ["//visibility:public"])
 
+exports_files([{path}])
+
 filegroup(
     name = "file",
-    srcs = ["{}"],
+    srcs = [{path}],
 )
 """
 
@@ -256,7 +258,7 @@ def _http_file_impl(ctx):
         integrity = ctx.attr.integrity,
     )
     ctx.file("WORKSPACE", "workspace(name = \"{name}\")".format(name = ctx.name))
-    ctx.file("file/BUILD", _HTTP_FILE_BUILD.format(downloaded_file_path))
+    ctx.file("file/BUILD", _HTTP_FILE_BUILD.format(path = repr(downloaded_file_path)))
 
     return _update_integrity_attr(ctx, _http_file_attrs, download_info)
 


### PR DESCRIPTION
Without this, with `--incompatible_no_implicit_file_export` you are no
longer allowed to directly depend on the downloaded file. Directly
depending on the downloaded file is required if you want to use
`executable = True`, and then make that file runnable with `bazel run`
where that doesn't work if you attempt to run the `filegroup`.

Exporting this file seems pretty safe since the user can also control
its path.

Closes #28859.

PiperOrigin-RevId: 880846461
Change-Id: Ic65f79bd9915031cd98b59fb73315c09717548b5

Commit https://github.com/bazelbuild/bazel/commit/c71bafd6d09867b36cd8e8777a9288d4ca73d074