### PR TITLE
Also send `--remote_cache_headers` to an HTTP cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.vfs.Path;
 import io.netty.channel.unix.DomainSocketAddress;
 import java.io.IOException;
+import java.util.Map.Entry;
 import java.net.URI;
 import javax.annotation.Nullable;
 
@@ -93,7 +94,7 @@ public final class CombinedCacheClientFactory {
               Math.toIntExact(options.remoteTimeout.toSeconds()),
               options.remoteMaxConnections,
               options.remoteVerifyDownloads,
-              ImmutableList.copyOf(options.remoteHeaders),
+              effectiveHeaders(options),
               digestUtil,
               retrier,
               creds,
@@ -107,7 +108,7 @@ public final class CombinedCacheClientFactory {
             Math.toIntExact(options.remoteTimeout.toSeconds()),
             options.remoteMaxConnections,
             options.remoteVerifyDownloads,
-            ImmutableList.copyOf(options.remoteHeaders),
+            effectiveHeaders(options),
             digestUtil,
             retrier,
             creds,
@@ -132,5 +133,13 @@ public final class CombinedCacheClientFactory {
     return options.remoteCache != null
         && (Ascii.toLowerCase(options.remoteCache).startsWith("http://")
             || Ascii.toLowerCase(options.remoteCache).startsWith("https://"));
+  }
+
+  public static ImmutableList<Entry<String, String>> effectiveHeaders(RemoteOptions options) {
+	return ImmutableList.<Entry<String, String>>builder()
+	  .addAll(options.remoteHeaders)
+	  .addAll(options.remoteCacheHeaders)
+	  .addAll(options.remoteExecHeaders)
+	  .build();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
@@ -139,7 +139,6 @@ public final class CombinedCacheClientFactory {
 	return ImmutableList.<Entry<String, String>>builder()
 	  .addAll(options.remoteHeaders)
 	  .addAll(options.remoteCacheHeaders)
-	  .addAll(options.remoteExecHeaders)
 	  .build();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -15,7 +15,8 @@ filegroup(
 
 java_test(
     name = "http",
-    srcs = glob(["*.java"]),
+    #srcs = glob(["*.java"]),
+		srcs = [ "HttpCacheClientTest.java", ],
     tags = [
         "requires-network",
     ],
@@ -25,6 +26,8 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/authandtls",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_runner",
         "//src/main/java/com/google/devtools/build/lib/remote:Retrier",
+        "//src/main/java/com/google/devtools/build/lib/remote:combined_cache_client_factory",
+        "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
         "//src/main/java/com/google/devtools/build/lib/remote/common:action_key",
         "//src/main/java/com/google/devtools/build/lib/remote/http",

--- a/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -15,8 +15,7 @@ filegroup(
 
 java_test(
     name = "http",
-    #srcs = glob(["*.java"]),
-		srcs = [ "HttpCacheClientTest.java", ],
+    srcs = glob(["*.java"]),
     tags = [
         "requires-network",
     ],

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -1008,7 +1008,7 @@ public class HttpCacheClientTest {
   }
 
   @Test
-  public void extraHeaders() throws Exception {
+  public void extraCacheHeaders() throws Exception {
 		ServerChannel server = null;
 		try {
 			RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
@@ -1033,8 +1033,8 @@ public class HttpCacheClientTest {
 							assertThat(request.headers().get("CommonKey2")).isEqualTo("CommonValue2");
 							assertThat(request.headers().get("CacheKey1")).isEqualTo("CacheValue1");
 							assertThat(request.headers().get("CacheKey2")).isEqualTo("CacheValue2");
-							assertThat(request.headers().get("ExecKey1")).isEqualTo("ExecValue1");
-							assertThat(request.headers().get("ExecKey2")).isEqualTo("ExecValue2");
+							assertThat(request.headers().get("ExecKey1")).isNull();
+							assertThat(request.headers().get("ExecKey2")).isNull();
 
 							ByteBuf content = ctx.alloc().buffer();
 							content.writeCharSequence("File Contents", StandardCharsets.US_ASCII);

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -344,7 +344,7 @@ public class HttpCacheClientTest {
 		return createHttpBlobStore(
 				serverChannel,
 				timeoutSeconds,
-				/* remoteVerifyDownloads= */ true,
+				remoteVerifyDownloads,
 				ImmutableList.of(),
 				creds,
 				authAndTlsOptions,
@@ -1020,7 +1020,7 @@ public class HttpCacheClientTest {
 						ImmutableList.of(
 								Map.entry("CacheKey1", "CacheValue1"),
 								Map.entry("CacheKey2", "CacheValue2"));
-				remoteOptions.remoteExecHeaders = 
+				remoteOptions.remoteExecHeaders =
 						ImmutableList.of(
 								Map.entry("ExecKey1", "ExecValue1"),
 								Map.entry("ExecKey2", "ExecValue2"));

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -38,9 +38,12 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
+import com.google.devtools.build.lib.remote.CombinedCacheClientFactory;
+import com.google.devtools.build.lib.remote.CombinedCacheClientFactory.CombinedCacheClient;
 import com.google.devtools.build.lib.remote.RemoteRetrier;
 import com.google.devtools.build.lib.remote.Retrier;
 import com.google.devtools.build.lib.remote.Retrier.ResultClassifier.Result;
+import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.common.ActionKey;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
@@ -103,6 +106,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -281,6 +285,7 @@ public class HttpCacheClientTest {
       ServerChannel serverChannel,
       int timeoutSeconds,
       boolean remoteVerifyDownloads,
+			ImmutableList<Entry<String, String>> extraHttpHeaders,
       @Nullable final Credentials creds,
       AuthAndTLSOptions authAndTlsOptions,
       Optional<RemoteRetrier> optRetrier)
@@ -305,7 +310,7 @@ public class HttpCacheClientTest {
           timeoutSeconds,
           /* remoteMaxConnections= */ 0,
           remoteVerifyDownloads,
-          ImmutableList.of(),
+          extraHttpHeaders,
           DIGEST_UTIL,
           retrier,
           creds,
@@ -317,7 +322,7 @@ public class HttpCacheClientTest {
           timeoutSeconds,
           /* remoteMaxConnections= */ 0,
           remoteVerifyDownloads,
-          ImmutableList.of(),
+          extraHttpHeaders,
           DIGEST_UTIL,
           retrier,
           creds,
@@ -327,6 +332,24 @@ public class HttpCacheClientTest {
           "unsupported socket address class " + socketAddress.getClass());
     }
   }
+
+	private HttpCacheClient createHttpBlobStore(
+			ServerChannel serverChannel,
+      int timeoutSeconds,
+      boolean remoteVerifyDownloads,
+      @Nullable final Credentials creds,
+      AuthAndTLSOptions authAndTlsOptions,
+      Optional<RemoteRetrier> optRetrier)
+      throws Exception {
+		return createHttpBlobStore(
+				serverChannel,
+				timeoutSeconds,
+				/* remoteVerifyDownloads= */ true,
+				ImmutableList.of(),
+				creds,
+				authAndTlsOptions,
+				optRetrier);
+	}
 
   private HttpCacheClient createHttpBlobStore(
       ServerChannel serverChannel,
@@ -982,5 +1005,59 @@ public class HttpCacheClientTest {
       }
       ++messageCount;
     }
+  }
+
+  @Test
+  public void extraHeaders() throws Exception {
+		ServerChannel server = null;
+		try {
+			RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+				remoteOptions.remoteHeaders =
+						ImmutableList.of(
+								Map.entry("CommonKey1", "CommonValue1"),
+								Map.entry("CommonKey2", "CommonValue2"));
+				remoteOptions.remoteCacheHeaders =
+						ImmutableList.of(
+								Map.entry("CacheKey1", "CacheValue1"),
+								Map.entry("CacheKey2", "CacheValue2"));
+				remoteOptions.remoteExecHeaders = 
+						ImmutableList.of(
+								Map.entry("ExecKey1", "ExecValue1"),
+								Map.entry("ExecKey2", "ExecValue2"));
+
+				server = testServer.start(
+					new SimpleChannelInboundHandler<FullHttpRequest>() {
+						@Override
+						protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {
+							assertThat(request.headers().get("CommonKey1")).isEqualTo("CommonValue1");
+							assertThat(request.headers().get("CommonKey2")).isEqualTo("CommonValue2");
+							assertThat(request.headers().get("CacheKey1")).isEqualTo("CacheValue1");
+							assertThat(request.headers().get("CacheKey2")).isEqualTo("CacheValue2");
+							assertThat(request.headers().get("ExecKey1")).isEqualTo("ExecValue1");
+							assertThat(request.headers().get("ExecKey2")).isEqualTo("ExecValue2");
+
+							ByteBuf content = ctx.alloc().buffer();
+							content.writeCharSequence("File Contents", StandardCharsets.US_ASCII);
+							FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, content);
+							HttpUtil.setContentLength(response, content.readableBytes());
+							ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+						}
+					});
+
+				HttpCacheClient blobStore = createHttpBlobStore(
+					server,
+					/* timeoutSeconds= */ 1, 
+					/* verifyDownloads= */ true,
+					CombinedCacheClientFactory.effectiveHeaders(remoteOptions),
+					newCredentials(),
+					Options.getDefaults(AuthAndTLSOptions.class),
+					/* optRetrier= */ Optional.empty());
+
+				ByteArrayOutputStream out = new ByteArrayOutputStream();
+				getFromFuture(blobStore.downloadBlob(remoteActionExecutionContext, DIGEST, out));
+				assertThat(out.toString(StandardCharsets.US_ASCII.name())).isEqualTo("File Contents");
+		} finally {
+			testServer.stop(server);
+		}
   }
 }


### PR DESCRIPTION
[Issue 28960](https://github.com/bazelbuild/bazel/issues/28960)


### Description
- Merge all HTTP header categories when building the remote cache request

### Motivation
- If a user wants to use different headers with remote_cache_header and remote_exec_header, it is not possible

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
