### PR TITLE
docs: Add strip_components parameter to download_and_extract and extract

### DIFF
--- a/site/en/remote/workspace.md
+++ b/site/en/remote/workspace.md
@@ -106,7 +106,9 @@ The actions that have been highlighted as potentially non-hermetic are as follow
   these may introduce any dependencies on the host environment.
 
 * `download`, `download_and_extract`: to ensure hermetic builds, make sure
-  that sha256 is specified
+  that sha256 is specified. The `download_and_extract` method now supports
+  `strip_components` for stripping leading path components. Note that
+  `strip_components` and `strip_prefix` cannot be used together.
 
 * `file`, `template`: this is not non-hermetic in itself, but may be a mechanism
   for introducing dependencies on the host environment into the repository.


### PR DESCRIPTION
This PR updates the documentation for `download_and_extract` and `extract` methods to include the new `strip_components` parameter and its mutual exclusivity with `strip_prefix`.

Due to limitations of the documentation search, a high-level note has been added to the most relevant available files that mention these functions, rather than a detailed API reference.