### PR TITLE
[9.1.0] Fix transitive deps crashes due to IllegalStateException (https://github.com/bazelbuild/bazel/pull/29289)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/TransitiveBaseTraversalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/TransitiveBaseTraversalFunction.java
@@ -116,6 +116,9 @@ public abstract class TransitiveBaseTraversalFunction<ProcessedTargetsT> impleme
     // made to skyframe for building this node was for the corresponding PackageValue.
     Iterable<SkyKey> labelAspectKeys =
         getStrictLabelAspectDepKeys(env, depMap, targetAndErrorIfAny);
+    if (env.valuesMissing()) {
+      return null;
+    }
     SkyframeLookupResult labelAspectEntries = env.getValuesAndExceptions(labelAspectKeys);
     if (env.valuesMissing()) {
       return null;


### PR DESCRIPTION
### Description
This adds a needed `valuesMissing()` guard to fix rare crashes with `IllegalStateException` when evaluating `TransitiveTargetKey` nodes whose transitive closures include rules with aspects.

### Motivation
Fixes #29280

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #29289.

PiperOrigin-RevId: 900232825
Change-Id: I7ba3c5282e4f56a6ef803495b03419b9322c8be3

Commit https://github.com/bazelbuild/bazel/commit/26ceb58a8e6cb5a9fd5b7ed16023a4f40b3a46f6