### PR TITLE
[9.1.0] Make include verification aware of Windows case-insensitivity (https://github.com/bazelbuild/bazel/pull/28810)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
@@ -13,7 +13,10 @@
 // limitations under the License.
 package com.google.devtools.build.lib.actions;
 
+import static java.util.Comparator.comparing;
+
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
 import com.google.devtools.build.lib.actions.Artifact.SourceArtifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
@@ -23,14 +26,17 @@ import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.util.Pair;
+import com.google.devtools.build.lib.util.StringEncoding;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 
 /** A cache of Artifacts, keyed by Path. */
@@ -53,42 +59,109 @@ public class ArtifactFactory implements ArtifactResolver {
 
   private static class SourceArtifactCache {
 
-    private class Entry {
-      private final SourceArtifact artifact;
-      private final int idOfBuild;
-
-      Entry(SourceArtifact artifact) {
-        this.artifact = artifact;
-        idOfBuild = buildId;
-      }
-
-      SourceArtifact getArtifact() {
-        return artifact;
-      }
-
-      boolean isArtifactValid() {
-        return idOfBuild == buildId;
+    private record Entry(SourceArtifact artifact, int buildId) {
+      boolean isInvalid(int currentBuildId) {
+        return buildId != currentBuildId;
       }
     }
-
-    private static final int CONCURRENCY_LEVEL = Runtime.getRuntime().availableProcessors();
 
     /**
      * The main Path to source artifact cache. There will always be exactly one canonical artifact
      * for a given source path.
+     *
+     * <p>Since some use cases require case-insensitive lookups, the map uses a case-insensitive key
+     * lookup. A ConcurrentSkipListMap supports this without a PathFragment wrapper, which saves
+     * memory. The corresponding value is either a single Entry, or a list of Entry objects if there
+     * are multiple artifacts with case-insensitively equivalent paths. This structure is heavily
+     * optimized for the common case of a single artifact per case-insensitive equivalence class and
+     * may perform poorly if there are many artifacts with case-insensitively equivalent paths.
      */
-    private final ConcurrentMap<PathFragment, Entry> pathToSourceArtifact =
-        new ConcurrentHashMap<>(16, 0.75f, CONCURRENCY_LEVEL);
+    private final ConcurrentMap<PathFragment, Object /* Entry | CopyOnWriteArrayList<Entry> */>
+        pathToSourceArtifact =
+            new ConcurrentSkipListMap<>(
+                comparing(
+                    pathFragment -> StringEncoding.internalToUnicode(pathFragment.getPathString()),
+                    String.CASE_INSENSITIVE_ORDER));
 
     /** Id of current build. Has to be increased every time before analysis starts. */
     private int buildId = -1;
+
+    @Nullable
+    private Entry unwrapCacheObject(PathFragment execPath, Object cacheObject) {
+      return switch (cacheObject) {
+        case null -> null;
+        case Entry entry -> entry.artifact().getExecPath().equals(execPath) ? entry : null;
+        case CopyOnWriteArrayList<?> entries -> {
+          for (Object entryObject : entries) {
+            var entry = (Entry) entryObject;
+            if (entry.artifact().getExecPath().equals(execPath)) {
+              yield entry;
+            }
+          }
+          yield null;
+        }
+        default ->
+            throw new IllegalStateException(
+                "Unexpected cache object type: %s, value: %s"
+                    .formatted(cacheObject.getClass(), cacheObject));
+      };
+    }
+
+    @Nullable
+    private Entry getEntry(PathFragment execPath) {
+      return unwrapCacheObject(execPath, pathToSourceArtifact.get(execPath));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Entry computeEntry(
+        PathFragment execPath, BiFunction<PathFragment, Entry, Entry> computeFunction) {
+      return unwrapCacheObject(
+          execPath, pathToSourceArtifact.compute(execPath, liftToCacheObject(computeFunction)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static BiFunction<PathFragment, Object, Object> liftToCacheObject(
+        BiFunction<PathFragment, Entry, Entry> computeFunction) {
+      return (execPath, cacheObject) ->
+          switch (cacheObject) {
+            // No entry for this case-insensitive path, thus also not for this exact casing.
+            case null -> computeFunction.apply(execPath, null);
+            // The lookup was case-insensitive, so the single cache entry may not be valid
+            // for this exact casing. If it isn't, switch to a list.
+            case Entry entry ->
+                entry.artifact().getExecPath().equals(execPath)
+                    ? computeFunction.apply(execPath, entry)
+                    : new CopyOnWriteArrayList<>(
+                        new Entry[] {entry, computeFunction.apply(execPath, null)});
+            case CopyOnWriteArrayList<?> rawEntries -> {
+              var entries = (CopyOnWriteArrayList<Entry>) rawEntries;
+              for (Entry entry : entries) {
+                // Update the existing entry for this exact casing if it exists.
+                if (entry.artifact().getExecPath().equals(execPath)) {
+                  Entry newEntry = computeFunction.apply(execPath, entry);
+                  if (newEntry != entry) {
+                    entries.set(entries.indexOf(entry), newEntry);
+                  }
+                  yield entries;
+                }
+              }
+              // No entry for this exact casing, add a new one.
+              entries.add(computeFunction.apply(execPath, null));
+              yield entries;
+            }
+            default ->
+                throw new IllegalStateException(
+                    "Unexpected cache object type: %s, value: %s"
+                        .formatted(cacheObject.getClass(), cacheObject));
+          };
+    }
 
     /** Returns artifact if it present in the cache, otherwise null. */
     @Nullable
     @ThreadSafe
     SourceArtifact getArtifact(PathFragment execPath) {
-      Entry cacheEntry = pathToSourceArtifact.get(execPath);
-      return cacheEntry == null ? null : cacheEntry.getArtifact();
+      Entry cacheEntry = getEntry(execPath);
+      return cacheEntry == null ? null : cacheEntry.artifact();
     }
 
     /**
@@ -101,10 +174,59 @@ public class ArtifactFactory implements ArtifactResolver {
     @Nullable
     @ThreadSafe
     SourceArtifact getArtifactIfValid(PathFragment execPath) {
-      Entry cacheEntry = pathToSourceArtifact.get(execPath);
-      return (cacheEntry == null || !cacheEntry.isArtifactValid())
-          ? null
-          : cacheEntry.getArtifact();
+      Entry cacheEntry = getEntry(execPath);
+      return (cacheEntry == null || cacheEntry.isInvalid(buildId)) ? null : cacheEntry.artifact();
+    }
+
+    /**
+     * Returns all entries with case-insensitively equivalent exec paths. The returned list contains
+     * the raw cache entries, which may or may not be valid for the current build.
+     */
+    @SuppressWarnings("unchecked")
+    @ThreadSafe
+    private ImmutableList<Entry> getEntriesWithAsciiCaseInsensitivePath(PathFragment execPath) {
+      Object cacheObject = pathToSourceArtifact.get(execPath);
+      return switch (cacheObject) {
+        case null -> ImmutableList.of();
+        case Entry entry -> ImmutableList.of(entry);
+        case CopyOnWriteArrayList<?> entries ->
+            ImmutableList.copyOf((CopyOnWriteArrayList<Entry>) entries);
+        default ->
+            throw new IllegalStateException(
+                "Unexpected cache object type: %s, value: %s"
+                    .formatted(cacheObject.getClass(), cacheObject));
+      };
+    }
+
+    /**
+     * Returns a list of artifacts with case-insensitively equivalent exec paths that are present in
+     * the cache and have been verified to be valid for this build. Note that if the artifacts'
+     * packages are not part of the current build, our differing methods of validating source roots
+     * (via {@link PackageRootResolver} and via {@link #findSourceRoot}) may disagree. In that case,
+     * the artifacts will be valid, but unusable by any action (since no action has properly
+     * declared them as inputs).
+     */
+    @ThreadSafe
+    private ImmutableList<SourceArtifact> getValidArtifactsWithAsciiCaseInsensitivePath(
+        PathFragment execPath) {
+      return getEntriesWithAsciiCaseInsensitivePath(execPath).stream()
+          .filter(entry -> !entry.isInvalid(buildId))
+          .map(Entry::artifact)
+          .collect(ImmutableList.toImmutableList());
+    }
+
+    /**
+     * Returns a list of all artifacts with case-insensitively equivalent exec paths that are
+     * present in the cache, regardless of whether they have been verified to be valid for this
+     * build. This is used to find stale artifacts from previous builds that can be revalidated
+     * using their original (correct-casing) exec paths.
+     */
+    @ThreadSafe
+    ImmutableList<SourceArtifact> getAllArtifactsWithAsciiCaseInsensitivePath(
+        PathFragment execPath) {
+      return getEntriesWithAsciiCaseInsensitivePath(execPath).stream()
+          .map(Entry::artifact)
+          .collect(ImmutableList.toImmutableList());
     }
 
     void newBuild() {
@@ -315,21 +437,22 @@ public class ArtifactFactory implements ArtifactResolver {
       return firstArtifact;
     }
     SourceArtifactCache.Entry newEntry =
-        sourceArtifactCache.pathToSourceArtifact.compute(
+        sourceArtifactCache.computeEntry(
             execPath,
             (k, entry) -> {
               if (entry == null
-                  || entry.getArtifact() == null
-                  || entry.getArtifact().differentOwnerOrRoot(owner, root)) {
+                  || entry.artifact() == null
+                  || entry.artifact().differentOwnerOrRoot(owner, root)) {
                 // There really should be a safety net that makes it impossible to create two
                 // Artifacts with the same exec path but a different Owner, but we also need to
                 // reuse Artifacts from previous builds.
-                return sourceArtifactCache
-                .new Entry((SourceArtifact) createArtifact(root, execPath, owner, type));
+                return new SourceArtifactCache.Entry(
+                    (SourceArtifact) createArtifact(root, execPath, owner, type),
+                    sourceArtifactCache.buildId);
               }
               return entry;
             });
-    return newEntry.getArtifact();
+    return newEntry.artifact();
   }
 
   private static Artifact createArtifact(
@@ -449,6 +572,53 @@ public class ArtifactFactory implements ArtifactResolver {
     return resolveSourceArtifactWithAncestor(execPath, null, null, repositoryName);
   }
 
+  @Override
+  public ImmutableList<SourceArtifact> resolveSourceArtifactsAsciiCaseInsensitively(
+      PathFragment execPath, RepositoryName repositoryName) {
+    if (isDefinitelyNotSourceExecPath(execPath)) {
+      return ImmutableList.of();
+    }
+
+    // Don't create an artifact if it's derived.
+    if (isDerivedArtifact(execPath)) {
+      return ImmutableList.of();
+    }
+    var artifacts = sourceArtifactCache.getValidArtifactsWithAsciiCaseInsensitivePath(execPath);
+    if (!artifacts.isEmpty()) {
+      return artifacts;
+    }
+    // The case-insensitive cache may have artifacts from a previous build that aren't valid yet.
+    // Try to revalidate them using their original (correct-casing) exec paths before falling back
+    // to creating a new artifact with the queried (potentially wrong-casing) exec path.
+    var staleArtifacts = sourceArtifactCache.getAllArtifactsWithAsciiCaseInsensitivePath(execPath);
+    if (!staleArtifacts.isEmpty()) {
+      var revalidated = ImmutableList.<SourceArtifact>builder();
+      for (SourceArtifact stale : staleArtifacts) {
+        Root sourceRoot =
+            findSourceRoot(
+                stale.getExecPath(),
+                /* baseExecPath= */ null,
+                /* baseRoot= */ null,
+                repositoryName);
+        SourceArtifact valid = createArtifactIfNotValid(sourceRoot, stale.getExecPath());
+        if (valid != null) {
+          revalidated.add(valid);
+        }
+      }
+      var result = revalidated.build();
+      if (!result.isEmpty()) {
+        return result;
+      }
+    }
+    Root sourceRoot =
+        findSourceRoot(execPath, /* baseExecPath= */ null, /* baseRoot= */ null, repositoryName);
+    SourceArtifact newArtifact = createArtifactIfNotValid(sourceRoot, execPath);
+    if (newArtifact == null) {
+      return ImmutableList.of();
+    }
+    return ImmutableList.of(newArtifact);
+  }
+
   @Nullable
   @Override
   public Map<PathFragment, SourceArtifact> resolveSourceArtifacts(
@@ -508,21 +678,22 @@ public class ArtifactFactory implements ArtifactResolver {
     if (artifact != null && sourceRoot.equals(artifact.getRoot().getRoot())) {
       // Source root of existing artifact hasn't changed so we should mark corresponding entry in
       // the cache as valid.
-      sourceArtifactCache.pathToSourceArtifact.compute(
-          execPath,
-          (k, cacheEntry) -> {
-            SourceArtifact validArtifact = cacheEntry.getArtifact();
-            if (!cacheEntry.isArtifactValid()) {
-              // Wasn't previously known to be valid.
-              return sourceArtifactCache.new Entry(validArtifact);
-            }
-            Preconditions.checkState(
-                artifact.equals(validArtifact),
-                "Mismatched artifacts: %s %s",
-                artifact,
-                validArtifact);
-            return cacheEntry;
-          });
+      var unused =
+          sourceArtifactCache.computeEntry(
+              execPath,
+              (k, cacheEntry) -> {
+                SourceArtifact validArtifact = cacheEntry.artifact();
+                if (cacheEntry.isInvalid(sourceArtifactCache.buildId)) {
+                  // Wasn't previously known to be valid.
+                  return new SourceArtifactCache.Entry(validArtifact, sourceArtifactCache.buildId);
+                }
+                Preconditions.checkState(
+                    artifact.equals(validArtifact),
+                    "Mismatched artifacts: %s %s",
+                    artifact,
+                    validArtifact);
+                return cacheEntry;
+              });
       return artifact;
     } else {
       // Must be a new artifact or artifact in the cache is stale, so create a new one.

--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactResolver.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.actions;
 
+import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.actions.Artifact.SourceArtifact;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.vfs.Path;
@@ -23,8 +24,8 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * An interface for resolving artifact names to {@link Artifact} objects. Should only be used
- * in the internal machinery of Blaze: rule implementations are not allowed to do this.
+ * An interface for resolving artifact names to {@link Artifact} objects. Should only be used in the
+ * internal machinery of Blaze: rule implementations are not allowed to do this.
  */
 public interface ArtifactResolver {
   /**
@@ -57,7 +58,11 @@ public interface ArtifactResolver {
    * @return an existing or new source Artifact for the given execPath. Returns null if the root can
    *     not be determined and the artifact did not exist before.
    */
+  @Nullable
   SourceArtifact resolveSourceArtifact(PathFragment execPath, RepositoryName repositoryName);
+
+  ImmutableList<SourceArtifact> resolveSourceArtifactsAsciiCaseInsensitively(
+      PathFragment execPath, RepositoryName repositoryName);
 
   /**
    * Resolves source Artifacts given execRoot-relative paths.

--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -323,6 +323,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:filetype",
         "//src/main/java/com/google/devtools/build/lib/util:hash_codes",
+        "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/skyframe:execution_phase_skykey",

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
@@ -16,6 +16,9 @@ package com.google.devtools.build.lib.rules.cpp;
 
 import static com.google.devtools.build.lib.analysis.constraints.ConstraintConstants.getOsFromConstraintsOrHost;
 
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.ActionExecutionException;
 import com.google.devtools.build.lib.actions.Artifact;
@@ -24,6 +27,7 @@ import com.google.devtools.build.lib.actions.ArtifactResolver;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
+import com.google.devtools.build.lib.collect.compacthashset.CompactHashSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.util.OS;
@@ -31,6 +35,7 @@ import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -150,15 +155,16 @@ final class HeaderDiscovery {
     // Check inclusions.
     IncludeProblems absolutePathProblems = new IncludeProblems();
     IncludeProblems unresolvablePathProblems = new IncludeProblems();
-    // Absolute includes from system paths are ignored. On Windows, which has a case-insensitive
-    // file system by default, the paths as reported by the compiler may differ in casing from
-    // those listed by the toolchain.
-    boolean caseInsensitiveSystemIncludes =
+    boolean possiblyCaseInsensitiveFileSystem =
         getOsFromConstraintsOrHost(action.getExecutionPlatform()) == OS.WINDOWS;
+    CompactHashSet<Artifact> sourceArtifactInputs = null;
     for (Path execPath : dependencies) {
       PathFragment execPathFragment = execPath.asFragment();
       if (execPathFragment.isAbsolute()) {
-        if (caseInsensitiveSystemIncludes) {
+        if (possiblyCaseInsensitiveFileSystem) {
+          // Absolute includes from system paths are ignored. With a case-insensitive file system,
+          // the paths as reported by the compiler may differ in casing from those listed by the
+          // toolchain.
           if (FileSystemUtils.startsWithAnyIgnoringCase(execPath, permittedSystemIncludePrefixes)) {
             continue;
           }
@@ -185,20 +191,54 @@ final class HeaderDiscovery {
           continue;
         }
       }
-      Artifact artifact = regularDerivedArtifacts.get(execPathFragment);
-      if (artifact == null) {
+      Collection<? extends Artifact> resolvedArtifacts = ImmutableList.of();
+      Artifact derivedArtifact = regularDerivedArtifacts.get(execPathFragment);
+      if (derivedArtifact == null) {
         Optional<PackageIdentifier> pkgId =
             PackageIdentifier.discoverFromExecPath(
                 execPathFragment, false, siblingRepositoryLayout);
         if (pkgId.isPresent()) {
-          artifact =
-              artifactResolver.resolveSourceArtifact(execPathFragment, pkgId.get().getRepository());
+          if (possiblyCaseInsensitiveFileSystem) {
+            resolvedArtifacts =
+                artifactResolver.resolveSourceArtifactsAsciiCaseInsensitively(
+                    execPathFragment, pkgId.get().getRepository());
+          } else {
+            var sourceArtifact =
+                artifactResolver.resolveSourceArtifact(
+                    execPathFragment, pkgId.get().getRepository());
+            if (sourceArtifact != null) {
+              resolvedArtifacts = ImmutableList.of(sourceArtifact);
+            }
+          }
         }
+      } else {
+        resolvedArtifacts = ImmutableList.of(derivedArtifact);
       }
-      if (artifact != null) {
+      if (!resolvedArtifacts.isEmpty()) {
         // We don't need to add the sourceFile itself as it is a mandatory input.
-        if (!artifact.equals(sourceFile)) {
-          inputs.add(artifact);
+        resolvedArtifacts = Collections2.filter(resolvedArtifacts, a -> !a.equals(sourceFile));
+        switch (resolvedArtifacts.size()) {
+          case 0 -> {}
+          case 1 -> inputs.add(Iterables.getOnlyElement(resolvedArtifacts));
+          default -> {
+            if (sourceArtifactInputs == null) {
+              sourceArtifactInputs = CompactHashSet.create();
+              for (Artifact input : action.getInputs().toList()) {
+                if (input.isSourceArtifact()) {
+                  sourceArtifactInputs.add(input);
+                }
+              }
+            }
+            if (Collections.disjoint(resolvedArtifacts, sourceArtifactInputs)) {
+              inputs.addAll(resolvedArtifacts);
+            } else {
+              for (Artifact resolvedArtifact : resolvedArtifacts) {
+                if (sourceArtifactInputs.contains(resolvedArtifact)) {
+                  inputs.add(resolvedArtifact);
+                }
+              }
+            }
+          }
         }
         continue;
       } else if (execPathFragment.getFileExtension().equals("cppmap")) {

--- a/src/test/java/com/google/devtools/build/lib/actions/ArtifactFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ArtifactFactoryTest.java
@@ -231,6 +231,212 @@ public class ArtifactFactoryTest {
     assertThat(actionGraph.getGeneratingAction(a)).isSameInstanceAs(originalAction);
   }
 
+  @Test
+  public void testResolveSourceArtifactCaseInsensitively_exactMatch() {
+    artifactFactory.noteAnalysisStarting();
+    Artifact.SourceArtifact original = artifactFactory.getSourceArtifact(fooRelative, clientRoot);
+
+    ImmutableList<Artifact.SourceArtifact> result =
+        artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(fooRelative, MAIN);
+
+    assertThat(result).containsExactly(original);
+  }
+
+  @Test
+  public void testResolveSourceArtifactCaseInsensitively_upperCaseLookupFindsLowerCaseArtifact() {
+    artifactFactory.noteAnalysisStarting();
+    PathFragment lowerPath = PathFragment.create("foo/foosource.txt");
+    Artifact.SourceArtifact original = artifactFactory.getSourceArtifact(lowerPath, clientRoot);
+
+    PathFragment upperPath = PathFragment.create("foo/FooSource.txt");
+    ImmutableList<Artifact.SourceArtifact> result =
+        artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(upperPath, MAIN);
+
+    assertThat(result).containsExactly(original);
+  }
+
+  @Test
+  public void testResolveSourceArtifactCaseInsensitively_lowerCaseLookupFindsUpperCaseArtifact() {
+    artifactFactory.noteAnalysisStarting();
+    PathFragment upperPath = PathFragment.create("foo/FooSource.txt");
+    Artifact.SourceArtifact original = artifactFactory.getSourceArtifact(upperPath, clientRoot);
+
+    PathFragment lowerPath = PathFragment.create("foo/foosource.txt");
+    ImmutableList<Artifact.SourceArtifact> result =
+        artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(lowerPath, MAIN);
+
+    assertThat(result).containsExactly(original);
+  }
+
+  @Test
+  public void testGetSourceArtifactDifferentCasings_returnsDifferentArtifacts() {
+    artifactFactory.noteAnalysisStarting();
+    PathFragment lower = PathFragment.create("foo/header.h");
+    PathFragment upper = PathFragment.create("foo/Header.h");
+    Artifact.SourceArtifact lowerArtifact = artifactFactory.getSourceArtifact(lower, clientRoot);
+    Artifact.SourceArtifact upperArtifact = artifactFactory.getSourceArtifact(upper, clientRoot);
+
+    assertThat(upperArtifact).isNotSameInstanceAs(lowerArtifact);
+    assertThat(lowerArtifact.getExecPath()).isEqualTo(lower);
+    assertThat(upperArtifact.getExecPath()).isEqualTo(upper);
+  }
+
+  @Test
+  public void testResolveSourceArtifactCaseInsensitively_multipleMatches() {
+    artifactFactory.noteAnalysisStarting();
+    PathFragment lower = PathFragment.create("foo/header.h");
+    PathFragment upper = PathFragment.create("foo/Header.h");
+    Artifact.SourceArtifact lowerArtifact = artifactFactory.getSourceArtifact(lower, clientRoot);
+    Artifact.SourceArtifact upperArtifact = artifactFactory.getSourceArtifact(upper, clientRoot);
+
+    ImmutableList<Artifact.SourceArtifact> resultFromLower =
+        artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(lower, MAIN);
+    ImmutableList<Artifact.SourceArtifact> resultFromUpper =
+        artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(upper, MAIN);
+
+    assertThat(resultFromLower).containsExactly(lowerArtifact, upperArtifact);
+    assertThat(resultFromUpper).containsExactly(lowerArtifact, upperArtifact);
+  }
+
+  @Test
+  public void testCaseInsensitiveLookupWithThreeVariants() {
+    artifactFactory.noteAnalysisStarting();
+    PathFragment path1 = PathFragment.create("foo/File.h");
+    PathFragment path2 = PathFragment.create("foo/file.h");
+    PathFragment path3 = PathFragment.create("foo/FILE.h");
+    Artifact.SourceArtifact a1 = artifactFactory.getSourceArtifact(path1, clientRoot);
+    Artifact.SourceArtifact a2 = artifactFactory.getSourceArtifact(path2, clientRoot);
+    Artifact.SourceArtifact a3 = artifactFactory.getSourceArtifact(path3, clientRoot);
+
+    assertThat(artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(path1, MAIN))
+        .containsExactly(a1, a2, a3);
+    assertThat(artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(path2, MAIN))
+        .containsExactly(a1, a2, a3);
+    assertThat(
+            artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(
+                PathFragment.create("foo/fIlE.h"), MAIN))
+        .containsExactly(a1, a2, a3);
+  }
+
+  @Test
+  public void testResolveSourceArtifactCaseInsensitively_derivedPathReturnsEmpty() {
+    artifactFactory.noteAnalysisStarting();
+    PathFragment derivedPath = PathFragment.create("bazel-out/x/bin/foo/header.h");
+
+    ImmutableList<Artifact.SourceArtifact> result =
+        artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(derivedPath, MAIN);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void testResolveSourceArtifactCaseInsensitively_staleArtifactRevalidatedViaSourceRoot() {
+    // First build: create an artifact.
+    artifactFactory.noteAnalysisStarting();
+    PathFragment path = PathFragment.create("foo/stale.h");
+    var unused = artifactFactory.getSourceArtifact(path, clientRoot);
+
+    // Second build: the artifact from the first build is invalid in the cache, but the method
+    // falls back to source root resolution which re-validates it.
+    artifactFactory.noteAnalysisStarting();
+    ImmutableList<Artifact.SourceArtifact> result =
+        artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(path, MAIN);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getExecPath()).isEqualTo(path);
+  }
+
+  @Test
+  public void testResolveSourceArtifactCaseInsensitively_uplevelReturnsEmpty() {
+    artifactFactory.noteAnalysisStarting();
+    PathFragment uplevelPath = PathFragment.create("../outside/header.h");
+
+    ImmutableList<Artifact.SourceArtifact> result =
+        artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(uplevelPath, MAIN);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void testResolveSourceArtifactCaseInsensitively_fallbackToSourceRootResolution() {
+    artifactFactory.noteAnalysisStarting();
+    // Path not in cache but resolvable via source roots (foo package exists).
+    PathFragment path = PathFragment.create("foo/brand_new.h");
+
+    ImmutableList<Artifact.SourceArtifact> result =
+        artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(path, MAIN);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getExecPath()).isEqualTo(path);
+  }
+
+  @Test
+  public void testExactLookupStillWorksWithCaseInsensitiveCache() {
+    artifactFactory.noteAnalysisStarting();
+    PathFragment lower = PathFragment.create("foo/header.h");
+    Artifact.SourceArtifact lowerArtifact = artifactFactory.getSourceArtifact(lower, clientRoot);
+
+    // Exact-case resolveSourceArtifact should return the correct artifact.
+    assertThat(artifactFactory.resolveSourceArtifact(lower, MAIN)).isSameInstanceAs(lowerArtifact);
+  }
+
+  @Test
+  public void
+      testResolveSourceArtifactCaseInsensitively_staleArtifactWithDifferentCasingRevalidated() {
+    // First build: create an artifact with specific casing.
+    artifactFactory.noteAnalysisStarting();
+    PathFragment originalPath = PathFragment.create("foo/Header.h");
+    Artifact.SourceArtifact original = artifactFactory.getSourceArtifact(originalPath, clientRoot);
+
+    // Second build: the artifact from the first build is stale. Resolve with different casing.
+    artifactFactory.noteAnalysisStarting();
+    PathFragment wrongCasePath = PathFragment.create("foo/header.h");
+    ImmutableList<Artifact.SourceArtifact> result =
+        artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(wrongCasePath, MAIN);
+
+    // Should return the original artifact with correct casing, not a new one.
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getExecPath()).isEqualTo(originalPath);
+    assertThat(result.get(0)).isSameInstanceAs(original);
+  }
+
+  @Test
+  public void
+      testResolveSourceArtifactCaseInsensitively_multipleStaleArtifactsWithDifferentCasingsRevalidated() {
+    // First build: create artifacts with different casings.
+    artifactFactory.noteAnalysisStarting();
+    PathFragment path1 = PathFragment.create("foo/Header.h");
+    PathFragment path2 = PathFragment.create("foo/HEADER.h");
+    Artifact.SourceArtifact artifact1 = artifactFactory.getSourceArtifact(path1, clientRoot);
+    Artifact.SourceArtifact artifact2 = artifactFactory.getSourceArtifact(path2, clientRoot);
+
+    // Second build: both are stale. Resolve with yet another casing.
+    artifactFactory.noteAnalysisStarting();
+    PathFragment queryCasePath = PathFragment.create("foo/header.h");
+    ImmutableList<Artifact.SourceArtifact> result =
+        artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(queryCasePath, MAIN);
+
+    // Both original artifacts should be revalidated and returned.
+    assertThat(result).containsExactly(artifact1, artifact2);
+  }
+
+  @Test
+  public void testClearResetsCaseInsensitiveCache() {
+    artifactFactory.noteAnalysisStarting();
+    PathFragment path = PathFragment.create("foo/header.h");
+    Artifact.SourceArtifact oldArtifact = artifactFactory.getSourceArtifact(path, clientRoot);
+
+    artifactFactory.clear();
+    setupRoots();
+    artifactFactory.noteAnalysisStarting();
+
+    Artifact.SourceArtifact newArtifact = artifactFactory.getSourceArtifact(path, clientRoot);
+    assertThat(newArtifact).isNotSameInstanceAs(oldArtifact);
+    ImmutableList<Artifact.SourceArtifact> result =
+        artifactFactory.resolveSourceArtifactsAsciiCaseInsensitively(path, MAIN);
+    assertThat(result).containsExactly(newArtifact);
+  }
+
   private static class MockPackageRootResolver implements PackageRootResolver {
     private final Map<PathFragment, Root> packageRoots = Maps.newHashMap();
 

--- a/src/test/java/com/google/devtools/build/lib/actions/util/ActionsTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/util/ActionsTestUtil.java
@@ -462,6 +462,10 @@ public final class ActionsTestUtil {
       super(owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), ImmutableList.copyOf(outputs));
     }
 
+    public NullAction(ActionOwner owner, NestedSet<Artifact> inputs) {
+      super(owner, inputs, ImmutableList.of(DUMMY_ARTIFACT));
+    }
+
     public NullAction(Artifact... outputs) {
       super(
           NULL_ACTION_OWNER,
@@ -926,6 +930,12 @@ public final class ActionsTestUtil {
 
     @Override
     public SourceArtifact resolveSourceArtifact(
+        PathFragment execPath, RepositoryName repositoryName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ImmutableList<SourceArtifact> resolveSourceArtifactsAsciiCaseInsensitively(
         PathFragment execPath, RepositoryName repositoryName) {
       throw new UnsupportedOperationException();
     }

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -507,15 +507,23 @@ java_test(
     srcs = ["HeaderDiscoveryTest.java"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/actions:artifact_owner",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/analysis:constraints/constraint_constants",
+        "//src/main/java/com/google/devtools/build/lib/analysis/platform",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/rules/cpp",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs",
+        "//src/main/java/net/starlark/java/syntax",
         "//src/test/java/com/google/devtools/build/lib/actions/util",
         "//third_party:guava",
         "//third_party:junit4",
         "//third_party:mockito",
+        "//third_party:truth",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscoveryTest.java
@@ -14,25 +14,44 @@
 
 package com.google.devtools.build.lib.rules.cpp;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.ActionExecutionException;
+import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.Artifact.SourceArtifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
+import com.google.devtools.build.lib.actions.ArtifactOwner;
 import com.google.devtools.build.lib.actions.ArtifactResolver;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
+import com.google.devtools.build.lib.analysis.constraints.ConstraintConstants;
+import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import java.util.List;
+import net.starlark.java.syntax.Location;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -45,12 +64,15 @@ public final class HeaderDiscoveryTest {
   private final FileSystem fs = new InMemoryFileSystem(DigestHashFunction.SHA256);
   private final Path execRoot = fs.getPath("/execroot");
   private final Path derivedRoot = execRoot.getChild(DERIVED_SEGMENT);
-  private final ArtifactRoot artifactRoot =
+  private final ArtifactRoot derivedArtifactRoot =
       ArtifactRoot.asDerivedRoot(execRoot, RootType.OUTPUT, DERIVED_SEGMENT);
+  private final ArtifactRoot sourceRoot = ArtifactRoot.asSourceRoot(Root.fromPath(execRoot));
 
   @Test
   public void errorsWhenMissingHeaders() {
     ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    when(artifactResolver.resolveSourceArtifactsAsciiCaseInsensitively(any(), any()))
+        .thenReturn(ImmutableList.of());
 
     assertThrows(
         ActionExecutionException.class,
@@ -64,6 +86,267 @@ public final class HeaderDiscoveryTest {
                     Order.STABLE_ORDER, treeArtifact(derivedRoot.getRelative("tree_artifact2")))));
   }
 
+  @Test
+  public void windowsPlatform_usesAsciiCaseInsensitiveResolution() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    SourceArtifact resolvedArtifact = sourceArtifact("pkg/Include/Header.h");
+    PathFragment depPath = PathFragment.create("pkg/include/header.h");
+    when(artifactResolver.resolveSourceArtifactsAsciiCaseInsensitively(
+            eq(depPath), eq(RepositoryName.MAIN)))
+        .thenReturn(ImmutableList.of(resolvedArtifact));
+
+    NestedSet<Artifact> result =
+        discoverInputs(
+            windowsAction(),
+            artifactResolver,
+            ImmutableList.of(execRoot.getRelative("pkg/include/header.h")),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER));
+
+    assertThat(result.toList()).containsExactly(resolvedArtifact);
+    verify(artifactResolver, never()).resolveSourceArtifact(any(), any());
+  }
+
+  @Test
+  public void nonWindowsPlatform_usesExactCaseResolution() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    SourceArtifact resolvedArtifact = sourceArtifact("pkg/header.h");
+    PathFragment depPath = PathFragment.create("pkg/header.h");
+    when(artifactResolver.resolveSourceArtifact(eq(depPath), eq(RepositoryName.MAIN)))
+        .thenReturn(resolvedArtifact);
+
+    NestedSet<Artifact> result =
+        discoverInputs(
+            nonWindowsAction(),
+            artifactResolver,
+            ImmutableList.of(execRoot.getRelative("pkg/header.h")),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER));
+
+    assertThat(result.toList()).containsExactly(resolvedArtifact);
+    verify(artifactResolver, never()).resolveSourceArtifactsAsciiCaseInsensitively(any(), any());
+  }
+
+  @Test
+  public void windowsPlatform_singleCaseInsensitiveMatch_addsToInputs() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    SourceArtifact resolvedArtifact = sourceArtifact("pkg/Include/BaseTsd.h");
+    when(artifactResolver.resolveSourceArtifactsAsciiCaseInsensitively(any(), any()))
+        .thenReturn(ImmutableList.of(resolvedArtifact));
+
+    NestedSet<Artifact> result =
+        discoverInputs(
+            windowsAction(),
+            artifactResolver,
+            ImmutableList.of(execRoot.getRelative("pkg/include/basetsd.h")),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER));
+
+    assertThat(result.toList()).containsExactly(resolvedArtifact);
+  }
+
+  @Test
+  public void windowsPlatform_multipleCaseInsensitiveMatches_prefersActionInputs()
+      throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    SourceArtifact declaredInput = sourceArtifact("pkg/Include/Header.h");
+    SourceArtifact otherVariant = sourceArtifact("pkg/include/header.h");
+    when(artifactResolver.resolveSourceArtifactsAsciiCaseInsensitively(any(), any()))
+        .thenReturn(ImmutableList.of(declaredInput, otherVariant));
+
+    // The action has declaredInput in its inputs.
+    NestedSet<Artifact> actionInputs =
+        NestedSetBuilder.<Artifact>stableOrder().add(declaredInput).build();
+
+    NestedSet<Artifact> result =
+        discoverInputs(
+            windowsAction(actionInputs),
+            artifactResolver,
+            ImmutableList.of(execRoot.getRelative("pkg/include/header.h")),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER));
+
+    // Only the variant that matches the declared input should be used.
+    assertThat(result.toList()).containsExactly(declaredInput);
+  }
+
+  @Test
+  public void windowsPlatform_multipleCaseInsensitiveMatches_noActionInputMatch_addsAll()
+      throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    SourceArtifact variant1 = sourceArtifact("pkg/Include/Header.h");
+    SourceArtifact variant2 = sourceArtifact("pkg/include/header.h");
+    when(artifactResolver.resolveSourceArtifactsAsciiCaseInsensitively(any(), any()))
+        .thenReturn(ImmutableList.of(variant1, variant2));
+
+    // No matching source artifacts in the action inputs.
+    NestedSet<Artifact> result =
+        discoverInputs(
+            windowsAction(),
+            artifactResolver,
+            ImmutableList.of(execRoot.getRelative("pkg/INCLUDE/HEADER.H")),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER));
+
+    // When none of the matches are in the action inputs, all variants are added.
+    assertThat(result.toList()).containsExactly(variant1, variant2);
+  }
+
+  @Test
+  public void windowsPlatform_absoluteSystemInclude_matchesCaseInsensitively() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    when(artifactResolver.resolveSourceArtifactsAsciiCaseInsensitively(any(), any()))
+        .thenReturn(ImmutableList.of());
+
+    Path systemIncludeDir = fs.getPath("/C/Program Files/MSVC/include");
+    // Compiler reports the path with different casing than the toolchain lists it.
+    Path dep = fs.getPath("/c/program files/msvc/include/windows.h");
+
+    // Should not throw — the absolute path should be filtered out as a system include.
+    NestedSet<Artifact> result =
+        HeaderDiscovery.discoverInputsFromDependencies(
+            windowsAction(),
+            ActionsTestUtil.createArtifact(derivedArtifactRoot, derivedRoot.getRelative("foo.cc")),
+            /* shouldValidateInclusions= */ true,
+            ImmutableList.of(dep),
+            /* permittedSystemIncludePrefixes= */ ImmutableList.of(systemIncludeDir),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            execRoot,
+            artifactResolver,
+            /* siblingRepositoryLayout= */ false,
+            PathMapper.NOOP);
+
+    assertThat(result.toList()).isEmpty();
+  }
+
+  @Test
+  public void windowsPlatform_absoluteSystemInclude_exactCaseAlsoMatches() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    when(artifactResolver.resolveSourceArtifactsAsciiCaseInsensitively(any(), any()))
+        .thenReturn(ImmutableList.of());
+
+    Path systemIncludeDir = fs.getPath("/C/Program Files/MSVC/include");
+    Path dep = fs.getPath("/C/Program Files/MSVC/include/windows.h");
+
+    NestedSet<Artifact> result =
+        HeaderDiscovery.discoverInputsFromDependencies(
+            windowsAction(),
+            ActionsTestUtil.createArtifact(derivedArtifactRoot, derivedRoot.getRelative("foo.cc")),
+            /* shouldValidateInclusions= */ true,
+            ImmutableList.of(dep),
+            /* permittedSystemIncludePrefixes= */ ImmutableList.of(systemIncludeDir),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            execRoot,
+            artifactResolver,
+            /* siblingRepositoryLayout= */ false,
+            PathMapper.NOOP);
+
+    assertThat(result.toList()).isEmpty();
+  }
+
+  @Test
+  public void windowsPlatform_sourceFileFilteredOut() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    SourceArtifact sourceFile = sourceArtifact("pkg/foo.cc");
+    when(artifactResolver.resolveSourceArtifactsAsciiCaseInsensitively(any(), any()))
+        .thenReturn(ImmutableList.of(sourceFile));
+
+    NestedSet<Artifact> result =
+        HeaderDiscovery.discoverInputsFromDependencies(
+            windowsAction(),
+            sourceFile,
+            /* shouldValidateInclusions= */ true,
+            ImmutableList.of(execRoot.getRelative("pkg/foo.cc")),
+            /* permittedSystemIncludePrefixes= */ ImmutableList.of(),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            execRoot,
+            artifactResolver,
+            /* siblingRepositoryLayout= */ false,
+            PathMapper.NOOP);
+
+    // The source file itself should be filtered out as it's a mandatory input.
+    assertThat(result.toList()).isEmpty();
+  }
+
+  @Test
+  public void windowsPlatform_derivedArtifactMatchedExactly() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    Artifact derivedArtifact =
+        ActionsTestUtil.createArtifact(derivedArtifactRoot, derivedRoot.getRelative("gen/foo.h"));
+
+    NestedSet<Artifact> result =
+        discoverInputs(
+            windowsAction(),
+            artifactResolver,
+            ImmutableList.of(derivedRoot.getRelative("gen/foo.h")),
+            NestedSetBuilder.create(Order.STABLE_ORDER, derivedArtifact));
+
+    // Derived artifacts should be matched by exact path, not going through
+    // case-insensitive resolution.
+    assertThat(result.toList()).containsExactly(derivedArtifact);
+    verify(artifactResolver, never()).resolveSourceArtifactsAsciiCaseInsensitively(any(), any());
+    verify(artifactResolver, never()).resolveSourceArtifact(any(), any());
+  }
+
+  @Test
+  public void windowsPlatform_unresolvedSourcePath_errors() {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    when(artifactResolver.resolveSourceArtifactsAsciiCaseInsensitively(any(), any()))
+        .thenReturn(ImmutableList.of());
+
+    assertThrows(
+        ActionExecutionException.class,
+        () ->
+            discoverInputs(
+                windowsAction(),
+                artifactResolver,
+                ImmutableList.of(execRoot.getRelative("pkg/missing.h")),
+                NestedSetBuilder.emptySet(Order.STABLE_ORDER)));
+  }
+
+  @Test
+  public void windowsPlatform_multipleDeps_mixedResolution() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    SourceArtifact sourceHeader = sourceArtifact("pkg/source.h");
+    Artifact derivedHeader =
+        ActionsTestUtil.createArtifact(derivedArtifactRoot, derivedRoot.getRelative("gen/gen.h"));
+
+    when(artifactResolver.resolveSourceArtifactsAsciiCaseInsensitively(
+            eq(PathFragment.create("pkg/source.h")), any()))
+        .thenReturn(ImmutableList.of(sourceHeader));
+
+    NestedSet<Artifact> result =
+        discoverInputs(
+            windowsAction(),
+            artifactResolver,
+            ImmutableList.of(
+                execRoot.getRelative("pkg/source.h"), derivedRoot.getRelative("gen/gen.h")),
+            NestedSetBuilder.create(Order.STABLE_ORDER, derivedHeader));
+
+    assertThat(result.toList()).containsExactly(sourceHeader, derivedHeader);
+  }
+
+  @Test
+  public void windowsPlatform_multipleCaseInsensitiveMatches_onlyOneInActionInputs()
+      throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    SourceArtifact variant1 = sourceArtifact("pkg/Header.h");
+    SourceArtifact variant2 = sourceArtifact("pkg/header.h");
+    SourceArtifact variant3 = sourceArtifact("pkg/HEADER.h");
+    when(artifactResolver.resolveSourceArtifactsAsciiCaseInsensitively(any(), any()))
+        .thenReturn(ImmutableList.of(variant1, variant2, variant3));
+
+    NestedSet<Artifact> actionInputs =
+        NestedSetBuilder.<Artifact>stableOrder().add(variant2).build();
+
+    NestedSet<Artifact> result =
+        discoverInputs(
+            windowsAction(actionInputs),
+            artifactResolver,
+            ImmutableList.of(execRoot.getRelative("pkg/HEADER.h")),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER));
+
+    // Only variant2 is in the action inputs, so only it should be selected.
+    assertThat(result.toList()).containsExactly(variant2);
+  }
+
+  // Helpers
+
   private void checkHeaderInclusion(
       ArtifactResolver artifactResolver,
       ImmutableList<Path> dependencies,
@@ -72,7 +355,7 @@ public final class HeaderDiscoveryTest {
     var unused =
         HeaderDiscovery.discoverInputsFromDependencies(
             new ActionsTestUtil.NullAction(),
-            ActionsTestUtil.createArtifact(artifactRoot, derivedRoot.getRelative("foo.cc")),
+            ActionsTestUtil.createArtifact(derivedArtifactRoot, derivedRoot.getRelative("foo.cc")),
             /* shouldValidateInclusions= */ true,
             dependencies,
             /* permittedSystemIncludePrefixes= */ ImmutableList.of(),
@@ -83,11 +366,86 @@ public final class HeaderDiscoveryTest {
             PathMapper.NOOP);
   }
 
+  private NestedSet<Artifact> discoverInputs(
+      ActionsTestUtil.NullAction action,
+      ArtifactResolver artifactResolver,
+      List<Path> dependencies,
+      NestedSet<Artifact> allowedDerivedInputs)
+      throws ActionExecutionException {
+    return HeaderDiscovery.discoverInputsFromDependencies(
+        action,
+        ActionsTestUtil.createArtifact(derivedArtifactRoot, derivedRoot.getRelative("foo.cc")),
+        /* shouldValidateInclusions= */ true,
+        dependencies,
+        /* permittedSystemIncludePrefixes= */ ImmutableList.of(),
+        allowedDerivedInputs,
+        execRoot,
+        artifactResolver,
+        /* siblingRepositoryLayout= */ false,
+        PathMapper.NOOP);
+  }
+
   private SpecialArtifact treeArtifact(Path path) {
     return SpecialArtifact.create(
-        artifactRoot,
-        artifactRoot.getExecPath().getRelative(artifactRoot.getRoot().relativize(path)),
+        derivedArtifactRoot,
+        derivedArtifactRoot
+            .getExecPath()
+            .getRelative(derivedArtifactRoot.getRoot().relativize(path)),
         ActionsTestUtil.NULL_ARTIFACT_OWNER,
         Artifact.SpecialArtifactType.TREE);
+  }
+
+  private SourceArtifact sourceArtifact(String execPath) {
+    return new SourceArtifact(sourceRoot, PathFragment.create(execPath), ArtifactOwner.NULL_OWNER);
+  }
+
+  private static PlatformInfo windowsPlatform() {
+    try {
+      return PlatformInfo.builder()
+          .setLabel(Label.parseCanonicalUnchecked("//test:windows_platform"))
+          .addConstraint(ConstraintConstants.OS_TO_DEFAULT_CONSTRAINT_VALUE.get(OS.WINDOWS))
+          .build();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static PlatformInfo linuxPlatform() {
+    try {
+      return PlatformInfo.builder()
+          .setLabel(Label.parseCanonicalUnchecked("//test:linux_platform"))
+          .addConstraint(ConstraintConstants.OS_TO_DEFAULT_CONSTRAINT_VALUE.get(OS.LINUX))
+          .build();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static ActionOwner actionOwnerWithPlatform(PlatformInfo platform) {
+    return ActionOwner.createDummy(
+        Label.parseCanonicalUnchecked("//pkg:target"),
+        new Location("dummy-file", 0, 0),
+        /* targetKind= */ "cc_library rule",
+        /* buildConfigurationMnemonic= */ "k8-fastbuild",
+        /* configurationChecksum= */ "checksum",
+        /* buildConfigurationEvent= */ null,
+        /* isToolConfiguration= */ false,
+        platform,
+        /* aspectDescriptors= */ ImmutableList.of(),
+        /* execProperties= */ ImmutableMap.of());
+  }
+
+  private ActionsTestUtil.NullAction windowsAction() {
+    return new ActionsTestUtil.NullAction(
+        actionOwnerWithPlatform(windowsPlatform()), ActionsTestUtil.DUMMY_ARTIFACT);
+  }
+
+  private ActionsTestUtil.NullAction windowsAction(NestedSet<Artifact> inputs) {
+    return new ActionsTestUtil.NullAction(actionOwnerWithPlatform(windowsPlatform()), inputs);
+  }
+
+  private ActionsTestUtil.NullAction nonWindowsAction() {
+    return new ActionsTestUtil.NullAction(
+        actionOwnerWithPlatform(linuxPlatform()), ActionsTestUtil.DUMMY_ARTIFACT);
   }
 }

--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -1310,5 +1310,49 @@ class BazelWindowsCppTest(test_base.TestBase):
     ])
     self.AssertExitCode(exit_code, 0, stderr)
 
+  def testUndeclaredInclusionOnCaseMismatchedIncludePath(self):
+    self.createModuleDotBazel()
+    self.ScratchFile(
+        'pkg/BUILD',
+        [
+            'load("@rules_cc//cc:cc_library.bzl", "cc_library")',
+            'cc_library(',
+            '    name = "lib",',
+            '    srcs = ["hello.cc"],',
+            '    hdrs = glob(["Include/**"]),',
+            ')',
+        ],
+    )
+    self.ScratchFile(
+        'pkg/hello.cc',
+        [
+            '#include "include/shared/basetsd.h"',
+            'int hello() { return base_tsd_value(); }',
+        ],
+    )
+    self.ScratchFile(
+        'pkg/Include/shared/BaseTsd.h',
+        [
+            '#pragma once',
+            'static inline int base_tsd_value() { return 1; }',
+        ],
+    )
+
+    self.RunBazel(['build', '//pkg:lib'])
+
+    # Modify the .cc file to trigger recompilation without re-analyzing the
+    # headers. On an incremental build, the header artifacts become stale in the
+    # cache and must be revalidated using case-insensitive matching.
+    self.ScratchFile(
+        'pkg/hello.cc',
+        [
+            '#include "include/shared/basetsd.h"',
+            'int hello() { return base_tsd_value() + 1; }',
+        ],
+    )
+
+    self.RunBazel(['build', '//pkg:lib'])
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
### Description

### Motivation
Fix #28803

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #28810.

PiperOrigin-RevId: 893719641
Change-Id: I4cd7a5ac6b1a35467ea38fdfd1063dc3ed35ffa0

Commit https://github.com/bazelbuild/bazel/commit/246ea9891e49909222be085f25cb70e0d21554bf