### PR TITLE
[8.8.0] Fix RemoteExternalOverlayFileSystem#resolveSymbolicLinks

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -275,6 +275,9 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
     var repoPath = externalDirectory.getChild(repo.getName());
     var remoteRepo = externalFs.getPath(repoPath);
     var walkResult = walk(remoteRepo);
+    for (var directory : walkResult.directories()) {
+      nativeFs.getPath(directory.asFragment()).createDirectory();
+    }
     var unused =
         getFromFuture(
             inputPrefetcher.prefetchFiles(
@@ -285,11 +288,10 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
                 ActionInputPrefetcher.Priority.CRITICAL,
                 ActionInputPrefetcher.Reason.INPUTS));
     // Create symlinks last as some platforms don't allow creating a symlink to a non-existent
-    // target.
+    // target. A symlink may have already been created as an input to an action.
     for (var remoteSymlink : walkResult.symlinks()) {
       var nativeSymlink = nativeFs.getPath(remoteSymlink.asFragment());
-      nativeSymlink.getParentDirectory().createDirectoryAndParents();
-      nativeSymlink.createSymbolicLink(remoteSymlink.readSymbolicLink());
+      FileSystemUtils.ensureSymbolicLink(nativeSymlink, remoteSymlink.readSymbolicLink());
     }
 
     // After the repo has been copied, atomically materialize the marker file. This ensures that the
@@ -302,10 +304,10 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
     markerFileSibling.renameTo(markerFile);
   }
 
