### PR TITLE
Move build_windows_jni.sh under scripts/bootstrap.

### DIFF
--- a/scripts/bootstrap/build_windows_jni.sh
+++ b/scripts/bootstrap/build_windows_jni.sh
@@ -95,10 +95,8 @@ fi
 
 # Convert all compilation units to Windows paths.
 WINDOWS_SOURCES=()
-for i in $*; do
-  if [[ "$i" =~ ^.*\.cc$ ]]; then
-    WINDOWS_SOURCES+=("\"$(cygpath -a -w $i)\"")
-  fi
+for f in src/main/native/common.cc src/main/native/windows/*.cc; do
+  WINDOWS_SOURCES+=("\"$(cygpath -a -w $f)\"")
 done
 
 # Copy jni headers to src/main/native folder

--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -337,12 +337,7 @@ function build_jni() {
     mkdir -p "$(dirname "$tmp_output")"
     mkdir -p "$(dirname "$output")"
 
-    # Keep this in sync with the `srcs` of //src/main/native/windows:windows_jni
-    local -r srcs="src/main/native/common.cc $(find src/main/native/windows -name '*.cc' -o -name '*.h')"
-    [ -n "$srcs" ] || fail "Could not find sources for Windows JNI library"
-
-    # do not quote $srcs because we need to expand it to multiple args
-    src/main/native/windows/build_windows_jni.sh "$tmp_output" ${srcs}
+    build_windows_jni.sh "$tmp_output"
 
     cp "$tmp_output" "$output"
     chmod 0555 "$output"


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
