### PR TITLE
Update docs for `strip_components` in `http_archive`

### DIFF
--- a/docs/rules/index.mdx
+++ b/docs/rules/index.mdx
@@ -80,6 +80,8 @@ the `@bazel_tools` built-in external repository.
 * Repository rules
   - [`git_repository`](/rules/lib/repo/git#git_repository)
   - [`http_archive`](/rules/lib/repo/http#http_archive)
+
+- [`http_file`](/rules/lib/repo/http#http_archive)
   - [`http_file`](/rules/lib/repo/http#http_archive)
   - [`http_jar`](/rules/lib/repo/http#http_jar)
   - [Utility functions on patching](/rules/lib/repo/utils)

--- a/site/en/rules/index.md
+++ b/site/en/rules/index.md
@@ -82,6 +82,8 @@ the `@bazel_tools` built-in external repository.
 * Repository rules
   - [`git_repository`](/rules/lib/repo/git#git_repository)
   - [`http_archive`](/rules/lib/repo/http#http_archive)
+
+- [`http_file`](/rules/lib/repo/http#http_archive)
   - [`http_file`](/rules/lib/repo/http#http_archive)
   - [`http_jar`](/rules/lib/repo/http#http_jar)
   - [Utility functions on patching](/rules/lib/repo/utils)


### PR DESCRIPTION
Adds documentation for the `strip_components` attribute in `http_archive`.