### PR TITLE
Update jarjar for multi-release support

### DIFF
--- a/third_party/jarjar/java/com/tonicsystems/jarjar/util/EntryStruct.java
+++ b/third_party/jarjar/java/com/tonicsystems/jarjar/util/EntryStruct.java
@@ -27,10 +27,6 @@ public final class EntryStruct {
     if (!name.endsWith(".class")) {
       return false;
     }
-    if (name.startsWith("META-INF/version")) {
-      // TODO(b/69678527): handle multi-release jar files
-      return false;
-    }
     return true;
   }
 

--- a/third_party/jarjar/java/com/tonicsystems/jarjar/util/JarTransformer.java
+++ b/third_party/jarjar/java/com/tonicsystems/jarjar/util/JarTransformer.java
@@ -41,7 +41,7 @@ public abstract class JarTransformer implements JarProcessor {
       }
       if (updateData) {
         struct.data = w.toByteArray();
-        struct.name = pathFromName(w.getClassName());
+        struct.name = replaceName(struct.name, w.getClassName());
       }
     }
     return true;
@@ -49,7 +49,11 @@ public abstract class JarTransformer implements JarProcessor {
 
   protected abstract ClassVisitor transform(ClassVisitor v);
 
-  private static String pathFromName(String className) {
-    return className.replace('.', '/') + ".class";
+  private static String replaceName(String name, String className) {
+    String prefix =
+        name.startsWith("META-INF/versions/")
+            ? name.substring(0, name.indexOf('/', "META-INF/versions/".length()) + 1)
+            : "";
+    return prefix + className.replace('.', '/') + ".class";
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->
Sync jarjar with the latest commit https://github.com/google/jarjar/commit/f870e037624e2076de208dd58c5f24529f6d53bf. It adds support for multi-release jars.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->
While upgrading to 8.5.1, we found an issue when running `bazel coverage`. JaCoCo's bundled Guava 33.4.5 introduces unrelocated final copies of SettableFuture in `META-INF/versions/9/`, which the JVM prefers when Multi-Release: true.
This caused error messages such as:
```
java.lang.IncompatibleClassChangeError: class com.uber.common.context.concurrent.ContextFluentFuture
    cannot inherit from final class com.google.common.util.concurrent.SettableFuture
```
The update here fixes it for us, so we want to make sure Bazel contains the fix.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
