### PR TITLE
Include `rctx.os.{name,arch}` in the pre declared inputs hash

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DigestWriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DigestWriter.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import com.google.devtools.build.skyframe.SkyFunctionException.Transience;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.StarlarkSemantics;
@@ -184,7 +185,12 @@ public class DigestWriter {
             .addString(repoDefinition.name())
             .addString(
                 GsonTypeAdapterUtil.SINGLE_EXTENSION_USAGES_VALUE_GSON.toJson(
-                    repoDefinition.attrValues()));
+                    repoDefinition.attrValues()))
+            // This info is accessible via rctx.os.{name,arch} and can also influence the
+            // result of a repo rule in subtle ways (e.g. behavior of host tools, line breaks,
+            // etc).
+            .addString(System.getProperty("os.name").toLowerCase(Locale.ROOT))
+            .addString(System.getProperty("os.arch").toLowerCase(Locale.ROOT));
     fp.addInt(environInputs.size());
     environInputs.forEach(
         (key, value) -> fp.addString(key.toString()).addNullableString(value.orElse(null)));


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
Fixes https://github.com/bazel-contrib/rules_go/issues/4581

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: The local and remote repo contents cache now include the host OS and CPU architecture in the cache key.
