### PR TITLE
Add set -u to CC coverage script

### DIFF
--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -37,7 +37,9 @@
 # gcda or profraw) and uses either lcov or gcov to get the coverage data.
 # The coverage data is placed in $COVERAGE_OUTPUT_FILE.
 
-if [[ -n "$VERBOSE_COVERAGE" ]]; then
+set -u
+
+if [[ -n "${VERBOSE_COVERAGE:-}" ]]; then
   set -x
 fi
 
@@ -46,12 +48,6 @@ function uses_llvm() {
   if stat "${COVERAGE_DIR}"/*.profraw >/dev/null 2>&1; then
     return 0
   fi
-  return 1
-}
-
-# Returns 0 if gcov must be used, 1 otherwise.
-function uses_gcov() {
-  [[ "$GCOV_COVERAGE" -eq "1"  ]] && return 0
   return 1
 }
 
@@ -109,6 +105,8 @@ function llvm_coverage_profdata() {
 # - output_file     The location of the file where the generated code coverage
 #                   report is written.
 function gcov_coverage() {
+  init_gcov
+
   local output_file="${1}"; shift
 
   # We'll save the standard output of each the gcov command in this log.
@@ -161,9 +159,9 @@ function gcov_coverage() {
           # because of a gcov issue that segfaults when both -i and -b are used
           # (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84879).
           if [[ $gcov_major_version -le 7 ]]; then
-              "${GCOV}" -i $COVERAGE_GCOV_OPTIONS -o "$(dirname ${gcda})" "${gcda}"
+              "${GCOV}" -i ${COVERAGE_GCOV_OPTIONS:-} -o "$(dirname ${gcda})" "${gcda}"
           else
-              "${GCOV}" -i -b $COVERAGE_GCOV_OPTIONS -o "$(dirname ${gcda})" "${gcda}"
+              "${GCOV}" -i -b ${COVERAGE_GCOV_OPTIONS:-} -o "$(dirname ${gcda})" "${gcda}"
           fi
 
           # Check the type of output: gcov 9 or later outputs compressed JSON
@@ -184,8 +182,6 @@ function gcov_coverage() {
 }
 
 function main() {
-  init_gcov
-
   # If llvm code coverage is used, we output the raw code coverage report in
   # the $COVERAGE_OUTPUT_FILE. This report will not be converted to any other
   # format by LcovMerger.


### PR DESCRIPTION
Previously if you were missing a required env var like `LLVM_PROFDATA`
you would see this error:

```
external/bazel_tools/tools/test/collect_cc_coverage.sh: line 99: : command not found
```

Since almost all of the env vars are required in this script we can fix
this with `set -u` instead of handling per-variable

Now you see:

```
external/bazel_tools/tools/test/collect_cc_coverage.sh: line 95: LLVM_PROFDATA: unbound variable
```
