### PR TITLE
[8.7.0] starlark interpreter: Fix string.splitlines() incorrectly splitting UTF8 characters (https://github.com/bazelbuild/bazel/pull/28909)

### DIFF
--- a/src/main/java/net/starlark/java/eval/StringModule.java
+++ b/src/main/java/net/starlark/java/eval/StringModule.java
@@ -579,7 +579,7 @@ final class StringModule implements StarlarkValue {
   }
 
   private static final Pattern SPLIT_LINES_PATTERN =
-      Pattern.compile("(?<line>.*)(?<break>(\\r\\n|\\r|\\n)?)");
+      Pattern.compile("(?<line>[^\\r\\n]*)(?<break>(\\r\\n|\\r|\\n)?)");
 
   @StarlarkMethod(
       name = "rfind",

--- a/src/test/java/net/starlark/java/eval/testdata/string_splitlines.star
+++ b/src/test/java/net/starlark/java/eval/testdata/string_splitlines.star
@@ -20,6 +20,12 @@ assert_eq("\r\n\r\n\r\n".splitlines(), ["", "", ""])
 # Escaped sequences
 assert_eq("\n\\n\\\n".splitlines(), ["", "\\n\\"])
 
+# UTF-8 characters with \u0085 in it
+# "包" is U+5305. UTF-8 is E5 8C 85.
+# If Starlark treats each byte as a Latin1 char, then 85 is \u0085 (NEL).
+# Java's Pattern.compile(".*") stops at \u0085.
+assert_eq("abc包def".splitlines(), ["abc包def"])
+
 # KeepEnds
 assert_eq("".splitlines(True), [])
 assert_eq("\n".splitlines(True), ["\n"])


### PR DESCRIPTION
string.splitlines() should not split on u+0085 (NEL) in UTF-8 as byte array mode.

Closes #28909.

RELNOTES[INC]: string.splitlines() no longer incorrectly treats u+0085 (NEL) as a
newline character

PiperOrigin-RevId: 880902483
Change-Id: Id7c26c84eb50259c576036f333b0ccdb83f681d5

Commit https://github.com/bazelbuild/bazel/commit/77acc77e4a0de240b193954acdfb657f6a01afbe