### PR TITLE
Fix appearances of `<code>` in flag docs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -212,9 +212,8 @@ public final class BuildLanguageOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
       effectTags = OptionEffectTag.LOADING_AND_ANALYSIS,
       help =
-          "If true, enables the <code>isolate</code> parameter in the <a"
-              + " href=\"https://bazel.build/rules/lib/globals/module#use_extension\"><code>use_extension</code></a>"
-              + " function.")
+          "If true, enables the `isolate` parameter in the "
+          + "[`use_extension`](https://bazel.build/rules/lib/globals/module#use_extension) function.")
   public boolean experimentalIsolatedExtensionUsages;
 
   @Option(
@@ -224,11 +223,10 @@ public final class BuildLanguageOptions extends OptionsBase {
       metadataTags = OptionMetadataTag.INCOMPATIBLE_CHANGE,
       effectTags = OptionEffectTag.LOADING_AND_ANALYSIS,
       help =
-          "If true, then methods on <code>repository_ctx</code> that are passed a Label will no"
+          "If true, then methods on `repository_ctx` that are passed a Label will no"
               + " longer automatically watch the file under that label for changes even if"
-              + " <code>watch = \"no\"</code>, and <code>repository_ctx.path</code> no longer"
-              + " causes the returned path to be watched. Use <code>repository_ctx.watch</code>"
-              + " instead.")
+              + " `watch = \"no\"`, and `repository_ctx.path` no longer"
+              + " causes the returned path to be watched. Use `repository_ctx.watch` instead.")
   public boolean incompatibleNoImplicitWatchLabel;
 
   @Option(
@@ -753,7 +751,7 @@ public final class BuildLanguageOptions extends OptionsBase {
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
       help =
           "Whether a target that provides an executable expands to the executable rather than the"
-              + " files in <code>DefaultInfo.files</code> under $(locations ...) expansion if the"
+              + " files in `DefaultInfo.files` under $(locations ...) expansion if the"
               + " number of files is not 1.")
   public boolean incompatibleLocationsPrefersExecutable;
 

--- a/src/main/java/com/google/devtools/build/lib/query2/common/CommonQueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/common/CommonQueryOptions.java
@@ -188,8 +188,8 @@ public class CommonQueryOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.QUERY,
       effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
       help =
-          "If enabled, every query command emits labels as if by the Starlark <code>str</code>"
-              + " function applied to a <code>Label</code> instance. This is useful for tools that"
+          "If enabled, every query command emits labels as if by the Starlark `str`"
+              + " function applied to a `Label` instance. This is useful for tools that"
               + " need to match the output of different query commands and/or labels emitted by"
               + " rules. If not enabled, output formatters are free to emit apparent repository"
               + " names (relative to the main repository) instead to make the output more"
@@ -406,6 +406,6 @@ public class CommonQueryOptions extends OptionsBase {
       help =
           "When specified, query results will be written directly to this file, and nothing will be"
               + " printed to Bazel's standard output stream (stdout). In benchmarks, this is"
-              + " generally faster than <code>bazel query &gt; file</code>.")
+              + " generally faster than `bazel query &gt; file`.")
   public String outputFile;
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -603,10 +603,10 @@ public class CommonCommandOptions extends OptionsBase {
           """
           Specifies additional environment variables to be available only for repository rules. \
           Note that repository rules see the full environment anyway, but in this way \
-          variables can be set via command-line flags and <code>.bazelrc</code> entries. \
-          The special syntax <code>=NAME</code> can be used to explicitly unset a variable. \
-          The string <code>%bazel_workspace%</code> in a value will be replaced with the absolute \
-          path of the workspace as printed by <code>bazel info workspace</code>.
+          variables can be set via command-line flags and `.bazelrc` entries. \
+          The special syntax `=NAME` can be used to explicitly unset a variable. \
+          The string `%bazel_workspace%` in a value will be replaced with the absolute \
+          path of the workspace as printed by `bazel info workspace`.
           """)
   public List<Converters.EnvVar> repositoryEnvironment;
 
@@ -618,7 +618,7 @@ public class CommonCommandOptions extends OptionsBase {
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
       help =
           """
-          If true, <code>--action_env=NAME=VALUE</code> will no longer affect repository rule \
+          If true, `--action_env=NAME=VALUE` will no longer affect repository rule \
           and module extension environments.
           """)
   public boolean repoEnvIgnoresActionEnv;


### PR DESCRIPTION
### Description

Use backticks instead of `<code>`

### Motivation

Using `<code> ... </code>` doesn't work as expected in the rendered docs. Use backticks instead.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
