### PR TITLE
[9.1.0] Add an implicit `_sort_key` field to module extension tags (https://github.com/bazelbuild/bazel/pull/27883)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
@@ -19,6 +19,7 @@ import static com.google.common.base.StandardSystemProperty.OS_ARCH;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
@@ -338,15 +339,18 @@ final class RegularRunnableExtension implements RunnableExtension {
             .getRelative(LabelConstants.MODULE_EXTENSION_WORKING_DIRECTORY_LOCATION)
             .getRelative(usagesValue.getExtensionUniqueName());
     ArrayList<StarlarkBazelModule> modules = new ArrayList<>();
-    for (AbridgedModule abridgedModule : usagesValue.getAbridgedModules()) {
-      ModuleKey moduleKey = abridgedModule.getKey();
+    ImmutableList<AbridgedModule> abridgedModules = usagesValue.getAbridgedModules();
+    for (int i = 0; i < abridgedModules.size(); i++) {
+      var abridgedModule = abridgedModules.get(i);
+      var moduleKey = abridgedModule.getKey();
       modules.add(
           StarlarkBazelModule.create(
               abridgedModule,
               extension,
               usagesValue.getRepoMappings().get(moduleKey),
               usagesValue.getExtensionUsages().get(moduleKey),
-              staticRepoMappingRecorder));
+              staticRepoMappingRecorder,
+              i));
     }
     ModuleExtensionUsage rootUsage = usagesValue.getExtensionUsages().get(ModuleKey.ROOT);
     boolean rootModuleHasNonDevDependency =

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModule.java
@@ -52,15 +52,23 @@ public class StarlarkBazelModule implements StarlarkValue {
       name = "bazel_module_tags",
       category = DocCategory.BUILTIN,
       doc =
-          "Contains the tags in a module for the module extension currently being processed. This"
-              + " object has a field for each tag class of the extension, and the value of the"
-              + " field is a list containing an object for each tag instance. This \"tag instance\""
-              + " object in turn has a field for each attribute of the tag class.\n\n"
-              + "When passed as positional arguments to <code>print()</code> or <code>fail()"
-              + "</code>, tag instance objects turn into a meaningful string representation of the"
-              + " form \"'install' tag at /home/user/workspace/MODULE.bazel:3:4\". This can be used"
-              + " to construct error messages that point to the location of the tag in the module"
-              + " file, e.g. <code>fail(\"Conflict between\", tag1, \"and\", tag2)</code>.")
+          """
+          Contains the tags in a module for the module extension currently being processed. This \
+          object has a field for each tag class of the extension, and the value of the field is a \
+          list containing an object for each tag instance. This "tag instance" object in turn has \
+          a field for each attribute of the tag class.
+          <p>Tag instance objects have a <code>_sort_key</code> field that returns an opaque value \
+          that can be compared with other sort keys to determine the relative order of tags, even \
+          across tag classes. Tags are ordered by their position within a module file and by the \
+          BFS ordering of modules in the dependency graph. This can be used with \
+          <code>sorted()</code> to recover the original order of tags: \
+          <code>sorted(tags, key=lambda tag: tag._sort_key)</code>.
+          <p>When passed as positional arguments to <code>print()</code> or <code>fail()</code>, \
+          tag instance objects turn into a meaningful string representation of the form "'install' \
+          tag at /home/user/workspace/MODULE.bazel:3:4". This can be used to construct error \
+          messages that point to the location of the tag in the module file, e.g. \
+          <code>fail("Conflict between", tag1, "and", tag2)</code>.\
+          """)
   static class Tags implements Structure {
     private final ImmutableMap<String, StarlarkList<TypeCheckedTag>> typeCheckedTags;
 
@@ -109,7 +117,8 @@ public class StarlarkBazelModule implements StarlarkValue {
       ModuleExtension extension,
       RepositoryMapping repoMapping,
       @Nullable ModuleExtensionUsage usage,
-      Label.RepoMappingRecorder repoMappingRecorder)
+      Label.RepoMappingRecorder repoMappingRecorder,
+      int moduleIndex)
       throws ExternalDepsException {
     LabelConverter labelConverter =
         new LabelConverter(
@@ -121,7 +130,8 @@ public class StarlarkBazelModule implements StarlarkValue {
     for (String tagClassName : extension.tagClasses().keySet()) {
       typeCheckedTags.put(tagClassName, new ArrayList<>());
     }
-    for (Tag tag : tags) {
+    for (int tagIndex = 0; tagIndex < tags.size(); tagIndex++) {
+      Tag tag = tags.get(tagIndex);
       TagClass tagClass = extension.tagClasses().get(tag.getTagName());
       if (tagClass == null) {
         throw ExternalDepsException.withMessage(
@@ -140,7 +150,12 @@ public class StarlarkBazelModule implements StarlarkValue {
           .get(tag.getTagName())
           .add(
               TypeCheckedTag.create(
-                  tagClass, tag, labelConverter, module.getKey().toDisplayString()));
+                  tagClass,
+                  tag,
+                  labelConverter,
+                  module.getKey().toDisplayString(),
+                  moduleIndex,
+                  tagIndex));
     }
     return new StarlarkBazelModule(
         module.getName(),

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTag.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTag.java
@@ -16,14 +16,18 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.bazel.repository.AttributeUtils;
 import com.google.devtools.build.lib.packages.LabelConverter;
 import com.google.devtools.build.lib.server.FailureDetails.ExternalDeps.Code;
+import java.util.Comparator;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.StarlarkSemantics;
 import net.starlark.java.eval.StarlarkThread;
+import net.starlark.java.eval.StarlarkValue;
 import net.starlark.java.eval.Structure;
 import net.starlark.java.spelling.SpellChecker;
 import net.starlark.java.syntax.Location;
@@ -34,9 +38,44 @@ import net.starlark.java.syntax.Location;
  */
 @StarlarkBuiltin(name = "bazel_module_tag", documented = false)
 public class TypeCheckedTag implements Structure {
+
+  /**
+   * An opaque object that can be used to sort tags in the order they are defined across all tag
+   * classes within a module file and across modules in BFS order.
+   */
+  @StarlarkBuiltin(name = "sort_key", documented = false)
+  private record SortKey(int moduleIndex, int tagIndex)
+      implements StarlarkValue, Comparable<SortKey> {
+    private static final Comparator<SortKey> COMPARATOR =
+        Comparator.comparingInt(SortKey::moduleIndex).thenComparingInt(SortKey::tagIndex);
+
+    @Override
+    public boolean isImmutable() {
+      return true;
+    }
+
+    @Override
+    public int compareTo(SortKey other) {
+      return COMPARATOR.compare(this, other);
+    }
+
+    @Override
+    public void repr(Printer printer, StarlarkSemantics semantics) {
+      printer.append("<sort_key>");
+    }
+
+    @Override
+    public void debugPrint(Printer printer, StarlarkThread thread) {
+      printer.append("<sort_key module=%d tag=%d>".formatted(moduleIndex, tagIndex));
+    }
+  }
+
+  private static final String SORT_KEY = "_sort_key";
+
   private final TagClass tagClass;
   private final ImmutableList<Object> attrValues;
   private final boolean devDependency;
+  private final SortKey sortKey;
 
   // The properties below are only used for error reporting.
   private final Location location;
@@ -46,18 +85,26 @@ public class TypeCheckedTag implements Structure {
       TagClass tagClass,
       ImmutableList<Object> attrValues,
       boolean devDependency,
+      int moduleIndex,
+      int tagIndex,
       Location location,
       String tagClassName) {
     this.tagClass = tagClass;
     this.attrValues = attrValues;
     this.devDependency = devDependency;
+    this.sortKey = new SortKey(moduleIndex, tagIndex);
     this.location = location;
     this.tagClassName = tagClassName;
   }
 
   /** Creates a {@link TypeCheckedTag}. */
   public static TypeCheckedTag create(
-      TagClass tagClass, Tag tag, LabelConverter labelConverter, String moduleDisplayString)
+      TagClass tagClass,
+      Tag tag,
+      LabelConverter labelConverter,
+      String moduleDisplayString,
+      int moduleIndex,
+      int tagIndex)
       throws ExternalDepsException {
     ImmutableList<Object> attrValues =
         AttributeUtils.typeCheckAttrValues(
@@ -70,7 +117,13 @@ public class TypeCheckedTag implements Structure {
             "'%s' tag".formatted(tag.getTagName()),
             "to the %s".formatted(moduleDisplayString));
     return new TypeCheckedTag(
-        tagClass, attrValues, tag.isDevDependency(), tag.getLocation(), tag.getTagName());
+        tagClass,
+        attrValues,
+        tag.isDevDependency(),
+        moduleIndex,
+        tagIndex,
+        tag.getLocation(),
+        tag.getTagName());
   }
 
   /**
@@ -91,6 +144,9 @@ public class TypeCheckedTag implements Structure {
   public Object getValue(String name) throws EvalException {
     Integer attrIndex = tagClass.attributeIndices().get(name);
     if (attrIndex == null) {
+      if (name.equals(SORT_KEY)) {
+        return sortKey;
+      }
       return null;
     }
     return attrValues.get(attrIndex);
@@ -98,7 +154,10 @@ public class TypeCheckedTag implements Structure {
 
   @Override
   public ImmutableCollection<String> getFieldNames() {
-    return tagClass.attributeIndices().keySet();
+    return ImmutableSet.<String>builderWithExpectedSize(tagClass.attributeIndices().size() + 1)
+        .addAll(tagClass.attributeIndices().keySet())
+        .add(SORT_KEY)
+        .build();
   }
 
   @Nullable

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -2804,6 +2804,59 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
   }
 
   @Test
+  public void tagSortOrder() throws Exception {
+    scratch.overwriteFile(
+        "MODULE.bazel",
+        "module(name='root',version='1.0')",
+        "bazel_dep(name='foo',version='1.0')",
+        "bazel_dep(name='data_repo',version='1.0')",
+        "ext = use_extension('//:defs.bzl', 'ext')",
+        "ext.baz(id = 7)",
+        "ext.foo(id = 2)",
+        "ext.baz(id = 9)",
+        "ext.bar(id = 42)",
+        "ext.foo(id = -1)",
+        "ext.foo(id = 5)",
+        "use_repo(ext, 'ext_data')");
+    scratch.file(
+        "defs.bzl",
+        "load('@data_repo//:defs.bzl','data_repo')",
+        "def _ext_impl(ctx):",
+        "  tags = []",
+        "  for module in ctx.modules:",
+        "    tags += module.tags.foo",
+        "    tags += module.tags.bar",
+        "    tags += module.tags.baz",
+        "  ids = [tag.id for tag in sorted(tags, key=lambda tag: tag._sort_key)]",
+        "  data_repo(name='ext_data',data=str(ids))",
+        "foo = tag_class(attrs = {'id': attr.int()})",
+        "bar = tag_class(attrs = {'id': attr.int()})",
+        "baz = tag_class(attrs = {'id': attr.int()})",
+        "ext = module_extension(implementation=_ext_impl,tag_classes={'foo':foo, 'bar':bar,"
+            + " 'baz':baz})");
+    scratch.overwriteFile("BUILD");
+    scratch.file("data.bzl", "load('@ext_data//:data.bzl', ext_data='data')", "data=ext_data");
+    registry.addModule(
+        createModuleKey("foo", "1.0"),
+        "module(name='foo',version='1.0')",
+        "bazel_dep(name='root',version='1.0')",
+        "ext = use_extension('@root//:defs.bzl','ext')",
+        "ext.bar(id = 3)",
+        "ext.foo(id = 4)",
+        "ext.baz(id = 1)");
+    invalidatePackages(false);
+
+    SkyKey skyKey = BzlLoadValue.keyForBuild(Label.parseCanonical("//:data.bzl"));
+    EvaluationResult<BzlLoadValue> result =
+        SkyframeExecutorTestUtils.evaluate(skyframeExecutor, skyKey, false, reporter);
+    if (result.hasError()) {
+      throw result.getError().getException();
+    }
+    assertThat(result.get(skyKey).getModule().getGlobal("data"))
+        .isEqualTo("[7, 2, 9, 42, -1, 5, 3, 4, 1]"); // sorted order
+  }
+
+  @Test
   public void innate() throws Exception {
     scratch.overwriteFile(
         "MODULE.bazel",

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
@@ -106,7 +106,8 @@ public class StarlarkBazelModuleTest {
                     fooKey, fooKey.getCanonicalRepoNameWithoutVersion(),
                     barKey, barKey.getCanonicalRepoNameWithoutVersion())),
             usage,
-            repoMappingRecorder);
+            repoMappingRecorder,
+            /* moduleIndex= */ 0);
 
     assertThat(moduleProxy.getName()).isEqualTo("foo");
     assertThat(moduleProxy.getVersion()).isEqualTo("1.0");
@@ -158,7 +159,8 @@ public class StarlarkBazelModuleTest {
                     module.getRepoMappingWithBazelDepsOnly(
                         ImmutableMap.of(fooKey, fooKey.getCanonicalRepoNameWithoutVersion())),
                     usage,
-                    new Label.SimpleRepoMappingRecorder()));
+                    new Label.SimpleRepoMappingRecorder(),
+                    /* moduleIndex= */ 0));
     assertThat(e).hasMessageThat().contains("does not have a tag class named blep");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTagTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTagTest.java
@@ -64,8 +64,10 @@ public class TypeCheckedTagTest {
             createTagClass(attr("foo", Type.INTEGER).build()),
             buildTag("tag_name").addAttr("foo", StarlarkInt.of(3)).setDevDependency().build(),
             /* labelConverter= */ null,
-            "root module");
-    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo");
+            "root module",
+            /* moduleIndex= */ 0,
+            /* tagIndex= */ 0);
+    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo", "_sort_key");
     assertThat(getattr(typeCheckedTag, "foo")).isEqualTo(StarlarkInt.of(3));
     assertThat(typeCheckedTag.isDevDependency()).isTrue();
   }
