### PR TITLE
Remove --incompatible_use_cc_configure_from_rules_cc

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
@@ -193,21 +193,6 @@ instantiate and return a repository rule. Created by \
   }
 
   @Override
-  public void failWithIncompatibleUseCcConfigureFromRulesCc(StarlarkThread thread)
-      throws EvalException {
-    if (thread
-        .getSemantics()
-        .getBool(BuildLanguageOptions.INCOMPATIBLE_USE_CC_CONFIGURE_FROM_RULES_CC)) {
-      throw Starlark.errorf(
-          "Incompatible flag "
-              + "--incompatible_use_cc_configure_from_rules_cc has been flipped. Please use "
-              + "cc_configure and related logic from https://github.com/bazelbuild/rules_cc. "
-              + "See https://github.com/bazelbuild/bazel/issues/10134 for details and migration "
-              + "instructions.");
-    }
-  }
-
-  @Override
   public Object moduleExtension(
       StarlarkCallable implementation,
       Dict<?, ?> tagClasses, // Dict<String, TagClass>

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -1308,6 +1308,16 @@ public final class BazelRulesModule extends BlazeModule {
         metadataTags = {OptionMetadataTag.DEPRECATED},
         help = "No-op.")
     public abstract Label getProtoToolchainForJ2Objc();
+
+    @Deprecated
+    @Option(
+        name = "incompatible_use_cc_configure_from_rules_cc",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.DEPRECATED},
+        help = "No-op.")
+    public abstract boolean getIncompatibleUseCcConfigureFromRulesCc();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -474,18 +474,6 @@ public final class BuildLanguageOptions extends OptionsBase {
   public boolean incompatibleDoNotSplitLinkingCmdline;
 
   @Option(
-      name = "incompatible_use_cc_configure_from_rules_cc",
-      defaultValue = "false",
-      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "When true, Bazel will no longer allow using cc_configure from @bazel_tools. "
-              + "Please see https://github.com/bazelbuild/bazel/issues/10134 for details and "
-              + "migration instructions.")
-  public boolean incompatibleUseCcConfigureFromRulesCc;
-
-  @Option(
       name = "incompatible_unambiguous_label_stringification",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
@@ -897,8 +885,6 @@ public final class BuildLanguageOptions extends OptionsBase {
                 INCOMPATIBLE_DO_NOT_SPLIT_LINKING_CMDLINE, incompatibleDoNotSplitLinkingCmdline)
             .set(INCOMPATIBLE_ENFORCE_STARLARK_UTF8, incompatibleEnforceStarlarkUtf8)
             .setBool(
-                INCOMPATIBLE_USE_CC_CONFIGURE_FROM_RULES_CC, incompatibleUseCcConfigureFromRulesCc)
-            .setBool(
                 INCOMPATIBLE_UNAMBIGUOUS_LABEL_STRINGIFICATION,
                 incompatibleUnambiguousLabelStringification)
             .set(MAX_COMPUTATION_STEPS, maxComputationSteps)
@@ -1082,8 +1068,6 @@ public final class BuildLanguageOptions extends OptionsBase {
   public static final String INCOMPATIBLE_REQUIRE_MNEMONIC_FOR_RUN_ACTIONS =
       "-incompatible_require_mnemonic_for_run_actions";
 
-  public static final String INCOMPATIBLE_USE_CC_CONFIGURE_FROM_RULES_CC =
-      "-incompatible_use_cc_configure_from_rules";
   public static final String INCOMPATIBLE_UNAMBIGUOUS_LABEL_STRINGIFICATION =
       "+incompatible_unambiguous_label_stringification";
   public static final String INCOMPATIBLE_DISABLE_STARLARK_HOST_TRANSITIONS =

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/repository/RepositoryModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/repository/RepositoryModuleApi.java
@@ -265,13 +265,4 @@ public interface RepositoryModuleApi {
           """)
   interface TagClassApi extends StarlarkValue {}
 
-  @StarlarkMethod(
-      name = "__do_not_use_fail_with_incompatible_use_cc_configure_from_rules_cc",
-      doc =
-          "When --incompatible_use_cc_configure_from_rules_cc is set to true, Bazel will "
-              + "fail the build. Please see https://github.com/bazelbuild/bazel/issues/10134 for "
-              + "details and migration instructions.",
-      documented = false,
-      useStarlarkThread = true)
-  void failWithIncompatibleUseCcConfigureFromRulesCc(StarlarkThread thread) throws EvalException;
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryIntegrationTest.java
@@ -66,35 +66,6 @@ public class StarlarkRepositoryIntegrationTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testfailWithIncompatibleUseCcConfigureFromRulesCcDoesNothing() throws Exception {
-    // A simple test that recreates local_repository with Starlark.
-    scratch.file("/repo2/MODULE.bazel", "module(name='repo2')");
-    scratch.file("/repo2/bar.txt");
-    scratch.file("/repo2/BUILD", "filegroup(name='bar', srcs=['bar.txt'])");
-    scratch.file(
-        "def.bzl",
-        """
-        __do_not_use_fail_with_incompatible_use_cc_configure_from_rules_cc()
-
-        def _impl(repository_ctx):
-            repository_ctx.symlink(repository_ctx.attr.path, "")
-
-        repo = repository_rule(
-            implementation = _impl,
-            local = True,
-            attrs = {"path": attr.string(mandatory = True)},
-        )
-        """);
-    scratch.file(rootDirectory.getRelative("BUILD").getPathString());
-    scratch.overwriteFile(
-        rootDirectory.getRelative("MODULE.bazel").getPathString(),
-        "repo = use_repo_rule('//:def.bzl', 'repo')",
-        "repo(name='foo', path='/repo2')");
-    invalidatePackages();
-    getConfiguredTargetAndData("@@+repo+foo//:bar");
-  }
-
-  @Test
   public void testStarlarkSymlinkFileFromRepository() throws Exception {
     // This test creates a symbolic link BUILD -> bar.txt.
     scratch.file("/repo2/bar.txt", "filegroup(name='bar', srcs=['foo.txt'])");

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -154,7 +154,6 @@ public class ConsistencyTest {
         "--incompatible_no_implicit_file_export=" + rand.nextBoolean(),
         "--incompatible_no_rule_outputs_param=" + rand.nextBoolean(),
         "--incompatible_run_shell_command_string=" + rand.nextBoolean(),
-        "--incompatible_use_cc_configure_from_rules_cc=" + rand.nextBoolean(),
         "--incompatible_unambiguous_label_stringification=" + rand.nextBoolean(),
         "--incompatible_resolve_select_keys_eagerly=" + rand.nextBoolean(),
         "--internal_starlark_flag_test_canary=" + rand.nextBoolean(),
@@ -200,8 +199,6 @@ public class ConsistencyTest {
         .setBool(BuildLanguageOptions.INCOMPATIBLE_NO_IMPLICIT_FILE_EXPORT, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_NO_RULE_OUTPUTS_PARAM, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_RUN_SHELL_COMMAND_STRING, rand.nextBoolean())
-        .setBool(
-            BuildLanguageOptions.INCOMPATIBLE_USE_CC_CONFIGURE_FROM_RULES_CC, rand.nextBoolean())
         .setBool(
             BuildLanguageOptions.INCOMPATIBLE_UNAMBIGUOUS_LABEL_STRINGIFICATION, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_RESOLVE_SELECT_KEYS_EAGERLY, rand.nextBoolean())


### PR DESCRIPTION
Seems to me like this has been obsoleted by a different rules_cc
strategy. cc_configure is already in rules_cc for 9.x+

Closes https://github.com/bazelbuild/bazel/issues/10134
