### PR TITLE
docs: Automated documentation sync from recent merged commits

### DIFF
--- a/docs/advanced/performance/memory.mdx
+++ b/docs/advanced/performance/memory.mdx
@@ -40,6 +40,10 @@ prevent most re-execution).
  incremental builds have to build from scratch (except for the on-disk action
  cache). Alone, it does not affect the high-water mark of the current build.
 
+*   The `SparseAggregateWriteStatusBuilder` is now a public API. This change helps reduce memory usage when writing to the remote analysis cache.
+
+*   The `--experimental_skycache_minimize_memory` flag now also reduces memory usage in the default execution mode (non-Skymeld).
+
 ### Trade build flexibility for memory with Skyfocus (Experimental) {#trade-flexibility}
 
 If you want to make Bazel use less memory *and* retain incremental build speeds,

--- a/docs/contribute/codebase.mdx
+++ b/docs/contribute/codebase.mdx
@@ -90,6 +90,10 @@ communicate with the server is in `src/main/protobuf/command_server.proto` .
 The main entry point of the server is `BlazeRuntime.main()` and the gRPC calls
 from the client are handled by `CommandServer.serveAndAwaitTermination()`.
 
+*   Internal API Change: Direct field access on `BuildRequestOptions` and `BlazeServerStartupOptions` is replaced by getter and setter methods.
+
+*   Native build options can now be defined using getter and setter methods in addition to public fields, allowing for more flexible option implementation.
+
 ## Directory layout {#directory-layout}
 
 Bazel creates a somewhat complicated set of directories during a build. A full