@@ -83,8 +85,10 @@ public class TypeCheckedTagTest {
             new LabelConverter(
                 PackageIdentifier.parse("@myrepo//mypkg"),
                 createRepositoryMapping(createModuleKey("test", "1.0"), "repo", "other_repo")),
-            "root module");
-    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo");
+            "root module",
+            /* moduleIndex= */ 0,
+            /* tagIndex= */ 0);
+    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo", "_sort_key");
     assertThat(getattr(typeCheckedTag, "foo"))
         .isEqualTo(
             StarlarkList.immutableOf(
@@ -104,8 +108,10 @@ public class TypeCheckedTagTest {
             new LabelConverter(
                 PackageIdentifier.parse("@myrepo//mypkg"),
                 createRepositoryMapping(createModuleKey("test", "1.0"), "repo", "other_repo")),
-            "root module");
-    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo");
+            "root module",
+            /* moduleIndex= */ 0,
+            /* tagIndex= */ 0);
+    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo", "_sort_key");
     assertThat(getattr(typeCheckedTag, "foo")).isEqualTo(Starlark.NONE);
     assertThat(typeCheckedTag.isDevDependency()).isTrue();
   }
@@ -120,8 +126,10 @@ public class TypeCheckedTagTest {
                     .build()),
             buildTag("tag_name").build(),
             null,
