### PR TITLE
docs: Move Spotify outside OSS section

### DIFF
--- a/docs/community/users.mdx
+++ b/docs/community/users.mdx
@@ -381,6 +381,10 @@ Snap, the developer of Snapchat messaging app, has migrated from Buck to Bazel
 in 2020 ([source](https://twitter.com/wew/status/1326957862816509953)). For more
 details about their process, see their [engineering blog](https://eng.snap.com/blog/).
 
+### [Spotify](https://spotify.com)
+
+Spotify is using Bazel to build their iOS and Android Apps ([source](https://twitter.com/BalestraPatrick/status/1573355078995566594)).
+
 ### [Stripe](https://stripe.com)
 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Stripe_Logo%2C_revised_2016.svg/320px-Stripe_Logo%2C_revised_2016.svg.png" width="150" align="right" />
 
@@ -720,10 +724,6 @@ networks.
 
 Sorbet is a fast, powerful type checker for a subset of Ruby. It scales to
 codebases with millions of lines of code and can be adopted incrementally.
-
-### [Spotify](https://spotify.com)
-
-Spotify is using Bazel to build their iOS and Android Apps ([source](https://twitter.com/BalestraPatrick/status/1573355078995566594)).
 
 ### [Tink](https://github.com/google/tink)
 


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

This updates the "Who's using Bazel?" page, so Spotify's mobile apps are not in
the "OSS projects using Bazel" section.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->
To my knowledge, Spotify's mobile apps are not OSS.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
