### PR TITLE
Reject dictionaries passed as lists

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/Type.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Type.java
@@ -732,6 +732,10 @@ public abstract class Type<T> {
         throws ConversionException {
       Iterable<?> iterable;
 
+      if (x instanceof Map) {
+        throw new ConversionException(this, x, what);
+      }
+
       if (x instanceof Iterable) {
         iterable = (Iterable<?>) x;
       } else if (x instanceof Depset) {

--- a/src/test/java/com/google/devtools/build/lib/packages/TypeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/TypeTest.java
@@ -290,6 +290,19 @@ public class TypeTest {
   }
 
   @Test
+  public void testStringListRejectsDict() throws Exception {
+    Type.ConversionException e =
+        assertThrows(
+            Type.ConversionException.class,
+            () -> Types.STRING_LIST.convert(ImmutableMap.of("foo", "bar"), "myattr"));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "expected value of type 'list(string)' for myattr,"
+                + " but got {\"foo\": \"bar\"} (Map)");
+  }
+
+  @Test
   public void testStringListBadElements() throws Exception {
     Object input = Arrays.<Object>asList("foo", "bar", StarlarkInt.of(1));
     Type.ConversionException e =


### PR DESCRIPTION
Previously it was valid to pass a dictionary to a starlark attribute
defined with `attr.string_list`, previously it would take its keys. Now
it is rejected.

Fixes https://github.com/bazelbuild/bazel/issues/17553
