### PR TITLE
packages: compute generator_location from the source root

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/Rule.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Rule.java
@@ -43,6 +43,7 @@ import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.StarlarkIm
 import com.google.devtools.build.lib.packages.Package.ConfigSettingVisibilityPolicy;
 import com.google.devtools.build.lib.server.FailureDetails.PackageLoading;
 import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerialization;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -351,18 +352,17 @@ public class Rule extends RuleOrMacroInstance implements Target {
    */
   @Nullable
   private String getRelativeLocation() {
-    // Determining the workspace root only works reliably if both location and label point to files
-    // in the same package.
-    // It would be preferable to construct the path from the label itself, but this doesn't work for
-    // rules created from function calls in a subincluded file, even if both files share a path
-    // prefix (for example, when //a/package:BUILD subincludes //a/package/with/a/subpackage:BUILD).
-    // We can revert to that approach once subincludes aren't supported anymore.
-    //
-    // TODO(b/151165647): this logic has always been wrong:
-    // it spuriously matches occurrences of the package name earlier in the path.
-    String absolutePath = location.toString();
-    int pos = absolutePath.indexOf(label.getPackageName());
-    return (pos < 0) ? null : absolutePath.substring(pos);
+    PathFragment locationPath = PathFragment.create(location.file());
+    PathFragment sourceRelativePath = locationPath;
+    if (locationPath.isAbsolute()) {
+      if (!pkg.getMetadata().sourceRoot().contains(locationPath)) {
+        return null;
+      }
+      sourceRelativePath = pkg.getMetadata().sourceRoot().relativize(locationPath);
+    }
+    return Location.fromFileLineColumn(
+            sourceRelativePath.getPathString(), location.line(), location.column())
+        .toString();
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/buildtool/QueryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/QueryIntegrationTest.java
@@ -615,13 +615,8 @@ public class QueryIntegrationTest extends BuildIntegrationTestCase {
 
   @Test
   public void ruleStackInBuildOutput() throws Exception {
-    /*
-     * See b/151165647 - This needs a non-trivial package name to avoid
-     * including extraneous directories in the generator_location.
-     */
-
     write(
-        "package/inc.bzl",
+        "p/inc.bzl",
         """
         def _impl(ctx): pass
         myrule = rule(implementation = _impl)
@@ -631,39 +626,37 @@ public class QueryIntegrationTest extends BuildIntegrationTestCase {
           myrule(name='a')
         """);
 
-    write("package/BUILD", "load('inc.bzl', 'f')\n" + "f()");
+    write("p/BUILD", "load('inc.bzl', 'f')\n" + "f()");
 
-    QueryOutput result = getQueryResult("//package:a", "--output=build");
+    QueryOutput result = getQueryResult("//p:a", "--output=build");
     assertSuccessfulExitCode(result);
-    // TODO(b/151165647): fix the heuristic that incorrectly creates generator_location by//
-    //  relativizing package name "p" relative to /foo/tmp/ regardless of segment boundaries.
     // TODO(b/151151653): the output should contain only workspace-relative paths.
     String workspaceDir = getWorkspace().toString();
     String expectedOut =
         "# "
             + workspaceDir
-            + "/package/BUILD:2:2\n"
+            + "/p/BUILD:2:2\n"
             + "myrule(\n"
             + "  name = \"a\",\n"
             + "  generator_name = \"a\",\n"
             + "  generator_function = \"f\",\n"
             + "  generator_location = "
-            + "\"package/BUILD:2:2\",\n"
+            + "\"p/BUILD:2:2\",\n"
             + ")\n"
             + "# Rule a instantiated at (most recent call last):\n"
             + "#   "
             + workspaceDir
-            + "/package/BUILD:2:2   in <toplevel>\n"
+            + "/p/BUILD:2:2   in <toplevel>\n"
             + "#   "
             + workspaceDir
-            + "/package/inc.bzl:4:4 in f\n"
+            + "/p/inc.bzl:4:4 in f\n"
             + "#   "
             + workspaceDir
-            + "/package/inc.bzl:6:9 in g\n"
+            + "/p/inc.bzl:6:9 in g\n"
             + "# Rule myrule defined at (most recent call last):\n"
             + "#   "
             + workspaceDir
-            + "/package/inc.bzl:2:14 in <toplevel>\n\n";
+            + "/p/inc.bzl:2:14 in <toplevel>\n\n";
 
     String out = new String(result.getStdout(), UTF_8);
 
@@ -710,13 +703,8 @@ public class QueryIntegrationTest extends BuildIntegrationTestCase {
    */
   @Test
   public void ruleStackRegressionTest() throws Exception {
-    /*
-     * See b/151165647 - This needs a non-trivial package name to avoid
-     * including extraneous directories in the generator_location.
-     */
-
     write(
-        "package/inc.bzl",
+        "p/inc.bzl",
         """
         def g(name):
             native.filegroup(name = name)
@@ -726,58 +714,58 @@ public class QueryIntegrationTest extends BuildIntegrationTestCase {
         """);
 
     write(
-        "package/BUILD",
+        "p/BUILD",
         """
         load("inc.bzl", "f")
         f(name = "a")
         f(name = "b")
         """);
-    QueryOutput result = getQueryResult("//package:all", "--output=build");
+    QueryOutput result = getQueryResult("//p:all", "--output=build");
     assertSuccessfulExitCode(result);
 
     String workspaceDir = getWorkspace().toString();
     String expectedOut =
         "# "
             + workspaceDir
-            + "/package/BUILD:2:2\n"
+            + "/p/BUILD:2:2\n"
             + "filegroup(\n"
             + "  name = \"a\",\n"
             + "  generator_name = \"a\",\n"
             + "  generator_function = \"f\",\n"
             + "  generator_location = "
-            + "\"package/BUILD:2:2\",\n"
+            + "\"p/BUILD:2:2\",\n"
             + ")\n"
             + "# Rule a instantiated at (most recent call last):\n"
             + "#   "
             + workspaceDir
-            + "/package/BUILD:2:2    in <toplevel>\n"
+            + "/p/BUILD:2:2    in <toplevel>\n"
             + "#   "
             + workspaceDir
-            + "/package/inc.bzl:5:6  in f\n"
+            + "/p/inc.bzl:5:6  in f\n"
             + "#   "
             + workspaceDir
-            + "/package/inc.bzl:2:21 in g\n"
+            + "/p/inc.bzl:2:21 in g\n"
             + "\n"
             + "# "
             + workspaceDir
-            + "/package/BUILD:3:2\n"
+            + "/p/BUILD:3:2\n"
             + "filegroup(\n"
             + "  name = \"b\",\n"
             + "  generator_name = \"b\",\n"
             + "  generator_function = \"f\",\n"
             + "  generator_location = "
-            + "\"package/BUILD:3:2\",\n"
+            + "\"p/BUILD:3:2\",\n"
             + ")\n"
             + "# Rule b instantiated at (most recent call last):\n"
             + "#   "
             + workspaceDir
-            + "/package/BUILD:3:2    in <toplevel>\n"
+            + "/p/BUILD:3:2    in <toplevel>\n"
             + "#   "
             + workspaceDir
-            + "/package/inc.bzl:5:6  in f\n"
+            + "/p/inc.bzl:5:6  in f\n"
             + "#   "
             + workspaceDir
-            + "/package/inc.bzl:2:21 in g\n\n";
+            + "/p/inc.bzl:2:21 in g\n\n";
 
     String out = new String(result.getStdout(), UTF_8);
     assertThat(out).isEqualTo(expectedOut);


### PR DESCRIPTION
## Summary
This change computes generator_location from the package source root instead of trying to find the package name inside an absolute path with a substring search.

## What changed
- build the generator_location path by relativizing the Starlark call site against the package source root
- keep returning null when Bazel cannot safely express the location relative to that root
- update the query integration regressions to exercise the short package name p, which is the case that previously produced the wrong location

## Root cause
Rule.getRelativeLocation() searched location.toString() for the package name and sliced the string from the first match. That could match unrelated earlier path segments, so short package names like p could produce malformed generator_location values.

## Impact
query --output=build now reports stable repository-relative generator_location values even when the package name is a short substring of an earlier absolute-path segment.

## Testing
Tried locally:
- bazel test //src/test/java/com/google/devtools/build/lib/buildtool:QueryIntegrationTest --test_filter='.*(ruleStackInBuildOutput|ruleStackRegressionTest)' --test_output=errors

Current local blocker:
- analysis completed, but execution on this machine is blocked by an unaccepted Xcode license (xcrun failed with code 69 from apple_support)
