### PR TITLE
remote: allow local fallback for buildRemoteAction failures

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -525,8 +525,6 @@ public class RemoteExecutionService {
                 blobPolicy);
       } catch (CredentialHelperException e) {
         throw createExecExceptionForCredentialHelperException(e);
-      } catch (RemoteExecutionCapabilitiesException e) {
-        throw createExecExceptionFromRemoteExecutionCapabilitiesException(e);
       }
 
       // Get the remote platform properties.

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -93,9 +93,17 @@ final class RemoteSpawnCache implements SpawnCache {
 
     Stopwatch totalTime = Stopwatch.createStarted();
 
-    RemoteAction action =
-        remoteExecutionService.buildRemoteAction(
-            spawn, context, MerkleTreeComputer.BlobPolicy.DISCARD);
+    RemoteAction action;
+    try {
+      action =
+          remoteExecutionService.buildRemoteAction(
+              spawn, context, MerkleTreeComputer.BlobPolicy.DISCARD);
+    } catch (RemoteExecutionCapabilitiesException e) {
+      if (options.remoteLocalFallbackForRemoteCache && options.remoteLocalFallback) {
+        return SpawnCache.NO_RESULT_NO_STORE;
+      }
+      throw createExecExceptionFromRemoteExecutionCapabilitiesException(e);
+    }
     SpawnMetrics.Builder spawnMetrics =
         SpawnMetrics.Builder.forRemoteExec()
             .setInputBytes(action.getInputBytes())

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -184,13 +184,18 @@ public class RemoteSpawnRunner implements SpawnRunner {
     boolean acceptCachedResult = remoteExecutionService.getReadCachePolicy(spawn).allowAnyCache();
     boolean uploadLocalResults = remoteExecutionService.getWriteCachePolicy(spawn).allowAnyCache();
 
-    RemoteAction action =
-        remoteExecutionService.buildRemoteAction(
-            spawn,
-            context,
-            remoteOptions.remoteDiscardMerkleTrees
-                ? MerkleTreeComputer.BlobPolicy.DISCARD
-                : MerkleTreeComputer.BlobPolicy.KEEP);
+    RemoteAction action;
+    try {
+      action =
+          remoteExecutionService.buildRemoteAction(
+              spawn,
+              context,
+              remoteOptions.remoteDiscardMerkleTrees
+                  ? MerkleTreeComputer.BlobPolicy.DISCARD
+                  : MerkleTreeComputer.BlobPolicy.KEEP);
+    } catch (RemoteExecutionCapabilitiesException e) {
+      return execLocallyAndUploadOrFail(null, spawn, context, uploadLocalResults, e);
+    }
 
     context.setDigest(digestUtil.asSpawnLogProto(action.getActionKey()));
 
@@ -555,7 +560,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
   }
 
   private SpawnResult execLocallyAndUploadOrFail(
-      RemoteAction action,
+      @Nullable RemoteAction action,
       Spawn spawn,
       SpawnExecutionContext context,
       boolean uploadLocalResults,
@@ -677,10 +682,16 @@ public class RemoteSpawnRunner implements SpawnRunner {
 
   @VisibleForTesting
   SpawnResult execLocallyAndUpload(
-      RemoteAction action, Spawn spawn, SpawnExecutionContext context, boolean uploadLocalResults)
+      @Nullable RemoteAction action,
+      Spawn spawn,
+      SpawnExecutionContext context,
+      boolean uploadLocalResults)
       throws ExecException, IOException, InterruptedException {
     SpawnResult result = execLocally(spawn, context);
-    if (uploadLocalResults && Status.SUCCESS.equals(result.status()) && result.exitCode() == 0) {
+    if (action != null
+        && uploadLocalResults
+        && Status.SUCCESS.equals(result.status())
+        && result.exitCode() == 0) {
       remoteExecutionService.uploadOutputs(
           action, result, () -> {}, remoteOptions.guardAgainstConcurrentChanges);
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -68,6 +68,7 @@ import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.events.StoredEventHandler;
 import com.google.devtools.build.lib.exec.ExecutionOptions;
+import com.google.devtools.build.lib.exec.SpawnCache;
 import com.google.devtools.build.lib.exec.SpawnCache.CacheHandle;
 import com.google.devtools.build.lib.exec.SpawnInputExpander;
 import com.google.devtools.build.lib.exec.SpawnRunner.ProgressStatus;
@@ -77,6 +78,7 @@ import com.google.devtools.build.lib.remote.CombinedCache.CachedActionResult;
 import com.google.devtools.build.lib.remote.RemoteExecutionService.RemoteActionResult;
 import com.google.devtools.build.lib.remote.common.ActionKey;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
+import com.google.devtools.build.lib.remote.common.RemoteExecutionCapabilitiesException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
@@ -1311,5 +1313,40 @@ public class RemoteSpawnCacheTest {
     // assert
     assertThat(cacheHandle.hasResult()).isFalse();
     assertThat(cacheHandle.willStore()).isTrue();
+  }
+
+  @Test
+  public void buildRemoteActionFailure_localFallback() throws Exception {
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.remoteLocalFallback = true;
+    remoteOptions.remoteLocalFallbackForRemoteCache = true;
+    remoteOptions.remoteAcceptCached = true;
+
+    RemoteSpawnCache cache = remoteSpawnCacheWithOptions(remoteOptions);
+    RemoteExecutionService service = cache.getRemoteExecutionService();
+    doThrow(new RemoteExecutionCapabilitiesException(new IOException("capabilities failed")))
+        .when(service)
+        .buildRemoteAction(any(), any(), any());
+
+    CacheHandle handle = cache.lookup(simpleSpawn, simplePolicy);
+
+    assertThat(handle.hasResult()).isFalse();
+    assertThat(handle.willStore()).isFalse();
+    assertThat(handle).isEqualTo(SpawnCache.NO_RESULT_NO_STORE);
+  }
+
+  @Test
+  public void buildRemoteActionFailure_noLocalFallback_shouldThrow() throws Exception {
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.remoteLocalFallback = false;
+    remoteOptions.remoteAcceptCached = true;
+
+    RemoteSpawnCache cache = remoteSpawnCacheWithOptions(remoteOptions);
+    RemoteExecutionService service = cache.getRemoteExecutionService();
+    doThrow(new RemoteExecutionCapabilitiesException(new IOException("capabilities failed")))
+        .when(service)
+        .buildRemoteAction(any(), any(), any());
+
+    assertThrows(ExecException.class, () -> cache.lookup(simpleSpawn, simplePolicy));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -62,6 +62,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
 import com.google.devtools.build.lib.actions.CommandLines.ParamFileActionInput;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ParameterFile.ParameterFileType;
 import com.google.devtools.build.lib.actions.ResourceSet;
@@ -89,6 +90,7 @@ import com.google.devtools.build.lib.remote.RemoteExecutionService.RemoteActionR
 import com.google.devtools.build.lib.remote.common.ActionKey;
 import com.google.devtools.build.lib.remote.common.BulkTransferException;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
+import com.google.devtools.build.lib.remote.common.RemoteExecutionCapabilitiesException;
 import com.google.devtools.build.lib.remote.common.OperationObserver;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
@@ -441,6 +443,50 @@ public class RemoteSpawnRunnerTest {
         .execLocallyAndUpload(any(), eq(spawn), eq(policy), /* uploadLocalResults= */ eq(true));
     verify(service).uploadOutputs(any(), eq(result), any(), any());
     verify(service, never()).downloadOutputs(any(), any());
+  }
+
+  @Test
+  public void remoteLocalFallback_buildRemoteActionFailure() throws Exception {
+    remoteOptions.remoteLocalFallback = true;
+
+    RemoteSpawnRunner runner = spy(newSpawnRunner());
+    RemoteExecutionService service = runner.getRemoteExecutionService();
+    doThrow(new RemoteExecutionCapabilitiesException(new IOException("capabilities failed")))
+        .when(service)
+        .buildRemoteAction(any(), any(), any());
+
+    Spawn spawn = newSimpleSpawn();
+    SpawnExecutionContext policy = getSpawnContext(spawn);
+
+    SpawnResult localResult =
+        new SpawnResult.Builder()
+            .setExitCode(0)
+            .setStatus(Status.SUCCESS)
+            .setRunnerName("local")
+            .build();
+    when(localRunner.exec(spawn, policy)).thenReturn(localResult);
+
+    SpawnResult result = runner.exec(spawn, policy);
+
+    assertThat(result).isEqualTo(localResult);
+    verify(localRunner).exec(spawn, policy);
+    verify(service, never()).uploadOutputs(any(), any(), any(), any());
+  }
+
+  @Test
+  public void buildRemoteActionFailure_noLocalFallback_shouldThrow() throws Exception {
+    remoteOptions.remoteLocalFallback = false;
+
+    RemoteSpawnRunner runner = spy(newSpawnRunner());
+    RemoteExecutionService service = runner.getRemoteExecutionService();
+    doThrow(new RemoteExecutionCapabilitiesException(new IOException("capabilities failed")))
+        .when(service)
+        .buildRemoteAction(any(), any(), any());
+
+    Spawn spawn = newSimpleSpawn();
+    SpawnExecutionContext policy = getSpawnContext(spawn);
+
+    assertThrows(ExecException.class, () -> runner.exec(spawn, policy));
   }
 
   @Test


### PR DESCRIPTION
If buildRemoteAction fails due to a RemoteExecutionCapabilitiesException, the failure should trigger local fallback if --remote_local_fallback is enabled.

Previously, RemoteExecutionCapabilitiesException was caught in buildRemoteAction and re-thrown as an ExecException, which is considered fatal and bypasses the fallback logic in RemoteSpawnRunner and RemoteSpawnCache.

Closes #29129
