### PR TITLE
Remove incompatible_use_specific_tool_files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -552,6 +552,16 @@ public final class BazelRulesModule extends BlazeModule {
 
     @Deprecated
     @Option(
+        name = "incompatible_use_specific_tool_files",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getUseSpecificToolFiles();
+
+    @Deprecated
+    @Option(
         name = "incompatible_load_python_rules_from_bzl",
         defaultValue = "false",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
@@ -290,8 +290,7 @@ public final class CppCompileActionBuilder implements StarlarkValue {
     addTransitiveMandatoryInputs(
         getShouldScanIncludes()
             ? compilerFilesWithoutIncludes
-            : configuration.getFragment(CppConfiguration.class).useSpecificToolFiles()
-                    && !getSourceFile().isTreeArtifact()
+            : !getSourceFile().isTreeArtifact()
                 ? (getActionName().equals(CppActionNames.ASSEMBLE)
                     ? ccToolchain.getAsFiles()
                     : ccToolchain.getCompilerFiles())

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -792,17 +792,13 @@ public final class CppConfiguration extends Fragment
     return cppOptions.getSaveFeatureState();
   }
 
-  public boolean useSpecificToolFiles() {
-    return cppOptions.getUseSpecificToolFiles();
-  }
-
   @StarlarkMethod(
       name = "incompatible_use_specific_tool_files",
       documented = false,
       useStarlarkThread = true)
   public boolean useSpecificToolFilesForStarlark(StarlarkThread thread) throws EvalException {
     CcModule.checkPrivateStarlarkificationAllowlist(thread);
-    return cppOptions.getUseSpecificToolFiles();
+    return true;
   }
 
   public boolean disableNoCopts() {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -874,17 +874,6 @@ public abstract class CppOptions extends FragmentOptions {
   public abstract boolean getSaveFeatureState();
 
   @Option(
-      name = "incompatible_use_specific_tool_files",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "Use cc toolchain's compiler_files, as_files, and ar_files as inputs to appropriate "
-              + "actions. See https://github.com/bazelbuild/bazel/issues/8531")
-  public abstract boolean getUseSpecificToolFiles();
-
-  @Option(
       name = "incompatible_disable_nocopts",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -277,7 +277,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:incompatible_dont_enable_host_nonhost_crosstool_features",
         "//command_line_option:incompatible_require_ctx_in_configure_features",
         "//command_line_option:incompatible_make_thinlto_command_lines_standalone",
-        "//command_line_option:incompatible_use_specific_tool_files",
         "//command_line_option:incompatible_disable_nocopts",
         "//command_line_option:incompatible_validate_top_level_header_inclusions",
         "//command_line_option:strict_system_includes",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainTest.java
@@ -909,7 +909,6 @@ public final class CcToolchainTest extends BuildViewTestCase {
         .setupCcToolchainConfig(
             mockToolsConfig,
             CcToolchainConfig.builder().withFeatures(CppRuleClasses.SUPPORTS_DYNAMIC_LINKER));
-    useConfiguration("--incompatible_use_specific_tool_files");
     ConfiguredTarget target = getConfiguredTarget("//a:a");
     CcToolchainProvider toolchainProvider = CcToolchainProvider.getFromTarget(target);
     RuleConfiguredTarget libTarget = (RuleConfiguredTarget) getConfiguredTarget("//a:l");

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -2422,8 +2422,6 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
             srcs = ["a.S"],
         )
         """);
-    useConfiguration("--incompatible_use_specific_tool_files");
-
     ConfiguredTarget target = getConfiguredTarget("//a:a");
     CcToolchainProvider toolchainProvider = CcToolchainProvider.getFromTarget(target);
 


### PR DESCRIPTION
This was flipped before bazel 1.0 in 030ca7fb98c56bfc63f5dc9e61e6a89c4b274293
