### PR TITLE
Remove GCOV symlink after use

### DIFF
--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -181,6 +181,8 @@ function gcov_coverage() {
       fi
     fi
   done < "${COVERAGE_MANIFEST}"
+
+  rm -f "${GCOV}"
 }
 
 function main() {


### PR DESCRIPTION
If you point GCOV to a tool that is an output of another bazel action,
its symlink becomes invalid when the sandbox is torn down. In this case
it leads to failures with tree artifacts:

```
ERROR: .../test/test_data/BUILD:223:8: error while validating output tree artifact test/test_data/c_test/_coverage: child gcov is a dangling symbolic link
```

We don't need to keep it after this anyways. This only fails with
`--experimental_fetch_all_coverage_outputs`
