### PR TITLE
Allow repo labels in `--fdo_optimize`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -176,37 +176,7 @@ public final class CppConfiguration extends Fragment
       linkoptsBuilder.add("-Wl,--eh-frame-hdr");
     }
 
-    PathFragment fdoPath = null;
-    Label fdoProfileLabel = null;
-    if (cppOptions.getFdoOptimize() != null) {
-      if (cppOptions.getFdoOptimize().startsWith("//")) {
-        try {
-          fdoProfileLabel = Label.parseCanonical(cppOptions.getFdoOptimize());
-        } catch (LabelSyntaxException e) {
-          throw new InvalidConfigurationException(e);
-        }
-      } else {
-        if (!cppOptions.getEnableFdoProfileAbsolutePath()) {
-          throw new InvalidConfigurationException(
-              "Please use --fdo_profile instead of an absolute path set with --fdo_optimize. Using"
-                  + " absolute paths may be temporary reenabled with"
-                  + " --enable_fdo_profile_absolute_path");
-        }
-        fdoPath = PathFragment.create(cppOptions.getFdoOptimize());
-        if (!fdoPath.isAbsolute()) {
-          throw new InvalidConfigurationException(
-              "Path of '"
-                  + fdoPath.getPathString()
-                  + "' in --fdo_optimize has to be either an absolute path or a label.");
-        }
-        try {
-          // We don't check for file existence, but at least the filename should be well-formed.
-          FileSystemUtils.checkBaseName(fdoPath.getBaseName());
-        } catch (IllegalArgumentException e) {
-          throw new InvalidConfigurationException(e);
-        }
-      }
-    }
+    FdoPathData fdoPathData = FdoPathData.get(cppOptions);
 
     PathFragment csFdoAbsolutePath = null;
     if (cppOptions.getCsFdoAbsolutePathForBuild() != null) {
@@ -276,8 +246,8 @@ public final class CppConfiguration extends Fragment
       }
     }
 
-    this.fdoPath = fdoPath == null ? null : fdoPath.getPathString();
-    this.fdoOptimizeLabel = fdoProfileLabel;
+    this.fdoPath = fdoPathData.fdoPath() == null ? null : fdoPathData.fdoPath().getPathString();
+    this.fdoOptimizeLabel = fdoPathData.fdoProfileLabel();
     this.csFdoAbsolutePath = csFdoAbsolutePath == null ? null : csFdoAbsolutePath.getPathString();
     this.propellerOptimizeAbsoluteCCProfile =
         propellerOptimizeAbsoluteCCProfile == null
@@ -302,6 +272,45 @@ public final class CppConfiguration extends Fragment
     this.compilationMode = compilationMode;
     this.collectCodeCoverage = commonOptions.getCollectCodeCoverage();
     this.appleGenerateDsym = cppOptions.getAppleGenerateDsym();
