### PR TITLE
docs: Add documentation for experimental_remote_output_service

### DIFF
--- a/docs/remote/caching.mdx
+++ b/docs/remote/caching.mdx
@@ -246,6 +246,12 @@ remote cache:
 build --remote_upload_local_results=false
 ```
 
+You can also specify an experimental remote output service endpoint. Note that this feature is a work-in-progress.
+
+```posix-terminal
+build --experimental_remote_output_service=grpc://your.host:port
+```
+
 ### Exclude specific targets from using the remote cache {#targets-remote-cache}
 
 To exclude specific targets from using the remote cache, tag the target with

--- a/site/en/remote/caching.md
+++ b/site/en/remote/caching.md
@@ -247,6 +247,12 @@ remote cache:
 build --remote_upload_local_results=false
 ```
 
+You can also specify an experimental remote output service endpoint. Note that this feature is a work-in-progress.
+
+```posix-terminal
+build --experimental_remote_output_service=grpc://your.host:port
+```
+
 ### Exclude specific targets from using the remote cache {:#targets-remote-cache}
 
 To exclude specific targets from using the remote cache, tag the target with


### PR DESCRIPTION
This PR adds documentation for the new `--experimental_remote_output_service` flag, which allows users to specify an endpoint for a remote output service.

The documentation is added to the remote caching page, as it is a related feature. A note is included to indicate that the feature is still experimental.

Fixes #21802