### PR TITLE
[9.1.0] Remove GCOV symlink after use (https://github.com/bazelbuild/bazel/pull/29109)

### DIFF
--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -179,6 +179,8 @@ function gcov_coverage() {
       fi
     fi
   done < "${COVERAGE_MANIFEST}"
+
+  rm -f "${GCOV}"
 }
 
 function main() {


### PR DESCRIPTION
If you point GCOV to a tool that is an output of another bazel action,
its symlink becomes invalid when the sandbox is torn down. In this case
it leads to failures with tree artifacts:

```
ERROR: .../test/test_data/BUILD:223:8: error while validating output tree artifact test/test_data/c_test/_coverage: child gcov is a dangling symbolic link
```

We don't need to keep it after this anyways. This only fails with
`--experimental_fetch_all_coverage_outputs`

Closes #29109.

PiperOrigin-RevId: 893564426
Change-Id: I6e94fc11ac98876e88a6184911576f68b6536b62

Commit https://github.com/bazelbuild/bazel/commit/b650f938d6587b28b8b5ee8d13e1081df0a61647