### PR TITLE
Remove 8 year old RC file warnings

### DIFF
--- a/src/main/cpp/option_processor-internal.h
+++ b/src/main/cpp/option_processor-internal.h
@@ -38,24 +38,6 @@ std::vector<std::string> DedupeBlazercPaths(
 void WarnAboutDuplicateRcFiles(const std::set<std::string>& read_files,
                                const std::deque<std::string>& loaded_rcs);
 
-// Get the legacy list of rc files that would have been loaded - this is to
-// provide a useful warning if files are being ignored that were loaded in a
-// previous version of Bazel.
-// TODO(b/3616816): Remove this once the warning is no longer useful.
-std::set<std::string> GetOldRcPaths(
-    const WorkspaceLayout* workspace_layout, const std::string& workspace,
-    const std::string& cwd, const std::string& path_to_binary,
-    const std::vector<std::string>& startup_args);
-
-// Returns what the "user bazelrc" would have been in the legacy rc list.
-std::string FindLegacyUserBazelrc(const char* cmd_line_rc_file,
-                                  const std::string& workspace);
-
-std::string FindSystemWideRc();
-
-std::string FindRcAlongsideBinary(const std::string& cwd,
-                                  const std::string& path_to_binary);
-
 blaze_exit_code::ExitCode ParseErrorToExitCode(RcFile::ParseError parse_error);
 
 }  // namespace internal

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -173,75 +173,6 @@ std::unique_ptr<CommandLine> OptionProcessor::SplitCommandLine(
 
 namespace internal {
 
-std::string FindLegacyUserBazelrc(const char* cmd_line_rc_file,
-                                  const std::string& workspace) {
-  if (cmd_line_rc_file != nullptr) {
-    string rcFile = blaze::AbsolutePathFromFlag(cmd_line_rc_file);
-    if (!blaze_util::CanReadFile(rcFile)) {
-      // The actual rc file reading will catch this - we ignore this here in the
-      // legacy version since this is just a warning. Exit eagerly though.
-      return "";
-    }
-    return rcFile;
-  }
-
-  string workspaceRcFile = blaze_util::JoinPath(workspace, kRcBasename);
-  if (blaze_util::CanReadFile(workspaceRcFile)) {
-    return workspaceRcFile;
-  }
-
-  string home = blaze::GetHomeDir();
-  if (!home.empty()) {
-    string userRcFile = blaze_util::JoinPath(home, kRcBasename);
-    if (blaze_util::CanReadFile(userRcFile)) {
-      return userRcFile;
-    }
-  }
-  return "";
-}
-
-std::set<std::string> GetOldRcPaths(
-    const WorkspaceLayout* workspace_layout, const std::string& workspace,
-    const std::string& cwd, const std::string& path_to_binary,
-    const std::vector<std::string>& startup_args,
-    const std::string& system_bazelrc_path) {
-  // Find the old list of rc files that would have been loaded here, so we can
-  // provide a useful warning about old rc files that might no longer be read.
-  std::vector<std::string> candidate_bazelrc_paths;
-  if (SearchNullaryOption(startup_args, "master_bazelrc", true)) {
-    const std::string workspace_rc =
-        workspace_layout->GetWorkspaceRcPath(workspace, startup_args);
-    const std::string binary_rc =
-        internal::FindRcAlongsideBinary(cwd, path_to_binary);
-    candidate_bazelrc_paths = {workspace_rc, binary_rc, system_bazelrc_path};
-  }
-  vector<std::string> cmd_line_rc_files =
-      GetAllUnaryOptionValues(startup_args, "--bazelrc", "/dev/null");
-  // Divide the cases where the vector is empty vs not, as
-  // `FindLegacyUserBazelrc` has a case for rc_file to be a nullptr.
-  if (cmd_line_rc_files.empty()) {
-    string user_bazelrc_path =
-        internal::FindLegacyUserBazelrc(nullptr, workspace);
-    if (!user_bazelrc_path.empty()) {
-      candidate_bazelrc_paths.push_back(user_bazelrc_path);
-    }
-  } else {
-    for (auto& rc_file : cmd_line_rc_files) {
-      string user_bazelrc_path =
-          internal::FindLegacyUserBazelrc(rc_file.c_str(), workspace);
-      if (!user_bazelrc_path.empty()) {
-        candidate_bazelrc_paths.push_back(user_bazelrc_path);
-      }
-    }
-  }
-  // DedupeBlazercPaths returns paths whose canonical path could be computed,
-  // therefore these paths must exist.
-  const std::vector<std::string> deduped_existing_blazerc_paths =
-      internal::DedupeBlazercPaths(candidate_bazelrc_paths);
-  return std::set<std::string>(deduped_existing_blazerc_paths.begin(),
-                               deduped_existing_blazerc_paths.end());
-}
-
 // Deduplicates the given paths based on their canonical form.
 // Computes the canonical form using blaze_util::MakeCanonical.
 // Returns the unique paths in their original form (not the canonical one).
@@ -260,28 +191,6 @@ std::vector<std::string> DedupeBlazercPaths(
     }
   }
   return result;
-}
-
-std::string FindSystemWideRc(const std::string& system_bazelrc_path) {
-  const std::string path =
-      blaze_util::MakeAbsoluteAndResolveEnvvars(system_bazelrc_path);
-  if (blaze_util::CanReadFile(path)) {
-    return path;
-  }
-  return "";
-}
-
-std::string FindRcAlongsideBinary(const std::string& cwd,
-                                  const std::string& path_to_binary) {
-  const std::string path = blaze_util::IsAbsolute(path_to_binary)
-                               ? path_to_binary
-                               : blaze_util::JoinPath(cwd, path_to_binary);
-  const std::string base = blaze_util::Basename(path_to_binary);
-  const std::string binary_blazerc_path = path + "." + base + "rc";
-  if (blaze_util::CanReadFile(binary_blazerc_path)) {
-    return binary_blazerc_path;
-  }
-  return "";
 }
 
 blaze_exit_code::ExitCode ParseErrorToExitCode(RcFile::ParseError parse_error) {
@@ -338,20 +247,6 @@ void WarnAboutDuplicateRcFiles(const std::set<std::string>& read_files,
                          << " is imported multiple times from " << top_level_rc;
     }
   }
