### PR TITLE
Add include/exclude filter to (download_and_)extract

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ArFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ArFunction.java
@@ -22,7 +22,9 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.apache.commons.compress.archivers.ar.ArArchiveEntry;
 import org.apache.commons.compress.archivers.ar.ArArchiveInputStream;
 
@@ -45,6 +47,7 @@ public class ArFunction implements Decompressor {
     }
 
     Map<String, String> renameFiles = descriptor.renameFiles();
+    Map<String, Pattern> patternCache = new HashMap<>();
 
     try (InputStream decompressorStream =
         new BufferedInputStream(descriptor.archivePath().getInputStream(), BUFFER_SIZE)) {
@@ -52,6 +55,9 @@ public class ArFunction implements Decompressor {
       ArArchiveEntry entry;
       while ((entry = arStream.getNextArEntry()) != null) {
         String entryName = entry.getName();
+        if (descriptor.skipArchiveEntry(entryName, patternCache)) {
+          continue;
+        }
         entryName = renameFiles.getOrDefault(entryName, entryName);
         PathFragment entryPathRelative = PathFragment.create(entryName);
         if (entryPathRelative.isAbsolute()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedFunction.java
@@ -32,6 +32,10 @@ import java.io.OutputStream;
  *
  * <p>It ignores the {@link DecompressorDescriptor#prefix()} setting because compressed files cannot
  * contain directories.
+ *
+ * <p>It ignores the {@link DecompressorDescriptor#includes()} and {@link
+ * DecompressorDescriptor#excludes()} setting because there is no reason to exclude/skip a set of
+ * files when there is only one file.
  */
 public abstract class CompressedFunction implements Decompressor {
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 
@@ -74,6 +75,7 @@ public abstract class CompressedTarFunction implements Decompressor {
     Set<String> availablePrefixes = new HashSet<>();
     // Store link, target info of symlinks, we create them after regular files are extracted.
     Map<Path, PathFragment> symlinks = new HashMap<>();
+    Map<String, Pattern> patternCache = new HashMap<>();
 
     try (InputStream compressedInputStream = descriptor.archivePath().getInputStream();
         InputStream decompressorStream =
@@ -87,6 +89,9 @@ public abstract class CompressedTarFunction implements Decompressor {
       TarArchiveEntry entry;
       while ((entry = tarStream.getNextTarEntry()) != null) {
         String entryName = toRawBytesString(entry.getName());
+        if (descriptor.skipArchiveEntry(entryName, patternCache)) {
+          continue;
+        }
         entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath =
             StripPrefixedPath.maybeDeprefix(entryName.getBytes(ISO_8859_1), prefix);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/DecompressorDescriptor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/DecompressorDescriptor.java
@@ -17,10 +17,14 @@ package com.google.devtools.build.lib.bazel.repository.decompressor;
 import static java.util.Objects.requireNonNull;
 
 import com.google.auto.value.AutoBuilder;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.UnixGlob;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * Description of an archive to be decompressed.
@@ -33,19 +37,67 @@ public record DecompressorDescriptor(
     Path archivePath,
     Path destinationPath,
     Optional<String> prefix,
-    ImmutableMap<String, String> renameFiles) {
+    ImmutableMap<String, String> renameFiles,
+    ImmutableList<String> includes,
+    ImmutableList<String> excludes) {
   public DecompressorDescriptor {
     requireNonNull(context, "context");
     requireNonNull(archivePath, "archivePath");
     requireNonNull(destinationPath, "destinationPath");
     requireNonNull(prefix, "prefix");
     requireNonNull(renameFiles, "renameFiles");
+    requireNonNull(includes, "includes");
+    requireNonNull(excludes, "excludes");
   }
 
   public static Builder builder() {
     return new AutoBuilder_DecompressorDescriptor_Builder()
         .setContext("")
-        .setRenameFiles(ImmutableMap.of());
+        .setRenameFiles(ImmutableMap.of())
+        .setIncludes(ImmutableList.of())
+        .setExcludes(ImmutableList.of());
+  }
+
+  /**
+   * Returns if a given archive entry should be skipped for decompression.
+   *
+   * <p>This follows the BSD tar logic - {@link #includes} is the list of glob patterns that should
+   * be decompressed. If no inclusions are specified, all entries are extracted. {@link #excludes}
+   * takes precedence over inclusions.
+   *
+   * @param archiveEntry The filepath of the archive entry.
+   * @param patternCache A cache for glob patterns.
+   * @return {@code true} if the entry should be skipped.
+   */
+  public boolean skipArchiveEntry(String archiveEntry, Map<String, Pattern> patternCache) {
+    if (!includes.isEmpty()) {
+      boolean include = false;
+      for (String includePattern : includes) {
+        if (UnixGlob.matches(includePattern, archiveEntry, patternCache)) {
+          include = true;
+          break;
+        }
+      }
+      if (!include) {
+        return true;
+      }
+    }
+
+    for (String excludePattern : excludes) {
+      if (UnixGlob.matches(excludePattern, archiveEntry, patternCache)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns if a given archive entry should be skipped for decompression.
+   *
+   * @see #skipArchiveEntry(String, Map)
+   */
+  public boolean skipArchiveEntry(String archiveEntry) {
+    return skipArchiveEntry(archiveEntry, null);
   }
 
   /** Builder for describing the file to be decompressed. */
@@ -61,6 +113,10 @@ public record DecompressorDescriptor(
     public abstract Builder setPrefix(String prefix);
 
     public abstract Builder setRenameFiles(Map<String, String> renameFiles);
+
+    public abstract Builder setIncludes(List<String> includes);
+
+    public abstract Builder setExcludes(List<String> excludes);
 
     public abstract DecompressorDescriptor build();
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressor.java
@@ -26,9 +26,12 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
 import org.apache.commons.compress.archivers.sevenz.SevenZFile;
@@ -50,6 +53,7 @@ public class SevenZDecompressor implements Decompressor {
     Optional<String> prefix = descriptor.prefix();
     ImmutableMap<String, String> renameFiles = descriptor.renameFiles();
     boolean foundPrefix = false;
+    Map<String, Pattern> patternCache = new HashMap<>();
 
     try (SevenZFile sevenZFile =
         SevenZFile.builder().setFile(descriptor.archivePath().getPathFile()).get()) {
@@ -78,6 +82,9 @@ public class SevenZDecompressor implements Decompressor {
          */
         if (isNullOrEmpty(entryName)) {
           throw new IOException("7z archive contains unnamed entry");
+        }
+        if (descriptor.skipArchiveEntry(entryName, patternCache)) {
+          continue;
         }
         entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath =

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /**
@@ -83,11 +84,15 @@ public class ZipDecompressor implements Decompressor {
     boolean foundPrefix = false;
     // Store link, target info of symlinks, we create them after regular files are extracted.
     Map<Path, PathFragment> symlinks = new HashMap<>();
+    Map<String, Pattern> patternCache = new HashMap<>();
 
     try (ZipReader reader = new ZipReader(descriptor.archivePath().getPathFile())) {
       Collection<ZipFileEntry> entries = reader.entries();
       for (ZipFileEntry entry : entries) {
         String entryName = entry.getName();
+        if (descriptor.skipArchiveEntry(entryName, patternCache)) {
+          continue;
+        }
         entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath =
             StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -47,6 +47,7 @@ import com.google.devtools.build.lib.events.ExtendedEventHandler.FetchProgress;
 import com.google.devtools.build.lib.packages.StarlarkInfo;
 import com.google.devtools.build.lib.packages.StructImpl;
 import com.google.devtools.build.lib.packages.StructProvider;
+import com.google.devtools.build.lib.packages.Types;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
@@ -1026,6 +1027,35 @@ the same path on case-insensitive filesystems.
             positional = false,
             named = true,
             defaultValue = "''"),
+        @Param(
+            name = "include",
+            positional = false,
+            allowedTypes = {@ParamType(type = Sequence.class, generic1 = String.class)},
+            defaultValue = "[]",
+            named = true,
+            doc =
+                """
+                Extract only files or directories that match the specified glob pattern. Glob
+                pattern matching support is the same as the Bazel Starlark <code>glob</code>
+                function. Pattern matching takes place directly on the paths from the archive
+                (before <code>strip_prefix</code> and <code>rename_files</code> is processed).
+                Note that exclusions specified with	<code>--exclude</code> take precedence over
+                inclusions. If no inclusions are explicitly specified, all entries are processed by
+                default.
+                """),
+        @Param(
+            name = "exclude",
+            positional = false,
+            allowedTypes = {@ParamType(type = Sequence.class, generic1 = String.class)},
+            defaultValue = "[]",
+            named = true,
+            doc =
+                """
+	              Do not process files or directories that match the specified glob pattern. Glob
+	              pattern matching support is the same as the Bazel Starlark <code>glob</code>
+	              function. Pattern matching takes place directly on the paths from the archive
+	              (before <code>strip_prefix</code> and <code>rename_files</code> is processed)
+	              """),
       })
   public StructImpl downloadAndExtract(
       Object url,
@@ -1040,8 +1070,12 @@ the same path on case-insensitive filesystems.
       String integrity,
       Dict<?, ?> renameFiles, // <String, String> expected
       String oldStripPrefix,
+      Sequence<?> include,
+      Sequence<?> exclude,
       StarlarkThread thread)
       throws RepositoryFunctionException, InterruptedException, EvalException {
+    List<String> includes = Types.STRING_LIST.convert(include, "'download_and_extract' argument");
+    List<String> excludes = Types.STRING_LIST.convert(exclude, "'download_and_extract' argument");
     stripPrefix = renamedStripPrefix("download_and_extract", stripPrefix, oldStripPrefix);
     ImmutableMap<URI, Map<String, List<String>>> authHeaders =
         getAuthHeaders(getAuthContents(authUnchecked, "auth"));
@@ -1145,6 +1179,8 @@ the same path on case-insensitive filesystems.
               .setDestinationPath(outputPath.getPath())
               .setPrefix(stripPrefix)
               .setRenameFiles(renameFilesMap)
+              .setIncludes(includes)
+              .setExcludes(excludes)
               .build(),
           // Type does NOT need to be passed here, as the existing code renames the archive path to
           // include the type extension. The decompression code then uses the file extension to get
@@ -1291,6 +1327,34 @@ the same path on case-insensitive filesystems.
                 """
                     + SUPPORTED_DECOMPRESSION_FORMATS
                     + " here."),
+        @Param(
+            name = "include",
+            positional = false,
+            allowedTypes = {@ParamType(type = Sequence.class, generic1 = String.class)},
+            defaultValue = "[]",
+            named = true,
+            doc =
+                """
+	              Extract only files or directories that match the	specified glob pattern. Glob
+	              pattern matching support is the same as the Bazel Starlark <code>glob</code>
+	              function. Patternmatching takes place directly on the paths from the archive (before
+	              <code>strip_prefix</code> and <code>rename_files</code> is processed). Note that
+	              exclusions  specified  with	<code>--exclude</code> take precedence over inclusions.
+	              If no  inclusions are explicitly specified, all entries are processed by default.
+	              """),
+        @Param(
+            name = "exclude",
+            positional = false,
+            allowedTypes = {@ParamType(type = Sequence.class, generic1 = String.class)},
+            defaultValue = "[]",
+            named = true,
+            doc =
+                """
+	              Do not process files or directories that match the specified glob pattern. Glob
+	              pattern matching support is the same as the Bazel Starlark <code>glob</code>
+	              function. Pattern matching takes place directly on the paths from the archive
+	              (before <code>strip_prefix</code> and <code>rename_files</code> is processed)
+	              """),
       })
   public void extract(
       Object archive,
@@ -1300,8 +1364,12 @@ the same path on case-insensitive filesystems.
       String watchArchive,
       String oldStripPrefix,
       String type,
+      Sequence<?> include,
+      Sequence<?> exclude,
       StarlarkThread thread)
       throws RepositoryFunctionException, InterruptedException, EvalException {
+    List<String> includes = Types.STRING_LIST.convert(include, "'extract' argument");
+    List<String> excludes = Types.STRING_LIST.convert(exclude, "'extract' argument");
     stripPrefix = renamedStripPrefix("extract", stripPrefix, oldStripPrefix);
     StarlarkPath archivePath = getPath(archive);
 
@@ -1341,6 +1409,8 @@ the same path on case-insensitive filesystems.
             .setDestinationPath(outputPath.getPath())
             .setPrefix(stripPrefix)
             .setRenameFiles(renameFilesMap)
+            .setIncludes(includes)
+            .setExcludes(excludes)
             .build(),
         Optional.ofNullable(type).filter(s -> !s.isBlank()));
     env.getListener().post(new ExtractProgress(outputPath.getPath().toString()));

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/ArFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/ArFunctionTest.java
@@ -14,14 +14,18 @@
 
 package com.google.devtools.build.lib.bazel.repository.decompressor;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.testutil.TestConstants;
 import com.google.devtools.build.lib.testutil.TestUtils;
+import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.util.FileSystems;
 import com.google.devtools.build.runfiles.Runfiles;
 import java.io.File;
@@ -33,12 +37,14 @@ import org.apache.commons.compress.archivers.ar.ArArchiveOutputStream;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests decompressing archives. */
 @RunWith(JUnit4.class)
 public class ArFunctionTest {
+  @Rule public TestName name = new TestName();
   @Rule public TemporaryFolder folder = new TemporaryFolder();
 
   /*
@@ -67,6 +73,19 @@ public class ArFunctionTest {
     // There are 20 bytes in the content "this is the second test file"
     assertThat(secondFile.getFileSize()).isEqualTo(29);
     assertThat(secondFile.isSymbolicLink()).isFalse();
+  }
+
+  @Test
+  public void testDecompressSingleFile() throws Exception {
+    Path outputDir =
+        decompress(
+            createDescriptorBuilder().setIncludes(ImmutableList.of("archived_first.txt")).build());
+
+    ImmutableList<String> files =
+        outputDir.readdir(Symlinks.NOFOLLOW).stream()
+            .map(Dirent::getName)
+            .collect(toImmutableList());
+    assertThat(files).containsExactly("archived_first.txt");
   }
 
   /**
@@ -120,7 +139,7 @@ public class ArFunctionTest {
     Path tarballPath = testFS.getPath(Runfiles.create().rlocation(path));
 
     Path workingDir = testFS.getPath(new File(TestUtils.tmpDir()).getCanonicalPath());
-    Path outDir = workingDir.getRelative("out");
+    Path outDir = workingDir.getRelative("out").getRelative(name.getMethodName());
 
     return DecompressorDescriptor.builder().setDestinationPath(outDir).setArchivePath(tarballPath);
   }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunctionTest.java
@@ -14,14 +14,18 @@
 
 package com.google.devtools.build.lib.bazel.repository.decompressor;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.bazel.repository.decompressor.TestArchiveDescriptor.INNER_FOLDER_NAME;
 import static com.google.devtools.build.lib.bazel.repository.decompressor.TestArchiveDescriptor.ROOT_FOLDER_NAME;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.util.FileSystems;
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -65,6 +69,21 @@ public class CompressedTarFunctionTest {
     Path outputDir = decompress(archiveDescriptor.createDescriptorBuilder().build());
 
     archiveDescriptor.assertOutputFiles(outputDir, ROOT_FOLDER_NAME, INNER_FOLDER_NAME);
+  }
+
+  @Test
+  public void testDecompressOnlyRegularFile() throws Exception {
+    Path outputDir =
+        decompress(
+            archiveDescriptor
+                .createDescriptorBuilder()
+                .setIncludes(ImmutableList.of("**/" + TestArchiveDescriptor.REGULAR_FILE_NAME))
+                .build());
+    Path fileDir = outputDir.getRelative(ROOT_FOLDER_NAME).getRelative(INNER_FOLDER_NAME);
+
+    ImmutableList<String> files =
+        fileDir.readdir(Symlinks.NOFOLLOW).stream().map(Dirent::getName).collect(toImmutableList());
+    assertThat(files).containsExactly(TestArchiveDescriptor.REGULAR_FILE_NAME);
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/DecompressorDescriptorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/DecompressorDescriptorTest.java
@@ -1,0 +1,106 @@
+package com.google.devtools.build.lib.bazel.repository.decompressor;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.util.FileSystems;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests {@link DecompressorDescriptor}. */
+@RunWith(JUnit4.class)
+public class DecompressorDescriptorTest {
+
+  /**
+   * Returns a {#link DecompressorDescriptor} with the given includes and excludes. Stubs all other
+   * required values.
+   */
+  public static DecompressorDescriptor inexDescriptor(
+      List<String> includes, List<String> excludes) {
+    FileSystem testFs = FileSystems.getNativeFileSystem();
+
+    return DecompressorDescriptor.builder()
+        .setIncludes(includes)
+        .setExcludes(excludes)
+        .setDestinationPath(testFs.getPath("/stubOutPath"))
+        .setArchivePath(testFs.getPath("/stubArchivePath"))
+        .build();
+  }
+
+  /** Asserts that a given archiveEntry should have been skipped. */
+  public static void assertSkipped(DecompressorDescriptor d, String archiveEntry) {
+    assertTrue(
+        String.format(
+            "DecompressorDescriptor includes: '%s' and excludes: '%s', but archive entry '%s' was NOT skipped",
+            d.includes().isEmpty() ? "[]" : String.join(", ", d.includes()),
+            d.excludes().isEmpty() ? "[]" : String.join(", ", d.excludes()),
+            archiveEntry),
+        d.skipArchiveEntry(archiveEntry));
+  }
+
+  /** Asserts that a given archiveEntry should have been processed. */
+  public static void assertProcessed(DecompressorDescriptor d, String archiveEntry) {
+    assertFalse(
+        String.format(
+            "DecompressorDescriptor includes: '%s' and excludes: '%s', but archive entry '%s' was NOT processed",
+            d.includes().isEmpty() ? "[]" : String.join(", ", d.includes()),
+            d.excludes().isEmpty() ? "[]" : String.join(", ", d.excludes()),
+            archiveEntry),
+        d.skipArchiveEntry(archiveEntry));
+  }
+
+  @Test
+  public void testEmptyIncludesSkipsNothing() {
+    DecompressorDescriptor d =
+        inexDescriptor(/* includes= */ ImmutableList.of(), /* excludes= */ ImmutableList.of());
+    assertProcessed(d, "anyFileEntry/path");
+    assertProcessed(d, "anyFileEntry/path2");
+  }
+
+  @Test
+  public void testIncludesExclusive() {
+    DecompressorDescriptor d =
+        inexDescriptor(
+            /* includes= */ ImmutableList.of("anyFileEntry**"), /* excludes= */ ImmutableList.of());
+    assertProcessed(d, "anyFileEntry/path");
+    assertSkipped(d, "excluded/file");
+  }
+
+  @Test
+  public void testExclude() {
+    DecompressorDescriptor d =
+        inexDescriptor(
+            /* includes= */ ImmutableList.of(),
+            /* excludes= */ ImmutableList.of("unneededData/**"));
+    assertProcessed(d, "anyFileEntry/path");
+    assertSkipped(d, "unneededData/large.file");
+  }
+
+  @Test
+  public void testExcludeTakesPrecedenceOverIncludes() {
+    DecompressorDescriptor d =
+        inexDescriptor(
+            /* includes= */ ImmutableList.of("anyFileEntry**"),
+            /* excludes= */ ImmutableList.of("anyFileEntry/**.exclude"));
+    assertProcessed(d, "anyFileEntry/path");
+    assertSkipped(d, "anyFileEntry/path2.exclude");
+  }
+
+  @Test
+  public void testMultipleIncludesExcludes() {
+    DecompressorDescriptor d =
+        inexDescriptor(
+            /* includes= */ ImmutableList.of("a/**", "b/**", "c/**"),
+            /* excludes= */ ImmutableList.of("b/**.exclude", "a/exclude"));
+    assertProcessed(d, "a/file/path");
+    assertSkipped(d, "a/exclude");
+    assertProcessed(d, "b/file/path");
+    assertSkipped(d, "b/file/path.exclude");
+    assertProcessed(d, "c/file/path");
+    assertSkipped(d, "d/file/path");
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressorTest.java
@@ -82,6 +82,22 @@ public class SevenZDecompressorTest {
     assertThat(fileDir.getRelative(REGULAR_FILENAME).getFileSize()).isNotEqualTo(0);
   }
 
+  /** Test decompressing a .7z file with excludes */
+  @Test
+  public void testDecompressWithExcludes() throws Exception {
+    Path outputDir =
+        decompress(
+            archiveDescriptor()
+                .createDescriptorBuilder()
+                .setExcludes(ImmutableList.of("**/" + REGULAR_FILENAME))
+                .build());
+
+    Path fileDir = outputDir.getRelative(ROOT_FOLDER_NAME).getRelative(INNER_FOLDER_NAME);
+    ImmutableList<String> files =
+        fileDir.readdir(Symlinks.NOFOLLOW).stream().map(Dirent::getName).collect(toImmutableList());
+    assertThat(files).isEmpty();
+  }
+
   /** Test decompressing a .7z file and stripping a prefix. */
   @Test
   public void testDecompressWithPrefix() throws Exception {

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/TestArchiveDescriptor.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/TestArchiveDescriptor.java
@@ -38,7 +38,7 @@ import java.nio.file.Files;
  */
 public class TestArchiveDescriptor {
   /* Regular file */
-  private static final String REGULAR_FILE_NAME = "regularFile";
+  static final String REGULAR_FILE_NAME = "regularFile";
 
   /* Hard link file, created by ln <REGULAR_FILE_NAME> <HARD_LINK_FILE_NAME> */
   private static final String HARD_LINK_FILE_NAME = "hardLinkFile";

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressorTest.java
@@ -14,14 +14,18 @@
 
 package com.google.devtools.build.lib.bazel.repository.decompressor;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.bazel.repository.decompressor.TestArchiveDescriptor.INNER_FOLDER_NAME;
 import static com.google.devtools.build.lib.bazel.repository.decompressor.TestArchiveDescriptor.ROOT_FOLDER_NAME;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.util.FileSystems;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -77,6 +81,24 @@ public class ZipDecompressorTest {
     Path outputDir = decompress(archiveDescriptor.createDescriptorBuilder().build());
 
     archiveDescriptor.assertOutputFiles(outputDir, ROOT_FOLDER_NAME, INNER_FOLDER_NAME);
+  }
+
+  @Test
+  public void testDecompressOnlyRegularFile() throws Exception {
+    TestArchiveDescriptor archiveDescriptor =
+        new TestArchiveDescriptor(ARCHIVE_NAME, "out/inner", false);
+    Path outputDir =
+        decompress(
+            archiveDescriptor
+                .createDescriptorBuilder()
+                .setIncludes(ImmutableList.of("**/" + TestArchiveDescriptor.REGULAR_FILE_NAME))
+                .build());
+
+    Path fileDir = outputDir.getRelative(ROOT_FOLDER_NAME).getRelative(INNER_FOLDER_NAME);
+
+    ImmutableList<String> files =
+        fileDir.readdir(Symlinks.NOFOLLOW).stream().map(Dirent::getName).collect(toImmutableList());
+    assertThat(files).containsExactly(TestArchiveDescriptor.REGULAR_FILE_NAME);
   }
 
   /**

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -3424,6 +3424,51 @@ EOF
   assert_contains "Second file: A" "$output_base/external/+repo+foo/out_dir/renamed-A.txt"
 }
 
+function test_extract_includes_excludes() {
+  local archive_tar="${TEST_TMPDIR}/archive.tar"
+
+  # Create a tar archive with multiple files.
+  pushd "${TEST_TMPDIR}"
+  mkdir prefix
+  mkdir prefix/include1
+  mkdir prefix/include2
+  echo "a" > prefix/include1/a.txt
+  echo "b" > prefix/include2/b.txt
+  echo "excluded" > prefix/include2/exclude.txt
+  echo "not included" > prefix/not_include.txt
+  tar -cvf archive.tar prefix
+  popd
+
+  cat > $(setup_module_dot_bazel) <<EOF
+repo = use_repo_rule('//:test.bzl', 'repo')
+repo(name = 'foo')
+EOF
+  touch BUILD
+
+  cat >test.bzl <<EOF
+def _impl(repository_ctx):
+  repository_ctx.extract(
+    '${archive_tar}', 'out_dir', 'prefix/',
+    include=['prefix/include**'],
+    exclude=['**/exclude.txt'])
+  repository_ctx.file("BUILD", "filegroup(name='bar', srcs=[])")
+
+repo = repository_rule(implementation=_impl)
+EOF
+
+  bazel build @foo//:bar >& $TEST_log || fail "Failed to build"
+
+  output_base="$(bazel info output_base)"
+  assert_contains "a" "$output_base/external/+repo+foo/out_dir/include1/a.txt"
+  assert_contains "b" "$output_base/external/+repo+foo/out_dir/include2/b.txt"
+  if [ -e "$output_base/external/+repo+foo/out_dir/include2/exclude.txt" ]; then
+    fail "File exclude.txt should not exist"
+  fi
+  if [ -e "$output_base/external/+repo+foo/out_dir/not_include.txt" ]; then
+    fail "File not_include.txt should not exist"
+  fi
+}
+
 # Regression test for https://github.com/bazelbuild/bazel/issues/12986
 # Verifies that tar entries with PAX headers, which are always encoded in UTF-8, are extracted
 # correctly.


### PR DESCRIPTION
`repository_ctx.extract()` and `repository_ctx.download_and_extract()` now support the `include` and `exclude` arguments to selectively include and exclude files during extraction.

The arguments take glob patterns and follow the behavior of BSD tar - copying from BSD tar man page:

```
--include
  Process only files or directories that match the specified
  pattern Note that exclusions specified with --exclude take
  precedence over inclusions. If no inclusions are explicitly
  specified, all entries are processed by default.

--exclude
  Do not process files or directories that match the specified
  pattern. Note that exclusions take precedence over patterns or
  filenames specified on the command line.
```

Glob support follows the existing Bazel starlark `glob()` function.

Fixes #28858

RELNOTES[NEW]: `repository_ctx.extract()` and `repository_ctx.download_and_extract()` now support the `include` and `exclude` arguments to selectively include and exclude files during extraction.
