### PR TITLE
bazel-info: preserve flag aliases in config

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/InfoCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/InfoCommand.java
@@ -24,7 +24,11 @@ import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.NoBuildEvent;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.analysis.config.InvalidConfigurationException;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
@@ -71,6 +75,7 @@ import com.google.devtools.build.lib.runtime.commands.info.WorkerMetricsInfoItem
 import com.google.devtools.build.lib.runtime.commands.info.WorkspaceInfoItem;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
+import com.google.devtools.build.lib.skyframe.RepositoryMappingValue.RepositoryMappingResolutionException;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.util.ExitCode;
@@ -187,10 +192,19 @@ public class InfoCommand implements BlazeCommand {
                 ensureSyncPackageLoading(env, optionsParsingResult);
                 // TODO(bazel-team): What if there are multiple configurations? [multi-config]
                 BuildOptions buildOptions = runtime.createBuildOptions(optionsParsingResult);
-                env.getSkyframeExecutor().setBaselineConfiguration(buildOptions, env.getReporter());
+                populateFlagAliases(buildOptions, env);
+                BuildOptions baselineConfiguration =
+                    env.getSkyframeExecutor().getBaselineConfigurationIfPresent();
+                if (!buildOptions.equals(baselineConfiguration)) {
+                  env.getSkyframeExecutor()
+                      .setBaselineConfiguration(buildOptions, env.getReporter());
+                }
                 return env.getSkyframeExecutor()
                     .getConfiguration(env.getReporter(), buildOptions, /* keepGoing= */ true);
               } catch (InvalidConfigurationException e) {
+                env.getReporter().handle(Event.error(e.getMessage()));
+                throw new AbruptExitRuntimeException(e.getDetailedExitCode());
+              } catch (RepositoryMappingResolutionException e) {
                 env.getReporter().handle(Event.error(e.getMessage()));
                 throw new AbruptExitRuntimeException(e.getDetailedExitCode());
               } catch (AbruptExitException e) {
@@ -278,6 +292,41 @@ public class InfoCommand implements BlazeCommand {
           InterruptedFailureDetails.detailedExitCode("info interrupted"));
     }
     return BlazeCommandResult.success();
+  }
+
+  private static void populateFlagAliases(BuildOptions buildOptions, CommandEnvironment env)
+      throws InterruptedException, RepositoryMappingResolutionException {
+    CoreOptions coreOptions = buildOptions.get(CoreOptions.class);
+    if (coreOptions == null) {
+      return;
+    }
+
+    Map<String, String> flagAliases = env.getSkyframeExecutor().getFlagAliases(env.getReporter());
+    if (flagAliases.isEmpty()) {
+      return;
+    }
+
+    Label.RepoContext repoContext =
+        Label.RepoContext.of(
+            RepositoryName.MAIN, env.getSkyframeExecutor().getMainRepoMapping(env.getReporter()));
+    TreeMap<String, Label> mergedFlagAliases = new TreeMap<>();
+    flagAliases.forEach(
+        (name, rawLabel) -> mergedFlagAliases.put(name, parseFlagAlias(rawLabel, repoContext)));
+    coreOptions
+        .getCommandLineFlagAliases()
+        .forEach(entry -> mergedFlagAliases.put(entry.getKey(), entry.getValue()));
+    coreOptions.setCommandLineFlagAliases(
+        mergedFlagAliases.entrySet().stream()
+            .map(entry -> Map.entry(entry.getKey(), entry.getValue()))
+            .collect(ImmutableList.toImmutableList()));
+  }
+
+  private static Label parseFlagAlias(String rawLabel, Label.RepoContext repoContext) {
+    try {
+      return Label.parseWithRepoContext(rawLabel, repoContext);
+    } catch (LabelSyntaxException e) {
+      throw new IllegalStateException("Failed to reparse --flag_alias value: " + rawLabel, e);
+    }
   }
 
   private static void ensureSyncPackageLoading(CommandEnvironment env, OptionsProvider options)

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -1568,6 +1568,18 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
         injectable(), adjustForExec(buildOptions, eventHandler));
   }
 
