### PR TITLE
skyframe: detect local repositories during package lookup

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/LocalRepositoryLookupFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/LocalRepositoryLookupFunction.java
@@ -13,16 +13,40 @@
 // limitations under the License.
 package com.google.devtools.build.lib.skyframe;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphValue;
+import com.google.devtools.build.lib.bazel.bzlmod.LocalPathRepoSpecs;
+import com.google.devtools.build.lib.bazel.bzlmod.Module;
+import com.google.devtools.build.lib.bazel.bzlmod.ModuleExtensionId;
+import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue;
+import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
+import com.google.devtools.build.lib.bazel.bzlmod.NonRegistryOverride;
+import com.google.devtools.build.lib.bazel.bzlmod.RepoRuleId;
+import com.google.devtools.build.lib.bazel.bzlmod.RepoSpec;
+import com.google.devtools.build.lib.bazel.bzlmod.SingleExtensionValue;
+import com.google.devtools.build.lib.bazel.repository.RepoDefinitionFunction;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.skyframe.SkyFunction;
 import com.google.devtools.build.skyframe.SkyFunctionException;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
+import com.google.devtools.build.skyframe.SkyframeLookupResult;
 import javax.annotation.Nullable;
 
 /** SkyFunction for {@link LocalRepositoryLookupValue}s. */
 public class LocalRepositoryLookupFunction implements SkyFunction {
+  private static final RepoRuleId NEW_LOCAL_REPOSITORY =
+      new RepoRuleId(LocalPathRepoSpecs.LOCAL_REPOSITORY.bzlFileLabel(), "new_local_repository");
 
-  public LocalRepositoryLookupFunction() {}
+  private final Path workspaceRoot;
+
+  public LocalRepositoryLookupFunction(Path workspaceRoot) {
+    this.workspaceRoot = workspaceRoot;
+  }
 
   // Implementation note: Although LocalRepositoryLookupValue.NOT_FOUND exists, it should never be
   // returned from this method.
@@ -30,7 +54,180 @@ public class LocalRepositoryLookupFunction implements SkyFunction {
   @Override
   public SkyValue compute(SkyKey skyKey, Environment env)
       throws SkyFunctionException, InterruptedException {
-    // TODO: #22208, #21515 - Figure out what to do here.
-    return LocalRepositoryLookupValue.mainRepository();
+    RootedPath directory = (RootedPath) skyKey.argument();
+
+    if (directory.getRootRelativePath().equals(PathFragment.EMPTY_FRAGMENT)) {
+      return LocalRepositoryLookupValue.mainRepository();
+    }
+
+    LocalRepositoryLookupValue repository = maybeCheckDirectoryForRepository(env, directory);
+    if (repository == null) {
+      return null;
+    }
+    if (repository.exists()) {
+      return repository;
+    }
+
+    return env.getValue(LocalRepositoryLookupValue.key(directory.getParentDirectory()));
+  }
+
+  @Nullable
+  private LocalRepositoryLookupValue maybeCheckDirectoryForRepository(Environment env, RootedPath directory)
+      throws InterruptedException {
+    RepositoryMappingValue repositoryMappingValue =
+        (RepositoryMappingValue) env.getValue(RepositoryMappingValue.key(RepositoryName.MAIN));
+    if (repositoryMappingValue == null) {
+      return null;
+    }
+    RootModuleFileValue rootModuleFileValue =
+        (RootModuleFileValue) env.getValue(ModuleFileValue.KEY_FOR_ROOT_MODULE);
+    if (rootModuleFileValue == null) {
+      return null;
+    }
+    BazelDepGraphValue bazelDepGraphValue = (BazelDepGraphValue) env.getValue(BazelDepGraphValue.KEY);
+    if (bazelDepGraphValue == null) {
+      return null;
+    }
+    RepositoryMapping repositoryMapping = repositoryMappingValue.repositoryMapping();
+    if (repositoryMapping == null) {
+      return LocalRepositoryLookupValue.notFound();
+    }
+
+    LocalRepositoryLookupValue repository =
+        maybeMatchCommandLineOverrides(directory, repositoryMapping, env);
+    if (repository != null) {
+      return repository;
+    }
+
+    repository = maybeMatchNonRegistryOverrides(directory, rootModuleFileValue);
+    if (repository != null) {
+      return repository;
+    }
+
+    repository = maybeMatchModuleRepositories(directory, bazelDepGraphValue);
+    if (repository != null) {
+      return repository;
+    }
+
+    return maybeMatchExtensionRepositories(directory, bazelDepGraphValue, env);
+  }
+
+  @Nullable
+  private LocalRepositoryLookupValue maybeMatchCommandLineOverrides(
+      RootedPath directory, RepositoryMapping repositoryMapping, Environment env) {
+    var repositoryOverrides = RepoDefinitionFunction.REPOSITORY_OVERRIDES.get(env);
+    if (repositoryOverrides == null) {
+      return null;
+    }
+    for (var entry : repositoryOverrides.entrySet()) {
+      RepositoryName repositoryName = repositoryMapping.get(entry.getKey());
+      if (!repositoryName.isVisible()) {
+        repositoryName = RepositoryName.createUnvalidated(entry.getKey());
+      }
+      if (repositoryName.isMain()) {
+        continue;
+      }
+      LocalRepositoryLookupValue repository =
+          maybeMatchPath(directory, repositoryName, entry.getValue());
+      if (repository != null) {
+        return repository;
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private LocalRepositoryLookupValue maybeMatchNonRegistryOverrides(
+      RootedPath directory, RootModuleFileValue rootModuleFileValue) {
+    for (var entry : rootModuleFileValue.nonRegistryOverrideCanonicalRepoToModuleName().entrySet()) {
+      var override = rootModuleFileValue.overrides().get(entry.getValue());
+      if (!(override instanceof NonRegistryOverride nonRegistryOverride)
+          || override == NonRegistryOverride.BAZEL_TOOLS_OVERRIDE) {
+        continue;
+      }
+      LocalRepositoryLookupValue repository =
+          maybeMatchRepoSpec(directory, entry.getKey(), nonRegistryOverride.repoSpec());
+      if (repository != null) {
+        return repository;
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private LocalRepositoryLookupValue maybeMatchModuleRepositories(
+      RootedPath directory, BazelDepGraphValue bazelDepGraphValue) {
+    for (var entry : bazelDepGraphValue.getCanonicalRepoNameLookup().entrySet()) {
+      if (entry.getKey().isMain()) {
+        continue;
+      }
+      Module module = bazelDepGraphValue.getDepGraph().get(entry.getValue());
+      if (module == null || module.getRepoSpec() == null) {
+        continue;
+      }
+      LocalRepositoryLookupValue repository =
+          maybeMatchRepoSpec(directory, entry.getKey(), module.getRepoSpec());
+      if (repository != null) {
+        return repository;
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private LocalRepositoryLookupValue maybeMatchExtensionRepositories(
+      RootedPath directory, BazelDepGraphValue bazelDepGraphValue, Environment env)
+      throws InterruptedException {
+    ImmutableSet<ModuleExtensionId> extensionIds =
+        ImmutableSet.copyOf(bazelDepGraphValue.getExtensionUniqueNames().keySet());
+    if (extensionIds.isEmpty()) {
+      return LocalRepositoryLookupValue.notFound();
+    }
+    SkyframeLookupResult extensionValues =
+        env.getValuesAndExceptions(
+            extensionIds.stream().map(SingleExtensionValue::key).collect(ImmutableSet.toImmutableSet()));
+    for (ModuleExtensionId extensionId : extensionIds) {
+      SingleExtensionValue extensionValue =
+          (SingleExtensionValue) extensionValues.get(SingleExtensionValue.key(extensionId));
+      if (extensionValue == null) {
+        return null;
+      }
+      for (var entry : extensionValue.canonicalRepoNameToInternalNames().entrySet()) {
+        RepoSpec repoSpec = extensionValue.generatedRepoSpecs().get(entry.getValue());
+        if (repoSpec == null) {
+          continue;
+        }
+        LocalRepositoryLookupValue repository =
+            maybeMatchRepoSpec(directory, entry.getKey(), repoSpec);
+        if (repository != null) {
+          return repository;
+        }
+      }
+    }
+    return LocalRepositoryLookupValue.notFound();
+  }
+
+  @Nullable
+  private LocalRepositoryLookupValue maybeMatchRepoSpec(
+      RootedPath directory, RepositoryName repositoryName, RepoSpec repoSpec) {
+    if (!repoSpec.repoRuleId().equals(LocalPathRepoSpecs.LOCAL_REPOSITORY)
+        && !repoSpec.repoRuleId().equals(NEW_LOCAL_REPOSITORY)) {
+      return null;
+    }
+    Object pathAttr = repoSpec.attributes().attributes().get("path");
+    if (!(pathAttr instanceof String path)) {
+      return null;
+    }
+    return maybeMatchPath(directory, repositoryName, PathFragment.create(path));
+  }
+
+  @Nullable
+  private LocalRepositoryLookupValue maybeMatchPath(
+      RootedPath directory, RepositoryName repositoryName, PathFragment repoPath) {
+    Path localRepositoryPath = workspaceRoot.getRelative(repoPath);
+    if (!directory.asPath().equals(localRepositoryPath)) {
+      return null;
+    }
+    return LocalRepositoryLookupValue.success(repositoryName, repoPath);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -958,7 +958,9 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     map.put(
         SkyFunctions.ACTION_TEMPLATE_EXPANSION,
         new ActionTemplateExpansionFunction(actionKeyContext));
-    map.put(SkyFunctions.LOCAL_REPOSITORY_LOOKUP, new LocalRepositoryLookupFunction());
+    map.put(
+        SkyFunctions.LOCAL_REPOSITORY_LOOKUP,
+        new LocalRepositoryLookupFunction(directories.getWorkspace()));
     map.put(
         SkyFunctions.REGISTERED_EXECUTION_PLATFORMS, new RegisteredExecutionPlatformsFunction());
     map.put(SkyFunctions.REGISTERED_TOOLCHAINS, new RegisteredToolchainsFunction());

--- a/src/main/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoader.java
@@ -186,7 +186,9 @@ public class BazelPackageLoader extends AbstractPackageLoader {
               .put(SkyFunctions.ACTION_ENVIRONMENT_VARIABLE, new ActionEnvironmentFunction())
               .put(SkyFunctions.REPOSITORY_ENVIRONMENT_VARIABLE, new RepoEnvironmentFunction())
               .put(SkyFunctions.DIRECTORY_LISTING, new DirectoryListingFunction())
-              .put(SkyFunctions.LOCAL_REPOSITORY_LOOKUP, new LocalRepositoryLookupFunction())
+              .put(
+                  SkyFunctions.LOCAL_REPOSITORY_LOOKUP,
+                  new LocalRepositoryLookupFunction(directories.getWorkspace()))
               .put(SkyFunctions.REPOSITORY_DIRECTORY, repositoryFetchFunction)
               .put(RepoDefinitionValue.REPO_DEFINITION, new RepoDefinitionFunction(directories))
               .put(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -151,7 +151,9 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                         CrossRepositoryLabelViolationStrategy.ERROR,
                         BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY))
                 .put(SkyFunctions.IGNORED_SUBDIRECTORIES, IgnoredSubdirectoriesFunction.NOOP)
-                .put(SkyFunctions.LOCAL_REPOSITORY_LOOKUP, new LocalRepositoryLookupFunction())
+                .put(
+                    SkyFunctions.LOCAL_REPOSITORY_LOOKUP,
+                    new LocalRepositoryLookupFunction(directories.getWorkspace()))
                 .put(SkyFunctions.PRECOMPUTED, new PrecomputedFunction())
                 .put(
                     SkyFunctions.REPOSITORY_DIRECTORY,

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryDelegatorTest.java
@@ -165,7 +165,9 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
                         new AtomicReference<>(ImmutableSet.of()),
                         CrossRepositoryLabelViolationStrategy.ERROR,
                         BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY))
-                .put(SkyFunctions.LOCAL_REPOSITORY_LOOKUP, new LocalRepositoryLookupFunction())
+                .put(
+                    SkyFunctions.LOCAL_REPOSITORY_LOOKUP,
+                    new LocalRepositoryLookupFunction(directories.getWorkspace()))
                 .put(SkyFunctions.PRECOMPUTED, new PrecomputedFunction())
                 .put(
                     SkyFunctions.BZL_COMPILE,

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ContainingPackageLookupFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ContainingPackageLookupFunctionTest.java
@@ -23,6 +23,9 @@ import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
+import com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphValue;
+import com.google.devtools.build.lib.bazel.bzlmod.InterimModule;
+import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
 import com.google.devtools.build.lib.bazel.repository.RepoDefinitionFunction;
 import com.google.devtools.build.lib.bazel.repository.RepoDefinitionValue;
 import com.google.devtools.build.lib.bazel.repository.RepositoryFetchFunction;
@@ -115,7 +118,20 @@ public class ContainingPackageLookupFunctionTest extends FoundationTestCase {
     skyFunctions.put(
         SkyFunctions.DIRECTORY_LISTING_STATE,
         new DirectoryListingStateFunction(externalFilesHelper, SyscallCache.NO_CACHE));
-    skyFunctions.put(SkyFunctions.LOCAL_REPOSITORY_LOOKUP, new LocalRepositoryLookupFunction());
+    skyFunctions.put(
+        SkyFunctions.LOCAL_REPOSITORY_LOOKUP,
+        new LocalRepositoryLookupFunction(directories.getWorkspace()));
+    skyFunctions.put(
+        SkyFunctions.MODULE_FILE,
+        (skyKey, env) ->
+            new RootModuleFileValue(
+                InterimModule.builder().build(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableSet.of()));
+    skyFunctions.put(
+        SkyFunctions.BAZEL_DEP_GRAPH, (skyKey, env) -> BazelDepGraphValue.createEmptyDepGraph());
     skyFunctions.put(
         FileSymlinkCycleUniquenessFunction.NAME, new FileSymlinkCycleUniquenessFunction());
     skyFunctions.put(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FileFunctionTest.java
@@ -39,6 +39,9 @@ import com.google.devtools.build.lib.actions.FileValue.SymlinkFileValueWithStore
 import com.google.devtools.build.lib.actions.FileValue.SymlinkFileValueWithoutStoredChain;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
+import com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphValue;
+import com.google.devtools.build.lib.bazel.bzlmod.InterimModule;
+import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
 import com.google.devtools.build.lib.bazel.repository.RepoDefinitionFunction;
 import com.google.devtools.build.lib.bazel.repository.RepoDefinitionValue;
 import com.google.devtools.build.lib.bazel.repository.RepositoryFetchFunction;
@@ -180,7 +183,21 @@ public class FileFunctionTest {
                         new AtomicReference<>(ImmutableSet.of()),
                         CrossRepositoryLabelViolationStrategy.ERROR,
                         BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY))
-                .put(SkyFunctions.LOCAL_REPOSITORY_LOOKUP, new LocalRepositoryLookupFunction())
+                .put(
+                    SkyFunctions.LOCAL_REPOSITORY_LOOKUP,
+                    new LocalRepositoryLookupFunction(directories.getWorkspace()))
+                .put(
+                    SkyFunctions.MODULE_FILE,
+                    (skyKey, env) ->
+                        new RootModuleFileValue(
+                            InterimModule.builder().build(),
+                            ImmutableMap.of(),
+                            ImmutableMap.of(),
+                            ImmutableMap.of(),
+                            ImmutableSet.of()))
+                .put(
+                    SkyFunctions.BAZEL_DEP_GRAPH,
+                    (skyKey, env) -> BazelDepGraphValue.createEmptyDepGraph())
                 .put(
                     SkyFunctions.REPOSITORY_DIRECTORY,
                     new RepositoryFetchFunction(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/GlobTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/GlobTestBase.java
@@ -28,6 +28,9 @@ import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
+import com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphValue;
+import com.google.devtools.build.lib.bazel.bzlmod.InterimModule;
+import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
 import com.google.devtools.build.lib.bazel.repository.RepoDefinitionValue;
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
@@ -172,7 +175,20 @@ public abstract class GlobTestBase {
     skyFunctions.put(SkyFunctions.FILE, new FileFunction(pkgLocator, directories));
     skyFunctions.put(
         FileSymlinkCycleUniquenessFunction.NAME, new FileSymlinkCycleUniquenessFunction());
-    skyFunctions.put(SkyFunctions.LOCAL_REPOSITORY_LOOKUP, new LocalRepositoryLookupFunction());
+    skyFunctions.put(
+        SkyFunctions.LOCAL_REPOSITORY_LOOKUP,
+        new LocalRepositoryLookupFunction(directories.getWorkspace()));
+    skyFunctions.put(
+        SkyFunctions.MODULE_FILE,
+        (skyKey, env) ->
+            new RootModuleFileValue(
+                InterimModule.builder().build(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableSet.of()));
+    skyFunctions.put(
+        SkyFunctions.BAZEL_DEP_GRAPH, (skyKey, env) -> BazelDepGraphValue.createEmptyDepGraph());
     skyFunctions.put(
         SkyFunctions.REPOSITORY_MAPPING,
         new SkyFunction() {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/LocalRepositoryLookupFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/LocalRepositoryLookupFunctionTest.java
@@ -17,10 +17,17 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
-import com.google.devtools.build.lib.bazel.repository.RepoDefinitionValue;
+import com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphValue;
+import com.google.devtools.build.lib.bazel.bzlmod.InterimModule;
+import com.google.devtools.build.lib.bazel.bzlmod.LocalPathRepoSpecs;
+import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
+import com.google.devtools.build.lib.bazel.bzlmod.NonRegistryOverride;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.NullEventHandler;
@@ -59,6 +66,9 @@ import org.junit.runners.JUnit4;
 public class LocalRepositoryLookupFunctionTest extends FoundationTestCase {
 
   private MemoizingEvaluator evaluator;
+  private AtomicReference<RepositoryMappingValue> repositoryMappingValue;
+  private AtomicReference<RootModuleFileValue> rootModuleFileValue;
+  private AtomicReference<BazelDepGraphValue> bazelDepGraphValue;
 
   @Before
   public final void setUp() throws Exception {
@@ -79,6 +89,10 @@ public class LocalRepositoryLookupFunctionTest extends FoundationTestCase {
             pkgLocator,
             ExternalFileAction.DEPEND_ON_EXTERNAL_PKG_FOR_EXTERNAL_REPO_PATHS,
             directories);
+    repositoryMappingValue =
+        new AtomicReference<>(RepositoryMappingValue.VALUE_FOR_EMPTY_ROOT_MODULE);
+    rootModuleFileValue = new AtomicReference<>(emptyRootModuleFileValue());
+    bazelDepGraphValue = new AtomicReference<>(BazelDepGraphValue.createEmptyDepGraph());
 
     Map<SkyFunctionName, SkyFunction> skyFunctions = new HashMap<>();
     skyFunctions.put(
@@ -98,7 +112,9 @@ public class LocalRepositoryLookupFunctionTest extends FoundationTestCase {
     skyFunctions.put(
         SkyFunctions.DIRECTORY_LISTING_STATE,
         new DirectoryListingStateFunction(externalFilesHelper, SyscallCache.NO_CACHE));
-    skyFunctions.put(SkyFunctions.LOCAL_REPOSITORY_LOOKUP, new LocalRepositoryLookupFunction());
+    skyFunctions.put(
+        SkyFunctions.LOCAL_REPOSITORY_LOOKUP,
+        new LocalRepositoryLookupFunction(directories.getWorkspace()));
     skyFunctions.put(
         FileSymlinkCycleUniquenessFunction.NAME, new FileSymlinkCycleUniquenessFunction());
     skyFunctions.put(
@@ -106,15 +122,23 @@ public class LocalRepositoryLookupFunctionTest extends FoundationTestCase {
         new SkyFunction() {
           @Override
           public SkyValue compute(SkyKey skyKey, Environment env) {
-            return RepositoryMappingValue.VALUE_FOR_EMPTY_ROOT_MODULE;
+            return repositoryMappingValue.get();
           }
         });
     skyFunctions.put(
-        RepoDefinitionValue.REPO_DEFINITION,
+        SkyFunctions.MODULE_FILE,
         new SkyFunction() {
           @Override
           public SkyValue compute(SkyKey skyKey, Environment env) {
-            return RepoDefinitionValue.NOT_FOUND;
+            return rootModuleFileValue.get();
+          }
+        });
+    skyFunctions.put(
+        SkyFunctions.BAZEL_DEP_GRAPH,
+        new SkyFunction() {
+          @Override
+          public SkyValue compute(SkyKey skyKey, Environment env) {
+            return bazelDepGraphValue.get();
           }
         });
 
@@ -145,6 +169,30 @@ public class LocalRepositoryLookupFunctionTest extends FoundationTestCase {
     return evaluator.evaluate(ImmutableList.of(directoryKey), evaluationContext);
   }
 
+  private void addVisibleLocalRepository(RepositoryName repositoryName, String path) {
+    repositoryMappingValue.set(
+        RepositoryMappingValue.createSpecial(
+            RepositoryMapping.create(
+                ImmutableMap.of("", RepositoryName.MAIN, repositoryName.getName(), repositoryName),
+                RepositoryName.MAIN)));
+    rootModuleFileValue.set(
+        new RootModuleFileValue(
+            InterimModule.builder().build(),
+            ImmutableMap.of("local_repo", new NonRegistryOverride(LocalPathRepoSpecs.create(path))),
+            ImmutableMap.of(repositoryName, "local_repo"),
+            ImmutableMap.of("local_repo", repositoryName.getName()),
+            ImmutableSet.of()));
+  }
+
+  private static RootModuleFileValue emptyRootModuleFileValue() {
+    return new RootModuleFileValue(
+        InterimModule.builder().build(),
+        ImmutableMap.of(),
+        ImmutableMap.of(),
+        ImmutableMap.of(),
+        ImmutableSet.of());
+  }
+
   @Test
   public void testNoPath() throws Exception {
     LocalRepositoryLookupValue repositoryLookupValue =
@@ -166,5 +214,22 @@ public class LocalRepositoryLookupFunctionTest extends FoundationTestCase {
     assertThat(repositoryLookupValue).isNotNull();
     assertThat(repositoryLookupValue.getRepository()).isEqualTo(RepositoryName.MAIN);
     assertThat(repositoryLookupValue.getPath()).isEqualTo(PathFragment.EMPTY_FRAGMENT);
+  }
+
+  @Test
+  public void testDirectoryInsideVisibleLocalRepository() throws Exception {
+    RepositoryName repositoryName = RepositoryName.createUnvalidated("local_repo");
+    addVisibleLocalRepository(repositoryName, "third_party/local_repo");
+
+    LocalRepositoryLookupValue repositoryLookupValue =
+        lookupDirectory(
+            RootedPath.toRootedPath(
+                Root.fromPath(rootDirectory),
+                PathFragment.create("third_party/local_repo/pkg")));
+
+    assertThat(repositoryLookupValue).isNotNull();
+    assertThat(repositoryLookupValue.getRepository()).isEqualTo(repositoryName);
+    assertThat(repositoryLookupValue.getPath())
+        .isEqualTo(PathFragment.create("third_party/local_repo"));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PackageLookupFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PackageLookupFunctionTest.java
@@ -25,12 +25,17 @@ import com.google.devtools.build.lib.actions.FileStateValue;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
+import com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphValue;
+import com.google.devtools.build.lib.bazel.bzlmod.InterimModule;
+import com.google.devtools.build.lib.bazel.bzlmod.LocalPathRepoSpecs;
 import com.google.devtools.build.lib.bazel.repository.RepoDefinitionFunction;
-import com.google.devtools.build.lib.bazel.repository.RepoDefinitionValue;
+import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
+import com.google.devtools.build.lib.bazel.bzlmod.NonRegistryOverride;
 import com.google.devtools.build.lib.bazel.repository.RepositoryFetchFunction;
 import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache;
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.NullEventHandler;
 import com.google.devtools.build.lib.io.FileSymlinkCycleUniquenessFunction;
@@ -76,6 +81,9 @@ public abstract class PackageLookupFunctionTest extends FoundationTestCase {
   private MemoizingEvaluator evaluator;
   private RecordingDifferencer differencer;
   private Path emptyPackagePath;
+  private AtomicReference<RepositoryMappingValue> repositoryMappingValue;
+  private AtomicReference<RootModuleFileValue> rootModuleFileValue;
+  private AtomicReference<BazelDepGraphValue> bazelDepGraphValue;
 
   protected abstract CrossRepositoryLabelViolationStrategy crossRepositoryLabelViolationStrategy();
 
@@ -92,6 +100,10 @@ public abstract class PackageLookupFunctionTest extends FoundationTestCase {
                 ImmutableList.of(Root.fromPath(emptyPackagePath), Root.fromPath(rootDirectory)),
                 BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY));
     deletedPackages = new AtomicReference<>(ImmutableSet.of());
+    repositoryMappingValue =
+        new AtomicReference<>(RepositoryMappingValue.VALUE_FOR_EMPTY_ROOT_MODULE);
+    rootModuleFileValue = new AtomicReference<>(emptyRootModuleFileValue());
+    bazelDepGraphValue = new AtomicReference<>(BazelDepGraphValue.createEmptyDepGraph());
     BlazeDirectories directories =
         new BlazeDirectories(
             new ServerDirectories(rootDirectory, outputBase, rootDirectory),
@@ -129,7 +141,9 @@ public abstract class PackageLookupFunctionTest extends FoundationTestCase {
             ruleClassProvider.getBazelStarlarkEnvironment(),
             Root.fromPath(directories.getWorkspace())));
     skyFunctions.put(SkyFunctions.IGNORED_SUBDIRECTORIES, IgnoredSubdirectoriesFunction.INSTANCE);
-    skyFunctions.put(SkyFunctions.LOCAL_REPOSITORY_LOOKUP, new LocalRepositoryLookupFunction());
+    skyFunctions.put(
+        SkyFunctions.LOCAL_REPOSITORY_LOOKUP,
+        new LocalRepositoryLookupFunction(directories.getWorkspace()));
     skyFunctions.put(
         FileSymlinkCycleUniquenessFunction.NAME, new FileSymlinkCycleUniquenessFunction());
 
@@ -142,15 +156,23 @@ public abstract class PackageLookupFunctionTest extends FoundationTestCase {
         new SkyFunction() {
           @Override
           public SkyValue compute(SkyKey skyKey, Environment env) {
-            return RepositoryMappingValue.VALUE_FOR_EMPTY_ROOT_MODULE;
+            return repositoryMappingValue.get();
           }
         });
     skyFunctions.put(
-        RepoDefinitionValue.REPO_DEFINITION,
+        SkyFunctions.MODULE_FILE,
         new SkyFunction() {
           @Override
           public SkyValue compute(SkyKey skyKey, Environment env) {
-            return RepoDefinitionValue.NOT_FOUND;
+            return rootModuleFileValue.get();
+          }
+        });
+    skyFunctions.put(
+        SkyFunctions.BAZEL_DEP_GRAPH,
+        new SkyFunction() {
+          @Override
+          public SkyValue compute(SkyKey skyKey, Environment env) {
+            return bazelDepGraphValue.get();
           }
         });
 
@@ -185,6 +207,30 @@ public abstract class PackageLookupFunctionTest extends FoundationTestCase {
             .setEventHandler(NullEventHandler.INSTANCE)
             .build();
     return evaluator.evaluate(ImmutableList.of(packageIdentifierSkyKey), evaluationContext);
+  }
+
+  protected final void addVisibleLocalRepository(RepositoryName repositoryName, String path) {
+    repositoryMappingValue.set(
+        RepositoryMappingValue.createSpecial(
+            RepositoryMapping.create(
+                ImmutableMap.of("", RepositoryName.MAIN, repositoryName.getName(), repositoryName),
+                RepositoryName.MAIN)));
+    rootModuleFileValue.set(
+        new RootModuleFileValue(
+            InterimModule.builder().build(),
+            ImmutableMap.of("local_repo", new NonRegistryOverride(LocalPathRepoSpecs.create(path))),
+            ImmutableMap.of(repositoryName, "local_repo"),
+            ImmutableMap.of("local_repo", repositoryName.getName()),
+            ImmutableSet.of()));
+  }
+
+  private static RootModuleFileValue emptyRootModuleFileValue() {
+    return new RootModuleFileValue(
+        InterimModule.builder().build(),
+        ImmutableMap.of(),
+        ImmutableMap.of(),
+        ImmutableMap.of(),
+        ImmutableSet.of());
   }
 
   @Test
@@ -388,6 +434,23 @@ public abstract class PackageLookupFunctionTest extends FoundationTestCase {
     @Override
     protected CrossRepositoryLabelViolationStrategy crossRepositoryLabelViolationStrategy() {
       return CrossRepositoryLabelViolationStrategy.ERROR;
+    }
+
+    @Test
+    public void testLookupInsideLocalRepositoryReturnsCorrectRepositoryHint() throws Exception {
+      RepositoryName repositoryName = RepositoryName.createUnvalidated("local_repo");
+      addVisibleLocalRepository(repositoryName, "third_party/local_repo");
+      scratch.file("third_party/local_repo/pkg/BUILD");
+
+      PackageLookupValue packageLookupValue = lookupPackage("third_party/local_repo/pkg");
+
+      assertThat(packageLookupValue.packageExists()).isFalse();
+      assertThat(packageLookupValue.getErrorReason()).isEqualTo(ErrorReason.INVALID_PACKAGE_NAME);
+      assertThat(
+              ((PackageLookupValue.IncorrectRepositoryReferencePackageLookupValue)
+                      packageLookupValue)
+                  .getCorrectedPackageIdentifier())
+          .isEqualTo(PackageIdentifier.create(repositoryName, PathFragment.create("pkg")));
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunctionTest.java
@@ -43,6 +43,9 @@ import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
+import com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphValue;
+import com.google.devtools.build.lib.bazel.bzlmod.InterimModule;
+import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.events.NullEventHandler;
@@ -176,7 +179,20 @@ public final class RecursiveFilesystemTraversalFunctionTest extends FoundationTe
             BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY));
     skyFunctions.put(SkyFunctions.IGNORED_SUBDIRECTORIES, IgnoredSubdirectoriesFunction.NOOP);
     skyFunctions.put(SkyFunctions.PACKAGE, PackageFunction.newBuilder().build());
-    skyFunctions.put(SkyFunctions.LOCAL_REPOSITORY_LOOKUP, new LocalRepositoryLookupFunction());
+    skyFunctions.put(
+        SkyFunctions.LOCAL_REPOSITORY_LOOKUP,
+        new LocalRepositoryLookupFunction(directories.getWorkspace()));
+    skyFunctions.put(
+        SkyFunctions.MODULE_FILE,
+        (skyKey, env) ->
+            new RootModuleFileValue(
+                InterimModule.builder().build(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableSet.of()));
+    skyFunctions.put(
+        SkyFunctions.BAZEL_DEP_GRAPH, (skyKey, env) -> BazelDepGraphValue.createEmptyDepGraph());
     skyFunctions.put(
         FileSymlinkInfiniteExpansionUniquenessFunction.NAME,
         new FileSymlinkInfiniteExpansionUniquenessFunction());


### PR DESCRIPTION
## Summary
This change teaches `LocalRepositoryLookupFunction` to recognize visible local repositories instead of unconditionally treating every workspace path as the main repository.

## What changed
- detect repository roots from command-line repository overrides
- detect `local_path_override`, `local_repository`, and `new_local_repository` repos from Bzlmod state
- thread the workspace root into `LocalRepositoryLookupFunction` so relative local paths resolve correctly
- add regression coverage for direct local-repository lookup and for the package-lookup error hint that should point users at the correct repository
- seed the extra Bzlmod SkyFunctions in local test evaluators that instantiate this function directly

## Root cause
`LocalRepositoryLookupFunction` was effectively stubbed out: once lookup walked back to the workspace root it always returned `mainRepository()`. That meant package lookup could misclassify visible local repositories as main-repo packages instead of returning an incorrect-repository-reference hint.

## Impact
Package lookup can now surface the correct repository for visible local repositories, which makes cross-repository label violations much easier to diagnose.

## Testing
Tried locally:
- `bazel test //src/test/java/com/google/devtools/build/lib/skyframe:LocalRepositoryLookupFunctionTest //src/test/java/com/google/devtools/build/lib/skyframe:PackageLookupFunctionTest --test_filter='.*(testDirectoryInsideVisibleLocalRepository|testLookupInsideLocalRepositoryReturnsCorrectRepositoryHint)' --test_output=errors`

Current local blocker:
- analysis completed, but execution on this machine is blocked by an unaccepted Xcode license (`xcrun failed with code 69` from `apple_support`)
