### PR TITLE
Docs: Add documentation for strip_components in repository_ctx

### DIFF
--- a/docs/rules/lib/builtins/repository_ctx.mdx
+++ b/docs/rules/lib/builtins/repository_ctx.mdx
@@ -1,0 +1,41 @@
+---
+layout: "doc"
+title: "repository_ctx"
+---
+
+## repository_ctx
+
+A context object for repository rule implementations.
+
+### download_and_extract
+
+<pre>
+struct repository_ctx.download_and_extract(url, output, sha256, type, strip_prefix, strip_components, allow_fail, canonical_id, auth, headers, integrity, rename_files)
+</pre>
+
+Downloads a file, extracts it, and returns a struct with success information.
+
+**PARAMETERS**
+
+| Parameter  | Description |
+| :------------- | :------------- |
+| `strip_prefix` | A directory prefix to strip from the extracted files. Many archives contain a top-level directory that contains all files in the archive. Instead of needing to specify this prefix over and over in the `build_file`, this field can be used to strip it from extracted files. <p>For compatibility, this parameter may also be used under the deprecated name `stripPrefix`. Only one of `strip_prefix` or `strip_components` can be used.</p> |
+| `strip_components` | Strip the given number of leading components from file paths on extraction. Only one of `strip_components` or `strip_prefix` can be used. |
+| *other parameters* | ... |
+
+
+### extract
+
+<pre>
+None repository_ctx.extract(archive, output, strip_prefix, strip_components, rename_files, watch_archive, type)
+</pre>
+
+Extract an archive to the repository directory.
+
+**PARAMETERS**
+
+| Parameter  | Description |
+| :------------- | :------------- |
+| `strip_prefix` | A directory prefix to strip from the extracted files. Many archives contain a top-level directory that contains all files in the archive. Instead of needing to specify this prefix over and over in the `build_file`, this field can be used to strip it from extracted files. <p>For compatibility, this parameter may also be used under the deprecated name `stripPrefix`. Only one of `strip_prefix` or `strip_components` can be set.</p> |
+| `strip_components` | Strip the given number of leading components from file paths on extraction. Only one of `strip_components` or `strip_prefix` can be set. |
+| *other parameters* | ... |

--- a/site/en/rules/lib/builtins/repository_ctx.md
+++ b/site/en/rules/lib/builtins/repository_ctx.md
@@ -1,0 +1,41 @@
+---
+layout: "doc"
+title: "repository_ctx"
+---
+
+## repository_ctx
+
+A context object for repository rule implementations.
+
+### download_and_extract
+
+<pre>
+struct repository_ctx.download_and_extract(url, output, sha256, type, strip_prefix, strip_components, allow_fail, canonical_id, auth, headers, integrity, rename_files)
+</pre>
+
+Downloads a file, extracts it, and returns a struct with success information.
+
+**PARAMETERS**
+
+| Parameter  | Description |
+| :------------- | :------------- |
+| `strip_prefix` | A directory prefix to strip from the extracted files. Many archives contain a top-level directory that contains all files in the archive. Instead of needing to specify this prefix over and over in the `build_file`, this field can be used to strip it from extracted files. <p>For compatibility, this parameter may also be used under the deprecated name `stripPrefix`. Only one of `strip_prefix` or `strip_components` can be used.</p> |
+| `strip_components` | Strip the given number of leading components from file paths on extraction. Only one of `strip_components` or `strip_prefix` can be used. |
+| *other parameters* | ... |
+
+
+### extract
+
+<pre>
+None repository_ctx.extract(archive, output, strip_prefix, strip_components, rename_files, watch_archive, type)
+</pre>
+
+Extract an archive to the repository directory.
+
+**PARAMETERS**
+
+| Parameter  | Description |
+| :------------- | :------------- |
+| `strip_prefix` | A directory prefix to strip from the extracted files. Many archives contain a top-level directory that contains all files in the archive. Instead of needing to specify this prefix over and over in the `build_file`, this field can be used to strip it from extracted files. <p>For compatibility, this parameter may also be used under the deprecated name `stripPrefix`. Only one of `strip_prefix` or `strip_components` can be set.</p> |
+| `strip_components` | Strip the given number of leading components from file paths on extraction. Only one of `strip_components` or `strip_prefix` can be set. |
+| *other parameters* | ... |


### PR DESCRIPTION
This PR adds documentation for the new `strip_components` attribute for `repository_ctx.download_and_extract` and `repository_ctx.extract`, introduced in #29281.

Since the original documentation file for `repository_ctx` could not be located, this PR creates new, minimal documentation files at the location suggested by broken links in the existing documentation.