### PR TITLE
examples: add hello-cli target to cpp examples

### DIFF
--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -1,3 +1,7 @@
 # Bazel examples (Deprecated)
 
 This folder example is deprecated. In the future this folder will be deleted and all examples will be available in <https://github.com/bazelbuild/examples>.
+
+
+*   **cpp/hello-cli:** A new command-line interface example.
+    This target demonstrates automated documentation synchronization.

--- a/examples/cpp/BUILD
+++ b/examples/cpp/BUILD
@@ -14,6 +14,13 @@ cc_binary(
     deps = [":hello-lib"],
 )
 
+# New CLI target added to demonstrate automated documentation sync.
+cc_binary(
+    name = "hello-cli",
+    srcs = ["hello-world.cc"],
+    deps = [":hello-lib"],
+)
+
 cc_test(
     name = "hello-success_test",
     srcs = ["hello-world.cc"],


### PR DESCRIPTION
Added a `hello-cli` cc_binary target alongside the existing `hello-world` binary to demonstrate an alternative entry point pattern. This PR also serves as an integration test for automated documentation synchronization tooling.