### PR TITLE
Docs: Add `strip_components` and update `strip_prefix` for `http_archive` and related functions

### DIFF
--- a/docs/external/repo.mdx
+++ b/docs/external/repo.mdx
@@ -33,8 +33,9 @@ run when the repo needs to be fetched.
 
 Attributes are arguments passed to the repo rule invocation. The schema of
 attributes accepted by a repo rule is specified using the `attrs` argument when
-the repo rule is defined with a call to `repository_rule`. An example defining
-`url` and `sha256` attributes as strings:
+the repo rule is defined with a call to `repository_rule`.
+
+For example, the `http_archive` rule defines `url`, `sha256`, `strip_prefix`, and `strip_components` attributes:
 
 ```python
 http_archive = repository_rule(
@@ -42,9 +43,19 @@ http_archive = repository_rule(
     attrs={
         "url": attr.string(mandatory=True),
         "sha256": attr.string(mandatory=True),
+        "strip_prefix": attr.string(),
+        "strip_components": attr.int(),
     }
 )
 ```
+
+*   `strip_prefix`: A directory prefix to strip from extracted files. For
+    compatibility, this parameter may also be used under the deprecated name
+    `stripPrefix`. Only one of `strip_prefix` or `strip_components` can be used.
+*   `strip_components`: Strip the given number of leading components from file
+    paths on extraction. Only one of `strip_components` or `strip_prefix` can be
+    used.
+
 
 To access an attribute within the implementation function, use
 `repository_ctx.attr.<attribute_name>`:

--- a/site/en/external/repo.md
+++ b/site/en/external/repo.md
@@ -34,8 +34,9 @@ run when the repo needs to be fetched.
 
 Attributes are arguments passed to the repo rule invocation. The schema of
 attributes accepted by a repo rule is specified using the `attrs` argument when
-the repo rule is defined with a call to `repository_rule`. An example defining
-`url` and `sha256` attributes as strings:
+the repo rule is defined with a call to `repository_rule`.
+
+For example, the `http_archive` rule defines `url`, `sha256`, `strip_prefix`, and `strip_components` attributes:
 
 ```python
 http_archive = repository_rule(
@@ -43,9 +44,19 @@ http_archive = repository_rule(
     attrs={
         "url": attr.string(mandatory=True),
         "sha256": attr.string(mandatory=True),
+        "strip_prefix": attr.string(),
+        "strip_components": attr.int(),
     }
 )
 ```
+
+*   `strip_prefix`: A directory prefix to strip from extracted files. For
+    compatibility, this parameter may also be used under the deprecated name
+    `stripPrefix`. Only one of `strip_prefix` or `strip_components` can be used.
+*   `strip_components`: Strip the given number of leading components from file
+    paths on extraction. Only one of `strip_components` or `strip_prefix` can be
+    used.
+
 
 To access an attribute within the implementation function, use
 `repository_ctx.attr.<attribute_name>`:


### PR DESCRIPTION
This PR updates the documentation for `http_archive` and the `extract`/`download_and_extract` functions to include the new `strip_components` attribute and clarify the usage of `strip_prefix`.

- Added `strip_components` to the `http_archive` example and its description.
- Updated the description of `strip_prefix` to mention that only one of `strip_prefix` or `strip_components` can be used.