-}
-
-std::vector<std::string> GetLostFiles(
-    const std::set<std::string>& old_files,
-    const std::set<std::string>& read_files_canon) {
-  std::vector<std::string> result;
-  for (const auto& old : old_files) {
-    std::string old_canon = blaze_util::MakeCanonical(old.c_str());
-    if (!old_canon.empty() &&
-        read_files_canon.find(old_canon) == read_files_canon.end()) {
-      result.push_back(old);
-    }
-  }
-  return result;
 }
 
 blaze_exit_code::ExitCode GetAndValidateExistingRcFiles(
@@ -464,29 +359,6 @@ blaze_exit_code::ExitCode OptionProcessor::GetRcFiles(
 
     result_rc_files->push_back(std::move(parsed_rc));
   }
-
-  // Provide a warning for any old file that might have been missed with the new
-  // expectations. This compares "canonical" paths to one another, so should not
-  // require additional transformation.
-  // TODO(b/36168162): Remove this warning along with
-  // internal::GetOldRcPaths and internal::FindLegacyUserBazelrc after
-  // the transition period has passed.
-  const std::set<std::string> old_files = internal::GetOldRcPaths(
-      workspace_layout, workspace, cwd, cmd_line->path_to_binary,
-      cmd_line->startup_args, internal::FindSystemWideRc(system_bazelrc_path_));
-
-  std::vector<std::string> lost_files =
-      internal::GetLostFiles(old_files, read_files_canonical_paths);
-  if (!lost_files.empty()) {
-    std::string joined_lost_rcs;
-    blaze_util::JoinStrings(lost_files, '\n', &joined_lost_rcs);
-    BAZEL_LOG(WARNING)
-        << "The following rc files are no longer being read, please transfer "
-           "their contents or import their path into one of the standard rc "
-           "files:\n"
-        << joined_lost_rcs;
-  }
-
   return blaze_exit_code::SUCCESS;
 }
 

