### PR TITLE
[8.8.0] Get the local and remote repo contents cache to work together

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BlazeDirectories.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BlazeDirectories.java
@@ -141,6 +141,7 @@ public final class BlazeDirectories {
   }
 
   /** Returns working directory of the server. */
+  @Nullable
   public Path getWorkingDirectory() {
     return workspace;
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -720,10 +720,18 @@ public class BazelRepositoryModule extends BlazeModule {
    */
   @Nullable
   private Path toPath(PathFragment path, CommandEnvironment env) {
-    if (path.isEmpty() || env.getBlazeWorkspace().getWorkspace() == null) {
+    if (path.isEmpty() || env.getDirectories().getWorkspace() == null) {
       return null;
     }
-    return env.getBlazeWorkspace().getWorkspace().getRelative(path);
+    // It is important to use getWorkspace() here, not getWorkingDirectory(). Both Paths have the
+    // same underlying PathFragment, but may differ in their FileSystem if the remote repo contents
+    // cache is in use. getWorkspace() uses the same FileSystem as everything other than the
+    // workspace directory, while getWorkingDirectory() uses the workspace directory's FileSystem.
+    // Even though the users of the returned Path may end up writing to it, they are not expected to
+    // update source files within the workspace. Thus, the correct FileSystem is the one from
+    // getWorkspace(), which e.g. allows moves from the external directory under the output base to
+    // the local repo contents cache without crossing FileSystems.
+    return env.getDirectories().getWorkspace().getRelative(path);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -298,6 +298,14 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
         }
         digestWriter.writeMarkerFile(result.recordedInputValues());
         if (result.reproducible() == Reproducibility.YES && !handler.isLocal(rule)) {
+          if (remoteRepoContentsCache != null) {
+            remoteRepoContentsCache.addToCache(
+                repositoryName,
+                repoRoot,
+                digestWriter.markerPath,
+                digestWriter.predeclaredInputHash,
+                env.getListener());
+          }
           if (repoContentsCache.isEnabled()) {
             // This repo is eligible for the repo contents cache.
             Path cachedRepoDir;
@@ -347,14 +355,6 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
             // entry as a candidate or will create a new one if it got GC'd in the meantime.
             throw new IllegalStateException(
                 "FileStateValue unexpectedly present for " + cachedRepoDir);
-          }
-          if (remoteRepoContentsCache != null) {
-            remoteRepoContentsCache.addToCache(
-                repositoryName,
-                repoRoot,
-                digestWriter.markerPath,
-                digestWriter.predeclaredInputHash,
-                env.getListener());
           }
         }
         return new RepositoryDirectoryValue.Success(

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -18,6 +18,7 @@
 import json
 import os
 import re
+import tempfile
 from absl.testing import absltest
 from src.test.py.bazel import test_base
 
@@ -90,6 +91,70 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     self.assertFalse(os.path.exists(os.path.join(repo_dir, 'BUILD')))
 
     # After expunging, without using repo contents cache: not cached
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel([
+        '--noexperimental_remote_repo_contents_cache',
+        'build',
+        '@my_repo//:haha',
+    ])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertTrue(os.path.exists(os.path.join(repo_dir, 'BUILD')))
+
+  def testLocalRepoContentsCacheInteraction(self):
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            '  rctx.file("BUILD", "filegroup(name=\'haha\')")',
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(_repo_impl)',
+        ],
+    )
+
+    repo_dir = self.RepoDir('my_repo')
+
+    # First fetch: not cached
+    repo_contents_cache = tempfile.mkdtemp(dir=os.environ['TEST_TMPDIR'])
+    _, _, stderr = self.RunBazel([
+        'build',
+        '@my_repo//:haha',
+        '--repo_contents_cache=' + repo_contents_cache,
+    ])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertTrue(os.path.exists(os.path.join(repo_dir, 'BUILD')))
+
+    # After expunging: cached, hits the local repo contents cache
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel([
+        'build',
+        '@my_repo//:haha',
+        '--repo_contents_cache=' + repo_contents_cache,
+    ])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertTrue(os.path.exists(os.path.join(repo_dir, 'BUILD')))
+
+    # After cleaning out local repo contents cache: cached, hits the remote
+    # cache
+    self.RunBazel(['clean', '--expunge'])
+    # Deleting the cache fails on Windows, so we just use a different directory.
+    _, _, stderr = self.RunBazel([
+        'build',
+        '@my_repo//:haha',
+        '--repo_contents_cache=' + repo_contents_cache + '2',
+    ])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertFalse(os.path.exists(os.path.join(repo_dir, 'BUILD')))
+
+    # After expunging, without using any repo contents cache: not cached
     self.RunBazel(['clean', '--expunge'])
     _, _, stderr = self.RunBazel([
         '--noexperimental_remote_repo_contents_cache',


### PR DESCRIPTION
* Also upload to the remote cache when the local cache is in use. The fix is simple but subtle: the logic for the two caches in `RepositoryFetchFunction` has to be flipped since the Skyframe restart after adding an entry to the local cache meant that the same code path would not be taken again.
* Fix a crash when using both by ensuring that the local repo contents cache uses the file system backing the output base, not the workspace directory:
```
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.RuntimeException: Unrecoverable error while evaluating node 'REPOSITORY_DIRECTORY:@@rules_python+' (requested by nodes 'REPO_FILE:@@rules_python+')
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:552)
Caused by: java.lang.IllegalArgumentException: Files are on different filesystems: .../external/@rules_python+.marker (on RemoteExternalOverlayFileSystem), .../.cache/bazel-repo/contents/_trash/... (on WindowsFileSystem)
	at com.google.devtools.build.lib.vfs.Path.checkSameFileSystem(Path.java:964)
	at com.google.devtools.build.lib.vfs.Path.renameTo(Path.java:630)
	at com.google.devtools.build.lib.vfs.FileSystemUtils.moveFile(FileSystemUtils.java:456)
	at com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache.moveToCache(LocalRepoContentsCache.java:172)
```

Closes https://github.com/bazelbuild/bazel/pull/28002.

PiperOrigin-RevId: 855211557
Change-Id: I2f3c40a6aef594682fba989853f7ee982f30c294
(cherry picked from commit https://github.com/bazelbuild/bazel/commit/b143070b825db7c968ee6e881959473693e17980)
