### PR TITLE
docs: Update docs for `--downloader_config`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -297,17 +297,17 @@ public abstract class RepositoryOptions extends OptionsBase {
           and preceded by a `#`. Example: `# evil.com is known to host malicious code`
 
           The `allow` and `block` directives take a host name as an argument. For
-          example: `block mvnrepository.com` or `allow github.com`. The given host
+          example: `block mvnrepository.com.example` or `allow github.com.example`. The given host
           and all subdomains will be allowed or blocked. Do not include the URL
           scheme (`http://` or `https://`). You can block all hosts with the `*`
           wildcard: `block *`.
 
           The `rewrite` directive takes two regex patterns: the first to match a URL
           and the second to substitute matched URLs with. For example, `rewrite
-          github.com/bazel-contrib/rules_python/releases/download/(.*)/(.*)
-          mycorp.com/rules_python_mirror/$1/$2` will cause the downloader
-          to access `mycorp.com/rules_python_mirror` whenever attempting
-          to download rules_python from GitHub. The substitute URL supports
+          github.com.example/bazel-contrib/rules_python/releases/download/(.*)/(.*)
+          mycorp.example/rules_python_mirror/$1/$2` will cause the downloader
+          to access `mycorp.example/rules_python_mirror` whenever attempting
+          to download rules_python from example.com. The substitute URL supports
           back-references starting from `$1`. It is possible for multiple
           `rewrite` directives for the same matched URL to be provided, and in
           this case multiple URLs will be returned and tried sequentially. Do not
@@ -324,23 +324,23 @@ public abstract class RepositoryOptions extends OptionsBase {
           worked around by rewrite the path to a blocked host:
 
           ```
-          block dummy_host.com
-          rewrite foo.com/bar/.* dummy_host.com
+          block dummy_host.invalid
+          rewrite example.com/bar/.* dummy_host.invalid
           ```
 
           An example config may look like:
 
           ```
-          all_blocked_message See mycorp.com/blocked-bazel-fetches for more information.
-          block mvnrepository.com
-          block maven-central.storage.googleapis.com
+          all_blocked_message See example.com/blocked-bazel-fetches for more information.
+          block mvnrepository.com.example
+          block maven-central.storage.googleapis.com.example
 
           # See internal doc id1234 for why gitblit is blocked
-          block gitblit.github.io
-          rewrite repo.maven.apache.org/maven2/(.*) artifacts.mycorp.com/libs-release/$1
+          block gitblit.github.com.example
+          rewrite repo.maven.apache.org.example/maven2/(.*) artifacts.mycorp.example/libs-release/$1
 
           # Use our GCS bucket for rules_python
-          rewrite github.com/bazel-contrib/rules_python/releases/download/(.*)/(.*) mycorp.com/rules_python_mirror/$1/$2
+          rewrite github.com.example/bazel-contrib/rules_python/releases/download/(.*)/(.*) mycorp.example/rules_python_mirror/$1/$2
           ```
 
           See also: [Insulating Builds from the Internet]

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -285,12 +285,68 @@ public abstract class RepositoryOptions extends OptionsBase {
       effectTags = {OptionEffectTag.UNKNOWN},
       converter = OptionsUtils.PathFragmentConverter.class,
       help =
-          "Specify a file to configure the remote downloader with. This file consists of lines, "
-              + "each of which starts with a directive (`allow`, `block` or `rewrite`) followed "
-              + "by either a host name (for `allow` and `block`) or two patterns, one to match "
-              + "against, and one to use as a substitute URL, with back-references starting from "
-              + "`$1`. It is possible for multiple `rewrite` directives for the same URL to be "
-              + "given, and in this case multiple URLs will be returned.")
+          """
+          Specify a file to configure the remote downloader with.
+
+          This file consists of directives, one per line, that adjust how the
+          Bazel downloader acts. The directives are: `allow`, `block`, `rewrite`,
+          and `all_blocked_message`. The directives are applied in the order
+          `rewrite, allow, block'.
+
+          Comments are allowed and must be on their own line (no trailing comments)
+          and preceded by a `#`. Example: `# evil.com is known to host malicious code`
+
+          The `allow` and `block` directives take a host name as an argument. For
+          example: `block mvnrepository.com` or `allow github.com`. The given host
+          and all subdomains will be allowed or blocked. Do not include the URL
+          scheme (`http://` or `https://`). You can block all hosts with the `*`
+          wildcard: `block *`.
+
+          The `rewrite` directive takes two regex patterns: the first to match a URL
+          and the second to substitute matched URLs with. For example, `rewrite
+          github.com/bazel-contrib/rules_python/releases/download/(.*)/(.*)
+          mycorp.com/rules_python_mirror/$1/$2` will cause the downloader
+          to access `mycorp.com/rules_python_mirror` whenever attempting
+          to download rules_python from GitHub. The substitute URL supports
+          back-references starting from `$1`. It is possible for multiple
+          `rewrite` directives for the same matched URL to be provided, and in
+          this case multiple URLs will be returned and tried sequentially. Do not
+          include the URL scheme (`http://` or `https://`) in the patterns.
+
+          The `all_blocked_message` directive allows you to customize the message
+          that is shown when the rewriter is configured to block all URLs for
+          a particular resource. This directive can only be given once, and the
+          message must exist on a single line. Example: `all_blocked_message
+          Hey, I think the downloader config is wrong. Bummer!`.
+
+          Note that it is not possible to directly block a particular path for
+          a given host while still allowing other paths on the host. This can be
+          worked around by rewrite the path to a blocked host:
+
+          ```
+          block dummy_host.com
+          rewrite foo.com/bar/.* dummy_host.com
+          ```
+
+          An example config may look like:
+
+          ```
+          all_blocked_message See mycorp.com/blocked-bazel-fetches for more information.
+          block mvnrepository.com
+          block maven-central.storage.googleapis.com
+
+          # See internal doc id1234 for why gitblit is blocked
+          block gitblit.github.io
+          rewrite repo.maven.apache.org/maven2/(.*) artifacts.mycorp.com/libs-release/$1
+
+          # Use our GCS bucket for rules_python
+          rewrite github.com/bazel-contrib/rules_python/releases/download/(.*)/(.*) mycorp.com/rules_python_mirror/$1/$2
+          ```
+
+          See also: [Insulating Builds from the Internet]
+
+          [Insulating Builds from the Internet]: https://bazel.build/external/faq#how-do-i-insulate-my-builds-from-the-internet
+          """)
   public abstract List<PathFragment> getDownloaderConfigs();
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java
@@ -48,17 +48,17 @@ import net.starlark.java.syntax.Location;
  * The directives are applied in the order `rewrite, allow, block'. An example config may look like:
  *
  * <pre>
- *     all_blocked_message See mycorp.com/blocked-bazel-fetches for more information.
- *     block mvnrepository.com
- *     block maven-central.storage.googleapis.com
- *     block gitblit.github.io
- *     rewrite repo.maven.apache.org/maven2/(.*) artifacts.mycorp.com/libs-release/$1
+ *     all_blocked_message See example.com/blocked-bazel-fetches for more information.
+ *     block mvnrepository.com.example
+ *     block maven-central.storage.googleapis.com.example
+ *     block gitblit.github.io.example
+ *     rewrite repo.maven.apache.org.example/maven2/(.*) artifacts.example.com/libs-release/$1
  *
- *     block github.com
- *     rewrite github.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(.*) \
- *             artifacts.mycorp.com/github-releases/$1/$2/releases/download/$3/$4
- *     rewrite github.com/([^/]+)/([^/]+)/archive/(.+).(tar.gz|zip) \
- *             artifacts.mycorp.com/api/vcs/downloadRelease/github.com/$1/$2/$3?ext=$4
+ *     block github.com.example
+ *     rewrite github.com.example/([^/]+)/([^/]+)/releases/download/([^/]+)/(.*) \
+ *             artifacts.example.com/github-releases/$1/$2/releases/download/$3/$4
+ *     rewrite github.com.example/([^/]+)/([^/]+)/archive/(.+).(tar.gz|zip) \
+ *             artifacts.example.com/api/vcs/downloadRelease/github.com.example/$1/$2/$3?ext=$4
  * </pre>
  *
  * In addition, you can block all hosts using the {@code *} wildcard.


### PR DESCRIPTION
### Description

Update the documentation for `--downloader_config`. This is basically just a rehash of what's already in `src/main/.../bazel/repository/downloader/UrlRewriterConfig.java`

### Motivation

The docs were unclear to me (see https://github.com/bazelbuild/bazel/issues/29286#issuecomment-4240432883) so I figured I'd clean them up.

### Build API Changes

No

### Checklist

- [ N/A ] I have added tests for the new use cases (if any).
- [ Y ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
