### PR TITLE
Allow passing a dictionary for resource_set

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -849,10 +849,14 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
     }
 
     if (resourceSetUnchecked != Starlark.NONE) {
-      validateResourceSetBuilder(resourceSetUnchecked);
-      builder.setResources(
-          StarlarkActionResourceSetBuilder.create(
-              (StarlarkCallable) resourceSetUnchecked, mnemonic, getSemantics()));
+      if (resourceSetUnchecked instanceof Dict) {
+        builder.setResources(parseResourceSetFromDict(resourceSetUnchecked));
+      } else {
+        validateResourceSetBuilder(resourceSetUnchecked);
+        builder.setResources(
+            StarlarkActionResourceSetBuilder.create(
+                (StarlarkCallable) resourceSetUnchecked, mnemonic, getSemantics()));
+      }
     }
 
     // Always register the action
@@ -965,7 +969,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       }
     }
 
-    private static double getNumericOrDefault(
+    static double getNumericOrDefault(
         Map<String, Object> resourceSetMap, String key, double defaultValue) throws EvalException {
       if (!resourceSetMap.containsKey(key)) {
         return defaultValue;
@@ -1002,6 +1006,29 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
     public int hashCode() {
       return Objects.hashCode(fn, mnemonic, semantics);
     }
+  }
+
+  private static ResourceSet parseResourceSetFromDict(Object resourceSetUnchecked)
+      throws EvalException {
+    Map<String, Object> resourceSetMapRaw =
+        Dict.cast(resourceSetUnchecked, String.class, Object.class, "resource_set");
+
+    if (!validResources.containsAll(resourceSetMapRaw.keySet())) {
+      String message =
+          String.format(
+              "Illegal resource keys: (%s)",
+              Joiner.on(",").join(Sets.difference(resourceSetMapRaw.keySet(), validResources)));
+      throw Starlark.errorf("%s", message);
+    }
+
+    return ResourceSet.create(
+        StarlarkActionResourceSetBuilder.getNumericOrDefault(
+            resourceSetMapRaw, ResourceSet.MEMORY, DEFAULT_RESOURCE_SET.getMemoryMb()),
+        StarlarkActionResourceSetBuilder.getNumericOrDefault(
+            resourceSetMapRaw, ResourceSet.CPU, DEFAULT_RESOURCE_SET.getCpuUsage()),
+        (int)
+            StarlarkActionResourceSetBuilder.getNumericOrDefault(
+                resourceSetMapRaw, "local_test", DEFAULT_RESOURCE_SET.getLocalTestCount()));
   }
 
   private static void validateResourceSetBuilder(Object fn) throws EvalException {

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -575,22 +575,24 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             name = "resource_set",
             allowedTypes = {
               @ParamType(type = StarlarkCallable.class),
+              @ParamType(type = Dict.class),
               @ParamType(type = NoneType.class),
             },
             defaultValue = "None",
             named = true,
             positional = false,
             doc =
-                "A callback function that returns a resource set dictionary, used to estimate"
-                    + " resource usage at execution time if this action is run locally.<p>The"
-                    + " function accepts two positional arguments: a string representing an OS name"
-                    + " (e.g. \"osx\"), and an integer representing the number of inputs to the"
-                    + " action. The returned dictionary may contain the following entries, each of"
-                    + " which may be a float or an int:<ul><li>\"cpu\": number of CPUs; default"
-                    + " 1<li>\"memory\": in MB; default 250<li>\"local_test\": number of local"
-                    + " tests; default 1</ul><p>If this parameter is set to <code>None</code> , the"
-                    + " default values are used.<p>The callback must be top-level (lambda and"
-                    + " nested functions aren't allowed)."),
+                "A callback function or dictionary used to estimate resource usage at execution"
+                    + " time if this action is run locally.<p>If a dictionary is passed directly, it"
+                    + " may contain the following entries, each of which may be a float or an"
+                    + " int:<ul><li>\"cpu\": number of CPUs; default 1<li>\"memory\": in MB; default"
+                    + " 250<li>\"local_test\": number of local tests; default 1</ul><p>If a callback"
+                    + " function is passed, it accepts two positional arguments: a string"
+                    + " representing an OS name (e.g. \"osx\"), and an integer representing the"
+                    + " number of inputs to the action. It must return a dictionary with the same"
+                    + " entries described above. The callback must be top-level (lambda and nested"
+                    + " functions aren't allowed).<p>If this parameter is set to <code>None</code>,"
+                    + " the default values are used."),
         @Param(
             name = "toolchain",
             allowedTypes = {
@@ -826,14 +828,15 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             name = "resource_set",
             allowedTypes = {
               @ParamType(type = StarlarkCallable.class),
+              @ParamType(type = Dict.class),
               @ParamType(type = NoneType.class),
             },
             defaultValue = "None",
             named = true,
             positional = false,
             doc =
-                "A callback function for estimating resource usage if run locally. See"
-                    + "<a href=\"#run.resource_set\"><code>ctx.actions.run()</code></a>."),
+                "A callback function or dictionary for estimating resource usage if run locally."
+                    + " See <a href=\"#run.resource_set\"><code>ctx.actions.run()</code></a>."),
         @Param(
             name = "toolchain",
             allowedTypes = {

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
@@ -976,6 +976,66 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testCreateStarlarkActionArgumentsWithResourceSet_dict() throws Exception {
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+
+    ev.exec(
+        "ruleContext.actions.run(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = ruleContext.files.srcs,",
+        "  resource_set = {\"cpu\": 4, \"memory\": 512},",
+        "  executable = 'executable')");
+    StarlarkAction action =
+        (StarlarkAction)
+            Iterables.getOnlyElement(
+                ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
+
+    assertThat(action.getResourceSetOrBuilder().buildResourceSet(OS.LINUX, 0))
+        .isEqualTo(ResourceSet.create(512, 4, 0));
+    assertThat(action.getResourceSetOrBuilder().buildResourceSet(OS.DARWIN, 100))
+        .isEqualTo(ResourceSet.create(512, 4, 0));
+  }
+
+  @Test
+  public void testCreateStarlarkActionArgumentsWithResourceSet_dictAllKeys() throws Exception {
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+
+    ev.exec(
+        "ruleContext.actions.run(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = ruleContext.files.srcs,",
+        "  resource_set = {\"cpu\": 8, \"memory\": 1024, \"local_test\": 2},",
+        "  executable = 'executable')");
+    StarlarkAction action =
+        (StarlarkAction)
+            Iterables.getOnlyElement(
+                ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
+
+    assertThat(action.getResourceSetOrBuilder().buildResourceSet(OS.LINUX, 0))
+        .isEqualTo(ResourceSet.create(1024, 8, 2));
+  }
+
+  @Test
+  public void testCreateStarlarkActionArgumentsWithResourceSet_dictIllegalKeys() throws Exception {
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+
+    EvalException thrown =
+        assertThrows(
+            EvalException.class,
+            () ->
+                ev.exec(
+                    "ruleContext.actions.run(",
+                    "  inputs = ruleContext.files.srcs,",
+                    "  outputs = ruleContext.files.srcs,",
+                    "  resource_set = {\"cpu\": 4, \"gpu\": 1},",
+                    "  executable = 'executable')"));
+    assertThat(thrown).hasMessageThat().contains("Illegal resource keys: (gpu)");
+  }
+
+  @Test
   public void testCreateStarlarkActionArgumentsWithoutUnusedInputsList() throws Exception {
     StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
     setRuleContext(ruleContext);


### PR DESCRIPTION
Previously this only allowed a top level starlark function. Now users
still can't pass lambdas but they can pass pre-computed dictionaries
with the relevant elements. This is useful since at the action creation
time the rule author can very likely know these ballpark resource
requests, but they don't have all the context from a top level function.

Fixes https://github.com/bazelbuild/bazel/issues/15187
