### PR TITLE
Remove the `target_compatible_with` attribute from `test_suite`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/test/TestSuiteRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/test/TestSuiteRule.java
@@ -107,6 +107,8 @@ public final class TestSuiteRule implements RuleDefinition {
             attr("$implicit_tests", LABEL_LIST)
                 .orderIndependent()
                 .nonconfigurable("Accessed in TestTargetUtils without config context"))
+        // Remove unused common attributes.
+        .removeAttribute(RuleClass.TARGET_COMPATIBLE_WITH_ATTR)
         .build();
   }
 

--- a/src/test/shell/integration/test_test.sh
+++ b/src/test/shell/integration/test_test.sh
@@ -202,6 +202,43 @@ EOF
   expect_log "//$pkg:test_b"
 }
 
+function test_test_suite_no_target_compatible_with() {
+  add_rules_shell "MODULE.bazel"
+  local -r pkg=$FUNCNAME
+  mkdir -p $pkg || fail "mkdir -p $pkg failed"
+  cat > $pkg/BUILD <<'EOF'
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+sh_test(
+    name = 'test_a',
+    srcs = [':a.sh'],
+)
+
+constraint_setting(
+    name = 'gate',
+)
+
+constraint_value(
+    name = 'requires_opt_in',
+    constraint_setting = ':gate',
+)
+
+test_suite(
+    name = 'suite',
+    target_compatible_with = [':requires_opt_in'],
+)
+EOF
+  cat > $pkg/a.sh <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+
+  chmod +x $pkg/a.sh
+  bazel test //$pkg:suite &> $TEST_log \
+      && fail "expected failure" || true
+  expect_log "//$pkg:suite: no such attribute 'target_compatible_with' in 'test_suite' rule"
+}
+
 function test_print_relative_test_log_paths() {
   add_rules_shell "MODULE.bazel"
   local -r pkg="$FUNCNAME"


### PR DESCRIPTION
The `test_suite` rule is not directly analyzed: instead it is used during target pattern expansion to realize a set of tests to be executed. Because of this, platform compatibility checks are never performed, so removing the attribute makes it more clear that this is not possible.

Addresses #29137 by at least ensuring a helpful error message.

RELNOTES: None.
