### PR TITLE
docs: Weekly Sync (2026-03-26)

### DIFF
--- a/docs/run/bazelrc.mdx
+++ b/docs/run/bazelrc.mdx
@@ -315,3 +315,8 @@ Each bazelrc file listed here has a corresponding flag which can be used to
 disable them (e.g. `--nosystem_rc`, `--noworkspace_rc`, `--nohome_rc`). You can
 also make Bazel ignore all bazelrcs by passing the `--ignore_all_rc_files`
 startup option.
+
+
+`import` statements in `.bazelrc` files are now limited to a recursive depth of 512.
+If you see a "Maximum import depth exceeded" error, consider refactoring your `.bazelrc` structure to reduce nesting.
+To disable this limit, set the `BAZEL_UNLIMITED_IMPORT_DEPTH` environment variable.

--- a/site/en/run/bazelrc.md
+++ b/site/en/run/bazelrc.md
@@ -317,3 +317,8 @@ Each bazelrc file listed here has a corresponding flag which can be used to
 disable them (e.g. `--nosystem_rc`, `--noworkspace_rc`, `--nohome_rc`). You can
 also make Bazel ignore all bazelrcs by passing the `--ignore_all_rc_files`
 startup option.
+
+
+`import` statements in `.bazelrc` files are now limited to a recursive depth of 512.
+If you see a "Maximum import depth exceeded" error, consider refactoring your `.bazelrc` structure to reduce nesting.
+To disable this limit, set the `BAZEL_UNLIMITED_IMPORT_DEPTH` environment variable.


### PR DESCRIPTION
Documents 6 behavioral changes in Bazel.

### Changes
- **Add an implicit `_sort_key` field to module extension tags (https://github.com/bazelbuild/bazel/pull/27883)** (site/en/external/extension.md): based on `a39cef7`.
- **Limit the maximum depth of `.bazelrc` recursive imports.** (site/en/run/bazelrc.md): based on `affe9e0`.
- **Enforce non-empty integrity for Bzlmod patches and overlays (https://github.com/bazelbuild/bazel/pull/29017)** (site/en/external/registry.md): based on `031d629`.
- **Move some test back to Google-specific parts of Bazel.** (site/en/versions/9.0.0/reference/be/python.md): based on `4219d02`.
- **Fix out-of-order BEP event publishing.** (site/en/remote/bep.md): based on `b7284e2`.
- **Add Bazel support for `--rewind_lost_inputs` (https://github.com/bazelbuild/bazel/pull/25477)** (site/en/remote/caching.md): based on `464eacb`.

All changes mirrored between Legacy and Modern docs.

RELNOTES: None