### PR TITLE
docs: Sync (2026-03-26)

### DIFF
--- a/docs/run/bazelrc.mdx
+++ b/docs/run/bazelrc.mdx
@@ -315,3 +315,8 @@ Each bazelrc file listed here has a corresponding flag which can be used to
 disable them (e.g. `--nosystem_rc`, `--noworkspace_rc`, `--nohome_rc`). You can
 also make Bazel ignore all bazelrcs by passing the `--ignore_all_rc_files`
 startup option.
+
+
+`import` statements in `.bazelrc` files are now limited to a recursive depth of 512.
+If you see a "Maximum import depth exceeded" error, consider refactoring your `.bazelrc` structure to reduce nesting.
+To disable this limit, set the `BAZEL_UNLIMITED_IMPORT_DEPTH` environment variable.

--- a/site/en/run/bazelrc.md
+++ b/site/en/run/bazelrc.md
@@ -317,3 +317,8 @@ Each bazelrc file listed here has a corresponding flag which can be used to
 disable them (e.g. `--nosystem_rc`, `--noworkspace_rc`, `--nohome_rc`). You can
 also make Bazel ignore all bazelrcs by passing the `--ignore_all_rc_files`
 startup option.
+
+
+`import` statements in `.bazelrc` files are now limited to a recursive depth of 512.
+If you see a "Maximum import depth exceeded" error, consider refactoring your `.bazelrc` structure to reduce nesting.
+To disable this limit, set the `BAZEL_UNLIMITED_IMPORT_DEPTH` environment variable.


### PR DESCRIPTION
Documents 1 new behavioral changes in Bazel.

### Changes
- **Limit the maximum depth of `.bazelrc` recursive imports.** (site/en/run/bazelrc.md): update based on `affe9e0`.

All changes mirrored identically between Legacy and Modern docs.

RELNOTES: None