### PR TITLE
[9.0.2] Correctly cross-jlink Windows arm64 builds (https://github.com/bazelbuild/bazel/pull/28988)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -353,6 +353,7 @@ use_repo(
     "openjdk_linux_vanilla",
     "openjdk_macos_aarch64_vanilla",
     "openjdk_macos_x86_64_vanilla",
+    "openjdk_win_arm64_jmods",
     "openjdk_win_arm64_vanilla",
     "openjdk_win_vanilla",
 )

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -373,7 +373,7 @@
   "moduleExtensions": {
     "//:repositories.bzl%async_profiler_repos": {
       "general": {
-        "bzlTransitiveDigest": "Ilg8GQT+f15+hygKAhbGD+qLdQhPyylJMENZ+S52+f8=",
+        "bzlTransitiveDigest": "a1xrHVXmxLybCb+A//ojsugr4+2DTldziVmOqT/ijHg=",
         "usagesDigest": "OtEjntl27qRj/reKm6+KihKPMyBd4tlRLe6Q/xITqWk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -138,6 +138,16 @@ def embedded_jdk_repositories():
         url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B1-ea-beta/OpenJDK25U-jdk_aarch64_windows_hotspot_25.0.3_1-ea.zip",
     )
 
+    # The Adoptium Temurin JDK above has JEP 493 enabled, which means it does not ship with jmods.
+    # These are needed for cross-jlinking (minimizing the JDK on a different platform).
+    # https://adoptium.net/news/2025/08/eclipse-temurin-jdk24-JEP493-enabled
+    http_file(
+        name = "openjdk_win_arm64_jmods",
+        integrity = "sha256-2rjwZCoUIYD7L9nLwLJindsYPkDMvpI4km5a9UlxFtg=",
+        downloaded_file_path = "temurin-win-arm64-jmods.zip",
+        url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B1-ea-beta/OpenJDK25U-jmods_aarch64_windows_hotspot_25.0.3_1-ea.zip",
+    )
+
 def _async_profiler_repos(ctx):
     http_file(
         name = "async_profiler",

--- a/src/BUILD
+++ b/src/BUILD
@@ -225,9 +225,15 @@ genrule(
     srcs = [
         ":embedded_jdk_vanilla",
         ":jdeps_modules.golden",
-    ],
+    ] + select({
+        "//src/conditions:windows_arm64": ["@openjdk_win_arm64_jmods//file"],
+        "//conditions:default": [],
+    }),
     outs = ["minimal_jdk.zip"],
-    cmd = "$(location :minimize_jdk) $(location :jdk_for_jlink) $(location :embedded_jdk_vanilla) $(location :jdeps_modules.golden) $@",
+    cmd = "$(location :minimize_jdk) $(location :jdk_for_jlink) $(location :embedded_jdk_vanilla) $(location :jdeps_modules.golden) $@" + select({
+        "//src/conditions:windows_arm64": " $(location @openjdk_win_arm64_jmods//file)",
+        "//conditions:default": "",
+    }),
     tools = [
         ":jdk_for_jlink",
         ":minimize_jdk",
@@ -240,9 +246,15 @@ genrule(
     srcs = [
         ":embedded_jdk_vanilla",
         ":jdeps_modules.golden",
-    ],
+    ] + select({
+        "//src/conditions:windows_arm64": ["@openjdk_win_arm64_jmods//file"],
+        "//conditions:default": [],
+    }),
     outs = ["allmodules_jdk.zip"],
-    cmd = "$(location :minimize_jdk) --allmodules $(location :jdk_for_jlink) $(location :embedded_jdk_vanilla) $(location :jdeps_modules.golden) $@",
+    cmd = "$(location :minimize_jdk) --allmodules $(location :jdk_for_jlink) $(location :embedded_jdk_vanilla) $(location :jdeps_modules.golden) $@" + select({
+        "//src/conditions:windows_arm64": " $(location @openjdk_win_arm64_jmods//file)",
+        "//conditions:default": "",
+    }),
     tools = [
         ":jdk_for_jlink",
         ":minimize_jdk",

--- a/src/minimize_jdk.sh
+++ b/src/minimize_jdk.sh
@@ -50,6 +50,13 @@ fi
 tooljdk=$1
 fulljdk=$2
 out=$4
+# Optional 5th argument: a separate jmods archive for JDKs that don't ship
+# with jmods (e.g. Adoptium Temurin with JEP 493 enabled).
+jmods_archive=${5:-}
+# Convert to absolute path since we cd later.
+if [ -n "$jmods_archive" ]; then
+  jmods_archive=$(cd "$(dirname "$jmods_archive")" && echo "$(pwd)/$(basename "$jmods_archive")")
+fi
 
 UNAME=$(uname -s | tr 'A-Z' 'a-z')
 # Options for the JVM that runs the Bazel server, which are either required or
@@ -66,6 +73,25 @@ if [[ "$UNAME" =~ msys_nt* ]]; then
   # The archives contain a single top-level directory.
   tool_jdk_home=$(cd tool_jdk.$$/* && pwd)
   cd full_jdk.$$/*
+  # If the full JDK doesn't ship with jmods (e.g. JEP 493), use the separately
+  # provided jmods archive.
+  if [ ! -f jmods/java.base.jmod ]; then
+    if [ -n "$jmods_archive" ]; then
+      unzip -q "$jmods_archive" -d jmods_tmp
+      # The archive contains a single top-level directory with jmod files.
+      mv jmods_tmp/*/* jmods_tmp/ 2>/dev/null || true
+      # Move all .jmod files into the jmods directory.
+      mkdir -p jmods
+      mv jmods_tmp/*.jmod jmods/
+      rm -rf jmods_tmp
+    else
+      echo >&2 "ERROR: Full JDK does not contain jmods/java.base.jmod and no" \
+        "separate jmods archive was provided. Cross-jlinking requires jmods." \
+        "JDKs with JEP 493 enabled (e.g. Adoptium Temurin 24+) need a separate" \
+        "jmods download."
+      exit 1
+    fi
+  fi
   # We have to add this module explicitly because it is windows specific, it allows
   # the usage of the Windows truststore
   # e.g. -Djavax.net.ssl.trustStoreType=WINDOWS-ROOT
@@ -98,6 +124,20 @@ else
   mkdir target_jdk
   tar xf "$fulljdk" --no-same-owner --strip-components=1 -C target_jdk
   cd target_jdk
+  # If the full JDK doesn't ship with jmods (e.g. JEP 493), use the separately
+  # provided jmods archive.
+  if [ ! -f jmods/java.base.jmod ]; then
+    if [ -n "$jmods_archive" ]; then
+      mkdir -p jmods
+      tar xf "$jmods_archive" --no-same-owner --strip-components=1 -C jmods --wildcards '*.jmod'
+    else
+      echo >&2 "ERROR: Full JDK does not contain jmods/java.base.jmod and no" \
+        "separate jmods archive was provided. Cross-jlinking requires jmods." \
+        "JDKs with JEP 493 enabled (e.g. Adoptium Temurin 24+) need a separate" \
+        "jmods download."
+      exit 1
+    fi
+  fi
   "../tool_jdk/bin/jlink" --module-path ./jmods/ --add-modules "$modules" \
     --vm=server --strip-debug --no-man-pages --no-header-files \
     --add-options=" ${JVM_OPTIONS}" \


### PR DESCRIPTION
### Description
Download the extracted post-[JEP 493](https://openjdk.org/jeps/493) jmods for Windows ARM64 and add a safety check to ensure that we don't unknowingly jlink the tool JDK's jmods.

### Motivation
Fixes #28941

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #28988.

PiperOrigin-RevId: 884547112
Change-Id: If6dadd9a23960d1dcceab6d487f4fc92911288f5

Commit https://github.com/bazelbuild/bazel/commit/0f7154be4d4da8b55ca07bc41e3c0fad56a1cf76