### PR TITLE
Remove `.d` inclusion validation logic

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
@@ -712,7 +712,7 @@ public class CcStarlarkInternal implements StarlarkValue {
       Object modmapFile,
       Object modmapInputFile,
       Sequence<?> additionalOutputs,
-      boolean needsIncludeValidation,
+      boolean unusedNeedsIncludeValidation,
       String toolchainType)
       throws EvalException, TypeException {
     CcActionContext ccActionContext;
@@ -747,7 +747,6 @@ public class CcStarlarkInternal implements StarlarkValue {
             dwoFile,
             ltoIndexingFile,
             usePic,
-            needsIncludeValidation,
             ccActionContext.getExecutionInfo());
     if (additionalCompilationInputsSet instanceof Depset additionalCompilationInputsDepset) {
       builder.addMandatoryInputs(additionalCompilationInputsDepset.getSet(Artifact.class));
@@ -922,7 +921,7 @@ public class CcStarlarkInternal implements StarlarkValue {
       Object diagnosticsTreeArtifact,
       Object ltoIndexingTreeArtifact,
       Object coptsFilterObject,
-      boolean needsIncludeValidation,
+      boolean unusedNeedsIncludeValidation,
       String toolchainType)
       throws RuleErrorException, EvalException {
     CoptsFilter coptsFilter =
@@ -970,7 +969,6 @@ public class CcStarlarkInternal implements StarlarkValue {
             /* dwoFile= */ null,
             /* ltoIndexingFile= */ null,
             usePic,
-            needsIncludeValidation,
             executionInfo);
     RuleContext ruleContext = starlarkRuleContext.getRuleContext();
     SpecialArtifact sourceArtifact = (SpecialArtifact) source;
@@ -1010,7 +1008,6 @@ public class CcStarlarkInternal implements StarlarkValue {
       Object dwoFile,
       Object ltoIndexingFile,
       boolean usePic,
-      boolean needsIncludeValidation,
       ImmutableMap<String, String> executionInfo)
       throws EvalException {
     CppCompileActionBuilder builder =
@@ -1038,7 +1035,6 @@ public class CcStarlarkInternal implements StarlarkValue {
         nullIfNone(dotdFile, Artifact.class),
         nullIfNone(diagnosticsFile, Artifact.class));
     builder.setPicMode(usePic);
-    builder.setNeedsIncludeValidation(needsIncludeValidation);
     return builder;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -103,7 +103,6 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -146,7 +145,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
   private final boolean shouldScanIncludes;
   private final boolean usePic;
   private final boolean useHeaderModules;
-  private final boolean needsIncludeValidation;
 
   private final CcCompilationContext ccCompilationContext;
   private final ImmutableList<Artifact> builtinIncludeFiles;
@@ -265,7 +263,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
       ImmutableList<Artifact> additionalIncludeScanningRoots,
       ImmutableMap<String, String> executionInfo,
       String actionName,
-      boolean needsIncludeValidation,
       ImmutableList<PathFragment> builtInIncludeDirectories,
       @Nullable Artifact grepIncludes,
       ImmutableList<Artifact> additionalOutputs,
@@ -301,7 +298,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     this.executionInfo = executionInfo;
     this.actionName = actionName;
     this.featureConfiguration = featureConfiguration;
-    this.needsIncludeValidation = needsIncludeValidation;
     this.builtInIncludeDirectories = builtInIncludeDirectories;
     this.additionalInputs = null;
     this.usedModules = null;
@@ -356,7 +352,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
       boolean shouldScanIncludes,
       boolean usePic,
       boolean useHeaderModules,
-      boolean needsIncludeValidation,
       CcCompilationContext ccCompilationContext,
       ImmutableList<Artifact> builtinIncludeFiles,
       ImmutableList<Artifact> additionalIncludeScanningRoots,
@@ -382,7 +377,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     this.shouldScanIncludes = shouldScanIncludes;
     this.usePic = usePic;
     this.useHeaderModules = useHeaderModules;
-    this.needsIncludeValidation = needsIncludeValidation;
     this.ccCompilationContext = ccCompilationContext;
     this.builtinIncludeFiles = builtinIncludeFiles;
     this.additionalIncludeScanningRoots = additionalIncludeScanningRoots;
@@ -654,11 +648,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
       }
       commandLineKey = computeCommandLineKey(options);
       ImmutableList<PathFragment> systemIncludeDirs = getSystemIncludeDirs(options);
-      boolean siblingLayout =
-          actionExecutionContext
-              .getOptions()
-              .getOptions(BuildLanguageOptions.class)
-              .experimentalSiblingRepositoryLayout;
       if (!shouldScanIncludes) {
         usedCpp20Modules = computeUsedCpp20Modules(actionExecutionContext);
         // When not actually doing include scanning, add all prunable headers to additionalInputs.
@@ -670,9 +659,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
                 .addTransitive(additionalPrunableHeaders)
                 .addAll(usedCpp20Modules)
                 .build();
-        if (needsIncludeValidation) {
-          verifyActionIncludePaths(systemIncludeDirs, siblingLayout);
-        }
         return additionalInputs;
       }
       IncludeScanningHeaderData.Builder includeScanningHeaderDataBuilder =
@@ -682,11 +668,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
               useHeaderModules);
       if (includeScanningHeaderDataBuilder == null) {
         return null;
-      }
-      // In theory, we could verify include paths even earlier, but we want to avoid the restart
-      // above necessitating a double-execution.
-      if (needsIncludeValidation) {
-        verifyActionIncludePaths(systemIncludeDirs, siblingLayout);
       }
       IncludeScanningHeaderData includeScanningHeaderData =
           includeScanningHeaderDataBuilder
@@ -1088,76 +1069,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     return mergeMaps(super.getExecutionInfo(), executionInfo);
   }
 
-  private static boolean validateInclude(
-      Set<Artifact> allowedIncludes, Iterable<PathFragment> ignoreDirs, Artifact include) {
-    // Only declared modules are added to an action and so they are always valid.
-    return include.isFileType(CppFileTypes.CPP_MODULE)
-        ||
-        // TODO(b/145253507): Exclude objc module maps from check, due to bad interaction with
-        // local_objc_modules feature.
-        include.isFileType(CppFileTypes.OBJC_MODULE_MAP)
-        ||
-        // It's a declared include/
-        allowedIncludes.contains(include)
-        ||
-        // Ignore headers from built-in include directories.
-        FileSystemUtils.startsWithAny(include.getExecPath(), ignoreDirs);
-  }
-
-  /**
-   * Enforce that the includes actually visited during the compile were properly declared in the
-   * rules.
-   *
-   * <p>The technique is to walk through all of the reported includes that gcc emits into the .d
-   * file, and verify that they came from acceptable relative include directories. This is done in
-   * two steps:
-   *
-   * <p>First, each included file is stripped of any include path prefix from {@code
-   * quoteIncludeDirs} to produce an effective relative include dir+name.
-   *
-   * <p>Second, the remaining directory is looked up in {@code declaredIncludeDirs}, a list of
-   * acceptable dirs. This list contains a set of dir fragments that have been calculated by the
-   * configured target to be allowable for inclusion by this source. If no match is found, an error
-   * is reported and an exception is thrown.
-   *
-   * @throws ActionExecutionException iff there was an undeclared dependency
-   */
-  @VisibleForTesting
-  public void validateInclusions(
-      ActionExecutionContext actionExecutionContext, NestedSet<Artifact> inputsForValidation)
-      throws ActionExecutionException {
-    if (!needsIncludeValidation) {
-      return;
-    }
-    IncludeProblems errors = new IncludeProblems();
-    Set<Artifact> allowedIncludes = new HashSet<>();
-    allowedIncludes.addAll(mandatoryInputs.toList());
-    allowedIncludes.addAll(ccCompilationContext.getDeclaredIncludeSrcs().toList());
-    allowedIncludes.addAll(additionalPrunableHeaders.toList());
-
-    Iterable<PathFragment> ignoreDirs =
-        cppConfiguration().isStrictSystemIncludes()
-            ? getBuiltInIncludeDirectories()
-            : getValidationIgnoredDirs();
-
-    // Copy the nested sets to hash sets for fast contains checking, but do so lazily.
-    // Avoid immutable sets here to limit memory churn.
-    for (Artifact input : inputsForValidation.toList()) {
-      if (!validateInclude(allowedIncludes, ignoreDirs, input)) {
-        errors.add(input.getExecPath().toString());
-      }
-    }
-    errors.assertProblemFree(
-        "undeclared inclusion(s) in rule '"
-            + this.getOwner().getLabel()
-            + "':\n"
-            + "this rule is missing dependency declarations for the following files "
-            + "included by '"
-            + getSourceFile().prettyPrint()
-            + "':",
-        this);
-  }
-
   private Iterable<PathFragment> getValidationIgnoredDirs() {
     List<PathFragment> cxxSystemIncludeDirs = getBuiltInIncludeDirectories();
     return Iterables.concat(
@@ -1412,9 +1323,9 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
 
     /*
      * getArguments() above captures all changes which affect the compilation command and hence the
-     * contents of the object file. But we need to also make sure that we re-execute the action if
-     * any of the fields that affect whether {@link #validateInclusions} will report an error or
-     * warning have changed, otherwise we might miss some errors.
+     * contents of the object file. Builtin include directories also influence post-processing of
+     * discovered includes because they determine which absolute headers are treated as system
+     * headers and ignored for input discovery.
      */
     fp.addPaths(builtInIncludeDirectories);
 
@@ -1553,7 +1464,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
               siblingRepositoryLayout,
               pathMapper);
       updateActionInputs(discoveredInputs);
-      validateInclusions(actionExecutionContext, discoveredInputs);
       return ActionResult.create(spawnResults);
     }
 
@@ -1582,10 +1492,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     }
     updateActionInputs(discoveredInputs);
 
