### PR TITLE
[8.7.0] Make main_output public API

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_common.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_common.bzl
@@ -74,7 +74,7 @@ def _link(
         always_link = _UNBOUND,
         only_for_dynamic_libs = _UNBOUND,
         link_artifact_name_suffix = _UNBOUND,
-        main_output = _UNBOUND,
+        main_output = None,
         use_shareable_artifact_factory = _UNBOUND,
         build_config = _UNBOUND,
         emit_interface_shared_library = _UNBOUND):
@@ -93,7 +93,6 @@ def _link(
        always_link != _UNBOUND or \
        only_for_dynamic_libs != _UNBOUND or \
        link_artifact_name_suffix != _UNBOUND or \
-       main_output != _UNBOUND or \
        use_shareable_artifact_factory != _UNBOUND or \
        build_config != _UNBOUND or \
        emit_interface_shared_library != _UNBOUND:
@@ -117,8 +116,6 @@ def _link(
         only_for_dynamic_libs = False
     if link_artifact_name_suffix == _UNBOUND:
         link_artifact_name_suffix = ""
-    if main_output == _UNBOUND:
-        main_output = None
     if use_shareable_artifact_factory == _UNBOUND:
         use_shareable_artifact_factory = False
     if build_config == _UNBOUND:

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -6436,14 +6436,6 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testCustomNameOutputArtifactRaisesError() throws Exception {
-    setupTestTransitiveLink(scratch, "output_type = 'dynamic_library'", " main_output=None");
-
-    AssertionError e = assertThrows(AssertionError.class, () -> getConfiguredTarget("//foo:bin"));
-    assertThat(e).hasMessageThat().contains("cannot use private API");
-  }
-
-  @Test
   public void testInterfaceLibraryProducedForTransitiveLinkOnWindows() throws Exception {
     getAnalysisMock()
         .ccSupport()


### PR DESCRIPTION
This is a cherry pick of https://github.com/bazelbuild/rules_cc/commit/170205b046318052d5009d595a337a65ff8fa425 since on this branch this code hasn't moved to rules_cc. This also cherry picks the test fix from 6b4c9bc7db8f007f3a922519614223f357c46bd7