### PR TITLE
[8.7.0] Make is_tool_configuration public (https://github.com/bazelbuild/bazel/pull/29056)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -759,12 +759,6 @@ public class BuildConfigurationValue
     return isExecConfiguration();
   }
 
-  @Override
-  public boolean isToolConfigurationForStarlark(StarlarkThread thread) throws EvalException {
-    BuiltinRestriction.failIfCalledOutsideDefaultAllowlist(thread);
-    return isToolConfiguration();
-  }
-
   public boolean checkVisibility() {
     return options.checkVisibility;
   }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/BuildConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/BuildConfigurationApi.java
@@ -97,8 +97,10 @@ public interface BuildConfigurationApi extends StarlarkValue {
   @StarlarkMethod(name = "stamp_binaries", documented = false, useStarlarkThread = true)
   boolean stampBinariesForStarlark(StarlarkThread thread) throws EvalException;
 
-  @StarlarkMethod(name = "is_tool_configuration", documented = false, useStarlarkThread = true)
-  boolean isToolConfigurationForStarlark(StarlarkThread thread) throws EvalException;
+  @StarlarkMethod(
+      name = "is_tool_configuration",
+      doc = "Returns true when building in the tool (exec) configuration.")
+  boolean isToolConfiguration();
 
   @StarlarkMethod(
       name = "has_separate_genfiles_directory",

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationStarlarkTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationStarlarkTest.java
@@ -71,7 +71,7 @@ public final class BuildConfigurationStarlarkTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testIsToolConfigurationIsBlocked() throws Exception {
+  public void testIsToolConfiguration() throws Exception {
     scratch.file(
         "example/BUILD",
         """
@@ -84,15 +84,14 @@ public final class BuildConfigurationStarlarkTest extends BuildViewTestCase {
         "example/rule.bzl",
         """
         def _impl(ctx):
-            ctx.configuration.is_tool_configuration()
+            if ctx.configuration.is_tool_configuration():
+                fail("should not be tool configuration")
             return [DefaultInfo()]
 
         custom_rule = rule(implementation = _impl)
         """);
 
-    AssertionError e =
-        assertThrows(AssertionError.class, () -> getConfiguredTarget("//example:custom"));
-    assertThat(e).hasMessageThat().contains("file '//example:rule.bzl' cannot use private API");
+    getConfiguredTarget("//example:custom");
   }
 
   @Test


### PR DESCRIPTION
This is a common ask from rules authors, most of whom check for `-exec-`
in `ctx.bin_dir.path` which is potentially fragile with path stripping.

Fixes https://github.com/bazelbuild/bazel/issues/14444

Closes #29056.

PiperOrigin-RevId: 889280554
Change-Id: Id4380e59603513e5d6bee38de269057500ce6573

Commit https://github.com/bazelbuild/bazel/commit/84c0253add3784b75ff08b6d049a7f152c7b7532