### PR TITLE
[9.1.0] Issue warnings for --no prefix on flags aliased to build settings.

### DIFF
--- a/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
@@ -1005,18 +1005,35 @@ class OptionsParserImpl {
     // Extracts the <arg> from '--<arg>=<value>' and '--<arg> <value>' formats on the command line
     String actualArg = (equalSign != -1) ? arg.substring(2, equalSign) : arg.substring(2);
 
-    if (!flagAliasMappings.containsKey(actualArg)) {
+    if (flagAliasMappings.containsKey(actualArg)) {
+      String alias = flagAliasMappings.get(actualArg);
+      return (equalSign != -1) ? "--" + alias + arg.substring(equalSign) : "--" + alias;
+    }
+
+    // If a valid alias is not found, check for unsupported --no<alias> flag semantics.
+    // If a native option is aliased and being used in this case, a deprecation
+    // warning will be added to notify the user that this usage is unsupported.
+    if (!actualArg.startsWith("no")) {
+      // If the arg does not start with "no", then the deprecation warning does not apply.
+      return arg;
+    }
+    String nameWithoutNo = actualArg.substring(2);
+    OptionDefinition def = optionsData.getOptionDefinitionFromName(nameWithoutNo);
+    // Only consider adding the deprecation warning if a native option is being aliased.
+    if (!flagAliasMappings.containsKey(nameWithoutNo) || def == null) {
       return arg;
     }
 
-    String alias = flagAliasMappings.get(actualArg);
-    actualArg = alias;
+    maybeAddDeprecationWarning(def, PriorityCategory.COMMAND_LINE);
+    // Only add the general deprecation warning if one wasn't already added for the specific flag.
+    // E.g. a specific deprecationWarning on the option definition.
+    if (def.getDeprecationWarning().isEmpty()) {
+      warnings.add(
+          String.format(
+              "Flag --no%s is deprecated. Use --%s=false instead.", nameWithoutNo, nameWithoutNo));
+    }
 
-    // Converts the arg back into a command line option, accounting for both '--<arg>=<value>' and
-    // '--<arg> <value>' formats
-    actualArg = (equalSign != -1) ? "--" + actualArg + arg.substring(equalSign) : "--" + actualArg;
-
-    return actualArg;
+    return arg;
   }
 
   private boolean containsSkippedPrefix(String arg) {

--- a/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
+++ b/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
@@ -253,6 +253,55 @@ public final class OptionsParserTest {
     public boolean ignoredWithoutValue;
   }
 
+  public static class BooleanAliasOptions extends OptionsBase {
+    @Option(
+        name = "foo",
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.NO_OP},
+        defaultValue = "true")
+    public boolean foo;
+
+    @Option(
+        name = "bar",
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.NO_OP},
+        defaultValue = "true")
+    public boolean bar;
+
+    @Option(
+        name = "flag_alias",
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.NO_OP},
+        defaultValue = "null",
+        allowMultiple = true)
+    public List<String> flagAlias;
+  }
+
+  public static class DeprecatedAliasOptions extends OptionsBase {
+    @Option(
+        name = "foo",
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.NO_OP},
+        defaultValue = "true",
+        deprecationWarning = "Don't use foo.")
+    public boolean foo;
+
+    @Option(
+        name = "bar",
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.NO_OP},
+        defaultValue = "true")
+    public boolean bar;
+
+    @Option(
+        name = "flag_alias",
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.NO_OP},
+        defaultValue = "null",
+        allowMultiple = true)
+    public List<String> flagAlias;
+  }
+
   public static class ExampleIncompatibleWithFoo extends OptionsBase {
 
     @Option(
@@ -2689,5 +2738,74 @@ public final class OptionsParserTest {
         "invocation policy",
         implicitDependent,
         expandedFrom);
+  }
+
+  @Test
+  public void aliasWithNoPrefix_emitsWarningIfNative() throws Exception {
+    OptionsParser parser =
+        OptionsParser.builder()
+            .withAliasFlag("flag_alias")
+            .optionsClasses(BooleanAliasOptions.class)
+            .build();
+    parser.parse("--flag_alias=foo=bar");
+
+    parser.parse("--nofoo");
+
+    // The actual flag should not change from default.
+    assertThat(parser.getOptions(BooleanAliasOptions.class).bar).isTrue();
+    // The alias flag should change.
+    assertThat(parser.getOptions(BooleanAliasOptions.class).foo).isFalse();
+    assertThat(parser.getWarnings())
+        .contains("Flag --nofoo is deprecated. Use --foo=false instead.");
+  }
+
+  @Test
+  public void aliasWithNoPrefix_failsIfNotNative() throws Exception {
+    OptionsParser parser =
+        OptionsParser.builder()
+            .withAliasFlag("flag_alias")
+            .optionsClasses(BooleanAliasOptions.class)
+            .build();
+    // Set up alias: baz=bar. baz is NOT a native flag.
+    parser.parse("--flag_alias=baz=bar");
+
+    // Use --nobaz. It should NOT swap and should fail as unrecognized.
+    assertThrows(OptionsParsingException.class, () -> parser.parse("--nobaz"));
+  }
+
+  @Test
+  public void aliasWithNoPrefixAndCustomWarning_emitsCustomWarning() throws Exception {
+    OptionsParser parser =
+        OptionsParser.builder()
+            .withAliasFlag("flag_alias")
+            .optionsClasses(DeprecatedAliasOptions.class)
+            .build();
+    parser.parse("--flag_alias=foo=bar");
+
+    parser.parse("--nofoo");
+
+    assertThat(parser.getWarnings()).contains("Option 'foo' is deprecated: Don't use foo.");
+  }
+
+  @Test
+  public void aliasWithNoPrefix_emitsCustomWarningIfAvailable() throws Exception {
+    OptionsParser parser =
+        OptionsParser.builder()
+            .withAliasFlag("flag_alias")
+            .optionsClasses(DeprecatedAliasOptions.class)
+            .build();
+    parser.parse("--flag_alias=foo=bar");
+
+    parser.parse("--nofoo");
+
+    // The actual flag should not change from default.
+    assertThat(parser.getOptions(DeprecatedAliasOptions.class).bar).isTrue();
+    // The alias flag should change.
+    assertThat(parser.getOptions(DeprecatedAliasOptions.class).foo).isFalse();
+    // Should show custom warning.
+    assertThat(parser.getWarnings()).contains("Option 'foo' is deprecated: Don't use foo.");
+    // Should NOT show generalized warning because a custom one was present.
+    assertThat(parser.getWarnings())
+        .doesNotContain("Flag --nofoo is deprecated. Use --foo=false instead.");
   }
 }


### PR DESCRIPTION
PiperOrigin-RevId: 888150955
Change-Id: Id170f120504024f7fb0bb26de4d43d1e00d1ba89

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
Add new logic for issuing warnings if a native flag is aliased but the user is still using the `--no` prefix semantic for negative boolean values.

### Motivation
This is deprecated usage moving forward with starlarkification and can cause problems with parsing graveyarded flags as seen with https://github.com/bazelbuild/bazel/issues/28537.

### Build API Changes
No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
