### PR TITLE
Make `new_git_repository` fail if used

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/GitRepositoryBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/GitRepositoryBlackBoxTest.java
@@ -29,7 +29,7 @@ import java.nio.file.Path;
 import org.junit.Test;
 
 /**
- * Black box tests for git_repository/new_git_repository. On Windows, runs without MSYS {@link
+ * Black box tests for git_repository. On Windows, runs without MSYS {@link
  * WorkspaceTestUtils#bazel}
  *
  * <p>General approach to testing:
@@ -48,7 +48,7 @@ import org.junit.Test;
  * should appear as a result of the build of the generated target "call_write_text" in the file
  * "out.txt".
  *
- * <p>3. We generate the new_git_repository repository rule, which refers to the git repository,
+ * <p>3. We generate the git_repository repository rule, which refers to the git repository,
  * created in #1, specifying different git repository attributes in each test. We call 'bazel build'
  * for the "call_write_text" target of the external repository, and asserting the contents in the
  * "out.txt" file.
@@ -58,7 +58,7 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
   private static final String HELLO_FROM_BRANCH = "Hello from branch!";
 
   /**
-   * Tests usage of new_git_repository workspace rule with the "tag" attribute. Please see the
+   * Tests usage of git_repository workspace rule with the "tag" attribute. Please see the
    * general approach description in the class javadoc comment.
    */
   @Test
@@ -73,9 +73,9 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     context()
         .write(
             "MODULE.bazel",
-            "new_git_repository = use_repo_rule(\"@bazel_tools//tools/build_defs/repo:git.bzl\","
-                + " \"new_git_repository\")",
-            "new_git_repository(",
+            "git_repository = use_repo_rule(\"@bazel_tools//tools/build_defs/repo:git.bzl\","
+                + " \"git_repository\")",
+            "git_repository(",
             "  name='ext',",
             String.format("  remote='%s',", PathUtils.pathToFileURI(repo.resolve(".git"))),
             "  tag='first',",
@@ -85,12 +85,12 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     // This creates Bazel without MSYS, see implementation for details.
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@ext//:call_write_text");
-    Path outPath = context().resolveBinPath(bazel, "external/+new_git_repository+ext/out.txt");
+    Path outPath = context().resolveBinPath(bazel, "external/+git_repository+ext/out.txt");
     WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_EXTERNAL_REPOSITORY);
   }
 
   /**
-   * Tests usage of new_git_repository workspace rule with the "commit" attribute. Please see the
+   * Tests usage of git_repository workspace rule with the "commit" attribute. Please see the
    * general approach description in the class javadoc comment.
    */
   @Test
@@ -105,9 +105,9 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     context()
         .write(
             "MODULE.bazel",
-            "new_git_repository = use_repo_rule(\"@bazel_tools//tools/build_defs/repo:git.bzl\","
-                + " \"new_git_repository\")",
-            "new_git_repository(",
+            "git_repository = use_repo_rule(\"@bazel_tools//tools/build_defs/repo:git.bzl\","
+                + " \"git_repository\")",
+            "git_repository(",
             "  name='ext',",
             String.format("  remote='%s',", PathUtils.pathToFileURI(repo.resolve(".git"))),
             String.format("  commit='%s',", commit),
@@ -117,12 +117,12 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     // This creates Bazel without MSYS, see implementation for details.
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@ext//:call_write_text");
-    Path outPath = context().resolveBinPath(bazel, "external/+new_git_repository+ext/out.txt");
+    Path outPath = context().resolveBinPath(bazel, "external/+git_repository+ext/out.txt");
     WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_EXTERNAL_REPOSITORY);
   }
 
   /**
-   * Tests usage of new_git_repository workspace rule with the "branch" attribute. Please see the
+   * Tests usage of git_repository workspace rule with the "branch" attribute. Please see the
    * general approach description in the class javadoc comment.
    */
   @Test
