### PR TITLE
[9.1.0] Increase `credential_helper_test` timeout (https://github.com/bazelbuild/bazel/pull/28986)

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/authandtls/credentialhelper/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/credentialhelper/BUILD
@@ -16,6 +16,7 @@ filegroup(
 
 java_test(
     name = "credentialhelper",
+    timeout = "long",
     srcs = glob(["*.java"]),
     data = [
         ":test_credential_helper",


### PR DESCRIPTION
### Description

### Motivation
This test flakily times out in CI pretty frequently.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #28986.

PiperOrigin-RevId: 883208467
Change-Id: Ideff68352a5bcba376f4dbad8401179bd32bc3e3

Commit https://github.com/bazelbuild/bazel/commit/6a70e55a7cfb0d73c44b1b076a952bf25877b7de