### PR TITLE
Format CLI progress counts consistently

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/AnalysisProgressReceiver.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/AnalysisProgressReceiver.java
@@ -13,6 +13,8 @@
 // limitations under the License.
 package com.google.devtools.build.lib.skyframe;
 
+import java.text.NumberFormat;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -22,6 +24,13 @@ import java.util.concurrent.atomic.AtomicInteger;
  * <p>Non-final to be mockable.
  */
 public class AnalysisProgressReceiver {
+  private static final ThreadLocal<NumberFormat> COUNT_FORMATTER =
+      ThreadLocal.withInitial(
+          () -> {
+            NumberFormat numberFormat = NumberFormat.getIntegerInstance(Locale.ENGLISH);
+            numberFormat.setGroupingUsed(true);
+            return numberFormat;
+          });
 
   private final AtomicInteger configuredTargetsCompleted = new AtomicInteger();
   private final AtomicInteger configuredTargetsDownloaded = new AtomicInteger();
@@ -69,21 +78,27 @@ public class AnalysisProgressReceiver {
     StringBuilder sb = new StringBuilder();
 
     long targets = configuredTargetsCompleted.get();
-    sb.append(targets).append(targets == 1 ? " target" : " targets").append(" configured");
+    sb.append(COUNT_FORMATTER.get().format(targets))
+        .append(targets == 1 ? " target" : " targets")
+        .append(" configured");
 
     long downloadedTargets = configuredTargetsDownloaded.get();
     if (downloadedTargets > 0) {
-      sb.append(" (").append(downloadedTargets).append(" remote cache hits)");
+      sb.append(" (")
+          .append(COUNT_FORMATTER.get().format(downloadedTargets))
+          .append(" remote cache hits)");
     }
 
     long aspects = configuredAspectsCompleted.get();
     if (aspects > 0) {
       sb.append(", ")
-          .append(aspects)
+          .append(COUNT_FORMATTER.get().format(aspects))
           .append(aspects == 1 ? " aspect application" : " aspect applications");
       long downloadedAspects = configuredAspectsDownloaded.get();
       if (downloadedAspects > 0) {
-        sb.append(" (").append(downloadedAspects).append(" remote cache hits)");
+        sb.append(" (")
+            .append(COUNT_FORMATTER.get().format(downloadedAspects))
+            .append(" remote cache hits)");
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageProgressReceiver.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageProgressReceiver.java
@@ -16,13 +16,22 @@ package com.google.devtools.build.lib.skyframe;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.util.Pair;
+import java.text.NumberFormat;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 
 /**
  * A class that, when being told about start and end of a package being loaded, keeps track of the
  * loading progress and provides it as a human-readable string intended for the progress bar.
  */
 public class PackageProgressReceiver {
+  private static final ThreadLocal<NumberFormat> COUNT_FORMATTER =
+      ThreadLocal.withInitial(
+          () -> {
+            NumberFormat numberFormat = NumberFormat.getIntegerInstance(Locale.ENGLISH);
+            numberFormat.setGroupingUsed(true);
+            return numberFormat;
+          });
 
   private int packagesCompleted;
   private LinkedHashSet<PackageIdentifier> pendingSet = new LinkedHashSet<>();
@@ -53,14 +62,17 @@ public class PackageProgressReceiver {
    * running activities. The later always include the oldest loading package not finished loading.
    */
   public synchronized Pair<String, String> progressState() {
-    String progress = "" + packagesCompleted + " packages loaded";
+    String progress = COUNT_FORMATTER.get().format(packagesCompleted) + " packages loaded";
     StringBuffer activity = new StringBuffer();
     if (pendingSet.size() > 0) {
       activity
           .append("currently loading: ")
           .append(Iterables.getFirst(pendingSet, null).toString());
       if (pendingSet.size() > 1) {
-        activity.append(" ... (" + pendingSet.size() + " packages)");
+        activity
+            .append(" ... (")
+            .append(COUNT_FORMATTER.get().format(pendingSet.size()))
+            .append(" packages)");
       }
     }
     return new Pair<String, String>(progress, activity.toString());

--- a/src/test/java/com/google/devtools/build/lib/skyframe/AnalysisProgressReceiverTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/AnalysisProgressReceiverTest.java
@@ -118,4 +118,18 @@ public class AnalysisProgressReceiverTest {
     progress.reset();
     assertThat(progress.getProgressString()).isEqualTo(defaultProgress);
   }
+
+  @Test
+  public void testLargeCountsUseGroupingSeparators() {
+    AnalysisProgressReceiver progress = new AnalysisProgressReceiver();
+    for (int i = 0; i < 1234; i++) {
+      progress.doneConfigureTarget();
+    }
+    for (int i = 0; i < 5678; i++) {
+      progress.doneConfigureAspect();
+    }
+
+    assertThat(progress.getProgressString())
+        .contains("1,234 targets configured, 5,678 aspect applications");
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PackageProgressReceiverTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PackageProgressReceiverTest.java
@@ -73,4 +73,20 @@ public class PackageProgressReceiverTest {
     assertThat(progress.progressState().getFirst()).isEqualTo(defaultState);
     assertThat(progress.progressState().getSecond()).isEqualTo(defaultActivity);
   }
+
+  @Test
+  public void testLargeCountsUseGroupingSeparators() {
+    PackageProgressReceiver progress = new PackageProgressReceiver();
+    for (int i = 0; i < 1234; i++) {
+      PackageIdentifier id = PackageIdentifier.createInMainRepo("foo/bar/pkg" + i);
+      progress.startReadPackage(id);
+      progress.doneReadPackage(id);
+    }
+    for (int i = 0; i < 1234; i++) {
+      progress.startReadPackage(PackageIdentifier.createInMainRepo("pending/pkg" + i));
+    }
+
+    assertThat(progress.progressState().getFirst()).isEqualTo("1,234 packages loaded");
+    assertThat(progress.progressState().getSecond()).contains("(1,234 packages)");
+  }
 }


### PR DESCRIPTION
Fixes #28855.

This change makes CLI progress counters format large numbers consistently by using grouped separators in both:

* analysis progress output
* package loading progress output

Previously, large counters were displayed inconsistently across progress messages, which made Bazel output harder to scan during large builds.

This change is user-visible only and does not alter build behavior. It only standardizes formatting for progress reporting.

Tests:

* added regression coverage for large values in `AnalysisProgressReceiverTest`
* added regression coverage for large values in `PackageProgressReceiverTest`
