### PR TITLE
[9.0.2] Treat `RUNFILES_TREE_MARKER` as a directory in `BuildEvent.forArtifac…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEvent.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.buildeventstream;
 
+import static com.google.devtools.build.lib.actions.FileArtifactValue.RUNFILES_TREE_MARKER;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
@@ -73,6 +75,11 @@ public interface BuildEvent extends ChainableEvent, ExtendedEventHandler.Postabl
       public static LocalFileType forArtifact(
           Artifact artifact, @Nullable FileArtifactValue metadata) {
         if (metadata != null) {
+          if (metadata.equals(RUNFILES_TREE_MARKER)) {
+            // TODO(tjgq): Remove RUNFILES_TREE_MARKER in favor of RunfilesProxyArtifactValue,
+            // which would make this special case unnecessary.
+            return LocalFileType.OUTPUT_DIRECTORY;
+          }
           return switch (metadata.getType()) {
             case DIRECTORY -> LocalFileType.OUTPUT_DIRECTORY;
             case SYMLINK -> LocalFileType.OUTPUT_SYMLINK;


### PR DESCRIPTION
…t()`.

https://github.com/bazelbuild/bazel/commit/952aabb464d25b87828927121911db1f03ad1df3 didn't fix #28330 because `BuildEvent.forArtifact()` (sometimes?) sees a `FileArtifactValue.RUNFILES_TREE_MARKER`, not a `RunfilesProxyArtifactValue`.

Fixes #28330.

PiperOrigin-RevId: 884388938
Change-Id: Ic5be6a83479d5afefd4a25a5b83049a2fe7b0244

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/7bf8f2b253e458a86e7a2802cdf2a93d6fc9442c