### PR TITLE
docs: Add `strip_components` to `http_archive`

### DIFF
--- a/site/en/external/repo.md
+++ b/site/en/external/repo.md
@@ -43,6 +43,15 @@ http_archive = repository_rule(
     attrs={
         "url": attr.string(mandatory=True),
         "sha256": attr.string(mandatory=True),
+
+
+        "strip_components": attr.int(
+            default=0,
+            doc="""
+Strip the given number of leading components from file paths on extraction.
+Only one of `strip_components` or `strip_prefix` can be set.
+"""
+        ),
     }
 )
 ```


### PR DESCRIPTION
This PR adds documentation for the new `strip_components` attribute to `http_archive` in `site/en/external/repo.md` and `docs/external/repo.mdx`.