### PR TITLE
Include both windows and unix files in `embedded_zipper_sources`

### DIFF
--- a/third_party/ijar/BUILD
+++ b/third_party/ijar/BUILD
@@ -108,14 +108,9 @@ filegroup(
         "zip_main.cc",
         "zlib_client.cc",
         "zlib_client.h",
-    ] + select({
-        "//src/conditions:windows": [
-            "mapped_file_windows.cc",
-        ],
-        "//conditions:default": [
-            "mapped_file_unix.cc",
-        ],
-    }),
+        "mapped_file_windows.cc",
+        "mapped_file_unix.cc",
+    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
### Description

This filegroup is being built for user's exec platform, which can be different from bazel's platform (= user's host platform). The `select()` selects with bazel's platform, making it impossible to build bazel's internal tools for a different platform.

### Motivation

This fixes the "input file not found" error when building with a remote execution platform that is different from the host.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
