### PR TITLE
[9.1.0] Allow toolchain features to mark paths for path mapping (https://github.com/bazelbuild/bazel/pull/28794)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.rules.cpp;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Collections2;
@@ -37,6 +39,7 @@ import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
 import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerialization;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.starlarkbuildapi.cpp.CcToolchainVariablesApi;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.LinkedHashMap;
@@ -104,6 +107,22 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
     }
   }
 
+  /** A chunk of an exec path that can be mapped upon expansion. */
+  @Immutable
+  @AutoCodec
+  @VisibleForSerialization
+  record RelativePathChunk(PathFragment execPath) implements StringChunk {
+
+    RelativePathChunk {
+      checkArgument(!execPath.isAbsolute(), "execPath is not relative: %s", execPath);
+    }
+
+    @Override
+    public String expand(CcToolchainVariables variables, PathMapper pathMapper) {
+      return pathMapper.map(execPath).getPathString();
+    }
+  }
+
   /**
    * Parser for toolchain string values.
    *
@@ -118,6 +137,8 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
    * <p>To get a literal percent character, "%%" can be used in the string.
    */
   public static class StringValueParser {
+
+    private static final String PATH_PREFIX = "path:";
 
     private final String value;
 
@@ -200,8 +221,22 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
       }
       int end = value.indexOf('}', current);
       final String name = value.substring(current, end);
-      usedVariables.add(name);
-      chunks.add(new VariableChunk(name));
+      if (name.startsWith(PATH_PREFIX)) {
+        String path = name.substring(PATH_PREFIX.length());
+        if (path.isEmpty()) {
+          abort("expected path after 'path:'");
+        }
+        // The provided path is expected to be an exec path, which always uses '/' as a separator
+        // and is relative. Ensure that it is parsed consistently.
+        var pathFragment = PathFragment.createForOs(path, OS.LINUX);
+        if (pathFragment.isAbsolute()) {
+          abort("expected relative Unix-style path after 'path:'");
+        }
+        chunks.add(new RelativePathChunk(pathFragment));
+      } else {
+        usedVariables.add(name);
+        chunks.add(new VariableChunk(name));
+      }
       current = end + 1;
     }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -284,6 +284,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/rules/cpp",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/testutils",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/testutils:round-tripping",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
         "//src/test/java/com/google/devtools/build/lib/packages:testutil",
         "//src/test/java/com/google/devtools/build/lib/testutil:TestConstants",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesTest.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.rules.cpp.CcToolchainVariables.VariableValu
 import com.google.devtools.build.lib.skyframe.serialization.testutils.RoundTripping;
 import com.google.devtools.build.lib.skyframe.serialization.testutils.SerializationTester;
 import com.google.devtools.build.lib.testutil.TestConstants;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -469,11 +470,21 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
   }
 
   private String getExpansionOfFlag(String value, CcToolchainVariables variables) throws Exception {
-    return getCommandLineForFlag(value, variables).get(0);
+    return getExpansionOfFlag(value, variables, PathMapper.NOOP);
+  }
+
+  private String getExpansionOfFlag(
+      String value, CcToolchainVariables variables, PathMapper pathMapper) throws Exception {
+    return getCommandLineForFlag(value, variables, pathMapper).getFirst();
   }
 
   private List<String> getCommandLineForFlagGroups(String groups, CcToolchainVariables variables)
       throws Exception {
+    return getCommandLineForFlagGroups(groups, variables, PathMapper.NOOP);
+  }
+
+  private List<String> getCommandLineForFlagGroups(
+      String groups, CcToolchainVariables variables, PathMapper pathMapper) throws Exception {
     FeatureConfiguration configuration =
         buildFeatures(
                 "features = [",
@@ -488,12 +499,14 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
                 "    ],",
                 ")]")
             .getFeatureConfiguration(ImmutableSet.of("a"));
-    return configuration.getCommandLine(CppActionNames.CPP_COMPILE, variables);
+    return configuration.getCommandLine(
+        CppActionNames.CPP_COMPILE, variables, /* inputMetadataProvider= */ null, pathMapper);
   }
 
-  private List<String> getCommandLineForFlag(String value, CcToolchainVariables variables)
-      throws Exception {
-    return getCommandLineForFlagGroups("flag_group(flags = ['" + value + "'])", variables);
+  private List<String> getCommandLineForFlag(
+      String value, CcToolchainVariables variables, PathMapper pathMapper) throws Exception {
+    return getCommandLineForFlagGroups(
+        "flag_group(flags = ['" + value + "'])", variables, pathMapper);
   }
 
   private String getFlagParsingError(String value) {
@@ -534,6 +547,33 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
         .isEmpty();
     assertThat(getFlagExpansionError("%{v}", createVariables()))
         .contains("Invalid toolchain configuration: Cannot find variable named 'v'");
+  }
+
+  @Test
+  public void testPathExpansion() throws Exception {
+    PathMapper pathMapper =
+        (PathFragment path) ->
+            path.startsWith(PathFragment.create("bazel-out"))
+                ? path.subFragment(0, 1).getRelative("cfg").getRelative(path.subFragment(2))
+                : path;
+    assertThat(getExpansionOfFlag("%{path:my/source.c}", CcToolchainVariables.empty(), pathMapper))
+        .isEqualTo("my/source.c");
+    assertThat(
+            getExpansionOfFlag(
+                "%{path:bazel-out/foobar/bin/my/artifact.a}",
+                CcToolchainVariables.empty(), pathMapper))
+        .isEqualTo("bazel-out/cfg/bin/my/artifact.a");
+
+    reporter.removeHandler(failFastHandler);
+    assertThrows(Throwable.class, () -> getExpansionOfFlag("%{path:/absolute/path}"));
+    assertContainsEvent(
+        "Invalid toolchain configuration: expected relative Unix-style path after 'path:' at"
+            + " position 2 while parsing a flag containing '%{path:/absolute/path}");
+
+    assertThrows(Throwable.class, () -> getExpansionOfFlag("%{path:}"));
+    assertContainsEvent(
+        "Invalid toolchain configuration: expected path after 'path:' at position 2 while parsing a"
+            + " flag containing '%{path:}");
   }
 
   private static CcToolchainVariables createStructureSequenceVariables(


### PR DESCRIPTION
### Description
rules_cc's rule-based toolchain can now inject paths into toolchain features that will be recognized as exec paths and path mapped appropriately by wrapping them in `${path:<the path>}`.

### Motivation
Work towards https://github.com/cerisier/toolchains_llvm_bootstrapped/issues/335

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #28794.

PiperOrigin-RevId: 892975371
Change-Id: I4178e05786e465feda5af96ee5725bfb31a8684d

Commit https://github.com/bazelbuild/bazel/commit/41a36ff029340823700e2f4dec0c7cf71fcbdb31