### PR TITLE
[9.1.0] Use `FileArtifactValue#setContentsProxy` for remote repo contents cache (https://github.com/bazelbuild/bazel/pull/28654)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -395,6 +395,11 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     return new InlineFileArtifactValue(bytes, hashFunction.hashBytes(bytes).asBytes());
   }
 
+  /**
+   * Prefer {@link #createForRemoteFileWithMaterializationData} if the remote file may be
+   * materialized in the local filesystem at a later point as this overload doesn't support {@link
+   * #setContentsProxy}.
+   */
   public static FileArtifactValue createForRemoteFile(byte[] digest, long size, int locationIndex) {
     return new RemoteFileArtifactValue(digest, size, locationIndex);
   }

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -823,14 +823,12 @@ public class CompactPersistentActionCache implements ActionCache {
       resolvedPath = PathFragment.create(getStringForIndex(indexer, VarInt.getVarInt(source)));
     }
 
-    FileArtifactValue metadata;
-    if (expirationTimeEpochMilli < 0) {
-      metadata = FileArtifactValue.createForRemoteFile(digest, size, locationIndex);
-    } else {
-      metadata =
-          FileArtifactValue.createForRemoteFileWithMaterializationData(
-              digest, size, locationIndex, Instant.ofEpochMilli(expirationTimeEpochMilli));
-    }
+    FileArtifactValue metadata =
+        FileArtifactValue.createForRemoteFileWithMaterializationData(
+            digest,
+            size,
+            locationIndex,
+            expirationTimeEpochMilli >= 0 ? Instant.ofEpochMilli(expirationTimeEpochMilli) : null);
 
     if (resolvedPath != null) {
       metadata = FileArtifactValue.createFromExistingWithResolvedPath(metadata, resolvedPath);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -805,7 +805,8 @@ public final class RemoteModule extends BlazeModule {
           env.getReporter(),
           buildRequestId,
           invocationId,
-          env.getSkyframeExecutor().getEvaluator());
+          env.getSkyframeExecutor().getEvaluator(),
+          remoteOptions.remoteCacheTtl);
     }
 
     buildEventArtifactUploaderFactoryDelegate.init(


### PR DESCRIPTION
Even though expiration times don't matter in Bazel (they aren't honored), supporting the contents proxy optimization avoids Skyframe invalidation when external repo files are materialized later.

Along the way ensure that the persistent action cache always recreates remote metadata via `FileArtifactValue.createForRemoteFileWithMaterializationData`. Before this change, such metadata would roundtrip into a `RemoteFileArtifactValue` (without the content proxy optimization) if `expirationTime` is set to `null`.

Closes #28654.

PiperOrigin-RevId: 884796123
Change-Id: Ib399aff3864f5fbbef230b64a7a5ef619bf854d0

Commit https://github.com/bazelbuild/bazel/commit/257a224b57c90cc4138b4006f2f70169c162cebd