### PR TITLE
ci: add missing team and area paths to PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -107,14 +107,60 @@ team-OSS:
 - changed-files:
   - any-glob-to-any-file: .github/**/*
 
-# team-Rules-Server
+team-Rules-Server:
+- changed-files:
+  - any-glob-to-any-file:
+    - src/main/java/com/google/devtools/build/lib/server/**/*
+    - src/main/java/com/google/devtools/build/lib/runtime/**/*
 
-# team-Starlark-Interpreter
+team-Starlark-Interpreter:
+- changed-files:
+  - any-glob-to-any-file:
+    - src/main/java/net/starlark/java/**/*
+    - src/test/java/net/starlark/java/**/*
 
-# team-Starlark-Integration
+team-Starlark-Integration:
+- changed-files:
+  - any-glob-to-any-file:
+    - src/main/java/com/google/devtools/build/lib/starlark/**/*
+    - src/test/java/com/google/devtools/build/lib/starlark/**/*
 
-# team-Rules-API
+team-Rules-API:
+- changed-files:
+  - any-glob-to-any-file:
+    - src/main/java/com/google/devtools/build/lib/starlarkbuildapi/**/*
 
-# team-Loading-API
+team-Loading-API:
+- changed-files:
+  - any-glob-to-any-file:
+    - src/main/java/com/google/devtools/build/lib/packages/**/*
 
-# team-Core
+team-Core:
+- changed-files:
+  - any-glob-to-any-file:
+    - src/main/java/com/google/devtools/build/lib/skyframe/**/*
+    - src/main/java/com/google/devtools/build/lib/vfs/**/*
+    - src/main/java/com/google/devtools/build/lib/events/**/*
+    - src/main/java/com/google/devtools/build/lib/buildeventservice/**/*
+
+area-Bzlmod:
+- changed-files:
+  - any-glob-to-any-file:
+    - src/main/java/com/google/devtools/build/lib/bazel/bzlmod/**/*
+    - src/test/java/com/google/devtools/build/lib/bazel/bzlmod/**/*
+
+area-EngProd:
+- changed-files:
+  - any-glob-to-any-file:
+    - scripts/bootstrap/**/*
+    - scripts/release/**/*
+    - tools/build_defs/pkg/**/*
+    - .bazelci/**/*
+
+area-Windows:
+- changed-files:
+  - any-glob-to-any-file:
+    - src/main/native/windows/**/*
+    - src/main/java/com/google/devtools/build/lib/windows/**/*
+    - src/test/java/com/google/devtools/build/lib/windows/**/*
+    - src/test/native/windows/**/*


### PR DESCRIPTION
### Description
This PR updates `.github/labeler.yml` to include path mappings for several teams and functional areas that were previously missing or listed as empty comments. It ensures that incoming Pull Requests are automatically categorized and routed to the correct reviewers.

### Motivation
Currently, many PRs in the Bazel repository (such as those involving Starlark, Windows-specific code, or Bzlmod) require manual labeling by maintainers. By filling in these gaps, we reduce manual triage overhead and speed up the review cycle by automatically identifying the relevant **team-** and **area-** labels based on the files changed.

**Teams added/updated:**
- `team-Rules-Server`
- `team-Starlark-Interpreter`
- `team-Starlark-Integration`
- `team-Rules-API`
- `team-Loading-API`
- `team-Core`
- `team-Bazel`

**Areas added/updated:**
- `area-Bzlmod`
- `area-EngProd`
- `area-Windows`

### Build API Changes
No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None