@@ -137,9 +137,9 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     context()
         .write(
             "MODULE.bazel",
-            "new_git_repository = use_repo_rule(\"@bazel_tools//tools/build_defs/repo:git.bzl\","
-                + " \"new_git_repository\")",
-            "new_git_repository(",
+            "git_repository = use_repo_rule(\"@bazel_tools//tools/build_defs/repo:git.bzl\","
+                + " \"git_repository\")",
+            "git_repository(",
             "  name='ext',",
             String.format("  remote='%s',", PathUtils.pathToFileURI(repo.resolve(".git"))),
             "  branch='main',",
@@ -149,12 +149,12 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     // This creates Bazel without MSYS, see implementation for details.
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@ext//:call_write_text");
-    Path outPath = context().resolveBinPath(bazel, "external/+new_git_repository+ext/out.txt");
+    Path outPath = context().resolveBinPath(bazel, "external/+git_repository+ext/out.txt");
     WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_EXTERNAL_REPOSITORY);
   }
 
   /**
-   * Tests usage of new_git_repository workspace rule without a "tag", "commit" or "branch"
+   * Tests usage of git_repository workspace rule without a "tag", "commit" or "branch"
    * attribute, which means the repository's default branch is to be checked out. Please see the
    * general approach description in the class javadoc comment.
    */
@@ -170,9 +170,9 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     context()
         .write(
             "MODULE.bazel",
-            "new_git_repository = use_repo_rule(\"@bazel_tools//tools/build_defs/repo:git.bzl\","
-                + " \"new_git_repository\")",
-            "new_git_repository(",
+            "git_repository = use_repo_rule(\"@bazel_tools//tools/build_defs/repo:git.bzl\","
+                + " \"git_repository\")",
+            "git_repository(",
             "  name='ext',",
             String.format("  remote='%s',", PathUtils.pathToFileURI(repo.resolve(".git"))),
             String.format("  build_file_content=\"\"\"%s\"\"\",", buildFileContent),
@@ -181,7 +181,7 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     // This creates Bazel without MSYS, see implementation for details.
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@ext//:call_write_text");
-    Path outPath = context().resolveBinPath(bazel, "external/+new_git_repository+ext/out.txt");
+    Path outPath = context().resolveBinPath(bazel, "external/+git_repository+ext/out.txt");
     WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_EXTERNAL_REPOSITORY);
   }
 

--- a/src/test/shell/bazel/bazel_embedded_starlark_test.sh
+++ b/src/test/shell/bazel/bazel_embedded_starlark_test.sh
@@ -109,7 +109,7 @@ EOF
   bazel run :foo | grep -q dragons || fail "wrong output"
 }
 
