### PR TITLE
[8.7.0] Allow --test_env / env= to override coverage env (https://github.com/…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -20,6 +20,7 @@ import static com.google.devtools.build.lib.packages.BuildType.LABEL;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
@@ -247,7 +248,7 @@ public final class TestActionBuilder {
     inputsBuilder.add(testXmlGeneratorExecutable);
 
     FilesToRunProvider collectCoverageScript = null;
-    TreeMap<String, String> extraTestEnv = new TreeMap<>();
+    TreeMap<String, String> coverageTestEnv = new TreeMap<>();
 
     int runsPerTest = getRunsPerTest(ruleContext);
     int shardCount = getShardCount(ruleContext);
@@ -278,7 +279,7 @@ public final class TestActionBuilder {
       if (ruleContext.isAttrDefined("$collect_cc_coverage", LABEL)) {
         Artifact collectCcCoverage = ruleContext.getPrerequisiteArtifact("$collect_cc_coverage");
         inputsBuilder.add(collectCcCoverage);
-        extraTestEnv.put(CC_CODE_COVERAGE_SCRIPT, collectCcCoverage.getExecPathString());
+        coverageTestEnv.put(CC_CODE_COVERAGE_SCRIPT, collectCcCoverage.getExecPathString());
       }
 
       if (!instrumentedFiles.getReportedToActualSources().isEmpty()) {
@@ -292,13 +293,13 @@ public final class TestActionBuilder {
                 instrumentedFiles.getReportedToActualSources(),
                 ":"));
         inputsBuilder.add(reportedToActualSourcesArtifact);
-        extraTestEnv.put(
+        coverageTestEnv.put(
             COVERAGE_REPORTED_TO_ACTUAL_SOURCES_FILE,
             reportedToActualSourcesArtifact.getExecPathString());
       }
 
       // lcov is the default CC coverage tool unless otherwise specified on the command line.
-      extraTestEnv.put(BAZEL_CC_COVERAGE_TOOL, GCOV_TOOL);
+      coverageTestEnv.put(BAZEL_CC_COVERAGE_TOOL, GCOV_TOOL);
 
       // We don't add this attribute to non-supported test target
       String lcovMergerAttr = null;
@@ -316,7 +317,7 @@ public final class TestActionBuilder {
               lcovMergerAttr,
               "the LCOV merger should be either an executable or a single artifact");
         }
-        extraTestEnv.put(LCOV_MERGER, lcovFilesToRun.getExecutable().getExecPathString());
+        coverageTestEnv.put(LCOV_MERGER, lcovFilesToRun.getExecutable().getExecPathString());
         inputsBuilder.addTransitive(lcovFilesToRun.getFilesToRun());
         lcovMergerFilesToRun = lcovFilesToRun.getFilesToRun();
       }
@@ -334,7 +335,7 @@ public final class TestActionBuilder {
               runsPerTest);
       inputsBuilder.add(instrumentedFileManifest);
       // TODO(ulfjack): Is this even ever set? If yes, does this cost us a lot of memory?
-      extraTestEnv.putAll(instrumentedFiles.getCoverageEnvironment());
+      coverageTestEnv.putAll(instrumentedFiles.getCoverageEnvironment());
     } else {
       executionSettings =
           new TestTargetExecutionSettings(
@@ -425,6 +426,7 @@ public final class TestActionBuilder {
                 coverageDirectory,
                 undeclaredOutputsDir,
                 testProperties,
+                ImmutableMap.copyOf(coverageTestEnv),
                 runfilesSupport
                     .getActionEnvironment()
                     .withAdditionalVariables(extraTestEnv, extraInheritedEnv),

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
@@ -155,6 +155,9 @@ public class TestRunnerAction extends AbstractAction
    */
   @Nullable private Optional<TestResultData> cachedTestResultData;
 
+  /** Environment variables specific to running code coverage */
+  private final ImmutableMap<String, String> coverageEnv;
+
   /** Any extra environment variables (and values) added by the rule that created this action. */
   private final ActionEnvironment extraTestEnv;
 
@@ -206,6 +209,7 @@ public class TestRunnerAction extends AbstractAction
       @Nullable Artifact coverageDirectory,
       Artifact undeclaredOutputsDir,
       TestTargetProperties testProperties,
+      ImmutableMap<String, String> coverageEnv,
       ActionEnvironment extraTestEnv,
       TestTargetExecutionSettings executionSettings,
       int shardNum,
@@ -270,6 +274,7 @@ public class TestRunnerAction extends AbstractAction
     this.testInfrastructureFailure = baseDir.getChild("test.infrastructure_failure");
     this.workspaceName = workspaceName;
 
+    this.coverageEnv = coverageEnv;
     this.extraTestEnv = extraTestEnv;
     this.requiredClientEnvVariables =
         LazySetConcatenation.from(
@@ -512,6 +517,7 @@ public class TestRunnerAction extends AbstractAction
     fp.addBoolean(executionSettings.getTestRunnerFailFast());
     RunUnder runUnder = executionSettings.getRunUnder();
     fp.addString(runUnder == null ? "" : runUnder.value());
+    fp.addStringMap(coverageEnv);
     extraTestEnv.addTo(fp);
     // TODO(ulfjack): It might be better for performance to hash the action and test envs in config,
     // and only add a hash here.
@@ -717,6 +723,8 @@ public class TestRunnerAction extends AbstractAction
   }
 
   public void setupEnvVariables(Map<String, String> env, Duration timeout) {
+    // Allow --test_env and rules to overwite these values
+    coverageEnv.forEach(env::putIfAbsent);
     env.put("TEST_TARGET", Label.print(getOwner().getLabel()));
     env.put("TEST_SIZE", getTestProperties().getSize().toString());
     env.put("TEST_TIMEOUT", Long.toString(timeout.getSeconds()));

--- a/src/main/java/com/google/devtools/build/lib/exec/TestPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/TestPolicy.java
@@ -96,9 +96,8 @@ public class TestPolicy {
     // Rule-specified test env.
     testAction.getExtraTestEnv().resolve(env, clientEnv);
 
-    // Setup any test-specific env variables; note that this does not overwrite existing values for
-    // TEST_RANDOM_SEED or TEST_SIZE if they're already set.
-    testAction.setupEnvVariables(env, timeout);
+    // Setup bazel test-specific env variables; note that this does not overwrite
+    // some values if they're already set.
 
     return env;
   }

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -197,6 +197,78 @@ EOF
   expect_log "ws: _main$"
 }
 
+function test_coverage_env_vars_can_be_overridden() {
+  add_rules_cc "MODULE.bazel"
+  mkdir -p foo
+
+  cat > foo/print_coverage_env.cc <<'EOF'
+#include <cstdlib>
+#include <cstdio>
+int main() {
+  const char* gcov = getenv("COVERAGE_GCOV_PATH");
+  const char* llvm = getenv("LLVM_COV");
+  const char* cc_script = getenv("CC_CODE_COVERAGE_SCRIPT");
+  printf("coverage_gcov_path: %s\n", gcov ? gcov : "(null)");
+  printf("llvm_cov: %s\n", llvm ? llvm : "(null)");
+  printf("cc_code_coverage_script: %s\n", cc_script ? cc_script : "(null)");
+  return 0;
+}
+EOF
+
+  cat > foo/BUILD <<'EOF'
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+cc_test(
+    name = "print_coverage_env",
+    srcs = ["print_coverage_env.cc"],
+)
+EOF
+
+  if is_darwin && has_ipv6_default_route; then
+    export JAVA_TOOL_OPTIONS="-Djava.net.preferIPv6Addresses=true"
+    export STARTUP_OPTS="--host_jvm_args=-Djava.net.preferIPv6Addresses=true"
+  else
+    export STARTUP_OPTS=""
+  fi
+
+  GCOV=/from/env BAZEL_LLVM_COV=/from/env bazel --ignore_all_rc_files $STARTUP_OPTS coverage --test_output=all \
+    //foo:print_coverage_env &> $TEST_log || true
+  expect_log "cc_code_coverage_script: .*collect_cc_coverage.sh"
+  expect_log "llvm_cov: /from/env"
+  expect_log "coverage_gcov_path: /from/env"
+
+  GCOV=/from/env BAZEL_LLVM_COV=/from/env bazel --ignore_all_rc_files $STARTUP_OPTS coverage --test_output=all \
+    --test_env=COVERAGE_GCOV_PATH=from_test_env \
+    --test_env=LLVM_COV=from_test_env \
+    --test_env=CC_CODE_COVERAGE_SCRIPT=from_test_env \
+    //foo:print_coverage_env &> $TEST_log || true
+  expect_log "coverage_gcov_path: from_test_env"
+  expect_log "llvm_cov: from_test_env"
+  expect_log "cc_code_coverage_script: from_test_env"
+
+  cat > foo/BUILD <<'EOF'
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+cc_test(
+    name = "print_coverage_env",
+    srcs = ["print_coverage_env.cc"],
+    size = "small",
+    env = {
+        "COVERAGE_GCOV_PATH": "from_rule_env",
+        "LLVM_COV": "from_rule_env",
+        "CC_CODE_COVERAGE_SCRIPT": "from_rule_env",
+    },
+)
+EOF
+
+  GCOV=/from/env BAZEL_LLVM_COV=/from/env bazel --ignore_all_rc_files $STARTUP_OPTS coverage --test_output=all \
+    --test_env=COVERAGE_GCOV_PATH=from_test_env \
+    --test_env=LLVM_COV=from_test_env \
+    --test_env=CC_CODE_COVERAGE_SCRIPT=from_test_env \
+    //foo:print_coverage_env &> $TEST_log || true
+  expect_log "coverage_gcov_path: from_rule_env"
+  expect_log "llvm_cov: from_rule_env"
+  expect_log "cc_code_coverage_script: from_rule_env"
+}
+
 function test_runfiles_java_runfiles_merges_env_vars() {
   runfiles_merges_runfiles_env_vars JAVA_RUNFILES PYTHON_RUNFILES
 }


### PR DESCRIPTION
…bazelbuild/bazel/pull/29110)

Bazel sets some environment variables for CC coverage collection that can be useful to override in some projects. Previously this was possible but as a side effect of 87b0a1f202992ac98f73bc230551b6166c313a06 it stopped working. This re-enables that and covers it in tests

Fixes https://github.com/bazelbuild/bazel/issues/23247

Closes #29110.

PiperOrigin-RevId: 892333567
Change-Id: If5dd77b1cc98390622276865ee80772fdbcb216c

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/15e078b9361333091df54e4f57fed88b7c4cd5bd