### PR TITLE
Invalidate extensions when workspace lockfile facts change

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -161,11 +161,6 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       var lockedExtensionMap = workspaceLockfile.getModuleExtensions().get(extensionId);
       var lockedExtension =
           lockedExtensionMap == null ? null : lockedExtensionMap.get(extension.getEvalFactors());
-      // Only validate workspace lockfile facts when the extension entry itself is in the
-      // workspace lockfile. Reproducible extensions are only stored in the hidden lockfile,
-      // so missing facts in the workspace lockfile are expected for them.
-      Facts factsToValidateAgainst =
-          lockedExtension != null ? workspaceLockfileFacts : lockfileFacts;
       if (lockedExtension == null) {
         lockedExtensionMap = hiddenLockfile.getModuleExtensions().get(extensionId);
         lockedExtension =
@@ -184,7 +179,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                   extension.getEvalFactors(),
                   lockedExtension,
                   lockfileFacts,
-                  factsToValidateAgainst);
+                  workspaceLockfileFacts);
           if (singleExtensionValue != null) {
             return singleExtensionValue;
           }
@@ -343,8 +338,6 @@ public class SingleExtensionEvalFunction implements SkyFunction {
         diffRecorder.record(
             "an input to the extension '" + extensionId + "' changed: " + reason.get());
       }
-      // Facts are never invalidated by Bazel itself, but the workspace lockfile may have been
-      // manually edited (or rolled back via version control) to remove or modify facts.
       if (!facts.equals(workspaceLockfileFacts)) {
         diffRecorder.record(
             "the facts of extension '" + extensionId + "' are not up-to-date");

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -161,6 +161,11 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       var lockedExtensionMap = workspaceLockfile.getModuleExtensions().get(extensionId);
       var lockedExtension =
           lockedExtensionMap == null ? null : lockedExtensionMap.get(extension.getEvalFactors());
+      // Only validate workspace lockfile facts when the extension entry itself is in the
+      // workspace lockfile. Reproducible extensions are only stored in the hidden lockfile,
+      // so missing facts in the workspace lockfile are expected for them.
+      Facts factsToValidateAgainst =
+          lockedExtension != null ? workspaceLockfileFacts : lockfileFacts;
       if (lockedExtension == null) {
         lockedExtensionMap = hiddenLockfile.getModuleExtensions().get(extensionId);
         lockedExtension =
@@ -178,7 +183,8 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                   usagesValue,
                   extension.getEvalFactors(),
                   lockedExtension,
-                  lockfileFacts);
+                  lockfileFacts,
+                  factsToValidateAgainst);
           if (singleExtensionValue != null) {
             return singleExtensionValue;
           }
@@ -306,7 +312,8 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       SingleExtensionUsagesValue usagesValue,
       ModuleExtensionEvalFactors evalFactors,
       LockFileModuleExtension lockedExtension,
-      Facts facts)
+      Facts facts,
+      Facts workspaceLockfileFacts)
       throws SingleExtensionEvalFunctionException,
           InterruptedException,
           NeedsSkyframeRestartException {
@@ -336,10 +343,15 @@ public class SingleExtensionEvalFunction implements SkyFunction {
         diffRecorder.record(
             "an input to the extension '" + extensionId + "' changed: " + reason.get());
       }
+      // Facts are never invalidated by Bazel itself, but the workspace lockfile may have been
+      // manually edited (or rolled back via version control) to remove or modify facts.
+      if (!facts.equals(workspaceLockfileFacts)) {
+        diffRecorder.record(
+            "the facts of extension '" + extensionId + "' are not up-to-date");
+      }
     } catch (DiffFoundEarlyExitException ignored) {
       // ignored
     }
