### PR TITLE
[9.1.0] fix copy_dynamic_libraries_to_binary for subdirectories

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -163,24 +163,13 @@ def _collect_runfiles(ctx, feature_configuration, cc_toolchain, libraries, cc_li
 
     return (builder.merge(ctx.runfiles(files = builder_artifacts, transitive_files = depset(builder_transitive_artifacts))), runtime_objects_for_coverage)
 
-def _get_target_sub_dir(target_name):
-    last_separator = target_name.rfind("/")
-    if last_separator == -1:
-        return ""
-    return target_name[0:last_separator]
-
-def _create_dynamic_libraries_copy_actions(ctx, dynamic_libraries_for_runtime):
+def _create_dynamic_libraries_copy_actions(ctx, binary, dynamic_libraries_for_runtime):
     result = []
     for lib in dynamic_libraries_for_runtime:
-        # If the binary and the DLL don't belong to the same package or the DLL is a source file,
-        # we should copy the DLL to the binary's directory.
-        if ctx.label.package != lib.owner.package or ctx.label.workspace_name != lib.owner.workspace_name or lib.is_source:
-            target_name = ctx.label.name
-            target_sub_dir = _get_target_sub_dir(target_name)
-            copy_file_path = lib.basename
-            if target_sub_dir != "":
-                copy_file_path = target_sub_dir + "/" + copy_file_path
-            copy = ctx.actions.declare_file(copy_file_path)
+        # If the binary and the DLL are not in the same directory, copy the DLL
+        # to the binary's directory.
+        if lib.dirname != binary.dirname:
+            copy = ctx.actions.declare_file(lib.basename, sibling = binary)
             ctx.actions.symlink(output = copy, target_file = lib, progress_message = "Copying Execution Dynamic Library")
             result.append(copy)
         else:
@@ -708,7 +697,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
         libraries = []
         for linker_input in linker_inputs:
             libraries.extend(linker_input.libraries)
-        copied_runtime_dynamic_libraries = _create_dynamic_libraries_copy_actions(ctx, _get_dynamic_libraries_for_runtime(is_static_mode, libraries))
+        copied_runtime_dynamic_libraries = _create_dynamic_libraries_copy_actions(ctx, binary, _get_dynamic_libraries_for_runtime(is_static_mode, libraries))
 
     # TODO(b/198254254)(bazel-team): Do we need to put original shared libraries (along with
     # mangled symlinks) into the RunfilesSupport object? It does not seem


### PR DESCRIPTION
### Description / Motivation

This is a new instance of a similar problem described in https://github.com/bazelbuild/bazel/issues/12448. In order for windows binaries to run, the (non-system) dlls need to be copied to the same directory. However, the code that determined that was only looking at the package label and the workspace, but not the actual subdirectory. Previously, this was fixed by adding the lib.is_source check, but this only solves it for source files (i.e. for` cc_import`) but not `cc_library`.

This is a crossport from rules_cc; See https://github.com/bazelbuild/rules_cc/pull/623.

The bug is _not_ present in bazel HEAD, because the cc code has been fully removed. However, the bug is present in all current release lines (9.x, 8.x, 7.x, 6.x). You can see this in the [rules_cc pipeline](https://buildkite.com/bazel/rules-cc/builds/4820) from before I disabled this test in rules_cc for the versions that use the bazel native code.

### Build API Changes

This could potentially be considered a breaking change; it makes `copy_dynamic_libraries_to_binary` behave like it said it would, but this bug has been present for so long that it is possible people have built workarounds for it into their code.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [n/a] I have updated the documentation (if applicable).

The tests are in rules_cc; see https://github.com/bazelbuild/rules_cc/pull/623.

### Release Notes

RELNOTES: None