### PR TITLE
WIP: Implement hierarchical constraint settings (refines_constraint_value)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/ConfigMatchingProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/ConfigMatchingProvider.java
@@ -173,6 +173,9 @@ public abstract class ConfigMatchingProvider implements TransitiveInfoProvider {
    * @param label the build label corresponding to this matcher
    * @param settingsMap the condition settings that trigger this matcher
    * @param flagSettingsMap the label-keyed settings that trigger this matcher
+   * @param constraintValueSettings the constraint value labels that trigger this matcher
+   * @param constraintValueRefinements maps constraint value labels to the constraint value labels
+   *     they refine via hierarchical constraint settings
    * @param result whether the current associated configuration matches, doesn't match, or is
    *     irresolvable due to specified issue
    */
@@ -181,9 +184,26 @@ public abstract class ConfigMatchingProvider implements TransitiveInfoProvider {
       ImmutableMultimap<String, String> settingsMap,
       ImmutableMap<Label, String> flagSettingsMap,
       ImmutableSet<Label> constraintValueSettings,
+      ImmutableMap<Label, Label> constraintValueRefinements,
       MatchResult result) {
     return new AutoValue_ConfigMatchingProvider(
-        label, settingsMap, flagSettingsMap, constraintValueSettings, result);
+        label,
+        settingsMap,
+        flagSettingsMap,
+        constraintValueSettings,
+        constraintValueRefinements,
+        result);
+  }
+
+  /** Overload for callers that do not need hierarchical constraint refinement. */
+  public static ConfigMatchingProvider create(
+      Label label,
+      ImmutableMultimap<String, String> settingsMap,
+      ImmutableMap<Label, String> flagSettingsMap,
+      ImmutableSet<Label> constraintValueSettings,
+      MatchResult result) {
+    return create(
+        label, settingsMap, flagSettingsMap, constraintValueSettings, ImmutableMap.of(), result);
   }
 
   /** The target's label. */