+  @Nullable
+  public BuildOptions getBaselineConfigurationIfPresent() throws InterruptedException {
+    SkyValue value =
+        memoizingEvaluator.getExistingValue(
+            BaselineOptionsFunction.BASELINE_CONFIGURATION.getKey());
+    if (!(value instanceof PrecomputedValue precomputedValue)) {
+      return null;
+    }
+    Object baselineConfiguration = precomputedValue.get();
+    return baselineConfiguration instanceof BuildOptions buildOptions ? buildOptions : null;
+  }
+
   private BuildOptions adjustForExec(BuildOptions buildOptions, ExtendedEventHandler eventHandler)
       throws InvalidConfigurationException, InterruptedException {
     StarlarkAttributeTransitionProvider execTransition;
@@ -3334,7 +3346,11 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     EvaluationResult<BazelDepGraphValue> evalResult =
         evaluate(
             ImmutableList.of(BazelDepGraphValue.KEY), false, DEFAULT_THREAD_COUNT, eventHandler);
-    var bzlmodDepGraph = evalResult.get(BazelDepGraphValue.KEY).getDepGraph();
+    BazelDepGraphValue bazelDepGraphValue = evalResult.get(BazelDepGraphValue.KEY);
+    if (evalResult.hasError() || bazelDepGraphValue == null) {
+      return ImmutableMap.of();
+    }
+    var bzlmodDepGraph = bazelDepGraphValue.getDepGraph();
     LinkedHashMap<String, String> aliasesMap = new LinkedHashMap<>();
     var rootModule = bzlmodDepGraph.entrySet().iterator().next().getValue();
     for (var module : bzlmodDepGraph.entrySet()) {

--- a/src/test/shell/integration/info_test.sh
+++ b/src/test/shell/integration/info_test.sh
@@ -110,4 +110,135 @@ function test_invalid_flag_error() {
   expect_log "Invalid registry URL: foobarbaz"
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/29176 and
+# https://github.com/bazelbuild/bazel/issues/22360.
+function write_incremental_info_repro() {
+  mkdir -p foo
+  cat > foo/BUILD <<'EOF'
+genrule(
+    name = "foo",
+    outs = ["out"],
+    cmd = "touch $@",
+)
+EOF
+}
+
+function write_flag_alias_repro() {
+  mkdir -p flags
+  cat > flags/rules.bzl <<'EOF'
+starlark_string_flag = rule(
+    implementation = lambda ctx: [],
+    build_setting = config.string(flag = True),
+)
+EOF
+  cat > flags/BUILD <<'EOF'
+load(":rules.bzl", "starlark_string_flag")
+
+starlark_string_flag(
+    name = "module_flag",
+    build_setting_default = "module_default",
+)
+
+starlark_string_flag(
+    name = "user_flag",
+    build_setting_default = "user_default",
+)
+EOF
+  cat > MODULE.bazel <<'EOF'
+module(name = "test")
+
+flag_alias(name = "module_alias", starlark_flag = "//flags:module_flag")
+EOF
+}
+
+function enable_disk_cache_in_test_bazelrc() {
+  echo "common --disk_cache=${TEST_TMPDIR}/disk-cache" >> "${TEST_TMPDIR}/bazelrc"
+}
+
+function run_nobuild_with_bep() {
+  local bep_file="$1"
+  local log_file="$2"
+  shift 2
+  bazel build --nobuild --build_event_text_file="${bep_file}" "$@" >"${log_file}" 2>&1 \
+    || fail "${PRODUCT_NAME} build failed"
+}
+
+function assert_targets_configured_metric_absent() {
+  local bep_file="$1"
+  if grep -q "targets_configured:" "${bep_file}"; then
+    cat "${bep_file}" >&2
+    fail "expected targets_configured metric to be absent in ${bep_file}"
+  fi
+}
+
+function assert_targets_configured_metric_present() {
+  local bep_file="$1"
+  if ! grep -Eq "targets_configured: [1-9][0-9]*" "${bep_file}"; then
+    cat "${bep_file}" >&2
+    fail "expected a non-zero targets_configured metric in ${bep_file}"
+  fi
+}
+
+function assert_analyzed_target_summary() {
+  local log_file="$1"
+  local expected_targets_configured="$2"
+  grep -Eq \
+    "Analyzed target //foo:foo \\(0 packages loaded, ${expected_targets_configured} target[s]? configured\\)\\." \
+    "${log_file}" \
+    || fail "expected analyzed target summary with ${expected_targets_configured} target(s) configured in ${log_file}"
+}
+
+function test_info_bazel_bin_invalidates_incremental_analysis() {
+  write_incremental_info_repro
+  enable_disk_cache_in_test_bazelrc
+
+  bazel build --nobuild //foo:foo >"${TEST_log}" 2>&1 \
+    || fail "${PRODUCT_NAME} initial build failed"
+  run_nobuild_with_bep warm.txt warm.log //foo:foo
+  assert_targets_configured_metric_absent warm.txt
+  assert_analyzed_target_summary warm.log 0
+
+  bazel info bazel-bin >"${TEST_log}" 2>&1 \
+    || fail "${PRODUCT_NAME} info bazel-bin failed"
+  run_nobuild_with_bep post.txt post.log //foo:foo
+  assert_targets_configured_metric_present post.txt
+  assert_analyzed_target_summary post.log 1
+}
+
+function test_info_output_base_keeps_incremental_analysis_warm() {
+  write_incremental_info_repro
+  enable_disk_cache_in_test_bazelrc
+
+  bazel build --nobuild //foo:foo >"${TEST_log}" 2>&1 \
+    || fail "${PRODUCT_NAME} initial build failed"
+  run_nobuild_with_bep warm.txt warm.log //foo:foo
+  assert_targets_configured_metric_absent warm.txt
+  assert_analyzed_target_summary warm.log 0
+
+  bazel info output_base >"${TEST_log}" 2>&1 \
+    || fail "${PRODUCT_NAME} info output_base failed"
+  run_nobuild_with_bep post.txt post.log //foo:foo
+  assert_targets_configured_metric_absent post.txt
+  assert_analyzed_target_summary post.log 0
+}
+
+function test_info_bazel_bin_invalidates_incremental_analysis_with_module_and_user_flag_aliases() {
+  write_incremental_info_repro
+  write_flag_alias_repro
+  enable_disk_cache_in_test_bazelrc
+  echo "common --flag_alias=user_alias=//flags:user_flag" >> "${TEST_TMPDIR}/bazelrc"
+
+  bazel build --nobuild //foo:foo >"${TEST_log}" 2>&1 \
+    || fail "${PRODUCT_NAME} initial build failed"
+  run_nobuild_with_bep warm.txt warm.log //foo:foo
+  assert_targets_configured_metric_absent warm.txt
+  assert_analyzed_target_summary warm.log 0
+
+  bazel info bazel-bin >"${TEST_log}" 2>&1 \
+    || fail "${PRODUCT_NAME} info bazel-bin failed"
+  run_nobuild_with_bep post.txt post.log //foo:foo
+  assert_targets_configured_metric_present post.txt
+  assert_analyzed_target_summary post.log 1
+}
+
 run_suite "Integration tests for ${PRODUCT_NAME} info."

--- a/src/test/shell/integration/info_test.sh
+++ b/src/test/shell/integration/info_test.sh
@@ -188,7 +188,7 @@ function assert_analyzed_target_summary() {
     || fail "expected analyzed target summary with ${expected_targets_configured} target(s) configured in ${log_file}"
 }
 
-function test_info_bazel_bin_invalidates_incremental_analysis() {
+function test_info_bazel_bin_keeps_incremental_analysis_warm() {
   write_incremental_info_repro
   enable_disk_cache_in_test_bazelrc
 
@@ -201,8 +201,8 @@ function test_info_bazel_bin_invalidates_incremental_analysis() {
   bazel info bazel-bin >"${TEST_log}" 2>&1 \
     || fail "${PRODUCT_NAME} info bazel-bin failed"
   run_nobuild_with_bep post.txt post.log //foo:foo
-  assert_targets_configured_metric_present post.txt
-  assert_analyzed_target_summary post.log 1
+  assert_targets_configured_metric_absent post.txt
+  assert_analyzed_target_summary post.log 0
 }
 
 function test_info_output_base_keeps_incremental_analysis_warm() {
@@ -222,7 +222,7 @@ function test_info_output_base_keeps_incremental_analysis_warm() {
   assert_analyzed_target_summary post.log 0
 }
 
-function test_info_bazel_bin_invalidates_incremental_analysis_with_module_and_user_flag_aliases() {
+function test_info_bazel_bin_keeps_incremental_analysis_warm_with_module_and_user_flag_aliases() {
   write_incremental_info_repro
   write_flag_alias_repro
   enable_disk_cache_in_test_bazelrc
@@ -237,8 +237,8 @@ function test_info_bazel_bin_invalidates_incremental_analysis_with_module_and_us
   bazel info bazel-bin >"${TEST_log}" 2>&1 \
     || fail "${PRODUCT_NAME} info bazel-bin failed"
   run_nobuild_with_bep post.txt post.log //foo:foo
-  assert_targets_configured_metric_present post.txt
-  assert_analyzed_target_summary post.log 1
+  assert_targets_configured_metric_absent post.txt
+  assert_analyzed_target_summary post.log 0
 }
 
 run_suite "Integration tests for ${PRODUCT_NAME} info."


### PR DESCRIPTION
## Summary

This PR addresses the incremental-analysis invalidation reported in
#29176 and related to #22360.

The first commit adds a shell integration repro for the user-visible
workflow:

```bash
bazel build --nobuild //foo:foo
bazel info bazel-bin
bazel build --nobuild //foo:foo
```

The second commit fixes `InfoCommand` so that config-dependent info keys
preserve the implicit module `--flag_alias` state used by the preceding
build instead of rewriting the baseline configuration with different
`CoreOptions`.

## Root Cause

`BlazeCommandDispatcher` injects module-defined `--flag_alias=...`
entries before command execution so Starlark flag aliases work in
configuration logic.

By the time `InfoCommand` rebuilt `BuildOptions` from
`OptionsParsingResult`, those implicit aliases were no longer present.
That made `bazel info bazel-bin` write a different baseline
configuration than the previous `build --nobuild`, which dirtied
`BASELINE_OPTIONS` and forced the next no-op build back through
analysis.

## Details

- add an end-to-end shell test in `info_test.sh` that exercises the real
  `build --nobuild -> info -> build --nobuild` flow
- keep `info output_base` as the control case that should not invalidate
  warm analysis
- teach `InfoCommand` to repopulate
  `CoreOptions.commandLineFlagAliases` from
  `SkyframeExecutor.getFlagAliases()` before requesting a configuration
- skip baseline reinjection when the rebuilt `BuildOptions` already
  match the current baseline, since precomputed-value injection still
  dirties `BASELINE_OPTIONS` even for equal values
- make `getFlagAliases()` fail closed on bzlmod graph errors so invalid
  registry paths still return the expected user error instead of
  crashing

## Why

Before this change, `bazel info bazel-bin` could perturb warm
incremental builds even when it was asking about the same effective
configuration the server had just analyzed. That makes `bazel info`
unexpectedly expensive in iterative workflows.

## Testing

- `bazel test //src/test/shell/integration:info_test --test_output=errors`