-    // hdrs_check: This cannot be switched off for C++ build actions,
-    // because doing so would allow for incorrect builds.
-    // HeadersCheckingMode.NONE should only be used for ObjC build actions.
-    validateInclusions(actionExecutionContext, discoveredInputs);
     return ActionResult.create(spawnResults);
   }
 
@@ -1786,7 +1692,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     return HeaderDiscovery.discoverInputsFromDependencies(
         this,
         getSourceFile(),
-        needsIncludeValidation,
         ImmutableList.<Path>builderWithExpectedSize(stdoutDeps.size() + stderrDeps.size())
             .addAll(stdoutDeps)
             .addAll(stderrDeps)
@@ -1812,7 +1717,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     return HeaderDiscovery.discoverInputsFromDependencies(
         this,
         getSourceFile(),
-        needsIncludeValidation,
         processDepset(actionExecutionContext, execRoot, dotDContents).getDependencies(),
         getPermittedSystemIncludePrefixes(execRoot),
         getAllowedDerivedInputs(),

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
@@ -76,7 +76,6 @@ public final class CppCompileActionBuilder implements StarlarkValue {
   private NestedSet<Artifact> additionalPrunableHeaders =
       NestedSetBuilder.emptySet(Order.STABLE_ORDER);
   private ImmutableList<Artifact> additionalOutputs = ImmutableList.of();
-  private boolean needsIncludeValidation;
 
   // New fields need to be added to the copy constructor.
 
@@ -131,7 +130,6 @@ public final class CppCompileActionBuilder implements StarlarkValue {
     this.ccToolchain = other.ccToolchain;
     this.actionName = other.actionName;
     this.additionalOutputs = other.additionalOutputs;
-    this.needsIncludeValidation = other.needsIncludeValidation;
     this.moduleFiles = other.moduleFiles;
     this.modmapFile = other.modmapFile;
     this.modmapInputFile = other.modmapInputFile;
@@ -178,12 +176,6 @@ public final class CppCompileActionBuilder implements StarlarkValue {
   @CanIgnoreReturnValue
   public CppCompileActionBuilder setAdditionalOutputs(ImmutableList<Artifact> additionalOutputs) {
     this.additionalOutputs = additionalOutputs;
-    return this;
-  }
-
-  @CanIgnoreReturnValue
-  public CppCompileActionBuilder setNeedsIncludeValidation(boolean needsIncludeValidation) {
-    this.needsIncludeValidation = needsIncludeValidation;
     return this;
   }
 
@@ -336,7 +328,6 @@ public final class CppCompileActionBuilder implements StarlarkValue {
         ImmutableList.copyOf(additionalIncludeScanningRoots),
         ImmutableMap.copyOf(executionInfo),
         actionName,
-        needsIncludeValidation,
         getBuiltinIncludeDirectories(),
         ccToolchain.getGrepIncludes(),
         additionalOutputs,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
@@ -38,8 +38,7 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**
- * HeaderDiscovery checks whether all header files that a compile action uses are actually declared
- * as inputs.
+ * HeaderDiscovery maps dynamically discovered include paths back to input artifacts.
  *
  * <p>Tree artifacts: a tree artifact with path P causes any header file prefixed by P to be
  * accepted. Testing whether a used header file is prefixed by any tree artifact is linear search,
@@ -56,14 +55,10 @@ final class HeaderDiscovery {
    * has run.
    *
    * <p>Artifacts are considered inputs but not "mandatory" inputs.
-   *
-   * @throws ActionExecutionException iff the .d is missing (when required), malformed, or has
-   *     unresolvable included artifacts.
    */
   static NestedSet<Artifact> discoverInputsFromDependencies(
       Action action,
       Artifact sourceFile,
-      boolean shouldValidateInclusions,
       Collection<Path> dependencies,
       List<Path> permittedSystemIncludePrefixes,
       NestedSet<Artifact> allowedDerivedInputs,
@@ -97,7 +92,6 @@ final class HeaderDiscovery {
     return runDiscovery(
         action,
         sourceFile,
-        shouldValidateInclusions,
         dependencies,
         permittedSystemIncludePrefixes,
         regularDerivedArtifacts,
@@ -111,7 +105,6 @@ final class HeaderDiscovery {
   private static NestedSet<Artifact> runDiscovery(
       Action action,
       Artifact sourceFile,
-      boolean shouldValidateInclusions,
       Collection<Path> dependencies,
       List<Path> permittedSystemIncludePrefixes,
       Map<PathFragment, Artifact> regularDerivedArtifacts,
@@ -147,9 +140,6 @@ final class HeaderDiscovery {
                 .getName()
                 .equals(execRoot.getBaseName());
 
-    // Check inclusions.
-    IncludeProblems absolutePathProblems = new IncludeProblems();
-    IncludeProblems unresolvablePathProblems = new IncludeProblems();
     // Absolute includes from system paths are ignored. On Windows, which has a case-insensitive
     // file system by default, the paths as reported by the compiler may differ in casing from
     // those listed by the toolchain.
@@ -177,11 +167,7 @@ final class HeaderDiscovery {
               LabelConstants.EXPERIMENTAL_EXTERNAL_PATH_PREFIX.getRelative(
                   execPath.relativeTo(execRoot.getParentDirectory()));
         } else {
-          // Since gcc is given only relative paths on the command line, non-builtin include paths
-          // here should never be absolute. If they are, it's probably due to a non-hermetic
-          // #include,
-          // and we should stop the build with an error.
-          absolutePathProblems.add(execPathFragment.getPathString());
+          // Ignore absolute paths outside the execution root. They do not map to declared inputs.
           continue;
         }
       }
@@ -213,31 +199,7 @@ final class HeaderDiscovery {
           findOwningTreeArtifact(execPathFragment, treeArtifacts, pathMapper);
       if (treeArtifact != null) {
         inputs.add(treeArtifact);
-      } else {
-        // Record a problem if we see files that we can't resolve, likely caused by undeclared
-        // includes or illegal include constructs.
-        unresolvablePathProblems.add(execPathFragment.getPathString());
       }
-    }
-    if (shouldValidateInclusions) {
-      absolutePathProblems.assertProblemFree(
-          "absolute path inclusion(s) found in rule '"
-              + action.getOwner().getLabel()
-              + "':\n"
-              + "the source file '"
-              + sourceFile.prettyPrint()
-              + "' includes the following non-builtin files with absolute paths "
-              + "(if these are builtin files, make sure these paths are in your toolchain):",
-          action);
-      unresolvablePathProblems.assertProblemFree(
-          "undeclared inclusion(s) in rule '"
-              + action.getOwner().getLabel()
-              + "':\n"
-              + "this rule is missing dependency declarations for the following files "
-              + "included by '"
-              + sourceFile.prettyPrint()
-              + "':",
-          action);
     }
     return inputs.build();
   }

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscoveryTest.java
@@ -14,7 +14,7 @@
 
 package com.google.devtools.build.lib.rules.cpp;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableList;
@@ -49,38 +49,36 @@ public final class HeaderDiscoveryTest {
       ArtifactRoot.asDerivedRoot(execRoot, RootType.OUTPUT, DERIVED_SEGMENT);
 
   @Test
-  public void errorsWhenMissingHeaders() {
+  public void ignoresMissingHeaders() throws Exception {
     ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
 
-    assertThrows(
-        ActionExecutionException.class,
-        () ->
-            checkHeaderInclusion(
-                artifactResolver,
-                ImmutableList.of(
-                    derivedRoot.getRelative("tree_artifact1/foo.h"),
-                    derivedRoot.getRelative("tree_artifact1/subdir/foo.h")),
-                NestedSetBuilder.create(
-                    Order.STABLE_ORDER, treeArtifact(derivedRoot.getRelative("tree_artifact2")))));
+    NestedSet<Artifact> discoveredInputs =
+        checkHeaderInclusion(
+            artifactResolver,
+            ImmutableList.of(
+                derivedRoot.getRelative("tree_artifact1/foo.h"),
+                derivedRoot.getRelative("tree_artifact1/subdir/foo.h")),
+            NestedSetBuilder.create(
+                Order.STABLE_ORDER, treeArtifact(derivedRoot.getRelative("tree_artifact2"))));
+
+    assertTrue(discoveredInputs.toList().isEmpty());
   }
 
-  private void checkHeaderInclusion(
+  private NestedSet<Artifact> checkHeaderInclusion(
       ArtifactResolver artifactResolver,
       ImmutableList<Path> dependencies,
       NestedSet<Artifact> includedHeaders)
       throws ActionExecutionException {
-    var unused =
-        HeaderDiscovery.discoverInputsFromDependencies(
-            new ActionsTestUtil.NullAction(),
-            ActionsTestUtil.createArtifact(artifactRoot, derivedRoot.getRelative("foo.cc")),
-            /* shouldValidateInclusions= */ true,
-            dependencies,
-            /* permittedSystemIncludePrefixes= */ ImmutableList.of(),
-            includedHeaders,
-            execRoot,
-            artifactResolver,
-            /* siblingRepositoryLayout= */ false,
-            PathMapper.NOOP);
+    return HeaderDiscovery.discoverInputsFromDependencies(
+        new ActionsTestUtil.NullAction(),
+        ActionsTestUtil.createArtifact(artifactRoot, derivedRoot.getRelative("foo.cc")),
+        dependencies,
+        /* permittedSystemIncludePrefixes= */ ImmutableList.of(),
+        includedHeaders,
+        execRoot,
+        artifactResolver,
+        /* siblingRepositoryLayout= */ false,
+        PathMapper.NOOP);
   }
 
   private SpecialArtifact treeArtifact(Path path) {

--- a/src/test/py/bazel/cc_import_test.py
+++ b/src/test/py/bazel/cc_import_test.py
@@ -234,17 +234,11 @@ class CcImportTest(test_base.TestBase):
     )
     self.assertEqual(stdout[0], 'HelloWorld')
 
-  def testCcImportHeaderCheck(self):
+  def testCcImportMissingHeaderDeclarationDoesNotFailBuild(self):
     self.createProjectFiles(provide_header=False)
-    # Build should fail, because lib/a.h is not declared in BUILD file, disable
-    # sandbox so that bazel produces same error across different platforms.
-    exit_code, _, stderr = self.RunBazel(
-        ['build', '//main:B', '--spawn_strategy=standalone'], allow_failure=True
+    self.RunBazel(
+        ['build', '//main:B', '--spawn_strategy=standalone']
     )
-    self.AssertExitCode(exit_code, 1, stderr)
-    self.assertIn('this rule is missing dependency declarations for the'
-                  ' following files included by \'main/b.cc\':',
-                  ''.join(stderr))
 
 
 if __name__ == '__main__':

--- a/src/test/shell/bazel/bazel_sandboxing_cpp_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_cpp_test.sh
@@ -202,7 +202,7 @@ function test_standalone_cpp_build_rebuilds_on_change() {
     || fail "Did not print expected string 'greetings from the modified header'"
 }
 
-function test_standalone_cpp_build_catches_missing_header() {
+function test_standalone_cpp_build_allows_undeclared_header() {
   cat << 'EOF' > examples/cpp/BUILD
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 cc_library(
@@ -212,10 +212,7 @@ cc_library(
 EOF
 
   bazel build $sandbox_flags --spawn_strategy=standalone //examples/cpp:hello-lib &> $TEST_log \
-    && fail "build should not have succeeded with missing header file"
-
-  fgrep "undeclared inclusion(s) in rule '//examples/cpp:hello-lib'" $TEST_log \
-    || fail "could not find 'undeclared inclusion' error message in bazel output"
+    || fail "build should have succeeded with undeclared header file"
 }
 
 # TODO(philwo) disabled for the same reason as test_sandboxed_cpp_build_catches_header_only_in_srcs

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1057,16 +1057,13 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 cc_library(
     name = "lib",
     srcs = ["lib.cc"],
-    # missing header declaration
+    # intentionally missing header declaration
     visibility = ["//baz:__subpackages__"],
 )
 EOF
 
   bazel build --experimental_sibling_repository_layout --spawn_strategy=standalone //external/foo:lib &> "$TEST_log" \
-    && fail "build should not have succeeded with missing header file"
-
-  expect_log "undeclared inclusion(s) in rule '//external/foo:lib'" \
-     "could not find 'undeclared inclusion' error message in bazel output"
+    || fail "expected build success"
 }
 
 function test_sibling_repository_layout_include_external_repo_output() {


### PR DESCRIPTION
This entirely removes the logic that results in this error:

```
this rule is missing dependency declarations for the following files included by 'f.c':
  'bazel-out/k8-fastbuild/bin/dep1/_virtual_includes/dep1_h/some_inc.h'
```

Specifically this feature validated that you aren't depending on files that aren't declared in your input tree. This same concern is handled better by a few different features:

- `layering_check` is a much more strict and complete version of this. You should use this if possible (not possible with `gcc`)
- sandboxing generally validates this, although it doesn't handle absolute paths that are referenced absolutely
- using remote exec generally solves this on a per-machine variance level since you have to have the same things installed there

This feature is tied up in a lot of issues:

- Currently failing this check is cached, even though this check validates non-hermetic behavior, which makes it very difficult to recover from
- There is no plan on how this logic would be moved to starlark
- There's no way to disable this
- Installing new system headers requires somehow invalidating your cc toolchain in order to add the new headers to the allowed list that is used for this