### PR TITLE
Replace hardcoded -g0 with toolchain features

### DIFF
--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -16,9 +16,6 @@
 See https://github.com/bazelbuild/bazel/discussions/19213.
 """
 
-# TODO: Remove when get_current_os_name is no longer needed
-load("@_builtins//:common/python/py_internal.bzl", "py_internal")
-
 # The fragments that make up Bazel's exec transition. The fragment() calls in
 # this file fill out this map.
 bazel_fragments = {}
@@ -316,9 +313,8 @@ bazel_fragments["CppOptions"] = fragment(
     func = lambda settings: {
         "//command_line_option:compiler": settings["//command_line_option:host_compiler"],
         "//command_line_option:grte_top": settings["//command_line_option:host_grte_top"],
-        # TODO: Properly fix https://github.com/bazelbuild/bazel/issues/24545 with features.
-        "//command_line_option:copt": settings["//command_line_option:host_copt"] + ([] if py_internal.get_current_os_name() == "windows" else ["-g0"]),
-        "//command_line_option:cxxopt": settings["//command_line_option:host_cxxopt"] + ([] if py_internal.get_current_os_name() == "windows" else ["-g0"]),
+        "//command_line_option:copt": settings["//command_line_option:host_copt"],
+        "//command_line_option:cxxopt": settings["//command_line_option:host_cxxopt"],
         "//command_line_option:conlyopt": settings["//command_line_option:host_conlyopt"],
         "//command_line_option:per_file_copt": settings["//command_line_option:host_per_file_copt"],
         "//command_line_option:linkopt": settings["//command_line_option:host_linkopt"],


### PR DESCRIPTION
Must be paired with a rules_cc version bump that includes https://github.com/bazelbuild/rules_cc/pull/649

Fixes https://github.com/bazelbuild/bazel/issues/13308
Fixes https://github.com/bazelbuild/bazel/issues/24545

RELNOTES[inc]: Remove default `-g0` for host tools. This is still added with the default CC toolchains or if you don't set `no_legacy_features`