-            "root module");
-    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo");
+            "root module",
+            /* moduleIndex= */ 0,
+            /* tagIndex= */ 0);
+    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo", "_sort_key");
     assertThat(getattr(typeCheckedTag, "foo"))
         .isEqualTo(
             Dict.builder()
@@ -143,8 +151,10 @@ public class TypeCheckedTagTest {
                 .addAttr("quux", StarlarkList.immutableOf("quuxValue1", "quuxValue2"))
                 .build(),
             /* labelConverter= */ null,
-            "root module");
-    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo", "bar", "quux");
+            "root module",
+            /* moduleIndex= */ 0,
+            /* tagIndex= */ 0);
+    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo", "bar", "quux", "_sort_key");
     assertThat(getattr(typeCheckedTag, "foo")).isEqualTo("fooValue");
     assertThat(getattr(typeCheckedTag, "bar")).isEqualTo(StarlarkInt.of(3));
     assertThat(getattr(typeCheckedTag, "quux"))
@@ -162,7 +172,9 @@ public class TypeCheckedTagTest {
                     createTagClass(attr("foo", Type.STRING).mandatory().build()),
                     buildTag("tag_name").build(),
                     /* labelConverter= */ null,
-                    "root module"));
+                    "root module",
+                    /* moduleIndex= */ 0,
+                    /* tagIndex= */ 0));
     assertThat(e).hasMessageThat().contains("mandatory attribute 'foo' isn't being specified");
   }
 
