### PR TITLE
Allow clean shutdown for json persistant workers

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/JsonWorkerMessageProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/JsonWorkerMessageProcessor.java
@@ -18,6 +18,7 @@ import com.google.devtools.build.lib.worker.WorkerProtocol.Input;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.MalformedJsonException;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.util.JsonFormat;
@@ -107,7 +108,20 @@ public final class JsonWorkerMessageProcessor implements WorkRequestHandler.Work
     Integer verbosity = null;
     String sandboxDir = null;
     try {
+      // After reading at least one ndjson message, gson returns END_DOCUMENT at EOF instead of
+      // throwing EOFException. Check for it before beginObject() to signal clean shutdown.
+      if (reader.peek() == JsonToken.END_DOCUMENT) {
+        return null;
+      }
       reader.beginObject();
+    } catch (EOFException e) {
+      // Clean EOF on an empty stream (no prior messages): Bazel closed stdin before starting
+      // any message. Return null to signal shutdown, matching proto behavior.
+      return null;
+    } catch (MalformedJsonException | IllegalStateException e) {
+      throw new IOException(e);
+    }
+    try {
       while (reader.hasNext()) {
         String name = reader.nextName();
         switch (name) {
@@ -149,7 +163,8 @@ public final class JsonWorkerMessageProcessor implements WorkRequestHandler.Work
         }
       }
       reader.endObject();
-    } catch (MalformedJsonException | IllegalStateException | EOFException e) {
+    } catch (MalformedJsonException | EOFException | IllegalStateException e) {
+      // EOF after beginObject() means a truncated message, not a clean shutdown.
       throw new IOException(e);
     }
 

--- a/src/main/java/com/google/devtools/build/lib/worker/JsonWorkerProtocol.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/JsonWorkerProtocol.java
@@ -18,6 +18,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.MalformedJsonException;
 import com.google.protobuf.util.JsonFormat;
 import com.google.protobuf.util.JsonFormat.Printer;
