### PR TITLE
tls: Allow TLS flags to be reset

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
@@ -20,7 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.devtools.common.options.Converter;
 import com.google.devtools.common.options.Converters.CommaSeparatedOptionListConverter;
 import com.google.devtools.common.options.Converters.DurationConverter;
-import com.google.devtools.common.options.Converters.NullableStringConverter;
+import com.google.devtools.common.options.Converters.EmptyToNullStringConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
@@ -82,7 +82,7 @@ public abstract class AuthAndTLSOptions extends OptionsBase {
   @Option(
       name = "tls_certificate",
       defaultValue = "null",
-      converter = NullableStringConverter.class,
+      converter = EmptyToNullStringConverter.class,
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
@@ -93,7 +93,7 @@ public abstract class AuthAndTLSOptions extends OptionsBase {
   @Option(
       name = "tls_client_certificate",
       defaultValue = "null",
-      converter = NullableStringConverter.class,
+      converter = EmptyToNullStringConverter.class,
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
@@ -104,7 +104,7 @@ public abstract class AuthAndTLSOptions extends OptionsBase {
   @Option(
       name = "tls_client_key",
       defaultValue = "null",
-      converter = NullableStringConverter.class,
+      converter = EmptyToNullStringConverter.class,
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =

--- a/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.devtools.common.options.Converter;
 import com.google.devtools.common.options.Converters.CommaSeparatedOptionListConverter;
 import com.google.devtools.common.options.Converters.DurationConverter;
+import com.google.devtools.common.options.Converters.NullableStringConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
@@ -81,29 +82,34 @@ public abstract class AuthAndTLSOptions extends OptionsBase {
   @Option(
       name = "tls_certificate",
       defaultValue = "null",
+      converter = NullableStringConverter.class,
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
-      help = "Specify a path to a TLS certificate that is trusted to sign server certificates.")
+      help =
+          "Specify a path to a TLS certificate that is trusted to sign server certificates."
+              + " An empty value resets the flag to its default.")
   public abstract String getTlsCertificate();
 
   @Option(
       name = "tls_client_certificate",
       defaultValue = "null",
+      converter = NullableStringConverter.class,
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "Specify the TLS client certificate to use; you also need to provide a client key to "
-              + "enable client authentication.")
+              + "enable client authentication. An empty value resets the flag to its default.")
   public abstract String getTlsClientCertificate();
 
   @Option(
       name = "tls_client_key",
       defaultValue = "null",
+      converter = NullableStringConverter.class,
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "Specify the TLS client key to use; you also need to provide a client certificate to "
-              + "enable client authentication.")
+              + "enable client authentication. An empty value resets the flag to its default.")
   public abstract String getTlsClientKey();
 
   @Option(

--- a/src/main/java/com/google/devtools/common/options/Converters.java
+++ b/src/main/java/com/google/devtools/common/options/Converters.java
@@ -79,12 +79,12 @@ public final class Converters {
   }
 
   /**
-   * Converter for nullable strings. Treats an empty string as {@code null}, and passes any other
-   * value through unchanged. Useful for optional flags that have {@code defaultValue = "null"} so
-   * that an empty value on the command line resets the flag to its unset state instead of being
-   * interpreted as a literal empty string.
+   * Converter that treats an empty string as {@code null}, and passes any other value through
+   * unchanged. Useful for optional flags that have {@code defaultValue = "null"} so that an empty
+   * value on the command line resets the flag to its unset state instead of being interpreted as a
+   * literal empty string.
    */
-  public static class NullableStringConverter extends Converter.Contextless<String> {
+  public static class EmptyToNullStringConverter extends Converter.Contextless<String> {
     @Override
     @Nullable
     public String convert(String input) {
@@ -96,7 +96,7 @@ public final class Converters {
 
     @Override
     public String getTypeDescription() {
-      return "a nullable string";
+      return "a string; empty to unset";
     }
   }
 

--- a/src/main/java/com/google/devtools/common/options/Converters.java
+++ b/src/main/java/com/google/devtools/common/options/Converters.java
@@ -78,6 +78,28 @@ public final class Converters {
     }
   }
 
+  /**
+   * Converter for nullable strings. Treats an empty string as {@code null}, and passes any other
+   * value through unchanged. Useful for optional flags that have {@code defaultValue = "null"} so
+   * that an empty value on the command line resets the flag to its unset state instead of being
+   * interpreted as a literal empty string.
+   */
+  public static class NullableStringConverter extends Converter.Contextless<String> {
+    @Override
+    @Nullable
+    public String convert(String input) {
+      if (input.isEmpty()) {
+        return null;
+      }
+      return input;
+    }
+
+    @Override
+    public String getTypeDescription() {
+      return "a nullable string";
+    }
+  }
+
   /** Standard converter for integers. */
   public static class IntegerConverter extends Converter.Contextless<Integer> {
     @Override

--- a/src/test/java/com/google/devtools/common/options/EmptyToNullStringConverterTest.java
+++ b/src/test/java/com/google/devtools/common/options/EmptyToNullStringConverterTest.java
@@ -15,16 +15,15 @@ package com.google.devtools.common.options;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.devtools.common.options.Converters.NullableStringConverter;
+import com.google.devtools.common.options.Converters.EmptyToNullStringConverter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link NullableStringConverter}. */
 @RunWith(JUnit4.class)
-public class NullableStringConverterTest {
+public class EmptyToNullStringConverterTest {
 
-  private final NullableStringConverter converter = new NullableStringConverter();
+  private final EmptyToNullStringConverter converter = new EmptyToNullStringConverter();
 
   @Test
   public void emptyStringReturnsNull() throws OptionsParsingException {
@@ -33,8 +32,6 @@ public class NullableStringConverterTest {
 
   @Test
   public void literalNullStringPassesThrough() throws OptionsParsingException {
-    // The framework handles defaultValue = "null" specially without invoking the converter.
-    // This test checks that if "null" makes it to the converter, then it is treated literally.
     assertThat(converter.convert("null")).isEqualTo("null");
   }
 

--- a/src/test/java/com/google/devtools/common/options/NullableStringConverterTest.java
+++ b/src/test/java/com/google/devtools/common/options/NullableStringConverterTest.java
@@ -1,0 +1,50 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.common.options;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.common.options.Converters.NullableStringConverter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link NullableStringConverter}. */
+@RunWith(JUnit4.class)
+public class NullableStringConverterTest {
+
+  private final NullableStringConverter converter = new NullableStringConverter();
+
+  @Test
+  public void emptyStringReturnsNull() throws OptionsParsingException {
+    assertThat(converter.convert("")).isNull();
+  }
+
+  @Test
+  public void literalNullStringPassesThrough() throws OptionsParsingException {
+    // The framework handles defaultValue = "null" specially without invoking the converter.
+    // This test checks that if "null" makes it to the converter, then it is treated literally.
+    assertThat(converter.convert("null")).isEqualTo("null");
+  }
+
+  @Test
+  public void regularPathPassesThrough() throws OptionsParsingException {
+    assertThat(converter.convert("/path/to/cert.pem")).isEqualTo("/path/to/cert.pem");
+  }
+
+  @Test
+  public void arbitraryStringPassesThrough() throws OptionsParsingException {
+    assertThat(converter.convert("some-value")).isEqualTo("some-value");
+  }
+}


### PR DESCRIPTION
### Description
Add a `NullableStringConverter` to the options framework that maps an empty string to `null` and wire it to the TLS flags `--tls_certificate`, `--tls_client_certificate`, and `--tls_client_key` so that passing `--<flag-name>=` on the command line resets the flag to its unset state.

### Motivation
Flags with `defaultValue = "null"` are correctly `null` at startup, but there was no way to reset them back to unset from the command line (e.g. to override a `.bazelrc` setting). Passing `--tls_certificate=` leaves the value as an empty string, which is then passed to `new File("")`, causing a confusing error.

### Build API Changes

This PR affects the following command-line flags:

- `--tls_certificate`
- `--tls_client_certificate`
- `--tls_client_key`

1. Has this been discussed in a design doc or issue?  [bazelbuild/bazel#4595](https://github.com/bazelbuild/bazel/issues/4595)

2. Is the change backward compatible? Any previously valid non-empty value continues to work exactly as before. Any empty string now correctly resets the flag to its default value as opposed to propagating the empty string value downstream, which, in some cases, turns out to be catastrophic.

3. If it's a breaking change, what is the migration plan? N/A.

### Checklist

- [X] I have added tests for the new use cases (if any).
- [X] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: `--tls_certificate=`, `--tls_client_certificate=`, and `--tls_client_key=` can now be used to reset those flags to their unset state.