### PR TITLE
[9.1.0] Modernize `CcToolchain{Features,Variables}` (https://github.com/bazel…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeatures.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeatures.java
@@ -16,11 +16,9 @@ package com.google.devtools.build.lib.rules.cpp;
 
 import static com.google.devtools.build.lib.rules.cpp.CcToolchainVariables.getSequenceValue;
 
-import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -49,7 +47,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.function.Function;
@@ -111,21 +108,8 @@ public class CcToolchainFeatures implements StarlarkValue {
 
   /** A single flag to be expanded under a set of variables. */
   @Immutable
-  public static class Flag implements Expandable {
-    private final ImmutableList<StringChunk> chunks;
-
-    public Flag(ImmutableList<StringChunk> chunks) {
-      this.chunks = chunks;
-    }
-
-    String getString() {
-      return Joiner.on("")
-          .join(
-              chunks.stream()
-                  .map(chunk -> chunk.getString())
-                  .collect(ImmutableList.toImmutableList()));
-    }
-
+  @AutoCodec
+  record Flag(ImmutableList<StringChunk> chunks) implements Expandable {
     /** Expand this flag into a single new entry in {@code commandLine}. */
     @Override
     public void expand(
@@ -141,24 +125,8 @@ public class CcToolchainFeatures implements StarlarkValue {
       commandLine.add(flag.toString().intern());
     }
 
-    @Override
-    public boolean equals(@Nullable Object object) {
-      if (this == object) {
-        return true;
-      }
-      if (object instanceof Flag that) {
-        return Iterables.elementsEqual(chunks, that.chunks);
-      }
-      return false;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(chunks);
-    }
-
     /** A single environment key/value pair to be expanded under a set of variables. */
-    public static Expandable create(ImmutableList<StringChunk> chunks) {
+    static Expandable create(ImmutableList<StringChunk> chunks) {
       if (chunks.size() == 1) {
         return new SingleChunkFlag(chunks.get(0));
       }
@@ -167,13 +135,8 @@ public class CcToolchainFeatures implements StarlarkValue {
 
     /** Optimization for single-chunk case */
     @Immutable
-    static class SingleChunkFlag implements Expandable {
-      private final StringChunk chunk;
-
-      @VisibleForSerialization
-      SingleChunkFlag(StringChunk chunk) {
-        this.chunk = chunk;
-      }
+    @AutoCodec
+    record SingleChunkFlag(StringChunk chunk) implements Expandable {
 
       @Override
       public void expand(
@@ -184,61 +147,16 @@ public class CcToolchainFeatures implements StarlarkValue {
           throws ExpansionException {
         commandLine.add(chunk.expand(variables, pathMapper));
       }
-
-      @Override
-      public boolean equals(Object o) {
-        if (this == o) {
-          return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-          return false;
-        }
-        SingleChunkFlag that = (SingleChunkFlag) o;
-        return chunk.equals(that.chunk);
-      }
-
-      String getString() {
-        return chunk.getString();
-      }
-
-      @Override
-      public int hashCode() {
-        return chunk.hashCode();
-      }
     }
   }
 
   /** A single environment key/value pair to be expanded under a set of variables. */
   @Immutable
-  public static class EnvEntry {
-    private final String key;
-    private final ImmutableList<StringChunk> valueChunks;
-    private final ImmutableSet<String> expandIfAllAvailable;
-
-    EnvEntry(
-        String key,
-        ImmutableList<StringChunk> valueChunks,
-        ImmutableSet<String> expandIfAllAvailable) {
-      this.key = key;
-      this.valueChunks = valueChunks;
-      this.expandIfAllAvailable = expandIfAllAvailable;
-    }
-
-    String getKey() {
-      return key;
-    }
-
-    String getValue() {
-      return Joiner.on("")
-          .join(
-              valueChunks.stream()
-                  .map(stringChunk -> stringChunk.getString())
-                  .collect(ImmutableList.toImmutableList()));
-    }
-
-    ImmutableSet<String> getExpandIfAllAvailable() {
-      return expandIfAllAvailable;
-    }
+  @AutoCodec
+  public record EnvEntry(
+      String key,
+      ImmutableList<StringChunk> valueChunks,
+      ImmutableSet<String> expandIfAllAvailable) {
 
     private boolean canBeExpanded(CcToolchainVariables variables) {
       for (String variable : expandIfAllAvailable) {
@@ -267,75 +185,28 @@ public class CcToolchainFeatures implements StarlarkValue {
       }
       envBuilder.put(key, value.toString());
     }
-
-    @Override
-    public boolean equals(@Nullable Object object) {
-      if (this == object) {
-        return true;
-      }
-      if (object instanceof EnvEntry that) {
-        return Objects.equals(key, that.key)
-            && Iterables.elementsEqual(valueChunks, that.valueChunks);
-      }
-      return false;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(key, valueChunks);
-    }
   }
 
   /** Used for equality check between a variable and a specific value. */
   @Immutable
-  static class VariableWithValue {
-    public final String variable;
-    public final String value;
-
-    public VariableWithValue(String variable, String value) {
-      this.variable = variable;
-      this.value = value;
-    }
-
-    String getVariable() {
-      return variable;
-    }
-
-    String getValue() {
-      return value;
-    }
-  }
+  @AutoCodec
+  record VariableWithValue(String variable, String value) {}
 
   /**
    * A group of flags. When iterateOverVariable is specified, we assume the variable is a sequence
    * and the flag_group will be expanded repeatedly for every value in the sequence.
    */
   @Immutable
-  static class FlagGroup implements Expandable {
-    private final ImmutableList<Expandable> expandables;
-    private String iterateOverVariable;
-    private final ImmutableSet<String> expandIfAllAvailable;
-    private final ImmutableSet<String> expandIfNoneAvailable;
-    private final String expandIfTrue;
-    private final String expandIfFalse;
-    private final VariableWithValue expandIfEqual;
-
-    FlagGroup(
-        ImmutableList<Expandable> expandables,
-        String iterateOverVariable,
-        ImmutableSet<String> expandIfAllAvailable,
-        ImmutableSet<String> expandIfNoneAvailable,
-        String expandIfTrue,
-        String expandIfFalse,
-        VariableWithValue expandIfEqual) {
-      this.expandables = expandables;
-      this.iterateOverVariable = iterateOverVariable;
-      this.expandIfAllAvailable = expandIfAllAvailable;
-      this.expandIfNoneAvailable = expandIfNoneAvailable;
-      this.expandIfTrue = expandIfTrue;
-      this.expandIfFalse = expandIfFalse;
-      this.expandIfEqual = expandIfEqual;
-    }
+  @AutoCodec
+  record FlagGroup(
+      ImmutableList<Expandable> expandables,
+      String iterateOverVariable,
+      ImmutableSet<String> expandIfAllAvailable,
+      ImmutableSet<String> expandIfNoneAvailable,
+      String expandIfTrue,
+      String expandIfFalse,
+      VariableWithValue expandIfEqual)
+      implements Expandable {
 
     @Override
     public void expand(
@@ -424,63 +295,6 @@ public class CcToolchainFeatures implements StarlarkValue {
         throws ExpansionException {
       expand(variables, inputMetadataProvider, pathMapper, commandLine);
     }
-
-    @Override
-    public boolean equals(@Nullable Object object) {
-      if (this == object) {
-        return true;
-      }
-      if (object instanceof FlagGroup that) {
-        return Iterables.elementsEqual(expandables, that.expandables)
-            && Objects.equals(iterateOverVariable, that.iterateOverVariable)
-            && Iterables.elementsEqual(expandIfAllAvailable, that.expandIfAllAvailable)
-            && Iterables.elementsEqual(expandIfNoneAvailable, that.expandIfNoneAvailable)
-            && Objects.equals(expandIfTrue, that.expandIfTrue)
-            && Objects.equals(expandIfFalse, that.expandIfFalse)
-            && Objects.equals(expandIfEqual, that.expandIfEqual);
-      }
-      return false;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(
-          expandables,
-          iterateOverVariable,
-          expandIfAllAvailable,
-          expandIfNoneAvailable,
-          expandIfTrue,
-          expandIfFalse,
-          expandIfEqual);
-    }
-
-    ImmutableList<Expandable> getExpandables() {
-      return expandables;
-    }
-
-    String getIterateOverVariable() {
-      return iterateOverVariable;
-    }
-
-    ImmutableSet<String> getExpandIfAllAvailable() {
-      return expandIfAllAvailable;
-    }
-
-    ImmutableSet<String> getExpandIfNoneAvailable() {
-      return expandIfNoneAvailable;
-    }
-
-    String getExpandIfTrue() {
-      return expandIfTrue;
-    }
-
-    String getExpandIfFalse() {
-      return expandIfFalse;
-    }
-
-    VariableWithValue getExpandIfEqual() {
-      return expandIfEqual;
-    }
   }
 
   private static boolean isWithFeaturesSatisfied(
@@ -489,8 +303,8 @@ public class CcToolchainFeatures implements StarlarkValue {
       return true;
     }
     for (WithFeatureSet featureSet : withFeatureSets) {
-      if (enabledFeatureNames.containsAll(featureSet.getFeatures())
-          && featureSet.getNotFeatures().stream().noneMatch(enabledFeatureNames::contains)) {
+      if (enabledFeatureNames.containsAll(featureSet.features())
+          && featureSet.notFeatures().stream().noneMatch(enabledFeatureNames::contains)) {
         return true;
       }
     }
@@ -499,22 +313,12 @@ public class CcToolchainFeatures implements StarlarkValue {
 
   /** Groups a set of flags to apply for certain actions. */
   @Immutable
-  public static class FlagSet {
-    private final ImmutableSet<String> actions;
-    private final ImmutableSet<String> expandIfAllAvailable;
-    private final ImmutableSet<WithFeatureSet> withFeatureSets;
-    private final ImmutableList<FlagGroup> flagGroups;
-
-    FlagSet(
-        ImmutableSet<String> actions,
-        ImmutableSet<String> expandIfAllAvailable,
-        ImmutableSet<WithFeatureSet> withFeatureSets,
-        ImmutableList<FlagGroup> flagGroups) {
-      this.actions = actions;
-      this.expandIfAllAvailable = expandIfAllAvailable;
-      this.withFeatureSets = withFeatureSets;
-      this.flagGroups = flagGroups;
-    }
+  @AutoCodec
+  public record FlagSet(
+      ImmutableSet<String> actions,
+      ImmutableSet<String> expandIfAllAvailable,
+      ImmutableSet<WithFeatureSet> withFeatureSets,
+      ImmutableList<FlagGroup> flagGroups) {
 
     /** Adds the flags that apply to the given {@code action} to {@code commandLine}. */
     private void expandCommandLine(
@@ -540,38 +344,6 @@ public class CcToolchainFeatures implements StarlarkValue {
         flagGroup.expandCommandLine(variables, inputMetadataProvider, pathMapper, commandLine);
       }
     }
-
-    @Override
-    public boolean equals(@Nullable Object object) {
-      if (object instanceof FlagSet that) {
-        return Iterables.elementsEqual(actions, that.actions)
-            && Iterables.elementsEqual(expandIfAllAvailable, that.expandIfAllAvailable)
-            && Iterables.elementsEqual(withFeatureSets, that.withFeatureSets)
-            && Iterables.elementsEqual(flagGroups, that.flagGroups);
-      }
-      return false;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(actions, expandIfAllAvailable, withFeatureSets, flagGroups);
-    }
-
-    ImmutableSet<String> getActions() {
-      return actions;
-    }
-
-    ImmutableSet<String> getExpandIfAllAvailable() {
-      return expandIfAllAvailable;
-    }
-
-    ImmutableSet<WithFeatureSet> getWithFeatureSets() {
-      return withFeatureSets;
-    }
-
-    ImmutableList<FlagGroup> getFlagGroups() {
-      return flagGroups;
-    }
   }
 
   /**
@@ -579,68 +351,16 @@ public class CcToolchainFeatures implements StarlarkValue {
    * is enabled, and every 'not_feature' is not enabled.
    */
   @Immutable
-  public static class WithFeatureSet {
-    private final ImmutableSet<String> features;
-    private final ImmutableSet<String> notFeatures;
-
-    WithFeatureSet(ImmutableSet<String> features, ImmutableSet<String> notFeatures) {
-      this.features = features;
-      this.notFeatures = notFeatures;
-    }
-
-    public ImmutableSet<String> getFeatures() {
-      return features;
-    }
-
-    public ImmutableSet<String> getNotFeatures() {
-      return notFeatures;
-    }
-
-    @Override
-    public boolean equals(@Nullable Object object) {
-      if (this == object) {
-        return true;
-      }
-      if (object instanceof WithFeatureSet that) {
-        return Iterables.elementsEqual(features, that.features)
-            && Iterables.elementsEqual(notFeatures, that.notFeatures);
-      }
-      return false;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(features, notFeatures);
-    }
-  }
+  @AutoCodec
+  public record WithFeatureSet(ImmutableSet<String> features, ImmutableSet<String> notFeatures) {}
 
   /** Groups a set of environment variables to apply for certain actions. */
   @Immutable
-  public static class EnvSet {
-    private final ImmutableSet<String> actions;
-    private final ImmutableList<EnvEntry> envEntries;
-    private final ImmutableSet<WithFeatureSet> withFeatureSets;
-
-    EnvSet(
-        ImmutableSet<String> actions,
-        ImmutableList<EnvEntry> envEntries,
-        ImmutableSet<WithFeatureSet> withFeatureSets) {
-      this.actions = actions;
-      this.envEntries = envEntries;
-      this.withFeatureSets = withFeatureSets;
-    }
-
-    ImmutableSet<String> getActions() {
-      return actions;
-    }
-
-    ImmutableList<EnvEntry> getEnvEntries() {
-      return envEntries;
-    }
-
-    ImmutableSet<WithFeatureSet> getWithFeatureSets() {
-      return withFeatureSets;
-    }
+  @AutoCodec
+  public record EnvSet(
+      ImmutableSet<String> actions,
+      ImmutableList<EnvEntry> envEntries,
+      ImmutableSet<WithFeatureSet> withFeatureSets) {
 
     /**
      * Adds the environment key/value pairs that apply to the given {@code action} to {@code
@@ -663,24 +383,6 @@ public class CcToolchainFeatures implements StarlarkValue {
         envEntry.addEnvEntry(variables, envBuilder, pathMapper);
       }
     }
-
-    @Override
-    public boolean equals(@Nullable Object object) {
-      if (this == object) {
-        return true;
-      }
-      if (object instanceof EnvSet that) {
-        return Iterables.elementsEqual(actions, that.actions)
-            && Iterables.elementsEqual(envEntries, that.envEntries)
-            && Iterables.elementsEqual(withFeatureSets, that.withFeatureSets);
-      }
-      return false;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(actions, envEntries, withFeatureSets);
-    }
   }
 
   /**
@@ -691,9 +393,7 @@ public class CcToolchainFeatures implements StarlarkValue {
    */
   interface CrosstoolSelectable {
 
-    /**
-     * Returns the name of this selectable.
-     */
+    /** Returns the name of this selectable. */
     String getName();
   }
 
@@ -905,9 +605,7 @@ public class CcToolchainFeatures implements StarlarkValue {
       };
     }
 
-    /**
-     * Returns a list of requirement hints that apply to the execution of this tool.
-     */
+    /** Returns a list of requirement hints that apply to the execution of this tool. */
     ImmutableSet<String> getExecutionRequirements() {
       return executionRequirements;
     }
@@ -984,32 +682,24 @@ public class CcToolchainFeatures implements StarlarkValue {
       return configName;
     }
 
-    /**
-     * Returns the name of the blaze action this action config applies to.
-     */
+    /** Returns the name of the blaze action this action config applies to. */
     String getActionName() {
       return actionName;
     }
 
     /**
-     * Returns the path to this action's tool relative to the provided crosstool path given a set
-     * of enabled features.
+     * Returns the path to this action's tool relative to the provided crosstool path given a set of
+     * enabled features.
      */
     private Tool getTool(final Set<String> enabledFeatureNames) {
-      Optional<Tool> tool =
-          tools
-              .stream()
-              .filter(t -> isWithFeaturesSatisfied(t.getWithFeatureSetSets(), enabledFeatureNames))
-              .findFirst();
-      if (tool.isPresent()) {
-        return tool.get();
-      } else {
-        throw new IllegalArgumentException(
-            "Matching tool for action "
-                + getActionName()
-                + " not "
-                + "found for given feature configuration");
-      }
+      return tools.stream()
+          .filter(t -> isWithFeaturesSatisfied(t.getWithFeatureSetSets(), enabledFeatureNames))
+          .findFirst()
+          .orElseThrow(
+              () ->
+                  new IllegalArgumentException(
+                      "Matching tool for action %s not found for given feature configuration"
+                          .formatted(getActionName())));
     }
 
     /** Adds the flags that apply to this action to {@code commandLine}. */
@@ -1072,22 +762,8 @@ public class CcToolchainFeatures implements StarlarkValue {
 
   /** A description of how artifacts of a certain type are named. */
   @Immutable
-  static class ArtifactNamePattern {
-    private final String prefix;
-    private final String extension;
-
-    private ArtifactNamePattern(String prefix, String extension) {
-      this.prefix = prefix;
-      this.extension = extension;
-    }
-
-    String getPrefix() {
-      return this.prefix;
-    }
-
-    String getExtension() {
-      return this.extension;
-    }
+  @AutoCodec
+  record ArtifactNamePattern(String prefix, String extension) {
 
     /** Returns the artifact name that this pattern selects. */
     private String getArtifactName(String baseName) {
@@ -1222,12 +898,16 @@ public class CcToolchainFeatures implements StarlarkValue {
       return requestedFeatures;
     }
 
-    /** @return whether an action config for the blaze action with the given name is enabled. */
+    /**
+     * @return whether an action config for the blaze action with the given name is enabled.
+     */
     boolean actionIsConfigured(String actionName) {
       return enabledActionConfigActionNames.contains(actionName);
     }
 
-    /** @return the command line for the given {@code action}. */
+    /**
+     * @return the command line for the given {@code action}.
+     */
     public List<String> getCommandLine(String action, CcToolchainVariables variables)
         throws ExpansionException {
       return getCommandLine(action, variables, /* inputMetadataProvider= */ null, PathMapper.NOOP);
@@ -1361,42 +1041,33 @@ public class CcToolchainFeatures implements StarlarkValue {
    */
   private final ImmutableList<CrosstoolSelectable> selectables;
 
-  /**
-   * Maps the selectables's name to the selectable.
-   */
+  /** Maps the selectables's name to the selectable. */
   private final ImmutableMap<String, CrosstoolSelectable> selectablesByName;
 
-  /**
-   * Maps an action's name to the ActionConfig.
-   */
+  /** Maps an action's name to the ActionConfig. */
   private final ImmutableMap<String, ActionConfig> actionConfigsByActionName;
 
-  /**
-   * Maps from a selectable to a set of all the selectables it has a direct 'implies' edge to.
-   */
+  /** Maps from a selectable to a set of all the selectables it has a direct 'implies' edge to. */
   private final ImmutableMultimap<CrosstoolSelectable, CrosstoolSelectable> implies;
 
   /**
-   * Maps from a selectable to all features that have an direct 'implies' edge to this
-   * selectable.
+   * Maps from a selectable to all features that have an direct 'implies' edge to this selectable.
    */
   private final ImmutableMultimap<CrosstoolSelectable, CrosstoolSelectable> impliedBy;
 
   /**
    * Maps from a selectable to a set of selecatable sets, where:
+   *
    * <ul>
-   * <li>a selectable set satisfies the 'requires' condition, if all selectables in the
-   *        selectable set are enabled</li>
-   * <li>the 'requires' condition is satisfied, if at least one of the selectable sets satisfies
-   *        the 'requires' condition.</li>
+   *   <li>a selectable set satisfies the 'requires' condition, if all selectables in the selectable
+   *       set are enabled
+   *   <li>the 'requires' condition is satisfied, if at least one of the selectable sets satisfies
+   *       the 'requires' condition.
    * </ul>
    */
-  private final ImmutableMultimap<CrosstoolSelectable, ImmutableSet<CrosstoolSelectable>>
-      requires;
+  private final ImmutableMultimap<CrosstoolSelectable, ImmutableSet<CrosstoolSelectable>> requires;
 
-  /**
-   * Maps from a string to the set of selectables that 'provide' it.
-   */
+  /** Maps from a string to the set of selectables that 'provide' it. */
   private final ImmutableMultimap<String, CrosstoolSelectable> provides;
 
   /**
@@ -1416,7 +1087,7 @@ public class CcToolchainFeatures implements StarlarkValue {
   private transient LoadingCache<ImmutableSet<String>, FeatureConfiguration> configurationCache =
       buildConfigurationCache();
 
-  private PathFragment ccToolchainPath;
+  private final PathFragment ccToolchainPath;
 
   /**
    * Constructs the feature configuration from a {@link CcToolchainConfigInfo}.
@@ -1545,19 +1216,14 @@ public class CcToolchainFeatures implements StarlarkValue {
     }
   }
 
-  /** @return an empty {@code FeatureConfiguration} cache. */
+  /**
+   * @return an empty {@code FeatureConfiguration} cache.
+   */
   private LoadingCache<ImmutableSet<String>, FeatureConfiguration> buildConfigurationCache() {
     return Caffeine.newBuilder()
         // TODO(klimek): Benchmark and tweak once we support a larger configuration.
         .maximumSize(10000)
-        .build(
-            new CacheLoader<ImmutableSet<String>, FeatureConfiguration>() {
-              @Override
-              public FeatureConfiguration load(ImmutableSet<String> requestedFeatures)
-                  throws CollidingProvidesException {
-                return computeFeatureConfiguration(requestedFeatures);
-              }
-            });
+        .build(requestedFeatures -> computeFeatureConfiguration(requestedFeatures));
   }
 
   @StarlarkMethod(
@@ -1681,6 +1347,6 @@ public class CcToolchainFeatures implements StarlarkValue {
    * Returns the artifact name extension selected by the toolchain for the given artifact category.
    */
   String getArtifactNameExtensionForCategory(ArtifactCategory artifactCategory) {
-    return artifactNamePatterns.get(artifactCategory).getExtension();
+    return artifactNamePatterns.get(artifactCategory).extension();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesLib.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesLib.java
@@ -107,7 +107,7 @@ public class CcToolchainFeaturesLib {
         getStarlarkProviderListFromStarlarkField(featureStruct, "flag_sets");
     for (StarlarkInfo flagSetObject : flagSets) {
       FlagSet flagSet = flagSetFromStarlark(flagSetObject, /* actionName= */ null);
-      if (flagSet.getActions().isEmpty()) {
+      if (flagSet.actions().isEmpty()) {
         throw infoError(
             flagSetObject,
             "A flag_set that belongs to a feature must have nonempty 'actions' parameter.");

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
@@ -34,6 +34,8 @@ import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.ExpansionException;
 import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
+import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerialization;
+import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.starlarkbuildapi.cpp.CcToolchainVariablesApi;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -71,54 +73,25 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
      * @param variables binding of variable names to their values for a single flag expansion.
      */
     String expand(CcToolchainVariables variables, PathMapper pathMapper) throws ExpansionException;
-
-    String getString();
   }
 
   /** A plain text chunk of a string (containing no variables). */
   @Immutable
-  private static final class StringLiteralChunk implements StringChunk {
-    private final String text;
-
-    StringLiteralChunk(String text) {
-      this.text = text;
-    }
+  @AutoCodec
+  @VisibleForSerialization
+  record StringLiteralChunk(String text) implements StringChunk {
 
     @Override
     public String expand(CcToolchainVariables variables, PathMapper pathMapper) {
-      return text;
-    }
-
-    @Override
-    public boolean equals(@Nullable Object object) {
-      if (this == object) {
-        return true;
-      }
-      if (object instanceof StringLiteralChunk that) {
-        return text.equals(that.text);
-      }
-      return false;
-    }
-
-    @Override
-    public int hashCode() {
-      return 31 + text.hashCode();
-    }
-
-    @Override
-    public String getString() {
       return text;
     }
   }
 
   /** A chunk of a string value into which a variable should be expanded. */
   @Immutable
-  private static final class VariableChunk implements StringChunk {
-    private final String variableName;
-
-    VariableChunk(String variableName) {
-      this.variableName = variableName;
-    }
+  @AutoCodec
+  @VisibleForSerialization
+  record VariableChunk(String variableName) implements StringChunk {
 
     @Override
     public String expand(CcToolchainVariables variables, PathMapper pathMapper)
@@ -128,27 +101,6 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
       // the nesting level of the NestedSequence was deeper than the nesting level of the flag
       // groups.
       return variables.getStringVariable(variableName, pathMapper);
-    }
-
-    @Override
-    public boolean equals(@Nullable Object object) {
-      if (this == object) {
-        return true;
-      }
-      if (object instanceof VariableChunk that) {
-        return variableName.equals(that.variableName);
-      }
-      return false;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(variableName);
-    }
-
-    @Override
-    public String getString() {
-      return "%{" + variableName + "}";
     }
   }
 
@@ -169,9 +121,7 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
 
     private final String value;
 
-    /**
-     * The current position in {@value} during parsing.
-     */
+    /** The current position in {@value} during parsing. */
     private int current = 0;
 
     private final ImmutableList.Builder<StringChunk> chunks = ImmutableList.builder();
@@ -541,14 +491,14 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
    * String)}, or {@link VariableValue#getStringValue(String, PathMapper)}, and you'll get error
    * handling for the other methods for free.
    */
-  abstract static class VariableValueAdapter implements VariableValue {
+  interface VariableValueAdapter extends VariableValue {
 
     @Override
-    public abstract boolean isTruthy();
+    boolean isTruthy();
 
     @Nullable
     @Override
-    public VariableValue getFieldValue(
+    default VariableValue getFieldValue(
         String variableName,
         String field,
         @Nullable InputMetadataProvider inputMetadataProvider,
@@ -567,7 +517,7 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
     }
 
     @Override
-    public String getStringValue(String variableName, PathMapper pathMapper)
+    default String getStringValue(String variableName, PathMapper pathMapper)
         throws ExpansionException {
       throw new ExpansionException(
           String.format(
@@ -597,14 +547,9 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
 
   /** Sequence of arbitrary VariableValue objects. */
   @Immutable
-  static final class Sequence extends VariableValueAdapter {
+  @AutoCodec
+  record Sequence(ImmutableList<?> values) implements VariableValueAdapter {
     private static final String SEQUENCE_VARIABLE_TYPE_NAME = "sequence";
-
-    private final ImmutableList<?> values;
-
-    Sequence(ImmutableList<?> values) {
-      this.values = values;
-    }
 
     Iterable<? extends VariableValue> getSequenceValue() {
       return Iterables.transform(values, CcToolchainVariables::asVariableValue);
@@ -619,22 +564,6 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
     public boolean isTruthy() {
       return !values.isEmpty();
     }
-
-    @Override
-    public boolean equals(Object other) {
-      if (!(other instanceof Sequence)) {
-        return false;
-      }
-      if (this == other) {
-        return true;
-      }
-      return Objects.equals(values, ((Sequence) other).values);
-    }
-
-    @Override
-    public int hashCode() {
-      return values.hashCode();
-    }
   }
 
   /**
@@ -642,10 +571,9 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
    * never live outside of {@code expand}, as the object overhead is prohibitively expensive.
    */
   @Immutable
-  static final class StringValue extends VariableValueAdapter {
+  @AutoCodec
+  record StringValue(String value) implements VariableValueAdapter {
     private static final String STRING_VARIABLE_TYPE_NAME = "string";
-
-    private final String value;
 
     StringValue(String value) {
       this.value = Preconditions.checkNotNull(value, "Cannot create StringValue from null");
@@ -665,37 +593,17 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
     public boolean isTruthy() {
       return !value.isEmpty();
     }
-
-    @Override
-    public boolean equals(Object other) {
-      if (!(other instanceof StringValue)) {
-        return false;
-      }
-      if (this == other) {
-        return true;
-      }
-      return Objects.equals(value, ((StringValue) other).value);
-    }
-
-    @Override
-    public int hashCode() {
-      return value.hashCode();
-    }
   }
 
   @Immutable
-  private static final class BooleanValue extends VariableValueAdapter {
+  @AutoCodec
+  @VisibleForSerialization
+  record BooleanValue(boolean value) implements VariableValueAdapter {
     private static final BooleanValue TRUE = new BooleanValue(true);
     private static final BooleanValue FALSE = new BooleanValue(false);
 
     private static BooleanValue of(boolean value) {
       return value ? TRUE : FALSE;
-    }
-
-    private final boolean value;
-
-    BooleanValue(boolean value) {
-      this.value = value;
     }
 
     @Override
@@ -720,14 +628,10 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
    * expensive.
    */
   @Immutable
-  private static final class ArtifactValue extends VariableValueAdapter {
+  @AutoCodec
+  @VisibleForSerialization
+  record ArtifactValue(Artifact value) implements VariableValueAdapter {
     private static final String ARTIFACT_VARIABLE_TYPE_NAME = "artifact";
-
-    private final Artifact value;
-
-    ArtifactValue(Artifact value) {
-      this.value = value;
-    }
 
     @Override
     public String getStringValue(String variableName, PathMapper pathMapper) {
@@ -743,33 +647,13 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
     public boolean isTruthy() {
       return true;
     }
-
-    @Override
-    public boolean equals(Object other) {
-      if (this == other) {
-        return true;
-      }
-      if (!(other instanceof ArtifactValue otherValue)) {
-        return false;
-      }
-      return value.equals(otherValue.value);
-    }
-
-    @Override
-    public int hashCode() {
-      return value.hashCode();
-    }
   }
 
   @Immutable
-  private static final class PathFragmentValue extends VariableValueAdapter {
+  @AutoCodec
+  @VisibleForSerialization
+  record PathFragmentValue(PathFragment value) implements VariableValueAdapter {
     private static final String PATH_FRAGMENT_VARIABLE_TYPE_NAME = "pathfragment";
-
-    private final PathFragment value;
-
-    PathFragmentValue(PathFragment value) {
-      this.value = value;
-    }
 
     @Override
     public String getStringValue(String variableName, PathMapper pathMapper) {
@@ -784,22 +668,6 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
     @Override
     public boolean isTruthy() {
       return true;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-      if (this == other) {
-        return true;
-      }
-      if (!(other instanceof PathFragmentValue otherValue)) {
-        return false;
-      }
-      return value.equals(otherValue.value);
-    }
-
-    @Override
-    public int hashCode() {
-      return value.hashCode();
     }
   }
 
@@ -904,7 +772,9 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
       return this;
     }
 
-    /** @return a new {@link CcToolchainVariables} object. */
+    /**
+     * @return a new {@link CcToolchainVariables} object.
+     */
     public CcToolchainVariables build() {
       if (variablesMap.size() == 1) {
         return new SingleVariables(
@@ -938,7 +808,7 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
    * <p>It's used to support NamedLibraryInfo, ObjectFileGroupInfo and VersionedLibraryInfo
    * structures create in {@code create_libraries_to_link_values.bzl}
    */
-  public static class StarlarkStructureAdapter extends VariableValueAdapter {
+  public static class StarlarkStructureAdapter implements VariableValueAdapter {
     private final Structure val;
 
     StarlarkStructureAdapter(Structure val) {

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesTest.java
@@ -41,7 +41,6 @@ import com.google.devtools.build.lib.skyframe.serialization.testutils.Serializat
 import com.google.devtools.build.lib.testutil.TestConstants;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import org.junit.Test;
@@ -367,8 +366,16 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
             CppActionNames.CPP_COMPILE, createVariables(), PathMapper.NOOP);
     assertThat(env)
         .containsExactly(
-            "foo", "bar", "cat", "meow", "dog", "woof",
-            "withFeature", "value1", "withoutNotFeature", "value4")
+            "foo",
+            "bar",
+            "cat",
+            "meow",
+            "dog",
+            "woof",
+            "withFeature",
+            "value1",
+            "withoutNotFeature",
+            "value4")
         .inOrder();
     assertThat(env).doesNotContainEntry("withoutFeature", "value2");
     assertThat(env).doesNotContainEntry("withNotFeature", "value3");
@@ -539,14 +546,9 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
    * overhead is prohibitively big.
    */
   @Immutable
-  private static final class StructureValue extends VariableValueAdapter {
+  private record StructureValue(ImmutableMap<String, VariableValue> value)
+      implements VariableValueAdapter {
     private static final String STRUCTURE_VARIABLE_TYPE_NAME = "structure";
-
-    private final ImmutableMap<String, VariableValue> value;
-
-    private StructureValue(ImmutableMap<String, VariableValue> value) {
-      this.value = value;
-    }
 
     @Nullable
     @Override
@@ -567,22 +569,6 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
     @Override
     public boolean isTruthy() {
       return !value.isEmpty();
-    }
-
-    @Override
-    public boolean equals(Object other) {
-      if (!(other instanceof StructureValue)) {
-        return false;
-      }
-      if (this == other) {
-        return true;
-      }
-      return Objects.equals(value, ((StructureValue) other).value);
-    }
-
-    @Override
-    public int hashCode() {
-      return value.hashCode();
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -2145,8 +2145,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(variable).isNotNull();
     VariableWithValue v = variableWithValueFromStarlark(variable);
     assertThat(v).isNotNull();
-    assertThat(v.variable).isEqualTo("abc");
-    assertThat(v.value).isEqualTo("def");
+    assertThat(v.variable()).isEqualTo("abc");
+    assertThat(v.value()).isEqualTo("def");
 
     createEnvEntryRule("six", /* key= */ "'abc'", /* value= */ "'def'");
     t = getConfiguredTarget("//six:a");
@@ -2692,8 +2692,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(withFeatureSetProvider).isNotNull();
     WithFeatureSet withFeatureSet = withFeatureSetFromStarlark(withFeatureSetProvider);
     assertThat(withFeatureSet).isNotNull();
-    assertThat(withFeatureSet.getFeatures()).containsExactly("f1", "f2");
-    assertThat(withFeatureSet.getNotFeatures()).containsExactly("nf1", "nf2");
+    assertThat(withFeatureSet.features()).containsExactly("f1", "f2");
+    assertThat(withFeatureSet.notFeatures()).containsExactly("nf1", "nf2");
 
     createVariableWithValueRule("six", /* name= */ "'abc'", /* value= */ "'def'");
     t = getConfiguredTarget("//six:a");
@@ -3257,8 +3257,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     StarlarkInfo flagGroupProvider = (StarlarkInfo) getMyInfoFromTarget(t).getValue("flaggroup");
     assertThat(flagGroupProvider).isNotNull();
     FlagGroup flagGroup = flagGroupFromStarlark(flagGroupProvider);
-    assertThat(flagGroup.getExpandables()).isNotEmpty();
-    assertThat(flagGroup.getExpandables().get(0)).isInstanceOf(SingleChunkFlag.class);
+    assertThat(flagGroup.expandables()).isNotEmpty();
+    assertThat(flagGroup.expandables().get(0)).isInstanceOf(SingleChunkFlag.class);
   }
 
   @Test
@@ -3875,7 +3875,7 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(flagSetStruct).isNotNull();
     FlagSet f = flagSetFromStarlark(flagSetStruct, /* actionName= */ "action");
     assertThat(f).isNotNull();
-    assertThat(f.getActions()).containsExactly("action");
+    assertThat(f.actions()).containsExactly("action");
   }
 
   private void createFlagSetRule(String pkg, String actions, String flagGroups, String withFeatures)
@@ -4129,7 +4129,7 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(a).isNotNull();
     assertThat(a.getActionName()).isEqualTo("actionname32._++-");
     assertThat(a.getImplies()).containsExactly("a", "b").inOrder();
-    assertThat(Iterables.getOnlyElement(a.getFlagSets()).getActions())
+    assertThat(Iterables.getOnlyElement(a.getFlagSets()).actions())
         .containsExactly("actionname32._++-");
   }
 


### PR DESCRIPTION
…build/bazel/pull/28789)

Switch from abstract classes to interfaces to enable widespread migration to records and delete a bunch of dead code.

Work towards enabling path mapping for `cc_args` by introducing a new `StringChunk` type (https://github.com/cerisier/toolchains_llvm_bootstrapped/issues/335)

No

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES: None

Closes #28789.

PiperOrigin-RevId: 888550389
Change-Id: Ie0b46d1d4491dd992abaee96ac5db2343647c38d

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/a5e137358645d54620cd2ae029ae339f83b7fa10
