### PR TITLE
Remove incompatible_dont_enable_host_nonhost_crosstool_features

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -1079,6 +1079,14 @@ public final class BazelRulesModule extends BlazeModule {
         converter = LabelConverter.class,
         help = "No-op.")
     public Label protoToolchainForJ2Objc;
+
+    @Option(
+        name = "incompatible_dont_enable_host_nonhost_crosstool_features",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        help = "No-op.")
+    public boolean dontEnableHostNonhost;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCommon.java
@@ -222,14 +222,6 @@ public final class CcCommon {
       allFeatures.addAll(OBJC_ACTIONS);
     }
 
-    if (!cppConfiguration.dontEnableHostNonhost()) {
-      if (toolchain.isToolConfiguration()) {
-        allFeatures.add("host");
-      } else {
-        allFeatures.add("nonhost");
-      }
-    }
-
     allFeatures.addAll(getCoverageFeatures(cppConfiguration));
 
     if (!allUnsupportedFeatures.contains(CppRuleClasses.FDO_INSTRUMENT)) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -771,7 +771,7 @@ public final class CppConfiguration extends Fragment
 
   @StarlarkMethod(name = "_dont_enable_host_nonhost", documented = false, structField = true)
   public boolean dontEnableHostNonhost() {
-    return cppOptions.dontEnableHostNonhost;
+    return true;
   }
 
   public boolean collectCodeCoverage() {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -786,17 +786,6 @@ public class CppOptions extends FragmentOptions {
   public boolean useLLVMCoverageMapFormat;
 
   @Option(
-      name = "incompatible_dont_enable_host_nonhost_crosstool_features",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "If true, Bazel will not enable 'host' and 'nonhost' features in the c++ toolchain "
-              + "(see https://github.com/bazelbuild/bazel/issues/7407 for more information).")
-  public boolean dontEnableHostNonhost;
-
-  @Option(
       name = "incompatible_make_thinlto_command_lines_standalone",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.TOOLCHAIN,

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -286,7 +286,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:incompatible_disable_legacy_cc_provider",
         "//command_line_option:incompatible_enable_cc_toolchain_resolution",
         "//command_line_option:incompatible_remove_legacy_whole_archive",
-        "//command_line_option:incompatible_dont_enable_host_nonhost_crosstool_features",
         "//command_line_option:incompatible_require_ctx_in_configure_features",
         "//command_line_option:incompatible_make_thinlto_command_lines_standalone",
         "//command_line_option:incompatible_use_specific_tool_files",


### PR DESCRIPTION
This was flipped in 2019 https://github.com/bazelbuild/bazel/issues/7407

The starlark API is read by rules_cc for backwards compatibility

Even if we brought back some functionality like this, I don't think we'd want to
use this old naming, we'd want to have `exec` in the name instead
