### PR TITLE
bazelrc: preserve empty config declarations

### DIFF
--- a/src/main/cpp/rc_file.cc
+++ b/src/main/cpp/rc_file.cc
@@ -142,6 +142,10 @@ RcFile::ParseError RcFile::ParseFile(
     const absl::string_view command = words[0];
     if (command != kCommandImport && command != kCommandTryImport &&
         command != kCommandTryImportIfBazelVersion) {
+      if (words.size() == 1 && command.find(':') != absl::string_view::npos) {
+        // Preserve empty config declarations so the server can tell they exist.
+        options_[command].push_back({"", rcfile_index});
+      }
       for (absl::string_view word : absl::MakeConstSpan(words).subspan(1)) {
         options_[command].push_back({std::string(word), rcfile_index});
       }

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -59,7 +59,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -667,7 +669,7 @@ public final class BlazeOptionHandler {
     ListMultimap<String, RcChunkOfArgs> commandToRcArgs = ArrayListMultimap.create();
 
     String lastRcFile = null;
-    ListMultimap<String, String> commandToArgMapForLastRc = null;
+    LinkedHashMap<String, List<String>> commandToArgMapForLastRc = null;
     for (ClientOptions.OptionOverride override : rawOverrides) {
       if (override.blazeRc < 0 || override.blazeRc >= rcFiles.size()) {
         eventHandler.handle(
@@ -714,23 +716,28 @@ public final class BlazeOptionHandler {
         if (lastRcFile != null) {
           // Go through the various commands identified in this rc file (or chunk of file) and
           // store them grouped first by command, then by rc chunk.
-          for (String commandKey : commandToArgMapForLastRc.keySet()) {
+          for (Map.Entry<String, List<String>> entry : commandToArgMapForLastRc.entrySet()) {
             commandToRcArgs.put(
-                commandKey,
-                new RcChunkOfArgs(lastRcFile, commandToArgMapForLastRc.get(commandKey)));
+                entry.getKey(), new RcChunkOfArgs(lastRcFile, ImmutableList.copyOf(entry.getValue())));
           }
         }
         lastRcFile = rcFile;
-        commandToArgMapForLastRc = ArrayListMultimap.create();
+        commandToArgMapForLastRc = new LinkedHashMap<>();
       }
 
-      commandToArgMapForLastRc.put(override.command, override.option);
+      List<String> argsForCommand =
+          commandToArgMapForLastRc.computeIfAbsent(override.command, unused -> new ArrayList<>());
+      if (!override.option.isEmpty()) {
+        argsForCommand.add(override.option);
+      } else if (override.command.indexOf(':') == -1) {
+        commandToArgMapForLastRc.remove(override.command);
+      }
     }
     if (lastRcFile != null) {
       // Once again, for this last rc file chunk, store them grouped by command.
-      for (String commandKey : commandToArgMapForLastRc.keySet()) {
+      for (Map.Entry<String, List<String>> entry : commandToArgMapForLastRc.entrySet()) {
         commandToRcArgs.put(
-            commandKey, new RcChunkOfArgs(lastRcFile, commandToArgMapForLastRc.get(commandKey)));
+            entry.getKey(), new RcChunkOfArgs(lastRcFile, ImmutableList.copyOf(entry.getValue())));
       }
     }
 

--- a/src/test/cpp/rc_options_test.cc
+++ b/src/test/cpp/rc_options_test.cc
@@ -143,6 +143,14 @@ TEST_F(RcOptionsTest, EmptyStartupLine) {
                                       no_expected_args);
 }
 
+TEST_F(RcOptionsTest, EmptyConfigLine) {
+  WriteRc("empty_config_line.bazelrc",
+          "common:foo");
+  SuccessfullyParseRcWithExpectedArgs(
+      "empty_config_line.bazelrc",
+      {{"common:foo", {""}}});
+}
+
 TEST_F(RcOptionsTest, StartupWithOnlyCommentedArg) {
   WriteRc("startup_with_comment.bazelrc",
           "startup # bar");

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
@@ -152,6 +152,19 @@ public class BlazeOptionHandlerTest {
   }
 
   @Test
+  public void testStructureRcOptionsAndConfigs_emptyConfig() throws Exception {
+    ListMultimap<String, RcChunkOfArgs> structuredRc =
+        BlazeOptionHandler.structureRcOptionsAndConfigs(
+            eventHandler,
+            Arrays.asList("rc1"),
+            Arrays.asList(new ClientOptions.OptionOverride(0, "common:foo", "")),
+            ImmutableSet.of("build"));
+    assertThat(structuredRc)
+        .containsExactly("common:foo", new RcChunkOfArgs("rc1", ImmutableList.of()));
+    assertThat(eventHandler.isEmpty()).isTrue();
+  }
+
+  @Test
   public void testStructureRcOptionsAndConfigs_invalidCommand() throws Exception {
     BlazeOptionHandler.structureRcOptionsAndConfigs(
         eventHandler,
@@ -427,6 +440,20 @@ public class BlazeOptionHandlerTest {
   }
 
   @Test
+  public void testExpandConfigOptions_emptyConfig() throws Exception {
+    parser.parse("--config=empty");
+    ListMultimap<String, RcChunkOfArgs> rcContent = ArrayListMultimap.create();
+    rcContent.put("common:empty", new RcChunkOfArgs("rc1", ImmutableList.of()));
+
+    optionHandler.expandConfigOptions(eventHandler, rcContent);
+
+    assertThat(eventHandler.getEvents()).isEmpty();
+    assertThat(parser.getResidue()).isEmpty();
+    assertThat(optionHandler.getRcfileNotes())
+        .containsExactly("Found applicable config definition common:empty in file rc1: ");
+  }
+
+  @Test
   public void testParseOptions_argless() {
     DetailedExitCode unused =
         optionHandler.parseOptions(
@@ -662,6 +689,28 @@ public class BlazeOptionHandlerTest {
     TestOptions options = parser.getOptions(TestOptions.class);
     assertThat(options).isNotNull();
     assertThat(options.testMultipleString).containsExactly("rc", "explicit", "config").inOrder();
+  }
+
+  @Test
+  public void testParseOptions_explicitEmptyConfig() {
+    DetailedExitCode unused =
+        optionHandler.parseOptions(
+            ImmutableList.of(
+                "build",
+                "--default_override=0:common:empty=",
+                "--rc_source=/somewhere/.blazerc",
+                "--test_multiple_string=explicit",
+                "--config=empty"),
+            eventHandler,
+            ImmutableList.builder());
+    assertThat(eventHandler.getEvents()).isEmpty();
+    assertThat(parser.getResidue()).isEmpty();
+    assertThat(optionHandler.getRcfileNotes())
+        .containsExactly("Found applicable config definition common:empty in file /somewhere/.blazerc: ");
+
+    TestOptions options = parser.getOptions(TestOptions.class);
+    assertThat(options).isNotNull();
+    assertThat(options.testMultipleString).containsExactly("explicit").inOrder();
   }
 
   @Test


### PR DESCRIPTION
### Description

A line like 'common:foo' used to disappear in the client because rc parsing only recorded tokens after the command name. That made --config=foo fail later as if the config had never been declared.

Preserve empty config declarations in the rc parser and carry them through the Java-side rc grouping logic as empty arg lists. That keeps the config defined without adding a bogus empty argument, so --config=foo now expands to nothing instead of failing.

Add parser and runtime tests for the rc file form and the --default_override wire format.

I am neither particularly good at java nor well-versed in bazel internals, but hopefully this is right :)

### Motivation

Fixes #12844

### Build API Changes
Yes, sort of; but non-breaking, since empty configs would not have worked before.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [n/a] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: bazelrc config declarations can now be empty