### PR TITLE
[8.8.0] Preserve order of recorded inputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -47,7 +47,7 @@ public abstract class BazelLockFileValue implements SkyValue {
   // https://cs.opensource.google/bazel/bazel/+/release-7.3.0:src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java;l=120-127;drc=5f5355b75c7c93fba1e15f6658f308953f4baf51
   // While this hack exists on 7.x, lockfile version increments should be done 2 at a time (i.e.
   // keep this number even).
-  public static final int LOCK_FILE_VERSION = 24;
+  public static final int LOCK_FILE_VERSION = 26;
 
   /** A valid empty lockfile. */
   public static final BazelLockFileValue EMPTY_LOCKFILE = builder().build();

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
@@ -20,11 +20,12 @@ import static com.google.devtools.build.lib.bazel.bzlmod.DelegateTypeAdapterFact
 import static com.google.devtools.build.lib.bazel.bzlmod.DelegateTypeAdapterFactory.IMMUTABLE_MAP;
 import static com.google.devtools.build.lib.bazel.bzlmod.DelegateTypeAdapterFactory.IMMUTABLE_SET;
 import static com.google.devtools.build.lib.bazel.bzlmod.DelegateTypeAdapterFactory.IMMUTABLE_SORTED_MAP;
+import static com.google.devtools.build.lib.rules.repository.RepoRecordedInput.NeverUpToDateRepoRecordedInput.PARSE_FAILURE;
+import static com.google.devtools.build.lib.util.StringEncoding.internalToUnicode;
+import static com.google.devtools.build.lib.util.StringEncoding.unicodeToInternal;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableTable;
-import com.google.common.collect.Table;
 import com.google.devtools.build.lib.bazel.bzlmod.Version.ParseException;
 import com.google.devtools.build.lib.bazel.repository.cache.DownloadCache;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
@@ -293,113 +294,34 @@ public final class GsonTypeAdapterUtil {
     }
   }
 
