### PR TITLE
Add `--null` to aquery and cquery.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/common/CommonQueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/common/CommonQueryOptions.java
@@ -54,6 +54,15 @@ public class CommonQueryOptions extends OptionsBase {
   public List<String> universeScope;
 
   @Option(
+      name = "null",
+      defaultValue = "null",
+      expansion = {"--line_terminator_null=true"},
+      documentationCategory = OptionDocumentationCategory.QUERY,
+      effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
+      help = "Whether each format is terminated with \\0 instead of newline.")
+  public Void isNull;
+
+  @Option(
       name = "line_terminator_null",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.QUERY,

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOptions.java
@@ -55,15 +55,6 @@ public class QueryOptions extends CommonQueryOptions {
   public boolean displayFullKind;
 
   @Option(
-      name = "null",
-      defaultValue = "null",
-      expansion = {"--line_terminator_null=true"},
-      documentationCategory = OptionDocumentationCategory.QUERY,
-      effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
-      help = "Whether each format is terminated with \\0 instead of newline.")
-  public Void isNull;
-
-  @Option(
       name = "order_results",
       defaultValue = "null",
       deprecationWarning =


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description

The `bazel query` command supports a [--null flag](https://bazel.build/reference/command-line-reference#query-flag--null) which expands out to [--line_terminator_null=true](https://bazel.build/reference/command-line-reference#query-flag--line_terminator_null).

This feature is useful for piping the output of the `query` command. The \0 (NUL) character is useful to unambiguously separate the output. Other tools such as GNU parallel, xargs, find, grep, etc... support separating input/output with NUL characters.

For all the reasons that the `--null` flag is useful for `query`, it should be added to `aquery` and `cquery` as well for consistency. They already support the `--line_terminator_null` flag anyway.

### Motivation

There is an inconsistency in between `query`, `aquery`, and `cquery` commands. It would be nice for all query commands to support the same flag.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
    * I didn't see any existing test cases for the `--null` flag in `query`. So I haven't added any new ones.
- [ ] I have updated the documentation (if applicable).
    * Not sure if I need to update the `.mdx` files or if they're autogenerated.

### Release Notes

RELNOTES[NEW]: bazel aquery/cquery now support the `--null` flag from the query command.

