### PR TITLE
Fix JVM crash from VerifyException in GrpcCacheClient.onNext()

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -503,8 +503,7 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
                   data.writeTo(out);
                 } catch (IOException e) {
                   // The output stream was likely closed due to cancellation (e.g. dynamic execution
-                  // choosing the local branch). Cancel the RPC and propagate the error through the
-                  // future instead of throwing an unchecked exception that would crash the JVM.
+                  // choosing the local branch).
                   if (requestStream != null) {
                     requestStream.cancel("output stream closed", e);
                   }

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -42,7 +42,6 @@ import com.google.bytestream.ByteStreamProto.ReadResponse;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
 import com.google.common.base.Preconditions;
-import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.flogger.GoogleLogger;
@@ -483,8 +482,11 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
                 .setReadOffset(rawOut.getCount())
                 .build(),
             new ClientResponseObserver<ReadRequest, ReadResponse>() {
+              private volatile ClientCallStreamObserver<ReadRequest> requestStream;
+
               @Override
               public void beforeStart(ClientCallStreamObserver<ReadRequest> requestStream) {
+                this.requestStream = requestStream;
                 future.addListener(
                     () -> {
                       if (future.isCancelled()) {
@@ -500,8 +502,14 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
                 try {
                   data.writeTo(out);
                 } catch (IOException e) {
-                  // Cancel the call.
-                  throw new VerifyException(e);
+                  // The output stream was likely closed due to cancellation (e.g. dynamic execution
+                  // choosing the local branch). Cancel the RPC and propagate the error through the
+                  // future instead of throwing an unchecked exception that would crash the JVM.
+                  if (requestStream != null) {
+                    requestStream.cancel("output stream closed", e);
+                  }
+                  future.setException(e);
+                  return;
                 }
                 // reset the stall backoff because we've made progress or been kept alive
                 progressiveBackoff.reset();


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->
When a remote cache blob download is cancelled (e.g. dynamic execution choosing the local branch), the output stream is closed via a directExecutor() listener on the download future (CombinedCache#downloadFile). A pending onNext() callback can still be drained afterwards via DelayedClientCall's pending-callback path, which, unlike the normal StreamObserver path, does not convert RuntimeExceptions into onError(). The onNext() handler writes to the closed output stream, then catches the IOException, and throws VerifyException, which escapes to the gRPC executor's worker thread and hits Bazel's default uncaught exception handler.

Replace the throw with graceful error handling: cancel the gRPC stream via the stored requestStream reference and propagate the error through the SettableFuture. In the common case (future already cancelled by dynamic execution), setException is a no-op and the build continues using the local branch.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->
Fixes #22930 

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
