### PR TITLE
Add pre-execution input discovery for StarlarkAction unused_inputs_list

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -41,7 +41,6 @@ import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.CoreOptions.OutputPathsMode;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
-import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.server.FailureDetails;
@@ -233,7 +232,9 @@ public class StarlarkAction extends SpawnAction {
 
     private final Optional<Artifact> unusedInputsList;
     private final Optional<Action> shadowedAction;
-    private final boolean unusedInputsListIsInput;
+    private final PathMapper pathMapper;
+    // Lazily computed: null means not yet checked, Boolean.TRUE/FALSE for the result.
+    @Nullable private volatile Boolean unusedInputsListIsInput;
     private boolean inputsDiscovered = false;
     private boolean prunedInputs = false;
 
@@ -273,8 +274,7 @@ public class StarlarkAction extends SpawnAction {
               : null;
       this.unusedInputsList = unusedInputsList;
       this.shadowedAction = shadowedAction;
-      this.unusedInputsListIsInput =
-          unusedInputsList.isPresent() && inputs.toList().contains(unusedInputsList.get());
+      this.pathMapper = PathMappers.create(this, outputPathsMode, true);
     }
 
     @AutoCodec.Instantiator
@@ -315,21 +315,28 @@ public class StarlarkAction extends SpawnAction {
               : null;
       this.unusedInputsList = unusedInputsList;
       this.shadowedAction = shadowedAction;
-      this.unusedInputsListIsInput =
-          unusedInputsList.isPresent()
-              && allStarlarkActionInputs.toList().contains(unusedInputsList.get());
+      this.pathMapper = PathMappers.create(this, outputPathsMode, true);
+    }
+
+    private boolean isUnusedInputsListAnInput() {
+      if (unusedInputsListIsInput == null) {
+        unusedInputsListIsInput =
+            unusedInputsList.isPresent()
+                && allStarlarkActionInputs.toList().contains(unusedInputsList.get());
+      }
+      return unusedInputsListIsInput;
     }
 
     @Override
     public NestedSet<Artifact> getSchedulingDependencies() {
-      if (!shadowedAction.isPresent() && !unusedInputsListIsInput) {
+      if (!shadowedAction.isPresent() && !isUnusedInputsListAnInput()) {
         return NestedSetBuilder.emptySet(Order.STABLE_ORDER);
       }
       NestedSetBuilder<Artifact> builder = NestedSetBuilder.stableOrder();
       if (shadowedAction.isPresent()) {
         builder.addTransitive(shadowedAction.get().getSchedulingDependencies());
       }
-      if (unusedInputsListIsInput) {
+      if (isUnusedInputsListAnInput()) {
         builder.add(unusedInputsList.get());
       }
       return builder.build();
@@ -411,18 +418,21 @@ public class StarlarkAction extends SpawnAction {
 
       // If the unused_inputs_list is also an action input (produced by a prior action), read it
       // to trim inputs before execution, avoiding the need to materialize unused inputs.
-      if (unusedInputsListIsInput) {
-        ImmutableSet<String> unusedPaths =
-            readUnusedInputsSet(actionExecutionContext, unusedInputsList.get());
-        if (!unusedPaths.isEmpty()) {
-          NestedSetBuilder<Artifact> trimmed = NestedSetBuilder.stableOrder();
-          for (Artifact input : allStarlarkActionInputs.toList()) {
-            if (!unusedPaths.contains(input.getExecPathString())) {
-              trimmed.add(input);
-            }
+      if (isUnusedInputsListAnInput()) {
+        try {
+          InputStream stream =
+              actionExecutionContext
+                  .getPathResolver()
+                  .toPath(unusedInputsList.get())
+                  .getInputStream();
+          NestedSet<Artifact> pruned = pruneUnusedInputs(stream, allStarlarkActionInputs);
+          if (pruned != null) {
+            inputsToUse = pruned;
+            prunedInputs = true;
           }
-          inputsToUse = trimmed.build();
-          prunedInputs = true;
+        } catch (IOException e) {
+          // File not readable (e.g., first build, remote execution without bytes).
+          // Fall back to using all inputs.
         }
       }
 
@@ -430,20 +440,41 @@ public class StarlarkAction extends SpawnAction {
       return inputsToUse;
     }
 
-    private static ImmutableSet<String> readUnusedInputsSet(
-        ActionExecutionContext actionExecutionContext, Artifact unusedInputsListArtifact) {
-      try {
-        return FileSystemUtils.readLinesAsLatin1(
-                actionExecutionContext.getPathResolver().toPath(unusedInputsListArtifact))
-            .stream()
-            .map(String::trim)
-            .filter(s -> !s.isEmpty())
-            .collect(ImmutableSet.toImmutableSet());
-      } catch (IOException e) {
-        // File not readable (e.g., first build, remote execution without bytes).
-        // Fall back to using all inputs.
-        return ImmutableSet.of();
+    /**
+     * Reads the unused inputs list from the given stream and removes them from the given inputs.
+     * Returns the pruned input set, or null if no inputs were pruned.
+     */
+    @Nullable
+    private NestedSet<Artifact> pruneUnusedInputs(
+        InputStream unusedInputsStream, NestedSet<Artifact> inputs) throws IOException {
+      Map<String, Artifact> usedInputsByMappedPath = null;
+      boolean sawUnusedInput = false;
+
+      try (BufferedReader br =
+          new BufferedReader(new InputStreamReader(unusedInputsStream, ISO_8859_1))) {
+        String line;
+        while ((line = br.readLine()) != null) {
+          line = line.trim();
+          if (line.isEmpty()) {
+            continue;
+          }
+          if (usedInputsByMappedPath == null) {
+            ImmutableList<Artifact> allInputs = inputs.toList();
+            usedInputsByMappedPath = Maps.newHashMapWithExpectedSize(allInputs.size());
+            for (Artifact input : allInputs) {
+              usedInputsByMappedPath.put(pathMapper.getMappedExecPathString(input), input);
+            }
+          }
+          if (usedInputsByMappedPath.remove(line) != null) {
+            sawUnusedInput = true;
+          }
+        }
       }
+
+      if (!sawUnusedInput) {
+        return null;
+      }
+      return NestedSetBuilder.wrap(Order.STABLE_ORDER, usedInputsByMappedPath.values());
     }
 
     private InputStream getUnusedInputListInputStream(
@@ -483,46 +514,19 @@ public class StarlarkAction extends SpawnAction {
         return;
       }
 
-      // Initialized lazily in case there are no unused inputs.
-      Map<String, Artifact> usedInputsByMappedPath = null;
-
-      boolean sawUnusedInput = false;
-
-      // Bazel encodes file system paths as raw bytes stored in a Latin-1 encoded string, so we need
-      // to make sure to also decode the unused input list as Latin-1.
-      try (BufferedReader br =
-          new BufferedReader(
-              new InputStreamReader(
-                  getUnusedInputListInputStream(actionExecutionContext, spawnResults),
-                  ISO_8859_1))) {
-        String line;
-        while ((line = br.readLine()) != null) {
-          line = line.trim();
-          if (line.isEmpty()) {
-            continue;
-          }
-          if (usedInputsByMappedPath == null) {
-            // Get all the action's inputs after execution which will include the shadowed action
-            // discovered inputs.
-            ImmutableList<Artifact> allInputs = getInputs().toList();
-            usedInputsByMappedPath = Maps.newHashMapWithExpectedSize(allInputs.size());
-            for (Artifact input : allInputs) {
-              usedInputsByMappedPath.put(pathMapper.getMappedExecPathString(input), input);
-            }
-          }
-          if (usedInputsByMappedPath.remove(line) != null) {
-            sawUnusedInput = true;
-          }
+      try {
+        NestedSet<Artifact> pruned =
+            pruneUnusedInputs(
+                getUnusedInputListInputStream(actionExecutionContext, spawnResults),
+                getInputs());
+        if (pruned != null) {
+          prunedInputs = true;
+          updateInputs(pruned);
         }
       } catch (IOException e) {
         throw new EnvironmentalExecException(
             e,
             createFailureDetail("Unused inputs read failure", Code.UNUSED_INPUT_LIST_READ_FAILURE));
-      }
-
-      prunedInputs = prunedInputs || sawUnusedInput;
-      if (sawUnusedInput) {
-        updateInputs(NestedSetBuilder.wrap(Order.STABLE_ORDER, usedInputsByMappedPath.values()));
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -41,6 +41,7 @@ import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.CoreOptions.OutputPathsMode;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.server.FailureDetails;
@@ -232,6 +233,7 @@ public class StarlarkAction extends SpawnAction {
 
     private final Optional<Artifact> unusedInputsList;
     private final Optional<Action> shadowedAction;
+    private final boolean unusedInputsListIsInput;
     private boolean inputsDiscovered = false;
     private boolean prunedInputs = false;
 
@@ -271,6 +273,8 @@ public class StarlarkAction extends SpawnAction {
               : null;
       this.unusedInputsList = unusedInputsList;
       this.shadowedAction = shadowedAction;
+      this.unusedInputsListIsInput =
+          unusedInputsList.isPresent() && inputs.toList().contains(unusedInputsList.get());
     }
 
     @AutoCodec.Instantiator
@@ -311,13 +315,24 @@ public class StarlarkAction extends SpawnAction {
               : null;
       this.unusedInputsList = unusedInputsList;
       this.shadowedAction = shadowedAction;
+      this.unusedInputsListIsInput =
+          unusedInputsList.isPresent()
+              && allStarlarkActionInputs.toList().contains(unusedInputsList.get());
     }
 
     @Override
     public NestedSet<Artifact> getSchedulingDependencies() {
-      return shadowedAction.isPresent()
-          ? shadowedAction.get().getSchedulingDependencies()
-          : NestedSetBuilder.emptySet(Order.STABLE_ORDER);
+      if (!shadowedAction.isPresent() && !unusedInputsListIsInput) {
+        return NestedSetBuilder.emptySet(Order.STABLE_ORDER);
+      }
+      NestedSetBuilder<Artifact> builder = NestedSetBuilder.stableOrder();
+      if (shadowedAction.isPresent()) {
+        builder.addTransitive(shadowedAction.get().getSchedulingDependencies());
+      }
+      if (unusedInputsListIsInput) {
+        builder.add(unusedInputsList.get());
+      }
+      return builder.build();
     }
 
     @Override
@@ -392,8 +407,43 @@ public class StarlarkAction extends SpawnAction {
       }
       // Otherwise, we need to "re-discover" all the original inputs: the unused ones that were
       // removed might now be needed.
-      updateInputs(allStarlarkActionInputs);
-      return allStarlarkActionInputs;
+      NestedSet<Artifact> inputsToUse = allStarlarkActionInputs;
+
+      // If the unused_inputs_list is also an action input (produced by a prior action), read it
+      // to trim inputs before execution, avoiding the need to materialize unused inputs.
+      if (unusedInputsListIsInput) {
+        ImmutableSet<String> unusedPaths =
+            readUnusedInputsSet(actionExecutionContext, unusedInputsList.get());
+        if (!unusedPaths.isEmpty()) {
+          NestedSetBuilder<Artifact> trimmed = NestedSetBuilder.stableOrder();
+          for (Artifact input : allStarlarkActionInputs.toList()) {
+            if (!unusedPaths.contains(input.getExecPathString())) {
+              trimmed.add(input);
+            }
+          }
+          inputsToUse = trimmed.build();
+          prunedInputs = true;
+        }
+      }
+
+      updateInputs(inputsToUse);
+      return inputsToUse;
+    }
+
+    private static ImmutableSet<String> readUnusedInputsSet(
+        ActionExecutionContext actionExecutionContext, Artifact unusedInputsListArtifact) {
+      try {
+        return FileSystemUtils.readLinesAsLatin1(
+                actionExecutionContext.getPathResolver().toPath(unusedInputsListArtifact))
+            .stream()
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .collect(ImmutableSet.toImmutableSet());
+      } catch (IOException e) {
+        // File not readable (e.g., first build, remote execution without bytes).
+        // Fall back to using all inputs.
+        return ImmutableSet.of();
+      }
     }
 
     private InputStream getUnusedInputListInputStream(
@@ -470,7 +520,7 @@ public class StarlarkAction extends SpawnAction {
             createFailureDetail("Unused inputs read failure", Code.UNUSED_INPUT_LIST_READ_FAILURE));
       }
 
-      prunedInputs = sawUnusedInput;
+      prunedInputs = prunedInputs || sawUnusedInput;
       if (sawUnusedInput) {
         updateInputs(NestedSetBuilder.wrap(Order.STABLE_ORDER, usedInputsByMappedPath.values()));
       }

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -809,6 +809,14 @@ sh_test(
 )
 
 sh_test(
+    name = "starlark_input_discovery_test",
+    srcs = ["starlark_input_discovery_test.sh"],
+    data = [":test-deps"],
+    shard_count = 2,
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+sh_test(
     name = "validation_actions_test",
     srcs = ["validation_actions_test.sh"],
     data = [":test-deps"],

--- a/src/test/shell/integration/starlark_input_discovery_test.sh
+++ b/src/test/shell/integration/starlark_input_discovery_test.sh
@@ -146,6 +146,70 @@ date +%s%N > "$1"
 EOF
   chmod +x pkg/write_stamp.sh
 
+  # check_sandbox.sh: verifies files are present or absent in the sandbox.
+  # Arguments: output_file expect_present... -- expect_absent...
+  cat > pkg/check_sandbox.sh << 'SANDBOXEOF'
+#!/bin/sh
+set -eu
+output_file="$1"
+shift
+mode="present"
+for arg in "$@"; do
+  if [ "${arg}" = "--" ]; then
+    mode="absent"
+    continue
+  fi
+  if [ "${mode}" = "present" ]; then
+    if [ ! -f "${arg}" ]; then
+      echo "FAIL: ${arg} should be in sandbox but is missing" >&2
+      exit 1
+    fi
+  else
+    if [ -f "${arg}" ]; then
+      resolved=$(readlink -f "${arg}" 2>/dev/null || echo "${arg}")
+      echo "FAIL: ${arg} should not be in sandbox but exists at ${resolved}" >&2
+      exit 1
+    fi
+  fi
+done
+echo "ok" > "${output_file}"
+SANDBOXEOF
+  chmod +x pkg/check_sandbox.sh
+
+  # Rule that checks file presence/absence in the sandbox.
+  cat > pkg/check_sandbox_rule.bzl << 'EOF'
+def _check_sandbox_impl(ctx):
+    inputs = ctx.attr.inputs.files
+    output = ctx.outputs.out
+    unused_inputs_list = ctx.file.unused_inputs_list
+    args = ctx.actions.args()
+    args.add(output)
+    args.add_all(ctx.files.expect_present)
+    args.add("--")
+    args.add_all(ctx.files.expect_absent)
+    all_inputs = depset([unused_inputs_list], transitive = [inputs])
+    ctx.actions.run(
+        inputs = all_inputs,
+        outputs = [output],
+        arguments = [args],
+        executable = ctx.executable.executable,
+        unused_inputs_list = unused_inputs_list,
+        execution_requirements = {"supports-path-mapping": "1"},
+    )
+
+check_sandbox_rule = rule(
+    attrs = {
+        "inputs": attr.label(),
+        "executable": attr.label(executable = True, cfg = "exec"),
+        "out": attr.output(),
+        "unused_inputs_list": attr.label(allow_single_file = True),
+        "expect_present": attr.label_list(allow_files = True),
+        "expect_absent": attr.label_list(allow_files = True),
+    },
+    implementation = _check_sandbox_impl,
+)
+EOF
+
   echo "contentA" > pkg/a.input
   echo "contentB" > pkg/b.input
   echo "contentC" > pkg/c.input
@@ -350,71 +414,6 @@ function test_input_discovery_unused_change_after_shutdown() {
 # The action script checks that b.input does NOT exist and fails if it does,
 # proving that pre-execution input discovery removed it from the sandbox.
 function test_input_discovery_removes_from_sandbox() {
-  cat > pkg/check_sandbox.sh << 'SANDBOXEOF'
-#!/bin/sh
-set -eu
-output_file="$1"
-shift
-# Arguments: expect_present... -- expect_absent...
-mode="present"
-for arg in "$@"; do
-  if [ "${arg}" = "--" ]; then
-    mode="absent"
-    continue
-  fi
-  if [ "${mode}" = "present" ]; then
-    if [ ! -f "${arg}" ]; then
-      echo "FAIL: ${arg} should be in sandbox but is missing" >&2
-      exit 1
-    fi
-  else
-    if [ -f "${arg}" ]; then
-      resolved=$(readlink -f "${arg}" 2>/dev/null || echo "${arg}")
-      echo "FAIL: ${arg} should not be in sandbox but exists at ${resolved}" >&2
-      exit 1
-    fi
-  fi
-done
-echo "ok" > "${output_file}"
-SANDBOXEOF
-  chmod +x pkg/check_sandbox.sh
-
-  # Rule that passes the unused input paths as arguments so the script
-  # can verify they are absent from the sandbox.
-  cat > pkg/check_sandbox_rule.bzl << 'EOF'
-def _check_sandbox_impl(ctx):
-    inputs = ctx.attr.inputs.files
-    output = ctx.outputs.out
-    unused_inputs_list = ctx.file.unused_inputs_list
-    # Arguments: output expect_present... -- expect_absent...
-    arguments = [output.path]
-    for f in ctx.files.expect_present:
-        arguments.append(f.path)
-    arguments.append("--")
-    for f in ctx.files.expect_absent:
-        arguments.append(f.path)
-    all_inputs = depset([unused_inputs_list], transitive = [inputs])
-    ctx.actions.run(
-        inputs = all_inputs,
-        outputs = [output],
-        arguments = arguments,
-        executable = ctx.executable.executable,
-        unused_inputs_list = unused_inputs_list,
-    )
-
-check_sandbox_rule = rule(
-    attrs = {
-        "inputs": attr.label(),
-        "executable": attr.label(executable = True, cfg = "exec"),
-        "out": attr.output(),
-        "unused_inputs_list": attr.label(allow_single_file = True),
-        "expect_present": attr.label_list(allow_files = True),
-        "expect_absent": attr.label_list(allow_files = True),
-    },
-    implementation = _check_sandbox_impl,
-)
-EOF
-
   cat > pkg/BUILD << 'EOF'
 load(":produce_unused_list.bzl", "produce_unused_list")
 load(":check_sandbox_rule.bzl", "check_sandbox_rule")
@@ -448,6 +447,108 @@ check_sandbox_rule(
 EOF
 
   bazel build --spawn_strategy=sandboxed //pkg:output || fail "build failed — b.input was present in sandbox"
+  local content
+  content=$(cat "${PRODUCT_NAME}-bin/pkg/output.out")
+  assert_equals "ok" "${content}"
+}
+
+# Tests that input discovery works correctly with path mapping
+# (--experimental_output_paths=strip). With path mapping, derived artifact paths
+# are stripped of their configuration segment. The unused_inputs_list producer
+# writes mapped paths (since it sees mapped paths at execution time), and
+# discoverInputs must match against those mapped paths.
+function test_input_discovery_with_path_mapping() {
+  # A rule that generates a derived file by copying a source file.
+  cat > pkg/generate.bzl << 'EOF'
+def _generate_impl(ctx):
+    out = ctx.outputs.out
+    src = ctx.file.src
+    ctx.actions.run_shell(
+        inputs = [src],
+        outputs = [out],
+        command = "cp %s %s" % (src.path, out.path),
+    )
+
+generate = rule(
+    attrs = {
+        "src": attr.label(allow_single_file = True),
+        "out": attr.output(),
+    },
+    implementation = _generate_impl,
+)
+EOF
+
+  # A rule that produces an unused_inputs_list containing the mapped paths of
+  # specified inputs. Uses a shell script to write the paths at execution time
+  # (when path mapping is active), so the paths in the file are mapped.
+  cat > pkg/produce_mapped_unused_list.bzl << 'EOF'
+def _produce_mapped_unused_list_impl(ctx):
+    unused_list = ctx.outputs.unused_list
+    # Write the unused input paths. At execution time with path mapping,
+    # file.path gives the analysis-time (unmapped) path. But the action's
+    # command line sees mapped paths. We use a shell script that receives
+    # the mapped paths as arguments.
+    args = ctx.actions.args()
+    args.add(unused_list)
+    args.add_all(ctx.files.unused_inputs)
+    ctx.actions.run_shell(
+        outputs = [unused_list],
+        inputs = ctx.files.unused_inputs,
+        arguments = [args],
+        command = 'out="$1"; shift; printf "%s\\n" "$@" > "$out"',
+        execution_requirements = {"supports-path-mapping": "1"},
+    )
+
+produce_mapped_unused_list = rule(
+    attrs = {
+        "unused_inputs": attr.label_list(allow_files = True),
+        "unused_list": attr.output(),
+    },
+    implementation = _produce_mapped_unused_list_impl,
+)
+EOF
+
+  cat > pkg/BUILD << 'EOF'
+load(":generate.bzl", "generate")
+load(":produce_mapped_unused_list.bzl", "produce_mapped_unused_list")
+load(":check_sandbox_rule.bzl", "check_sandbox_rule")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+generate(name = "gen_a", src = "a.input", out = "a.gen")
+generate(name = "gen_b", src = "b.input", out = "b.gen")
+generate(name = "gen_c", src = "c.input", out = "c.gen")
+
+filegroup(
+    name = "all_gen",
+    srcs = ["a.gen", "b.gen", "c.gen"],
+)
+
+produce_mapped_unused_list(
+    name = "unused_list",
+    unused_inputs = ["b.gen"],
+    unused_list = "unused.list",
+)
+
+sh_binary(
+    name = "check_sandbox",
+    srcs = ["check_sandbox.sh"],
+)
+
+check_sandbox_rule(
+    name = "output",
+    out = "output.out",
+    executable = ":check_sandbox",
+    inputs = ":all_gen",
+    unused_inputs_list = ":unused.list",
+    expect_present = ["a.gen", "c.gen"],
+    expect_absent = ["b.gen"],
+)
+EOF
+
+  bazel build \
+    --experimental_output_paths=strip \
+    --spawn_strategy=sandboxed \
+    //pkg:output || fail "build failed with path mapping"
   local content
   content=$(cat "${PRODUCT_NAME}-bin/pkg/output.out")
   assert_equals "ok" "${content}"

--- a/src/test/shell/integration/starlark_input_discovery_test.sh
+++ b/src/test/shell/integration/starlark_input_discovery_test.sh
@@ -414,6 +414,10 @@ function test_input_discovery_unused_change_after_shutdown() {
 # The action script checks that b.input does NOT exist and fails if it does,
 # proving that pre-execution input discovery removed it from the sandbox.
 function test_input_discovery_removes_from_sandbox() {
+  if is_windows; then
+    # Sandboxing is not available on Windows.
+    return 0
+  fi
   cat > pkg/BUILD << 'EOF'
 load(":produce_unused_list.bzl", "produce_unused_list")
 load(":check_sandbox_rule.bzl", "check_sandbox_rule")
@@ -458,6 +462,10 @@ EOF
 # writes mapped paths (since it sees mapped paths at execution time), and
 # discoverInputs must match against those mapped paths.
 function test_input_discovery_with_path_mapping() {
+  if is_windows; then
+    # Sandboxing is not available on Windows.
+    return 0
+  fi
   # A rule that generates a derived file by copying a source file.
   cat > pkg/generate.bzl << 'EOF'
 def _generate_impl(ctx):

--- a/src/test/shell/integration/starlark_input_discovery_test.sh
+++ b/src/test/shell/integration/starlark_input_discovery_test.sh
@@ -346,4 +346,111 @@ function test_input_discovery_unused_change_after_shutdown() {
   assert_action_cached "${stamp1}"
 }
 
+# Tests that unused inputs are actually absent from the execution sandbox.
+# The action script checks that b.input does NOT exist and fails if it does,
+# proving that pre-execution input discovery removed it from the sandbox.
+function test_input_discovery_removes_from_sandbox() {
+  cat > pkg/check_sandbox.sh << 'SANDBOXEOF'
+#!/bin/sh
+set -eu
+output_file="$1"
+shift
+# Arguments: expect_present... -- expect_absent...
+mode="present"
+for arg in "$@"; do
+  if [ "${arg}" = "--" ]; then
+    mode="absent"
+    continue
+  fi
+  if [ "${mode}" = "present" ]; then
+    if [ ! -f "${arg}" ]; then
+      echo "FAIL: ${arg} should be in sandbox but is missing" >&2
+      exit 1
+    fi
+  else
+    if [ -f "${arg}" ]; then
+      resolved=$(readlink -f "${arg}" 2>/dev/null || echo "${arg}")
+      echo "FAIL: ${arg} should not be in sandbox but exists at ${resolved}" >&2
+      exit 1
+    fi
+  fi
+done
+echo "ok" > "${output_file}"
+SANDBOXEOF
+  chmod +x pkg/check_sandbox.sh
+
+  # Rule that passes the unused input paths as arguments so the script
+  # can verify they are absent from the sandbox.
+  cat > pkg/check_sandbox_rule.bzl << 'EOF'
+def _check_sandbox_impl(ctx):
+    inputs = ctx.attr.inputs.files
+    output = ctx.outputs.out
+    unused_inputs_list = ctx.file.unused_inputs_list
+    # Arguments: output expect_present... -- expect_absent...
+    arguments = [output.path]
+    for f in ctx.files.expect_present:
+        arguments.append(f.path)
+    arguments.append("--")
+    for f in ctx.files.expect_absent:
+        arguments.append(f.path)
+    all_inputs = depset([unused_inputs_list], transitive = [inputs])
+    ctx.actions.run(
+        inputs = all_inputs,
+        outputs = [output],
+        arguments = arguments,
+        executable = ctx.executable.executable,
+        unused_inputs_list = unused_inputs_list,
+    )
+
+check_sandbox_rule = rule(
+    attrs = {
+        "inputs": attr.label(),
+        "executable": attr.label(executable = True, cfg = "exec"),
+        "out": attr.output(),
+        "unused_inputs_list": attr.label(allow_single_file = True),
+        "expect_present": attr.label_list(allow_files = True),
+        "expect_absent": attr.label_list(allow_files = True),
+    },
+    implementation = _check_sandbox_impl,
+)
+EOF
+
+  cat > pkg/BUILD << 'EOF'
+load(":produce_unused_list.bzl", "produce_unused_list")
+load(":check_sandbox_rule.bzl", "check_sandbox_rule")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+filegroup(
+    name = "all_inputs",
+    srcs = glob(["*.input"]),
+)
+
+produce_unused_list(
+    name = "unused_list",
+    unused_inputs = ["b.input"],
+    unused_list = "unused.list",
+)
+
+sh_binary(
+    name = "check_sandbox",
+    srcs = ["check_sandbox.sh"],
+)
+
+check_sandbox_rule(
+    name = "output",
+    out = "output.out",
+    executable = ":check_sandbox",
+    inputs = ":all_inputs",
+    unused_inputs_list = ":unused.list",
+    expect_present = ["a.input", "c.input"],
+    expect_absent = ["b.input"],
+)
+EOF
+
+  bazel build --spawn_strategy=sandboxed //pkg:output || fail "build failed — b.input was present in sandbox"
+  local content
+  content=$(cat "${PRODUCT_NAME}-bin/pkg/output.out")
+  assert_equals "ok" "${content}"
+}
+
 run_suite "Tests Starlark input discovery with unused_inputs_list as input"

--- a/src/test/shell/integration/starlark_input_discovery_test.sh
+++ b/src/test/shell/integration/starlark_input_discovery_test.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# --- begin runfiles.bash initialization ---
+# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
+set -euo pipefail
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+if is_windows; then
+  export LC_ALL=C.utf8
+elif is_linux; then
+  export LC_ALL=C.UTF-8
+else
+  export LC_ALL=en_US.UTF-8
+fi
+
+add_to_bazelrc "build --package_path=%workspace%"
+add_to_bazelrc "build --spawn_strategy=local"
+
+#### HELPER FUNCTIONS ##################################################
+
+function set_up() {
+  mkdir -p pkg
+
+  add_rules_shell "MODULE.bazel"
+
+  # Rule that produces an unused_inputs_list file (the "producer" action).
+  # This writes out the list of inputs that should be considered unused.
+  cat > pkg/produce_unused_list.bzl << 'EOF'
+def _produce_unused_list_impl(ctx):
+    unused_list = ctx.outputs.unused_list
+    content = "\n".join([f.path for f in ctx.files.unused_inputs])
+    ctx.actions.write(
+        output = unused_list,
+        content = content,
+    )
+
+produce_unused_list = rule(
+    attrs = {
+        "unused_inputs": attr.label_list(allow_files = True),
+        "unused_list": attr.output(),
+    },
+    implementation = _produce_unused_list_impl,
+)
+EOF
+
+  # Rule that consumes the unused_inputs_list as an input and uses it for
+  # input discovery. Writes a nanosecond timestamp to the output so we can
+  # detect whether the action re-ran (the output changes only if re-executed).
+  cat > pkg/consume_with_discovery.bzl << 'EOF'
+def _consume_with_discovery_impl(ctx):
+    inputs = ctx.attr.inputs.files
+    output = ctx.outputs.out
+    unused_inputs_list = ctx.file.unused_inputs_list
+    all_inputs = depset([unused_inputs_list], transitive = [inputs])
+    ctx.actions.run(
+        inputs = all_inputs,
+        outputs = [output],
+        arguments = [output.path],
+        executable = ctx.executable.executable,
+        unused_inputs_list = unused_inputs_list,
+    )
+
+consume_with_discovery = rule(
+    attrs = {
+        "inputs": attr.label(),
+        "executable": attr.label(executable = True, cfg = "exec"),
+        "out": attr.output(),
+        "unused_inputs_list": attr.label(allow_single_file = True),
+    },
+    implementation = _consume_with_discovery_impl,
+)
+EOF
+
+  cat > pkg/BUILD << 'EOF'
+load(":produce_unused_list.bzl", "produce_unused_list")
+load(":consume_with_discovery.bzl", "consume_with_discovery")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+filegroup(
+    name = "all_inputs",
+    srcs = glob(["*.input"]),
+)
+
+produce_unused_list(
+    name = "unused_list",
+    unused_inputs = ["b.input"],
+    unused_list = "unused.list",
+)
+
+sh_binary(
+    name = "write_stamp",
+    srcs = ["write_stamp.sh"],
+)
+
+consume_with_discovery(
+    name = "output",
+    out = "output.out",
+    executable = ":write_stamp",
+    inputs = ":all_inputs",
+    unused_inputs_list = ":unused.list",
+)
+EOF
+
+  # write_stamp.sh: writes a nanosecond timestamp to the output.
+  # If the action re-runs, the timestamp changes; if cached, it stays the same.
+  # Usage: write_stamp.sh output_file
+  cat > pkg/write_stamp.sh << 'EOF'
+#!/bin/sh
+set -eu
+date +%s%N > "$1"
+EOF
+  chmod +x pkg/write_stamp.sh
+
+  echo "contentA" > pkg/a.input
+  echo "contentB" > pkg/b.input
+  echo "contentC" > pkg/c.input
+}
+
+function tear_down() {
+  bazel clean
+  bazel shutdown
+  rm -rf pkg
+}
+
+# ----------------------------------------------------------------------
+# HELPER FUNCTIONS
+# ----------------------------------------------------------------------
+
+# Get the stamp value from the output file.
+function get_output_stamp() {
+  cat "${PRODUCT_NAME}-bin/pkg/output.out"
+}
+
+function do_build() {
+  bazel build //pkg:output "$@"
+}
+
+# Assert the action ran (stamp changed).
+function assert_action_ran() {
+  local before="$1"
+  local after
+  after=$(get_output_stamp)
+  if [ "${before}" = "${after}" ]; then
+    fail "Expected action to re-run, but stamp is unchanged: ${before}"
+  fi
+}
+
+# Assert the action did NOT run (stamp unchanged).
+function assert_action_cached() {
+  local before="$1"
+  local after
+  after=$(get_output_stamp)
+  assert_equals "${before}" "${after}"
+}
+
+# ----------------------------------------------------------------------
+# TESTS
+# ----------------------------------------------------------------------
+
+# Tests that when unused_inputs_list is produced by a prior action (which
+# traces the import tree), it is read during discoverInputs to trim inputs.
+function test_input_discovery_trims_unused_inputs() {
+  do_build || fail "build failed"
+  local stamp1
+  stamp1=$(get_output_stamp)
+
+  # Change b.input (unused — not reachable from a.input).
+  # The action should NOT re-run.
+
+  echo "newContentB" > pkg/b.input
+  do_build || fail "rebuild failed"
+  assert_action_cached "${stamp1}"
+}
+
+# Tests that changing a used input triggers a rebuild.
+function test_input_discovery_used_change_triggers_rebuild() {
+  do_build || fail "initial build failed"
+  local stamp1
+  stamp1=$(get_output_stamp)
+
+  # Change c.input (used — imported by a.input).
+
+  echo "newContentC" > pkg/c.input
+  do_build || fail "rebuild failed"
+  assert_action_ran "${stamp1}"
+}
+
+# Tests that when the unused_inputs_list changes (different inputs become
+# unused), the action correctly adjusts.
+function test_input_discovery_list_changes() {
+  do_build || fail "initial build failed"
+  local stamp1
+  stamp1=$(get_output_stamp)
+
+  # Change the producer to mark "c" as unused instead of "b".
+  cat > pkg/BUILD << 'EOF'
+load(":produce_unused_list.bzl", "produce_unused_list")
+load(":consume_with_discovery.bzl", "consume_with_discovery")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+filegroup(
+    name = "all_inputs",
+    srcs = glob(["*.input"]),
+)
+
+produce_unused_list(
+    name = "unused_list",
+    unused_inputs = ["c.input"],
+    unused_list = "unused.list",
+)
+
+sh_binary(
+    name = "write_stamp",
+    srcs = ["write_stamp.sh"],
+)
+
+consume_with_discovery(
+    name = "output",
+    out = "output.out",
+    executable = ":write_stamp",
+    inputs = ":all_inputs",
+    unused_inputs_list = ":unused.list",
+)
+EOF
+
+  do_build || fail "rebuild failed"
+  assert_action_ran "${stamp1}"
+  local stamp2
+  stamp2=$(get_output_stamp)
+
+  # Now change c.input (newly unused). Should NOT re-run.
+
+  echo "changedC" > pkg/c.input
+  do_build || fail "rebuild failed"
+  assert_action_cached "${stamp2}"
+
+  # Change b.input (no longer unused). Should re-run.
+
+  echo "changedB" > pkg/b.input
+  do_build || fail "rebuild failed"
+  assert_action_ran "${stamp2}"
+}
+
+# Tests that when no inputs are unused, changing any input triggers a rebuild.
+function test_input_discovery_all_inputs_used() {
+  cat > pkg/BUILD << 'EOF'
+load(":produce_unused_list.bzl", "produce_unused_list")
+load(":consume_with_discovery.bzl", "consume_with_discovery")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+filegroup(
+    name = "all_inputs",
+    srcs = glob(["*.input"]),
+)
+
+produce_unused_list(
+    name = "unused_list",
+    unused_inputs = [],
+    unused_list = "unused.list",
+)
+
+sh_binary(
+    name = "write_stamp",
+    srcs = ["write_stamp.sh"],
+)
+
+consume_with_discovery(
+    name = "output",
+    out = "output.out",
+    executable = ":write_stamp",
+    inputs = ":all_inputs",
+    unused_inputs_list = ":unused.list",
+)
+EOF
+
+  do_build || fail "initial build failed"
+  local stamp1
+  stamp1=$(get_output_stamp)
+
+  # Change b.input — should re-run since all inputs are used.
+
+  echo "newContentB" > pkg/b.input
+  do_build || fail "rebuild failed"
+  assert_action_ran "${stamp1}"
+}
+
+# Tests that after server shutdown, the action cache preserves pruned inputs.
+function test_input_discovery_cached_after_shutdown() {
+  do_build || fail "initial build failed"
+  local stamp1
+  stamp1=$(get_output_stamp)
+
+  bazel shutdown
+
+  do_build || fail "rebuild after shutdown failed"
+  assert_action_cached "${stamp1}"
+}
+
+# Tests that after server shutdown, changing an unused input does not cause
+# the action to re-run. The action cache entry stores the pruned input set,
+# so changes to pruned inputs are invisible to the cache check.
+function test_input_discovery_unused_change_after_shutdown() {
+  do_build || fail "initial build failed"
+  local stamp1
+  stamp1=$(get_output_stamp)
+
+  bazel shutdown
+
+  echo "newContentB" > pkg/b.input
+  do_build || fail "rebuild after shutdown failed"
+  assert_action_cached "${stamp1}"
+}
+
+run_suite "Tests Starlark input discovery with unused_inputs_list as input"


### PR DESCRIPTION
When unused_inputs_list is produced by a prior action and passed as an input to the consuming action, read it during discoverInputs() to trim unused inputs before execution.

Resolves #14292.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

This hooks up input discovery for Starlark actions by way of passing in the unused_inputs_list as an input to the action.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

Input discovery can drastically improve build performance by decreasing the number of inputs needed to be added to an execution sandbox, and by decreasing the entropy of the cache key.  C++ actions got this by native include scanning, but other actions had no way to access this feature.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)

-->

1. Has this been discussed in a design doc or issue? #14292 
2. Is the change backward compatible? I'm not sure what the policy is here.  Technically actions that used to not be able to see certain inputs (that they claimed to not read) now might not have those inputs in their sandbox), so yes a breaking change by implementation, but not a breaking change by spec.
3. If it's a breaking change, what is the migration plan? None yes.
### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES[INC]: unused_inputs_list artifacts that are passed as an input to an action (i.e. the file was produced by a previous action) will now prune the actions inputs before the action is executed, instead of only after.