-  private record WalkResult(List<Path> files, List<Path> symlinks) {}
+  private record WalkResult(List<Path> files, List<Path> symlinks, List<Path> directories) {}
 
   private static WalkResult walk(Path root) throws IOException {
-    var result = new WalkResult(new ArrayList<>(), new ArrayList<>());
+    var result = new WalkResult(new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
     walk(root, result);
     return result;
   }
@@ -316,7 +318,10 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
       switch (dirent.getType()) {
         case FILE -> result.files.add(fromChild);
         case SYMLINK -> result.symlinks.add(fromChild);
-        case DIRECTORY -> walk(fromChild, result);
+        case DIRECTORY -> {
+          result.directories.add(fromChild);
+          walk(fromChild, result);
+        }
         default -> throw new IOException("Unsupported file type: " + dirent);
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -145,6 +145,11 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
   }
 
   public void afterCommand() {
+    if (cache == null) {
+      // Not all commands cause beforeCommand to be called, but afterCommand is called
+      // unconditionally.
+      return;
+    }
     this.cache = null;
     this.inputPrefetcher = null;
     this.reporter = null;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -525,7 +525,8 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
 
   @Override
   public Path resolveSymbolicLinks(PathFragment path) throws IOException {
-    return fsForPath(path).resolveSymbolicLinks(path);
+    // Ensure that the return value doesn't leave the overlay file system.
+    return getPath(fsForPath(path).resolveSymbolicLinks(path).asFragment());
   }
 
   @Nullable

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -268,10 +268,6 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
           try {
             if (remoteRepoContentsCache.lookupCache(
                 repositoryName, repoRoot, digestWriter.predeclaredInputHash, env.getListener())) {
-              env.getListener()
-                  .handle(
-                      Event.debug(
-                          "Got %s from the remote repo contents cache".formatted(repositoryName)));
               return new RepositoryDirectoryValue.Success(
                   repoRoot, /* isFetchingDelayed= */ false, excludeRepoFromVendoring);
             }

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -948,7 +948,8 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
   private void checkSameFileSystem(Path that) {
     if (this.fileSystem != that.fileSystem) {
       throw new IllegalArgumentException(
-          "Files are on different filesystems: " + this + ", " + that);
+          "Files are on different filesystems: %s (on %s), %s (on %s)"
+              .formatted(this, this.fileSystem, that, that.fileSystem));
     }
   }
 }

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -482,7 +482,11 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     with open(self.Path('bazel-bin/main/out.txt')) as f:
       self.assertEqual(f.read(), 'hello')
 
-  def testUseRepoFileInBuildRule_actionDoesNotUseCache(self):
+  def do_testUseRepoFileInBuildRule_actionDoesNotUseCache(
+      self, extra_flags=None
+  ):
+    if extra_flags is None:
+      extra_flags = []
     self.ScratchFile(
         'MODULE.bazel',
         [
@@ -518,7 +522,7 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     repo_dir = self.RepoDir('my_repo')
 
     # First fetch: not cached
-    _, _, stderr = self.RunBazel(['build', '//main:use_data'])
+    _, _, stderr = self.RunBazel(['build', '//main:use_data'] + extra_flags)
     self.assertIn('JUST FETCHED', '\n'.join(stderr))
     self.assertTrue(os.path.exists(os.path.join(repo_dir, 'BUILD')))
     self.assertTrue(os.path.exists(os.path.join(repo_dir, 'data.txt')))
@@ -528,13 +532,24 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
 
     # After expunging: repo and build action cached
     self.RunBazel(['clean', '--expunge'])
-    _, _, stderr = self.RunBazel(['build', '//main:use_data'])
+    _, _, stderr = self.RunBazel(['build', '//main:use_data'] + extra_flags)
     self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
     self.assertFalse(os.path.exists(os.path.join(repo_dir, 'BUILD')))
     self.assertTrue(os.path.exists(os.path.join(repo_dir, 'data.txt')))
     self.assertTrue(os.path.exists(self.Path('bazel-bin/main/out.txt')))
     with open(self.Path('bazel-bin/main/out.txt')) as f:
       self.assertEqual(f.read(), 'hello')
+
+  def testUseRepoFileInBuildRule_actionDoesNotUseCache(self):
+    self.do_testUseRepoFileInBuildRule_actionDoesNotUseCache()
+
+  def testUseRepoFileInBuildRule_actionDoesNotUseCache_withExplicitSandboxBase(
+      self,
+  ):
+    tmpdir = self.ScratchDir('sandbox_base')
+    self.do_testUseRepoFileInBuildRule_actionDoesNotUseCache(
+        extra_flags=['--sandbox_base=' + tmpdir]
+    )
 
   def testLostRemoteFile_build(self):
     # Create a repo with two BUILD files (one in a subpackage), build a target


### PR DESCRIPTION
Ensures that the returned `Path` is still in the overlay file system.

Also make the error message emitted by `Path#checkSameFileSystem` more informative. This is motivated by and helped discover the above as the fix for the following crash observed when using the remote repo contents cache with an explicit `--sandbox_base`:

```
Caused by: java.lang.IllegalArgumentException: Files are on different filesystems: /dev/shm/bazel-sandbox.b10976335efa519b0184f3091ac8e21f7beefb92142303f9ab2c3341f45a2f28/linux-sandbox/18/execroot/_main/external/c-ares+/configs/ares_build.h (on com.google.devtools.build.lib.unix.UnixFileSystem@5e0a8154), /home/ubuntu/.cache/bazel/_bazel_ubuntu/123/execroot/_main/external/c-ares+/configs/ares_build.h (on com.google.devtools.build.lib.remote.RemoteExternalOverlayFileSystem@6cd9bfda)
        at com.google.devtools.build.lib.vfs.Path.checkSameFileSystem(Path.java:964)
        at com.google.devtools.build.lib.vfs.Path.createSymbolicLink(Path.java:523)
        at com.google.devtools.build.lib.vfs.Path.createSymbolicLink(Path.java:535)
        at com.google.devtools.build.lib.sandbox.SymlinkedSandboxedSpawn.copyFile(SymlinkedSandboxedSpawn.java:129)
```

Alternative to https://github.com/bazelbuild/bazel/pull/27721

Closes #27802.

PiperOrigin-RevId: 837832265
Change-Id: I3b73167496b011aef66954d59ca3804b4b64996f
(cherry picked from commit 8eaf6a90db1d0e95fbade4dd2b7e3b8c57d03629)

