### PR TITLE
[8.7.0] Add Socket Secure (SOCKS) proxy support

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
@@ -232,9 +232,7 @@ public class ProxyHelper {
 
     // Here there be dragons.
     // Supports http://, https://, socks://, socks4://, socks5:// or no protocol (defaults to HTTP)
-    Pattern urlPattern =
-        Pattern.compile(
-            "^(https?://|socks[45]?://)?(([^:@]+?)(?::([^@]+?))?@)?([^:]+)(?::(\\d+))?/?$");
+    Pattern urlPattern = Pattern.compile("^(https?://|socks[45]?://)?(([^:@]+?)(?::([^@]+?))?@)?([^:]+)(?::(\\d+))?/?$");
     Matcher matcher = urlPattern.matcher(proxyAddress);
     if (!matcher.matches()) {
       throw new IOException("Proxy address " + proxyAddress + " is not a valid URL");

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
@@ -231,8 +231,10 @@ public class ProxyHelper {
     }
 
     // Here there be dragons.
+    // Supports http://, https://, socks://, socks4://, socks5:// or no protocol (defaults to HTTP)
     Pattern urlPattern =
-        Pattern.compile("^(https?://)?(([^:@]+?)(?::([^@]+?))?@)?([^:]+)(?::(\\d+))?/?$");
+        Pattern.compile(
+            "^(https?://|socks[45]?://)?(([^:@]+?)(?::([^@]+?))?@)?([^:]+)(?::(\\d+))?/?$");
     Matcher matcher = urlPattern.matcher(proxyAddress);
     if (!matcher.matches()) {
       throw new IOException("Proxy address " + proxyAddress + " is not a valid URL");
@@ -251,19 +253,22 @@ public class ProxyHelper {
           proxyAddress.replace(idAndPassword, ""); // Used to remove id+pwd from logging
     }
 
-    boolean https;
-    if (protocol == null) {
-      https = false;
-    } else {
-      https =
-          switch (protocol) {
-            case "https://" -> true;
-            case "http://" -> false;
-            default -> throw new IOException("Invalid proxy protocol for " + cleanProxyAddress);
-          };
+    Proxy.Type proxyType = Proxy.Type.HTTP;
+    int defaultPort = 80;
+
+    if (protocol != null) {
+      switch (protocol) {
+        case "https://" -> defaultPort = 443;
+        case "http://" -> defaultPort = 80;
+        case "socks://", "socks4://", "socks5://" -> {
+          proxyType = Proxy.Type.SOCKS;
+          defaultPort = 1080;
+        }
+        default -> throw new IOException("Invalid proxy protocol for " + cleanProxyAddress);
+      }
     }
 
-    int port = https ? 443 : 80; // Default port numbers
+    int port = defaultPort;
 
     if (portRaw != null) {
       try {
@@ -273,7 +278,7 @@ public class ProxyHelper {
       }
     }
 
-    Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(hostname, port));
+    Proxy proxy = new Proxy(proxyType, new InetSocketAddress(hostname, port));
 
     // Determine credentials: URL credentials take precedence over system properties
     String username = urlUsername;

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
@@ -270,6 +270,9 @@ public class ProxyHelper {
         }
         default -> throw new IOException("Invalid proxy protocol for " + cleanProxyAddress);
       }
+    } else {
+      proxyType = Proxy.Type.HTTP;
+      defaultPort = 80;
     }
 
     int port = defaultPort;

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
@@ -251,7 +251,7 @@ public class ProxyHelper {
           proxyAddress.replace(idAndPassword, ""); // Used to remove id+pwd from logging
     }
 
-    Proxy.Type proxyType = Proxy.Type.HTTP;
+    Proxy.Type proxyType;
     int defaultPort;
 
     if (protocol != null) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
@@ -252,12 +252,18 @@ public class ProxyHelper {
     }
 
     Proxy.Type proxyType = Proxy.Type.HTTP;
-    int defaultPort = 80;
+    int defaultPort;
 
     if (protocol != null) {
       switch (protocol) {
-        case "https://" -> defaultPort = 443;
-        case "http://" -> defaultPort = 80;
+        case "https://" -> {
+          proxyType = Proxy.Type.HTTP;
+          defaultPort = 443;
+        }
+        case "http://" -> {
+          proxyType = Proxy.Type.HTTP;
+          defaultPort = 80;
+        }
         case "socks://", "socks4://", "socks5://" -> {
           proxyType = Proxy.Type.SOCKS;
           defaultPort = 1080;

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelperTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.net.Proxy;
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelperTest.java
@@ -453,4 +453,55 @@ public class ProxyHelperTest {
       }
     }
   }
+
+  // Tests for SOCKS proxy support
+
+  @Test
+  public void testSocks5ProxyDefaultPort() throws Exception {
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("socks5://my.example.com");
+    assertThat(proxyInfo.proxy().type()).isEqualTo(Proxy.Type.SOCKS);
+    assertThat(proxyInfo.proxy().toString()).endsWith(":1080");
+  }
+
+  @Test
+  public void testSocks5ProxyExplicitPort() throws Exception {
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("socks5://my.example.com:5000");
+    assertThat(proxyInfo.proxy().type()).isEqualTo(Proxy.Type.SOCKS);
+    assertThat(proxyInfo.proxy().toString()).endsWith(":5000");
+  }
+
+  @Test
+  public void testSocks4ProxyDefaultPort() throws Exception {
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("socks4://my.example.com");
+    assertThat(proxyInfo.proxy().type()).isEqualTo(Proxy.Type.SOCKS);
+    assertThat(proxyInfo.proxy().toString()).endsWith(":1080");
+  }
+
+  @Test
+  public void testSocksProxyDefaultPort() throws Exception {
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("socks://my.example.com");
+    assertThat(proxyInfo.proxy().type()).isEqualTo(Proxy.Type.SOCKS);
+    assertThat(proxyInfo.proxy().toString()).endsWith(":1080");
+  }
+
+  @Test
+  public void testSocks5ProxyWithAuth() throws Exception {
+    ProxyInfo proxyInfo = ProxyHelper.createProxy("socks5://user:pass@my.example.com:1080");
+    assertThat(proxyInfo.proxy().type()).isEqualTo(Proxy.Type.SOCKS);
+    assertThat(proxyInfo.proxy().toString()).endsWith(":1080");
+    assertThat(proxyInfo.hasCredentials()).isTrue();
+    String encoded = proxyInfo.getProxyAuthorizationHeader().substring("Basic ".length());
+    String decoded = new String(Base64.getDecoder().decode(encoded), UTF_8);
+    assertThat(decoded).isEqualTo("user:pass");
+  }
+
+  @Test
+  public void testCreateIfNeededSocks5Proxy() throws Exception {
+    ProxyHelper helper =
+        new ProxyHelper(ImmutableMap.of("HTTPS_PROXY", "socks5://localhost:5000"));
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("https://www.something.com"));
+    assertThat(proxyInfo.proxy().type()).isEqualTo(Proxy.Type.SOCKS);
+    assertThat(proxyInfo.proxy().toString()).contains("localhost");
+    assertThat(proxyInfo.proxy().toString()).endsWith(":5000");
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelperTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.net.Proxy;
-import java.net.URI;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -499,7 +499,7 @@ public class ProxyHelperTest {
   public void testCreateIfNeededSocks5Proxy() throws Exception {
     ProxyHelper helper =
         new ProxyHelper(ImmutableMap.of("HTTPS_PROXY", "socks5://localhost:5000"));
-    ProxyInfo proxyInfo = helper.createProxyIfNeeded(URI.create("https://www.something.com"));
+    ProxyInfo proxyInfo = helper.createProxyIfNeeded(new URL("https://www.something.com"));
     assertThat(proxyInfo.proxy().type()).isEqualTo(Proxy.Type.SOCKS);
     assertThat(proxyInfo.proxy().toString()).contains("localhost");
     assertThat(proxyInfo.proxy().toString()).endsWith(":5000");


### PR DESCRIPTION
  ### Description

 `ProxyHelper.java` only supported HTTP/HTTPS proxies, rejecting SOCKS proxy URLs with the error "Proxy address socks5://... is not a valid URL". This change adds support for `socks://`, `socks4://`, and `socks5://` proxy schemes.

  Changes:
  - Updated URL validation regex to accept SOCKS proxy schemes
  - Added logic to create `Proxy.Type.SOCKS` when SOCKS schemes are detected
  - Set default port to 1080 for SOCKS proxies (standard SOCKS port)
  - Added tests for SOCKS proxy functionality

  ### Motivation

  Fixes https://github.com/bazelbuild/bazel/issues/29301

  ### Build API Changes

  No

  ### Checklist

  - [x] I have added tests for the new use cases (if any).
  - [x] I have updated the documentation (if applicable).

  ### Release Notes

  RELNOTES[NEW]: Added SOCKS proxy support. Bazel now accepts `socks://`, `socks4://`, and `socks5://` URLs in `HTTPS_PROXY`/`HTTP_PROXY` environment variables and related system properties.