### PR TITLE
[9.1.0] Add deprecation warning to --build_python_zip

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/python/PythonOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PythonOptions.java
@@ -35,9 +35,12 @@ public class PythonOptions extends FragmentOptions {
   @Option(
       name = "build_python_zip",
       defaultValue = "auto",
-      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
-      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
-      help = "Build python executable zip; on on Windows, off on other platforms")
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {OptionEffectTag.NO_OP},
+      deprecationWarning =
+          "The '--no' prefix is no longer supported for this flag. Please use"
+              + " --build_python_zip=false instead.",
+      help = "Deprecated. No-op.")
   public TriState buildPythonZip;
 
   @Option(


### PR DESCRIPTION
Fork of https://github.com/bazelbuild/bazel/pull/28527.

Fixes #28528.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/51c8fc75bfa232a2e5db9cd7e69e683785f09b99