### PR TITLE
[9.1.0] Fix macOS getconf in server (https://github.com/bazelbuild/bazel/pull/29131)

### DIFF
--- a/src/main/cpp/option_processor_unix.cc
+++ b/src/main/cpp/option_processor_unix.cc
@@ -15,6 +15,11 @@
 #include <string>
 #include <vector>
 
+#ifdef __APPLE__
+#include <sys/syslimits.h>
+#include <unistd.h>
+#endif
+
 #include "src/main/cpp/option_processor-internal.h"
 
 // On OSX, there apparently is no header that defines this.
@@ -29,6 +34,19 @@ std::vector<std::string> GetProcessedEnv() {
   for (char** env = environ; *env != nullptr; env++) {
     processed_env.emplace_back(*env);
   }
+
+#ifdef __APPLE__
+  for (int key : {_CS_DARWIN_USER_TEMP_DIR, _CS_DARWIN_USER_CACHE_DIR}) {
+    char buf[PATH_MAX];
+    if (confstr(key, buf, sizeof(buf)) > 0) {
+      const char* name = (key == _CS_DARWIN_USER_TEMP_DIR)
+                             ? "DARWIN_USER_TEMP_DIR"
+                             : "DARWIN_USER_CACHE_DIR";
+      processed_env.push_back(std::string(name) + "=" + buf);
+    }
+  }
+#endif
+
   return processed_env;
 }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
@@ -32,7 +32,6 @@ import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
 import com.google.devtools.build.lib.shell.Command;
 import com.google.devtools.build.lib.shell.CommandException;
-import com.google.devtools.build.lib.shell.CommandResult;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.StringEncoding;
 import com.google.devtools.build.lib.vfs.FileSystem;
@@ -52,10 +51,6 @@ import javax.annotation.Nullable;
 final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
-
-  /** Path to the {@code getconf} system tool to use. */
-  @VisibleForTesting
-  static String getconfBinary = "/usr/bin/getconf";
 
   /** Path to the {@code sandbox-exec} system tool to use. */
   @VisibleForTesting
@@ -124,7 +119,7 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
    * @param sandboxBase path to the sandbox base directory
    */
   DarwinSandboxedSpawnRunner(CommandEnvironment cmdEnv, Path sandboxBase, TreeDeleter treeDeleter)
-      throws IOException, InterruptedException {
+      throws IOException {
     super(cmdEnv);
     this.execRoot = cmdEnv.getExecRoot();
     this.allowNetwork = SandboxHelpers.shouldAllowNetwork(cmdEnv.getOptions());
@@ -148,8 +143,7 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     }
   }
 
-  private ImmutableSet<Path> getAlwaysWritableDirs(FileSystem fs)
-      throws IOException, InterruptedException {
+  private ImmutableSet<Path> getAlwaysWritableDirs(FileSystem fs) throws IOException {
     HashSet<Path> writableDirs = new HashSet<>();
 
     addPathToSetIfExists(fs, writableDirs, "/dev");
@@ -158,9 +152,12 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     addPathToSetIfExists(fs, writableDirs, "/private/var/tmp");
 
     // On macOS, processes may write to not only $TMPDIR but also to two other temporary
-    // directories. We have to get their location by calling "getconf".
-    addPathToSetIfExists(fs, writableDirs, getConfStr("DARWIN_USER_TEMP_DIR"));
-    addPathToSetIfExists(fs, writableDirs, getConfStr("DARWIN_USER_CACHE_DIR"));
+    // directories. We get their values from from getconf from the client. This comes
+    // from the client instead of being computed here because after logging out and back
+    // in getconf no longer works when run from a server process from a previous user
+    // session. See https://github.com/bazelbuild/bazel/issues/7692.
+    addPathToSetIfExists(fs, writableDirs, clientEnv.get("DARWIN_USER_TEMP_DIR"));
+    addPathToSetIfExists(fs, writableDirs, clientEnv.get("DARWIN_USER_CACHE_DIR"));
     // We don't add any value for $TMPDIR here, instead we compute its value later in
     // {@link #actuallyExec} and add it as a writable directory in
     // {@link AbstractSandboxSpawnRunner#getWritableDirs}.
@@ -174,19 +171,6 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     addPathToSetIfExists(writableDirs, homeDir.getRelative("Library/Developer"));
 
     return ImmutableSet.copyOf(writableDirs);
-  }
-
-  /** Returns the value of a POSIX or X/Open system configuration variable. */
-  private String getConfStr(String confVar) throws IOException, InterruptedException {
-    ImmutableList<String> args = ImmutableList.of(getconfBinary, confVar);
-    Command cmd = new Command(args, clientEnv);
-    CommandResult res;
-    try {
-      res = cmd.execute();
-    } catch (CommandException e) {
-      throw new IOException("getconf failed", e);
-    }
-    return new String(res.getStdout(), UTF_8).trim();
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunnerTest.java
@@ -59,9 +59,6 @@ public final class DarwinSandboxedSpawnRunnerTest extends SandboxedSpawnRunnerTe
   /** Path to the base of the sandbox to pass to the spawn runner. */
   private Path sandboxBase;
 
-  /** Location of the real {@code getconf} binary; saved while the test is running. */
-  private String oldGetconf;
-
   /** Location of the real {@code sandbox-exec} binary; saved while the test is running. */
   private String oldSandboxExec;
 
@@ -79,15 +76,6 @@ public final class DarwinSandboxedSpawnRunnerTest extends SandboxedSpawnRunnerTe
     sandboxBase = execRoot.getRelative("sandbox");
     sandboxBase.createDirectory();
 
-    // The mock getconf tool always prints an arbitrary path regardless of the arguments it
-    // receives. We must print a syntactically-valid path, however, to not confuse the consumer
-    // of this output.
-    Path getconf = execRoot.getRelative("getconf");
-    FileSystemUtils.writeContentAsLatin1(getconf, "#!/bin/sh\necho /tmp");
-    getconf.setExecutable(true);
-    oldGetconf = DarwinSandboxedSpawnRunner.getconfBinary;
-    DarwinSandboxedSpawnRunner.getconfBinary = getconf.toString();
-
     // The mock sandbox-exec just executes the given command and returns its output.
     Path sandboxExec = execRoot.getRelative("sandbox-exec");
     FileSystemUtils.writeContentAsLatin1(sandboxExec,
@@ -103,7 +91,6 @@ public final class DarwinSandboxedSpawnRunnerTest extends SandboxedSpawnRunnerTe
   @After
   public void tearDown() {
     DarwinSandboxedSpawnRunner.sandboxExecBinary = oldSandboxExec;
-    DarwinSandboxedSpawnRunner.getconfBinary = oldGetconf;
   }
 
   private void doSimpleExecutionTest(DarwinSandboxedSpawnRunner runner) throws Exception {


### PR DESCRIPTION
Calling getconf from a server process that lives longer than the user
session on macOS leads to failures. Now this value is computed in the
client and forwarded to the server.

Fixes https://github.com/bazelbuild/bazel/issues/7692

Closes #29131.

PiperOrigin-RevId: 892332643
Change-Id: I5d0bb169ca3c9c4e241612074863700a4ddf6a07

Commit https://github.com/bazelbuild/bazel/commit/bc4413e23798e80cda87968040400eafbf81b163