### PR TITLE
[9.1.0] Include `rctx.os.{name,arch}` in the pre declared inputs hash (https://github.com/bazelbuild/bazel/pull/29148)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DigestWriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DigestWriter.java
@@ -14,6 +14,7 @@
 //
 package com.google.devtools.build.lib.bazel.repository;
 
+import static com.google.common.base.StandardSystemProperty.OS_NAME;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 import com.google.common.base.Preconditions;
@@ -32,6 +33,7 @@ import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import com.google.devtools.build.skyframe.SkyFunctionException.Transience;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.StarlarkSemantics;
@@ -184,7 +186,12 @@ public class DigestWriter {
             .addString(repoDefinition.name())
             .addString(
                 GsonTypeAdapterUtil.SINGLE_EXTENSION_USAGES_VALUE_GSON.toJson(
-                    repoDefinition.attrValues()));
+                    repoDefinition.attrValues()))
+            // This info is accessible via rctx.os.{name,arch} and can also influence the
+            // result of a repo rule in subtle ways (e.g. behavior of host tools, line breaks,
+            // etc).
+            .addString(OS_NAME.value().toLowerCase(Locale.ROOT))
+            .addString(System.getProperty("os.arch").toLowerCase(Locale.ROOT));
     fp.addInt(environInputs.size());
     environInputs.forEach(
         (key, value) -> fp.addString(key.toString()).addNullableString(value.orElse(null)));


### PR DESCRIPTION
### Description

### Motivation
Fixes https://github.com/bazel-contrib/rules_go/issues/4581

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: The local and remote repo contents cache now include the host OS and CPU architecture in the cache key.

Closes #29148.

PiperOrigin-RevId: 893352625
Change-Id: I02c0ded7ffe2b5aa9bc2ef489dc5240b5716ebdf

Commit https://github.com/bazelbuild/bazel/commit/2ec24b41c4c28c677349cfca027e82707278c04f