@@ -72,7 +73,20 @@ final class JsonWorkerProtocol implements WorkerProtocolImpl {
     String output = null;
     Integer requestId = null;
     try {
+      // After reading at least one ndjson message, gson returns END_DOCUMENT at EOF instead of
+      // throwing EOFException. Check for it before beginObject() to signal clean shutdown.
+      if (reader.peek() == JsonToken.END_DOCUMENT) {
+        return null;
+      }
       reader.beginObject();
+    } catch (EOFException e) {
+      // Clean EOF on an empty stream (no prior messages): the worker closed its stdout before
+      // starting any message. Return null to signal shutdown, matching proto behavior.
+      return null;
+    } catch (MalformedJsonException | IllegalStateException e) {
+      throw new IOException("Could not parse json work response", e);
+    }
+    try {
       while (reader.hasNext()) {
         String name = reader.nextName();
         switch (name) {
@@ -102,7 +116,8 @@ final class JsonWorkerProtocol implements WorkerProtocolImpl {
       }
       reader.endObject();
     } catch (MalformedJsonException | EOFException | IllegalStateException e) {
-      throw new IOException("Could not parse json work request correctly", e);
+      // EOF after beginObject() means a truncated message, not a clean shutdown.
+      throw new IOException("Could not parse json work response", e);
     }
 
     WorkResponse.Builder responseBuilder = WorkResponse.newBuilder();

--- a/src/test/java/com/google/devtools/build/lib/worker/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/worker/BUILD
@@ -130,6 +130,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/worker:worker_pool_impl",
         "//src/main/java/com/google/devtools/build/lib/worker:worker_process_metrics",
         "//src/main/java/com/google/devtools/build/lib/worker:worker_process_status",
+        "//src/main/java/com/google/devtools/build/lib/worker:worker_protocol",
         "//src/main/java/com/google/devtools/build/lib/worker:worker_spawn_runner",
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/protobuf:worker_protocol_java_proto",
@@ -169,6 +170,7 @@ java_test(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/worker:work_request_handlers",
         "//src/main/protobuf:worker_protocol_java_proto",
+        "//third_party:gson",
         "//third_party:junit4",
         "//third_party:mockito",
         "//third_party:truth",

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkRequestHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkRequestHandlerTest.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.worker;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.devtools.build.lib.worker.WorkRequestHandler.RequestInfo;
 import com.google.devtools.build.lib.worker.WorkRequestHandler.WorkRequestCallback;
@@ -22,11 +23,16 @@ import com.google.devtools.build.lib.worker.WorkRequestHandler.WorkRequestHandle
 import com.google.devtools.build.lib.worker.WorkRequestHandler.WorkerMessageProcessor;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
+import com.google.gson.stream.JsonReader;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.InterruptedIOException;
+import java.io.OutputStreamWriter;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.PrintStream;
@@ -162,6 +168,71 @@ public class WorkRequestHandlerTest {
     }
     assertThat(workerThreads.get(0).isAlive()).isFalse();
     assertThat(workerThreads.get(1).isAlive()).isFalse();
+  }
+
+  @Test
+  public void testMultiplexWorkRequest_json_stopsThreadsOnShutdown()
+      throws IOException, InterruptedException {
+    PipedOutputStream src = new PipedOutputStream();
+    PipedInputStream dest = new PipedInputStream();
+
+    Semaphore started = new Semaphore(0);
+    Semaphore eternity = new Semaphore(0);
+    Semaphore stopped = new Semaphore(0);
+    List<Thread> workerThreads = new ArrayList<>();
+    JsonWorkerMessageProcessor jsonProcessor =
+        new JsonWorkerMessageProcessor(
+            new JsonReader(
+                new BufferedReader(new InputStreamReader(new PipedInputStream(src), UTF_8))),
+            new BufferedWriter(new OutputStreamWriter(new PipedOutputStream(dest), UTF_8)));
+    StoppableWorkerMessageProcessor messageProcessor =
+        new StoppableWorkerMessageProcessor(jsonProcessor);
+    ByteArrayOutputStream stderrStream = new ByteArrayOutputStream();
+    WorkRequestHandler handler =
+        new WorkRequestHandler(
+            (args, err) -> {
+              synchronized (workerThreads) {
+                workerThreads.add(Thread.currentThread());
+              }
+              started.release();
+              try {
+                eternity.acquire();
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              return 0;
+            },
+            new PrintStream(stderrStream),
+            messageProcessor);
+
+    Thread t =
+        new Thread(
+            () -> {
+              try {
+                handler.processRequests();
+                stopped.release();
+              } catch (IOException e) {
+                throw new AssertionError("Unhandled exception", e);
+              }
+            });
+    t.start();
+    // Write two JSON work requests (ndjson format).
+    src.write("{\"requestId\":42,\"arguments\":[\"--sources\",\"A.java\"]}\n".getBytes(UTF_8));
+    src.write("{\"requestId\":43,\"arguments\":[\"--sources\",\"A.java\"]}\n".getBytes(UTF_8));
+    src.flush();
+
+    started.acquire(2);
+    assertThat(workerThreads).hasSize(2);
+    // Closing stdin should trigger clean shutdown via EOF → null return.
+    src.close();
+    stopped.acquire();
+    while (workerThreads.get(0).isAlive() || workerThreads.get(1).isAlive()) {
+      Thread.sleep(1);
+    }
+    assertThat(workerThreads.get(0).isAlive()).isFalse();
+    assertThat(workerThreads.get(1).isAlive()).isFalse();
+    // Verify this was a clean shutdown, not an error-driven one. 
+    assertThat(stderrStream.toString(UTF_8)).doesNotContain("Error reading next WorkRequest");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerTest.java
@@ -19,6 +19,7 @@ import static com.google.devtools.build.lib.actions.ExecutionRequirements.Worker
 import static com.google.devtools.build.lib.actions.ExecutionRequirements.WorkerProtocolFormat.PROTO;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertNull;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -200,7 +201,7 @@ public final class WorkerTest {
   public void testGetResponse_badJson_throws()
       throws IOException, InterruptedException, UserExecException {
     verifyGetResponseFailure(
-        "{ \"output\": \"I'm missing a bracket\"", "Could not parse json work request correctly");
+        "{ \"output\": \"I'm missing a bracket\"", "Could not parse json work response");
   }
 
   @Test
@@ -237,5 +238,13 @@ public final class WorkerTest {
         WorkResponse.newBuilder().setExitCode(1).setOutput("test output").setRequestId(1).build();
 
     assertThat(readResponse).isEqualTo(response);
+  }
+
+  @Test
+  public void testGetResponse_json_eof_returnsNull() throws IOException {
+    ByteArrayOutputStream workerStdin = new ByteArrayOutputStream();
+    ByteArrayInputStream workerStdout = new ByteArrayInputStream(new byte[0]);
+    JsonWorkerProtocol protocol = new JsonWorkerProtocol(workerStdin, workerStdout);
+    assertNull(protocol.getResponse());
   }
 }


### PR DESCRIPTION
### Description
Allows persistent workers using the JSON protocol to cleanly shutdown by matching protobuf protocol behavior

### Motivation
Without this, there's no way for a worker using the json protocol to signal it's shutting down, and bazel prints spurious error messages about failing to parse a json work response. proto workers basically match this behavior, and don't have the same challenge. 

I'm working on implementing a persistent worker for and in rust, and while it's *possible* to use proto, I prefer using json for the simplicity unless the performance becomes an issue. 

### Build API Changes
No

### Checklist
- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes
RELNOTES: Allow clean shutdown of persistent workers using the json protocol
