### PR TITLE
Enable --enable_platform_specific_config by default

### DIFF
--- a/docs/run/bazelrc.mdx
+++ b/docs/run/bazelrc.mdx
@@ -261,12 +261,15 @@ This syntax does not extend to the use of `startup` to set
 
 #### `--enable_platform_specific_config`
 
-Platform specific configs in the `.bazelrc` can be automatically enabled using
-`--enable_platform_specific_config`. For example, if the host OS is Linux and
-the `build` command is run, the `build:linux` configuration will be
-automatically enabled. Supported OS identifiers are `linux`, `macos`, `windows`,
-`freebsd`, and `openbsd`. Enabling this flag is equivalent to using
-`--config=linux` on Linux, `--config=windows` on Windows, and so on.
+In the `.bazelrc` you can use platform specific configs that will be
+automatically enabled based on the host OS. For example, if the host OS
+is Linux and the `build` command is run, the `build:linux` configuration
+will be automatically enabled. Supported OS identifiers are `linux`,
+`macos`, `windows`, `freebsd`, and `openbsd`.
+
+This is equivalent to using `--config=linux` on Linux,
+`--config=windows` on Windows, and so on. This can be disabled with
+`--enable_platform_specific_config=false`.
 
 See [--enable_platform_specific_config](/reference/command-line-reference#flag--enable_platform_specific_config).
 

--- a/site/en/run/bazelrc.md
+++ b/site/en/run/bazelrc.md
@@ -262,13 +262,15 @@ This syntax does not extend to the use of `startup` to set
 
 #### `--enable_platform_specific_config` {:#enable_platform_specific_config}
 
-Platform specific configs in the `.bazelrc` can be automatically enabled using
-`--enable_platform_specific_config`. For example, if the host OS is Linux and
-the `build` command is run, the `build:linux` configuration will be
-automatically enabled. Supported OS identifiers are `linux`, `macos`, `windows`,
-`freebsd`, and `openbsd`. Enabling this flag is equivalent to using
-`--config=linux` on Linux, `--config=windows` on Windows, `--config=macos` on
-macOS, `--config=freebsd` on FreeBSD, and `--config=openbsd` on OpenBSD.
+In the `.bazelrc` you can use platform specific configs that will be
+automatically enabled based on the host OS. For example, if the host OS
+is Linux and the `build` command is run, the `build:linux` configuration
+will be automatically enabled. Supported OS identifiers are `linux`,
+`macos`, `windows`, `freebsd`, and `openbsd`.
+
+This is equivalent to using `--config=linux` on Linux,
+`--config=windows` on Windows, and so on. This can be disabled with
+`--enable_platform_specific_config=false`.
 
 See [--enable_platform_specific_config](/reference/command-line-reference#flag--enable_platform_specific_config).
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -47,7 +47,7 @@ public class CommonCommandOptions extends OptionsBase {
   // value during options parsing based on its (string) name.
   @Option(
       name = "enable_platform_specific_config",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =

--- a/src/main/java/com/google/devtools/build/lib/runtime/ConfigExpander.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/ConfigExpander.java
@@ -61,11 +61,12 @@ final class ConfigExpander {
    * should enable the platform specific config.
    */
   private static boolean shouldEnablePlatformSpecificConfig(
-      OptionValueDescription enablePlatformSpecificConfigDescription,
+      @Nullable OptionValueDescription enablePlatformSpecificConfigDescription,
       ListMultimap<String, RcChunkOfArgs> commandToRcArgs,
       List<String> commandsToParse) {
-    if (enablePlatformSpecificConfigDescription == null
-        || !(boolean) enablePlatformSpecificConfigDescription.getValue()) {
+    // If the option was never explicitly set, the default value (true) applies.
+    if (enablePlatformSpecificConfigDescription != null
+        && !(boolean) enablePlatformSpecificConfigDescription.getValue()) {
       return false;
     }
 
@@ -135,6 +136,12 @@ final class ConfigExpander {
         optionsParser.getOptionValueDescription("enable_platform_specific_config");
     if (shouldEnablePlatformSpecificConfig(
         enablePlatformSpecificConfigDescription, commandToRcArgs, commandsToParse)) {
+      // Parse a fresh instance at this late point so the platform config expansion gets a late
+      // priority, ensuring platform-specific options override non-platform-specific ones
+      // regardless of where --enable_platform_specific_config was originally set in the rc file.
+      optionsParser.parse("--enable_platform_specific_config=true");
+      enablePlatformSpecificConfigDescription =
+          optionsParser.getOptionValueDescription("enable_platform_specific_config");
       var expansion =
           getExpansion(
               eventHandler,
@@ -144,7 +151,7 @@ final class ConfigExpander {
               rcFileNotesConsumer,
               fallbackData);
       ParsedOptionDescription optionToExpand =
-          Iterables.getOnlyElement(enablePlatformSpecificConfigDescription.getCanonicalInstances());
+          Iterables.getLast(enablePlatformSpecificConfigDescription.getCanonicalInstances());
       var ignoredArgs =
           optionsParser.parseArgsAsExpansionOfOption(
               optionToExpand, "enabled by --enable_platform_specific_config", expansion);

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
@@ -126,6 +126,9 @@ public class BlazeOptionHandlerTest {
     structuredArgs.put(
         "build:platform_config",
         new RcChunkOfArgs("rc1", ImmutableList.of("--enable_platform_specific_config")));
+    structuredArgs.put(
+        "build:platform_config_disabled",
+        new RcChunkOfArgs("rc1", ImmutableList.of("--enable_platform_specific_config=false")));
     return structuredArgs;
   }
 
@@ -325,12 +328,87 @@ public class BlazeOptionHandlerTest {
   }
 
   @Test
+  public void testExpandConfigOptions_withPlatformSpecificConfigDisabledInConfig()
+      throws Exception {
+    parser.parse("--config=platform_config_disabled");
+    optionHandler.expandConfigOptions(eventHandler, structuredArgsForDifferentPlatforms());
+    assertThat(parser.getResidue()).isEmpty();
+  }
+
+  @Test
   public void testExpandConfigOptions_withPlatformSpecificConfigEnabledWhenNothingSpecified()
       throws Exception {
     parser.parse("--enable_platform_specific_config");
     optionHandler.parseRcOptions(eventHandler, ArrayListMultimap.create());
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).isEmpty();
+  }
+
+  @Test
+  public void testExpandConfigOptions_platformSpecificConfigOverridesRegardlessOfOrder()
+      throws Exception {
+    // Platform-specific config options should override non-platform-specific options even when
+    // --enable_platform_specific_config appears before the non-platform-specific option in the
+    // bazelrc (or is enabled by default).
+    ListMultimap<String, RcChunkOfArgs> structuredArgs = ArrayListMultimap.create();
+    structuredArgs.put(
+        "build",
+        new RcChunkOfArgs("rc1", ImmutableList.of("--enable_platform_specific_config")));
+    structuredArgs.put(
+        "build",
+        new RcChunkOfArgs("rc1", ImmutableList.of("--test_multiple_string=common_value")));
+    structuredArgs.put(
+        "build:linux",
+        new RcChunkOfArgs("rc1", ImmutableList.of("--test_multiple_string=linux_value")));
+    structuredArgs.put(
+        "build:macos",
+        new RcChunkOfArgs("rc1", ImmutableList.of("--test_multiple_string=macos_value")));
+    structuredArgs.put(
+        "build:windows",
+        new RcChunkOfArgs("rc1", ImmutableList.of("--test_multiple_string=windows_value")));
+    structuredArgs.put(
+        "build:freebsd",
+        new RcChunkOfArgs("rc1", ImmutableList.of("--test_multiple_string=freebsd_value")));
+    structuredArgs.put(
+        "build:openbsd",
+        new RcChunkOfArgs("rc1", ImmutableList.of("--test_multiple_string=openbsd_value")));
+
+    optionHandler.parseRcOptions(eventHandler, structuredArgs);
+    optionHandler.expandConfigOptions(eventHandler, structuredArgs);
+
+    TestOptions options = parser.getOptions(TestOptions.class);
+    assertThat(options).isNotNull();
+    // The platform-specific value should come after the common value, meaning the last value
+    // (the platform-specific one) takes precedence for last-write-wins options.
+    switch (OS.getCurrent()) {
+      case LINUX:
+        assertThat(options.testMultipleString)
+            .containsExactly("common_value", "linux_value")
+            .inOrder();
+        break;
+      case DARWIN:
+        assertThat(options.testMultipleString)
+            .containsExactly("common_value", "macos_value")
+            .inOrder();
+        break;
+      case WINDOWS:
+        assertThat(options.testMultipleString)
+            .containsExactly("common_value", "windows_value")
+            .inOrder();
+        break;
+      case FREEBSD:
+        assertThat(options.testMultipleString)
+            .containsExactly("common_value", "freebsd_value")
+            .inOrder();
+        break;
+      case OPENBSD:
+        assertThat(options.testMultipleString)
+            .containsExactly("common_value", "openbsd_value")
+            .inOrder();
+        break;
+      default:
+        assertThat(options.testMultipleString).containsExactly("common_value");
+    }
   }
 
   @Test


### PR DESCRIPTION
I think in the common case this is what users would prefer. It's
possible this conflicts with non-automatic configs with the same
platform name, but that seems low risk since likely they would be
intended for the same purpose.

This is an updated version of 93f57a42389eb3bfe3335e3b1f9fd186e6ddae47
which was reverted because of https://github.com/bazelbuild/bazel/issues/27063

Fixes https://github.com/bazelbuild/bazel/issues/27063

RELNOTES[inc]: Enable --enable_platform_specific_config by default