--- a/docs/docs/cc-toolchain-config-reference.mdx
+++ b/docs/docs/cc-toolchain-config-reference.mdx
@@ -93,6 +93,8 @@ fully fledged C++ features in Bazel without modifying the
 Bazel binary. C++ rules support multiple unique actions documented in detail
 [in the Bazel source code](https://source.bazel.build/bazel/+/4f547a7ea86df80e4c76145ffdbb0c8b75ba3afa:tools/build_defs/cc/action_names.bzl).
 
+
+*   **C++:** The iteration order of toolchain features and action configurations is now deterministic, improving build reproducibility.
 ## Features {#features}
 
 A feature is an entity that requires command-line flags, actions,

--- a/docs/extending/depsets.mdx
+++ b/docs/extending/depsets.mdx
@@ -24,6 +24,8 @@ Example uses of depsets include:
 *   For an interpreted language, storing the transitive source files that are
     included in an executable's runfiles.
 
+*   **Performance:** Optimized environment constraint checking to reduce memory usage and improve performance, especially for builds with complex environment definitions.
+
 ## Description and operations
 
 Conceptually, a depset is a directed acyclic graph (DAG) that typically looks

--- a/docs/external/extension.mdx
+++ b/docs/external/extension.mdx
@@ -118,6 +118,8 @@ def _maven_impl(ctx):
   _generate_hub_repo(name = "maven", repo_attrs)
 ```
 
+*   Module extension tags now have an implicit `_sort_key` field. This integer value reflects the order in which tags were declared across all `MODULE.bazel` files.
+
 ### Extension identity
 
 Module extensions are identified by the name and the `.bzl` file that appears

--- a/docs/install/compile-source.mdx
+++ b/docs/install/compile-source.mdx
@@ -169,6 +169,8 @@ your PATH so that you can run "bazel" everywhere.)
 
 You can also build Bazel from scratch, without using an existing Bazel binary.
 
+*   The bootstrap script now explicitly enables required annotation processors during compilation. This improves bootstrap reliability across different JDK versions.
+
 ### Step 1: Download Bazel's sources (distribution archive) {#download-distfile}
 
 (This step is the same for all platforms.)

--- a/docs/reference/skyframe.mdx
+++ b/docs/reference/skyframe.mdx
@@ -120,6 +120,8 @@ This is useful, for example, if one changes a comment in a C++ file: then the
 `.o` file generated from it will be the same, thus, it is unnecessary to call
 the linker again.
 
+
+*   **Options:** The `MethodOptionDefinition.getDeclaringClass()` method now works correctly, returning the `OptionsBase` subclass that declares the option.
 ## Incremental Linking / Compilation
 
 The main limitation of this model is that the invalidation of a node is an

--- a/docs/remote/cache-local.mdx
+++ b/docs/remote/cache-local.mdx
@@ -36,6 +36,8 @@ strategy. Local cache hits are not included in this summary. If you are getting
 0 processes (or a number lower than expected), run `bazel clean` followed by
 your build/test command.
 
+*   The `--disk_cache` flag can now be used without a path to enable the disk cache at a default location (`<outputUserRoot>/cache/disk`).
+
 ## Troubleshooting cache hits {#troubleshooting-cache-hits}
 
 If you are not getting the cache hit rate you are expecting, do the following:

--- a/docs/remote/cache-remote.mdx
+++ b/docs/remote/cache-remote.mdx
@@ -108,6 +108,10 @@ If you are not getting the cache hit rate you are expecting, do the following:
       set to `false`: either at the command line or in a
       [bazelrc](/run/bazelrc#bazelrc-file-locations) file.
 
+*   `RemoteAnalysisCachingOptions`: The `mode` field is now private and accessed via the `getMode()` method.
+
+*   The remote repository contents cache now supports all reproducible repository rules, including those that dynamically discover their inputs (e.g., via `repository_ctx.execute`).
+
 ### Ensure caching across machines {#caching-across-machines}
 
 After cache hits are happening as expected on the same machine, run the

--- a/site/en/advanced/performance/memory.md
+++ b/site/en/advanced/performance/memory.md
@@ -42,6 +42,10 @@ prevent most re-execution).
  incremental builds have to build from scratch (except for the on-disk action
  cache). Alone, it does not affect the high-water mark of the current build.
 
+
+*   The `SparseAggregateWriteStatusBuilder` is now a public API. This change helps reduce memory usage when writing to the remote analysis cache.
+
+*   The `--experimental_skycache_minimize_memory` flag now also reduces memory usage in the default execution mode (non-Skymeld).
 ### Trade build flexibility for memory with Skyfocus (Experimental) {:#trade-flexibility}
 
 If you want to make Bazel use less memory *and* retain incremental build speeds,

--- a/site/en/contribute/codebase.md
+++ b/site/en/contribute/codebase.md
@@ -144,6 +144,10 @@ execute, the following sequence of events happens:
 3.  The command line options are parsed. Each command has different command line
     options, which are described in the `@Command` annotation.
 
+*   Internal API Change: Direct field access on `BuildRequestOptions` and `BlazeServerStartupOptions` is replaced by getter and setter methods.
+
+*   Native build options can now be defined using getter and setter methods in addition to public fields, allowing for more flexible option implementation.
+
 4.  An event bus is created. The event bus is a stream for events that happen
     during the build. Some of these are exported to outside of Bazel under the
     aegis of the Build Event Protocol in order to tell the world how the build

--- a/site/en/docs/cc-toolchain-config-reference.md
+++ b/site/en/docs/cc-toolchain-config-reference.md
@@ -97,6 +97,8 @@ fully fledged C++ features in Bazel without modifying the
 Bazel binary. C++ rules support multiple unique actions documented in detail
 [in the Bazel source code](https://source.bazel.build/bazel/+/4f547a7ea86df80e4c76145ffdbb0c8b75ba3afa:tools/build_defs/cc/action_names.bzl).
 
+*   **C++:** The iteration order of toolchain features and action configurations is now deterministic, improving build reproducibility.
+
 ## Features {:#features}
 
 A feature is an entity that requires command-line flags, actions,

--- a/site/en/extending/depsets.md
+++ b/site/en/extending/depsets.md
@@ -25,6 +25,8 @@ Example uses of depsets include:
 *   For an interpreted language, storing the transitive source files that are
     included in an executable's runfiles.
 
+*   **Performance:** Optimized environment constraint checking to reduce memory usage and improve performance, especially for builds with complex environment definitions.
+
 ## Description and operations
 
 Conceptually, a depset is a directed acyclic graph (DAG) that typically looks

--- a/site/en/external/extension.md
+++ b/site/en/external/extension.md
@@ -95,6 +95,8 @@ rules, except that they get a [`module_ctx`](/rules/lib/builtins/module_ctx) obj
 which grants access to all modules using the extension and all pertinent tags.
 The implementation function then calls repo rules to generate repos.
 
+
+*   Module extension tags now have an implicit `_sort_key` field. This integer value reflects the order in which tags were declared across all `MODULE.bazel` files.
 ```python
 # @rules_jvm_external//:extensions.bzl
 

--- a/site/en/install/compile-source.md
+++ b/site/en/install/compile-source.md
@@ -170,6 +170,8 @@ your PATH so that you can run "bazel" everywhere.)
 
 You can also build Bazel from scratch, without using an existing Bazel binary.
 