@@ -179,7 +191,9 @@ public class TypeCheckedTagTest {
                             .build()),
                     buildTag("tag_name").addAttr("foo", "maybe").build(),
                     /* labelConverter= */ null,
-                    "root module"));
+                    "root module",
+                    /* moduleIndex= */ 0,
+                    /* tagIndex= */ 0));
     assertThat(e)
         .hasMessageThat()
         .contains(
@@ -196,7 +210,74 @@ public class TypeCheckedTagTest {
                     createTagClass(attr("foo", Type.STRING).build()),
                     buildTag("tag_name").addAttr("bar", "maybe").build(),
                     /* labelConverter= */ null,
-                    "root module"));
+                    "root module",
+                    /* moduleIndex= */ 0,
+                    /* tagIndex= */ 0));
     assertThat(e).hasMessageThat().contains("unknown attribute 'bar' provided");
+  }
+
+  @Test
+  public void sortKey() throws Exception {
+    TypeCheckedTag module1Tag1 =
+        TypeCheckedTag.create(
+            createTagClass(attr("foo", Type.STRING).build()),
+            buildTag("tag_name").addAttr("foo", "value1").build(),
+            /* labelConverter= */ null,
+            "root module",
+            /* moduleIndex= */ 1,
+            /* tagIndex= */ 1);
+    TypeCheckedTag module2Tag1 =
+        TypeCheckedTag.create(
+            createTagClass(attr("foo", Type.STRING).build()),
+            buildTag("tag_name").addAttr("foo", "value2").build(),
+            /* labelConverter= */ null,
+            "root module",
+            /* moduleIndex= */ 2,
+            /* tagIndex= */ 1);
+    TypeCheckedTag module1Tag2 =
+        TypeCheckedTag.create(
+            createTagClass(attr("foo", Type.STRING).build()),
+            buildTag("tag_name").addAttr("foo", "value3").build(),
+            /* labelConverter= */ null,
+            "root module",
+            /* moduleIndex= */ 1,
+            /* tagIndex= */ 2);
+    TypeCheckedTag module2Tag2 =
+        TypeCheckedTag.create(
+            createTagClass(attr("foo", Type.STRING).build()),
+            buildTag("tag_name").addAttr("foo", "value4").build(),
+            /* labelConverter= */ null,
+            "root module",
+            /* moduleIndex= */ 2,
+            /* tagIndex= */ 2);
+
+    @SuppressWarnings("unchecked") // We know that _sort_key is a Comparable.
+    var keyM1T1 = (Comparable<Object>) getattr(module1Tag1, "_sort_key");
+    @SuppressWarnings("unchecked") // We know that _sort_key is a Comparable.
+    var keyM2T1 = (Comparable<Object>) getattr(module2Tag1, "_sort_key");
+    @SuppressWarnings("unchecked") // We know that _sort_key is a Comparable.
+    var keyM1T2 = (Comparable<Object>) getattr(module1Tag2, "_sort_key");
+    @SuppressWarnings("unchecked") // We know that _sort_key is a Comparable.
+    var keyM2T2 = (Comparable<Object>) getattr(module2Tag2, "_sort_key");
+
+    assertThat(keyM1T1).isLessThan(keyM2T1);
+    assertThat(keyM2T1).isGreaterThan(keyM1T1);
+    assertThat(keyM1T1).isLessThan(keyM1T2);
+    assertThat(keyM1T2).isGreaterThan(keyM1T1);
+    assertThat(keyM2T1).isLessThan(keyM2T2);
+    assertThat(keyM2T2).isGreaterThan(keyM2T1);
+  }
+
+  @Test
+  public void sortKeyIsInFieldNames() throws Exception {
+    TypeCheckedTag typeCheckedTag =
+        TypeCheckedTag.create(
+            createTagClass(attr("foo", Type.INTEGER).build()),
+            buildTag("tag_name").addAttr("foo", StarlarkInt.of(3)).build(),
+            /* labelConverter= */ null,
+            "root module",
+            /* moduleIndex= */ 0,
+            /* tagIndex= */ 0);
+    assertThat(typeCheckedTag.getFieldNames()).contains("_sort_key");
   }
 }


### PR DESCRIPTION
RELNOTES: Module extension tags now have an implicit `_sort_key` field that can be compared to derive the order in which tags from different classes appear in the MODULE.bazel file.

Context: rules_go's go_sdk extension has `from_file` and `download` tags, both of which end up registering a toolchain. For consistency, this should happen in the order the tags are specified by the user, but so far the necessary information isn't available. See https://github.com/bazel-contrib/rules_go/pull/4526/changes#r2586719526.

Closes #27883.

PiperOrigin-RevId: 889269434
Change-Id: I57e8db2bee61f29b2fc3c72b71f30e1bc3ce94e6

Commit https://github.com/bazelbuild/bazel/commit/a39cef7d8171fb39663f541ed03434bd126414dc