-    // There is intentionally no diff check for facts - they are never invalidated by Bazel.
     if (!diffRecorder.anyDiffsDetected()) {
       return createSingleExtensionValue(
           lockedExtension.getGeneratedRepoSpecs(),

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -3253,5 +3253,122 @@ class BazelLockfileTest(test_base.TestBase):
     self.assertNotIn('has changed its facts', stderr)
 
 
+  def testDeletedFactsDetectedByErrorMode(self):
+    """Test that ERROR mode detects facts deleted from the workspace lockfile.
+
+    Regression test for https://github.com/bazelbuild/bazel/issues/29161
+    """
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'lockfile_ext = use_extension("extension.bzl", "lockfile_ext")',
+            'use_repo(lockfile_ext, "hello")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def impl(ctx):',
+            '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
+            'repo_rule = repository_rule(',
+            '    implementation = impl,',
+            '    attrs = {"hash": attr.string()},',
+            ')',
+            'def _mod_ext_impl(ctx):',
+            '    metadata = {"hello": {"hash": "olleh"}}',
+            '    repo_rule(',
+            '        name = "hello",',
+            '        hash = metadata["hello"]["hash"],',
+            '    )',
+            '    return ctx.extension_metadata(',
+            '        facts = metadata,',
+            '    )',
+            'lockfile_ext = module_extension(implementation = _mod_ext_impl)',
+        ],
+    )
+
+    # Initial build to generate lockfile with facts
+    self.RunBazel(['build', '@hello//:all', '--lockfile_mode=update'])
+
+    # Verify facts are in the lockfile
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read().strip())
+    extension_id = '//:extension.bzl%lockfile_ext'
+    self.assertIn(extension_id, lockfile['facts'])
+
+    # Delete facts from the workspace lockfile
+    del lockfile['facts'][extension_id]
+    with open(self.Path('MODULE.bazel.lock'), 'w') as f:
+      json.dump(lockfile, f, indent=2)
+
+    # ERROR mode should detect the missing facts
+    exit_code, stdout, stderr = self.RunBazel(
+        ['build', '@hello//:all', '--lockfile_mode=error'], allow_failure=True
+    )
+    self.assertNotEqual(exit_code, 0)
+
+  def testDeletedFactsRegeneratedByUpdateMode(self):
+    """Test that UPDATE mode regenerates facts deleted from the workspace lockfile.
+
+    Regression test for https://github.com/bazelbuild/bazel/issues/29161
+    """
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'lockfile_ext = use_extension("extension.bzl", "lockfile_ext")',
+            'use_repo(lockfile_ext, "hello")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def impl(ctx):',
+            '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
+            'repo_rule = repository_rule(',
+            '    implementation = impl,',
+            '    attrs = {"hash": attr.string()},',
+            ')',
+            'def _mod_ext_impl(ctx):',
+            '    metadata = {"hello": {"hash": "olleh"}}',
+            '    repo_rule(',
+            '        name = "hello",',
+            '        hash = metadata["hello"]["hash"],',
+            '    )',
+            '    return ctx.extension_metadata(',
+            '        facts = metadata,',
+            '    )',
+            'lockfile_ext = module_extension(implementation = _mod_ext_impl)',
+        ],
+    )
+
+    # Initial build to generate lockfile with facts
+    self.RunBazel(['build', '@hello//:all', '--lockfile_mode=update'])
+
+    # Verify facts are in the lockfile
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read().strip())
+    extension_id = '//:extension.bzl%lockfile_ext'
+    self.assertIn(extension_id, lockfile['facts'])
+
+    # Delete facts from the workspace lockfile
+    del lockfile['facts'][extension_id]
+    with open(self.Path('MODULE.bazel.lock'), 'w') as f:
+      json.dump(lockfile, f, indent=2)
+
+    # UPDATE mode should regenerate the facts
+    self.RunBazel(['build', '@hello//:all', '--lockfile_mode=update'])
+
+    # Verify facts are back in the lockfile
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read().strip())
+    self.assertIn(extension_id, lockfile['facts'])
+    self.assertEqual(
+        lockfile['facts'][extension_id],
+        {'hello': {'hash': 'olleh'}},
+    )
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
When the facts in the workspace lockfile change compared to Bazel's in-memory state, for example due to a merge conflict resolution, the extension is now invalidated so that the facts can be regenerated.

### Motivation
Fixes #29161

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
