### PR TITLE
Add query option to display full Starlark rule path when displaying kind

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/AbstractUnorderedFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/AbstractUnorderedFormatter.java
@@ -20,6 +20,8 @@ import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.graph.Digraph;
 import com.google.devtools.build.lib.graph.Node;
 import com.google.devtools.build.lib.packages.LabelPrinter;
+import com.google.devtools.build.lib.packages.Rule;
+import com.google.devtools.build.lib.packages.RuleClassId;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.query2.common.CommonQueryOptions;
 import com.google.devtools.build.lib.query2.engine.OutputFormatterCallback;
@@ -30,6 +32,15 @@ import java.io.OutputStream;
 import javax.annotation.Nullable;
 
 abstract class AbstractUnorderedFormatter extends OutputFormatter implements StreamedFormatter {
+
+  static String getKind(QueryOptions options, Target target) {
+    if (options.displayFullKind && target instanceof Rule rule) {
+      RuleClassId ruleClassId = rule.getRuleClassObject().getRuleClassId();
+      return ruleClassId.key() + Rule.targetKindSuffix();
+    }
+
+    return target.getTargetKind();
+  }
 
   @Override
   public void setOptions(

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/LabelOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/LabelOutputFormatter.java
@@ -44,13 +44,13 @@ class LabelOutputFormatter extends AbstractUnorderedFormatter {
   @Override
   public OutputFormatterCallback<Target> createPostFactoStreamCallback(
       OutputStream out, final QueryOptions options, LabelPrinter labelPrinter) {
-    return new TextOutputFormatterCallback<Target>(out) {
+    return new TextOutputFormatterCallback<>(out) {
       @Override
       public void processOutput(Iterable<Target> partialResult) throws IOException {
         String lineTerm = options.getLineTerminator();
         for (Target target : partialResult) {
           if (showKind) {
-            writer.append(target.getTargetKind());
+            writer.append(getKind(options, target));
             writer.append(' ');
           }
           Label label = target.getLabel();

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/LocationOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/LocationOutputFormatter.java
@@ -75,7 +75,7 @@ class LocationOutputFormatter extends AbstractUnorderedFormatter {
   @Override
   public OutputFormatterCallback<Target> createPostFactoStreamCallback(
       OutputStream out, final QueryOptions options, LabelPrinter labelPrinter) {
-    return new TextOutputFormatterCallback<Target>(out) {
+    return new TextOutputFormatterCallback<>(out) {
 
       @Override
       public void processOutput(Iterable<Target> partialResult) throws IOException {
@@ -84,7 +84,7 @@ class LocationOutputFormatter extends AbstractUnorderedFormatter {
           writer
               .append(FormatUtils.getLocation(target, relativeLocations))
               .append(": ")
-              .append(target.getTargetKind())
+              .append(getKind(options, target))
               .append(" ")
               .append(labelPrinter.toString(target.getLabel()))
               .append(lineTerm);

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOptions.java
@@ -44,6 +44,16 @@ public class QueryOptions extends CommonQueryOptions {
   public String outputFormat;
 
   @Option(
+      name = "output:display_full_kind",
+      defaultValue = "False",
+      documentationCategory = OptionDocumentationCategory.QUERY,
+      effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
+      help =
+          "When displaying rule kind, whether to display the short rule name, or the full name for"
+              + " Starlark rules.")
+  public boolean displayFullKind;
+
+  @Option(
       name = "null",
       defaultValue = "null",
       expansion = {"--line_terminator_null=true"},

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/XmlOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/XmlOutputFormatter.java
@@ -149,7 +149,7 @@ class XmlOutputFormatter extends AbstractUnorderedFormatter {
     Element elem;
     if (target instanceof Rule rule) {
       elem = doc.createElement("rule");
-      elem.setAttribute("class", rule.getRuleClass());
+      elem.setAttribute("class", getRuleClass(queryOptions, rule));
       for (Attribute attr : rule.getAttributes()) {
         if (rule.isAttributeValueExplicitlySpecified(attr) || queryOptions.xmlShowDefaultValues) {
           // TODO(b/162524370): mayTreatMultipleAsNone should be true for types that drop multiple
@@ -252,6 +252,15 @@ class XmlOutputFormatter extends AbstractUnorderedFormatter {
 
     elem.setAttribute("location", location);
     return elem;
+  }
+
+  // This is distinct from AbstractUnorderedFormatter.getKind because it should **not** have the
+  // " rule" suffix expected from --output=label_kind and --output=location.
+  private static String getRuleClass(QueryOptions queryOptions, Rule rule) {
+    if (queryOptions.displayFullKind) {
+      return rule.getRuleClassObject().getRuleClassId().key();
+    }
+    return rule.getRuleClass();
   }
 
   private static void addPackageGroupsToElement(

--- a/src/test/shell/integration/bazel_query_test.sh
+++ b/src/test/shell/integration/bazel_query_test.sh
@@ -524,7 +524,7 @@ EOF
   done
 }
 
-function test_location_output_relative_locations() {
+function test_location_output() {
   rm -rf foo
   mkdir -p foo
   cat > foo/BUILD <<EOF
@@ -534,15 +534,40 @@ EOF
 
   bazel query --output=location '//foo' >& $TEST_log || fail "Expected success"
   expect_log "${TEST_TMPDIR}/.*/foo/BUILD"
+  expect_log " sh_library rule"
   expect_log "//foo:foo"
+}
+
+function test_location_output_relative_locations() {
+  rm -rf foo
+  mkdir -p foo
+  cat > foo/BUILD <<EOF
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
+sh_library(name='foo')
+EOF
 
   bazel query --output=location --relative_locations '//foo' >& $TEST_log || fail "Expected success"
   # Query with --relative_locations should not show full path
   expect_not_log "${TEST_TMPDIR}/.*/foo/BUILD"
   expect_log "^foo/BUILD"
+  expect_log " sh_library rule"
   expect_log "//foo:foo"
 }
 
+function test_location_output_display_full_kind() {
+  rm -rf foo
+  mkdir -p foo
+  cat > foo/BUILD <<EOF
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
+sh_library(name='foo')
+EOF
+
+  bazel query --output=location \
+      --output:display_full_kind \
+      '//foo' >& $TEST_log || fail "Expected success"
+  expect_log "@@rules_shell.//shell/private:sh_library.bzl%sh_library rule"
+  expect_log "//foo:foo"
+}
 function test_location_output_source_files() {
   add_rules_python "MODULE.bazel"
   rm -rf foo
@@ -599,11 +624,46 @@ EOF
   LC_CTYPE=C expect_not_log "${TEST_TMPDIR}/.*/foo/BUILD:[0-9]*:[0-9]*" $TEST_log
 }
 
+function test_xml_output() {
+  add_rules_python "MODULE.bazel"
+  rm -rf foo
+  mkdir -p foo
+  cat > foo/BUILD <<EOF
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
+
+sh_library(name = "main")
+EOF
+  touch foo/main.py || fail "Could not touch foo/main.py"
+
+  bazel query --output=xml \
+    '//foo:main' >& $TEST_log || fail "Expected success"
+  expect_log "<rule class=\"sh_library\""
+  expect_log "location=\"${TEST_TMPDIR}/.*/foo/BUILD:[0-9]*:[0-9]*"
+}
+
+function test_xml_output_display_full_kind() {
+  add_rules_python "MODULE.bazel"
+  rm -rf foo
+  mkdir -p foo
+  cat > foo/BUILD <<EOF
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
+
+sh_library(name = "main")
+EOF
+
+  bazel query --output=xml \
+    --output:display_full_kind \
+    '//foo:main' >& $TEST_log || fail "Expected success"
+  expect_log "<rule class=\"@@rules_shell+//shell/private:sh_library.bzl%sh_library\""
+  expect_log "location=\"${TEST_TMPDIR}/.*/foo/BUILD:[0-9]*:[0-9]*"
+}
+
 function test_xml_output_source_files() {
   add_rules_python "MODULE.bazel"
   rm -rf foo
   mkdir -p foo
   cat > foo/BUILD <<EOF
+# Use py_binary to have a source file.
 load('@rules_python//python:py_binary.bzl', 'py_binary')
 
 py_binary(
@@ -1446,6 +1506,39 @@ EOF
   # Force a C locale to ensure that grep matches the characters byte-by-byte
   # even though the proto file is not valid UTF-8.
   LC_CTYPE=C grep -q "//foo:äöüÄÖÜß🌱" $TEST_log || fail "Expected Unicode target in query output"
+}
+
+function test_label_kind() {
+  mkdir -p foo bar || fail "Couldn't make directories"
+  cat <<'EOF' > foo/BUILD || fail "Couldn't write BUILD file"
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
+platform(name = 'p')
+sh_library(name = 'b')
+EOF
+  touch bar/BUILD || fail "Couldn't write BUILD file"
+  bazel query --output=label_kind \
+      '//foo:all' \
+      >& "$TEST_log" || fail "Expected failure"
+  expect_log "sh_library rule //foo:b"
+  expect_log "platform rule //foo:p"
+}
+
+function test_label_kind_display_full_kind() {
+  mkdir -p foo bar || fail "Couldn't make directories"
+  cat <<'EOF' > foo/BUILD || fail "Couldn't write BUILD file"
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
+platform(name = 'p')
+sh_library(name = 'b')
+EOF
+  touch bar/BUILD || fail "Couldn't write BUILD file"
+  bazel query --keep_going --output=label_kind \
+      --output:display_full_kind \
+      '//foo:all' \
+      >& "$TEST_log" || fail "Expected failure"
+  # Starlark rules show the full label to the defining bzl file.
+  expect_log "@@rules_shell.//shell/private:sh_library.bzl%sh_library rule //foo:b"
+  # Native rules only show the name.
+  expect_log "platform rule //foo:p"
 }
 
 run_suite "${PRODUCT_NAME} query tests"


### PR DESCRIPTION
This applies to `--output=label_kind`, `--output=location`, and `--output=xml`.

Without the flag:
```
$ bazel query --output=label_kind -- //foo:all
sh_library rule //foo:lib
platform rule //foo:platform
```

With the flag:
```
$ bazel query --output=label_kind --output:display_full_kind -- //foo:all
@@rules_shell+//shell/private:sh_library.bzl%sh_library rule //foo:lib
platform rule //foo:platform
```

RELNOTES: Adds `--output:display_full_kind` for query options to display the full kind for Starlark rules with the `label_kind`, `location`, and `xml` output formats.
