### PR TITLE
[8.7.0] Reproduce a Skyframe cycle with the repo contents cache in a test

### DIFF
--- a/src/test/py/bazel/bzlmod/repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/repo_contents_cache_test.py
@@ -391,6 +391,65 @@ class RepoContentsCacheTest(test_base.TestBase):
     _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'], cwd=dir_b)
     self.assertIn('JUST FETCHED', '\n'.join(stderr))
 
+  def testReverseDependencyDirection(self):
+    # Set up two repos that retain their predeclared input hashes across two
+    #  builds but still reverse their dependency direction. Depending on how
+    # repo cache candidates are checked, this could lead to a Skyframe cycle.
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(',
+            '  name = "foo",',
+            '  deps_file = "//:foo_deps.txt",',
+            ')',
+            'repo(',
+            '  name = "bar",',
+            '  deps_file = "//:bar_deps.txt",',
+            ')',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            '  deps = rctx.read(rctx.attr.deps_file).splitlines()',
+            '  output = ""',
+            '  for dep in deps:',
+            '    if dep:',
+            '      output += "{}: {}\\n".format(dep, rctx.read(Label(dep)))',
+            '  rctx.file("output.txt", output)',
+            '  rctx.file("BUILD", "exports_files([\'output.txt\'])")',
+            '  print("JUST FETCHED: %s" % rctx.original_name)',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(',
+            '  implementation = _repo_impl,',
+            '  attrs = {',
+            '    "deps_file": attr.label(),  }',
+            ')',
+        ],
+    )
+
+    self.ScratchFile('foo_deps.txt', ['@bar//:output.txt'])
+    self.ScratchFile('bar_deps.txt', [''])
+
+    # First fetch: not cached
+    _, _, stderr = self.RunBazel(['build', '@foo//:output.txt'])
+    self.assertIn('JUST FETCHED: bar', '\n'.join(stderr))
+    self.assertIn('JUST FETCHED: foo', '\n'.join(stderr))
+
+    # After expunging and reversing the dependency direction: not cached
+    self.RunBazel(['clean', '--expunge'])
+    self.ScratchFile('foo_deps.txt', [''])
+    self.ScratchFile('bar_deps.txt', ['@foo//:output.txt'])
+    exit_code, stdout, stderr = self.RunBazel(
+        ['build', '@foo//:output.txt'], allow_failure=True
+    )
+    # TODO: b/xxxxxxx - This is NOT the intended behavior.
+    self.AssertNotExitCode(exit_code, 0, stderr, stdout)
+    self.assertIn('possible dependency cycle detected', '\n'.join(stderr))
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
This documents an issue with the current implementation, not the intended behavior.

~Also improve the cycle detector to actually show the cycle in this case.~ not included in the cherry-pick

Work towards https://github.com/bazelbuild/bazel/issues/27517

Closes https://github.com/bazelbuild/bazel/pull/27419.

PiperOrigin-RevId: 829118042
Change-Id: Iaafda95216ac8afd9cd93f5a91b17a27e3611d63
(cherry picked from commit 0336a868180136b9042924247ac9fb16dd8b0f50)