### PR TITLE
[9.1.0] Avoid copying on disk cache hits if supported by the file system (htt…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.exec.SpawnCheckingCacheEvent;
 import com.google.devtools.build.lib.exec.SpawnProgressEvent;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.LazyFileOutputStream;
+import com.google.devtools.build.lib.remote.common.MaybePathBacked;
 import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.ProgressStatusListener;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
@@ -738,7 +739,7 @@ public class CombinedCache extends AbstractReferenceCounted {
    * An {@link OutputStream} that reports all the write operations with {@link
    * DownloadProgressReporter}.
    */
-  private static class ReportingOutputStream extends OutputStream {
+  private static class ReportingOutputStream extends OutputStream implements MaybePathBacked {
 
     private final OutputStream out;
     private final DownloadProgressReporter reporter;
@@ -774,6 +775,12 @@ public class CombinedCache extends AbstractReferenceCounted {
     @Override
     public void close() throws IOException {
       out.close();
+    }
+
+    @Nullable
+    @Override
+    public Path maybeGetPath() {
+      return out instanceof MaybePathBacked maybePathBacked ? maybePathBacked.maybeGetPath() : null;
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
@@ -57,8 +57,7 @@ public final class CombinedCacheClientFactory {
       httpCacheClient = createHttp(options, creds, authAndTlsOptions, digestUtil, retrier);
     }
     if (isDiskCache(options)) {
-      diskCacheClient =
-          createDiskCache(workingDirectory, options, digestUtil, options.remoteVerifyDownloads);
+      diskCacheClient = createDiskCache(workingDirectory, options, digestUtil);
     }
     if (httpCacheClient == null && diskCacheClient == null) {
       throw new IllegalArgumentException(
@@ -120,10 +119,9 @@ public final class CombinedCacheClientFactory {
   }
 
   public static DiskCacheClient createDiskCache(
-      Path workingDirectory, RemoteOptions options, DigestUtil digestUtil, boolean verifyDownloads)
-      throws IOException {
+      Path workingDirectory, RemoteOptions options, DigestUtil digestUtil) throws IOException {
     Path cacheDir = workingDirectory.getRelative(Preconditions.checkNotNull(options.diskCache));
-    return new DiskCacheClient(cacheDir, digestUtil, verifyDownloads);
+    return new DiskCacheClient(cacheDir, digestUtil);
   }
 
   public static boolean isDiskCache(RemoteOptions options) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -722,10 +722,7 @@ public final class RemoteModule extends BlazeModule {
         try {
           diskCacheClient =
               CombinedCacheClientFactory.createDiskCache(
-                  env.getWorkingDirectory(),
-                  remoteOptions,
-                  digestUtil,
-                  remoteOptions.remoteVerifyDownloads);
+                  env.getWorkingDirectory(), remoteOptions, digestUtil);
         } catch (Exception e) {
           handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
           return;
@@ -760,10 +757,7 @@ public final class RemoteModule extends BlazeModule {
         try {
           diskCacheClient =
               CombinedCacheClientFactory.createDiskCache(
-                  env.getWorkingDirectory(),
-                  remoteOptions,
-                  digestUtil,
-                  remoteOptions.remoteVerifyDownloads);
+                  env.getWorkingDirectory(), remoteOptions, digestUtil);
         } catch (Exception e) {
           handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
           return;

--- a/src/main/java/com/google/devtools/build/lib/remote/common/LazyFileOutputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/LazyFileOutputStream.java
@@ -17,13 +17,14 @@ import com.google.devtools.build.lib.vfs.Path;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import javax.annotation.Nullable;
 
 /**
  * Creates an {@link OutputStream} backed by a file that isn't actually opened until the first data
  * is written. This is useful to only have as many open file descriptors as necessary at a time to
  * avoid running into system limits.
  */
-public class LazyFileOutputStream extends OutputStream {
+public class LazyFileOutputStream extends OutputStream implements MaybePathBacked {
 
   private final Path path;
   private OutputStream out;
@@ -52,8 +53,9 @@ public class LazyFileOutputStream extends OutputStream {
 
   @Override
   public void flush() throws IOException {
-    ensureOpen();
-    out.flush();
+    if (out != null) {
+      out.flush();
+    }
   }
 
   @Override
@@ -78,5 +80,11 @@ public class LazyFileOutputStream extends OutputStream {
     if (out == null) {
       out = path.getOutputStream();
     }
+  }
+
+  @Override
+  @Nullable
+  public Path maybeGetPath() {
+    return path;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/common/MaybePathBacked.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/MaybePathBacked.java
@@ -1,0 +1,27 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.common;
+
+import com.google.devtools.build.lib.vfs.Path;
+import javax.annotation.Nullable;
+
+/**
+ * An interface to mark {@link java.io.OutputStream}s that may be known to write to an associated
+ * {@link Path}.
+ */
+public interface MaybePathBacked {
+  /** If this stream is backed by a Path, returns that Path. Otherwise, returns null. */
+  @Nullable
+  Path maybeGetPath();
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -30,6 +30,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.remote.Store;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
+import com.google.devtools.build.lib.remote.common.MaybePathBacked;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
 import com.google.devtools.build.lib.remote.util.DigestOutputStream;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
@@ -45,7 +46,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.UUID;
 import java.util.concurrent.Executors;
-import javax.annotation.Nullable;
 
 /**
  * An on-disk store for the remote action cache.
@@ -78,18 +78,7 @@ public class DiskCacheClient {
       MoreExecutors.listeningDecorator(
           Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("disk-cache-", 0).factory()));
 
-  private final boolean verifyDownloads;
-  private final DigestUtil digestUtil;
-
-  /**
-   * @param verifyDownloads whether verify the digest of downloaded content are the same as the
-   *     digest used to index that file.
-   */
-  public DiskCacheClient(Path root, DigestUtil digestUtil, boolean verifyDownloads)
-      throws IOException {
-    this.digestUtil = digestUtil;
-    this.verifyDownloads = verifyDownloads;
-
+  public DiskCacheClient(Path root, DigestUtil digestUtil) throws IOException {
     Path fnRoot =
         isOldStyleDigestFunction(digestUtil.getDigestFunction())
             ? root
@@ -152,23 +141,29 @@ public class DiskCacheClient {
           if (!refresh(path)) {
             throw new CacheNotFoundException(digest);
           }
-          try (InputStream in = path.getInputStream()) {
-            in.transferTo(out);
+          Path outPath = null;
+          if (out instanceof MaybePathBacked maybePathBacked) {
+            outPath = maybePathBacked.maybeGetPath();
+          }
+
+          if (outPath != null) {
+            // If the output stream is path-backed, the filesystem may be able to avoid copying the
+            // file.
+            FileSystemUtils.copyFile(path, outPath);
+          } else {
+            try (InputStream in = path.getInputStream()) {
+              in.transferTo(out);
+            }
           }
           return null;
         });
   }
 
   public ListenableFuture<Void> downloadBlob(Digest digest, OutputStream out) {
-    @Nullable
-    DigestOutputStream digestOut = verifyDownloads ? digestUtil.newDigestOutputStream(out) : null;
     return Futures.transformAsync(
-        download(digest, digestOut != null ? digestOut : out, Store.CAS),
+        download(digest, out, Store.CAS),
         (v) -> {
           try {
-            if (digestOut != null) {
-              Utils.verifyBlobContents(digest, digestOut.digest());
-            }
             out.flush();
             return immediateFuture(null);
           } catch (IOException e) {

--- a/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
@@ -29,7 +29,6 @@ import build.bazel.remote.execution.v2.Tree;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.remote.Store;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
-import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.testutil.TestUtils;
@@ -69,7 +68,7 @@ public class DiskCacheClientTest {
 
   @Before
   public void setUp() throws Exception {
-    client = new DiskCacheClient(root, DIGEST_UTIL, /* verifyDownloads= */ true);
+    client = new DiskCacheClient(root, DIGEST_UTIL);
   }
 
   @After
@@ -108,10 +107,7 @@ public class DiskCacheClientTest {
     assumeNotNull(BazelHashFunctions.BLAKE3); // BLAKE3 not available in Blaze.
 
     DiskCacheClient client =
-        new DiskCacheClient(
-            root,
-            new DigestUtil(SyscallCache.NO_CACHE, BazelHashFunctions.BLAKE3),
-            /* verifyDownloads= */ true);
+        new DiskCacheClient(root, new DigestUtil(SyscallCache.NO_CACHE, BazelHashFunctions.BLAKE3));
     Digest digest = Digest.newBuilder().setHash("0123456789abcdef").setSizeBytes(42).build();
     Path path = client.toPath(digest, Store.CAS);
 
@@ -123,10 +119,7 @@ public class DiskCacheClientTest {
     assumeNotNull(BazelHashFunctions.BLAKE3); // BLAKE3 not available in Blaze.
 
     DiskCacheClient client =
-        new DiskCacheClient(
-            root,
-            new DigestUtil(SyscallCache.NO_CACHE, BazelHashFunctions.BLAKE3),
-            /* verifyDownloads= */ true);
+        new DiskCacheClient(root, new DigestUtil(SyscallCache.NO_CACHE, BazelHashFunctions.BLAKE3));
     Digest digest = Digest.newBuilder().setHash("0123456789abcdef").setSizeBytes(42).build();
     Path path = client.toPath(digest, Store.AC);
 
@@ -229,17 +222,6 @@ public class DiskCacheClientTest {
     assertThrows(
         CacheNotFoundException.class,
         () -> getFromFuture(client.downloadBlob(getDigest("contents"), out.getOutputStream())));
-  }
-
-  @Test
-  public void downloadBlob_whenCorrupted_throwsOutputDigestMismatchException() throws Exception {
-    Digest digest = getDigest("contents");
-    populateCas(digest, "corrupted contents");
-    Path out = fs.getPath("/out");
-
-    assertThrows(
-        OutputDigestMismatchException.class,
-        () -> getFromFuture(client.downloadBlob(digest, out.getOutputStream())));
   }
 
   @Test
@@ -358,8 +340,7 @@ public class DiskCacheClientTest {
   public void concurrentUploadDownload()
       throws IOException, ExecutionException, InterruptedException {
     var nativeDiskCacheDir = TestUtils.createUniqueTmpDir(FileSystems.getNativeFileSystem());
-    var nativeClient =
-        new DiskCacheClient(nativeDiskCacheDir, DIGEST_UTIL, /* verifyDownloads= */ false);
+    var nativeClient = new DiskCacheClient(nativeDiskCacheDir, DIGEST_UTIL);
     var tasks = new ArrayList<Future<?>>();
     // Use 1 MB blobs to increase the window for concurrent access during write/rename.
     var contentSize = 1024 * 1024;

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
@@ -53,7 +53,7 @@ class OnDiskBlobStoreCache extends CombinedCache {
       throws IOException {
     super(
         /* remoteCacheClient= */ null,
-        new DiskCacheClient(cacheDir, digestUtil, /* verifyDownloads= */ true),
+        new DiskCacheClient(cacheDir, digestUtil),
         /* symlinkTemplate= */ null,
         digestUtil);
     this.remoteWorkerOptions = remoteWorkerOptions;


### PR DESCRIPTION
…ps://github.com/bazelbuild/bazel/pull/28369)

RELNOTES: Bazel no longer verifies the digests of disk cache entries upon a cache hit. This honors the description but not the previous behavior of the `--remote_verify_downloads` flag, which in fact controlled digest verification for both remote and disk caches.

In the process, `LazyFileOutputStream#flush` had to be changed to not open the stream if not open yet, otherwise it would override the existing contents.

Tested manually by running a fully cached build of `//src:bazel` and then verifying that `du -kh bazel-bin/src/bazel` prints `0B` on macOS.

Closes #28369.

PiperOrigin-RevId: 881397852
Change-Id: Icf3535ff31e314605c6003bd48602f6e00317022

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/7666e2a9f263c1e9225a5afdc852fcdd6dc96b