### PR TITLE
[9.0.2] Fix launcher/launcher_maker for cross build (https://github.com/bazelbuild/bazel/pull/29200)

### DIFF
--- a/tools/build_defs.bzl
+++ b/tools/build_defs.bzl
@@ -27,7 +27,17 @@ def _single_binary_toolchain_rule_impl(ctx):
         binary = ctx.file.binary,
     )
 
-_single_binary_toolchain_rule = rule(
+_single_target_binary_toolchain_rule = rule(
+    implementation = _single_binary_toolchain_rule_impl,
+    attrs = {
+        "binary": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+    },
+)
+
+_single_exec_binary_toolchain_rule = rule(
     implementation = _single_binary_toolchain_rule_impl,
     attrs = {
         "binary": attr.label(
@@ -41,11 +51,23 @@ def single_binary_toolchain(
         *,
         name,
         toolchain_type,
-        binary = None,
+        target_binary = None,
+        exec_binary = None,
         target_compatible_with = [],
         exec_compatible_with = []):
     """Declares a toolchain together with its implementation for an optional single binary."""
     impl_name = name + "_impl"
+
+    if exec_binary and target_binary:
+        fail("Cannot specify both exec_binary and target_binary for a single_binary_toolchain.")
+    elif target_binary:
+        binary = target_binary
+        _single_binary_toolchain_rule = _single_target_binary_toolchain_rule
+    elif exec_binary:
+        binary = exec_binary
+        _single_binary_toolchain_rule = _single_exec_binary_toolchain_rule
+    else:
+        fail("Must specify either exec_binary or target_binary for a single_binary_toolchain.")
 
     _single_binary_toolchain_rule(
         name = impl_name,

--- a/tools/launcher/BUILD.bootstrap
+++ b/tools/launcher/BUILD.bootstrap
@@ -16,6 +16,6 @@ toolchain_type(name = "launcher_maker_toolchain_type")
 
 single_binary_toolchain(
    name = "foo",
-   binary = ":launcher_maker",
+   exec_binary = ":launcher_maker",
    toolchain_type = "launcher_maker_toolchain_type",
 )

--- a/tools/launcher/BUILD.tools
+++ b/tools/launcher/BUILD.tools
@@ -43,27 +43,27 @@ toolchain_type(name = "launcher_maker_toolchain_type")
 #  needing to build from source.
 IS_HOST_WINDOWS and single_binary_toolchain(
     name = "1_prebuilt_launcher",
-    binary = "launcher.exe",
+    target_binary = "launcher.exe",
     target_compatible_with = HOST_CONSTRAINTS,
     toolchain_type = ":launcher_toolchain_type",
 )
 
 single_binary_toolchain(
     name = "2_source_launcher_toolchain",
-    binary = "//src/tools/launcher",
+    target_binary = "//src/tools/launcher",
     target_compatible_with = ["@platforms//os:windows"],
     toolchain_type = ":launcher_toolchain_type",
 )
 
 single_binary_toolchain(
     name = "3_no_launcher_toolchain",
-    binary = "empty.sh",
+    target_binary = "empty.sh",
     toolchain_type = ":launcher_toolchain_type",
 )
 
 IS_HOST_WINDOWS and single_binary_toolchain(
     name = "1_prebuilt_launcher_maker",
-    binary = "launcher_maker.exe",
+    exec_binary = "launcher_maker.exe",
     exec_compatible_with = HOST_CONSTRAINTS,
     target_compatible_with = ["@platforms//os:windows"],
     toolchain_type = ":launcher_maker_toolchain_type",
@@ -71,13 +71,13 @@ IS_HOST_WINDOWS and single_binary_toolchain(
 
 single_binary_toolchain(
     name = "2_source_launcher_maker_toolchain",
-    binary = "//src/tools/launcher:launcher_maker",
+    exec_binary = "//src/tools/launcher:launcher_maker",
     target_compatible_with = ["@platforms//os:windows"],
     toolchain_type = ":launcher_maker_toolchain_type",
 )
 
 single_binary_toolchain(
     name = "3_no_launcher_maker_toolchain",
-    binary = "empty.sh",
+    exec_binary = "empty.sh",
     toolchain_type = ":launcher_maker_toolchain_type",
 )


### PR DESCRIPTION
### Description

Fix launcher/launcher_maker for cross build. launcher will be used in the build output, so it should use cfg=target. launcher_maker is used to combine a binary for target and launcher for target into the final output at build time, so it should use cfg=exec.

### Motivation

To make py_binary launcher work when building on linux (exec) for windows (target).

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Fix launcher/launcher_maker for cross build, e.g. build windows binary on linux machine.

Closes #29200.

PiperOrigin-RevId: 895761405
Change-Id: I0b3dd3431d25fb4fb9ea827f344eb5cf42c11276

Commit https://github.com/bazelbuild/bazel/commit/4ff312727ec3eedb4f1206127393819917ec2714