+*   The bootstrap script now explicitly enables required annotation processors during compilation. This improves bootstrap reliability across different JDK versions.
+
 ### Step 1: Download Bazel's sources (distribution archive) {:#download-distfile}
 
 (This step is the same for all platforms.)

--- a/site/en/reference/skyframe.md
+++ b/site/en/reference/skyframe.md
@@ -23,6 +23,8 @@ The data model consists of the following items:
 *   `Skyframe`. Code name for the incremental evaluation framework Bazel is
     based on.
 
+*   **Options:** The `MethodOptionDefinition.getDeclaringClass()` method now works correctly, returning the `OptionsBase` subclass that declares the option.
+
 ## Evaluation
 
 A build is achieved by evaluating the node that represents the build request.

--- a/site/en/remote/cache-local.md
+++ b/site/en/remote/cache-local.md
@@ -18,6 +18,8 @@ logs between two Bazel invocations, see
 Everything presented in that guide also applies to remote caching with local
 execution. However, local execution presents some additional challenges.
 
+*   The `--disk_cache` flag can now be used without a path to enable the disk cache at a default location (`<outputUserRoot>/cache/disk`).
+
 ## Checking your cache hit rate {:#cache-hits}
 
 Successful remote cache hits will show up in the status line, similar to

--- a/site/en/remote/cache-remote.md
+++ b/site/en/remote/cache-remote.md
@@ -139,6 +139,10 @@ not happening across machines, do the following:
     for discrepancies as well as properties from the host environment leaking
     into either of the builds.
 
+*   `RemoteAnalysisCachingOptions`: The `mode` field is now private and accessed via the `getMode()` method.
+
+
+*   The remote repository contents cache now supports all reproducible repository rules, including those that dynamically discover their inputs (e.g., via `repository_ctx.execute`).
 ## Comparing the execution logs {:#compare-logs}
 
 The execution log contains records of actions executed during the build.


### PR DESCRIPTION
Description

Automated documentation synchronization. This PR updates the Bazel DevSite (site/en/) and Mintlify (docs/) documentation by parsing and incorporating the latest changes from 12 recent commits.

Commits processed in this run:

08f4e3b — Fix bootstrap_distfile_test...
1527433 — Update RemoteAnalysisCachingOptions to use the new...
14fc007 — Add disk cache support for default location...
3b1b226 — Make MethodOptionDefinition.getDeclaringClass() work...
4d344a9 — Update BuildRequestOptions and BlazeServerStartupOptions...
5bd53e1 — Implement the option to wrap options classes...
4dd50f7 — Reduce RAM use of remote analysis cache writers...
ffebc5b — Support dynamic inputs with the remote repo content...
a39cef7 — Add an implicit _sort_key field to module extensions...
0740ad3 — Honor --experimental_skycache_minimize_memory...
44127c8 — Flatten the nested sets in EnvironmentLabels...
5b3e143 — Make the iteration order of various maps in CcToolchain...

Motivation
This change ensures that the technical documentation remains in lockstep with recent codebase changes. By automating the sync between release notes and formal documentation, we reduce "docs debt" and ensure users have access to the most current configuration options and performance optimizations immediately after they are implemented.

Build API Changes
No

Checklist
[x] I have updated the documentation (if applicable).

Release Notes
RELNOTES: None 