### PR TITLE
Expand params files in UI with --expand_param_files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
@@ -42,6 +42,7 @@ import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import com.google.devtools.common.options.OptionsProvider;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import javax.annotation.Nullable;
@@ -454,9 +455,17 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
 
   /**
    * Report a subcommand event to this Executor's Reporter and, if action logging is enabled, post
-   * it on its EventBus.
+   * it on its EventBus. Uses the spawn's own arguments.
    */
   public void maybeReportSubcommand(Spawn spawn, @Nullable String spawnRunner) {
+    maybeReportSubcommand(spawn, spawn.getArguments(), spawnRunner);
+  }
+
+  /**
+   * Report a subcommand event with the given arguments (which may have param files expanded).
+   */
+  public void maybeReportSubcommand(
+      Spawn spawn, List<String> arguments, @Nullable String spawnRunner) {
     ShowSubcommands showSubcommands = executor.reportsSubcommands();
     if (!showSubcommands.shouldShowSubcommands) {
       return;
@@ -488,7 +497,7 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         CommandFailureUtils.describeCommand(
             CommandDescriptionForm.COMPLETE,
             showSubcommands.prettyPrintArgs,
-            spawn.getArguments(),
+            arguments,
             spawn.getEnvironment(),
             /* environmentVariablesToClear= */ null,
             getExecRoot().getPathString(),

--- a/src/main/java/com/google/devtools/build/lib/actions/CommandLines.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/CommandLines.java
@@ -134,6 +134,7 @@ public abstract sealed class CommandLines {
             paramFiles.add(
                 new ParamFileActionInput(
                     paramFileExecPath,
+                    paramArg,
                     ParameterFile.flagsOnly(chunk.arguments(pathMapper)),
                     paramFileInfo.getFileType()));
             for (String positionalArg : ParameterFile.nonFlags(chunk.arguments(pathMapper))) {
@@ -143,7 +144,10 @@ public abstract sealed class CommandLines {
           } else {
             paramFiles.add(
                 new ParamFileActionInput(
-                    paramFileExecPath, chunk.arguments(pathMapper), paramFileInfo.getFileType()));
+                    paramFileExecPath,
+                    paramArg,
+                    chunk.arguments(pathMapper),
+                    paramFileInfo.getFileType()));
           }
         }
       }
@@ -219,12 +223,22 @@ public abstract sealed class CommandLines {
   /** An in-memory param file virtual action input. */
   public static final class ParamFileActionInput extends VirtualActionInput {
     private final PathFragment paramFileExecPath;
+    private final String paramFileArg;
     private final Iterable<String> arguments;
     private final ParameterFileType type;
 
     public ParamFileActionInput(
         PathFragment paramFileExecPath, Iterable<String> arguments, ParameterFileType type) {
+      this(paramFileExecPath, "@" + paramFileExecPath.getPathString(), arguments, type);
+    }
+
+    public ParamFileActionInput(
+        PathFragment paramFileExecPath,
+        String paramFileArg,
+        Iterable<String> arguments,
+        ParameterFileType type) {
       this.paramFileExecPath = paramFileExecPath;
+      this.paramFileArg = paramFileArg;
       this.arguments = arguments;
       this.type = type;
     }
@@ -244,6 +258,11 @@ public abstract sealed class CommandLines {
     @Override
     public String getExecPathString() {
       return paramFileExecPath.getPathString();
+    }
+
+    /** Returns the argument that references this param file on the primary command line. */
+    public String getParamFileArg() {
+      return paramFileArg;
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -82,16 +82,15 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
   /**
    * Expands param file references in a spawn's arguments with the actual param file contents.
    *
-   * <p>For each argument that matches a param file reference (e.g. {@code @path/to/param_file}),
-   * the argument is replaced with the contents of the corresponding param file found in the spawn's
-   * input files.
+   * <p>For each argument that matches a param file reference, the argument is replaced with the
+   * contents of the corresponding param file found in the spawn's input files.
    */
   public static ImmutableList<String> expandParamFiles(Spawn spawn) {
     ImmutableMap.Builder<String, CommandLines.ParamFileActionInput> paramFileMapBuilder =
         ImmutableMap.builder();
     for (ActionInput input : spawn.getInputFiles().toList()) {
       if (input instanceof CommandLines.ParamFileActionInput paramFileActionInput) {
-        paramFileMapBuilder.put(paramFileActionInput.getExecPathString(), paramFileActionInput);
+        paramFileMapBuilder.put(paramFileActionInput.getParamFileArg(), paramFileActionInput);
       }
     }
     ImmutableMap<String, CommandLines.ParamFileActionInput> paramFileMap =
@@ -103,15 +102,12 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
 
     ArrayList<String> expandedArgs = new ArrayList<>();
     for (String arg : spawn.getArguments()) {
-      if (arg.startsWith("@") && arg.length() > 1) {
-        String path = arg.substring(1);
-        CommandLines.ParamFileActionInput paramFile = paramFileMap.get(path);
-        if (paramFile != null) {
-          for (String paramArg : paramFile.getArguments()) {
-            expandedArgs.add(paramArg);
-          }
-          continue;
+      CommandLines.ParamFileActionInput paramFile = paramFileMap.get(arg);
+      if (paramFile != null) {
+        for (String paramArg : paramFile.getArguments()) {
+          expandedArgs.add(paramArg);
         }
+        continue;
       }
       expandedArgs.add(arg);
     }

--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -20,10 +20,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.ActionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.CommandLines;
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
@@ -51,6 +53,8 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.SortedMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
@@ -73,6 +77,45 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
   protected AbstractSpawnStrategy(SpawnRunner spawnRunner, ExecutionOptions executionOptions) {
     this.spawnRunner = spawnRunner;
     this.executionOptions = executionOptions;
+  }
+
+  /**
+   * Expands param file references in a spawn's arguments with the actual param file contents.
+   *
+   * <p>For each argument that matches a param file reference (e.g. {@code @path/to/param_file}),
+   * the argument is replaced with the contents of the corresponding param file found in the spawn's
+   * input files.
+   */
+  public static ImmutableList<String> expandParamFiles(Spawn spawn) {
+    ImmutableMap.Builder<String, CommandLines.ParamFileActionInput> paramFileMapBuilder =
+        ImmutableMap.builder();
+    for (ActionInput input : spawn.getInputFiles().toList()) {
+      if (input instanceof CommandLines.ParamFileActionInput paramFileActionInput) {
+        paramFileMapBuilder.put(paramFileActionInput.getExecPathString(), paramFileActionInput);
+      }
+    }
+    ImmutableMap<String, CommandLines.ParamFileActionInput> paramFileMap =
+        paramFileMapBuilder.buildOrThrow();
+
+    if (paramFileMap.isEmpty()) {
+      return spawn.getArguments();
+    }
+
+    ArrayList<String> expandedArgs = new ArrayList<>();
+    for (String arg : spawn.getArguments()) {
+      if (arg.startsWith("@") && arg.length() > 1) {
+        String path = arg.substring(1);
+        CommandLines.ParamFileActionInput paramFile = paramFileMap.get(path);
+        if (paramFile != null) {
+          for (String paramArg : paramFile.getArguments()) {
+            expandedArgs.add(paramArg);
+          }
+          continue;
+        }
+      }
+      expandedArgs.add(arg);
+    }
+    return ImmutableList.copyOf(expandedArgs);
   }
 
   /**
@@ -103,7 +146,12 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
       ActionExecutionContext actionExecutionContext,
       @Nullable SandboxedSpawnStrategy.StopConcurrentSpawns stopConcurrentSpawns)
       throws ExecException, InterruptedException {
-    actionExecutionContext.maybeReportSubcommand(spawn, spawnRunner.getName());
+    if (executionOptions.getExpandParamFiles()) {
+      actionExecutionContext.maybeReportSubcommand(
+          spawn, expandParamFiles(spawn), spawnRunner.getName());
+    } else {
+      actionExecutionContext.maybeReportSubcommand(spawn, spawnRunner.getName());
+    }
 
     final Duration timeout = Spawns.getTimeout(spawn);
     SpawnExecutionContext context =
@@ -200,11 +248,17 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
     if (spawnResult.status() != Status.SUCCESS) {
       String cwd = actionExecutionContext.getExecRoot().getPathString();
       String resultMessage = spawnResult.getFailureMessage();
-      String message =
-          !Strings.isNullOrEmpty(resultMessage)
-              ? resultMessage
-              : CommandFailureUtils.describeCommandFailure(
-                  executionOptions.getVerboseFailures(), cwd, spawn);
+      String message;
+      if (!Strings.isNullOrEmpty(resultMessage)) {
+        message = resultMessage;
+      } else {
+        message =
+            CommandFailureUtils.describeCommandFailure(
+                executionOptions.getVerboseFailures(),
+                cwd,
+                spawn,
+                executionOptions.getExpandParamFiles() ? expandParamFiles(spawn) : null);
+      }
       throw new SpawnExecException(message, spawnResult, /* forciblyRunRemotely= */ false);
     }
     return ImmutableList.of(spawnResult);

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -196,6 +196,18 @@ public abstract class ExecutionOptions extends OptionsBase {
   public abstract ShowSubcommands getShowSubcommands();
 
   @Option(
+      name = "expand_param_files",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
+      help =
+          "When displaying subcommands (--subcommands) or printing the command line of a failed"
+              + " action (--verbose_failures), expand the contents of param files. When enabled,"
+              + " param file references like @path/to/param_file are replaced with the actual"
+              + " arguments they contain.")
+  public abstract boolean getExpandParamFiles();
+
+  @Option(
       name = "check_up_to_date",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,

--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -35,6 +35,7 @@ import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.events.Reporter;
+import com.google.devtools.build.lib.exec.AbstractSpawnStrategy;
 import com.google.devtools.build.lib.exec.BinTools;
 import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.SpawnExecutingEvent;
@@ -73,6 +74,7 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
 
   private final SandboxOptions sandboxOptions;
   private final boolean verboseFailures;
+  private final boolean expandParamFiles;
   private final ImmutableSet<Path> inaccessiblePaths;
   protected final BinTools binTools;
   private final Path execRoot;
@@ -82,8 +84,9 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
 
   public AbstractSandboxSpawnRunner(CommandEnvironment cmdEnv) {
     this.sandboxOptions = cmdEnv.getOptions().getOptions(SandboxOptions.class);
-    this.verboseFailures =
-        cmdEnv.getOptions().getOptions(ExecutionOptions.class).getVerboseFailures();
+    ExecutionOptions executionOptions = cmdEnv.getOptions().getOptions(ExecutionOptions.class);
+    this.verboseFailures = executionOptions.getVerboseFailures();
+    this.expandParamFiles = executionOptions.getExpandParamFiles();
     this.inaccessiblePaths =
         sandboxOptions.getInaccessiblePaths(cmdEnv.getRuntime().getFileSystem());
     this.binTools = cmdEnv.getBlazeWorkspace().getBinTools();
@@ -190,7 +193,12 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
           true, sandbox.getSandboxExecRoot().getPathString(), sandbox);
     } else {
       return CommandFailureUtils.describeCommandFailure(
-              verboseFailures, sandbox.getSandboxExecRoot().getPathString(), originalSpawn)
+              verboseFailures,
+              sandbox.getSandboxExecRoot().getPathString(),
+              originalSpawn,
+              expandParamFiles
+                  ? AbstractSpawnStrategy.expandParamFiles(originalSpawn)
+                  : null)
           + SANDBOX_DEBUG_SUGGESTION;
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
@@ -149,6 +149,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:resource_manager",
         "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/exec:abstract_spawn_strategy",
         "//src/main/java/com/google/devtools/build/lib/exec:bin_tools",
         "//src/main/java/com/google/devtools/build/lib/exec:execution_options",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_runner",

--- a/src/main/java/com/google/devtools/build/lib/util/CommandFailureUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/util/CommandFailureUtils.java
@@ -193,17 +193,29 @@ public class CommandFailureUtils {
     return shortCommandName + " failed: " + output;
   }
 
+  /**
+   * Describes a command failure using the command's own arguments, or the given {@code arguments} if
+   * non-null (e.g. with param files expanded).
+   */
   public static String describeCommandFailure(
-      boolean verboseFailures, @Nullable String cwd, DescribableExecutionUnit command) {
+      boolean verboseFailures,
+      @Nullable String cwd,
+      DescribableExecutionUnit command,
+      @Nullable Collection<String> arguments) {
     return describeCommandFailure(
         verboseFailures,
         command.getMnemonic(),
-        command.getArguments(),
+        arguments != null ? arguments : command.getArguments(),
         command.getEnvironment(),
         cwd,
         command.getConfigurationChecksum(),
         command.getTargetDescription(),
         command.getExecutionPlatformLabel(),
         /* spawnRunner= */ null);
+  }
+
+  public static String describeCommandFailure(
+      boolean verboseFailures, @Nullable String cwd, DescribableExecutionUnit command) {
+    return describeCommandFailure(verboseFailures, cwd, command, /* arguments= */ null);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/actions/CommandLinesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/CommandLinesTest.java
@@ -97,6 +97,27 @@ public class CommandLinesTest {
   }
 
   @Test
+  public void expand_paramFileWithCustomFlagFormat_preservesParamFileArg() throws Exception {
+    CommandLines commandLines =
+        CommandLines.builder()
+            .addCommandLine(
+                CommandLine.of(ImmutableList.of("--foo", "--bar")),
+                ParamFileInfo.builder(ParameterFileType.UNQUOTED)
+                    .setFlagFormatString("--flagfile=%s")
+                    .setUseAlways(true)
+                    .build())
+            .build();
+
+    ExpandedCommandLines expanded =
+        commandLines.expand(inputMetadataProvider, execPath, NO_LIMIT, PathMapper.NOOP, 0);
+
+    assertThat(expanded.arguments()).containsExactly("--flagfile=output.txt-0.params");
+    assertThat(expanded.getParamFiles()).hasSize(1);
+    assertThat(expanded.getParamFiles().get(0).getParamFileArg())
+        .isEqualTo("--flagfile=output.txt-0.params");
+  }
+
+  @Test
   public void expand_paramFileCommandWithinLimits_returnsNoParamFile() throws Exception {
     CommandLines commandLines =
         CommandLines.builder()

--- a/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.CommandLines;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
@@ -330,6 +331,24 @@ public class AbstractSpawnStrategyTest {
             ParameterFileType.UNQUOTED);
     Spawn spawn =
         new SpawnBuilder("/bin/gcc", "@output/foo-0.params", "-o", "foo.o")
+            .withInput(paramFile)
+            .build();
+    ImmutableList<String> result = AbstractSpawnStrategy.expandParamFiles(spawn);
+    assertThat(result)
+        .containsExactly("/bin/gcc", "-lfoo", "-lbar", "-lbaz", "-o", "foo.o")
+        .inOrder();
+  }
+
+  @Test
+  public void testExpandParamFiles_expandsCustomParamFileReference() throws Exception {
+    CommandLines.ParamFileActionInput paramFile =
+        new CommandLines.ParamFileActionInput(
+            PathFragment.create("output/foo-0.params"),
+            "--param=output/foo-0.params",
+            ImmutableList.of("-lfoo", "-lbar", "-lbaz"),
+            ParameterFileType.UNQUOTED);
+    Spawn spawn =
+        new SpawnBuilder("/bin/gcc", "--param=output/foo-0.params", "-o", "foo.o")
             .withInput(paramFile)
             .build();
     ImmutableList<String> result = AbstractSpawnStrategy.expandParamFiles(spawn);

--- a/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
@@ -26,9 +26,10 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.CommandLines;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
+import com.google.devtools.build.lib.actions.ParameterFile.ParameterFileType;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnExecutedEvent;
 import com.google.devtools.build.lib.actions.SpawnResult;
@@ -310,6 +311,65 @@ public class AbstractSpawnStrategyTest {
     // Must only be called exactly once.
     verify(spawnRunner).exec(any(Spawn.class), any(SpawnExecutionContext.class));
     verify(entry).store(eq(result));
+  }
+
+  @Test
+  public void testExpandParamFiles_noParamFiles() throws Exception {
+    Spawn spawn =
+        new SpawnBuilder("/bin/gcc", "-c", "foo.c", "-o", "foo.o").build();
+    ImmutableList<String> result = AbstractSpawnStrategy.expandParamFiles(spawn);
+    assertThat(result).containsExactly("/bin/gcc", "-c", "foo.c", "-o", "foo.o").inOrder();
+  }
+
+  @Test
+  public void testExpandParamFiles_expandsParamFileReference() throws Exception {
+    CommandLines.ParamFileActionInput paramFile =
+        new CommandLines.ParamFileActionInput(
+            PathFragment.create("output/foo-0.params"),
+            ImmutableList.of("-lfoo", "-lbar", "-lbaz"),
+            ParameterFileType.UNQUOTED);
+    Spawn spawn =
+        new SpawnBuilder("/bin/gcc", "@output/foo-0.params", "-o", "foo.o")
+            .withInput(paramFile)
+            .build();
+    ImmutableList<String> result = AbstractSpawnStrategy.expandParamFiles(spawn);
+    assertThat(result)
+        .containsExactly("/bin/gcc", "-lfoo", "-lbar", "-lbaz", "-o", "foo.o")
+        .inOrder();
+  }
+
+  @Test
+  public void testExpandParamFiles_multipleParamFiles() throws Exception {
+    CommandLines.ParamFileActionInput paramFile1 =
+        new CommandLines.ParamFileActionInput(
+            PathFragment.create("output/foo-0.params"),
+            ImmutableList.of("-lfoo", "-lbar"),
+            ParameterFileType.UNQUOTED);
+    CommandLines.ParamFileActionInput paramFile2 =
+        new CommandLines.ParamFileActionInput(
+            PathFragment.create("output/foo-1.params"),
+            ImmutableList.of("src1.o", "src2.o"),
+            ParameterFileType.UNQUOTED);
+    Spawn spawn =
+        new SpawnBuilder("/bin/gcc", "@output/foo-0.params", "@output/foo-1.params", "-o", "foo.o")
+            .withInput(paramFile1)
+            .withInput(paramFile2)
+            .build();
+    ImmutableList<String> result = AbstractSpawnStrategy.expandParamFiles(spawn);
+    assertThat(result)
+        .containsExactly("/bin/gcc", "-lfoo", "-lbar", "src1.o", "src2.o", "-o", "foo.o")
+        .inOrder();
+  }
+
+  @Test
+  public void testExpandParamFiles_unmatchedAtSignNotExpanded() throws Exception {
+    // An argument starting with @ that doesn't match any param file should be left alone.
+    Spawn spawn =
+        new SpawnBuilder("/bin/gcc", "@some/other/file", "-o", "foo.o").build();
+    ImmutableList<String> result = AbstractSpawnStrategy.expandParamFiles(spawn);
+    assertThat(result)
+        .containsExactly("/bin/gcc", "@some/other/file", "-o", "foo.o")
+        .inOrder();
   }
 
   @Test

--- a/src/test/shell/integration/ui_test.sh
+++ b/src/test/shell/integration/ui_test.sh
@@ -456,6 +456,84 @@ function test_subcommand_notdefault {
   expect_not_log "dragons"
 }
 
+function test_expand_param_files_with_subcommands {
+  local pkg="pkg_param_expand"
+  mkdir -p "$pkg"
+  cat > "$pkg/rule.bzl" <<'EOF'
+def _impl(ctx):
+  out = ctx.outputs.out
+  args = ctx.actions.args()
+  args.add("--flag_from_param_file")
+  args.add("--another_flag_from_param_file")
+  args.use_param_file("@%s", use_always = True)
+  ctx.actions.run_shell(
+    outputs = [out],
+    arguments = [out.path, args],
+    command = 'touch "$1"',
+  )
+
+param_rule = rule(
+  implementation = _impl,
+  attrs = {},
+  outputs = {"out": "%{name}.out"},
+)
+EOF
+  cat > "$pkg/BUILD" <<'EOF'
+load(":rule.bzl", "param_rule")
+
+param_rule(name = "param_test1")
+param_rule(name = "param_test2")
+EOF
+
+  bazel build -s "//$pkg:param_test1" 2>$TEST_log \
+    || fail "bazel build failed"
+  expect_log "@.*\.params"
+  expect_not_log "flag_from_param_file"
+
+  bazel build -s --expand_param_files "//$pkg:param_test2" 2>$TEST_log \
+    || fail "bazel build failed"
+  expect_log "flag_from_param_file"
+  expect_log "another_flag_from_param_file"
+}
+
+function test_expand_param_files_with_verbose_failures {
+  local pkg="pkg_param_verbose"
+  mkdir -p "$pkg"
+  cat > "$pkg/rule.bzl" <<'EOF'
+def _impl(ctx):
+  args = ctx.actions.args()
+  args.add("--flag_from_param_file")
+  args.add("--another_flag_from_param_file")
+  args.use_param_file("@%s", use_always = True)
+  ctx.actions.run(
+    outputs = [ctx.outputs.out],
+    executable = "/bin/false",
+    arguments = [args],
+  )
+
+param_rule = rule(
+  implementation = _impl,
+  attrs = {},
+  outputs = {"out": "%{name}.out"},
+)
+EOF
+  cat > "$pkg/BUILD" <<'EOF'
+load(":rule.bzl", "param_rule")
+
+param_rule(name = "param_test")
+EOF
+
+  bazel build --verbose_failures "//$pkg:param_test" \
+    2>$TEST_log && fail "expected build failure" || true
+  expect_log "@.*\.params"
+  expect_not_log "flag_from_param_file"
+
+  bazel build --verbose_failures --expand_param_files "//$pkg:param_test" \
+    2>$TEST_log && fail "expected build failure" || true
+  expect_log "flag_from_param_file"
+  expect_log "another_flag_from_param_file"
+}
+
 function test_loading_progress {
   bazel clean || fail "${PRODUCT_NAME} clean failed"
   bazel test pkg:true 2>$TEST_log \

--- a/src/test/shell/integration/ui_test.sh
+++ b/src/test/shell/integration/ui_test.sh
@@ -465,7 +465,7 @@ def _impl(ctx):
   args = ctx.actions.args()
   args.add("--flag_from_param_file")
   args.add("--another_flag_from_param_file")
-  args.use_param_file("@%s", use_always = True)
+  args.use_param_file("--flagfile=%s", use_always = True)
   ctx.actions.run_shell(
     outputs = [out],
     arguments = [out.path, args],
@@ -487,13 +487,14 @@ EOF
 
   bazel build -s "//$pkg:param_test1" 2>$TEST_log \
     || fail "bazel build failed"
-  expect_log "@.*\.params"
+  expect_log "--flagfile=.*\.params"
   expect_not_log "flag_from_param_file"
 
   bazel build -s --expand_param_files "//$pkg:param_test2" 2>$TEST_log \
     || fail "bazel build failed"
   expect_log "flag_from_param_file"
   expect_log "another_flag_from_param_file"
+  expect_not_log "--flagfile=.*\.params"
 }
 
 function test_expand_param_files_with_verbose_failures {
@@ -504,11 +505,11 @@ def _impl(ctx):
   args = ctx.actions.args()
   args.add("--flag_from_param_file")
   args.add("--another_flag_from_param_file")
-  args.use_param_file("@%s", use_always = True)
-  ctx.actions.run(
+  args.use_param_file("--flagfile=%s", use_always = True)
+  ctx.actions.run_shell(
     outputs = [ctx.outputs.out],
-    executable = "/bin/false",
     arguments = [args],
+    command = "exit 1",
   )
 
 param_rule = rule(
@@ -525,13 +526,14 @@ EOF
 
   bazel build --verbose_failures "//$pkg:param_test" \
     2>$TEST_log && fail "expected build failure" || true
-  expect_log "@.*\.params"
+  expect_log "--flagfile=.*\.params"
   expect_not_log "flag_from_param_file"
 
   bazel build --verbose_failures --expand_param_files "//$pkg:param_test" \
     2>$TEST_log && fail "expected build failure" || true
   expect_log "flag_from_param_file"
   expect_log "another_flag_from_param_file"
+  expect_not_log "--flagfile=.*\.params"
 }
 
 function test_loading_progress {


### PR DESCRIPTION
With this new flag, params files in actions are expanded to their
arguments inline if you use `--subcommands` / `--verbose_failures`

Fixes https://github.com/bazelbuild/bazel/issues/15221