-  /**
-   * Converts Guava tables into a JSON array of 3-tuples (one per cell). Each 3-tuple is a JSON
-   * array itself (rowKey, columnKey, value). For example, a JSON snippet could be: {@code [
-   * ["row1", "col1", "value1"], ["row2", "col2", "value2"], ... ]}
-   */
-  public static final TypeAdapterFactory IMMUTABLE_TABLE =
-      new TypeAdapterFactory() {
-        @Nullable
-        @Override
-        @SuppressWarnings("unchecked")
-        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
-          if (typeToken.getRawType() != ImmutableTable.class) {
-            return null;
-          }
-          Type type = typeToken.getType();
-          if (!(type instanceof ParameterizedType)) {
-            return null;
-          }
-          Type[] typeArgs = ((ParameterizedType) typeToken.getType()).getActualTypeArguments();
-          if (typeArgs.length != 3) {
-            return null;
-          }
-          var rowTypeAdapter = (TypeAdapter<Object>) gson.getAdapter(TypeToken.get(typeArgs[0]));
-          var colTypeAdapter = (TypeAdapter<Object>) gson.getAdapter(TypeToken.get(typeArgs[1]));
-          var valTypeAdapter = (TypeAdapter<Object>) gson.getAdapter(TypeToken.get(typeArgs[2]));
-          if (rowTypeAdapter == null || colTypeAdapter == null || valTypeAdapter == null) {
-            return null;
-          }
-          return (TypeAdapter<T>)
-              new TypeAdapter<ImmutableTable<Object, Object, Object>>() {
-                @Override
-                public void write(JsonWriter jsonWriter, ImmutableTable<Object, Object, Object> t)
-                    throws IOException {
-                  jsonWriter.beginArray();
-                  for (Table.Cell<Object, Object, Object> cell : t.cellSet()) {
-                    jsonWriter.beginArray();
-                    rowTypeAdapter.write(jsonWriter, cell.getRowKey());
-                    colTypeAdapter.write(jsonWriter, cell.getColumnKey());
-                    valTypeAdapter.write(jsonWriter, cell.getValue());
-                    jsonWriter.endArray();
-                  }
-                  jsonWriter.endArray();
-                }
-
-                @Override
-                public ImmutableTable<Object, Object, Object> read(JsonReader jsonReader)
-                    throws IOException {
-                  var builder = ImmutableTable.builder();
-                  jsonReader.beginArray();
-                  while (jsonReader.peek() != JsonToken.END_ARRAY) {
-                    jsonReader.beginArray();
-                    builder.put(
-                        rowTypeAdapter.read(jsonReader),
-                        colTypeAdapter.read(jsonReader),
-                        valTypeAdapter.read(jsonReader));
-                    jsonReader.endArray();
-                  }
-                  jsonReader.endArray();
-                  return builder.buildOrThrow();
-                }
-              };
-        }
-      };
-
-  private static final TypeAdapter<RepoRecordedInput.File> REPO_RECORDED_INPUT_FILE_TYPE_ADAPTER =
+  // This is needed because Bazel uses a custom String encoding internally, see StringEncoding for
+  // details.
+  public static final TypeAdapter<String> STRING_ADAPTER =
       new TypeAdapter<>() {
         @Override
-        public void write(JsonWriter jsonWriter, RepoRecordedInput.File value) throws IOException {
-          jsonWriter.value(value.toStringInternal());
+        public void write(JsonWriter jsonWriter, String s) throws IOException {
+          jsonWriter.value(internalToUnicode(s));
         }
 
         @Override
-        public RepoRecordedInput.File read(JsonReader jsonReader) throws IOException {
-          return (RepoRecordedInput.File)
-              RepoRecordedInput.File.PARSER.parse(jsonReader.nextString());
+        public String read(JsonReader jsonReader) throws IOException {
+          return unicodeToInternal(jsonReader.nextString());
         }
       };
 
-  private static final TypeAdapter<RepoRecordedInput.Dirents>
-      REPO_RECORDED_INPUT_DIRENTS_TYPE_ADAPTER =
+  private static final TypeAdapter<RepoRecordedInput.WithValue>
+      REPO_RECORDED_INPUT_WITH_VALUE_TYPE_ADAPTER =
           new TypeAdapter<>() {
             @Override
-            public void write(JsonWriter jsonWriter, RepoRecordedInput.Dirents value)
+            public void write(JsonWriter jsonWriter, RepoRecordedInput.WithValue value)
                 throws IOException {
-              jsonWriter.value(value.toStringInternal());
+              jsonWriter.value(internalToUnicode(value.toString()));
             }
 
             @Override
-            public RepoRecordedInput.Dirents read(JsonReader jsonReader) throws IOException {
-              return (RepoRecordedInput.Dirents)
-                  RepoRecordedInput.Dirents.PARSER.parse(jsonReader.nextString());
-            }
-          };
-
-  private static final TypeAdapter<RepoRecordedInput.EnvVar>
-      REPO_RECORDED_INPUT_ENV_VAR_TYPE_ADAPTER =
-          new TypeAdapter<>() {
-            @Override
-            public void write(JsonWriter jsonWriter, RepoRecordedInput.EnvVar value)
-                throws IOException {
-              jsonWriter.value(value.toStringInternal());
-            }
-
-            @Override
-            public RepoRecordedInput.EnvVar read(JsonReader jsonReader) throws IOException {
-              return (RepoRecordedInput.EnvVar)
-                  RepoRecordedInput.EnvVar.PARSER.parse(jsonReader.nextString());
+            public RepoRecordedInput.WithValue read(JsonReader jsonReader) throws IOException {
+              return RepoRecordedInput.WithValue.parse(unicodeToInternal(jsonReader.nextString()))
+                  .orElseGet(() -> new RepoRecordedInput.WithValue(PARSE_FAILURE, ""));
             }
           };
 
@@ -475,7 +397,7 @@ public final class GsonTypeAdapterUtil {
         .registerTypeAdapterFactory(IMMUTABLE_BIMAP)
         .registerTypeAdapterFactory(IMMUTABLE_SET)
         .registerTypeAdapterFactory(OPTIONAL)
-        .registerTypeAdapterFactory(IMMUTABLE_TABLE)
+        .registerTypeAdapter(String.class, STRING_ADAPTER)
         .registerTypeAdapter(Label.class, LABEL_TYPE_ADAPTER)
         .registerTypeAdapter(RepoRuleId.class, REPO_RULE_ID_TYPE_ADAPTER)
         .registerTypeAdapter(RepositoryName.class, REPOSITORY_NAME_TYPE_ADAPTER)
@@ -487,11 +409,8 @@ public final class GsonTypeAdapterUtil {
         .registerTypeAdapter(ModuleExtensionId.IsolationKey.class, ISOLATION_KEY_TYPE_ADAPTER)
         .registerTypeAdapter(AttributeValues.class, new AttributeValuesAdapter())
         .registerTypeAdapter(byte[].class, BYTE_ARRAY_TYPE_ADAPTER)
-        .registerTypeAdapter(RepoRecordedInput.File.class, REPO_RECORDED_INPUT_FILE_TYPE_ADAPTER)
         .registerTypeAdapter(
-            RepoRecordedInput.Dirents.class, REPO_RECORDED_INPUT_DIRENTS_TYPE_ADAPTER)
-        .registerTypeAdapter(
-            RepoRecordedInput.EnvVar.class, REPO_RECORDED_INPUT_ENV_VAR_TYPE_ADAPTER);
+            RepoRecordedInput.WithValue.class, REPO_RECORDED_INPUT_WITH_VALUE_TYPE_ADAPTER);
   }
 
   private GsonTypeAdapterUtil() {}

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InnateRunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InnateRunnableExtension.java
@@ -21,8 +21,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
@@ -39,7 +37,6 @@ import com.google.devtools.build.lib.skyframe.BzlLoadFunction;
 import com.google.devtools.build.lib.skyframe.BzlLoadValue;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import java.util.Map.Entry;
-import java.util.Optional;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
@@ -151,11 +148,6 @@ final class InnateRunnableExtension implements RunnableExtension {
   }
 
   @Override
-  public ImmutableMap<String, Optional<String>> getStaticEnvVars() {
-    return ImmutableMap.of();
-  }
-
-  @Override
   public RunModuleExtensionResult run(
       Environment env,
       SingleExtensionUsagesValue usagesValue,
@@ -237,11 +229,8 @@ final class InnateRunnableExtension implements RunnableExtension {
               attributesValue));
     }
     return new RunModuleExtensionResult(
-        ImmutableSortedMap.of(),
-        ImmutableSortedMap.of(),
-        ImmutableSortedMap.of(),
+        ImmutableList.of(),
         generatedRepoSpecs.buildOrThrow(),
-        ModuleExtensionMetadata.REPRODUCIBLE,
-        ImmutableTable.of());
+        ModuleExtensionMetadata.REPRODUCIBLE);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/LockFileModuleExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/LockFileModuleExtension.java
@@ -15,10 +15,8 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.ImmutableTable;
-import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.rules.repository.RepoRecordedInput;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
@@ -35,8 +33,7 @@ public abstract class LockFileModuleExtension {
 
   public static Builder builder() {
     return new AutoValue_LockFileModuleExtension.Builder()
-        .setModuleExtensionMetadata(Optional.empty())
-        .setRecordedRepoMappingEntries(ImmutableTable.of());
+        .setModuleExtensionMetadata(Optional.empty());
   }
 
   @SuppressWarnings("mutable")
@@ -45,18 +42,11 @@ public abstract class LockFileModuleExtension {
   @SuppressWarnings("mutable")
   public abstract byte[] getUsagesDigest();
 
-  public abstract ImmutableSortedMap<RepoRecordedInput.File, String> getRecordedFileInputs();
-
-  public abstract ImmutableSortedMap<RepoRecordedInput.Dirents, String> getRecordedDirentsInputs();
-
-  public abstract ImmutableSortedMap<RepoRecordedInput.EnvVar, Optional<String>> getEnvVariables();
+  public abstract ImmutableList<RepoRecordedInput.WithValue> getRecordedInputs();
 
   public abstract ImmutableMap<String, RepoSpec> getGeneratedRepoSpecs();
 
   public abstract Optional<LockfileModuleExtensionMetadata> getModuleExtensionMetadata();
-
-  public abstract ImmutableTable<RepositoryName, String, RepositoryName>
-      getRecordedRepoMappingEntries();
 
   public boolean isReproducible() {
     return getModuleExtensionMetadata()
@@ -72,22 +62,12 @@ public abstract class LockFileModuleExtension {
 
     public abstract Builder setUsagesDigest(byte[] digest);
 
-    public abstract Builder setRecordedFileInputs(
-        ImmutableSortedMap<RepoRecordedInput.File, String> value);
-
-    public abstract Builder setRecordedDirentsInputs(
-        ImmutableSortedMap<RepoRecordedInput.Dirents, String> value);
-
-    public abstract Builder setEnvVariables(
-        ImmutableSortedMap<RepoRecordedInput.EnvVar, Optional<String>> value);
+    public abstract Builder setRecordedInputs(ImmutableList<RepoRecordedInput.WithValue> value);
 
     public abstract Builder setGeneratedRepoSpecs(ImmutableMap<String, RepoSpec> value);
 
     public abstract Builder setModuleExtensionMetadata(
         Optional<LockfileModuleExtensionMetadata> value);
-
-    public abstract Builder setRecordedRepoMappingEntries(
-        ImmutableTable<RepositoryName, String, RepositoryName> value);
 
     public abstract LockFileModuleExtension build();
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
@@ -206,11 +206,6 @@ final class RegularRunnableExtension implements RunnableExtension {
   }
 
   @Override
-  public ImmutableMap<String, Optional<String>> getStaticEnvVars() {
-    return staticEnvVars;
-  }
-
-  @Override
   public byte[] getBzlTransitiveDigest() {
     return BazelModuleContext.of(bzlLoadValue.getModule()).bzlTransitiveDigest();
   }
@@ -274,13 +269,10 @@ final class RegularRunnableExtension implements RunnableExtension {
             directories,
             env.getListener());
     ModuleExtensionMetadata moduleExtensionMetadata;
-    var repoMappingRecorder = new Label.RepoMappingRecorder();
-    repoMappingRecorder.mergeEntries(bzlLoadValue.getRecordedRepoMappings());
     try (Mutability mu =
             Mutability.create("module extension", usagesValue.getExtensionUniqueName());
         ModuleExtensionContext moduleContext =
-            createContext(
-                env, usagesValue, starlarkSemantics, extensionId, repoMappingRecorder, facts)) {
+            createContext(env, usagesValue, starlarkSemantics, extensionId, facts, bzlLoadValue)) {
       StarlarkThread thread =
           StarlarkThread.create(
               mu,
@@ -289,9 +281,7 @@ final class RegularRunnableExtension implements RunnableExtension {
               SymbolGenerator.create(extensionId));
       thread.setPrintHandler(Event.makeDebugPrintHandler(env.getListener()));
       threadContext.storeInThread(thread);
-      // This is used by the `Label()` constructor in Starlark, to record any attempts to resolve
-      // apparent repo names to canonical repo names. See #20721 for why this is necessary.
-      thread.setThreadLocal(Label.RepoMappingRecorder.class, repoMappingRecorder);
+      moduleContext.storeRepoMappingRecorderInThread(thread);
       try (SilentCloseable c =
           Profiler.instance()
               .profile(ProfilerTask.BZLMOD, () -> "evaluate module extension: " + extensionId)) {
@@ -317,12 +307,9 @@ final class RegularRunnableExtension implements RunnableExtension {
       moduleContext.markSuccessful();
       env.getListener().post(ModuleExtensionEvaluationProgress.finished(extensionId));
       return new RunModuleExtensionResult(
-          moduleContext.getRecordedFileInputs(),
-          moduleContext.getRecordedDirentsInputs(),
-          moduleContext.getRecordedEnvVarInputs(),
+          moduleContext.getRecordedInputs(),
           threadContext.createRepos(starlarkSemantics),
-          moduleExtensionMetadata,
-          repoMappingRecorder.recordedEntries());
+          moduleExtensionMetadata);
     } catch (EvalException e) {
       env.getListener().handle(Event.error(e.getInnermostLocation(), e.getMessageWithStack()));
       throw ExternalDepsException.withMessage(
@@ -340,9 +327,11 @@ final class RegularRunnableExtension implements RunnableExtension {
       SingleExtensionUsagesValue usagesValue,
       StarlarkSemantics starlarkSemantics,
       ModuleExtensionId extensionId,
-      Label.RepoMappingRecorder repoMappingRecorder,
-      Facts facts)
+      Facts facts,
+      BzlLoadValue bzlLoadValue)
       throws ExternalDepsException {
+    var staticRepoMappingRecorder = new Label.SimpleRepoMappingRecorder();
+    staticRepoMappingRecorder.record(bzlLoadValue.getRecordedRepoMappings());
     Path workingDirectory =
         directories
             .getOutputBase()
@@ -357,7 +346,7 @@ final class RegularRunnableExtension implements RunnableExtension {
               extension,
               usagesValue.getRepoMappings().get(moduleKey),
               usagesValue.getExtensionUsages().get(moduleKey),
-              repoMappingRecorder));
+              staticRepoMappingRecorder));
     }
     ModuleExtensionUsage rootUsage = usagesValue.getExtensionUsages().get(ModuleKey.ROOT);
     boolean rootModuleHasNonDevDependency =
@@ -376,6 +365,8 @@ final class RegularRunnableExtension implements RunnableExtension {
         extensionId,
         StarlarkList.immutableCopyOf(modules),
         facts,
-        rootModuleHasNonDevDependency);
+        rootModuleHasNonDevDependency,
+        staticEnvVars,
+        staticRepoMappingRecorder.recordedEntries());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RunnableExtension.java
@@ -15,14 +15,11 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.ImmutableTable;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
-import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.rules.repository.RepoRecordedInput;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
-import java.util.Optional;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.StarlarkSemantics;
 
@@ -33,16 +30,14 @@ import net.starlark.java.eval.StarlarkSemantics;
  *
  * <p>The general idiom is to "load" such a {@link RunnableExtension} object by getting as much
  * information about it as needed to determine whether it can be reused from the lockfile (hence
- * methods such as {@link #getEvalFactors()}, {@link #getBzlTransitiveDigest()}, {@link
- * #getStaticEnvVars()}). Then the {@link #run} method can be called if it's determined that we
- * can't reuse the cached results in the lockfile and have to re-run this extension.
+ * methods such as {@link #getEvalFactors()} and {@link #getBzlTransitiveDigest()}). Then the {@link
+ * #run} method can be called if it's determined that we can't reuse the cached results in the
+ * lockfile and have to re-run this extension.
  */
 interface RunnableExtension {
   ModuleExtensionEvalFactors getEvalFactors();
 
   byte[] getBzlTransitiveDigest();
-
-  ImmutableMap<String, Optional<String>> getStaticEnvVars();
 
   /** Runs the extension. Returns null if a Skyframe restart is required. */
   @Nullable
@@ -57,10 +52,7 @@ interface RunnableExtension {
 
   /* Holds the result data from running a module extension */
   record RunModuleExtensionResult(
-      ImmutableSortedMap<RepoRecordedInput.File, String> recordedFileInputs,
-      ImmutableSortedMap<RepoRecordedInput.Dirents, String> recordedDirentsInputs,
-      ImmutableSortedMap<RepoRecordedInput.EnvVar, Optional<String>> recordedEnvVarInputs,
+      ImmutableList<RepoRecordedInput.WithValue> recordedInputs,
       ImmutableMap<String, RepoSpec> generatedRepoSpecs,
-      ModuleExtensionMetadata moduleExtensionMetadata,
-      ImmutableTable<RepositoryName, String, RepositoryName> recordedRepoMappingEntries) {}
+      ModuleExtensionMetadata moduleExtensionMetadata) {}
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -16,15 +16,10 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import static com.google.common.collect.ImmutableBiMap.toImmutableBiMap;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.ImmutableTable;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Table;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.bazel.bzlmod.RunnableExtension.RunModuleExtensionResult;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
@@ -45,8 +40,8 @@ import com.google.devtools.build.skyframe.SkyFunction;
 import com.google.devtools.build.skyframe.SkyFunctionException;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
-import com.google.devtools.build.skyframe.SkyframeLookupResult;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -220,9 +215,14 @@ public class SingleExtensionEvalFunction implements SkyFunction {
 
     if (!lockfileMode.equals(LockfileMode.OFF)) {
       var nonVisibleRepoNames =
-          moduleExtensionResult.recordedRepoMappingEntries().values().stream()
-              .filter(repoName -> !repoName.isVisible())
-              .map(RepositoryName::toString)
+          moduleExtensionResult.recordedInputs().stream()
+              .filter(
+                  inputAndValue ->
+                      inputAndValue.input() instanceof RepoRecordedInput.RecordedRepoMapping
+                          && inputAndValue.value() == null)
+              .map(entry -> (RepoRecordedInput.RecordedRepoMapping) entry.input())
+              .map(RepoRecordedInput.RecordedRepoMapping::apparentName)
+              .map(apparentName -> "@" + apparentName)
               .collect(joining(", "));
       if (!nonVisibleRepoNames.isEmpty()) {
         env.getListener()
@@ -252,7 +252,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     // rollback), which would cause false-positive validation errors.
     if (lockfileMode.equals(LockfileMode.ERROR) && !newFacts.equals(workspaceLockfileFacts)) {
       String reason =
-          "The extension '%s' has changed its facts: %s != %s"
+          "the extension '%s' has changed its facts: %s != %s"
               .formatted(
                   extensionId,
                   Starlark.repr(newFacts.value()),
@@ -269,15 +269,6 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     // result is taken from the lockfile, we can already populate the lockfile info. This is
     // necessary to prevent the extension from rerunning when only the imports change.
     if (lockfileMode == LockfileMode.UPDATE || lockfileMode == LockfileMode.REFRESH) {
-      var envVariables =
-          ImmutableMap.<RepoRecordedInput.EnvVar, Optional<String>>builder()
-              // The environment variable dependencies statically declared via the 'environ'
-              // attribute.
-              .putAll(RepoRecordedInput.EnvVar.wrap(extension.getStaticEnvVars()))
-              // The environment variable dependencies dynamically declared via the 'getenv' method.
-              .putAll(moduleExtensionResult.recordedEnvVarInputs())
-              .buildKeepingLast();
-
       lockFileInfo =
           Optional.of(
               new LockFileModuleExtension.WithFactors(
@@ -287,13 +278,9 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                       .setUsagesDigest(
                           SingleExtensionUsagesValue.hashForEvaluation(
                               GsonTypeAdapterUtil.SINGLE_EXTENSION_USAGES_VALUE_GSON, usagesValue))
-                      .setRecordedFileInputs(moduleExtensionResult.recordedFileInputs())
-                      .setRecordedDirentsInputs(moduleExtensionResult.recordedDirentsInputs())
-                      .setEnvVariables(ImmutableSortedMap.copyOf(envVariables))
+                      .setRecordedInputs(moduleExtensionResult.recordedInputs())
                       .setGeneratedRepoSpecs(generatedRepoSpecs)
                       .setModuleExtensionMetadata(lockfileModuleExtensionMetadata)
-                      .setRecordedRepoMappingEntries(
-                          moduleExtensionResult.recordedRepoMappingEntries())
                       .build()));
     } else {
       lockFileInfo = Optional.empty();
@@ -335,19 +322,9 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       if (!Arrays.equals(
           extension.getBzlTransitiveDigest(), lockedExtension.getBzlTransitiveDigest())) {
         diffRecorder.record(
-            "The implementation of the extension '"
+            "the implementation of the extension '"
                 + extensionId
                 + "' or one of its transitive .bzl files has changed");
-      }
-      if (didRecordedInputsChange(
-          env,
-          directories,
-          // didRecordedInputsChange expects possibly null String values.
-          Maps.transformValues(lockedExtension.getEnvVariables(), v -> v.orElse(null)))) {
-        diffRecorder.record(
-            "The environment variables the extension '"
-                + extensionId
-                + "' depends on (or their values) have changed");
       }
       // Check extension data in lockfile is still valid, disregarding usage information that is not
       // relevant for the evaluation of the extension.
@@ -355,23 +332,13 @@ public class SingleExtensionEvalFunction implements SkyFunction {
           SingleExtensionUsagesValue.hashForEvaluation(
               GsonTypeAdapterUtil.SINGLE_EXTENSION_USAGES_VALUE_GSON, usagesValue),
           lockedExtension.getUsagesDigest())) {
-        diffRecorder.record("The usages of the extension '" + extensionId + "' have changed");
+        diffRecorder.record("the usages of the extension '" + extensionId + "' have changed");
       }
-      if (didRepoMappingsChange(env, lockedExtension.getRecordedRepoMappingEntries())) {
+      Optional<String> reason =
+          didRecordedInputsChange(env, directories, lockedExtension.getRecordedInputs());
+      if (reason.isPresent()) {
         diffRecorder.record(
-            "The repo mappings of certain repos used by the extension '"
-                + extensionId
-                + "' have changed");
-      }
-      if (didRecordedInputsChange(env, directories, lockedExtension.getRecordedFileInputs())) {
-        diffRecorder.record(
-            "One or more files the extension '" + extensionId + "' is using have changed");
-      }
-      if (didRecordedInputsChange(env, directories, lockedExtension.getRecordedDirentsInputs())) {
-        diffRecorder.record(
-            "One or more directory listings watched by the extension '"
-                + extensionId
-                + "' have changed");
+            "an input to the extension '" + extensionId + "' changed: " + reason.get());
       }
     } catch (DiffFoundEarlyExitException ignored) {
       // ignored
@@ -423,63 +390,17 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     }
   }
 
-  private static boolean didRepoMappingsChange(
-      Environment env, ImmutableTable<RepositoryName, String, RepositoryName> recordedRepoMappings)
-      throws InterruptedException, NeedsSkyframeRestartException {
-    // Request repo mappings for any 'source repos' in the recorded mapping entries.
-    // Note specially that the main repo needs to be treated differently: if any .bzl file from the
-    // main repo was used for module extension eval, it _has_ to be before WORKSPACE is evaluated
-    // (see relevant code in BzlLoadFunction#getRepositoryMapping), so we only request the main repo
-    // mapping _without_ WORKSPACE repos. See #20942 for more information.
-    SkyframeLookupResult result =
-        env.getValuesAndExceptions(
-            recordedRepoMappings.rowKeySet().stream()
-                .map(
-                    repoName ->
-                        repoName.isMain()
-                            ? RepositoryMappingValue.KEY_FOR_ROOT_MODULE_WITHOUT_WORKSPACE_REPOS
-                            : RepositoryMappingValue.key(repoName))
-                .collect(toImmutableSet()));
-    if (env.valuesMissing()) {
-      // This likely means that one of the 'source repos' in the recorded mapping entries is no
-      // longer there.
-      throw new NeedsSkyframeRestartException();
-    }
-    for (Table.Cell<RepositoryName, String, RepositoryName> cell : recordedRepoMappings.cellSet()) {
-      RepositoryMappingValue repoMappingValue =
-          (RepositoryMappingValue)
-              result.get(
-                  cell.getRowKey().isMain()
-                      ? RepositoryMappingValue.KEY_FOR_ROOT_MODULE_WITHOUT_WORKSPACE_REPOS
-                      : RepositoryMappingValue.key(cell.getRowKey()));
-      if (repoMappingValue == null) {
-        throw new NeedsSkyframeRestartException();
-      }
-      // Very importantly, `repoMappingValue` here could be for a repo that's no longer existent in
-      // the dep graph. See
-      // bazel_lockfile_test.testExtensionRepoMappingChange_sourceRepoNoLongerExistent for a test
-      // case.
-      if (repoMappingValue.equals(RepositoryMappingValue.NOT_FOUND_VALUE)
-          || !cell.getValue()
-              .equals(repoMappingValue.repositoryMapping().get(cell.getColumnKey()))) {
-        // Wee woo wee woo -- diff detected!
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static boolean didRecordedInputsChange(
+  private static Optional<String> didRecordedInputsChange(
       Environment env,
       BlazeDirectories directories,
-      Map<? extends RepoRecordedInput, String> recordedInputs)
+      List<RepoRecordedInput.WithValue> recordedInputs)
       throws InterruptedException, NeedsSkyframeRestartException {
     Optional<String> outdated =
         RepoRecordedInput.isAnyValueOutdated(env, directories, recordedInputs);
     if (env.valuesMissing()) {
       throw new NeedsSkyframeRestartException();
     }
-    return outdated.isPresent();
+    return outdated;
   }
 
   private SingleExtensionValue createSingleExtensionValue(
@@ -533,7 +454,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     return new SingleExtensionEvalFunctionException(
         ExternalDepsException.withMessage(
             Code.BAD_LOCKFILE,
-            "MODULE.bazel.lock is no longer up-to-date because: %s. Please run `bazel mod deps"
+            "MODULE.bazel.lock is no longer up-to-date because %s. Please run `bazel mod deps"
                 + " --lockfile_mode=update` to update your lockfile.",
             reason));
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/LocalRepoContentsCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/LocalRepoContentsCache.java
@@ -158,7 +158,7 @@ public final class LocalRepoContentsCache {
    */
   public Path moveToCache(
       Path fetchedRepoDir, Path fetchedRepoMarkerFile, String predeclaredInputHash)
-      throws IOException, InterruptedException {
+      throws IOException {
     Preconditions.checkState(path != null);
 
     Path entryDir = path.getRelative(predeclaredInputHash);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -14,15 +14,18 @@
 
 package com.google.devtools.build.lib.bazel.repository.starlark;
 
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Ascii;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.Futures;
@@ -52,14 +55,12 @@ import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.remote.RemoteExternalOverlayFileSystem;
 import com.google.devtools.build.lib.rules.repository.NeedsSkyframeRestartException;
 import com.google.devtools.build.lib.rules.repository.RepoRecordedInput;
-import com.google.devtools.build.lib.rules.repository.RepoRecordedInput.Dirents;
 import com.google.devtools.build.lib.rules.repository.RepoRecordedInput.RepoCacheFriendlyPath;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction.RepositoryFunctionException;
 import com.google.devtools.build.lib.runtime.ProcessWrapper;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor.ExecutionResult;
-import com.google.devtools.build.lib.skyframe.ActionEnvironmentFunction;
 import com.google.devtools.build.lib.unsafe.StringUnsafe;
 import com.google.devtools.build.lib.util.OsUtils;
 import com.google.devtools.build.lib.util.io.OutErr;
@@ -85,12 +86,11 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -167,9 +167,8 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
   @Nullable private final ProcessWrapper processWrapper;
   protected final StarlarkSemantics starlarkSemantics;
   protected final String identifyingStringForLogging;
-  private final HashMap<RepoRecordedInput.File, String> recordedFileInputs = new HashMap<>();
-  private final HashMap<RepoRecordedInput.Dirents, String> recordedDirentsInputs = new HashMap<>();
-  private final HashSet<String> accumulatedEnvKeys = new HashSet<>();
+  protected final Label.RepoMappingRecorder repoMappingRecorder;
+  private final LinkedHashMap<RepoRecordedInput, String> recordedInputs = new LinkedHashMap<>();
   private final RepositoryRemoteExecutor remoteExecutor;
   private final List<AsyncTask> asyncTasks;
   private final boolean allowWatchingPathsOutsideWorkspace;
@@ -209,6 +208,13 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
             Thread.ofVirtual()
                 .name("downloads[" + identifyingStringForLogging + "]-", 0)
                 .factory());
+    // This is used by the `Label()` constructor in Starlark, to record any attempts to resolve
+    // apparent repo names to canonical repo names. See #20721 for why this is necessary.
+    this.repoMappingRecorder =
+        (fromRepo, apparentRepoName, canonicalRepoName) ->
+            recordInput(
+                new RepoRecordedInput.RecordedRepoMapping(fromRepo, apparentRepoName),
+                canonicalRepoName.isVisible() ? canonicalRepoName.getName() : null);
   }
 
   /**
@@ -241,6 +247,19 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
     }
   }
 
+  public void storeRepoMappingRecorderInThread(StarlarkThread thread) {
+    repoMappingRecorder.storeInThread(thread);
+  }
+
+  protected void recordInput(RepoRecordedInput input, @Nullable String value) {
+    if (recordedInputs.containsKey(input) && !Objects.equals(recordedInputs.get(input), value)) {
+      throw new IllegalStateException(
+          "Conflicting values recorded for input %s: '%s' vs. '%s'"
+              .formatted(input, recordedInputs.get(input), value));
+    }
+    recordedInputs.put(input, value);
+  }
+
   private boolean cancelPendingAsyncTasks() {
     boolean hadPendingItems = false;
     for (AsyncTask task : asyncTasks) {
@@ -270,21 +289,11 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
   @ForOverride
   protected abstract boolean shouldDeleteWorkingDirectoryOnClose(boolean successful);
 
-  /** Returns the file digests used by this context object so far. */
-  public ImmutableSortedMap<RepoRecordedInput.File, String> getRecordedFileInputs() {
-    return ImmutableSortedMap.copyOf(recordedFileInputs);
-  }
-
-  public ImmutableSortedMap<Dirents, String> getRecordedDirentsInputs() {
-    return ImmutableSortedMap.copyOf(recordedDirentsInputs);
-  }
-
-  public ImmutableSortedMap<RepoRecordedInput.EnvVar, Optional<String>> getRecordedEnvVarInputs()
-      throws InterruptedException {
-    // getEnvVarValues doesn't return null since the Skyframe dependencies have already been
-    // established by getenv calls.
-    return RepoRecordedInput.EnvVar.wrap(
-        RepositoryFunction.getEnvVarValues(env, accumulatedEnvKeys));
+  /** Returns all recorded inputs in the order they were recorded. */
+  public ImmutableList<RepoRecordedInput.WithValue> getRecordedInputs() {
+    return recordedInputs.entrySet().stream()
+        .map(e -> new RepoRecordedInput.WithValue(e.getKey(), e.getValue()))
+        .collect(toImmutableList());
   }
 
   protected void checkInOutputDirectory(String operation, StarlarkPath path)
@@ -1480,16 +1489,17 @@ Strip the given number of leading components from file paths on extraction. Only
   @Nullable
   public String getEnvironmentValue(String name, Object defaultValue)
       throws InterruptedException, NeedsSkyframeRestartException {
-    // Must look up via AEF, rather than solely copy from `this.repoEnvVariables`, in order to
+    // Must look up via Skyframe, rather than solely copy from `this.repoEnvVariables`, in order to
     // establish a SkyKey dependency relationship.
-    if (env.getValue(ActionEnvironmentFunction.key(name)) == null) {
-      throw new NeedsSkyframeRestartException();
+    var nameAndValue = RepositoryFunction.getEnvVarValues(env, ImmutableSet.of(name));
+    if (nameAndValue == null) {
+      return null;
     }
-
     // However, to account for --repo_env we take the value from `this.repoEnvVariables`.
     // See https://github.com/bazelbuild/bazel/pull/20787#discussion_r1445571248 .
+    var entry = Iterables.getOnlyElement(RepoRecordedInput.EnvVar.wrap(nameAndValue).entrySet());
     String envVarValue = repoEnvVariables.get(name);
-    accumulatedEnvKeys.add(name);
+    recordInput(entry.getKey(), envVarValue);
     return envVarValue != null ? envVarValue : nullIfNone(defaultValue, String.class);
   }
 
@@ -1659,7 +1669,7 @@ Strip the given number of leading components from file paths on extraction. Only
         throw new NeedsSkyframeRestartException();
       }
 
-      recordedFileInputs.put(
+      recordInput(
           recordedInput,
           RepoRecordedInput.File.fileValueToMarkerValue((RootedPath) skyKey.argument(), fileValue));
     } catch (IOException e) {
@@ -1678,8 +1688,7 @@ Strip the given number of leading components from file paths on extraction. Only
       throw new NeedsSkyframeRestartException();
     }
     try {
-      recordedDirentsInputs.put(
-          recordedInput, RepoRecordedInput.Dirents.getDirentsMarkerValue(path));
+      recordInput(recordedInput, RepoRecordedInput.Dirents.getDirentsMarkerValue(path));
     } catch (IOException e) {
       throw new RepositoryFunctionException(e, Transience.TRANSIENT);
     }
@@ -1813,7 +1822,7 @@ Strip the given number of leading components from file paths on extraction. Only
       boolean quiet,
       String workingDirectory)
       throws EvalException, InterruptedException {
-    Preconditions.checkState(canExecuteRemote());
+    checkState(canExecuteRemote());
 
     ImmutableSortedMap.Builder<PathFragment, Path> inputsBuilder =
         ImmutableSortedMap.naturalOrder();

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -19,7 +19,6 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import com.github.difflib.patch.PatchFailedException;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.devtools.build.docgen.annot.DocCategory;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.bazel.debug.WorkspaceRuleEvent;
@@ -54,7 +53,6 @@ import com.google.devtools.build.skyframe.SkyFunctionException.Transience;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.InvalidPathException;
-import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.Param;
@@ -85,7 +83,6 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
   private final StructImpl attrObject;
   private final IgnoredSubdirectories ignoredSubdirectories;
   private final SyscallCache syscallCache;
-  private final HashMap<RepoRecordedInput.DirTree, String> recordedDirTreeInputs = new HashMap<>();
 
   /**
    * Create a new context (repository_ctx) object for a Starlark repository rule ({@code rule}
@@ -140,10 +137,6 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
   @Override
   protected boolean shouldDeleteWorkingDirectoryOnClose(boolean successful) {
     return !successful;
-  }
-
-  public ImmutableSortedMap<RepoRecordedInput.DirTree, String> getRecordedDirTreeInputs() {
-    return ImmutableSortedMap.copyOf(recordedDirTreeInputs);
   }
 
   @StarlarkMethod(
@@ -602,7 +595,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
         throw new NeedsSkyframeRestartException();
       }
 
-      recordedDirTreeInputs.put(recordedInput, digestValue.hexDigest());
+      recordInput(recordedInput, digestValue.hexDigest());
     } catch (IOException e) {
       throw new RepositoryFunctionException(e, Transience.TRANSIENT);
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -271,13 +271,13 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
               "repository " + ((RepositoryName) key.argument()).getDisplayForm(mainRepoMapping),
               SymbolGenerator.create(key));
       thread.setPrintHandler(Event.makeDebugPrintHandler(env.getListener()));
-      var repoMappingRecorder = new Label.RepoMappingRecorder();
-      // For repos defined in Bzlmod, record any used repo mappings in the marker file.
+      var repoMappingRecorder = new Label.SimpleRepoMappingRecorder();
+      // For repos defined in Bzlmod, record any repo mappings used by the rule's implementation in
+      // the marker file. The repo mappings recorded while loading the repo rule definition are
+      // instead folded into the predeclared input hash (see DigestWriter#computePredeclaredInputHash).
       // Repos defined in WORKSPACE are impossible to verify given the chunked loading (we'd have to
       // record which chunk the repo mapping was used in, and ain't nobody got time for that).
       if (!isWorkspaceRepo(rule)) {
-        repoMappingRecorder.mergeEntries(
-            rule.getRuleClassObject().getRuleDefinitionEnvironmentRepoMappingEntries());
         thread.setThreadLocal(Label.RepoMappingRecorder.class, repoMappingRecorder);
       }
 
@@ -328,13 +328,10 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
       }
 
       // Modify marker data to include the files/dirents/env vars used by the rule's implementation
-      // function.
-      recordedInputValues.putAll(starlarkRepositoryContext.getRecordedFileInputs());
-      recordedInputValues.putAll(starlarkRepositoryContext.getRecordedDirentsInputs());
-      recordedInputValues.putAll(starlarkRepositoryContext.getRecordedDirTreeInputs());
-      recordedInputValues.putAll(
-          Maps.transformValues(
-              starlarkRepositoryContext.getRecordedEnvVarInputs(), v -> v.orElse(null)));
+      // function, in the order they were recorded.
+      for (RepoRecordedInput.WithValue wv : starlarkRepositoryContext.getRecordedInputs()) {
+        recordedInputValues.put(wv.input(), wv.value());
+      }
 
       for (Table.Cell<RepositoryName, String, RepositoryName> repoMappings :
           repoMappingRecorder.recordedEntries().cellSet()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
@@ -119,8 +119,8 @@ public class StarlarkRepositoryModule implements RepositoryModuleApi {
       builder.setRuleDefinitionEnvironmentLabelAndDigest(
           moduleContext.label(), moduleContext.bzlTransitiveDigest());
     }
-    Label.RepoMappingRecorder repoMappingRecorder =
-        thread.getThreadLocal(Label.RepoMappingRecorder.class);
+    Label.SimpleRepoMappingRecorder repoMappingRecorder =
+        (Label.SimpleRepoMappingRecorder) thread.getThreadLocal(Label.RepoMappingRecorder.class);
     if (repoMappingRecorder != null) {
       builder.setRuleDefinitionEnvironmentRepoMappingEntries(repoMappingRecorder.recordedEntries());
     }

--- a/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
@@ -232,7 +232,7 @@ public final class Label implements Comparable<Label>, StarlarkValue, SkyKey, Co
     Parts parts = Parts.parse(raw);
     Label parsed = parseWithPackageContextInternal(parts, packageContext);
     if (repoMappingRecorder != null && parts.repo() != null && !parts.repoIsCanonical()) {
-      repoMappingRecorder.entries.put(
+      repoMappingRecorder.record(
           packageContext.currentRepo(), parts.repo(), parsed.getRepository());
     }
     return parsed;
@@ -252,12 +252,31 @@ public final class Label implements Comparable<Label>, StarlarkValue, SkyKey, Co
   }
 
   /** Records repo mapping entries used by {@link #parseWithPackageContext}. */
-  public static final class RepoMappingRecorder {
-    /** {@code <fromRepo, apparentRepoName, canonicalRepoName> } */
+  public interface RepoMappingRecorder {
+    void record(RepositoryName fromRepo, String apparentRepoName, RepositoryName canonicalRepoName);
+
+    default void record(Table<RepositoryName, String, RepositoryName> entries) {
+      for (Table.Cell<RepositoryName, String, RepositoryName> cell : entries.cellSet()) {
+        record(cell.getRowKey(), cell.getColumnKey(), cell.getValue());
+      }
+    }
+
+    default void storeInThread(StarlarkThread thread) {
+      thread.setThreadLocal(RepoMappingRecorder.class, this);
+    }
+  }
+
+  /**
+   * A {@link RepoMappingRecorder} backed by a {@link Table} that is used for BUILD and .bzl load
+   * threads.
+   */
+  public static final class SimpleRepoMappingRecorder implements RepoMappingRecorder {
     Table<RepositoryName, String, RepositoryName> entries = HashBasedTable.create();
 
-    public void mergeEntries(Table<RepositoryName, String, RepositoryName> entries) {
-      this.entries.putAll(entries);
+    @Override
+    public void record(
+        RepositoryName fromRepo, String apparentRepoName, RepositoryName canonicalRepoName) {
+      entries.put(fromRepo, apparentRepoName, canonicalRepoName);
     }
 
     public ImmutableTable<RepositoryName, String, RepositoryName> recordedEntries() {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -275,6 +275,9 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
     var repoPath = externalDirectory.getChild(repo.getName());
     var remoteRepo = externalFs.getPath(repoPath);
     var walkResult = walk(remoteRepo);
+    for (var directory : walkResult.directories()) {
+      nativeFs.getPath(directory.asFragment()).createDirectory();
+    }
     var unused =
         getFromFuture(
             inputPrefetcher.prefetchFiles(
@@ -285,11 +288,10 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
                 ActionInputPrefetcher.Priority.CRITICAL,
                 ActionInputPrefetcher.Reason.INPUTS));
     // Create symlinks last as some platforms don't allow creating a symlink to a non-existent
-    // target.
+    // target. A symlink may have already been created as an input to an action.
     for (var remoteSymlink : walkResult.symlinks()) {
       var nativeSymlink = nativeFs.getPath(remoteSymlink.asFragment());
-      nativeSymlink.getParentDirectory().createDirectoryAndParents();
-      nativeSymlink.createSymbolicLink(remoteSymlink.readSymbolicLink());
+      FileSystemUtils.ensureSymbolicLink(nativeSymlink, remoteSymlink.readSymbolicLink());
     }
 
     // After the repo has been copied, atomically materialize the marker file. This ensures that the
@@ -302,10 +304,10 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
     markerFileSibling.renameTo(markerFile);
   }
 
-  private record WalkResult(List<Path> files, List<Path> symlinks) {}
+  private record WalkResult(List<Path> files, List<Path> symlinks, List<Path> directories) {}
 
   private static WalkResult walk(Path root) throws IOException {
-    var result = new WalkResult(new ArrayList<>(), new ArrayList<>());
+    var result = new WalkResult(new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
     walk(root, result);
     return result;
   }
@@ -316,7 +318,10 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
       switch (dirent.getType()) {
         case FILE -> result.files.add(fromChild);
         case SYMLINK -> result.symlinks.add(fromChild);
-        case DIRECTORY -> walk(fromChild, result);
+        case DIRECTORY -> {
+          result.directories.add(fromChild);
+          walk(fromChild, result);
+        }
         default -> throw new IOException("Unsupported file type: " + dirent);
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -145,6 +145,11 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
   }
 
   public void afterCommand() {
+    if (cache == null) {
+      // Not all commands cause beforeCommand to be called, but afterCommand is called
+      // unconditionally.
+      return;
+    }
     this.cache = null;
     this.inputPrefetcher = null;
     this.reporter = null;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -525,7 +525,8 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
 
   @Override
   public Path resolveSymbolicLinks(PathFragment path) throws IOException {
-    return fsForPath(path).resolveSymbolicLinks(path);
+    // Ensure that the return value doesn't leave the overlay file system.
+    return getPath(fsForPath(path).resolveSymbolicLinks(path).asFragment());
   }
 
   @Nullable

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInput.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInput.java
@@ -15,14 +15,15 @@
 package com.google.devtools.build.lib.rules.repository;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.ImmutableSortedMap.toImmutableSortedMap;
-import static java.util.Comparator.naturalOrder;
+import static java.util.Map.Entry.comparingByKey;
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
@@ -44,7 +45,6 @@ import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import com.google.devtools.build.skyframe.SkyKey;
 import java.io.IOException;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -67,7 +67,7 @@ import javax.annotation.Nullable;
  * input is stored as a string, with a prefix denoting its type, followed by a colon, and then the
  * information identifying that specific input.
  */
-public abstract sealed class RepoRecordedInput implements Comparable<RepoRecordedInput> {
+public abstract sealed class RepoRecordedInput {
   /** Represents a parser for a specific type of recorded inputs. */
   public abstract static class Parser {
     /**
@@ -83,14 +83,6 @@ public abstract sealed class RepoRecordedInput implements Comparable<RepoRecorde
      */
     public abstract RepoRecordedInput parse(String s);
   }
-
-  private static final Comparator<RepoRecordedInput> COMPARATOR =
-      (o1, o2) ->
-          o1 == o2
-              ? 0
-              : Comparator.comparing((RepoRecordedInput rri) -> rri.getParser().getPrefix())
-                  .thenComparing(RepoRecordedInput::toStringInternal)
-                  .compare(o1, o2);
 
   /**
    * Parses a recorded input from its string representation.
@@ -115,27 +107,80 @@ public abstract sealed class RepoRecordedInput implements Comparable<RepoRecorde
     return NeverUpToDateRepoRecordedInput.PARSE_FAILURE;
   }
 
+  /** A recorded input along with its recorded value. */
+  public record WithValue(RepoRecordedInput input, @Nullable String value) {
+    /** Parses a {@link WithValue} from its string representation. */
+    public static Optional<RepoRecordedInput.WithValue> parse(String s) {
+      int sChar = s.indexOf(' ');
+      if (sChar > 0) {
+        var input = RepoRecordedInput.parse(unescape(s.substring(0, sChar)));
+        if (!input.equals(NeverUpToDateRepoRecordedInput.PARSE_FAILURE)) {
+          return Optional.of(new WithValue(input, unescape(s.substring(sChar + 1))));
+        }
+      }
+      return Optional.empty();
+    }
+
+    /** Converts this {@link WithValue} to a string in a format compatible with {@link #parse}. */
+    @Override
+    public String toString() {
+      return escape(input.toString()) + " " + escape(value);
+    }
+
+    @VisibleForTesting
+    static String escape(String str) {
+      return str == null
+          ? "\\0"
+          : str.replace("\\", "\\\\").replace("\n", "\\n").replace(" ", "\\s");
+    }
+
+    @VisibleForTesting
+    @Nullable
+    static String unescape(String str) {
+      if (str.equals("\\0")) {
+        return null; // \0 == null string
+      }
+      StringBuilder result = new StringBuilder();
+      boolean escaped = false;
+      for (int i = 0; i < str.length(); i++) {
+        char c = str.charAt(i);
+        if (escaped) {
+          if (c == 'n') { // n means new line
+            result.append("\n");
+          } else if (c == 's') { // s means space
+            result.append(" ");
+          } else { // Any other escaped characters are just un-escaped
+            result.append(c);
+          }
+          escaped = false;
+        } else if (c == '\\') {
+          escaped = true;
+        } else {
+          result.append(c);
+        }
+      }
+      return result.toString();
+    }
+  }
+
   /**
    * Returns whether all values are still up-to-date for each recorded input. If Skyframe values are
    * missing, the return value should be ignored; callers are responsible for checking {@code
    * env.valuesMissing()} and triggering a Skyframe restart if needed.
    */
   public static Optional<String> isAnyValueOutdated(
-      Environment env,
-      BlazeDirectories directories,
-      Map<? extends RepoRecordedInput, String> recordedInputValues)
+      Environment env, BlazeDirectories directories, List<WithValue> recordedInputValues)
       throws InterruptedException {
     env.getValuesAndExceptions(
-        recordedInputValues.keySet().stream()
-            .map(rri -> rri.getSkyKey(directories))
+        recordedInputValues.stream()
+            .map(riv -> riv.input().getSkyKey(directories))
             .collect(toImmutableSet()));
     if (env.valuesMissing()) {
       return UNDECIDED;
     }
-    for (Map.Entry<? extends RepoRecordedInput, String> recordedInputValue :
-        recordedInputValues.entrySet()) {
+    for (var recordedInput : recordedInputValues) {
       Optional<String> reason =
-          recordedInputValue.getKey().isOutdated(env, directories, recordedInputValue.getValue());
+          recordedInput.input().isOutdated(env, directories, recordedInput.value());
       if (reason.isPresent()) {
         return reason;
       }
@@ -152,11 +197,6 @@ public abstract sealed class RepoRecordedInput implements Comparable<RepoRecorde
   @Override
   public final String toString() {
     return getParser().getPrefix() + ":" + toStringInternal();
-  }
-
-  @Override
-  public int compareTo(RepoRecordedInput o) {
-    return COMPARATOR.compare(this, o);
   }
 
   /**
@@ -546,12 +586,11 @@ public abstract sealed class RepoRecordedInput implements Comparable<RepoRecorde
 
     final String name;
 
-    public static ImmutableSortedMap<EnvVar, Optional<String>> wrap(
+    public static ImmutableMap<EnvVar, Optional<String>> wrap(
         Map<String, Optional<String>> envVars) {
       return envVars.entrySet().stream()
-          .collect(
-              toImmutableSortedMap(
-                  naturalOrder(), e -> new EnvVar(e.getKey()), Map.Entry::getValue));
+          .sorted(comparingByKey())
+          .collect(toImmutableMap(e -> new EnvVar(e.getKey()), Map.Entry::getValue));
     }
 
     private EnvVar(String name) {
@@ -600,7 +639,7 @@ public abstract sealed class RepoRecordedInput implements Comparable<RepoRecorde
       // Note that `oldValue` can be null if the env var was not set.
       if (!Objects.equals(oldValue, v)) {
         return Optional.of(
-            "value of %s changed: %s -> %s"
+            "environment variable %s changed: %s -> %s"
                 .formatted(
                     name,
                     oldValue == null ? "" : "'%s'".formatted(oldValue),
@@ -637,6 +676,10 @@ public abstract sealed class RepoRecordedInput implements Comparable<RepoRecorde
     public RecordedRepoMapping(RepositoryName sourceRepo, String apparentName) {
       this.sourceRepo = sourceRepo;
       this.apparentName = apparentName;
+    }
+
+    public String apparentName() {
+      return apparentName;
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -831,9 +831,6 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
               .addInt(environ.size());
       environ.forEach(
           (key, value) -> fp.addString(key.toString()).addNullableString(value.orElse(null)));
-      // The repo mapping entries recorded while loading the repo rule definition are part of the
-      // predeclared inputs: they influence how labels in the rule's implementation resolve, so a
-      // change in them must invalidate the repo (and its repo contents cache entries).
       var repoMappingEntries =
           rule.getRuleClassObject().getRuleDefinitionEnvironmentRepoMappingEntries();
       var repoMappingCells =

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -18,11 +18,11 @@ package com.google.devtools.build.lib.rules.repository;
 import static com.google.devtools.build.lib.skyframe.RepositoryMappingFunction.REPOSITORY_OVERRIDES;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Table;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.bazel.bzlmod.BzlmodRepoRuleValue;
@@ -64,7 +64,7 @@ import com.google.devtools.build.skyframe.SkyValue;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
-import java.util.TreeMap;
+import java.util.LinkedHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -671,41 +671,6 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
         source, /* isFetchingDelayed= */ false, /* excludeFromVendoring= */ true);
   }
 
-  // Escape a value for the marker file
-  @VisibleForTesting
-  static String escape(String str) {
-    return str == null ? "\\0" : str.replace("\\", "\\\\").replace("\n", "\\n").replace(" ", "\\s");
-  }
-
-  // Unescape a value from the marker file
-  @Nullable
-  @VisibleForTesting
-  static String unescape(String str) {
-    if (str.equals("\\0")) {
-      return null; // \0 == null string
-    }
-    StringBuilder result = new StringBuilder();
-    boolean escaped = false;
-    for (int i = 0; i < str.length(); i++) {
-      char c = str.charAt(i);
-      if (escaped) {
-        if (c == 'n') { // n means new line
-          result.append("\n");
-        } else if (c == 's') { // s means space
-          result.append(" ");
-        } else { // Any other escaped characters are just un-escaped
-          result.append(c);
-        }
-        escaped = false;
-      } else if (c == '\\') {
-        escaped = true;
-      } else {
-        result.append(c);
-      }
-    }
-    return result.toString();
-  }
-
   private static class DigestWriter {
     // Input value map to force repo invalidation upon an invalid marker file.
     private static final ImmutableMap<RepoRecordedInput, String> PARSE_FAILURE =
@@ -746,10 +711,10 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
       StringBuilder builder = new StringBuilder();
       builder.append(predeclaredInputHash).append("\n");
       for (Map.Entry<RepoRecordedInput, String> recordedInput :
-          new TreeMap<RepoRecordedInput, String>(recordedInputValues).entrySet()) {
-        String key = recordedInput.getKey().toString();
-        String value = recordedInput.getValue();
-        builder.append(escape(key)).append(" ").append(escape(value)).append("\n");
+          new LinkedHashMap<RepoRecordedInput, String>(recordedInputValues).entrySet()) {
+        builder
+            .append(new RepoRecordedInput.WithValue(recordedInput.getKey(), recordedInput.getValue()))
+            .append("\n");
       }
       String content = builder.toString();
       try {
@@ -827,15 +792,13 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
                 "");
           }
           firstLineVerified = true;
-          recordedInputValues = new TreeMap<>();
+          recordedInputValues = new LinkedHashMap<>();
         } else {
-          int sChar = line.indexOf(' ');
-          if (sChar > 0) {
-            RepoRecordedInput input = RepoRecordedInput.parse(unescape(line.substring(0, sChar)));
-            if (!input.equals(NeverUpToDateRepoRecordedInput.PARSE_FAILURE)) {
-              recordedInputValues.put(input, unescape(line.substring(sChar + 1)));
-              continue;
-            }
+          Optional<RepoRecordedInput.WithValue> withValue =
+              RepoRecordedInput.WithValue.parse(line);
+          if (withValue.isPresent()) {
+            recordedInputValues.put(withValue.get().input(), withValue.get().value());
+            continue;
           }
           // On parse failure, just forget everything else and mark the whole input out of date.
           return PARSE_FAILURE;
@@ -868,6 +831,20 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
               .addInt(environ.size());
       environ.forEach(
           (key, value) -> fp.addString(key.toString()).addNullableString(value.orElse(null)));
+      // The repo mapping entries recorded while loading the repo rule definition are part of the
+      // predeclared inputs: they influence how labels in the rule's implementation resolve, so a
+      // change in them must invalidate the repo (and its repo contents cache entries).
+      var repoMappingEntries =
+          rule.getRuleClassObject().getRuleDefinitionEnvironmentRepoMappingEntries();
+      var repoMappingCells =
+          repoMappingEntries == null ? ImmutableSet.<Table.Cell<RepositoryName, String, RepositoryName>>of() : repoMappingEntries.cellSet();
+      fp.addInt(repoMappingCells.size());
+      repoMappingCells.forEach(
+          entry -> {
+            fp.addString(entry.getRowKey().getName());
+            fp.addString(entry.getColumnKey());
+            fp.addString(entry.getValue().getName());
+          });
       return fp.hexDigestAndReset();
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -268,10 +268,6 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
           try {
             if (remoteRepoContentsCache.lookupCache(
                 repositoryName, repoRoot, digestWriter.predeclaredInputHash, env.getListener())) {
-              env.getListener()
-                  .handle(
-                      Event.debug(
-                          "Got %s from the remote repo contents cache".formatted(repositoryName)));
               return new RepositoryDirectoryValue.Success(
                   repoRoot, /* isFetchingDelayed= */ false, excludeRepoFromVendoring);
             }

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
@@ -239,7 +239,12 @@ public abstract class RepositoryFunction {
       Map<RepoRecordedInput, String> recordedInputValues,
       Environment env)
       throws InterruptedException {
-    return RepoRecordedInput.isAnyValueOutdated(env, directories, recordedInputValues);
+    return RepoRecordedInput.isAnyValueOutdated(
+        env,
+        directories,
+        recordedInputValues.entrySet().stream()
+            .map(e -> new RepoRecordedInput.WithValue(e.getKey(), e.getValue()))
+            .collect(com.google.common.collect.ImmutableList.toImmutableList()));
   }
 
   public static RootedPath getRootedPathFromLabel(Label label, Environment env)

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
@@ -806,7 +806,7 @@ public class BzlLoadFunction implements SkyFunction {
     if (mainRepoMapping == null) {
       return null;
     }
-    Label.RepoMappingRecorder repoMappingRecorder = new Label.RepoMappingRecorder();
+    var repoMappingRecorder = new Label.SimpleRepoMappingRecorder();
     ImmutableList<Pair<String, Location>> programLoads = getLoadsFromProgram(prog);
     ImmutableList<Label> loadLabels =
         getLoadLabels(
@@ -867,7 +867,7 @@ public class BzlLoadFunction implements SkyFunction {
       BzlLoadValue v = loadValues.get(i++);
       loadMap.put(load.first, v.getModule()); // dups ok
       fp.addBytes(v.getTransitiveDigest());
-      repoMappingRecorder.mergeEntries(v.getRecordedRepoMappings());
+      repoMappingRecorder.record(v.getRecordedRepoMappings());
     }
 
     // Retrieve predeclared symbols and complete the digest computation.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -1920,19 +1920,17 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
       Map.Entry<SkyKey, ErrorInfo> firstError = Iterables.get(evalResult.errorMap().entrySet(), 0);
       ErrorInfo error = firstError.getValue();
       Throwable e = error.getException();
-      // Wrap loading failed exceptions
-      if (e != null && e instanceof NoSuchThingException noSuchThingException) {
-        e = new InvalidConfigurationException(noSuchThingException.getDetailedExitCode(), e);
+      if (e instanceof InvalidConfigurationException invalidConfigurationException) {
+        throw invalidConfigurationException;
+      } else if (e instanceof DetailedException detailedException) {
+        throw new InvalidConfigurationException(detailedException.getDetailedExitCode(), e);
       } else if (e == null && !error.getCycleInfo().isEmpty()) {
         cyclesReporter.reportCycles(error.getCycleInfo(), firstError.getKey(), eventHandler);
-        e =
-            new InvalidConfigurationException(
+        throw new InvalidConfigurationException(
                 "cannot load build configuration because of this cycle", Code.CYCLE);
       }
-      if (e != null) {
-        Throwables.throwIfInstanceOf(e, InvalidConfigurationException.class);
-      }
-      throw new IllegalStateException("Unknown error during configuration creation evaluation", e);
+      throw new IllegalStateException(
+          "Unknown error during configuration creation evaluation", e);
     }
 
     // Prepare and return the results.

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -948,7 +948,8 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
   private void checkSameFileSystem(Path that) {
     if (this.fileSystem != that.fileSystem) {
       throw new IllegalArgumentException(
-          "Files are on different filesystems: " + this + ", " + that);
+          "Files are on different filesystems: %s (on %s), %s (on %s)"
+              .formatted(this, this.fileSystem, that, that.fileSystem));
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -56,6 +56,8 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/packages/semantics",
         "//src/main/java/com/google/devtools/build/lib/pkgcache",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/local_repository_rule",
+        "//src/main/java/com/google/devtools/build/lib/rules:repository/repo_recorded_input",
+        "//src/main/java/com/google/devtools/build/lib/rules:repository/repository_directory_value",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/repository_function",
         "//src/main/java/com/google/devtools/build/lib/skyframe:bzl_compile",
         "//src/main/java/com/google/devtools/build/lib/skyframe:bzl_load_cycle_reporter",

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModuleTest.java
@@ -16,8 +16,8 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.devtools.build.lib.cmdline.Label;
 import java.util.Optional;
 import net.starlark.java.eval.Dict;
@@ -46,18 +46,14 @@ public class BazelLockFileModuleTest {
         LockFileModuleExtension.builder()
             .setBzlTransitiveDigest(new byte[] {1, 2, 3})
             .setUsagesDigest(new byte[] {4, 5, 6})
-            .setRecordedFileInputs(ImmutableSortedMap.of())
-            .setRecordedDirentsInputs(ImmutableSortedMap.of())
-            .setEnvVariables(ImmutableSortedMap.of())
+            .setRecordedInputs(ImmutableList.of())
             .setGeneratedRepoSpecs(ImmutableMap.of())
             .build();
     reproducibleResult =
         LockFileModuleExtension.builder()
             .setBzlTransitiveDigest(new byte[] {1, 2, 3})
             .setUsagesDigest(new byte[] {4, 5, 6})
-            .setRecordedFileInputs(ImmutableSortedMap.of())
-            .setRecordedDirentsInputs(ImmutableSortedMap.of())
-            .setEnvVariables(ImmutableSortedMap.of())
+            .setRecordedInputs(ImmutableList.of())
             .setGeneratedRepoSpecs(ImmutableMap.of())
             .setModuleExtensionMetadata(
                 LockfileModuleExtensionMetadata.of(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -49,6 +49,7 @@ import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
 import com.google.devtools.build.lib.rules.repository.LocalRepositoryFunction;
 import com.google.devtools.build.lib.rules.repository.LocalRepositoryRule;
+import com.google.devtools.build.lib.rules.repository.RepoRecordedInput;
 import com.google.devtools.build.lib.rules.repository.RepositoryDelegatorFunction;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction;
 import com.google.devtools.build.lib.skyframe.BazelSkyframeExecutorConstants;
@@ -924,8 +925,11 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
                 .lockFileInfo()
                 .get()
                 .moduleExtension()
-                .getRecordedRepoMappingEntries())
-        .containsCell(RepositoryName.create("foo+"), "bar", RepositoryName.create("bar+"));
+                .getRecordedInputs())
+        .contains(
+            new RepoRecordedInput.WithValue(
+                new RepoRecordedInput.RecordedRepoMapping(RepositoryName.create("foo+"), "bar"),
+                "bar+"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
@@ -91,7 +91,7 @@ public class StarlarkBazelModuleTest {
     Module module = buildModule("foo", "1.0").setKey(fooKey).addDep("bar", barKey).build();
     AbridgedModule abridgedModule = AbridgedModule.from(module);
 
-    Label.RepoMappingRecorder repoMappingRecorder = new Label.RepoMappingRecorder();
+    var repoMappingRecorder = new Label.SimpleRepoMappingRecorder();
     StarlarkBazelModule moduleProxy =
         StarlarkBazelModule.create(
             abridgedModule,
@@ -152,7 +152,7 @@ public class StarlarkBazelModuleTest {
                     module.getRepoMappingWithBazelDepsOnly(
                         ImmutableMap.of(fooKey, fooKey.getCanonicalRepoNameWithoutVersion())),
                     usage,
-                    new Label.RepoMappingRecorder()));
+                    new Label.SimpleRepoMappingRecorder()));
     assertThat(e).hasMessageThat().contains("does not have a tag class named blep");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/BUILD
@@ -30,6 +30,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/packages/semantics",
         "//src/main/java/com/google/devtools/build/lib/pkgcache",
+        "//src/main/java/com/google/devtools/build/lib/rules:repository/repo_recorded_input",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/repository_function",
         "//src/main/java/com/google/devtools/build/lib/skyframe:configured_target_and_data",
         "//src/main/java/com/google/devtools/build/lib/skyframe:package_lookup_value",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
@@ -49,6 +49,7 @@ import com.google.devtools.build.lib.packages.WorkspaceFactoryHelper;
 import com.google.devtools.build.lib.packages.WorkspaceFileValue;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
+import com.google.devtools.build.lib.rules.repository.RepoRecordedInput;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction.RepositoryFunctionException;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor.ExecutionResult;
@@ -589,7 +590,10 @@ public final class StarlarkRepositoryContextTest {
     scratch.file(root.getRelative("foo").getPathString());
     StarlarkPath unusedPath = context.getPath(fakeFileLabel);
     String unusedRead = context.readFile(fakeFileLabel, "no", thread);
-    assertThat(context.getRecordedFileInputs()).isNotEmpty();
+    assertThat(
+            context.getRecordedInputs().stream()
+                .filter(inputAndValue -> inputAndValue.input() instanceof RepoRecordedInput.File))
+        .isNotEmpty();
   }
 
   @Test
@@ -602,6 +606,9 @@ public final class StarlarkRepositoryContextTest {
     scratch.file(root.getRelative("foo").getPathString());
     StarlarkPath unusedPath = context.getPath(fakeFileLabel);
     String unusedRead = context.readFile(fakeFileLabel, "no", thread);
-    assertThat(context.getRecordedFileInputs()).isEmpty();
+    assertThat(
+            context.getRecordedInputs().stream()
+                .filter(inputAndValue -> inputAndValue.input() instanceof RepoRecordedInput.File))
+        .isEmpty();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/cmdline/LabelTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/LabelTest.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Tables;
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.cmdline.Label.PackageContext;
 import com.google.devtools.build.lib.cmdline.Label.RepoContext;
-import com.google.devtools.build.lib.cmdline.Label.RepoMappingRecorder;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.skyframe.serialization.testutils.SerializationTester;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -537,7 +536,7 @@ public class LabelTest {
             PackageIdentifier.create(bar, PathFragment.EMPTY_FRAGMENT),
             RepositoryMapping.create(ImmutableMap.of("foo", quux, "quux", foo), bar));
 
-    RepoMappingRecorder recorder = new RepoMappingRecorder();
+    var recorder = new Label.SimpleRepoMappingRecorder();
     // Not recorded: no repo part
     var unused = Label.parseWithPackageContext("//foo/bar", fooPackageContext, recorder);
     // Recorded: <foo, bar, quux>

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInputTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInputTest.java
@@ -1,4 +1,4 @@
-// Copyright 2015 The Bazel Authors. All rights reserved.
+// Copyright 2025 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,17 +31,16 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
-/** Tests for {@link RepositoryFunction} */
+/** Test class for {@link RepoRecordedInput}. */
 @RunWith(JUnit4.class)
-public class RepositoryFunctionTest extends BuildViewTestCase {
-
+public class RepoRecordedInputTest extends BuildViewTestCase {
   private static void assertMarkerFileEscaping(String testCase) {
-    String escaped = RepositoryDelegatorFunction.escape(testCase);
-    assertThat(RepositoryDelegatorFunction.unescape(escaped)).isEqualTo(testCase);
+    String escaped = RepoRecordedInput.WithValue.escape(testCase);
+    assertThat(RepoRecordedInput.WithValue.unescape(escaped)).isEqualTo(testCase);
   }
 
   @Test
-  public void testMarkerFileEscaping() throws Exception {
+  public void testMarkerFileEscaping() {
     assertMarkerFileEscaping(null);
     assertMarkerFileEscaping("\\0");
     assertMarkerFileEscaping("a\\0");

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -727,9 +727,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 48, stderr)
     self.assertIn(
         (
-            'ERROR: MODULE.bazel.lock is no longer up-to-date because: The '
-            "implementation of the extension '@@//:extension.bzl%lockfile_ext' "
-            'or one of its transitive .bzl files has changed. Please run'
+            'ERROR: MODULE.bazel.lock is no longer up-to-date because the'
+            " implementation of the extension '@@//:extension.bzl%lockfile_ext'"
+            ' or one of its transitive .bzl files has changed. Please run'
             ' `bazel mod deps --lockfile_mode=update` to update your lockfile.'
         ),
         stderr,
@@ -915,11 +915,11 @@ class BazelLockfileTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 48, stderr)
     self.assertIn(
         (
-            'ERROR: MODULE.bazel.lock is no longer up-to-date because: The'
-            ' environment variables the extension'
-            " '@@//:extension.bzl%lockfile_ext' depends"
-            ' on (or their values) have changed. Please run'
-            ' `bazel mod deps --lockfile_mode=update` to update your lockfile.'
+            'ERROR: MODULE.bazel.lock is no longer up-to-date because an input'
+            " to the extension '@@//:extension.bzl%lockfile_ext' changed:"
+            " environment variable SET_ME changed: 'High in sky' -> 'Down to"
+            " earth'. Please run `bazel mod deps --lockfile_mode=update` to"
+            ' update your lockfile.'
         ),
         stderr,
     )
@@ -2176,9 +2176,9 @@ class BazelLockfileTest(test_base.TestBase):
       lockfile = json.loads(f.read().strip())
       self.assertIn('//:ext.bzl%ext', lockfile['moduleExtensions'])
       extension = lockfile['moduleExtensions']['//:ext.bzl%ext']['general']
-      self.assertIn('recordedRepoMappingEntries', extension)
-      extension['recordedRepoMappingEntries'].append(
-          ['_unknown_source_repo', 'other_name', 'bar+']
+      self.assertIn('recordedInputs', extension)
+      extension['recordedInputs'].append(
+          'REPO_MAPPING:_unknown_source_repo,other_name bar+'
       )
 
     with open(self.Path('MODULE.bazel.lock'), 'w') as f:
@@ -2975,7 +2975,7 @@ class BazelLockfileTest(test_base.TestBase):
     self.assertIn('Fetching metadata for world...', stderr)
     self.assertIn('world: hash=drw', stderr)
     self.assertIn(
-        'ERROR: MODULE.bazel.lock is no longer up-to-date because: The'
+        'ERROR: MODULE.bazel.lock is no longer up-to-date because the'
         " extension '@@//:extension.bzl%lockfile_ext' has changed its facts:"
         ' {"hello": {"hash": "olh"}, "world": {"hash": "drw"}} != {"hello":'
         ' {"hash": "olleh"}, "world": {"hash": "dlrow"}}',

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -482,7 +482,11 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     with open(self.Path('bazel-bin/main/out.txt')) as f:
       self.assertEqual(f.read(), 'hello')
 
-  def testUseRepoFileInBuildRule_actionDoesNotUseCache(self):
+  def do_testUseRepoFileInBuildRule_actionDoesNotUseCache(
+      self, extra_flags=None
+  ):
+    if extra_flags is None:
+      extra_flags = []
     self.ScratchFile(
         'MODULE.bazel',
         [
@@ -518,7 +522,7 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     repo_dir = self.RepoDir('my_repo')
 
     # First fetch: not cached
-    _, _, stderr = self.RunBazel(['build', '//main:use_data'])
+    _, _, stderr = self.RunBazel(['build', '//main:use_data'] + extra_flags)
     self.assertIn('JUST FETCHED', '\n'.join(stderr))
     self.assertTrue(os.path.exists(os.path.join(repo_dir, 'BUILD')))
     self.assertTrue(os.path.exists(os.path.join(repo_dir, 'data.txt')))
@@ -528,13 +532,24 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
 
     # After expunging: repo and build action cached
     self.RunBazel(['clean', '--expunge'])
-    _, _, stderr = self.RunBazel(['build', '//main:use_data'])
+    _, _, stderr = self.RunBazel(['build', '//main:use_data'] + extra_flags)
     self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
     self.assertFalse(os.path.exists(os.path.join(repo_dir, 'BUILD')))
     self.assertTrue(os.path.exists(os.path.join(repo_dir, 'data.txt')))
     self.assertTrue(os.path.exists(self.Path('bazel-bin/main/out.txt')))
     with open(self.Path('bazel-bin/main/out.txt')) as f:
       self.assertEqual(f.read(), 'hello')
+
+  def testUseRepoFileInBuildRule_actionDoesNotUseCache(self):
+    self.do_testUseRepoFileInBuildRule_actionDoesNotUseCache()
+
+  def testUseRepoFileInBuildRule_actionDoesNotUseCache_withExplicitSandboxBase(
+      self,
+  ):
+    tmpdir = self.ScratchDir('sandbox_base')
+    self.do_testUseRepoFileInBuildRule_actionDoesNotUseCache(
+        extra_flags=['--sandbox_base=' + tmpdir]
+    )
 
   def testLostRemoteFile_build(self):
     # Create a repo with two BUILD files (one in a subpackage), build a target

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 24,
+  "lockFileVersion": 26,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -140,11 +140,10 @@
       "general": {
         "bzlTransitiveDigest": "VhEtmxw1yzb9rBZVsKTdti7p+nDM/Fv1p9TmKdO45+Q=",
         "usagesDigest": "fycyB39YnXIJkfWCIXLUKJMZzANcuLy9ZE73hRucjFk=",
-        "recordedFileInputs": {
-          "@@pybind11_bazel+//MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
-        },
-        "recordedDirentsInputs": {},
-        "envVariables": {},
+        "recordedInputs": [
+          "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
+          "FILE:@@pybind11_bazel+//MODULE.bazel 88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
+        ],
         "generatedRepoSpecs": {
           "local_config_python": {
             "repoRuleId": "@@pybind11_bazel+//:python_configure.bzl%python_configure",
@@ -160,23 +159,16 @@
               ]
             }
           }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "pybind11_bazel+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
+        }
       }
     },
     "@@rules_fuzzing+//fuzzing/private:extensions.bzl%non_module_dependencies": {
       "general": {
         "bzlTransitiveDigest": "CYUiFDCnL2VGx3uotIu/VuGabgObnZra2zzRUJCX0sU=",
         "usagesDigest": "wy6ISK6UOcBEjj/mvJ/S3WeXoO67X+1llb9yPyFtPgc=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
+        "recordedInputs": [
+          "REPO_MAPPING:rules_fuzzing+,bazel_tools bazel_tools"
+        ],
         "generatedRepoSpecs": {
           "platforms": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
@@ -243,23 +235,16 @@
               "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer-api/0.20.1/jazzer-api-0.20.1.jar"
             }
           }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_fuzzing+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
+        }
       }
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "03Qju4tW0vE+0RBuZGuV2A4Hx6AiSkdNahYvworx2aM=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
+        "recordedInputs": [
+          "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
+        ],
         "generatedRepoSpecs": {
           "com_github_jetbrains_kotlin_git": {
             "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
@@ -307,30 +292,46 @@
               ]
             }
           }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_kotlin+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
+        }
       }
     },
     "@@rules_python+//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
         "bzlTransitiveDigest": "lFXtGLhTWi+586Hk5wxd2is/yHXqyHDL7B2EAPLG4qA=",
         "usagesDigest": "OLoIStnzNObNalKEMRq99FqenhPGLFZ5utVLV4sz7OI=",
-        "recordedFileInputs": {
-          "@@rules_python+//tools/publish/requirements_darwin.txt": "2994136eab7e57b083c3de76faf46f70fad130bc8e7360a7fed2b288b69e79dc",
-          "@@rules_python+//tools/publish/requirements_linux.txt": "8175b4c8df50ae2f22d1706961884beeb54e7da27bd2447018314a175981997d",
-          "@@rules_python+//tools/publish/requirements_windows.txt": "7673adc71dc1a81d3661b90924d7a7c0fc998cd508b3cb4174337cef3f2de556"
-        },
-        "recordedDirentsInputs": {},
-        "envVariables": {
-          "RULES_PYTHON_REPO_DEBUG": null,
-          "RULES_PYTHON_REPO_DEBUG_VERBOSITY": null
-        },
+        "recordedInputs": [
+          "REPO_MAPPING:bazel_features+,bazel_features_globals bazel_features++version_extension+bazel_features_globals",
+          "REPO_MAPPING:bazel_features+,bazel_features_version bazel_features++version_extension+bazel_features_version",
+          "REPO_MAPPING:rules_python+,bazel_features bazel_features+",
+          "REPO_MAPPING:rules_python+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_python+,pypi__build rules_python++internal_deps+pypi__build",
+          "REPO_MAPPING:rules_python+,pypi__click rules_python++internal_deps+pypi__click",
+          "REPO_MAPPING:rules_python+,pypi__colorama rules_python++internal_deps+pypi__colorama",
+          "REPO_MAPPING:rules_python+,pypi__importlib_metadata rules_python++internal_deps+pypi__importlib_metadata",
+          "REPO_MAPPING:rules_python+,pypi__installer rules_python++internal_deps+pypi__installer",
+          "REPO_MAPPING:rules_python+,pypi__more_itertools rules_python++internal_deps+pypi__more_itertools",
+          "REPO_MAPPING:rules_python+,pypi__packaging rules_python++internal_deps+pypi__packaging",
+          "REPO_MAPPING:rules_python+,pypi__pep517 rules_python++internal_deps+pypi__pep517",
+          "REPO_MAPPING:rules_python+,pypi__pip rules_python++internal_deps+pypi__pip",
+          "REPO_MAPPING:rules_python+,pypi__pip_tools rules_python++internal_deps+pypi__pip_tools",
+          "REPO_MAPPING:rules_python+,pypi__pyproject_hooks rules_python++internal_deps+pypi__pyproject_hooks",
+          "REPO_MAPPING:rules_python+,pypi__setuptools rules_python++internal_deps+pypi__setuptools",
+          "REPO_MAPPING:rules_python+,pypi__tomli rules_python++internal_deps+pypi__tomli",
+          "REPO_MAPPING:rules_python+,pypi__wheel rules_python++internal_deps+pypi__wheel",
+          "REPO_MAPPING:rules_python+,pypi__zipp rules_python++internal_deps+pypi__zipp",
+          "REPO_MAPPING:rules_python+,pythons_hub rules_python++python+pythons_hub",
+          "REPO_MAPPING:rules_python++python+pythons_hub,python_3_10_host rules_python++python+python_3_10_host",
+          "REPO_MAPPING:rules_python++python+pythons_hub,python_3_11_host rules_python++python+python_3_11_host",
+          "REPO_MAPPING:rules_python++python+pythons_hub,python_3_12_host rules_python++python+python_3_12_host",
+          "REPO_MAPPING:rules_python++python+pythons_hub,python_3_8_host rules_python++python+python_3_8_host",
+          "REPO_MAPPING:rules_python++python+pythons_hub,python_3_9_host rules_python++python+python_3_9_host",
+          "ENV:RULES_PYTHON_REPO_DEBUG \\0",
+          "ENV:RULES_PYTHON_REPO_DEBUG_VERBOSITY \\0",
+          "FILE:@@rules_python+//tools/publish/requirements_darwin.txt 2994136eab7e57b083c3de76faf46f70fad130bc8e7360a7fed2b288b69e79dc",
+          "FILE:@@rules_python+//tools/publish/requirements_linux.txt 8175b4c8df50ae2f22d1706961884beeb54e7da27bd2447018314a175981997d",
+          "FILE:@@rules_python+//tools/publish/requirements_windows.txt 7673adc71dc1a81d3661b90924d7a7c0fc998cd508b3cb4174337cef3f2de556"
+        ],
         "generatedRepoSpecs": {
           "rules_python_publish_deps_311_backports_tarfile_py3_none_any_77e284d7": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
@@ -2676,139 +2677,7 @@
               "groups": {}
             }
           }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "bazel_features+",
-            "bazel_features_globals",
-            "bazel_features++version_extension+bazel_features_globals"
-          ],
-          [
-            "bazel_features+",
-            "bazel_features_version",
-            "bazel_features++version_extension+bazel_features_version"
-          ],
-          [
-            "rules_python+",
-            "bazel_features",
-            "bazel_features+"
-          ],
-          [
-            "rules_python+",
-            "bazel_skylib",
-            "bazel_skylib+"
-          ],
-          [
-            "rules_python+",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "rules_python+",
-            "pypi__build",
-            "rules_python++internal_deps+pypi__build"
-          ],
-          [
-            "rules_python+",
-            "pypi__click",
-            "rules_python++internal_deps+pypi__click"
-          ],
-          [
-            "rules_python+",
-            "pypi__colorama",
-            "rules_python++internal_deps+pypi__colorama"
-          ],
-          [
-            "rules_python+",
-            "pypi__importlib_metadata",
-            "rules_python++internal_deps+pypi__importlib_metadata"
-          ],
-          [
-            "rules_python+",
-            "pypi__installer",
-            "rules_python++internal_deps+pypi__installer"
-          ],
-          [
-            "rules_python+",
-            "pypi__more_itertools",
-            "rules_python++internal_deps+pypi__more_itertools"
-          ],
-          [
-            "rules_python+",
-            "pypi__packaging",
-            "rules_python++internal_deps+pypi__packaging"
-          ],
-          [
-            "rules_python+",
-            "pypi__pep517",
-            "rules_python++internal_deps+pypi__pep517"
-          ],
-          [
-            "rules_python+",
-            "pypi__pip",
-            "rules_python++internal_deps+pypi__pip"
-          ],
-          [
-            "rules_python+",
-            "pypi__pip_tools",
-            "rules_python++internal_deps+pypi__pip_tools"
-          ],
-          [
-            "rules_python+",
-            "pypi__pyproject_hooks",
-            "rules_python++internal_deps+pypi__pyproject_hooks"
-          ],
-          [
-            "rules_python+",
-            "pypi__setuptools",
-            "rules_python++internal_deps+pypi__setuptools"
-          ],
-          [
-            "rules_python+",
-            "pypi__tomli",
-            "rules_python++internal_deps+pypi__tomli"
-          ],
-          [
-            "rules_python+",
-            "pypi__wheel",
-            "rules_python++internal_deps+pypi__wheel"
-          ],
-          [
-            "rules_python+",
-            "pypi__zipp",
-            "rules_python++internal_deps+pypi__zipp"
-          ],
-          [
-            "rules_python+",
-            "pythons_hub",
-            "rules_python++python+pythons_hub"
-          ],
-          [
-            "rules_python++python+pythons_hub",
-            "python_3_10_host",
-            "rules_python++python+python_3_10_host"
-          ],
-          [
-            "rules_python++python+pythons_hub",
-            "python_3_11_host",
-            "rules_python++python+python_3_11_host"
-          ],
-          [
-            "rules_python++python+pythons_hub",
-            "python_3_12_host",
-            "rules_python++python+python_3_12_host"
-          ],
-          [
-            "rules_python++python+pythons_hub",
-            "python_3_8_host",
-            "rules_python++python+python_3_8_host"
-          ],
-          [
-            "rules_python++python+pythons_hub",
-            "python_3_9_host",
-            "rules_python++python+python_3_9_host"
-          ]
-        ]
+        }
       }
     }
   },


### PR DESCRIPTION
Recorded inputs for repo rules and module extensions are no longer separated by type, but recorded in the order they are encountered. This is necessary preparatory work to avoid Skyframe cycles that could otherwise occur while checking cache, lockfile or marker file entries for up-to-dateness.

This requires a breaking change to the lockfile structure, but has the positive side effect that each recorded input is now represented as a single line in the lockfile and thus more compact.

Along the way, the error message for an out-of-date lockfile entry with `--lockfile_mode=errors` are improved and now include the precise reason for the invalidation.

For repository rules, the repo mapping entries recorded while loading the repo rule definition are now included in the predeclared inputs hash, which makes cache entries more specific and avoids unnecessary Skyframe lookups.

Work towards #27517

Closes #27603.

PiperOrigin-RevId: 844721202
Change-Id: Id063a88508591086b07bd89a822cf22b2d90610d
(cherry picked from commit 41ccfefb88e9d816453eb42e549895b179c64061)

