### PR TITLE
fix(run): clarify sharded test errors with --script_path

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -131,7 +131,8 @@ public class RunCommand implements BlazeCommand {
                 + " option is set, the target is not run from %{product}. Use '%{product} run"
                 + " --script_path=foo //foo && ./foo' to invoke target '//foo' This differs from"
                 + " '%{product} run //foo' in that the %{product} lock is released and the"
-                + " executable is connected to the terminal's stdin.")
+                + " executable is connected to the terminal's stdin. This option cannot be used"
+                + " with tests that use sharding or --runs_per_test.")
     public PathFragment scriptPath;
 
     @Option(
@@ -211,6 +212,14 @@ public class RunCommand implements BlazeCommand {
   private static final String MULTIPLE_TESTS_MESSAGE =
       "'run' only works with tests with one shard ('--test_sharding_strategy=disabled' is okay) "
           + "and without --runs_per_test";
+
+  private static final String MULTIPLE_TESTS_WITH_SCRIPT_PATH_MESSAGE =
+      "'run --script_path' only works with tests with one shard"
+          + " ('--test_sharding_strategy=disabled' is okay) and without --runs_per_test";
+
+  static String multipleTestsMessage(boolean hasScriptPath) {
+    return hasScriptPath ? MULTIPLE_TESTS_WITH_SCRIPT_PATH_MESSAGE : MULTIPLE_TESTS_MESSAGE;
+  }
 
   private static final ImmutableSortedSet<String> ENV_VARIABLES_TO_CLEAR_UNCONDITIONALLY =
       ImmutableSortedSet.of(
@@ -694,7 +703,13 @@ public class RunCommand implements BlazeCommand {
       TestPolicy testPolicy)
       throws RunCommandException {
     if (builtTargets.targetToRun.getProvider(TestProvider.class) != null) {
-      return getTestCommandLine(env, builtTargets, options, argsFromResidue, testPolicy);
+      return getTestCommandLine(
+          env,
+          builtTargets,
+          options,
+          argsFromResidue,
+          testPolicy,
+          runOptions.scriptPath != null);
     }
 
     ActionEnvironment actionEnvironment = ActionEnvironment.EMPTY;
@@ -756,14 +771,15 @@ public class RunCommand implements BlazeCommand {
       BuiltTargets builtTargets,
       OptionsParsingResult options,
       ImmutableList<String> argsFromResidue,
-      TestPolicy testPolicy)
+      TestPolicy testPolicy,
+      boolean hasScriptPath)
       throws RunCommandException {
     ImmutableList<Artifact.DerivedArtifact> statusArtifacts =
         TestProvider.getTestStatusArtifacts(builtTargets.targetToRun);
     if (statusArtifacts.size() != 1) {
       throw new RunCommandException(
           reportAndCreateFailureResult(
-              env, MULTIPLE_TESTS_MESSAGE, Code.TOO_MANY_TEST_SHARDS_OR_RUNS),
+              env, multipleTestsMessage(hasScriptPath), Code.TOO_MANY_TEST_SHARDS_OR_RUNS),
           builtTargets.stopTime);
     }
 

--- a/src/test/java/com/google/devtools/build/lib/runtime/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BUILD
@@ -222,6 +222,16 @@ java_test(
 )
 
 java_test(
+    name = "RunCommandTest",
+    srcs = ["commands/RunCommandTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/runtime/commands",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
+java_test(
     name = "RunCommandLineTest",
     srcs = ["commands/RunCommandLineTest.java"],
     deps = [

--- a/src/test/java/com/google/devtools/build/lib/runtime/commands/RunCommandTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/commands/RunCommandTest.java
@@ -1,0 +1,42 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.runtime.commands;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests {@link RunCommand}. */
+@RunWith(JUnit4.class)
+public final class RunCommandTest {
+
+  @Test
+  public void multipleTestsMessage_withoutScriptPath_usesRunWording() {
+    assertThat(RunCommand.multipleTestsMessage(false))
+        .isEqualTo(
+            "'run' only works with tests with one shard"
+                + " ('--test_sharding_strategy=disabled' is okay) and without --runs_per_test");
+  }
+
+  @Test
+  public void multipleTestsMessage_withScriptPath_mentionsScriptPath() {
+    assertThat(RunCommand.multipleTestsMessage(true))
+        .isEqualTo(
+            "'run --script_path' only works with tests with one shard"
+                + " ('--test_sharding_strategy=disabled' is okay) and without --runs_per_test");
+  }
+}


### PR DESCRIPTION
Fixes #16193.

Summary

This change improves the clarity of the error message shown when running sharded tests with bazel run in --script_path mode.

Previously, the error message did not explicitly indicate that the limitation was specific to --script_path, which could make it unclear why sharded tests or --runs_per_test were rejected in this context.

This change:

updates the error message to explicitly mention --script_path when that mode is active
documents the sharding and --runs_per_test limitation in the corresponding flag help text
adds focused unit tests to verify the correct error message is selected

This is a user-facing clarity improvement only and does not change the underlying behavior of bazel run.

Testing
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer bazel test \
  //src/test/java/com/google/devtools/build/lib/runtime:RunCommandTest \
  //src/test/java/com/google/devtools/build/lib/runtime:RunCommandLineTest