### PR TITLE
packages: allow idempotent exports_files visibility

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkNativeModule.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkNativeModule.java
@@ -591,12 +591,8 @@ public class StarlarkNativeModule implements StarlarkNativeModuleApi {
       }
       try {
         InputFile inputFile = targetDefinitionContext.createInputFile(file, loc);
-        // TODO: #19922 - The use of identity inequality in this visibility check seems suspect,
-        // since the same logical visibility may have multiple RuleVisibility instances. But it's
-        // unclear why we want to support idempotent exports_files() with the same logical
-        // visibility at all. With Macro-Aware Visibility, it becomes possible for two identical
-        // visibility lines to declare different actual visibility values depending on context.
-        if (inputFile.isVisibilitySpecified() && inputFile.getVisibility() != visibility) {
+        if (inputFile.isVisibilitySpecified()
+            && !inputFile.getVisibility().equals(visibility)) {
           throw Starlark.errorf(
               "visibility for exported file '%s' declared twice", inputFile.getName());
         }

--- a/src/test/java/com/google/devtools/build/lib/packages/PackageFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/PackageFactoryTest.java
@@ -1038,6 +1038,15 @@ public final class PackageFactoryTest extends PackageLoadingTestCase {
   }
 
   @Test
+  public void testExportTwiceCustomVisibilityOK() throws Exception {
+    expectEvalSuccess(
+        "exports_files([\"a.cc\"],",
+        "    visibility = [ \"//friend:__pkg__\" ])",
+        "exports_files([\"a.cc\"],",
+        "    visibility = [ \"//friend:__pkg__\" ])");
+  }
+
+  @Test
   public void testExportTwiceFail() throws Exception {
     expectEvalError(
         "visibility for exported file 'a.cc' declared twice",


### PR DESCRIPTION
## Summary
This change makes repeated exports_files() declarations with the same logical visibility idempotent, even when the visibility is represented by distinct RuleVisibility instances.

## What changed
- compare exported-file visibility with logical equality instead of object identity
- add regression coverage for calling exports_files() twice with the same custom package visibility

## Root cause
exports_files() used != to compare visibilities. That works for singleton public and private visibilities, but it rejects repeated custom visibilities because each parse can allocate a fresh RuleVisibility object even when the declared labels are identical.

## Impact
Packages can safely repeat the same custom visibility in exports_files() without tripping a false "declared twice" error, while genuinely conflicting visibilities still fail.

## Testing
Tried locally:
- bazel test //src/test/java/com/google/devtools/build/lib/packages:PackagesTests --test_filter='.*testExportTwice(CustomVisibilityOK|PublicOK|Fail).*' --test_output=errors

Current local blocker:
- analysis completed, but execution on this machine is blocked by an unaccepted Xcode license (xcrun failed with code 69 from apple_support)