--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -273,33 +273,6 @@ TEST_F(GetRcFileTest,
   EXPECT_THAT(parsed_rcs, IsEmpty());
 }
 
-TEST_F(GetRcFileTest, GetRcFilesWarnsAboutIgnoredMasterRcFiles) {
-  std::string workspace_rc;
-  ASSERT_TRUE(SetUpLegacyMasterRcFileInWorkspace("", &workspace_rc));
-  std::string binary_rc;
-  ASSERT_TRUE(SetUpLegacyMasterRcFileAlongsideBinary("", &binary_rc));
-
-  const CommandLine cmd_line = CommandLine(binary_path_, {}, "build", {});
-  std::string error = "check that this string is not modified";
-  std::vector<std::unique_ptr<RcFile>> parsed_rcs;
-
-  testing::internal::CaptureStderr();
-  const blaze_exit_code::ExitCode exit_code =
-      option_processor_->GetRcFiles(workspace_layout_.get(), workspace_, cwd_,
-                                    &cmd_line, &parsed_rcs, &error);
-  const std::string output = testing::internal::GetCapturedStderr();
-
-  EXPECT_EQ(blaze_exit_code::SUCCESS, exit_code);
-  EXPECT_EQ("check that this string is not modified", error);
-
-  // Expect that GetRcFiles outputs a warning about these files that are not
-  // read as expected.
-  EXPECT_THAT(output,
-              HasSubstr("The following rc files are no longer being read"));
-  EXPECT_THAT(output, HasSubstr(workspace_rc));
-  EXPECT_THAT(output, HasSubstr(binary_rc));
-}
-
 TEST_F(GetRcFileTest, GetRcFilesReadsCommandLineRc) {
   const std::string cmdline_rc_path =
       blaze_util::JoinPath(workspace_, "mybazelrc");

--- a/src/test/shell/integration/bazel_command_log_test.sh
+++ b/src/test/shell/integration/bazel_command_log_test.sh
@@ -46,8 +46,6 @@ function strip_lines_from_bazel_cc() {
     -e '/^WARNING: The startup option --host_javabase is deprecated; prefer --server_javabase.$/d' \
     -e '/^WARNING: The home directory is not defined, no home_rc will be looked for.$/d' \
     -e '/^WARNING: ignoring JAVA_TOOL_OPTIONS in environment.$/d' \
-    -e '/^WARNING: The following rc files are no longer being read, please transfer their contents or import their path into one of the standard rc files:$/d' \
-    -e '/^\/etc\/bazel.bazelrc$/d' \
     -e '/Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release/d' \
     -e '/^E[0-9]* /d' \
     $TEST_log)

--- a/src/test/shell/integration/client_test.sh
+++ b/src/test/shell/integration/client_test.sh
@@ -31,8 +31,6 @@ function strip_lines_from_bazel_cc() {
   clean_log=$(\
     sed \
     -e '/^WARNING: ignoring JAVA_TOOL_OPTIONS in environment.$/d' \
-    -e '/^WARNING: The following rc files are no longer being read, please transfer their contents or import their path into one of the standard rc files:$/d' \
-    -e '/^\/etc\/bazel.bazelrc$/d' \
     $TEST_log)
 
   echo "$clean_log" > $TEST_log


### PR DESCRIPTION
These warnings were added when updating what RC files are read. I think
these have lived long enough.

https://github.com/bazelbuild/bazel/issues/6319
