### PR TITLE
Docs: Add strip_components to http_archive and repository_ctx extraction methods

### DIFF
--- a/docs/external/repo.mdx
+++ b/docs/external/repo.mdx
@@ -79,6 +79,14 @@ non-hermetic functions (finding a binary, executing a binary, creating a file in
 the repository or downloading a file from the Internet). See [the API
 docs](/rules/lib/builtins/repository_ctx) for more context. Example:
 
+The input parameter `repository_ctx` can be used to access attribute values, and
+non-hermetic functions (finding a binary, executing a binary, creating a file in
+the repository or downloading a file from the Internet). Extraction functions
+like `repository_ctx.extract()` and `repository_ctx.download_and_extract()` now
+support a `strip_components` attribute, which is mutually exclusive with
+`strip_prefix`. See [the API docs](/rules/lib/builtins/repository_ctx) for more
+context. Example:
+
 ```python
 def _impl(repository_ctx):
   repository_ctx.symlink(repository_ctx.attr.path, "")

--- a/site/en/external/repo.md
+++ b/site/en/external/repo.md
@@ -80,6 +80,14 @@ non-hermetic functions (finding a binary, executing a binary, creating a file in
 the repository or downloading a file from the Internet). See [the API
 docs](/rules/lib/builtins/repository_ctx) for more context. Example:
 
+The input parameter `repository_ctx` can be used to access attribute values, and
+non-hermetic functions (finding a binary, executing a binary, creating a file in
+the repository or downloading a file from the Internet). Extraction functions
+like `repository_ctx.extract()` and `repository_ctx.download_and_extract()` now
+support a `strip_components` attribute, which is mutually exclusive with
+`strip_prefix`. See [the API docs](/rules/lib/builtins/repository_ctx) for more
+context. Example:
+
 ```python
 def _impl(repository_ctx):
   repository_ctx.symlink(repository_ctx.attr.path, "")


### PR DESCRIPTION
This PR updates the documentation for repository rules to reflect the addition of the `strip_components` attribute to `http_archive`, `repository_ctx.extract()`, and `repository_ctx.download_and_extract()`. The `http_archive` example now includes `strip_components`, and a note has been added to the `repository_ctx` section clarifying the use of `strip_components` and its mutual exclusivity with `strip_prefix` for extraction functions. This update corresponds to the changes in https://github.com/bazelbuild/bazel/pull/29281.