### PR TITLE
Docs: Add `strip_components` to `http_archive` documentation

### DIFF
--- a/docs/external/repo.mdx
+++ b/docs/external/repo.mdx
@@ -53,6 +53,7 @@ To access an attribute within the implementation function, use
 def _impl(repository_ctx):
     url = repository_ctx.attr.url
     checksum = repository_ctx.attr.sha256
+    strip_components = repository_ctx.attr.strip_components
 ```
 
 All `repository_rule`s have the implicitly defined attribute `name`. This is a

--- a/site/en/external/repo.md
+++ b/site/en/external/repo.md
@@ -54,6 +54,7 @@ To access an attribute within the implementation function, use
 def _impl(repository_ctx):
     url = repository_ctx.attr.url
     checksum = repository_ctx.attr.sha256
+    strip_components = repository_ctx.attr.strip_components
 ```
 
 All `repository_rule`s have the implicitly defined attribute `name`. This is a


### PR DESCRIPTION
This PR updates the documentation for `http_archive` to include the new `strip_components` attribute, as introduced in https://github.com/bazelbuild/bazel/pull/29281. It also clarifies that `strip_components` and `strip_prefix` are mutually exclusive.