### PR TITLE
Allow multiple integrity hashes on the integrity field

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCache.java
@@ -26,6 +26,11 @@ import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
@@ -36,6 +41,25 @@ import javax.annotation.Nullable;
  * that the cache directory is not subject to concurrent file deletion.
  */
 public class DownloadCache {
+
+  /**
+   * An ordering of hash algorithms from "weakest" to "strongest".
+   *
+   * <p>This ordering is used when evaluating multiple hashes in the integrity field per
+   * https://www.w3.org/TR/sri-2/#priority
+   */
+  public static List<KeyType> DEFAULT_KEY_TYPE_ORDERING =
+      new ArrayList<>(
+          Arrays.asList(
+              KeyType.SHA1,
+              KeyType.SHA256,
+              // Blake3 has variable number of bits, but in Bazel, the default of 256 is used.
+              // Arbitrarily added after SHA256 since it has the same number of bits and is
+              // considered more modern.
+              // TODO: allow customizing ordering to avoid this Bazel-imposed ordering.
+              KeyType.BLAKE3,
+              KeyType.SHA384,
+              KeyType.SHA512));
 
   /** The types of cache keys used. */
   public enum KeyType {
@@ -48,11 +72,22 @@ public class DownloadCache {
     private final String stringRepr;
     private final String regexp;
     private final String hashName;
+    private static final Map<String, KeyType> BY_HASH_NAME = new HashMap<>();
+
+    static {
+      for (KeyType k: values()) {
+        BY_HASH_NAME.put(k.hashName, k);
+      }
+    }
 
     KeyType(String stringRepr, String regexp, String hashName) {
       this.stringRepr = stringRepr;
       this.regexp = regexp;
       this.hashName = hashName;
+    }
+
+    public static KeyType getByHashName(String hashName) {
+      return BY_HASH_NAME.get(hashName);
     }
 
     public boolean isValid(@Nullable String checksum) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
@@ -36,5 +36,6 @@ java_library(
         "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:jsr305",
+        "@maven//:org_apache_commons_commons_lang3",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Checksum.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Checksum.java
@@ -16,12 +16,28 @@ package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import com.google.common.base.Ascii;
 import com.google.common.hash.HashCode;
+import com.google.devtools.build.lib.bazel.repository.cache.DownloadCache;
 import com.google.devtools.build.lib.bazel.repository.cache.DownloadCache.KeyType;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 
 /** The content checksum for an HTTP download, which knows its own type. */
 public class Checksum {
+
+  public static final List<String> KNOWN_HASH_NAMES = Arrays.stream(KeyType.values())
+      .map(KeyType::getHashName).toList();
+
   /** Exception thrown to indicate that a string is not a valid checksum for that key type. */
   public static final class InvalidChecksumException extends Exception {
     private InvalidChecksumException(KeyType keyType, String hash) {
@@ -76,47 +92,163 @@ public class Checksum {
     }
   }
 
-  /** Constructs a new Checksum from a hash in Subresource Integrity format. */
+  /**
+   * Constructs a new Checksum from a hash in Subresource Integrity format.
+   *
+   * <p>Generally follows web's <a href="https://www.w3.org/TR/sri-2/">subresource integrity
+   * spec</a> with the following differences:
+   *
+   * <ul>
+   *   <li>Per the spec, multiple integrity hashes with the same hash algorithm are allowed. For
+   *       Bazel, if there are multiple integrity hashes AND they are the strongest hash algorithm,
+   *       an exception will be thrown. In Bazel, dependencies should be deterministic.
+   *   <li>If there are no valid hash algorithms detected, web allows the resource to load. For
+   *       Bazel, an error will be thrown since the intention of setting an integrity is to ensure
+   *       that it is checked.
+   * </ul>
+   */
+  public static Checksum fromSubresourceIntegrity(
+      String integrity, @Nullable List<String> parseWarnings) throws InvalidChecksumException {
+    if (!integrity.isEmpty() && integrity.isBlank()) {
+      throw new InvalidChecksumException(String.format("Provided checksum is blank (%d whitespace characters)", integrity.length()));
+    }
+
+    Map<KeyType, List<Checksum>> metadata = parseMetadata(integrity, parseWarnings);
+    if (metadata.isEmpty()) {
+      throw new InvalidChecksumException(String.format("No valid checksums found in integrity '%s'", integrity));
+    }
+
+    @Nonnull KeyType strongestHashAlgo = findStrongestAlgorithm(metadata.keySet());
+    List<Checksum> checksums = metadata.get(strongestHashAlgo);
+
+    // The SRI spec allows multiple checksums with the "strongest" algorithm to allow for different
+    // payloads from the same resource. This isn't allowed here to keep with the build philosophy of
+    // reproducibility - a resource should always return the same content, so only a single checksum
+    // per algorithm hash should be provided.
+    if (checksums.size() > 1) {
+      Checksum c1 = checksums.get(0);
+      Checksum c2 = checksums.get(1);
+      String sriFormat1 = String.format("%s-%s", c1.getKeyType().getHashName(), Base64.getEncoder()
+          .encodeToString(c1.getHashCode().asBytes()));
+      String sriFormat2 = String.format("%s-%s", c2.getKeyType().getHashName(), Base64.getEncoder()
+          .encodeToString(c2.getHashCode().asBytes()));
+
+      throw new InvalidChecksumException(
+          String.format(
+              "Duplicate hash algorithm in list of integrity hashes:\n\t%s\n\t%s", sriFormat1, sriFormat2));
+    }
+
+    return checksums.getFirst();
+  }
+
+  private static KeyType findStrongestAlgorithm(Set<KeyType> keyTypes) {
+    Optional<KeyType> strongest =
+        keyTypes.stream()
+            .max(
+                new Comparator<KeyType>() {
+                  @Override
+                  public int compare(KeyType o1, KeyType o2) {
+                    return DownloadCache.DEFAULT_KEY_TYPE_ORDERING.indexOf(o1)
+                        - DownloadCache.DEFAULT_KEY_TYPE_ORDERING.indexOf(o2);
+                  }
+                });
+    return strongest.orElse(null);
+  }
+
   public static Checksum fromSubresourceIntegrity(String integrity)
       throws InvalidChecksumException {
-    KeyType keyType;
-    byte[] hash;
-    int expectedLength;
+    return fromSubresourceIntegrity(integrity, null);
+  }
 
-    if (integrity.startsWith("sha1-")) {
-      keyType = KeyType.SHA1;
-      expectedLength = 20;
-      hash = base64Decode(integrity.substring(5));
-    } else if (integrity.startsWith("sha256-")) {
-      keyType = KeyType.SHA256;
-      expectedLength = 32;
-      hash = base64Decode(integrity.substring(7));
-    } else if (integrity.startsWith("sha384-")) {
-      keyType = KeyType.SHA384;
-      expectedLength = 48;
-      hash = base64Decode(integrity.substring(7));
-    } else if (integrity.startsWith("sha512-")) {
-      keyType = KeyType.SHA512;
-      expectedLength = 64;
-      hash = base64Decode(integrity.substring(7));
-    } else if (integrity.startsWith("blake3-")) {
-      keyType = KeyType.BLAKE3;
-      expectedLength = 32;
-      hash = base64Decode(integrity.substring(7));
-    } else {
-      throw new InvalidChecksumException(
-          "Unsupported checksum algorithm: '"
-              + integrity
-              + "' (expected SHA-1, SHA-256, SHA-384, or SHA-512)");
+  /**
+   * Parses the subresource integrity field.
+   *
+   * <p>Generally follows the <a href="https://www.w3.org/TR/sri-2/#parse-metadata-section">SRI spec
+   * for parsing</a>.
+   *
+   * @param integrityAttr The SRI integrity hash (multiple hashes allowed separated by whitespace).
+   * @param parseWarnings If not null, errors in parsing are added to this list.
+   */
+  private static Map<KeyType, List<Checksum>> parseMetadata(
+      String integrityAttr, @Nullable List<String> parseWarnings) {
+    Map<KeyType, List<Checksum>> result = new HashMap<>();
+
+    for (String integrityHash : StringUtils.split(integrityAttr)) {
+      KeyType hashAlgorithm = parseHashAlgorithm(integrityHash);
+      if (hashAlgorithm == null) {
+        if (parseWarnings != null) {
+          parseWarnings.add(
+              String.format("Unknown hash algorithm for integrity: '%s'.", integrityHash));
+        }
+        continue;
+      }
+
+      // The SRI spec allows for future options on the hash after the '?' character. No actual
+      // options are defined for now. Note them and ignore.
+      String hashAndMaybeOptions = integrityHash.substring(hashAlgorithm.getHashName().length()+1);
+      String hash = StringUtils.substringBefore(hashAndMaybeOptions, "?");
+      String options = StringUtils.substringAfter(hashAndMaybeOptions, "?");
+
+      if (!options.isEmpty() && parseWarnings != null) {
+        parseWarnings.add(
+            String.format(
+                "Ignoring unknown integrity options '%s' from integrity '%s'.",
+                options, integrityHash));
+      }
+
+      byte[] hashBytes = null;
+      try {
+        hashBytes = Base64.getDecoder().decode(hash);
+      } catch (IllegalArgumentException e) {
+        if (parseWarnings != null) {
+          parseWarnings.add(String.format("Ignoring invalid base64 '%s'.", integrityHash));
+        }
+        continue;
+      }
+
+      Checksum checksum = null;
+      try {
+        checksum =
+            Checksum.fromString(
+                hashAlgorithm,
+                HashCode.fromBytes(hashBytes).toString(),
+                /* useSubresourceIntegrity= */ true);
+      } catch (InvalidChecksumException e) {
+        if (parseWarnings != null) {
+          parseWarnings.add(String.format("Ignoring invalid checksum '%s'.", integrityHash));
+        }
+        continue;
+      }
+
+      if (!result.containsKey(hashAlgorithm)) {
+        result.put(hashAlgorithm, new ArrayList<>());
+      }
+      result.get(hashAlgorithm).add(checksum);
+    }
+    return result;
+  }
+
+  /**
+   * Parses the {@link KeyType} from the given integrity hash.
+   *
+   * <p>Eg. Given the integrity hash:
+   *
+   * <pre>
+   * <code>sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=</code> returns {@link KeyType.KeyType.SHA256}
+   * <code>invalid-prefixNotValidUnknown</code> returns {@code null}
+   * <code>sha256</code> returns {@code null}
+   * </pre>
+   */
+  private static KeyType parseHashAlgorithm(String integrity) {
+    for (String hashName : KNOWN_HASH_NAMES) {
+      if (integrity.startsWith(hashName)
+          && integrity.length() > hashName.length()
+          && integrity.charAt(hashName.length()) == '-') {
+        return KeyType.getByHashName(hashName);
+      }
     }
 
-    if (hash.length != expectedLength) {
-      throw new InvalidChecksumException(
-          "Invalid " + keyType + " SRI checksum '" + integrity + "'");
-    }
-
-    return Checksum.fromString(
-        keyType, HashCode.fromBytes(hash).toString(), /* useSubresourceIntegrity= */ true);
+    return null;
   }
 
   private static String toSubresourceIntegrity(KeyType keyType, HashCode hashCode) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -512,13 +512,19 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
       return Optional.empty();
     }
 
+    List<String> subresourceIntegrityParseWarnings = new ArrayList<>();
     try {
-      return Optional.of(Checksum.fromSubresourceIntegrity(integrity));
+      return Optional.of(Checksum.fromSubresourceIntegrity(integrity, subresourceIntegrityParseWarnings));
     } catch (Checksum.InvalidChecksumException e) {
       warnAboutChecksumError(urls, e.getMessage());
       throw new RepositoryFunctionException(
           Starlark.errorf("Checksum error in %s: %s", identifyingStringForLogging, e.getMessage()),
           Transience.PERSISTENT);
+    } finally {
+      if (!subresourceIntegrityParseWarnings.isEmpty()) {
+        // Let the user know of any parse errors (these are non-fatal but nice to know).
+        reportProgress(String.join(" ", subresourceIntegrityParseWarnings));
+      }
     }
   }
 
@@ -759,7 +765,10 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
                 easier but should be set before shipping. \
                 If provided, the repository cache will first be checked for a file with the \
                 given checksum; a download will only be attempted if the file was not found in \
-                the cache. After a successful download, the file will be added to the cache.
+                the cache. After a successful download, the file will be added to the cache. \
+                Multiple sets of integrity checksums, separated by spaces, may be provided. \
+                Eg. Providing the sha256, sha384 and sha512 hashes of the download. The \
+                "strongest" known hash will be used.
                 """),
         @Param(
             name = "block",
@@ -1006,6 +1015,9 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
                 If provided, the repository cache will first be checked for a file with the \
                 given checksum; a download will only be attempted if the file was not found in \
                 the cache. After a successful download, the file will be added to the cache. \
+                Multiple sets of integrity checksums, separated by spaces, may be provided. \
+                Eg. Providing the sha256, sha384 and sha512 hashes of the download. The \
+                "strongest" known hash algorithm will be used. \
                 """),
         @Param(
             name = "rename_files",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/cache/DownloadCacheTest.java
@@ -31,7 +31,9 @@ import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import org.junit.After;
@@ -298,5 +300,15 @@ public class DownloadCacheTest {
         downloadCache.get(
             hash, targetPath, keyType, /* canonicalId= */ null, /* mayHardlink= */ true);
     assertThat(lookupNoId).isEqualTo(targetPath);
+  }
+
+  /**
+   * Ensures that the constant {@link DownloadCache#DEFAULT_KEY_TYPE_ORDERING} is updated whenever a
+   * new {@link DownloadCache.KeyType} is added.
+   */
+  @Test
+  public void keyTypeOrderingComplete() {
+    // Each key should be in the ordering.
+    assertThat(DownloadCache.DEFAULT_KEY_TYPE_ORDERING).containsExactlyElementsIn(KeyType.values());
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
@@ -32,6 +32,7 @@ java_library(
         "//third_party:junit4",
         "//third_party:mockito",
         "//third_party:truth",
+        "@maven//:org_apache_commons_commons_lang3",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ChecksumTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ChecksumTest.java
@@ -1,0 +1,121 @@
+package com.google.devtools.build.lib.bazel.repository.downloader;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.devtools.build.lib.bazel.repository.cache.DownloadCache.KeyType;
+import com.google.devtools.build.lib.bazel.repository.downloader.Checksum.InvalidChecksumException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ChecksumTest {
+
+  // echo -n "sha256-"; openssl dgst -sha256 -binary /dev/null | openssl base64 -A; echo
+  private static final String SHA256_INTEGRITY_EMPTY =
+      "sha256-O4v8fJvidQTu5H/np7Vl1oly/FDDfzthaP8khIm9PM0=";
+
+  // echo "bazel" > bazel.txt
+  // echo -n "sha256-"; openssl dgst -sha256 -binary bazel.txt | openssl base64 -A; echo
+  private static final String SHA256_INTEGRITY_BAZEL = "sha256-DfROnrnkTO+tVhos1X9jVCC7+9oG95BU9YmZLHyREac=";
+
+  // echo -n "sha384-"; openssl dgst -sha384 -binary /dev/null | openssl base64 -A; echo
+  private static final String SHA384_INTEGRITY_EMPTY =
+      "sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb";
+
+  // echo -n "sha512-"; openssl dgst -sha512 -binary /dev/null | openssl base64 -A; echo
+  private static final String SHA512_INTEGRITY_EMPTY =
+      "sha512-z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg==";
+
+  @Test
+  public void fromSubresourceIntegrity_valid() throws InvalidChecksumException {
+    Checksum checksum256 = Checksum.fromSubresourceIntegrity(SHA256_INTEGRITY_EMPTY);
+    assertThat(checksum256.getKeyType()).isEqualTo(KeyType.SHA256);
+    String sha256Base64 = "sha256-" + Base64.getEncoder().encodeToString(checksum256.getHashCode().asBytes());
+    assertThat(SHA256_INTEGRITY_EMPTY).isEqualTo(sha256Base64);
+
+    Checksum checksum384 = Checksum.fromSubresourceIntegrity(SHA384_INTEGRITY_EMPTY);
+    assertThat(checksum384.getKeyType()).isEqualTo(KeyType.SHA384);
+    String sha384Base64 = "sha384-" + Base64.getEncoder().encodeToString(checksum384.getHashCode().asBytes());
+    assertThat(SHA384_INTEGRITY_EMPTY).isEqualTo(sha384Base64);
+
+    Checksum checksum512 = Checksum.fromSubresourceIntegrity(SHA512_INTEGRITY_EMPTY);
+    assertThat(checksum512.getKeyType()).isEqualTo(KeyType.SHA512);
+    String sha512Base64 = "sha512-" + Base64.getEncoder().encodeToString(checksum512.getHashCode().asBytes());
+    assertThat(SHA512_INTEGRITY_EMPTY).isEqualTo(sha512Base64);
+  }
+
+  @Test
+  public void fromSubresourceIntegrity_strongestAlgorithm() throws InvalidChecksumException {
+    Checksum checksum =
+        Checksum.fromSubresourceIntegrity(SHA512_INTEGRITY_EMPTY + "    " + SHA384_INTEGRITY_EMPTY);
+    assertThat(checksum.getKeyType()).isEqualTo(KeyType.SHA512);
+
+    assertThat(
+            Checksum.fromSubresourceIntegrity(
+                    SHA256_INTEGRITY_EMPTY + " " + SHA384_INTEGRITY_EMPTY)
+                .getKeyType())
+        .isEqualTo(KeyType.SHA384);
+  }
+
+  @Test
+  public void fromSubresourceIntegrity_ignoresInvalidUnknownAlgorithmsHashes()
+      throws InvalidChecksumException {
+    String integrityAttr =
+        String.join(
+            " ",
+            List.of(
+                "randomstring",
+                "ed25519-JrQLj5P/89iXES9+vFgrIy29clF9CC/oPPsw3c5D0bs=",
+                "sha256-tooshort",
+                "sha256-invalid_characters",
+                SHA256_INTEGRITY_EMPTY + "?foo=bar",
+                SHA384_INTEGRITY_EMPTY));
+
+    List<String> parseWarnings = new ArrayList<>();
+    Checksum checksum = Checksum.fromSubresourceIntegrity(integrityAttr, parseWarnings);
+
+    assertThat(checksum.getKeyType()).isEqualTo(KeyType.SHA384);
+
+    String sha384Base64 = "sha384-" + Base64.getEncoder().encodeToString(checksum.getHashCode().asBytes());
+    assertThat(SHA384_INTEGRITY_EMPTY).isEqualTo(sha384Base64);
+
+    String allWarnings = String.join(";", parseWarnings);
+    assertThat(allWarnings).contains("Unknown hash algorithm for integrity: 'randomstring'.");
+    assertThat(allWarnings).contains("Unknown hash algorithm for integrity: 'ed25519-JrQLj5P/89iXES9+vFgrIy29clF9CC/oPPsw3c5D0bs='.");
+    assertThat(allWarnings).contains("Ignoring invalid checksum 'sha256-tooshort'.");
+    assertThat(allWarnings).contains(String.format("Ignoring unknown integrity options '%s' from integrity '%s'.", "foo=bar", SHA256_INTEGRITY_EMPTY + "?foo=bar"));
+    assertThat(allWarnings).contains("Ignoring invalid base64 'sha256-invalid_characters'.");
+  }
+
+  @Test
+  public void fromSubresourceIntegrity_duplicateAlgorithmThrows() {
+    String integrityAttr =
+        String.join(
+            " ",
+            List.of(
+                SHA256_INTEGRITY_EMPTY,
+                SHA256_INTEGRITY_BAZEL));
+
+    InvalidChecksumException e = assertThrows(InvalidChecksumException.class,
+        () -> {
+          Checksum.fromSubresourceIntegrity(integrityAttr);
+        });
+    assertThat(e).hasMessageThat().contains("Duplicate hash algorithm in list of integrity hashes");
+    assertThat(e).hasMessageThat().contains(SHA256_INTEGRITY_EMPTY);
+    assertThat(e).hasMessageThat().contains(SHA256_INTEGRITY_BAZEL);
+  }
+
+  @Test
+  public void fromSubresourceIntegrity_noValidAlgorithmThrows() {
+       InvalidChecksumException e = assertThrows(InvalidChecksumException.class,
+        () -> {
+          Checksum.fromSubresourceIntegrity("foobar bad checksums");
+        });
+    assertThat(e).hasMessageThat().contains("No valid checksums found in integrity 'foobar bad checksums'");
+  }
+}

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -1160,6 +1160,55 @@ EOF
   bazel build @repo//... || fail "Expected integrity check to succeed"
 }
 
+function test_multiple_integrity_hashes_correct() {
+  REPO_PATH=$TEST_TMPDIR/repo
+  mkdir -p "$REPO_PATH"
+  cd "$REPO_PATH"
+  setup_module_dot_bazel
+  touch BUILD
+  zip -r repo.zip *
+  integrity256="sha256-$(cat repo.zip | openssl dgst -sha256 -binary | openssl base64 -A)"
+  integrity384="sha384-$(cat repo.zip | openssl dgst -sha384 -binary | openssl base64 -A)"
+  integrity512="sha512-$(cat repo.zip | openssl dgst -sha512 -binary | openssl base64 -A)"
+  startup_server $PWD
+  cd -
+
+  cat > $(setup_module_dot_bazel) <<EOF
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "repo",
+    integrity = "$integrity256 $integrity384 $integrity512",
+    url = "http://127.0.0.1:$fileserver_port/repo.zip",
+)
+EOF
+  bazel build @repo//... || fail "Expected integrity check to succeed"
+}
+
+function test_multiple_integrity_hashes_strongest_used() {
+  REPO_PATH=$TEST_TMPDIR/repo
+  mkdir -p "$REPO_PATH"
+  cd "$REPO_PATH"
+  setup_module_dot_bazel
+  touch BUILD
+  zip -r repo.zip *
+  # Even though the sha256 and sha384 hashes are wrong, only the sha512 integrity is used.
+  integrity512="sha512-$(cat repo.zip | openssl dgst -sha512 -binary | openssl base64 -A)"
+  wrongintegrity256="sha256-O4v8fJvidQTu5H/np7Vl1oly/FDDfzthaP8khIm9PM0="
+  wrongintegrity384="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"
+  startup_server $PWD
+  cd -
+
+  cat > $(setup_module_dot_bazel) <<EOF
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "repo",
+    integrity = "$wrongintegrity256 $wrongintegrity384 $integrity512",
+    url = "http://127.0.0.1:$fileserver_port/repo.zip",
+)
+EOF
+  bazel build @repo//... || fail "Expected integrity check to succeed"
+}
+
 function test_integrity_weird() {
   REPO_PATH=$TEST_TMPDIR/repo
   mkdir -p "$REPO_PATH"
@@ -1179,7 +1228,7 @@ http_archive(
 )
 EOF
   bazel build @repo//... &> $TEST_log 2>&1 && fail "Expected to fail"
-  expect_log "Unsupported checksum algorithm: 'a random string'"
+  expect_log "No valid checksums found in integrity 'a random string'"
   shutdown_server
 }
 
@@ -1219,7 +1268,7 @@ http_archive(
 )
 EOF
   bazel build @repo//... &> $TEST_log 2>&1 && fail "Expected to fail"
-  expect_log "Invalid base64 'Yab3Yqr2BlLL8zKHm43MLP2BviEpoGHalX0Dnq538L='"
+  expect_log "No valid checksums found in integrity 'sha256-Yab3Yqr2BlLL8zKHm43MLP2BviEpoGHalX0Dnq538L='"
   shutdown_server
 }
 


### PR DESCRIPTION


<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
This aligns the integrity field more closely with the web spec: https://www.w3.org/TR/sri-2/ Specifically, multiple hashes can now be provided.

Before - only one integrity hash could be provided:

>  repository_ctx.download("url", integrity="sha256-1234")

After - multiple integrity hashes can now be provided:

>  repository_ctx.download("url", integrity="sha256-1234 sha384-1234 sha512-1234")

Per the spec, only the strongest algorithm will be used. In the latter example, the sha512 hash would be used.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

Fixes #15758

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

> 1. Has this been discussed in a design doc or issue? (Please link it)

See #15758

> 2. Is the change backward compatible?

Possibly? Some error messages are changed when there are bad integrity hashes. 
Existing Bazel builds will still continue to work.

> 3. If it's a breaking change, what is the migration plan?

There is no migration plan.

### Checklist

- [X] I have added tests for the new use cases (if any).
- [X] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: The `integrity` field of `repository_ctx.download()` and `download_and_extract()` can now take multiple integrity hashes, separated by spaces.
