### PR TITLE
[8.8.0] Prepare for the addition of a remote repo contents cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -100,7 +100,7 @@ import com.google.devtools.build.lib.runtime.CommonCommandOptions;
 import com.google.devtools.build.lib.runtime.InfoItem;
 import com.google.devtools.build.lib.runtime.ProcessWrapper;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor;
-import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutorFactory;
+import com.google.devtools.build.lib.runtime.RepositoryRemoteHelpersFactory;
 import com.google.devtools.build.lib.runtime.ServerBuilder;
 import com.google.devtools.build.lib.runtime.WorkspaceBuilder;
 import com.google.devtools.build.lib.server.FailureDetails.ExternalRepository;
@@ -655,11 +655,11 @@ public class BazelRepositoryModule extends BlazeModule {
             Optional.of(RootedPath.toRootedPath(Root.absoluteRoot(filesystem), resolvedFile));
       }
 
-      RepositoryRemoteExecutorFactory remoteExecutorFactory =
-          env.getRuntime().getRepositoryRemoteExecutorFactory();
+      RepositoryRemoteHelpersFactory repositoryRemoteHelpersFactory =
+          env.getRuntime().getRepositoryHelpersFactory();
       RepositoryRemoteExecutor remoteExecutor = null;
-      if (remoteExecutorFactory != null) {
-        remoteExecutor = remoteExecutorFactory.create();
+      if (repositoryRemoteHelpersFactory != null) {
+        remoteExecutor = repositoryRemoteHelpersFactory.createExecutor();
       }
       starlarkRepositoryFunction.setRepositoryRemoteExecutor(remoteExecutor);
       singleExtensionEvalFunction.setRepositoryRemoteExecutor(remoteExecutor);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorManager.java
@@ -18,7 +18,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hasher;
-import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache;
+import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.profiler.Profiler;
@@ -89,7 +89,7 @@ public class VendorManager {
           actualMarkerFile =
               cacheRepoDir
                   .getParentDirectory()
-                  .getChild(cacheRepoDir.getBaseName() + RepoContentsCache.RECORDED_INPUTS_SUFFIX);
+                  .getChild(cacheRepoDir.getBaseName() + LocalRepoContentsCache.RECORDED_INPUTS_SUFFIX);
         } else {
           actualMarkerFile = markerUnderExternal;
         }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/BUILD
@@ -17,7 +17,7 @@ java_library(
     name = "cache",
     srcs = [
         "DownloadCache.java",
-        "RepoContentsCache.java",
+        "LocalRepoContentsCache.java",
         "RepositoryCache.java",
     ],
     deps = [

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/LocalRepoContentsCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/LocalRepoContentsCache.java
@@ -55,7 +55,7 @@ import javax.annotation.Nullable;
  * up-to-date), the recorded inputs file has its mtime updated. Cached repos whose recorded inputs
  * file is older than {@code --repo_contents_cache_gc_max_age} are garbage collected.
  */
-public final class RepoContentsCache {
+public final class LocalRepoContentsCache {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
   public static final String RECORDED_INPUTS_SUFFIX = ".recorded_inputs";
 
@@ -133,7 +133,7 @@ public final class RepoContentsCache {
               Comparator.comparingLong(
                       (Path path) ->
                           mtimes.computeIfAbsent(
-                              path, RepoContentsCache::getLastModifiedTimeOrZero))
+                              path, LocalRepoContentsCache::getLastModifiedTimeOrZero))
                   .reversed())
           .map(CandidateRepo::fromRecordedInputsFile)
           .collect(toImmutableList());
@@ -251,7 +251,7 @@ public final class RepoContentsCache {
       var recordedInputsFiles =
           path.getChild(dirent.getName()).getDirectoryEntries().stream()
               .filter(file -> file.getBaseName().endsWith(RECORDED_INPUTS_SUFFIX))
-              .sorted(comparingLong(RepoContentsCache::getLastModifiedTimeOrZero).reversed())
+              .sorted(comparingLong(LocalRepoContentsCache::getLastModifiedTimeOrZero).reversed())
               .collect(toImmutableList());
       var seen = new HashSet<HashCode>();
       for (Path recordedInputsFile : recordedInputsFiles) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepositoryCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepositoryCache.java
@@ -19,7 +19,7 @@ import javax.annotation.Nullable;
 
 /**
  * A cache directory related to repositories, containing both the {@link DownloadCache} and the
- * {@link RepoContentsCache}.
+ * {@link LocalRepoContentsCache}.
  */
 public class RepositoryCache {
   // Repository cache subdirectories
@@ -27,13 +27,13 @@ public class RepositoryCache {
   private static final String CONTENTS_DIR = "contents";
 
   private final DownloadCache downloadCache;
-  private final RepoContentsCache repoContentsCache;
+  private final LocalRepoContentsCache repoContentsCache;
 
   @Nullable private Path path;
 
   public RepositoryCache() {
     downloadCache = new DownloadCache();
-    repoContentsCache = new RepoContentsCache();
+    repoContentsCache = new LocalRepoContentsCache();
   }
 
   public void setPath(@Nullable Path path) {
@@ -51,7 +51,7 @@ public class RepositoryCache {
     return downloadCache;
   }
 
-  public RepoContentsCache getRepoContentsCache() {
+  public LocalRepoContentsCache getRepoContentsCache() {
     return repoContentsCache;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -18,7 +18,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.DigestFunction;
-import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.google.auth.Credentials;
 import com.google.common.annotations.VisibleForTesting;
@@ -82,7 +81,7 @@ import com.google.devtools.build.lib.runtime.BuildEventArtifactUploaderFactory;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.runtime.CommandLinePathFactory;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor;
-import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutorFactory;
+import com.google.devtools.build.lib.runtime.RepositoryRemoteHelpersFactory;
 import com.google.devtools.build.lib.runtime.ServerBuilder;
 import com.google.devtools.build.lib.runtime.WorkspaceBuilder;
 import com.google.devtools.build.lib.server.FailureDetails;
@@ -166,8 +165,8 @@ public final class RemoteModule extends BlazeModule {
   private final BuildEventArtifactUploaderFactoryDelegate
       buildEventArtifactUploaderFactoryDelegate = new BuildEventArtifactUploaderFactoryDelegate();
 
-  private final RepositoryRemoteExecutorFactoryDelegate repositoryRemoteExecutorFactoryDelegate =
-      new RepositoryRemoteExecutorFactoryDelegate();
+  private final RepositoryRemoteHelpersFactoryDelegate repositoryRemoteHelpersFactoryDelegate =
+      new RepositoryRemoteHelpersFactoryDelegate();
 
   private Downloader remoteDownloader;
 
@@ -177,7 +176,7 @@ public final class RemoteModule extends BlazeModule {
   public void serverInit(OptionsParsingResult startupOptions, ServerBuilder builder) {
     builder.addBuildEventArtifactUploaderFactory(
         buildEventArtifactUploaderFactoryDelegate, "remote");
-    builder.setRepositoryRemoteExecutorFactory(repositoryRemoteExecutorFactoryDelegate);
+    builder.setRepositoryHelpersFactory(repositoryRemoteHelpersFactoryDelegate);
   }
 
   /** Returns whether remote execution should be enabled. */
@@ -672,15 +671,6 @@ public final class RemoteModule extends BlazeModule {
               remoteOutputChecker,
               outputService,
               knownMissingCasDigests);
-      repositoryRemoteExecutorFactoryDelegate.init(
-          new RemoteRepositoryRemoteExecutorFactory(
-              remoteCache,
-              remoteExecutor,
-              digestUtil,
-              buildRequestId,
-              invocationId,
-              remoteOptions.remoteInstanceName,
-              remoteOptions.remoteAcceptCached));
     } else {
       if (enableDiskCache) {
         try {
@@ -709,6 +699,14 @@ public final class RemoteModule extends BlazeModule {
               knownMissingCasDigests);
     }
 
+    repositoryRemoteHelpersFactoryDelegate.init(
+        new RemoteRepositoryHelpersFactory(
+            actionContextProvider.getCombinedCache(),
+            actionContextProvider.getRemoteExecutionClient(),
+            buildRequestId,
+            invocationId,
+            remoteOptions.remoteInstanceName,
+            remoteOptions.remoteAcceptCached));
     buildEventArtifactUploaderFactoryDelegate.init(
         new ByteStreamBuildEventArtifactUploaderFactory(
             executorService,
@@ -904,7 +902,7 @@ public final class RemoteModule extends BlazeModule {
     lastBuildId = Preconditions.checkNotNull(env).getCommandId().toString();
 
     buildEventArtifactUploaderFactoryDelegate.reset();
-    repositoryRemoteExecutorFactoryDelegate.reset();
+    repositoryRemoteHelpersFactoryDelegate.reset();
     remoteDownloader = null;
     actionContextProvider = null;
     actionInputFetcher = null;
@@ -1122,12 +1120,12 @@ public final class RemoteModule extends BlazeModule {
                 .build()));
   }
 
-  private static class RepositoryRemoteExecutorFactoryDelegate
-      implements RepositoryRemoteExecutorFactory {
+  private static class RepositoryRemoteHelpersFactoryDelegate
+      implements RepositoryRemoteHelpersFactory {
 
-    private volatile RepositoryRemoteExecutorFactory delegate;
+    private volatile RepositoryRemoteHelpersFactory delegate;
 
-    public void init(RepositoryRemoteExecutorFactory delegate) {
+    void init(RepositoryRemoteHelpersFactory delegate) {
       Preconditions.checkState(this.delegate == null);
       this.delegate = delegate;
     }
@@ -1138,12 +1136,12 @@ public final class RemoteModule extends BlazeModule {
 
     @Nullable
     @Override
-    public RepositoryRemoteExecutor create() {
-      RepositoryRemoteExecutorFactory delegate = this.delegate;
+    public RepositoryRemoteExecutor createExecutor() {
+      RepositoryRemoteHelpersFactory delegate = this.delegate;
       if (delegate == null) {
         return null;
       }
-      return delegate.create();
+      return delegate.createExecutor();
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryHelpersFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryHelpersFactory.java
@@ -14,45 +14,46 @@
 package com.google.devtools.build.lib.remote;
 
 import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
-import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor;
-import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutorFactory;
+import com.google.devtools.build.lib.runtime.RepositoryRemoteHelpersFactory;
+import javax.annotation.Nullable;
 
 /** Factory for {@link RemoteRepositoryRemoteExecutor}. */
-class RemoteRepositoryRemoteExecutorFactory implements RepositoryRemoteExecutorFactory {
+class RemoteRepositoryHelpersFactory implements RepositoryRemoteHelpersFactory {
 
-  private final RemoteExecutionCache remoteExecutionCache;
-  private final RemoteExecutionClient remoteExecutor;
-  private final DigestUtil digestUtil;
+  private final CombinedCache cache;
+  @Nullable private final RemoteExecutionClient remoteExecutor;
   private final String buildRequestId;
   private final String commandId;
 
   private final String remoteInstanceName;
   private final boolean acceptCached;
 
-  RemoteRepositoryRemoteExecutorFactory(
-      RemoteExecutionCache remoteExecutionCache,
-      RemoteExecutionClient remoteExecutor,
-      DigestUtil digestUtil,
+  RemoteRepositoryHelpersFactory(
+      CombinedCache cache,
+      @Nullable RemoteExecutionClient remoteExecutor,
       String buildRequestId,
       String commandId,
       String remoteInstanceName,
       boolean acceptCached) {
-    this.remoteExecutionCache = remoteExecutionCache;
+    this.cache = cache;
     this.remoteExecutor = remoteExecutor;
-    this.digestUtil = digestUtil;
     this.buildRequestId = buildRequestId;
     this.commandId = commandId;
     this.remoteInstanceName = remoteInstanceName;
     this.acceptCached = acceptCached;
   }
 
+  @Nullable
   @Override
-  public RepositoryRemoteExecutor create() {
+  public RepositoryRemoteExecutor createExecutor() {
+    if (remoteExecutor == null) {
+      return null;
+    }
     return new RemoteRepositoryRemoteExecutor(
-        remoteExecutionCache,
+        (RemoteExecutionCache) cache,
         remoteExecutor,
-        digestUtil,
+        cache.digestUtil,
         buildRequestId,
         commandId,
         remoteInstanceName,

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -23,13 +23,12 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.bazel.bzlmod.BzlmodRepoRuleValue;
 import com.google.devtools.build.lib.bazel.bzlmod.VendorFileValue;
-import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache;
-import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache.CandidateRepo;
+import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache;
+import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache.CandidateRepo;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.packages.Rule;
@@ -64,7 +63,6 @@ import com.google.devtools.build.skyframe.SkyValue;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -113,7 +111,7 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
   private final ExternalPackageHelper externalPackageHelper;
   private final Supplier<Map<String, String>> repoEnvironmentSupplier;
   private final Supplier<Map<String, String>> clientEnvironmentSupplier;
-  private final RepoContentsCache repoContentsCache;
+  private final LocalRepoContentsCache repoContentsCache;
 
   public RepositoryDelegatorFunction(
       ImmutableMap<String, RepositoryFunction> handlers,
@@ -123,7 +121,7 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
       Supplier<Map<String, String>> clientEnvironmentSupplier,
       BlazeDirectories directories,
       ExternalPackageHelper externalPackageHelper,
-      RepoContentsCache repoContentsCache) {
+      LocalRepoContentsCache repoContentsCache) {
     this.handlers = handlers;
     this.starlarkHandler = starlarkHandler;
     this.isFetch = isFetch;

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -195,7 +195,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
   private final BuildEventArtifactUploaderFactoryMap buildEventArtifactUploaderFactoryMap;
   private final ActionKeyContext actionKeyContext;
   private final ImmutableMap<String, AuthHeadersProvider> authHeadersProviderMap;
-  @Nullable private final RepositoryRemoteExecutorFactory repositoryRemoteExecutorFactory;
+  @Nullable private final RepositoryRemoteHelpersFactory repositoryRemoteHelpersFactory;
 
   // Workspace state (currently exactly one workspace per server)
   private BlazeWorkspace workspace;
@@ -228,7 +228,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
       String productName,
       BuildEventArtifactUploaderFactoryMap buildEventArtifactUploaderFactoryMap,
       ImmutableMap<String, AuthHeadersProvider> authHeadersProviderMap,
-      RepositoryRemoteExecutorFactory repositoryRemoteExecutorFactory,
+      RepositoryRemoteHelpersFactory repositoryRemoteHelpersFactory,
       InstrumentationOutputFactory instrumentationOutputFactory,
       FileSystemLock installBaseLock) {
     // Server state
@@ -259,7 +259,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
     this.buildEventArtifactUploaderFactoryMap = buildEventArtifactUploaderFactoryMap;
     this.authHeadersProviderMap =
         Preconditions.checkNotNull(authHeadersProviderMap, "authHeadersProviderMap");
-    this.repositoryRemoteExecutorFactory = repositoryRemoteExecutorFactory;
+    this.repositoryRemoteHelpersFactory = repositoryRemoteHelpersFactory;
     this.instrumentationOutputFactory = instrumentationOutputFactory;
     this.installBaseLock = installBaseLock;
   }
@@ -1568,8 +1568,8 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
     return authHeadersProviderMap;
   }
 
-  public RepositoryRemoteExecutorFactory getRepositoryRemoteExecutorFactory() {
-    return repositoryRemoteExecutorFactory;
+  public RepositoryRemoteHelpersFactory getRepositoryHelpersFactory() {
+    return repositoryRemoteHelpersFactory;
   }
 
   /**
@@ -1706,7 +1706,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
               productName,
               serverBuilder.getBuildEventArtifactUploaderMap(),
               serverBuilder.getAuthHeadersProvidersMap(),
-              serverBuilder.getRepositoryRemoteExecutorFactory(),
+              serverBuilder.getRepositoryHelpersFactory(),
               serverBuilder.createInstrumentationOutputFactory(),
               installBaseLock);
       AutoProfiler.setClock(runtime.getClock());

--- a/src/main/java/com/google/devtools/build/lib/runtime/RepositoryRemoteHelpersFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/RepositoryRemoteHelpersFactory.java
@@ -16,9 +16,9 @@ package com.google.devtools.build.lib.runtime;
 import javax.annotation.Nullable;
 
 /** Factory for {@link RepositoryRemoteExecutor}. */
-public interface RepositoryRemoteExecutorFactory {
+public interface RepositoryRemoteHelpersFactory {
 
   /** Returns a new {@link RepositoryRemoteExecutor} or {@code null}. */
   @Nullable
-  RepositoryRemoteExecutor create();
+  RepositoryRemoteExecutor createExecutor();
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/ServerBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/ServerBuilder.java
@@ -39,7 +39,7 @@ public final class ServerBuilder {
       new BuildEventArtifactUploaderFactoryMap.Builder();
   private final ImmutableMap.Builder<String, AuthHeadersProvider> authHeadersProvidersMap =
       ImmutableMap.builder();
-  private RepositoryRemoteExecutorFactory repositoryRemoteExecutorFactory;
+  private RepositoryRemoteHelpersFactory repositoryRemoteHelpersFactory;
   private final InstrumentationOutputFactory.Builder instrumentationOutputFactoryBuilder =
       new InstrumentationOutputFactory.Builder();
 
@@ -77,8 +77,8 @@ public final class ServerBuilder {
     return buildEventArtifactUploaderFactories.build();
   }
 
-  public RepositoryRemoteExecutorFactory getRepositoryRemoteExecutorFactory() {
-    return repositoryRemoteExecutorFactory;
+  public RepositoryRemoteHelpersFactory getRepositoryHelpersFactory() {
+    return repositoryRemoteHelpersFactory;
   }
 
   /**
@@ -166,9 +166,9 @@ public final class ServerBuilder {
   }
 
   @CanIgnoreReturnValue
-  public ServerBuilder setRepositoryRemoteExecutorFactory(
-      RepositoryRemoteExecutorFactory repositoryRemoteExecutorFactory) {
-    this.repositoryRemoteExecutorFactory = repositoryRemoteExecutorFactory;
+  public ServerBuilder setRepositoryHelpersFactory(
+      RepositoryRemoteHelpersFactory repositoryRemoteHelpersFactory) {
+    this.repositoryRemoteHelpersFactory = repositoryRemoteHelpersFactory;
     return this;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisMock.java
@@ -36,7 +36,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
-import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache;
+import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryFunction;
 import com.google.devtools.build.lib.packages.util.LoadingMock;
 import com.google.devtools.build.lib.packages.util.MockCcSupport;
@@ -221,7 +221,7 @@ public abstract class AnalysisMock extends LoadingMock {
                 ImmutableMap::of,
                 directories,
                 BazelSkyframeExecutorConstants.EXTERNAL_PACKAGE_HELPER,
-                new RepoContentsCache()))
+                new LocalRepoContentsCache()))
         .put(
             SkyFunctions.MODULE_FILE,
             new ModuleFileFunction(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
@@ -32,7 +32,7 @@ import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
-import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache;
+import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryFunction;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryModule;
 import com.google.devtools.build.lib.clock.BlazeClock;
@@ -168,7 +168,7 @@ public class BazelModuleResolutionFunctionTest extends FoundationTestCase {
                         ImmutableMap::of,
                         directories,
                         BazelSkyframeExecutorConstants.EXTERNAL_PACKAGE_HELPER,
-                        new RepoContentsCache()))
+                        new LocalRepoContentsCache()))
                 .put(
                     BzlmodRepoRuleValue.BZLMOD_REPO_RULE,
                     new BzlmodRepoRuleFunction(ruleClassProvider, directories))

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
@@ -32,7 +32,7 @@ import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.InterimModuleBuilder;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
-import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache;
+import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryModule;
 import com.google.devtools.build.lib.clock.BlazeClock;
@@ -200,7 +200,7 @@ public class DiscoveryTest extends FoundationTestCase {
                         ImmutableMap::of,
                         directories,
                         BazelSkyframeExecutorConstants.EXTERNAL_PACKAGE_HELPER,
-                        new RepoContentsCache()))
+                        new LocalRepoContentsCache()))
                 .put(
                     BzlmodRepoRuleValue.BZLMOD_REPO_RULE,
                     new BzlmodRepoRuleFunction(ruleClassProvider, directories))

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -34,7 +34,7 @@ import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
-import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache;
+import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryFunction;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryModule;
 import com.google.devtools.build.lib.clock.BlazeClock;
@@ -245,7 +245,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
                         ImmutableMap::of,
                         directories,
                         BazelSkyframeExecutorConstants.EXTERNAL_PACKAGE_HELPER,
-                        new RepoContentsCache()))
+                        new LocalRepoContentsCache()))
                 .put(
                     BzlmodRepoRuleValue.BZLMOD_REPO_RULE,
                     new BzlmodRepoRuleFunction(ruleClassProvider, directories))

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -34,7 +34,7 @@ import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.InterimModuleBuilder;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
-import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache;
+import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryModule;
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
@@ -181,7 +181,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                         ImmutableMap::of,
                         directories,
                         BazelSkyframeExecutorConstants.EXTERNAL_PACKAGE_HELPER,
-                        new RepoContentsCache()))
+                        new LocalRepoContentsCache()))
                 .put(
                     BzlmodRepoRuleValue.BZLMOD_REPO_RULE,
                     new BzlmodRepoRuleFunction(ruleClassProvider, directories))

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
@@ -46,7 +46,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
-import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache;
+import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryFunction;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryModule;
 import com.google.devtools.build.lib.clock.BlazeClock;
@@ -146,7 +146,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
             /* clientEnvironmentSupplier= */ ImmutableMap::of,
             directories,
             BazelSkyframeExecutorConstants.EXTERNAL_PACKAGE_HELPER,
-            new RepoContentsCache());
+            new LocalRepoContentsCache());
     AtomicReference<PathPackageLocator> pkgLocator =
         new AtomicReference<>(
             new PathPackageLocator(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ContainingPackageLookupFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ContainingPackageLookupFunctionTest.java
@@ -26,7 +26,7 @@ import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.bazel.bzlmod.BzlmodRepoRuleValue;
-import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache;
+import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache;
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -154,7 +154,7 @@ public class ContainingPackageLookupFunctionTest extends FoundationTestCase {
             ImmutableMap::of,
             directories,
             BazelSkyframeExecutorConstants.EXTERNAL_PACKAGE_HELPER,
-            new RepoContentsCache()));
+            new LocalRepoContentsCache()));
     skyFunctions.put(
         SkyFunctions.REPOSITORY_MAPPING,
         new SkyFunction() {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FileFunctionTest.java
@@ -41,7 +41,7 @@ import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.bazel.bzlmod.BzlmodRepoRuleValue;
-import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache;
+import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache;
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.events.NullEventHandler;
@@ -219,7 +219,7 @@ public class FileFunctionTest {
                         ImmutableMap::of,
                         directories,
                         BazelSkyframeExecutorConstants.EXTERNAL_PACKAGE_HELPER,
-                        new RepoContentsCache()))
+                        new LocalRepoContentsCache()))
                 .put(
                     SkyFunctions.REPOSITORY_MAPPING,
                     new SkyFunction() {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PackageLookupFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PackageLookupFunctionTest.java
@@ -29,7 +29,7 @@ import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.bazel.bzlmod.BzlmodRepoRuleValue;
-import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache;
+import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache;
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -169,7 +169,7 @@ public abstract class PackageLookupFunctionTest extends FoundationTestCase {
             ImmutableMap::of,
             directories,
             BazelSkyframeExecutorConstants.EXTERNAL_PACKAGE_HELPER,
-            new RepoContentsCache()));
+            new LocalRepoContentsCache()));
     skyFunctions.put(
         SkyFunctions.REPOSITORY_MAPPING,
         new SkyFunction() {


### PR DESCRIPTION
Prepare for the addition of a remote repo contents cache
* Rename `RepoContentsCache` to `LocalRepoContentsCache`
* Generalize `RemoteRepositoryRemoteExecutorFactory` to `RemoteRepositoryHelperFactory`

Work towards https://github.com/bazelbuild/bazel/issues/6359

Closes https://github.com/bazelbuild/bazel/pull/27311.

PiperOrigin-RevId: 822553693
Change-Id: I1bad204340c06621cea806368d6bec99ca450a0f
(cherry-picked from 32be423e3eb51112b9c3d50369297336c7cb04aa)