+  }
+
+  private record FdoPathData(PathFragment fdoPath, Label fdoProfileLabel) {
+    private static FdoPathData get(CppOptions cppOptions) throws InvalidConfigurationException {
+      PathFragment fdoPath = null;
+      Label fdoProfileLabel = null;
+
+      if (cppOptions.getFdoOptimize() != null) {
+        try {
+          fdoProfileLabel = Label.parseCanonical(cppOptions.getFdoOptimize());
+          return new FdoPathData(fdoPath, fdoProfileLabel);
+        } catch (LabelSyntaxException ignored) {
+          // This isn't a Label, so just continue trying other flags.
+        }
+
+        if (!cppOptions.getEnableFdoProfileAbsolutePath()) {
+          throw new InvalidConfigurationException(
+              "Please use --fdo_profile instead of an absolute path set with --fdo_optimize. Using"
+                  + " absolute paths may be temporary reenabled with"
+                  + " --enable_fdo_profile_absolute_path");
+        }
+
+        // Try to process the flag value as a path.
+        fdoPath = PathFragment.create(cppOptions.getFdoOptimize());
+        if (!fdoPath.isAbsolute()) {
+          throw new InvalidConfigurationException(
+              "Path of '"
+                  + fdoPath.getPathString()
+                  + "' in --fdo_optimize has to be either an absolute path or a label.");
+        }
+        try {
+          // We don't check for file existence, but at least the filename should be well-formed.
+          FileSystemUtils.checkBaseName(fdoPath.getBaseName());
+        } catch (IllegalArgumentException e) {
+          throw new InvalidConfigurationException(e);
+        }
+      }
+      return new FdoPathData(fdoPath, fdoProfileLabel);
+    }
   }
 
   @Nullable

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainTest.java
@@ -627,10 +627,68 @@ public final class CcToolchainTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testZipperInclusionDependsOnFdoOptimization() throws Exception {
-    reporter.removeHandler(failFastHandler);
+  public void testZipperInclusionDependsOnFdoOptimization_notSet() throws Exception {
+    setUpFdoZipper();
+
+    useConfiguration();
+    assertThat(getPrerequisites(getConfiguredTarget("//a:b"), ":zipper")).isEmpty();
+  }
+
+  @Test
+  public void testZipperInclusionDependsOnFdoOptimization_viaFdoOptimize_packageLabel() throws Exception {
+    setUpFdoZipper();
+
+    useConfiguration("-c", "opt", "--fdo_optimize=//fdo:fdo");
+    assertThat(getPrerequisites(getConfiguredTarget("//a:b"), ":zipper")).isNotEmpty();
+  }
+
+  @Test
+  public void testZipperInclusionDependsOnFdoOptimization_viaFdoOptimize_packageFile() throws Exception {
+    setUpFdoZipper();
+
+    useConfiguration("-c", "opt", "--fdo_optimize=//fdo:my_profile.afdo");
+    assertThat(getPrerequisites(getConfiguredTarget("//a:b"), ":zipper")).isNotEmpty();
+  }
+
+  // Regression test for #29002.
+  @Test
+  public void testZipperInclusionDependsOnFdoOptimization_viaFdoOptimize_repoLabel() throws Exception {
+    if (!analysisMock.isThisBazel()) {
+      // Separate repos only work in bazel.
+      return;
+    }
+
+    // Set up a repo with the profile data.
+    scratch.appendFile(
+            "MODULE.bazel",
+            """
+            bazel_dep(name = "fdo")
+            local_path_override(module_name = "fdo", path = "/fdo")
+            """);
+
+    scratch.file("/fdo/MODULE.bazel", "module(name = 'fdo')");
+    setUpFdoZipper("a", "/fdo");
+    invalidatePackages();
+
+    useConfiguration("-c", "opt", "--fdo_optimize=@@fdo+//:fdo");
+    assertThat(getPrerequisites(getConfiguredTarget("//a:b"), ":zipper")).isNotEmpty();
+  }
+
+  @Test
+  public void testZipperInclusionDependsOnFdoOptimization_viaFdoProfile() throws Exception {
+    setUpFdoZipper();
+
+    useConfiguration("-c", "opt", "--fdo_profile=//fdo:fdo");
+    assertThat(getPrerequisites(getConfiguredTarget("//a:b"), ":zipper")).isNotEmpty();
+  }
+
+  private void setUpFdoZipper() throws IOException {
+    setUpFdoZipper("a", "fdo");
+  }
+
+  private void setUpFdoZipper(String pkgDir, String fdoDir) throws IOException {
     scratch.file(
-        "a/BUILD",
+        pkgDir + "/BUILD",
         """
         load("@rules_cc//cc/toolchains:cc_toolchain.bzl", "cc_toolchain")
         load(":cc_toolchain_config.bzl", "cc_toolchain_config")
@@ -655,9 +713,11 @@ public final class CcToolchainTest extends BuildViewTestCase {
 
         cc_toolchain_config(name = "toolchain_config")
         """);
-    scratch.file("fdo/my_profile.afdo", "");
+    scratch.file(pkgDir + "/cc_toolchain_config.bzl", MockCcSupport.EMPTY_CC_TOOLCHAIN);
+
+    scratch.file(fdoDir + "/my_profile.afdo", "");
     scratch.file(
-        "fdo/BUILD",
+        fdoDir + "/BUILD",
         """
         load("@rules_cc//cc/toolchains:fdo_profile.bzl", "fdo_profile")
         exports_files(["my_profile.afdo"])
@@ -667,16 +727,6 @@ public final class CcToolchainTest extends BuildViewTestCase {
             profile = ":my_profile.profdata",
         )
         """);
-    scratch.file("a/cc_toolchain_config.bzl", MockCcSupport.EMPTY_CC_TOOLCHAIN);
-
-    useConfiguration();
-    assertThat(getPrerequisites(getConfiguredTarget("//a:b"), ":zipper")).isEmpty();
-
-    useConfiguration("-c", "opt", "--fdo_optimize=//fdo:my_profile.afdo");
-    assertThat(getPrerequisites(getConfiguredTarget("//a:b"), ":zipper")).isNotEmpty();
-
-    useConfiguration("-c", "opt", "--fdo_profile=//fdo:fdo");
-    assertThat(getPrerequisites(getConfiguredTarget("//a:b"), ":zipper")).isNotEmpty();
   }
 
   private void loadCcToolchainConfigLib() throws IOException {


### PR DESCRIPTION
Handle all types of label with `--fdo_optimize`.
    
Fixes #29002

RELNOTES: The flag `--fdo_optimize` now accepts repo labels as well as package labels.
