### PR TITLE
Add repository_ctx.digest() function

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -17,6 +17,7 @@ import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.ExecuteWasmEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.ExtractEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.FileEvent;
+import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.IntegrityHashEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.LoadWasmEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.OsEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.RenameEvent;
@@ -388,6 +389,25 @@ public final class WorkspaceRuleEvent implements Postable {
     }
     if (context != null) {
       result = result.setContext(context);
+    }
+    return new WorkspaceRuleEvent(result.build());
+  }
+
+  /** Creates a new WorkspaceRuleEvent for an integrityHash event. */
+  public static WorkspaceRuleEvent newIntegrityHashEvent(
+      String path, String algorithm, String context, Location location) {
+    IntegrityHashEvent e =
+        WorkspaceLogProtos.IntegrityHashEvent.newBuilder()
+            .setPath(path)
+            .setAlgorithm(algorithm)
+            .build();
+    WorkspaceLogProtos.WorkspaceEvent.Builder result =
+        WorkspaceLogProtos.WorkspaceEvent.newBuilder().setIntegrityHashEvent(e);
+    if (location != null) {
+      result.setLocation(location.toString());
+    }
+    if (context != null) {
+      result.setContext(context);
     }
     return new WorkspaceRuleEvent(result.build());
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -14,10 +14,10 @@
 package com.google.devtools.build.lib.bazel.debug;
 
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos;
+import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.DigestEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.ExecuteWasmEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.ExtractEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.FileEvent;
-import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.IntegrityHashEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.LoadWasmEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.OsEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.RenameEvent;
@@ -393,16 +393,17 @@ public final class WorkspaceRuleEvent implements Postable {
     return new WorkspaceRuleEvent(result.build());
   }
 
-  /** Creates a new WorkspaceRuleEvent for an integrityHash event. */
-  public static WorkspaceRuleEvent newIntegrityHashEvent(
-      String path, String algorithm, String context, Location location) {
-    IntegrityHashEvent e =
-        WorkspaceLogProtos.IntegrityHashEvent.newBuilder()
+  /** Creates a new WorkspaceRuleEvent for a digest event. */
+  public static WorkspaceRuleEvent newDigestEvent(
+      String path, String format, String algorithm, String context, Location location) {
+    DigestEvent e =
+        WorkspaceLogProtos.DigestEvent.newBuilder()
             .setPath(path)
+            .setFormat(format)
             .setAlgorithm(algorithm)
             .build();
     WorkspaceLogProtos.WorkspaceEvent.Builder result =
-        WorkspaceLogProtos.WorkspaceEvent.newBuilder().setIntegrityHashEvent(e);
+        WorkspaceLogProtos.WorkspaceEvent.newBuilder().setDigestEvent(e);
     if (location != null) {
       result.setLocation(location.toString());
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -395,12 +395,12 @@ public final class WorkspaceRuleEvent implements Postable {
 
   /** Creates a new WorkspaceRuleEvent for a digest event. */
   public static WorkspaceRuleEvent newDigestEvent(
-      String path, String format, String algorithm, String context, Location location) {
+      String path, String algorithm, String format, String context, Location location) {
     DigestEvent e =
         WorkspaceLogProtos.DigestEvent.newBuilder()
             .setPath(path)
-            .setFormat(format)
             .setAlgorithm(algorithm)
+            .setFormat(format)
             .build();
     WorkspaceLogProtos.WorkspaceEvent.Builder result =
         WorkspaceLogProtos.WorkspaceEvent.newBuilder().setDigestEvent(e);

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
@@ -162,6 +162,14 @@ message ExecuteWasmEvent {
   int64 memory_limit_bytes = 5;
 }
 
+// Information on "integrity_hash" event in repository_ctx.
+message IntegrityHashEvent {
+  // The path of the file to hash.
+  string path = 1;
+  // The hash algorithm to use.
+  string algorithm = 2;
+}
+
 message WorkspaceEvent {
   // Location in the code (.bzl file) where the event originates.
   string location = 1;
@@ -186,5 +194,6 @@ message WorkspaceEvent {
     RenameEvent rename_event = 15;
     LoadWasmEvent load_wasm_event = 16;
     ExecuteWasmEvent execute_wasm_event = 17;
+    IntegrityHashEvent integrity_hash_event = 18;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
@@ -162,12 +162,14 @@ message ExecuteWasmEvent {
   int64 memory_limit_bytes = 5;
 }
 
-// Information on "integrity_hash" event in repository_ctx.
-message IntegrityHashEvent {
+// Information on "digest" event in repository_ctx.
+message DigestEvent {
   // The path of the file to hash.
   string path = 1;
+  // The format of the digest.
+  string format = 2;
   // The hash algorithm to use.
-  string algorithm = 2;
+  string algorithm = 3;
 }
 
 message WorkspaceEvent {
@@ -194,6 +196,6 @@ message WorkspaceEvent {
     RenameEvent rename_event = 15;
     LoadWasmEvent load_wasm_event = 16;
     ExecuteWasmEvent execute_wasm_event = 17;
-    IntegrityHashEvent integrity_hash_event = 18;
+    DigestEvent digest_event = 18;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
@@ -166,10 +166,10 @@ message ExecuteWasmEvent {
 message DigestEvent {
   // The path of the file to hash.
   string path = 1;
-  // The format of the digest.
-  string format = 2;
   // The hash algorithm to use.
-  string algorithm = 3;
+  string algorithm = 2;
+  // The format of the digest.
+  string format = 3;
 }
 
 message WorkspaceEvent {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -19,6 +19,9 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import com.github.difflib.patch.PatchFailedException;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.HashFunction;
+import com.google.common.io.ByteSource;
 import com.google.devtools.build.docgen.annot.DocCategory;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.bazel.debug.WorkspaceRuleEvent;
@@ -36,6 +39,7 @@ import com.google.devtools.build.lib.rules.repository.RepoRecordedInput.RepoCach
 import com.google.devtools.build.lib.runtime.ProcessWrapper;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor;
 import com.google.devtools.build.lib.util.StringUtilities;
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -43,8 +47,10 @@ import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import com.google.devtools.build.skyframe.SkyFunctionException.Transience;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.InvalidPathException;
+import java.util.Base64;
 import java.util.Map;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.Param;
@@ -625,6 +631,87 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
     return new RepoMetadata(
         reproducible ? RepoMetadata.Reproducibility.YES : RepoMetadata.Reproducibility.NO,
         Dict.cast(attrs, String.class, Object.class, "attrs_for_reproducibility"));
+  }
+
+  @StarlarkMethod(
+      name = "integrity_hash",
+      doc = "Calculates the subresource integrity hash for the given file.",
+      useStarlarkThread = true,
+      parameters = {
+        @Param(
+            name = "algorithm",
+            defaultValue = "''",
+            doc =
+                "The hash algorithm to use. Supported algorithms are: 'sha256', 'sha384', 'sha512'"),
+        @Param(
+            name = "path",
+            defaultValue = "''",
+            allowedTypes = {
+              @ParamType(type = String.class),
+              @ParamType(type = Label.class),
+              @ParamType(type = StarlarkPath.class)
+            },
+            doc = "Path of the file to calculate a subresource integrity hash."),
+        @Param(
+            name = "watch",
+            defaultValue = "'auto'",
+            positional = false,
+            named = true,
+            doc =
+                """
+                  Whether to <a href="#watch">watch</a> the file. Can be the string 'yes', 'no', \
+                  or 'auto'. Passing 'yes' is equivalent to immediately invoking the \
+                  <a href="#watch"><code>watch()</code></a> method; passing 'no' does not \
+                  attempt to watch the file; passing 'auto' will only attempt to watch the \
+                  file when it is legal to do so (see <code>watch()</code> docs for more \
+                  information.
+                  """)
+      })
+  public String integrityHash(String algorithm, Object path, String watch, StarlarkThread thread)
+      throws RepositoryFunctionException, EvalException, InterruptedException {
+    StarlarkPath p = getPath(path);
+    maybeWatch(p, ShouldWatch.fromString(watch));
+    if (p.isDir()) {
+      throw Starlark.errorf("attempting to integrity_hash() a directory: %s", p);
+    }
+    String algorithmStandardized = algorithm.strip().toLowerCase().replace("-", "");
+
+    // Bazel supports a wide set of hashing algorithms, but we reduce the set to the following
+    // (which matches the SRI spec: https://www.w3.org/TR/sri-2/). This currently omits:
+    //
+    // sha1 - not secure, broken.
+    // gitsha1 - this is just sha1 with some extra headers
+    // blake3 - bad reason being I didn't want to decide what the SRI hash algorithm representation
+    //          should be (Should it be blake3-<hash>/blake3-256-<hash>/blake3256-<hash>/...)
+    ImmutableSet<String> allowedIntegrityHashes = ImmutableSet.of("sha256", "sha384", "sha512");
+    if (!allowedIntegrityHashes.contains(algorithmStandardized)) {
+      throw Starlark.errorf(
+          "algorithm '%s' is not supported. Allowed algorithms are: %s",
+          algorithm, String.join(", ", allowedIntegrityHashes));
+    }
+
+    WorkspaceRuleEvent w =
+        WorkspaceRuleEvent.newIntegrityHashEvent(
+            p.toString(),
+            algorithmStandardized,
+            identifyingStringForLogging,
+            thread.getCallerLocation());
+    env.getListener().post(w);
+
+    HashFunction hashFn = DigestHashFunction.getHashFunctionFromName(algorithmStandardized);
+    try {
+      ByteSource byteSource =
+          new ByteSource() {
+            @Override
+            public InputStream openStream() throws IOException {
+              return p.getPath().getInputStream();
+            }
+          };
+      String hash = Base64.getEncoder().encodeToString((byteSource.hash(hashFn).asBytes()));
+      return String.format("%s-%s", algorithmStandardized, hash);
+    } catch (IOException e) {
+      throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+    }
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -51,6 +51,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.InvalidPathException;
 import java.util.Base64;
+import java.util.HexFormat;
 import java.util.Map;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.Param;
@@ -634,15 +635,20 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
   }
 
   @StarlarkMethod(
-      name = "integrity_hash",
-      doc = "Calculates the subresource integrity hash for the given file.",
+      name = "digest",
+      doc = "Returns the digest for the given file.",
       useStarlarkThread = true,
       parameters = {
         @Param(
             name = "algorithm",
             defaultValue = "''",
             doc =
-                "The hash algorithm to use. Supported algorithms are: 'sha256', 'sha384', 'sha512'"),
+                "The hash algorithm to use. Supported algorithms are: 'sha256', 'sha384', 'sha512'."),
+        @Param(
+            name = "format",
+            defaultValue = "''",
+            doc =
+                "The format to output the digest in. Supported formats are: 'sri', 'hex'."),
         @Param(
             name = "path",
             defaultValue = "''",
@@ -667,13 +673,14 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
                   information.
                   """)
       })
-  public String integrityHash(String algorithm, Object path, String watch, StarlarkThread thread)
+  public String digest(String algorithm, String format, Object path, String watch, StarlarkThread thread)
       throws RepositoryFunctionException, EvalException, InterruptedException {
     StarlarkPath p = getPath(path);
     maybeWatch(p, ShouldWatch.fromString(watch));
     if (p.isDir()) {
       throw Starlark.errorf("attempting to integrity_hash() a directory: %s", p);
     }
+    // Users can pass in "sha-256" as well as "sha256".
     String algorithmStandardized = algorithm.strip().toLowerCase().replace("-", "");
 
     // Bazel supports a wide set of hashing algorithms, but we reduce the set to the following
@@ -689,11 +696,18 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
           "algorithm '%s' is not supported. Allowed algorithms are: %s",
           algorithm, String.join(", ", allowedIntegrityHashes));
     }
+    ImmutableSet<String> allowedFormats = ImmutableSet.of("sri", "hex");
+    if (!allowedFormats.contains(format)) {
+      throw Starlark.errorf(
+          "format '%s' is not supported. Allowed formats are: %s",
+          format, String.join(", ", allowedFormats));
+    }
 
     WorkspaceRuleEvent w =
-        WorkspaceRuleEvent.newIntegrityHashEvent(
+        WorkspaceRuleEvent.newDigestEvent(
             p.toString(),
             algorithmStandardized,
+	    format,
             identifyingStringForLogging,
             thread.getCallerLocation());
     env.getListener().post(w);
@@ -707,8 +721,18 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
               return p.getPath().getInputStream();
             }
           };
-      String hash = Base64.getEncoder().encodeToString((byteSource.hash(hashFn).asBytes()));
-      return String.format("%s-%s", algorithmStandardized, hash);
+      byte[] b = byteSource.hash(hashFn).asBytes();
+      switch (format) {
+      case "sri":
+	  String hash = Base64.getEncoder().encodeToString(b);
+	  return String.format("%s-%s", algorithmStandardized, hash);
+      case "hex":
+	  return HexFormat.of().formatHex(b);
+      default:
+	  throw Starlark.errorf(
+              "unknown format '%s' is not supported. Allowed formats are: %s",
+	      format, String.join(", ", allowedFormats));
+      }
     } catch (IOException e) {
       throw new RepositoryFunctionException(e, Transience.TRANSIENT);
     }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
@@ -618,4 +618,41 @@ public final class StarlarkRepositoryContextTest {
                 .filter(inputAndValue -> inputAndValue.input() instanceof RepoRecordedInput.File))
         .isEmpty();
   }
+
+  @Test
+  public void testIntegrityHash() throws Exception {
+    setUpRepo("test");
+    context.createFile(context.getPath("foo/bar"), "", false, false, thread);
+
+    String integrity256 =
+        context.integrityHash("sha256", context.getPath("foo/bar"), "auto", thread);
+    String integrity384 =
+        context.integrityHash("sha384", context.getPath("foo/bar"), "auto", thread);
+    String integrity512 =
+        context.integrityHash("sha512", context.getPath("foo/bar"), "auto", thread);
+
+    // This is the hash for an empty file. Example code to generate hashes (change hash alg
+    // accordingly)
+    // $ touch empty.txt
+    // $ shasum -a 256 empty.txt | awk '{ print $1 }' | xxd -r -p | base64
+    // $ openssl dgst -sha256 -binary empty.txt | openssl base64 -A; echo
+    assertThat(integrity256).isEqualTo("sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=");
+    assertThat(integrity384)
+        .isEqualTo("sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb");
+    assertThat(integrity512)
+        .isEqualTo(
+            "sha512-z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg==");
+  }
+
+  @Test
+  public void testIntegrityHash_incorrectAlgorithm() throws Exception {
+    setUpRepo("test");
+    context.createFile(context.getPath("foo/bar"), "", false, false, thread);
+
+    EvalException thrown =
+        assertThrows(
+            EvalException.class,
+            () -> context.integrityHash("sha", context.getPath("foo/bar"), "auto", thread));
+    assertThat(thrown).hasMessageThat().contains("algorithm 'sha' is not supported");
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
@@ -620,28 +620,42 @@ public final class StarlarkRepositoryContextTest {
   }
 
   @Test
-  public void testIntegrityHash() throws Exception {
+  public void testDigest() throws Exception {
     setUpRepo("test");
     context.createFile(context.getPath("foo/bar"), "", false, false, thread);
 
     String integrity256 =
-        context.integrityHash("sha256", context.getPath("foo/bar"), "auto", thread);
+        context.digest("sha256", "sri", context.getPath("foo/bar"), "auto", thread);
+    String hex256 =
+        context.digest("sha256", "hex", context.getPath("foo/bar"), "auto", thread);
     String integrity384 =
-        context.integrityHash("sha384", context.getPath("foo/bar"), "auto", thread);
+        context.digest("sha384", "sri", context.getPath("foo/bar"), "auto", thread);
+    String hex384 =
+        context.digest("sha384", "hex", context.getPath("foo/bar"), "auto", thread);
     String integrity512 =
-        context.integrityHash("sha512", context.getPath("foo/bar"), "auto", thread);
+        context.digest("sha512", "sri", context.getPath("foo/bar"), "auto", thread);
+    String hex512 =
+        context.digest("sha512", "hex", context.getPath("foo/bar"), "auto", thread);
 
-    // This is the hash for an empty file. Example code to generate hashes (change hash alg
+    // This is the SRI hash for an empty file. Example code to generate hashes (change hash alg
     // accordingly)
-    // $ touch empty.txt
-    // $ shasum -a 256 empty.txt | awk '{ print $1 }' | xxd -r -p | base64
-    // $ openssl dgst -sha256 -binary empty.txt | openssl base64 -A; echo
+    // $ shasum -a 256 /dev/null | awk '{ print $1 }' | xxd -r -p | base64
+    // $ openssl dgst -sha256 -binary /dev/null | openssl base64 -A; echo
+    // Same for the hex format:
+    // $ shasum -a 256 /dev/null
+    // $ openssl dgst -sha256 /dev/null; echo
     assertThat(integrity256).isEqualTo("sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=");
+    assertThat(hex256).isEqualTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
     assertThat(integrity384)
         .isEqualTo("sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb");
+    assertThat(hex384)
+        .isEqualTo("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b");
     assertThat(integrity512)
         .isEqualTo(
             "sha512-z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg==");
+    assertThat(hex512)
+        .isEqualTo(
+            "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e");
   }
 
   @Test
@@ -652,7 +666,19 @@ public final class StarlarkRepositoryContextTest {
     EvalException thrown =
         assertThrows(
             EvalException.class,
-            () -> context.integrityHash("sha", context.getPath("foo/bar"), "auto", thread));
+            () -> context.digest("sha", "sri", context.getPath("foo/bar"), "auto", thread));
     assertThat(thrown).hasMessageThat().contains("algorithm 'sha' is not supported");
+  }
+
+  @Test
+  public void testIntegrityHash_incorrectFormat() throws Exception {
+    setUpRepo("test");
+    context.createFile(context.getPath("foo/bar"), "", false, false, thread);
+
+    EvalException thrown =
+        assertThrows(
+            EvalException.class,
+            () -> context.digest("sha256", "bytes", context.getPath("foo/bar"), "auto", thread));
+    assertThat(thrown).hasMessageThat().contains("format 'bytes' is not supported");
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
The `repository_ctx.digest` function calculates the sha digest of a
given file. Example usage to generate the sri format and hex format for an empty
file:

```
ctx.integrity_hash("sha256", "sri", ctx.attr.file)
# returns string "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
ctx.integrity_hash("sha256", "hex", ctx.attr.file)
# returns string "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

ctx.integrity_hash("sha384", "sri", ctx.attr.file)
# returns string "sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"

ctx.integrity_hash("sha512", "sri", ctx.attr.file)
# returns string "sha512-z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg=="
```

https://www.w3.org/TR/sri-2/ - the Subresource Integrity spec

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->
Fixes #15759

I also came across https://github.com/hermeticbuild/sha256.star which is building this in pure starlark.  

### Build API Changes

> 1. Has this been discussed in a design doc or issue? (Please link it)

#15759

> 2. Is the change backward compatible?

Yes, this only adds a new function on `repository_ctx`

> 3. If it's a breaking change, what is the migration plan?

N/A

### Checklist

- [X] I have added tests for the new use cases (if any).
- [X] I have updated the documentation (if applicable).

### Release Notes
RELNOTES[NEW]: Add starlark method `repository_ctx.digest` to output the digest of a file.
<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->


