### PR TITLE
Enforce non-empty integrity for Bzlmod patches and overlays

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -15,7 +15,6 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -456,7 +455,7 @@ public class IndexRegistry implements Registry {
     if (sourceUrl == null) {
       throw new IOException(String.format("Missing source URL for module %s", key));
     }
-    if (sourceJson.integrity == null) {
+    if (sourceJson.integrity == null || sourceJson.integrity.isBlank()) {
       throw new IOException(String.format("Missing integrity for module %s", key));
     }
 
@@ -495,6 +494,10 @@ public class IndexRegistry implements Registry {
     ImmutableMap.Builder<String, String> remotePatches = new ImmutableMap.Builder<>();
     if (sourceJson.patches != null) {
       for (Map.Entry<String, String> entry : sourceJson.patches.entrySet()) {
+        if (entry.getValue() == null || entry.getValue().isBlank()) {
+          throw new IOException(
+              String.format("Missing integrity for patch %s of module %s", entry.getKey(), key));
+        }
         remotePatches.put(
             constructUrl(
                 getUrl(),
@@ -507,32 +510,37 @@ public class IndexRegistry implements Registry {
       }
     }
 
-    ImmutableMap<String, String> sourceJsonOverlay =
-        sourceJson.overlay != null ? ImmutableMap.copyOf(sourceJson.overlay) : ImmutableMap.of();
-    ImmutableMap<String, ArchiveRepoSpecBuilder.RemoteFile> overlay =
-        sourceJsonOverlay.entrySet().stream()
-            .collect(
-                toImmutableMap(
-                    Entry::getKey,
-                    entry ->
-                        new ArchiveRepoSpecBuilder.RemoteFile(
-                            entry.getValue(), // integrity
-                            // URLs in the registry itself are not mirrored.
-                            ImmutableList.of(
-                                constructUrl(
-                                    getUrl(),
-                                    "modules",
-                                    key.name(),
-                                    key.version().toString(),
-                                    "overlay",
-                                    entry.getKey())))));
+    ImmutableMap.Builder<String, ArchiveRepoSpecBuilder.RemoteFile> overlay =
+        ImmutableMap.builder();
+    if (sourceJson.overlay != null) {
+      for (Map.Entry<String, String> entry : sourceJson.overlay.entrySet()) {
+        if (entry.getValue() == null || entry.getValue().isBlank()) {
+          throw new IOException(
+              String.format(
+                  "Missing integrity for overlay file %s of module %s", entry.getKey(), key));
+        }
+        overlay.put(
+            entry.getKey(),
+            new ArchiveRepoSpecBuilder.RemoteFile(
+                entry.getValue(), // integrity
+                // URLs in the registry itself are not mirrored.
+                ImmutableList.of(
+                    constructUrl(
+                        getUrl(),
+                        "modules",
+                        key.name(),
+                        key.version().toString(),
+                        "overlay",
+                        entry.getKey()))));
+      }
+    }
 
     return new ArchiveRepoSpecBuilder()
         .setUrls(urls.build())
         .setIntegrity(sourceJson.integrity)
         .setStripPrefix(Strings.nullToEmpty(sourceJson.stripPrefix))
         .setRemotePatches(remotePatches.buildKeepingLast())
-        .setOverlay(overlay)
+        .setOverlay(overlay.buildOrThrow())
         .setRemoteModuleFile(
             new RemoteFile(
                 moduleFileChecksum.toSubresourceIntegrity(), ImmutableList.of(moduleFileUrl)))
@@ -545,11 +553,16 @@ public class IndexRegistry implements Registry {
       GitRepoSourceJson sourceJson,
       String moduleFileUrl,
       Checksum moduleFileChecksum,
-      ModuleKey key) {
+      ModuleKey key)
+      throws IOException {
     // Build remote patches as key-value pairs of "url" => "integrity".
     ImmutableMap.Builder<String, String> remotePatches = new ImmutableMap.Builder<>();
     if (sourceJson.patches != null) {
       for (Map.Entry<String, String> entry : sourceJson.patches.entrySet()) {
+        if (entry.getValue() == null || entry.getValue().isBlank()) {
+          throw new IOException(
+              String.format("Missing integrity for patch %s of module %s", entry.getKey(), key));
+        }
         remotePatches.put(
             constructUrl(
                 getUrl(),

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -854,6 +854,259 @@ public class IndexRegistryTest extends FoundationTestCase {
                     sha256(registryJson)));
   }
 
+  @Test
+  public void testGetArchiveRepoSpec_emptyMainIntegrity() throws Exception {
+    server.serve(
+        "/modules/foo/1.0/source.json",
+        "{",
+        "  \"url\": \"http://mysite.com/thing.zip\",",
+        "  \"integrity\": \"\"",
+        "}");
+    server.serve("/modules/foo/1.0/MODULE.bazel", "module(name = \"foo\", version = \"1.0\")");
+    server.start();
+
+    Registry registry =
+        registryFactory.createRegistry(
+            server.getUrl(),
+            LockfileMode.UPDATE,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            Optional.empty(),
+            ImmutableSet.of());
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () ->
+                registry.getRepoSpec(
+                    createModuleKey("foo", "1.0"),
+                    ImmutableMap.of(
+                        server.getUrl() + "/modules/foo/1.0/MODULE.bazel",
+                        Optional.of(sha256("module(name = \"foo\", version = \"1.0\")"))),
+                    reporter,
+                    downloadManager));
+    assertThat(e).hasMessageThat().contains("Missing integrity for module foo@1.0");
+  }
+
+  @Test
+  public void testGetArchiveRepoSpec_emptyPatchIntegrity() throws Exception {
+    server.serve(
+        "/modules/foo/1.0/source.json",
+        "{",
+        "  \"url\": \"http://mysite.com/thing.zip\",",
+        "  \"integrity\": \"sha256-blah\",",
+        "  \"patches\": {",
+        "    \"fix.patch\": \"\"",
+        "  }",
+        "}");
+    server.serve("/modules/foo/1.0/MODULE.bazel", "module(name = \"foo\", version = \"1.0\")");
+    server.start();
+
+    Registry registry =
+        registryFactory.createRegistry(
+            server.getUrl(),
+            LockfileMode.UPDATE,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            Optional.empty(),
+            ImmutableSet.of());
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () ->
+                registry.getRepoSpec(
+                    createModuleKey("foo", "1.0"),
+                    ImmutableMap.of(
+                        server.getUrl() + "/modules/foo/1.0/MODULE.bazel",
+                        Optional.of(sha256("module(name = \"foo\", version = \"1.0\")"))),
+                    reporter,
+                    downloadManager));
+    assertThat(e).hasMessageThat().contains("Missing integrity for patch fix.patch of module foo@1.0");
+  }
+
+  @Test
+  public void testGetArchiveRepoSpec_emptyOverlayIntegrity() throws Exception {
+    server.serve(
+        "/modules/foo/1.0/source.json",
+        "{",
+        "  \"url\": \"http://mysite.com/thing.zip\",",
+        "  \"integrity\": \"sha256-blah\",",
+        "  \"overlay\": {",
+        "    \"BUILD.bazel\": \"\"",
+        "  }",
+        "}");
+    server.serve("/modules/foo/1.0/MODULE.bazel", "module(name = \"foo\", version = \"1.0\")");
+    server.start();
+
+    Registry registry =
+        registryFactory.createRegistry(
+            server.getUrl(),
+            LockfileMode.UPDATE,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            Optional.empty(),
+            ImmutableSet.of());
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () ->
+                registry.getRepoSpec(
+                    createModuleKey("foo", "1.0"),
+                    ImmutableMap.of(
+                        server.getUrl() + "/modules/foo/1.0/MODULE.bazel",
+                        Optional.of(sha256("module(name = \"foo\", version = \"1.0\")"))),
+                    reporter,
+                    downloadManager));
+    assertThat(e)
+        .hasMessageThat()
+        .contains("Missing integrity for overlay file BUILD.bazel of module foo@1.0");
+  }
+
+  @Test
+  public void testGetGitRepoSpec_emptyPatchIntegrity() throws Exception {
+    server.serve(
+        "/modules/foo/1.0/source.json",
+        """
+        {
+            "type": "git_repository",
+            "remote": "https://github.com/raspberrypi/pico-sdk.git",
+            "commit": "4b6e647590213f253f2789ad9026df1d00f38c5d",
+            "patches": {
+                "foo.patch": ""
+            }
+        }
+        """);
+    server.serve("/modules/foo/1.0/MODULE.bazel", "module(name = \"foo\", version = \"1.0\")");
+    server.start();
+
+    Registry registry =
+        registryFactory.createRegistry(
+            server.getUrl(),
+            LockfileMode.UPDATE,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            Optional.empty(),
+            ImmutableSet.of());
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () ->
+                registry.getRepoSpec(
+                    createModuleKey("foo", "1.0"),
+                    ImmutableMap.of(
+                        server.getUrl() + "/modules/foo/1.0/MODULE.bazel",
+                        Optional.of(sha256("module(name = \"foo\", version = \"1.0\")"))),
+                    reporter,
+                    downloadManager));
+    assertThat(e).hasMessageThat().contains("Missing integrity for patch foo.patch of module foo@1.0");
+  }
+
+  @Test
+  public void testGetArchiveRepoSpec_whitespacePatchIntegrity() throws Exception {
+    server.serve(
+        "/modules/foo/1.0/source.json",
+        "{",
+        "  \"url\": \"http://mysite.com/thing.zip\",",
+        "  \"integrity\": \"sha256-blah\",",
+        "  \"patches\": {",
+        "    \"fix.patch\": \"  \"",
+        "  }",
+        "}");
+    server.serve("/modules/foo/1.0/MODULE.bazel", "module(name = \"foo\", version = \"1.0\")");
+    server.start();
+
+    Registry registry =
+        registryFactory.createRegistry(
+            server.getUrl(),
+            LockfileMode.UPDATE,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            Optional.empty(),
+            ImmutableSet.of());
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () ->
+                registry.getRepoSpec(
+                    createModuleKey("foo", "1.0"),
+                    ImmutableMap.of(
+                        server.getUrl() + "/modules/foo/1.0/MODULE.bazel",
+                        Optional.of(sha256("module(name = \"foo\", version = \"1.0\")"))),
+                    reporter,
+                    downloadManager));
+    assertThat(e).hasMessageThat().contains("Missing integrity for patch fix.patch of module foo@1.0");
+  }
+
+  @Test
+  public void testGetArchiveRepoSpec_whitespaceOverlayIntegrity() throws Exception {
+    server.serve(
+        "/modules/foo/1.0/source.json",
+        "{",
+        "  \"url\": \"http://mysite.com/thing.zip\",",
+        "  \"integrity\": \"sha256-blah\",",
+        "  \"overlay\": {",
+        "    \"BUILD.bazel\": \"\t\"",
+        "  }",
+        "}");
+    server.serve("/modules/foo/1.0/MODULE.bazel", "module(name = \"foo\", version = \"1.0\")");
+    server.start();
+
+    Registry registry =
+        registryFactory.createRegistry(
+            server.getUrl(),
+            LockfileMode.UPDATE,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            Optional.empty(),
+            ImmutableSet.of());
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () ->
+                registry.getRepoSpec(
+                    createModuleKey("foo", "1.0"),
+                    ImmutableMap.of(
+                        server.getUrl() + "/modules/foo/1.0/MODULE.bazel",
+                        Optional.of(sha256("module(name = \"foo\", version = \"1.0\")"))),
+                    reporter,
+                    downloadManager));
+    assertThat(e)
+        .hasMessageThat()
+        .contains("Missing integrity for overlay file BUILD.bazel of module foo@1.0");
+  }
+
+  @Test
+  public void testGetArchiveRepoSpec_whitespaceIntegrity() throws Exception {
+    server.serve(
+        "/modules/foo/1.0/source.json",
+        "{",
+        "  \"url\": \"http://mysite.com/thing.zip\",",
+        "  \"integrity\": \" \"",
+        "}");
+    server.serve("/modules/foo/1.0/MODULE.bazel", "module(name = \"foo\", version = \"1.0\")");
+    server.start();
+
+    Registry registry =
+        registryFactory.createRegistry(
+            server.getUrl(),
+            LockfileMode.UPDATE,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            Optional.empty(),
+            ImmutableSet.of());
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () ->
+                registry.getRepoSpec(
+                    createModuleKey("foo", "1.0"),
+                    ImmutableMap.of(
+                        server.getUrl() + "/modules/foo/1.0/MODULE.bazel",
+                        Optional.of(sha256("module(name = \"foo\", version = \"1.0\")"))),
+                    reporter,
+                    downloadManager));
+    assertThat(e).hasMessageThat().contains("Missing integrity for module foo@1.0");
+  }
+
   private static Checksum sha256(String content) throws Checksum.InvalidChecksumException {
     return Checksum.fromString(
         DownloadCache.KeyType.SHA256, Hashing.sha256().hashString(content, UTF_8).toString());


### PR DESCRIPTION
### Description
This PR enforces that integrity strings for Bzlmod patches and overlay files in `source.json` are not empty.

### Motivation
Empty integrity strings (" ") in `source.json` were previously being treated as "no integrity check required," which allowed bypass of checksum enforcement for these remote files. This fix ensures that an empty integrity string is treated as an error, maintaining the security and hermeticity of Bzlmod-managed dependencies.

### Build API Changes
No

### Checklist
- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes
RELNOTES: Bzlmod now enforces that integrity strings for patches and overlay files in `source.json` are non-empty.