@@ -196,6 +216,13 @@ public abstract class ConfigMatchingProvider implements TransitiveInfoProvider {
   public abstract ImmutableSet<Label> constraintValuesSetting();
 
   /**
+   * Maps constraint value labels to the constraint value labels they refine via hierarchical
+   * constraint settings. Used for determining select() specialization across constraint settings
+   * linked by {@code refines_constraint_value}.
+   */
+  public abstract ImmutableMap<Label, Label> constraintValueRefinements();
+
+  /**
    * Whether or not the configuration criteria defined by this target match its actual
    * configuration.
    */
@@ -204,6 +231,10 @@ public abstract class ConfigMatchingProvider implements TransitiveInfoProvider {
   /**
    * Returns true if this matcher's conditions are a proper superset of another matcher's
    * conditions, i.e. if this matcher is a specialization of the other one.
+   *
+   * <p>For constraint values, this also considers hierarchical refinement: if this matcher's
+   * constraint value refines (via {@code refines_constraint_value}) a constraint value in the other
+   * matcher, this matcher is considered more specific.
    */
   public boolean refines(ConfigMatchingProvider other) {
     ImmutableSet<Map.Entry<String, String>> settings = ImmutableSet.copyOf(settingsMap().entries());
@@ -212,18 +243,62 @@ public abstract class ConfigMatchingProvider implements TransitiveInfoProvider {
     ImmutableSet<Map.Entry<Label, String>> flagSettings = flagSettingsMap().entrySet();
     ImmutableSet<Map.Entry<Label, String>> otherFlagSettings = other.flagSettingsMap().entrySet();
 
-    ImmutableSet<Label> constraintValueSettings = constraintValuesSetting();
-    ImmutableSet<Label> otherConstraintValueSettings = other.constraintValuesSetting();
-
     if (!settings.containsAll(otherSettings)
-        || !flagSettings.containsAll(otherFlagSettings)
-        || !constraintValueSettings.containsAll(otherConstraintValueSettings)) {
+        || !flagSettings.containsAll(otherFlagSettings)) {
       return false; // Not a superset.
+    }
+
+    // For constraint values, check "covers" relationship: each of the other's constraint values
+    // must be either directly in ours or refined by one of ours.
+    if (!constraintValuesCovers(other.constraintValuesSetting())) {
+      return false;
     }
 
     return settings.size() > otherSettings.size()
         || flagSettings.size() > otherFlagSettings.size()
-        || constraintValueSettings.size() > otherConstraintValueSettings.size();
+        || constraintValuesSetting().size() > other.constraintValuesSetting().size()
+        || constraintValuesStrictlyRefines(other.constraintValuesSetting());
+  }
+
+  /**
+   * Returns true if every constraint value label in {@code other} is either directly present in
+   * this provider's constraint values or is refined by one of this provider's constraint values via
+   * the hierarchical constraint setting relationship.
+   */
+  private boolean constraintValuesCovers(ImmutableSet<Label> other) {
+    ImmutableSet<Label> mine = constraintValuesSetting();
+    for (Label otherLabel : other) {
+      if (mine.contains(otherLabel)) {
+        continue;
+      }
+      boolean covered = false;
+      for (Label myLabel : mine) {
+        Label refinesLabel = constraintValueRefinements().get(myLabel);
+        if (otherLabel.equals(refinesLabel)) {
+          covered = true;
+          break;
+        }
+      }
+      if (!covered) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Returns true if at least one of this provider's constraint values hierarchically refines a
+   * constraint value in {@code other} (rather than matching it directly). This means this provider
+   * is strictly more specific even if the set sizes are the same.
+   */
+  private boolean constraintValuesStrictlyRefines(ImmutableSet<Label> other) {
+    for (Label myLabel : constraintValuesSetting()) {
+      Label refinesLabel = constraintValueRefinements().get(myLabel);
+      if (refinesLabel != null && other.contains(refinesLabel)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /** Format this provider as its label. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollection.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollection.java
@@ -209,6 +209,19 @@ public abstract class ConstraintCollection
   }
 
   /**
+   * Returns whether any constraint value in this collection (including from parents) has the given
+   * label.
+   */
+  public boolean hasConstraintValueWithLabel(Label label) {
+    for (ConstraintValueInfo cv : constraints().values()) {
+      if (cv.label().equals(label)) {
+        return true;
+      }
+    }
+    return parent() != null && parent().hasConstraintValueWithLabel(label);
+  }
+
+  /**
    * Returns the {@link ConstraintValueInfo} for the given {@link ConstraintSettingInfo}, or {@code
    * null} if none exists.
    */

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintSettingInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintSettingInfo.java
@@ -37,10 +37,15 @@ public class ConstraintSettingInfo extends NativeInfo implements ConstraintSetti
 
   private final Label label;
   @Nullable private final Label defaultConstraintValueLabel;
+  @Nullable private final Label refinesConstraintValueLabel;
 
-  private ConstraintSettingInfo(Label label, Label defaultConstraintValueLabel) {
+  private ConstraintSettingInfo(
+      Label label,
+      @Nullable Label defaultConstraintValueLabel,
+      @Nullable Label refinesConstraintValueLabel) {
     this.label = label;
     this.defaultConstraintValueLabel = defaultConstraintValueLabel;
+    this.refinesConstraintValueLabel = refinesConstraintValueLabel;
   }
 
   @Override
@@ -65,6 +70,17 @@ public class ConstraintSettingInfo extends NativeInfo implements ConstraintSetti
       return null;
     }
     return ConstraintValueInfo.create(this, defaultConstraintValueLabel);
+  }
+
+  @Override
+  public boolean hasRefinesConstraintValue() {
+    return refinesConstraintValueLabel != null;
+  }
+
+  @Override
+  @Nullable
+  public Label refinesConstraintValueLabel() {
+    return refinesConstraintValueLabel;
   }
 
   /** Add this constraint setting to the given fingerprint. */
@@ -92,17 +108,29 @@ public class ConstraintSettingInfo extends NativeInfo implements ConstraintSetti
     if (defaultConstraintValueLabel != null) {
       printer.append(", default_constraint_value=").str(defaultConstraintValueLabel, semantics);
     }
+    if (refinesConstraintValueLabel != null) {
+      printer.append(", refines_constraint_value=").str(refinesConstraintValueLabel, semantics);
+    }
     printer.append(")");
   }
 
   /** Returns a new {@link ConstraintSettingInfo} with the given data. */
   public static ConstraintSettingInfo create(Label constraintSetting) {
-    return create(constraintSetting, null);
+    return create(constraintSetting, null, null);
   }
 
   /** Returns a new {@link ConstraintSettingInfo} with the given data. */
   public static ConstraintSettingInfo create(
-      Label constraintSetting, Label defaultConstraintValue) {
-    return new ConstraintSettingInfo(constraintSetting, defaultConstraintValue);
+      Label constraintSetting, @Nullable Label defaultConstraintValue) {
+    return create(constraintSetting, defaultConstraintValue, null);
+  }
+
+  /** Returns a new {@link ConstraintSettingInfo} with the given data. */
+  public static ConstraintSettingInfo create(
+      Label constraintSetting,
+      @Nullable Label defaultConstraintValue,
+      @Nullable Label refinesConstraintValue) {
+    return new ConstraintSettingInfo(
+        constraintSetting, defaultConstraintValue, refinesConstraintValue);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintValueInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintValueInfo.java
@@ -76,11 +76,15 @@ public class ConstraintValueInfo extends NativeInfo implements ConstraintValueIn
    */
   public ConfigMatchingProvider configMatchingProvider(PlatformInfo platformInfo) {
     ConstraintValueInfo platformValue = platformInfo.constraints().get(this.constraint());
+    Label refinesLabel = constraint().refinesConstraintValueLabel();
+    ImmutableMap<Label, Label> refinements =
+        refinesLabel != null ? ImmutableMap.of(label(), refinesLabel) : ImmutableMap.of();
     return ConfigMatchingProvider.create(
         label,
         ImmutableMultimap.of(),
         ImmutableMap.of(),
-        ImmutableSet.of(),
+        ImmutableSet.of(label()),
+        refinements,
         computeMatchResult(platformValue));
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
@@ -158,6 +158,7 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
             settings.nativeFlagSettings,
             userDefinedFlags.getSpecifiedFlagValues(),
             ImmutableSet.copyOf(getSpecifiedConstraintValues(ruleContext)),
+            getConstraintValueRefinements(ruleContext),
             Stream.of(userDefinedFlags.result(), nativeFlagsResult, constraintValuesResult)
                 .reduce(MatchResult::combine)
                 .get());
@@ -847,5 +848,25 @@ Either remove one of these settings or ensure they match the same value.
     return ruleContext.getPrerequisites(ConfigSettingRule.CONSTRAINT_VALUES_ATTRIBUTE).stream()
         .map(TransitiveInfoCollection::getLabel)
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Builds a map from constraint value labels to the constraint value labels they refine, based on
+   * the {@code refines_constraint_value} attribute on their constraint settings.
+   */
+  private static ImmutableMap<Label, Label> getConstraintValueRefinements(
+      RuleContext ruleContext) {
+    ImmutableMap.Builder<Label, Label> refinements = ImmutableMap.builder();
+    for (TransitiveInfoCollection dep :
+        ruleContext.getPrerequisites(ConfigSettingRule.CONSTRAINT_VALUES_ATTRIBUTE)) {
+      ConstraintValueInfo cvInfo = PlatformProviderUtils.constraintValue(dep);
+      if (cvInfo != null) {
+        Label refinedLabel = cvInfo.constraint().refinesConstraintValueLabel();
+        if (refinedLabel != null) {
+          refinements.put(dep.getLabel(), refinedLabel);
+        }
+      }
+    }
+    return refinements.buildOrThrow();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/ConstraintSetting.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/ConstraintSetting.java
@@ -47,15 +47,21 @@ public class ConstraintSetting implements RuleConfiguredTargetFactory {
         ruleContext
             .attributes()
             .get(ConstraintSettingRule.DEFAULT_CONSTRAINT_VALUE_ATTR, BuildType.NODEP_LABEL);
+    Label refinesConstraintValue =
+        ruleContext
+            .attributes()
+            .get(ConstraintSettingRule.REFINES_CONSTRAINT_VALUE_ATTR, BuildType.NODEP_LABEL);
 
     validateDefaultConstraintValue(ruleContext, constraintSetting, defaultConstraintValue);
+    validateRefinesConstraintValue(ruleContext, defaultConstraintValue, refinesConstraintValue);
 
     return new RuleConfiguredTargetBuilder(ruleContext)
         .addProvider(RunfilesProvider.class, RunfilesProvider.EMPTY)
         .addProvider(FileProvider.class, FileProvider.EMPTY)
         .addProvider(FilesToRunProvider.class, FilesToRunProvider.EMPTY)
         .addNativeDeclaredProvider(
-            ConstraintSettingInfo.create(constraintSetting, defaultConstraintValue))
+            ConstraintSettingInfo.create(
+                constraintSetting, defaultConstraintValue, refinesConstraintValue))
         .build();
   }
 
@@ -92,6 +98,22 @@ public class ConstraintSetting implements RuleConfiguredTargetFactory {
       throw ruleContext.throwWithAttributeError(
           ConstraintSettingRule.DEFAULT_CONSTRAINT_VALUE_ATTR,
           "The default constraint value '" + defaultConstraintValue + "' does not exist");
+    }
+  }
+
+  private void validateRefinesConstraintValue(
+      RuleContext ruleContext,
+      @Nullable Label defaultConstraintValue,
+      @Nullable Label refinesConstraintValue)
+      throws RuleErrorException {
+    if (refinesConstraintValue == null) {
+      return;
+    }
+
+    if (defaultConstraintValue != null) {
+      throw ruleContext.throwWithAttributeError(
+          ConstraintSettingRule.REFINES_CONSTRAINT_VALUE_ATTR,
+          "refines_constraint_value and default_constraint_value are mutually exclusive.");
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/ConstraintSettingRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/ConstraintSettingRule.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.packages.Types;
 public class ConstraintSettingRule implements RuleDefinition {
   public static final String RULE_NAME = "constraint_setting";
   public static final String DEFAULT_CONSTRAINT_VALUE_ATTR = "default_constraint_value";
+  public static final String REFINES_CONSTRAINT_VALUE_ATTR = "refines_constraint_value";
 
   @Override
   public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment env) {
@@ -60,6 +61,18 @@ public class ConstraintSettingRule implements RuleDefinition {
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(
             attr(DEFAULT_CONSTRAINT_VALUE_ATTR, BuildType.NODEP_LABEL)
+                .nonconfigurable("constants must be consistent across configurations"))
+        /* <!-- #BLAZE_RULE(constraint_setting).ATTRIBUTE(refines_constraint_value) -->
+        The label of the <code>constraint_value</code> that this constraint setting refines. If set,
+        any platform specifying a <code>constraint_value</code> of this setting must also specify
+        the refined <code>constraint_value</code>. Additionally, in <code>select()</code>
+        expressions, a <code>constraint_value</code> of this setting is considered more specific
+        than the refined <code>constraint_value</code>, resolving ambiguity.
+
+        <p>This attribute is mutually exclusive with <code>default_constraint_value</code>.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(
+            attr(REFINES_CONSTRAINT_VALUE_ATTR, BuildType.NODEP_LABEL)
                 .nonconfigurable("constants must be consistent across configurations"))
         .build();
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/Platform.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/Platform.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.RunfilesProvider;
 import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
 import com.google.devtools.build.lib.analysis.platform.ConstraintCollection;
+import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.analysis.platform.PlatformProviderUtils;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -104,11 +105,46 @@ public class Platform implements RuleConfiguredTargetFactory {
       throw ruleContext.throwWithAttributeError(PlatformRule.EXEC_PROPS_ATTR, e.getMessage());
     }
 
+    validateRefinementConstraints(
+        ruleContext,
+        PlatformProviderUtils.constraintValues(
+            ruleContext.getPrerequisites(PlatformRule.CONSTRAINT_VALUES_ATTR)),
+        platformInfo);
+
     return new RuleConfiguredTargetBuilder(ruleContext)
         .addProvider(RunfilesProvider.class, RunfilesProvider.EMPTY)
         .addProvider(FileProvider.class, FileProvider.EMPTY)
         .addProvider(FilesToRunProvider.class, FilesToRunProvider.EMPTY)
         .addNativeDeclaredProvider(platformInfo)
         .build();
+  }
+
+  /**
+   * Validates that for every constraint value from a refining constraint setting, the refined
+   * constraint value is also present in the platform (directly or via parent).
+   */
+  private static void validateRefinementConstraints(
+      RuleContext ruleContext,
+      Iterable<ConstraintValueInfo> constraintValues,
+      PlatformInfo platformInfo)
+      throws RuleErrorException {
+    for (ConstraintValueInfo cv : constraintValues) {
+      Label refinedLabel = cv.constraint().refinesConstraintValueLabel();
+      if (refinedLabel != null
+          && !platformInfo.constraints().hasConstraintValueWithLabel(refinedLabel)) {
+        throw ruleContext.throwWithAttributeError(
+            PlatformRule.CONSTRAINT_VALUES_ATTR,
+            String.format(
+                "Constraint value %s is for constraint setting %s which refines constraint value"
+                    + " %s, but the platform does not include %s in its constraint_values."
+                    + " To fix, run: buildozer 'add constraint_values %s' %s",
+                cv.label(),
+                cv.constraint().label(),
+                refinedLabel,
+                refinedLabel,
+                refinedLabel,
+                ruleContext.getLabel()));
+      }
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/ConstraintSettingInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/ConstraintSettingInfoApi.java
@@ -54,4 +54,19 @@ public interface ConstraintSettingInfoApi extends StructApi {
       doc = "Whether there is a default constraint_value for this setting.",
       structField = true)
   boolean hasDefaultConstraintValue();
+
+  @StarlarkMethod(
+      name = "refines_constraint_value",
+      doc = "The constraint_value that this constraint setting refines, or None.",
+      structField = true,
+      allowReturnNones = true,
+      enableOnlyWithFlag = BuildLanguageOptions.EXPERIMENTAL_PLATFORMS_API)
+  @Nullable
+  Label refinesConstraintValueLabel();
+
+  @StarlarkMethod(
+      name = "has_refines_constraint_value",
+      doc = "Whether this constraint setting refines a constraint_value.",
+      structField = true)
+  boolean hasRefinesConstraintValue();
 }

--- a/src/test/java/com/google/devtools/build/lib/analysis/ConfigurableAttributesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/ConfigurableAttributesTest.java
@@ -2366,4 +2366,198 @@ public class ConfigurableAttributesTest extends BuildViewTestCase {
         /*expected:*/ ImmutableList.of(DEFAULTDEP_INPUT),
         /*not expected:*/ ImmutableList.of(ADEP_INPUT, BDEP_INPUT));
   }
+
+  @Test
+  public void selectOnHierarchicalConstraints_configSetting() throws Exception {
+    // Tests that hierarchical constraint settings resolve select() ambiguity.
+    scratch.file(
+        "conditions/BUILD",
+        """
+        constraint_setting(name = 'libc')
+        constraint_value(name = 'glibc', constraint_setting = 'libc')
+        constraint_setting(
+            name = 'glibc_version',
+            refines_constraint_value = ':glibc',
+        )
+        constraint_value(name = 'glibc_2_42', constraint_setting = 'glibc_version')
+        platform(
+            name = 'glibc_2_42_platform',
+            constraint_values = [':glibc', ':glibc_2_42'],
+        )
+        config_setting(
+            name = 'is_glibc',
+            constraint_values = [':glibc'],
+        )
+        config_setting(
+            name = 'is_glibc_2_42',
+            constraint_values = [':glibc_2_42'],
+        )
+        """);
+    scratch.file(
+        "check/BUILD",
+        """
+        filegroup(name = 'glibc_dep', srcs = ['glibcfile'])
+        filegroup(name = 'glibc_2_42_dep', srcs = ['glibc242file'])
+        filegroup(name = 'hello',
+            srcs = select({
+                '//conditions:is_glibc': [':glibc_dep'],
+                '//conditions:is_glibc_2_42': [':glibc_2_42_dep'],
+            }))
+        """);
+    // Both match, but is_glibc_2_42 refines is_glibc, so it wins.
+    checkRule(
+        "//check:hello",
+        "srcs",
+        ImmutableList.of("--experimental_platforms=//conditions:glibc_2_42_platform"),
+        /*expected:*/ ImmutableList.of("src check/glibc242file"),
+        /*not expected:*/ ImmutableList.of("src check/glibcfile"));
+  }
+
+  @Test
+  public void selectOnHierarchicalConstraints_directConstraintValues() throws Exception {
+    // Tests select()ing directly on constraint_values with hierarchical refinement.
+    scratch.file(
+        "conditions/BUILD",
+        """
+        constraint_setting(name = 'libc')
+        constraint_value(name = 'glibc', constraint_setting = 'libc')
+        constraint_setting(
+            name = 'glibc_version',
+            refines_constraint_value = ':glibc',
+        )
+        constraint_value(name = 'glibc_2_42', constraint_setting = 'glibc_version')
+        platform(
+            name = 'glibc_2_42_platform',
+            constraint_values = [':glibc', ':glibc_2_42'],
+        )
+        """);
+    scratch.file(
+        "check/defs.bzl",
+        """
+        def _impl(ctx):
+          pass
+        simple_rule = rule(
+          implementation = _impl,
+          attrs = {'srcs': attr.label_list(allow_files = True)}
+        )
+        """);
+    scratch.file(
+        "check/BUILD",
+        """
+        load('//check:defs.bzl', 'simple_rule')
+        filegroup(name = 'glibc_dep', srcs = ['glibcfile'])
+        filegroup(name = 'glibc_2_42_dep', srcs = ['glibc242file'])
+        simple_rule(name = 'hello',
+            srcs = select({
+                '//conditions:glibc': [':glibc_dep'],
+                '//conditions:glibc_2_42': [':glibc_2_42_dep'],
+            }))
+        """);
+    // Both match, but glibc_2_42 refines glibc (via hierarchical setting), so it wins.
+    checkRule(
+        "//check:hello",
+        "srcs",
+        ImmutableList.of("--platforms=//conditions:glibc_2_42_platform"),
+        /*expected:*/ ImmutableList.of("src check/glibc242file"),
+        /*not expected:*/ ImmutableList.of("src check/glibcfile"));
+  }
+
+  @Test
+  public void selectOnHierarchicalConstraints_onlyRefinedMatches() throws Exception {
+    // When only the refined constraint matches (platform doesn't have the refining value),
+    // the refined branch should be selected.
+    scratch.file(
+        "conditions/BUILD",
+        """
+        constraint_setting(name = 'libc')
+        constraint_value(name = 'glibc', constraint_setting = 'libc')
+        constraint_setting(
+            name = 'glibc_version',
+            refines_constraint_value = ':glibc',
+        )
+        constraint_value(name = 'glibc_2_42', constraint_setting = 'glibc_version')
+        platform(
+            name = 'glibc_platform',
+            constraint_values = [':glibc'],
+        )
+        config_setting(
+            name = 'is_glibc',
+            constraint_values = [':glibc'],
+        )
+        config_setting(
+            name = 'is_glibc_2_42',
+            constraint_values = [':glibc_2_42'],
+        )
+        """);
+    scratch.file(
+        "check/BUILD",
+        """
+        filegroup(name = 'glibc_dep', srcs = ['glibcfile'])
+        filegroup(name = 'glibc_2_42_dep', srcs = ['glibc242file'])
+        filegroup(name = 'defaultdep', srcs = ['defaultfile'])
+        filegroup(name = 'hello',
+            srcs = select({
+                '//conditions:is_glibc': [':glibc_dep'],
+                '//conditions:is_glibc_2_42': [':glibc_2_42_dep'],
+                '//conditions:default': [':defaultdep'],
+            }))
+        """);
+    // Only is_glibc matches (platform has glibc but not glibc_2_42).
+    checkRule(
+        "//check:hello",
+        "srcs",
+        ImmutableList.of("--experimental_platforms=//conditions:glibc_platform"),
+        /*expected:*/ ImmutableList.of("src check/glibcfile"),
+        /*not expected:*/ ImmutableList.of("src check/glibc242file", "src check/defaultfile"));
+  }
+
+  @Test
+  public void selectOnHierarchicalConstraints_noAmbiguityWithExtraSettings() throws Exception {
+    // When the refining config_setting also has additional flag values, it should still
+    // refine the base constraint.
+    scratch.file(
+        "conditions/BUILD",
+        """
+        constraint_setting(name = 'libc')
+        constraint_value(name = 'glibc', constraint_setting = 'libc')
+        constraint_setting(
+            name = 'glibc_version',
+            refines_constraint_value = ':glibc',
+        )
+        constraint_value(name = 'glibc_2_42', constraint_setting = 'glibc_version')
+        platform(
+            name = 'glibc_2_42_platform',
+            constraint_values = [':glibc', ':glibc_2_42'],
+        )
+        config_setting(
+            name = 'is_glibc',
+            constraint_values = [':glibc'],
+        )
+        config_setting(
+            name = 'is_glibc_2_42_dbg',
+            constraint_values = [':glibc_2_42'],
+            values = {'compilation_mode': 'dbg'},
+        )
+        """);
+    scratch.file(
+        "check/BUILD",
+        """
+        filegroup(name = 'glibc_dep', srcs = ['glibcfile'])
+        filegroup(name = 'glibc_2_42_dbg_dep', srcs = ['glibc242dbgfile'])
+        filegroup(name = 'hello',
+            srcs = select({
+                '//conditions:is_glibc': [':glibc_dep'],
+                '//conditions:is_glibc_2_42_dbg': [':glibc_2_42_dbg_dep'],
+            }))
+        """);
+    // is_glibc_2_42_dbg refines is_glibc (hierarchical constraint + extra flag)
+    checkRule(
+        "//check:hello",
+        "srcs",
+        ImmutableList.of(
+            "--experimental_platforms=//conditions:glibc_2_42_platform",
+            "--compilation_mode=dbg"),
+        /*expected:*/ ImmutableList.of("src check/glibc242dbgfile"),
+        /*not expected:*/ ImmutableList.of("src check/glibcfile"));
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/BUILD
@@ -283,3 +283,15 @@ java_test(
         "//third_party:truth",
     ],
 )
+
+java_test(
+    name = "ConfigMatchingProviderTest",
+    srcs = ["ConfigMatchingProviderTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/analysis/config:config_matching_provider",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//third_party:guava",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/ConfigMatchingProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/ConfigMatchingProviderTest.java
@@ -1,0 +1,211 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.analysis.config;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.cmdline.Label;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link ConfigMatchingProvider}, focused on refinement logic. */
+@RunWith(JUnit4.class)
+public class ConfigMatchingProviderTest {
+
+  private static Label label(String labelStr) {
+    return Label.parseCanonicalUnchecked(labelStr);
+  }
+
+  @Test
+  public void refines_supersetConstraintValues() {
+    // A with 2 constraint values refines B with 1 constraint value (standard superset).
+    ConfigMatchingProvider a =
+        ConfigMatchingProvider.create(
+            label("//test:a"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(label("//cv:x"), label("//cv:y")),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    ConfigMatchingProvider b =
+        ConfigMatchingProvider.create(
+            label("//test:b"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(label("//cv:x")),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    assertThat(a.refines(b)).isTrue();
+    assertThat(b.refines(a)).isFalse();
+  }
+
+  @Test
+  public void refines_hierarchicalConstraintValues() {
+    // A has glibc_2_42 (which refines glibc), B has glibc.
+    // A should refine B via hierarchical constraint.
+    ConfigMatchingProvider a =
+        ConfigMatchingProvider.create(
+            label("//test:a"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(label("//libc/glibc:2_42")),
+            ImmutableMap.of(label("//libc/glibc:2_42"), label("//libc:glibc")),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    ConfigMatchingProvider b =
+        ConfigMatchingProvider.create(
+            label("//test:b"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(label("//libc:glibc")),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    assertThat(a.refines(b)).isTrue();
+    assertThat(b.refines(a)).isFalse();
+  }
+
+  @Test
+  public void refines_hierarchicalWithSharedConstraint() {
+    // A: {glibc_2_42, x86} where glibc_2_42 refines glibc.
+    // B: {glibc, x86}
+    // A refines B because glibc_2_42 hierarchically covers glibc and x86 matches directly.
+    ConfigMatchingProvider a =
+        ConfigMatchingProvider.create(
+            label("//test:a"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(label("//libc/glibc:2_42"), label("//cpu:x86")),
+            ImmutableMap.of(label("//libc/glibc:2_42"), label("//libc:glibc")),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    ConfigMatchingProvider b =
+        ConfigMatchingProvider.create(
+            label("//test:b"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(label("//libc:glibc"), label("//cpu:x86")),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    assertThat(a.refines(b)).isTrue();
+    assertThat(b.refines(a)).isFalse();
+  }
+
+  @Test
+  public void refines_hierarchicalDoesNotRefineUnrelated() {
+    // glibc_2_42 refines glibc, but NOT musl.
+    ConfigMatchingProvider a =
+        ConfigMatchingProvider.create(
+            label("//test:a"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(label("//libc/glibc:2_42")),
+            ImmutableMap.of(label("//libc/glibc:2_42"), label("//libc:glibc")),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    ConfigMatchingProvider b =
+        ConfigMatchingProvider.create(
+            label("//test:b"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(label("//libc:musl")),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    assertThat(a.refines(b)).isFalse();
+    assertThat(b.refines(a)).isFalse();
+  }
+
+  @Test
+  public void refines_hierarchicalPlusExtraFlag() {
+    // A has glibc_2_42 (refines glibc) AND a native flag.
+    // B has glibc only.
+    // A refines B (hierarchical constraint + additional flag).
+    ConfigMatchingProvider a =
+        ConfigMatchingProvider.create(
+            label("//test:a"),
+            ImmutableMultimap.of("compilation_mode", "dbg"),
+            ImmutableMap.of(),
+            ImmutableSet.of(label("//libc/glibc:2_42")),
+            ImmutableMap.of(label("//libc/glibc:2_42"), label("//libc:glibc")),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    ConfigMatchingProvider b =
+        ConfigMatchingProvider.create(
+            label("//test:b"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(label("//libc:glibc")),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    assertThat(a.refines(b)).isTrue();
+    assertThat(b.refines(a)).isFalse();
+  }
+
+  @Test
+  public void refines_identicalConstraints_noRefinement() {
+    // Same constraint values, same sizes. Neither refines the other.
+    ConfigMatchingProvider a =
+        ConfigMatchingProvider.create(
+            label("//test:a"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(label("//cv:x")),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    ConfigMatchingProvider b =
+        ConfigMatchingProvider.create(
+            label("//test:b"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(label("//cv:x")),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    assertThat(a.refines(b)).isFalse();
+    assertThat(b.refines(a)).isFalse();
+  }
+
+  @Test
+  public void refines_disjointConstraints_noRefinement() {
+    // Completely different constraint values. Neither refines.
+    ConfigMatchingProvider a =
+        ConfigMatchingProvider.create(
+            label("//test:a"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(label("//cv:x")),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    ConfigMatchingProvider b =
+        ConfigMatchingProvider.create(
+            label("//test:b"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(label("//cv:y")),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    assertThat(a.refines(b)).isFalse();
+    assertThat(b.refines(a)).isFalse();
+  }
+
+  @Test
+  public void refines_emptyConstraints_noRefinement() {
+    // Both empty. Neither refines.
+    ConfigMatchingProvider a =
+        ConfigMatchingProvider.create(
+            label("//test:a"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    ConfigMatchingProvider b =
+        ConfigMatchingProvider.create(
+            label("//test:b"),
+            ImmutableMultimap.of(),
+            ImmutableMap.of(),
+            ImmutableSet.of(),
+            ConfigMatchingProvider.MatchResult.MATCH);
+    assertThat(a.refines(b)).isFalse();
+    assertThat(b.refines(a)).isFalse();
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
@@ -3431,4 +3431,233 @@ public final class ConfigSettingTest extends BuildViewTestCase {
           .doesNotContain(PrecomputedValue.STAMP_SETTING_MARKER.getKey());
     }
   }
+
+  @Test
+  public void refinesSettingWithHierarchicalConstraintValues() throws Exception {
+    scratch.file(
+        "test/BUILD",
+        """
+        constraint_setting(name = "libc")
+
+        constraint_value(
+            name = "glibc",
+            constraint_setting = "libc",
+        )
+
+        constraint_setting(
+            name = "glibc_version",
+            refines_constraint_value = ":glibc",
+        )
+
+        constraint_value(
+            name = "glibc_2_42",
+            constraint_setting = "glibc_version",
+        )
+
+        platform(
+            name = "glibc_platform",
+            constraint_values = [
+                ":glibc",
+                ":glibc_2_42",
+            ],
+        )
+
+        config_setting(
+            name = "is_glibc",
+            constraint_values = [":glibc"],
+        )
+
+        config_setting(
+            name = "is_glibc_2_42",
+            constraint_values = [":glibc_2_42"],
+        )
+        """);
+    useConfiguration("--platforms=//test:glibc_platform");
+    assertThat(
+            getConfigMatchingProvider("//test:is_glibc_2_42")
+                .refines(getConfigMatchingProvider("//test:is_glibc")))
+        .isTrue();
+    assertThat(
+            getConfigMatchingProvider("//test:is_glibc")
+                .refines(getConfigMatchingProvider("//test:is_glibc_2_42")))
+        .isFalse();
+  }
+
+  @Test
+  public void hierarchicalConstraintRefinesWithAdditionalConstraints() throws Exception {
+    scratch.file(
+        "test/BUILD",
+        """
+        constraint_setting(name = "libc")
+
+        constraint_value(
+            name = "glibc",
+            constraint_setting = "libc",
+        )
+
+        constraint_setting(
+            name = "glibc_version",
+            refines_constraint_value = ":glibc",
+        )
+
+        constraint_value(
+            name = "glibc_2_42",
+            constraint_setting = "glibc_version",
+        )
+
+        constraint_setting(name = "arch")
+
+        constraint_value(
+            name = "x86_64",
+            constraint_setting = "arch",
+        )
+
+        platform(
+            name = "platform",
+            constraint_values = [
+                ":glibc",
+                ":glibc_2_42",
+                ":x86_64",
+            ],
+        )
+
+        config_setting(
+            name = "is_glibc_x86",
+            constraint_values = [
+                ":glibc",
+                ":x86_64",
+            ],
+        )
+
+        config_setting(
+            name = "is_glibc_2_42_x86",
+            constraint_values = [
+                ":glibc_2_42",
+                ":x86_64",
+            ],
+        )
+        """);
+    useConfiguration("--platforms=//test:platform");
+    // is_glibc_2_42_x86 refines is_glibc_x86 because glibc_2_42 refines glibc
+    // and both share x86_64
+    assertThat(
+            getConfigMatchingProvider("//test:is_glibc_2_42_x86")
+                .refines(getConfigMatchingProvider("//test:is_glibc_x86")))
+        .isTrue();
+    assertThat(
+            getConfigMatchingProvider("//test:is_glibc_x86")
+                .refines(getConfigMatchingProvider("//test:is_glibc_2_42_x86")))
+        .isFalse();
+  }
+
+  @Test
+  public void hierarchicalConstraintDoesNotRefineUnrelatedConstraint() throws Exception {
+    scratch.file(
+        "test/BUILD",
+        """
+        constraint_setting(name = "libc")
+
+        constraint_value(
+            name = "glibc",
+            constraint_setting = "libc",
+        )
+
+        constraint_value(
+            name = "musl",
+            constraint_setting = "libc",
+        )
+
+        constraint_setting(
+            name = "glibc_version",
+            refines_constraint_value = ":glibc",
+        )
+
+        constraint_value(
+            name = "glibc_2_42",
+            constraint_setting = "glibc_version",
+        )
+
+        platform(
+            name = "platform",
+            constraint_values = [
+                ":glibc",
+                ":glibc_2_42",
+            ],
+        )
+
+        config_setting(
+            name = "is_musl",
+            constraint_values = [":musl"],
+        )
+
+        config_setting(
+            name = "is_glibc_2_42",
+            constraint_values = [":glibc_2_42"],
+        )
+        """);
+    useConfiguration("--platforms=//test:platform");
+    // glibc_2_42 refines glibc, NOT musl - so neither should refine the other
+    assertThat(
+            getConfigMatchingProvider("//test:is_glibc_2_42")
+                .refines(getConfigMatchingProvider("//test:is_musl")))
+        .isFalse();
+    assertThat(
+            getConfigMatchingProvider("//test:is_musl")
+                .refines(getConfigMatchingProvider("//test:is_glibc_2_42")))
+        .isFalse();
+  }
+
+  @Test
+  public void hierarchicalConstraintValueMatches() throws Exception {
+    scratch.file(
+        "test/BUILD",
+        """
+        constraint_setting(name = "libc")
+
+        constraint_value(
+            name = "glibc",
+            constraint_setting = "libc",
+        )
+
+        constraint_setting(
+            name = "glibc_version",
+            refines_constraint_value = ":glibc",
+        )
+
+        constraint_value(
+            name = "glibc_2_42",
+            constraint_setting = "glibc_version",
+        )
+
+        constraint_value(
+            name = "glibc_2_40",
+            constraint_setting = "glibc_version",
+        )
+
+        platform(
+            name = "glibc_2_42_platform",
+            constraint_values = [
+                ":glibc",
+                ":glibc_2_42",
+            ],
+        )
+
+        platform(
+            name = "glibc_2_40_platform",
+            constraint_values = [
+                ":glibc",
+                ":glibc_2_40",
+            ],
+        )
+
+        config_setting(
+            name = "is_glibc_2_42",
+            constraint_values = [":glibc_2_42"],
+        )
+        """);
+    useConfiguration("--platforms=//test:glibc_2_42_platform");
+    assertThat(getConfigMatchingProviderResultAsBoolean("//test:is_glibc_2_42")).isTrue();
+    useConfiguration("--platforms=//test:glibc_2_40_platform");
+    assertThat(getConfigMatchingProviderResultAsBoolean("//test:is_glibc_2_42")).isFalse();
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/ConstraintTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/ConstraintTest.java
@@ -273,4 +273,273 @@ public class ConstraintTest extends BuildViewTestCase {
     boolean hasConstraintValue = (boolean) info.getValue("has_default_value");
     assertThat(hasConstraintValue).isFalse();
   }
+
+  @Test
+  public void testConstraint_refinesConstraintValue() throws Exception {
+    scratch.file(
+        "libc/BUILD",
+        """
+        constraint_setting(name = "libc")
+
+        constraint_value(
+            name = "glibc",
+            constraint_setting = ":libc",
+        )
+        """);
+    scratch.file(
+        "libc/glibc/BUILD",
+        """
+        constraint_setting(
+            name = "version",
+            refines_constraint_value = "//libc:glibc",
+        )
+
+        constraint_value(
+            name = "2_42",
+            constraint_setting = ":version",
+        )
+        """);
+
+    ConfiguredTarget setting = getConfiguredTarget("//libc/glibc:version");
+    assertThat(setting).isNotNull();
+    ConstraintSettingInfo constraintSettingInfo = PlatformProviderUtils.constraintSetting(setting);
+    assertThat(constraintSettingInfo).isNotNull();
+    assertThat(constraintSettingInfo.hasRefinesConstraintValue()).isTrue();
+    assertThat(constraintSettingInfo.refinesConstraintValueLabel())
+        .isEqualTo(Label.parseCanonical("//libc:glibc"));
+    assertThat(constraintSettingInfo.hasDefaultConstraintValue()).isFalse();
+  }
+
+  @Test
+  public void testConstraint_refinesConstraintValue_notSet() throws Exception {
+    ConfiguredTarget setting = getConfiguredTarget("//constraint:basic");
+    assertThat(setting).isNotNull();
+    ConstraintSettingInfo constraintSettingInfo = PlatformProviderUtils.constraintSetting(setting);
+    assertThat(constraintSettingInfo.hasRefinesConstraintValue()).isFalse();
+    assertThat(constraintSettingInfo.refinesConstraintValueLabel()).isNull();
+  }
+
+  @Test
+  public void testConstraint_refinesConstraintValue_mutuallyExclusiveWithDefault() throws Exception {
+    checkError(
+        "exclusive",
+        "bad_setting",
+        "mutually exclusive",
+        """
+        constraint_setting(
+            name = "bad_setting",
+            default_constraint_value = ":some_value",
+            refines_constraint_value = "//constraint:foo",
+        )
+
+        constraint_value(
+            name = "some_value",
+            constraint_setting = ":bad_setting",
+        )
+        """);
+  }
+
+  @Test
+  public void testConstraint_refinesConstraintValue_starlark() throws Exception {
+    setBuildLanguageOptions("--experimental_platforms_api=true");
+    scratch.file(
+        "libc/BUILD",
+        """
+        constraint_setting(name = "libc")
+
+        constraint_value(
+            name = "glibc",
+            constraint_setting = ":libc",
+        )
+        """);
+    scratch.file(
+        "libc/glibc/BUILD",
+        """
+        constraint_setting(
+            name = "version",
+            refines_constraint_value = "//libc:glibc",
+        )
+
+        constraint_value(
+            name = "2_42",
+            constraint_setting = ":version",
+        )
+        """);
+
+    scratch.file(
+        "verify/verify.bzl",
+        """
+        result = provider()
+
+        def _impl(ctx):
+            constraint_setting = ctx.attr.constraint_setting[platform_common.ConstraintSettingInfo]
+            refines_value = constraint_setting.refines_constraint_value
+            has_refines_value = constraint_setting.has_refines_constraint_value
+            return [result(
+                refines_value = refines_value,
+                has_refines_value = has_refines_value,
+            )]
+
+        verify = rule(
+            implementation = _impl,
+            attrs = {
+                "constraint_setting": attr.label(
+                    providers = [platform_common.ConstraintSettingInfo],
+                ),
+            },
+        )
+        """);
+    scratch.file(
+        "verify/BUILD",
+        """
+        load(":verify.bzl", "verify")
+
+        verify(
+            name = "verify",
+            constraint_setting = "//libc/glibc:version",
+        )
+        """);
+
+    ConfiguredTarget myRuleTarget = getConfiguredTarget("//verify:verify");
+    StructImpl info =
+        (StructImpl)
+            myRuleTarget.get(
+                new StarlarkProvider.Key(
+                    keyForBuild(Label.parseCanonical("//verify:verify.bzl")), "result"));
+
+    Label refinesValue = (Label) info.getValue("refines_value");
+    assertThat(refinesValue).isEqualTo(Label.parseCanonicalUnchecked("//libc:glibc"));
+
+    boolean hasRefinesValue = (boolean) info.getValue("has_refines_value");
+    assertThat(hasRefinesValue).isTrue();
+  }
+
+  @Test
+  public void testPlatform_refiningConstraintWithoutRefinedValue_fails() throws Exception {
+    scratch.file(
+        "libc/BUILD",
+        """
+        constraint_setting(name = "libc")
+
+        constraint_value(
+            name = "glibc",
+            constraint_setting = ":libc",
+        )
+
+        constraint_value(
+            name = "musl",
+            constraint_setting = ":libc",
+        )
+        """);
+    scratch.file(
+        "libc/glibc/BUILD",
+        """
+        constraint_setting(
+            name = "version",
+            refines_constraint_value = "//libc:glibc",
+        )
+
+        constraint_value(
+            name = "2_42",
+            constraint_setting = ":version",
+        )
+        """);
+    checkError(
+        "plat",
+        "bad_platform",
+        "does not include //libc:glibc",
+        """
+        platform(
+            name = "bad_platform",
+            constraint_values = ["//libc/glibc:2_42"],
+        )
+        """);
+  }
+
+  @Test
+  public void testPlatform_refiningConstraintWithRefinedValue_succeeds() throws Exception {
+    scratch.file(
+        "libc/BUILD",
+        """
+        constraint_setting(name = "libc")
+
+        constraint_value(
+            name = "glibc",
+            constraint_setting = ":libc",
+        )
+        """);
+    scratch.file(
+        "libc/glibc/BUILD",
+        """
+        constraint_setting(
+            name = "version",
+            refines_constraint_value = "//libc:glibc",
+        )
+
+        constraint_value(
+            name = "2_42",
+            constraint_setting = ":version",
+        )
+        """);
+    scratch.file(
+        "plat/BUILD",
+        """
+        platform(
+            name = "good_platform",
+            constraint_values = [
+                "//libc:glibc",
+                "//libc/glibc:2_42",
+            ],
+        )
+        """);
+
+    // Should succeed without errors.
+    getConfiguredTarget("//plat:good_platform");
+    assertNoEvents();
+  }
+
+  @Test
+  public void testPlatform_refiningConstraintWithRefinedValueFromParent_succeeds() throws Exception {
+    scratch.file(
+        "libc/BUILD",
+        """
+        constraint_setting(name = "libc")
+
+        constraint_value(
+            name = "glibc",
+            constraint_setting = ":libc",
+        )
+        """);
+    scratch.file(
+        "libc/glibc/BUILD",
+        """
+        constraint_setting(
+            name = "version",
+            refines_constraint_value = "//libc:glibc",
+        )
+
+        constraint_value(
+            name = "2_42",
+            constraint_setting = ":version",
+        )
+        """);
+    scratch.file(
+        "plat/BUILD",
+        """
+        platform(
+            name = "parent_platform",
+            constraint_values = ["//libc:glibc"],
+        )
+
+        platform(
+            name = "child_platform",
+            parents = [":parent_platform"],
+            constraint_values = ["//libc/glibc:2_42"],
+        )
+        """);
+
+    // Should succeed because parent provides //libc:glibc.
+    getConfiguredTarget("//plat:child_platform");
+    assertNoEvents();
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `refines_constraint_value` attribute to `constraint_setting`, enabling one constraint setting to refine another's constraint value (e.g., `//libc/glibc:version` refines `//libc:glibc`).
- Platforms specifying a refining constraint value must also specify the refined value, with actionable buildozer fixup suggestions on error.
- In `select()`, a constraint value from a refining setting is considered more specific than the refined value, resolving what would otherwise be an ambiguous match error.
- The attribute is mutually exclusive with `default_constraint_value`.

Implements the design in https://docs.google.com/document/d/1Lq-0aPBOT0cat1wcFbnPmurbyo05NpZXu0uGq12H_HE/edit?usp=sharing.

Discussion: #28877

## Test plan

- [x] `ConstraintTest`: 6 new tests for attribute creation, validation, mutual exclusivity, Starlark API, and platform validation (missing/present/parent-inherited refined values)
- [x] `ConfigSettingTest`: 4 new tests for config_setting refinement with hierarchical constraints, additional constraints, unrelated constraints, and matching
- [x] `ConfigurableAttributesTest`: 4 new integration tests for select() resolution with hierarchical config_settings and bare constraint_values
- [x] `ConfigMatchingProviderTest` (new): 8 unit tests for the `refines()` method covering superset, hierarchical, shared constraints, unrelated, extra flags, identical, disjoint, and empty cases
- [x] All existing tests in PlatformRulesTests, ConfigRulesTests, ConfigurableAttributesTest, PlatformAnalysisTests, and ProducersTests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
