### PR TITLE
Make patch fuzzing default to the same as patch CLI

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/PatchUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/PatchUtil.java
@@ -221,7 +221,7 @@ public class PatchUtil {
       Patch<String> tmpPatch = new Patch<>();
       tmpPatch.addDelta(delta);
       try {
-        newContent = tmpPatch.applyFuzzy(newContent, 0);
+        newContent = tmpPatch.applyFuzzy(newContent, 2);
       } catch (PatchFailedException | IndexOutOfBoundsException e) {
         throw new PatchFailedException(
             String.format(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -480,7 +480,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
           The patch file should be a standard \
           <a href="https://en.wikipedia.org/wiki/Diff#Unified_format"> \
           unified diff format</a> file. \
-          The Bazel-native patch implementation doesn't support fuzz match and binary patch \
+          The Bazel-native patch implementation doesn't support binary patch \
           like the patch command line tool.
           """,
       useStarlarkThread = true,

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/PatchUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/PatchUtilTest.java
@@ -552,7 +552,15 @@ public final class PatchUtilTest {
   @Test
   public void testChunkDoesNotMatch() throws IOException {
     scratch.file(
-        "/root/foo.cc", "#include <stdio.h>", "", "void main(){", "  printf(\"Hello foo\");", "}");
+        "/root/foo.cc",
+        "line1",
+        "line2",
+        "line3",
+        "line4",
+        "line5",
+        "line6",
+        "line7",
+        "line8");
     Path patchFile =
         scratch.file(
             "/root/patchfile",
@@ -560,12 +568,16 @@ public final class PatchUtilTest {
             "index f3008f9..ec4aaa0 100644",
             "--- a/foo.cc",
             "+++ b/foo.cc",
-            "@@ -2,4 +2,5 @@",
-            " ",
-            " void main(){",
-            "   printf(\"Hello bar\");", // Should be "Hello foo"
-            "+  printf(\"Hello from patch\");",
-            " }");
+            "@@ -1,8 +1,9 @@",
+            " line1",
+            " line2",
+            " line3",
+            " WRONG", // Should be "line4", in the middle so fuzz can't help
+            " ALSO WRONG", // Should be "line5"
+            " line6",
+            "+inserted",
+            " line7",
+            " line8");
     PatchFailedException expected =
         assertThrows(PatchFailedException.class, () -> PatchUtil.apply(patchFile, 1, root));
     assertThat(expected)
@@ -599,6 +611,41 @@ public final class PatchUtilTest {
     assertThat(expected)
         .hasMessageThat()
         .contains("Wrong chunk detected near line 11:  }, does not expect a context line here.");
+  }
+
+  @Test
+  public void testMatchWithFuzz() throws IOException, PatchFailedException {
+    Path foo =
+        scratch.file(
+            "/root/foo.cc",
+            "#include <stdio.h>",
+            "",
+            "void main(){",
+            "  printf(\"Hello foo\");",
+            "}");
+    Path patchFile =
+        scratch.file(
+            "/root/patchfile",
+            "diff --git a/foo.cc b/foo.cc",
+            "index f3008f9..ec4aaa0 100644",
+            "--- a/foo.cc",
+            "+++ b/foo.cc",
+            "@@ -2,4 +2,5 @@",
+            " ",
+            " void main(){",
+            "   printf(\"Hello foo\");",
+            "+  printf(\"Hello from patch\");",
+            " WRONG CONTEXT LINE"); // Last context line doesn't match, but fuzz can drop it
+    PatchUtil.apply(patchFile, 1, root);
+    ImmutableList<String> newFoo =
+        ImmutableList.of(
+            "#include <stdio.h>",
+            "",
+            "void main(){",
+            "  printf(\"Hello foo\");",
+            "  printf(\"Hello from patch\");",
+            "}");
+    assertThat(FileSystemUtils.readLines(foo, UTF_8)).isEqualTo(newFoo);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
@@ -417,9 +417,12 @@ public final class StarlarkRepositoryContextTest {
     setUpRepo("test");
     StarlarkPath foo = context.getPath("foo");
     StarlarkPath patchFile = context.getPath("my.patch");
-    context.createFile(foo, "line three\n", false, true, thread);
     context.createFile(
-        context.getPath("my.patch"), "--- foo\n+++ foo\n" + ONE_LINE_PATCH, false, true, thread);
+        foo, "line1\nline2\nWRONG\nALSO WRONG\nline5\nline6\n", false, true, thread);
+    String patch =
+        "--- foo\n+++ foo\n@@ -1,6 +1,7 @@\n line1\n line2\n line3\n line4\n+inserted\n"
+            + " line5\n line6\n";
+    context.createFile(context.getPath("my.patch"), patch, false, true, thread);
     try {
       context.patch(patchFile, StarlarkInt.of(0), "auto", thread);
       fail("Expected RepositoryFunctionException");

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -196,7 +196,7 @@
   "moduleExtensions": {
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "PccQ6UTHkecrVtXdFLtprZbzhM+6WnJG5drs66ijzVw=",
+        "bzlTransitiveDigest": "83DWGETXAnfUa4VM0HxTOPLY3/OZ02XUWVZLnhahKcM=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
@@ -253,7 +253,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "flPKelOmYiwBOhdYc+/ri/LjJvsXWCFnjiMP6XPAZ0g=",
+        "bzlTransitiveDigest": "7ww6Au8z2kFDoyxVTCrQlqCRtKEiZ+ajiOElIe/qCM4=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -125,7 +125,7 @@ _common_attrs = {
         doc =
             "A list of files that are to be applied as patches after " +
             "extracting the archive. By default, it uses the Bazel-native patch implementation " +
-            "which doesn't support fuzz match and binary patch, but Bazel will fall back to use " +
+            "which doesn't support binary patch, but Bazel will fall back to use " +
             "patch command line tool if `patch_tool` attribute is specified or there are " +
             "arguments other than `-p` in `patch_args` attribute.",
     ),

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -377,7 +377,7 @@ following: """ + READABLE_ARCHIVE_FORMATS + ".",
         doc =
             "A list of files that are to be applied as patches after " +
             "extracting the archive. By default, it uses the Bazel-native patch implementation " +
-            "which doesn't support fuzz match and binary patch, but Bazel will fall back to use " +
+            "which doesn't support binary patch, but Bazel will fall back to use " +
             "patch command line tool if `patch_tool` attribute is specified or there are " +
             "arguments other than `-p` in `patch_args` attribute.",
     ),


### PR DESCRIPTION
The patch cli tool defaults to a fuzz factor of 2, this mirrors that so
patches work in bazel in the same way.

Fixes https://github.com/bazelbuild/bazel/issues/23959