### PR TITLE
[8.7.0] Fix an issue which causes hermetic sandbox mount /proc incorrectly.

### DIFF
--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -433,21 +433,45 @@ static void MakeFilesystemMostlyReadOnly() {
 }
 
 static void MountProcAndSys() {
-  // Mount a new proc on top of the old one, because the old one still refers to
-  // our parent PID namespace.
-  if (mount("/proc", "/proc", "proc", MS_NODEV | MS_NOEXEC | MS_NOSUID,
-            nullptr) < 0) {
-    DIE("mount /proc");
-  }
+  if (opt.hermetic) {
+    if (CreateTarget("proc", true) < 0) {
+      DIE("CreateTarget proc");
+    }
+    if (mount("proc", "proc", "proc", MS_NODEV | MS_NOEXEC | MS_NOSUID,
+              nullptr) < 0) {
+      DIE("mount proc");
+    }
 
-  if (opt.create_netns == NO_NETNS) {
-    return;
-  }
+    if (CreateTarget("sys", true) < 0) {
+      DIE("CreateTarget sys");
+    }
 
-  // Same for sys, but only if a separate network namespace was requested.
-  if (mount("none", "/sys", "sysfs",
-            MS_NOEXEC | MS_NOSUID | MS_NODEV | MS_RDONLY, nullptr) < 0) {
-    DIE("mount /sys");
+    if (opt.create_netns != NO_NETNS) {
+      if (mount("none", "sys", "sysfs",
+                MS_NOEXEC | MS_NOSUID | MS_NODEV | MS_RDONLY, nullptr) < 0) {
+        DIE("mount sys");
+      }
+    } else {
+      // In hermetic mode without a new network namespace, we cannot mount a
+      // fresh sysfs because we share the network namespace with the host (this
+      // fails with EPERM in a user namespace). Bind-mount the host /sys
+      // instead.
+      if (mount("/sys", "sys", nullptr, MS_BIND | MS_REC, nullptr) < 0) {
+        DIE("bind mount /sys to sys");
+      }
+    }
+  } else {
+    if (mount("proc", "/proc", "proc", MS_NODEV | MS_NOEXEC | MS_NOSUID,
+              nullptr) < 0) {
+      DIE("mount /proc");
+    }
+
+    if (opt.create_netns != NO_NETNS) {
+      if (mount("none", "/sys", "sysfs",
+                MS_NOEXEC | MS_NOSUID | MS_NODEV | MS_RDONLY, nullptr) < 0) {
+        DIE("mount /sys");
+      }
+    }
   }
 }
 
@@ -602,17 +626,31 @@ static void CreateEmptyFile() {
 
 static void MountDev() {
   if (CreateTarget("dev", true) < 0) {
-    DIE("CreateTarget /dev");
+    DIE("CreateTarget dev");
   }
-  const char *devs[] = {"/dev/null", "/dev/random", "/dev/urandom", "/dev/zero",
-                        NULL};
+
+  const char* devs[] = {"/dev/null", "/dev/random", "/dev/urandom",
+                        "/dev/zero", "/dev/full",   NULL};
   for (int i = 0; devs[i] != NULL; i++) {
     LinkFile(devs[i] + 1);
+    PRINT_DEBUG("bind mount: %s -> dev/%s", devs[i], devs[i] + 5);
     if (mount(devs[i], devs[i] + 1, NULL, MS_BIND, NULL) < 0) {
-      DIE("mount");
+      DIE("mount %s", devs[i]);
     }
   }
+
+  if (CreateTarget("dev/shm", true) == 0) {
+    PRINT_DEBUG("mounting tmpfs on dev/shm");
+    if (mount("tmpfs", "dev/shm", "tmpfs", MS_NOSUID | MS_NODEV, "mode=1777") <
+        0) {
+      DIE("mount dev/shm");
+    }
+  }
+
   SymlinkFile("/proc/self/fd", "dev/fd");
+  SymlinkFile("/proc/self/fd/0", "dev/stdin");
+  SymlinkFile("/proc/self/fd/1", "dev/stdout");
+  SymlinkFile("/proc/self/fd/2", "dev/stderr");
 }
 
 static void MountAllMounts() {

--- a/src/test/tools/BUILD
+++ b/src/test/tools/BUILD
@@ -26,7 +26,21 @@ cc_test(
 sh_test(
     name = "daemonize_test",
     srcs = ["daemonize_test.sh"],
-    data = ["//src/main/tools:daemonize"],
+    data = [
+        "//src/main/tools:daemonize",
+    ],
+    deps = [
+        "//src/test/shell:bashunit",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
+sh_test(
+    name = "linux-sandbox_test",
+    srcs = ["linux-sandbox_test.sh"],
+    data = [
+        "//src/main/tools:linux-sandbox",
+    ],
     deps = [
         "//src/test/shell:bashunit",
         "@bazel_tools//tools/bash/runfiles",

--- a/src/test/tools/BUILD
+++ b/src/test/tools/BUILD
@@ -41,6 +41,10 @@ sh_test(
     data = [
         "//src/main/tools:linux-sandbox",
     ],
+    tags = [
+        "no_macos",
+        "no_windows",
+    ],
     deps = [
         "//src/test/shell:bashunit",
         "@bazel_tools//tools/bash/runfiles",

--- a/src/test/tools/daemonize_test.sh
+++ b/src/test/tools/daemonize_test.sh
@@ -14,28 +14,7 @@
 
 set -euo pipefail
 
-# --- begin runfiles.bash initialization ---
-# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
-if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-  if [[ -f "$0.runfiles_manifest" ]]; then
-    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
-  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
-    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
-  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-    export RUNFILES_DIR="$0.runfiles"
-  fi
-fi
-if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
-elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
-            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
-else
-  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
-  exit 1
-fi
-# --- end runfiles.bash initialization ---
-
+source "${TEST_SRCDIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
 source "$(rlocation "io_bazel/src/test/shell/unittest.bash")"
 
 readonly DAEMONIZE=$(rlocation "io_bazel/src/main/tools/daemonize")

--- a/src/test/tools/linux-sandbox_test.sh
+++ b/src/test/tools/linux-sandbox_test.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "${TEST_SRCDIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+source "$(rlocation "io_bazel/src/test/shell/unittest.bash")"
+
+readonly LINUX_SANDBOX=$(rlocation "io_bazel/src/main/tools/linux-sandbox")
+
+set_up() {
+  cd "${TEST_TMPDIR}"
+  mkdir -p root/work
+}
+
+readonly VERIFICATION_SCRIPT='
+  FAILED=0
+  check_type() {
+    local path=$1
+    local expected=$2
+    local actual=$(stat -f -c %T "$path" 2>/dev/null)
+    if [ "$actual" != "$expected" ]; then
+      echo "Failure: $path type is not $expected (actual: $actual)"
+      FAILED=1
+    fi
+  }
+  check_symlink() {
+    local path=$1
+    if ! [ -L "$path" ]; then
+      echo "Failure: $path is not a symlink"
+      FAILED=1
+    fi
+  }
+  check_char_dev() {
+    local path=$1
+    if ! [ -c "$path" ]; then
+      echo "Failure: $path is not a character device"
+      FAILED=1
+    fi
+  }
+  check_dir() {
+    local path=$1
+    if ! [ -d "$path" ]; then
+      echo "Failure: $path is not a directory"
+      FAILED=1
+    fi
+  }
+
+  check_type /sys sysfs
+  check_type /proc proc
+  check_type /dev/shm tmpfs
+
+  check_symlink /dev/stdin
+  check_symlink /dev/stdout
+  check_symlink /dev/stderr
+
+  check_char_dev /dev/null
+  check_char_dev /dev/zero
+  check_char_dev /dev/full
+  check_char_dev /dev/random
+  check_char_dev /dev/urandom
+
+  check_dir /proc/self/fd
+
+  exit $FAILED
+'
+
+test_mounts_non_hermetic_no_netns() {
+  "${LINUX_SANDBOX}" -W "${TEST_TMPDIR}" -- /bin/sh -c "${VERIFICATION_SCRIPT}" \
+    &> "$TEST_log" || fail "sandbox not set up correctly"
+}
+
+test_mounts_non_hermetic_netns() {
+  "${LINUX_SANDBOX}" -n -W "${TEST_TMPDIR}" -- /bin/sh -c "${VERIFICATION_SCRIPT}" \
+    &> "$TEST_log" || fail "sandbox not set up correctly"
+}
+
+test_mounts_hermetic_no_netns() {
+  "${LINUX_SANDBOX}" -W "${TEST_TMPDIR}/root/work" -h "${TEST_TMPDIR}/root" \
+    -M /bin -m /bin -M /lib -m /lib -M /lib64 -m /lib64 -M /usr -m /usr \
+    -- /bin/sh -c "${VERIFICATION_SCRIPT}" \
+    &> "$TEST_log" || fail "sandbox not set up correctly"
+}
+
+test_mounts_hermetic_netns() {
+  "${LINUX_SANDBOX}" -n -W "${TEST_TMPDIR}/root/work" -h "${TEST_TMPDIR}/root" \
+    -M /bin -m /bin -M /lib -m /lib -M /lib64 -m /lib64 -M /usr -m /usr \
+    -- /bin/sh -c "${VERIFICATION_SCRIPT}" \
+    &> "$TEST_log" || fail "sandbox not set up correctly"
+}
+
+run_suite "linux-sandbox mounts tests"


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/28964.

PiperOrigin-RevId: 896590510
Change-Id: I9de1de6e2b57770a750d6b9a04bbc90042ea2eda

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/c115a593df81c73199276a1800c6325249734105