-test_new_git_repository() {
+test_git_repository() {
   EXTREPODIR=`pwd`
   export GIT_CONFIG_NOSYSTEM=YES
   mkdir extgit
@@ -129,8 +129,8 @@ EOF
   mkdir main
   cd main
   cat > $(setup_module_dot_bazel) <<EOF
-new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
-new_git_repository(
+git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+git_repository(
   name="ext",
   remote="file://${EXTREPODIR}/extgit/.git",
   tag="mytag",

--- a/src/test/shell/bazel/external_patching_test.sh
+++ b/src/test/shell/bazel/external_patching_test.sh
@@ -429,8 +429,8 @@ EOF
 +echo There are dragons...
 EOF
   cat > $(setup_module_dot_bazel) <<EOF
-new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
-new_git_repository(
+git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+git_repository(
   name="ext",
   remote="${EXTREPODIR}/extgit/.git",
   tag="mytag",
@@ -470,8 +470,8 @@ EOF
 
   # Verify that changes to the patches attribute trigger enough rebuilding
   cat > $(setup_module_dot_bazel) <<EOF
-new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
-new_git_repository(
+git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+git_repository(
   name="ext",
   remote="${EXTREPODIR}/extgit/.git",
   tag="mytag",
@@ -633,8 +633,8 @@ EOF
   mkdir main
   cd main
   cat > $(setup_module_dot_bazel) <<EOF
-new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
-new_git_repository(
+git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+git_repository(
   name="withbuild",
   remote="${EXTREPODIR}/withbuild/.git",
   tag="mytag",
@@ -701,8 +701,8 @@ EOF
   mkdir main
   cd main
   cat > $(setup_module_dot_bazel) <<EOF
-new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
-new_git_repository(
+git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+git_repository(
   name="withbuild",
   remote="${EXTREPODIR}/withbuild/.git",
   tag="mytag",

--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Test git_repository and new_git_repository workspace rules.
+# Test git_repository workspace rules.
 #
 
 set -euo pipefail
@@ -161,31 +161,31 @@ function test_git_repository_shallow_since() {
     # We need the revious day, because git adds current time to the specified date.
     do_git_repository_test "52f9a3f87a2dd17ae0e5847bbae9734f09354afd" "" "2015-07-15"
 }
-function test_new_git_repository_with_build_file() {
-  do_new_git_repository_test "0-initial" "build_file"
+function test_git_repository_with_build_file() {
+  do_git_repository_test_with_build "0-initial" "build_file"
 }
 
-function test_new_git_repository_with_build_file_strip_prefix() {
-  do_new_git_repository_test "3-subdir-bare" "build_file" "pluto"
+function test_git_repository_with_build_file_strip_prefix() {
+  do_git_repository_test_with_build "3-subdir-bare" "build_file" "pluto"
 }
 
-function test_new_git_repository_with_build_file_strip_prefix_default_branch() {
-  do_new_git_repository_test "" "build_file" "pluto"
+function test_git_repository_with_build_file_strip_prefix_default_branch() {
+  do_git_repository_test_with_build "" "build_file" "pluto"
 }
 
-function test_new_git_repository_with_build_file_content() {
-  do_new_git_repository_test "0-initial" "build_file_content"
+function test_git_repository_with_build_file_content() {
+  do_git_repository_test_with_build "0-initial" "build_file_content"
 }
 
-function test_new_git_repository_with_build_file_content_strip_prefix() {
-  do_new_git_repository_test "3-subdir-bare" "build_file_content" "pluto"
+function test_git_repository_with_build_file_content_strip_prefix() {
+  do_git_repository_test_with_build "3-subdir-bare" "build_file_content" "pluto"
 }
 
-function test_new_git_repository_with_build_file_content_strip_prefix_default_branch() {
-  do_new_git_repository_test "" "build_file_content" "pluto"
+function test_git_repository_with_build_file_content_strip_prefix_default_branch() {
+  do_git_repository_test_with_build "" "build_file_content" "pluto"
 }
 
-# Test cloning a Git repository using the new_git_repository rule.
+# Test cloning a Git repository using the git_repository rule with a BUILD file.
 #
 # This test uses the pluto Git repository at tag 0-initial, which contains the
 # following files:
@@ -213,7 +213,7 @@ function test_new_git_repository_with_build_file_content_strip_prefix_default_br
 #
 # //planets has a dependency on a target in the $TEST_TMPDIR/pluto Git
 # repository.
-function do_new_git_repository_test() {
+function do_git_repository_test_with_build() {
   local pluto_repo_dir=$(get_pluto_repo)
   local strip_prefix=""
   local tag=""
@@ -224,8 +224,8 @@ function do_new_git_repository_test() {
 
   if [ "$2" == "build_file" ]; then
     cat >> MODULE.bazel <<EOF
-new_git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'new_git_repository')
-new_git_repository(
+git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+git_repository(
     name = "pluto",
     remote = "$pluto_repo_dir",
     $tag
@@ -246,8 +246,8 @@ filegroup(
 EOF
   else
     cat >> MODULE.bazel <<EOF
-new_git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'new_git_repository')
-new_git_repository(
+git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+git_repository(
     name = "pluto",
     remote = "$pluto_repo_dir",
     $tag
@@ -281,12 +281,12 @@ EOF
       expect_log "Pluto is a dwarf planet"
   fi
 
-  git_repos_count=$(find $(bazel info output_base)/external/+new_git_repository+pluto -type d -name .git | wc -l)
+  git_repos_count=$(find $(bazel info output_base)/external/+git_repository+pluto -type d -name .git | wc -l)
   assert_equals $git_repos_count 0
 }
 
 # Test cloning a Git repository that has a submodule using the
-# new_git_repository rule.
+# git_repository rule.
 #
 # This test uses the outer-planets Git repository at revision 1-submodule, which
 # contains the following files:
@@ -308,13 +308,13 @@ EOF
 #
 # planets has a dependency on targets in the $TEST_TMPDIR/outer_planets Git
 # repository.
-function test_new_git_repository_submodules() {
+function test_git_repository_submodules() {
   local outer_planets_repo_dir=$TEST_TMPDIR/repos/outer-planets
 
   # Create a workspace that clones the outer_planets repository.
   cat >> MODULE.bazel <<EOF
-new_git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'new_git_repository')
-new_git_repository(
+git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+git_repository(
     name = "outer_planets",
     remote = "$outer_planets_repo_dir",
     tag = "1-submodule",
@@ -360,13 +360,13 @@ EOF
   expect_log "Pluto is a planet"
 }
 
-function test_new_git_repository_submodules_with_recursive_init_modules() {
+function test_git_repository_submodules_with_recursive_init_modules() {
   local outer_planets_repo_dir=$TEST_TMPDIR/repos/outer-planets
 
   # Create a workspace that clones the outer_planets repository.
   cat >> MODULE.bazel <<EOF
-new_git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'new_git_repository')
-new_git_repository(
+git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+git_repository(
     name = "outer_planets",
     remote = "$outer_planets_repo_dir",
     tag = "1-submodule",

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -270,5 +270,37 @@ The reasons are:
 """,
 )
 
-# TODO(bazel_7.x): Remove before bazel 7.x
-new_git_repository = git_repository
+def _new_git_repository_implementation(ctx):
+  fail(
+    """
+    The repository rule 'new_git_repository' is deprecated. To fix, replace usage of
+    'new_git_repository' with the drop-in replacement 'git_repository' in your MODULE.bazel file.
+    Eg.
+
+    Replace the following:
+
+    new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+    new_git_repository(
+        name = "bazel",
+        remote = "https://github.com/bazelbuild/bazel.git",
+        commit = "93f38093f8e24875c1d015e67311853756bdb27e"
+    )
+
+    With:
+
+    git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+    git_repository(
+        name = "bazel",
+        remote = "https://github.com/bazelbuild/bazel.git",
+        commit = "93f38093f8e24875c1d015e67311853756bdb27e"
+    )
+""")
+
+# Use was blocked ~April, 2026. After the release of Bazel 9.0 and before Bazel 10.0.
+# TODO: This should eventually be removed within some time frame. Bazel 12.0 - that would be about
+# three years from now.
+new_git_repository = repository_rule(
+  implementation = _new_git_repository_implementation,
+  attrs = _common_attrs,
+  doc = """Deprecated - use the drop-in replacement 'git_repository' instead""",
+)

--- a/tools/build_defs/repo/git_worker.bzl
+++ b/tools/build_defs/repo/git_worker.bzl
@@ -41,11 +41,11 @@ after fetching and resetting the repo to the specified instance.""",
 def git_repo(ctx, directory):
     """ Fetches data from git repository and checks out file tree.
 
-    Called by git_repository or new_git_repository rules.
+    Called by git_repository rule.
 
     Args:
         ctx: Context of the calling rules, for reading the attributes.
-        Please refer to the git_repository and new_git_repository rules for the description.
+        Please refer to the git_repository rule for the description.
         directory: Directory where to check out the file tree.
     Returns:
         The struct with the following fields:


### PR DESCRIPTION
The note in git.bzl says that 'new_git_repository' should be removed by Bazel
7. This ~removes it since it's just an alias of `git_repository`~ replaces it with a failure message and fix instructions.  Users should use `git_repository` instead of `new_git repository`.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->
Replaces the implementation of the repository rule `new_git_repository` with an implementation that fails immediately when used. 

Example error message:

```
Error in fail:
    The repository rule 'new_git_repository' is deprecated. To fix, replace usage of
    'new_git_repository' with the drop-in replacement 'git_repository' in your MODULE.bazel file.
    Eg.

    Replace the following:

    new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
    new_git_repository(
        name = "bazel",
        remote = "https://github.com/bazelbuild/bazel.git",
        commit = "93f38093f8e24875c1d015e67311853756bdb27e"
    )

    With:

    git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
    git_repository(
        name = "bazel",
        remote = "https://github.com/bazelbuild/bazel.git",
        commit = "93f38093f8e24875c1d015e67311853756bdb27e"
    )
```


### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->
The note in `git.bzl` says this should have been removed before Bazel 7. We are now at Bazel 9.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

> 1. Has this been discussed in a design doc or issue? (Please link it)

I have no knowledge of a discussion taking place on this.  The note in `git.bzl` saying this should be removed implies that there was such a discussion or intent.

> 2. Is the change backward compatible?

No, anyone who is using `new_git_repository` will fail after getting this change.

> 3. If it's a breaking change, what is the migration plan?

Users should use `git_repository` instead.

### Checklist

- [N/A] I have added tests for the new use cases (if any).
- [X] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES[INC]: Removes the deprecated repository rule `new_git_repository`. Users should use `git_repository` instead (they are the same)
