### PR TITLE
[9.0.2] Allow platform-specific startup bazelrc flags (https://github.com/baz…

### DIFF
--- a/docs/run/bazelrc.mdx
+++ b/docs/run/bazelrc.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Write bazelrc configuration files'
+title: "Write bazelrc configuration files"
 ---
 
 Bazel accepts many options. Some options are varied frequently (for example,
@@ -20,7 +20,6 @@ before the command (`build`, `test`, etc).
 1.  **The system RC file**, unless `--nosystem_rc` is present.
 
     Path:
-
     - On Linux/macOS/Unixes: `/etc/bazel.bazelrc`
     - On Windows: `%ProgramData%\bazel.bazelrc`
 
@@ -42,7 +41,6 @@ before the command (`build`, `test`, etc).
 3.  **The home RC file**, unless `--nohome_rc` is present.
 
     Path:
-
     - On Linux/macOS/Unixes: `$HOME/.bazelrc`
     - On Windows: `%USERPROFILE%\.bazelrc` if exists, or `%HOME%/.bazelrc`
 
@@ -54,13 +52,16 @@ before the command (`build`, `test`, etc).
     The environment variable can include multiple comma-separated paths.
 
 5.  **The user-specified RC file**, if specified with
-    <code>--bazelrc=<var>file</var></code>
+
+    <code>
+      --bazelrc=<var>file</var>
+    </code>
 
     This flag is optional but can also be specified multiple times.
 
     `/dev/null` indicates that all further `--bazelrc`s will be ignored, which
-     is useful to disable the search for a user rc file, such as in release
-     builds.
+    is useful to disable the search for a user rc file, such as in release
+    builds.
 
     For example:
 
@@ -89,13 +90,13 @@ relative to the workspace root, write `import %workspace%/path/to/bazelrc`.
 
 The difference between the various import statements is as follows:
 
-*   `import` - Bazel will fail if the `import`'ed file is missing (or can't be
-    read)
-*   `try-import` - An attempt to import the file will be made, but unlike
-    `import`, Bazel will NOT fail if the file is missing (or can't be read).
-*   `try-import-if-bazel-version` - Similar to `try-import`, but an additional
-    condition on the current Bazel version is checked before attempting to do
-    the import. See below for the syntax.
+- `import` - Bazel will fail if the `import`'ed file is missing (or can't be
+  read)
+- `try-import` - An attempt to import the file will be made, but unlike
+  `import`, Bazel will NOT fail if the file is missing (or can't be read).
+- `try-import-if-bazel-version` - Similar to `try-import`, but an additional
+  condition on the current Bazel version is checked before attempting to do
+  the import. See below for the syntax.
 
 Conditional Bazel version imports can be useful if a project needs to work under
 several Bazel versions or during the transition from one Bazel version to
@@ -140,30 +141,30 @@ try-import-if-bazel-version ~1 %workspace%/configs/v1_flags.rc
 
 Import precedence:
 
--   Options in the imported file take precedence over options specified before
-    the import statement.
--   Options specified after the import statement take precedence over the
-    options in the imported file.
--   Options in files imported later take precedence over files imported earlier.
+- Options in the imported file take precedence over options specified before
+  the import statement.
+- Options specified after the import statement take precedence over the
+  options in the imported file.
+- Options in files imported later take precedence over files imported earlier.
 
 #### Option defaults {:#option-defaults}
 
 Most lines of a bazelrc define default option values. The first word on each
 line specifies when these defaults are applied:
 
--   `startup`: startup options, which go before the command, and are described
-    in `bazel help startup_options`.
--   `common`: options that should be applied to all Bazel commands that support
-    them. If a command does not support an option specified in this way, the
-    option is ignored so long as it is valid for *some* other Bazel command.
-    Note that this only applies to option names: If the current command accepts
-    an option with the specified name, but doesn't support the specified value,
-    it will fail.
--   `always`: options that apply to all Bazel commands. If a command does not
-    support an option specified in this way, it will fail.
--   _`command`_: Bazel command, such as `build` or `query` to which the options
-    apply. These options also apply to all commands that inherit from the
-    specified command. (For example, `test` inherits from `build`.)
+- `startup`: startup options, which go before the command, and are described
+  in `bazel help startup_options`.
+- `common`: options that should be applied to all Bazel commands that support
+  them. If a command does not support an option specified in this way, the
+  option is ignored so long as it is valid for _some_ other Bazel command.
+  Note that this only applies to option names: If the current command accepts
+  an option with the specified name, but doesn't support the specified value,
+  it will fail.
+- `always`: options that apply to all Bazel commands. If a command does not
+  support an option specified in this way, it will fail.
+- _`command`_: Bazel command, such as `build` or `query` to which the options
+  apply. These options also apply to all commands that inherit from the
+  specified command. (For example, `test` inherits from `build`.)
 
 Each of these lines may be used more than once and the arguments that follow the
 first word are combined as if they had appeared on a single line. (Users of CVS,
@@ -186,44 +187,43 @@ so the effective flags are `--verbose_failures` and `--test_tmpdir=/tmp/bar`.
 
 Option precedence:
 
--   Options on the command line always take precedence over those in rc files.
-    For example, if a rc file says `build -c opt` but the command line flag is
-    `-c dbg`, the command line flag takes precedence.
--   Within the rc file, precedence is governed by specificity: lines for a more
-    specific command take precedence over lines for a less specific command.
+- Options on the command line always take precedence over those in rc files.
+  For example, if a rc file says `build -c opt` but the command line flag is
+  `-c dbg`, the command line flag takes precedence.
+- Within the rc file, precedence is governed by specificity: lines for a more
+  specific command take precedence over lines for a less specific command.
 
-    Specificity is defined by inheritance. Some commands inherit options from
-    other commands, making the inheriting command more specific than the base
-    command. For example `test` inherits from the `build` command, so all `bazel
-    build` flags are valid for `bazel test`, and all `build` lines apply also to
-    `bazel test` unless there's a `test` line for the same option. If the rc
-    file says:
+  Specificity is defined by inheritance. Some commands inherit options from
+  other commands, making the inheriting command more specific than the base
+  command. For example `test` inherits from the `build` command, so all `bazel
+build` flags are valid for `bazel test`, and all `build` lines apply also to
+  `bazel test` unless there's a `test` line for the same option. If the rc
+  file says:
 
-    ```posix-terminal
-    test -c dbg --test_env=PATH
+  ```posix-terminal
+  test -c dbg --test_env=PATH
 
-    build -c opt --verbose_failures
-    ```
+  build -c opt --verbose_failures
+  ```
 
-    then `bazel build //foo` will use `-c opt --verbose_failures`, and `bazel
-    test //foo` will use `--verbose_failures -c dbg --test_env=PATH`.
+  then `bazel build //foo` will use `-c opt --verbose_failures`, and `bazel
+test //foo` will use `--verbose_failures -c dbg --test_env=PATH`.
 
-    The inheritance (specificity) graph is:
+  The inheritance (specificity) graph is:
+  - Every command inherits from `common`
+  - The following commands inherit from (and are more specific than)
+    `build`: `test`, `run`, `clean`, `mobile-install`, `info`,
+    `print_action`, `config`, `cquery`, and `aquery`
+  - `coverage`, `fetch`, and `vendor` inherit from `test`
 
-    *   Every command inherits from `common`
-    *   The following commands inherit from (and are more specific than)
-        `build`: `test`, `run`, `clean`, `mobile-install`, `info`,
-        `print_action`, `config`, `cquery`, and `aquery`
-    *   `coverage`, `fetch`, and `vendor` inherit from `test`
+- Two lines specifying options for the same command at equal specificity are
+  parsed in the order in which they appear within the file.
 
--   Two lines specifying options for the same command at equal specificity are
-    parsed in the order in which they appear within the file.
-
--   Because this precedence rule does not match the file order, it helps
-    readability if you follow the precedence order within rc files: start with
-    `common` options at the top, and end with the most-specific commands at the
-    bottom of the file. This way, the order in which the options are read is the
-    same as the order in which they are applied, which is more intuitive.
+- Because this precedence rule does not match the file order, it helps
+  readability if you follow the precedence order within rc files: start with
+  `common` options at the top, and end with the most-specific commands at the
+  bottom of the file. This way, the order in which the options are read is the
+  same as the order in which they are applied, which is more intuitive.
 
 The arguments specified on a line of an rc file may include arguments that are
 not options, such as the names of build targets, and so on. These, like the
@@ -266,6 +266,11 @@ automatically enabled. Supported OS identifiers are `linux`, `macos`, `windows`,
 `--config=linux` on Linux, `--config=windows` on Windows, and so on.
 
 See [--enable_platform_specific_config](/reference/command-line-reference#flag--enable_platform_specific_config).
+
+Platform specific configurations also apply to `startup` options. For
+example `startup:linux --some_startup_option` will be applied when the
+host OS is Linux. Supported OS identifiers are `linux`, `macos`,
+`windows`, `freebsd`, and `openbsd`. This behavior is always enabled.
 
 #### Example {:#bazelrc-example}
 

--- a/site/en/run/bazelrc.md
+++ b/site/en/run/bazelrc.md
@@ -272,6 +272,11 @@ macOS, `--config=freebsd` on FreeBSD, and `--config=openbsd` on OpenBSD.
 
 See [--enable_platform_specific_config](/reference/command-line-reference#flag--enable_platform_specific_config).
 
+Platform specific configurations also apply to `startup` options. For
+example `startup:linux --some_startup_option` will be applied when the
+host OS is Linux. Supported OS identifiers are `linux`, `macos`,
+`windows`, `freebsd`, and `openbsd`. This behavior is always enabled.
+
 #### Example {:#bazelrc-example}
 
 Here's an example `~/.bazelrc` file:

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -619,6 +619,32 @@ blaze_exit_code::ExitCode OptionProcessor::ParseStartupOptions(
     }
   }
 
+  std::string platform_config;
+#if defined(__linux__)
+  platform_config = "linux";
+#elif defined(__APPLE__)
+  platform_config = "macos";
+#elif defined(_WIN32)
+  platform_config = "windows";
+#elif defined(__FreeBSD__)
+  platform_config = "freebsd";
+#elif defined(__OpenBSD__)
+  platform_config = "openbsd";
+#endif
+
+  if (!platform_config.empty()) {
+    for (const auto* blazerc : rc_files) {
+      const auto iter = blazerc->options().find("startup:" + platform_config);
+      if (iter == blazerc->options().end()) continue;
+
+      for (const RcOption& option : iter->second) {
+        const std::string& source_path =
+            blazerc->canonical_source_paths()[option.source_index];
+        rcstartup_flags.push_back({source_path, option.option});
+      }
+    }
+  }
+
   for (const std::string& arg : cmd_line_->startup_args) {
     if (!IsArg(arg)) {
       break;

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -92,6 +92,9 @@ public final class BlazeOptionHandler {
   // being ignored as long as they are recognized by at least one (other) command.
   static final String COMMON_PSEUDO_COMMAND = "common";
 
+  // Startup options are processed by the C++ client before the Java server starts.
+  private static final String STARTUP_PSEUDO_COMMAND = "startup";
+
   private static final ImmutableSet<String> BUILD_COMMAND_ANCESTORS =
       ImmutableSet.of("build", COMMON_PSEUDO_COMMAND, ALWAYS_PSEUDO_COMMAND);
 
@@ -697,7 +700,8 @@ public final class BlazeOptionHandler {
       }
       if (!validCommands.contains(command)
           && !command.equals(ALWAYS_PSEUDO_COMMAND)
-          && !command.equals(COMMON_PSEUDO_COMMAND)) {
+          && !command.equals(COMMON_PSEUDO_COMMAND)
+          && !command.equals(STARTUP_PSEUDO_COMMAND)) {
         eventHandler.handle(
             Event.warn(
                 "while reading option defaults file '"

--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -608,6 +608,56 @@ TEST_F(ParseOptionsTest, CommandLineBazelrcHasPriorityOverDefaultBazelrc) {
                    "--max_idle_secs=123\n"));
 }
 
+TEST_F(ParseOptionsTest, PlatformSpecificBazelrcOptions) {
+  std::string workspace_rc;
+  ASSERT_TRUE(
+      SetUpWorkspaceRcFile("startup --max_idle_secs=1\n"
+                           "startup:linux --max_idle_secs=2\n"
+                           "startup:macos --max_idle_secs=3\n"
+                           "startup:windows --max_idle_secs=4\n"
+                           "startup:freebsd --max_idle_secs=5\n"
+                           "startup:openbsd --max_idle_secs=6\n",
+                           &workspace_rc));
+
+  const std::vector<std::string> args = {binary_path_, "build"};
+  ParseOptionsAndCheckOutput(args, blaze_exit_code::SUCCESS, "", "");
+
+  int expected = 1;
+#if defined(__linux__)
+  expected = 2;
+#elif defined(__APPLE__)
+  expected = 3;
+#elif defined(_WIN32)
+  expected = 4;
+#elif defined(__FreeBSD__)
+  expected = 5;
+#elif defined(__OpenBSD__)
+  expected = 6;
+#endif
+
+  EXPECT_EQ(expected,
+            option_processor_->GetParsedStartupOptions()->max_idle_secs);
+
+  testing::internal::CaptureStderr();
+  option_processor_->PrintStartupOptionsProvenanceMessage();
+  const std::string output = testing::internal::GetCapturedStderr();
+
+  if (expected > 1) {
+    EXPECT_THAT(
+        output,
+        MatchesRegex(
+            "INFO: Reading 'startup' options from .*workspace.*bazelrc: "
+            "--max_idle_secs=1 --max_idle_secs=" +
+            std::to_string(expected) + "\n"));
+  } else {
+    EXPECT_THAT(
+        output,
+        MatchesRegex(
+            "INFO: Reading 'startup' options from .*workspace.*bazelrc: "
+            "--max_idle_secs=1\n"));
+  }
+}
+
 class BlazercImportTest : public ParseOptionsTest {
  protected:
   void TestBazelRcImportsMaintainsFlagOrdering(const std::string& import_type) {

--- a/src/test/cpp/rc_options_test.cc
+++ b/src/test/cpp/rc_options_test.cc
@@ -569,5 +569,32 @@ TEST(RemoteFileTest, ParsingRemoteFiles) {
                                                    "--max_idle_secs=123")))))));
 }
 
+TEST_F(RcOptionsTest, StartupConfigurationPlatformSpecific) {
+  WriteRc("startup_config.bazelrc",
+          "startup --max_idle_secs=10800  # Default\n"
+          "startup:linux --max_idle_secs=3600  # Linux specific\n"
+          "startup:linux --connect_timeout_secs=60  # Linux specific\n"
+          "startup:macos --max_idle_secs=1800  # macOS Specific\n"
+          "startup:macos --connect_timeout_secs=120  # macOS Specific\n");
+  SuccessfullyParseRcWithExpectedArgs(
+      "startup_config.bazelrc",
+      {{"startup", {"--max_idle_secs=10800"}},
+       {"startup:linux", {"--max_idle_secs=3600", "--connect_timeout_secs=60"}},
+       {"startup:macos",
+        {"--max_idle_secs=1800", "--connect_timeout_secs=120"}}});
+}
+
+TEST_F(RcOptionsTest, StartupConfigurationMultipleOptionsForPlatform) {
+  WriteRc("startup_config_multiple.bazelrc",
+          "startup:linux --host_jvm_args=-Xms256m\n"
+          "startup:linux --host_jvm_args=-Xmx2g\n"
+          "startup:linux --connect_timeout_secs=120\n");
+  SuccessfullyParseRcWithExpectedArgs(
+      "startup_config_multiple.bazelrc",
+      {{"startup:linux",
+        {"--host_jvm_args=-Xms256m", "--host_jvm_args=-Xmx2g",
+         "--connect_timeout_secs=120"}}});
+}
+
 }  // namespace
 }  // namespace blaze


### PR DESCRIPTION
…elbuild/bazel/pull/26882)

This enables the use of `startup:linux`, `startup:macos`, etc. This is always enabled.

Fixes https://github.com/bazelbuild/bazel/issues/22763

RELNOTES[inc]: Add support for `startup:linux`, `startup:macos`, etc bazelrc options.

Closes #26882.

PiperOrigin-RevId: 896083689
Change-Id: Id4da6e6689e337951664317755596cfd4ab52703

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/ea7b4ba1ea04795b850965a590006e54344307c0