### PR TITLE
Fix docs2mdx handling of <> and {} in inline code blocks

### DIFF
--- a/scripts/docs/docs2mdx.py
+++ b/scripts/docs/docs2mdx.py
@@ -95,11 +95,18 @@ class AcornSafeMarkdownConverter(markdownify.MarkdownConverter):
   def convert_code(self, node, text, parent_tags):
     """Normalize whitespace in inline code before converting.
 
-    Multi-line <code> elements in the source HTML cause acorn parse errors
-    when curly braces span line boundaries. Collapsing whitespace first
-    lets the standard backtick conversion handle them on a single line.
+    Args:
+      node: The HTML element being converted.
+      text: The text content within the code tag.
+      parent_tags: A list of parent tag names.
+
+    Returns:
+      The converted markdown string.
     """
     if "pre" not in parent_tags:
+      # Multi-line <code> elements in the source HTML cause acorn parse errors
+      # when curly braces span line boundaries. Collapsing whitespace first
+      # lets the standard backtick conversion handle them on a single line.
       text = " ".join(text.split())
 
     return super().convert_code(node, text, parent_tags)

--- a/scripts/docs/docs2mdx.py
+++ b/scripts/docs/docs2mdx.py
@@ -93,9 +93,16 @@ class AcornSafeMarkdownConverter(markdownify.MarkdownConverter):
   """Custom converter that produces Acorn-parsable MDX output."""
 
   def convert_code(self, node, text, parent_tags):
-    """Escape sensitive characters in code blocks so they're not mishandled."""
-    text = super().convert_code(node, text, parent_tags)
-    return _escape_chars(text, _REPLACED_CODE_CHARACTERS)
+    """Normalize whitespace in inline code before converting.
+
+    Multi-line <code> elements in the source HTML cause acorn parse errors
+    when curly braces span line boundaries. Collapsing whitespace first
+    lets the standard backtick conversion handle them on a single line.
+    """
+    if "pre" not in parent_tags:
+      text = " ".join(text.split())
+
+    return super().convert_code(node, text, parent_tags)
 
   def escape(self, text, parent_tags):
     """Custom escape handling."""


### PR DESCRIPTION
In the Mintlify site, some pages (like [the command line reference](https://preview.bazel.build/reference/command-line-reference)) have literal `&lt;` and `&lcub;` strings in code blocks. Change the converter to produce results that properly render inline curly braces and angle brackets.

RELNOTES: None
