### PR TITLE
Treat source directories as directories

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/Artifact.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Artifact.java
@@ -332,6 +332,15 @@ public abstract sealed class Artifact
 
     SourceArtifact getSourceArtifact(PathFragment execPath, ArtifactRoot root, ArtifactOwner owner);
 
+    default SourceArtifact getSourceArtifact(
+        PathFragment execPath, ArtifactRoot root, ArtifactOwner owner, boolean isDirectory) {
+      SourceArtifact artifact = getSourceArtifact(execPath, root, owner);
+      if (isDirectory) {
+        artifact.markAsDirectory();
+      }
+      return artifact;
+    }
+
     /**
      * Whether to include the generating action key when serializing the given derived artifact in
      * the given context.
@@ -765,11 +774,18 @@ public abstract sealed class Artifact
    */
   public static final class SourceArtifact extends Artifact {
     private final ArtifactOwner owner;
+    private volatile boolean isDirectory;
 
     @VisibleForTesting
     public SourceArtifact(ArtifactRoot root, PathFragment execPath, ArtifactOwner owner) {
+      this(root, execPath, owner, /* isDirectory= */ false);
+    }
+
+    public SourceArtifact(
+        ArtifactRoot root, PathFragment execPath, ArtifactOwner owner, boolean isDirectory) {
       super(root, execPath, execPath.hashCode());
       this.owner = owner;
+      this.isDirectory = isDirectory;
     }
 
     /**
@@ -802,6 +818,11 @@ public abstract sealed class Artifact
     }
 
     @Override
+    public boolean isDirectory() {
+      return isDirectory;
+    }
+
+    @Override
     public ArtifactOwner getArtifactOwner() {
       return owner;
     }
@@ -813,6 +834,10 @@ public abstract sealed class Artifact
 
     boolean differentOwnerOrRoot(ArtifactOwner owner, ArtifactRoot root) {
       return !this.owner.equals(owner) || !this.getRoot().equals(root);
+    }
+
+    void markAsDirectory() {
+      isDirectory = true;
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactCodecs.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactCodecs.java
@@ -267,6 +267,7 @@ public final class ArtifactCodecs {
       context.serialize(obj.getExecPath(), codedOut);
       context.serialize(obj.getRoot(), codedOut);
       context.serialize(obj.getArtifactOwner(), codedOut);
+      codedOut.writeBoolNoTag(obj.isDirectory());
     }
 
     @Override
@@ -279,6 +280,7 @@ public final class ArtifactCodecs {
       context.deserialize(codedIn, builder, DeserializedSourceArtifactBuilder::setExecPath);
       context.deserialize(codedIn, builder, DeserializedSourceArtifactBuilder::setRoot);
       context.deserialize(codedIn, builder, DeserializedSourceArtifactBuilder::setOwner);
+      builder.setIsDirectory(codedIn.readBool());
       return builder;
     }
   }
@@ -288,6 +290,7 @@ public final class ArtifactCodecs {
     private PathFragment execPath;
     private ArtifactRoot root;
     private ArtifactOwner owner;
+    private boolean isDirectory;
 
     private DeserializedSourceArtifactBuilder(ArtifactSerializationContext context) {
       this.context = context;
@@ -295,7 +298,7 @@ public final class ArtifactCodecs {
 
     @Override
     public SourceArtifact call() {
-      return context.getSourceArtifact(execPath, root, owner);
+      return context.getSourceArtifact(execPath, root, owner, isDirectory);
     }
 
     private static void setExecPath(DeserializedSourceArtifactBuilder builder, Object value) {
@@ -308,6 +311,10 @@ public final class ArtifactCodecs {
 
     private static void setOwner(DeserializedSourceArtifactBuilder builder, Object value) {
       builder.owner = (ArtifactOwner) value;
+    }
+
+    private void setIsDirectory(boolean isDirectory) {
+      this.isDirectory = isDirectory;
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
@@ -284,20 +284,30 @@ public class ArtifactFactory implements ArtifactResolver {
 
   @Override
   public SourceArtifact getSourceArtifact(PathFragment execPath, Root root, ArtifactOwner owner) {
+    return getSourceArtifact(execPath, root, owner, /* isDirectory= */ false);
+  }
+
+  public SourceArtifact getSourceArtifact(
+      PathFragment execPath, Root root, ArtifactOwner owner, boolean isDirectory) {
     // TODO(jungjw): Come up with a more reliable way to distinguish external source roots.
     ArtifactRoot artifactRoot =
         root.asPath() != null && root.asPath().startsWith(externalSourceBase)
             ? ArtifactRoot.asExternalSourceRoot(root)
             : ArtifactRoot.asSourceRoot(root);
-    return getSourceArtifact(execPath, artifactRoot, owner);
+    return getSourceArtifact(execPath, artifactRoot, owner, isDirectory);
   }
 
   public SourceArtifact getSourceArtifact(
       PathFragment execPath, ArtifactRoot root, ArtifactOwner owner) {
+    return getSourceArtifact(execPath, root, owner, /* isDirectory= */ false);
+  }
+
+  public SourceArtifact getSourceArtifact(
+      PathFragment execPath, ArtifactRoot root, ArtifactOwner owner, boolean isDirectory) {
     Preconditions.checkArgument(
         execPath.isAbsolute() == root.getRoot().isAbsolute(), "%s %s %s", execPath, root, owner);
     Preconditions.checkNotNull(owner, "%s %s", execPath, root);
-    return (SourceArtifact) getArtifact(root, execPath, owner, /* type= */ null);
+    return (SourceArtifact) getArtifact(root, execPath, owner, /* type= */ null, isDirectory);
   }
 
   private void validatePath(PathFragment rootRelativePath, ArtifactRoot root) {
@@ -335,7 +345,8 @@ public class ArtifactFactory implements ArtifactResolver {
       PathFragment rootRelativePath, ArtifactRoot root, ArtifactOwner owner) {
     validatePath(rootRelativePath, root);
     return (Artifact.DerivedArtifact)
-        getArtifact(root, root.getExecPath().getRelative(rootRelativePath), owner, null);
+        getArtifact(
+            root, root.getExecPath().getRelative(rootRelativePath), owner, null, false);
   }
 
   /**
@@ -354,7 +365,8 @@ public class ArtifactFactory implements ArtifactResolver {
             root,
             root.getExecPath().getRelative(rootRelativePath),
             owner,
-            SpecialArtifactType.FILESET);
+            SpecialArtifactType.FILESET,
+            false);
   }
 
   public Artifact.DerivedArtifact getRunfilesArtifact(
@@ -365,7 +377,8 @@ public class ArtifactFactory implements ArtifactResolver {
             root,
             root.getExecPath().getRelative(rootRelativePath),
             owner,
-            SpecialArtifactType.RUNFILES);
+            SpecialArtifactType.RUNFILES,
+            false);
   }
 
   /**
@@ -383,7 +396,8 @@ public class ArtifactFactory implements ArtifactResolver {
             root,
             root.getExecPath().getRelative(rootRelativePath),
             owner,
-            SpecialArtifactType.TREE);
+            SpecialArtifactType.TREE,
+            false);
   }
 
   /**
@@ -401,7 +415,8 @@ public class ArtifactFactory implements ArtifactResolver {
             root,
             root.getExecPath().getRelative(rootRelativePath),
             owner,
-            SpecialArtifactType.UNRESOLVED_SYMLINK);
+            SpecialArtifactType.UNRESOLVED_SYMLINK,
+            false);
   }
 
   public Artifact.DerivedArtifact getConstantMetadataArtifact(
@@ -412,7 +427,8 @@ public class ArtifactFactory implements ArtifactResolver {
             root,
             root.getExecPath().getRelative(rootRelativePath),
             owner,
-            SpecialArtifactType.CONSTANT_METADATA);
+            SpecialArtifactType.CONSTANT_METADATA,
+            false);
   }
 
   /**
@@ -423,17 +439,21 @@ public class ArtifactFactory implements ArtifactResolver {
       ArtifactRoot root,
       PathFragment execPath,
       ArtifactOwner owner,
-      @Nullable SpecialArtifactType type) {
+      @Nullable SpecialArtifactType type,
+      boolean isDirectory) {
     Preconditions.checkNotNull(root);
     Preconditions.checkNotNull(execPath);
 
     if (!root.isSourceRoot()) {
-      return createArtifact(root, execPath, owner, type);
+      return createArtifact(root, execPath, owner, type, isDirectory);
     }
 
     // Double-checked locking to avoid locking cost when possible.
     SourceArtifact firstArtifact = sourceArtifactCache.getArtifact(execPath);
     if (firstArtifact != null && !firstArtifact.differentOwnerOrRoot(owner, root)) {
+      if (isDirectory) {
+        firstArtifact.markAsDirectory();
+      }
       return firstArtifact;
     }
     SourceArtifactCache.Entry newEntry =
@@ -447,8 +467,11 @@ public class ArtifactFactory implements ArtifactResolver {
                 // Artifacts with the same exec path but a different Owner, but we also need to
                 // reuse Artifacts from previous builds.
                 return new SourceArtifactCache.Entry(
-                    (SourceArtifact) createArtifact(root, execPath, owner, type),
+                    (SourceArtifact) createArtifact(root, execPath, owner, type, isDirectory),
                     sourceArtifactCache.buildId);
+              }
+              if (isDirectory) {
+                entry.artifact().markAsDirectory();
               }
               return entry;
             });
@@ -459,11 +482,12 @@ public class ArtifactFactory implements ArtifactResolver {
       ArtifactRoot root,
       PathFragment execPath,
       ArtifactOwner owner,
-      @Nullable SpecialArtifactType type) {
+      @Nullable SpecialArtifactType type,
+      boolean isDirectory) {
     Preconditions.checkNotNull(owner);
     if (type == null) {
       return root.isSourceRoot()
-          ? new Artifact.SourceArtifact(root, execPath, owner)
+          ? new Artifact.SourceArtifact(root, execPath, owner, isDirectory)
           : DerivedArtifact.create(root, execPath, (ActionLookupKey) owner);
     } else {
       return SpecialArtifact.create(root, execPath, (ActionLookupKey) owner, type);

--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTargetFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTargetFactory.java
@@ -331,7 +331,8 @@ public final class ConfiguredTargetFactory {
               ConfiguredTargetKey.builder()
                   .setLabel(target.getLabel())
                   .setConfiguration(config)
-                  .build());
+                  .build(),
+              inputFile.getPath().isDirectory());
       return new InputFileConfiguredTarget(targetContext, artifact);
     } else if (target instanceof PackageGroup packageGroup) {
       TargetContext targetContext =

--- a/src/test/java/com/google/devtools/build/lib/actions/ArtifactTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ArtifactTest.java
@@ -382,6 +382,36 @@ public final class ArtifactTest {
   }
 
   @Test
+  public void sourceArtifactCodecPreservesDirectoryBit() throws Exception {
+    Root root = Root.fromPath(scratch.dir("/"));
+    ArtifactRoot artifactRoot = ArtifactRoot.asSourceRoot(root);
+    ArtifactFactory artifactFactory =
+        new ArtifactFactory(execDir.getParentDirectory(), "blaze-out");
+
+    ObjectCodecs objectCodecs =
+        new ObjectCodecs(
+            AutoRegistry.get()
+                .getBuilder()
+                .addReferenceConstant(scratch.getFileSystem())
+                .setAllowDefaultCodec(true)
+                .build(),
+            ImmutableClassToInstanceMap.builder()
+                .put(FileSystem.class, scratch.getFileSystem())
+                .put(ArtifactSerializationContext.class, artifactFactory::getSourceArtifact)
+                .put(RootCodecDependencies.class, new RootCodecDependencies(artifactRoot.getRoot()))
+                .build());
+
+    ArtifactOwner owner = new LabelArtifactOwner(Label.parseCanonicalUnchecked("//foo:bar"));
+    SourceArtifact sourceArtifact =
+        new SourceArtifact(artifactRoot, PathFragment.create("src/dir"), owner, true);
+
+    SourceArtifact deserialized =
+        (SourceArtifact) objectCodecs.deserialize(objectCodecs.serialize(sourceArtifact));
+
+    assertThat(deserialized.isDirectory()).isTrue();
+  }
+
+  @Test
   public void testLongDirname() throws Exception {
     String dirName = createDirNameArtifact().getDirname();
 

--- a/src/test/shell/bazel/bazel_symlink_test.sh
+++ b/src/test/shell/bazel/bazel_symlink_test.sh
@@ -458,6 +458,83 @@ EOF
   expect_symlink bazel-bin/a/a.link
 }
 
+function test_source_directory_is_directory_from_glob() {
+  mkdir -p a/dir
+  cat > a/BUILD <<'EOF'
+load(":rule.bzl", "check_dirs")
+
+filegroup(
+    name = "srcs",
+    srcs = glob(
+        ["dir", "dir/**"],
+        exclude_directories = 0,
+    ),
+)
+
+check_dirs(
+    name = "check",
+    data = ":srcs",
+)
+EOF
+
+  cat > a/rule.bzl <<'EOF'
+def _check_dirs_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name + ".txt")
+    ctx.actions.write(out, "done")
+
+    for file in sorted(ctx.files.data, key = lambda f: f.short_path):
+        kind = "directory" if file.is_directory else "file"
+        print("%s is %s" % (file.short_path, kind))
+
+    return DefaultInfo(files = depset([out]))
+
+check_dirs = rule(
+    implementation = _check_dirs_impl,
+    attrs = {
+        "data": attr.label(allow_files = True),
+    },
+)
+EOF
+
+  touch a/dir/file.txt
+
+  bazel build //a:check >& "$TEST_log" || fail "build failed"
+  expect_log "a/dir is directory"
+  expect_log "a/dir/file.txt is file"
+}
+
+function test_symlink_source_directory_created_from_symlink_action() {
+  mkdir -p a/source_dir
+  cat > a/a.bzl <<'EOF'
+def _a_impl(ctx):
+    symlink = ctx.actions.declare_directory(ctx.label.name + ".link")
+    ctx.actions.symlink(
+        output = symlink,
+        target_file = ctx.files.src[0],
+    )
+    return DefaultInfo(files = depset([symlink]))
+
+a = rule(
+    implementation = _a_impl,
+    attrs = {
+        "src": attr.label(allow_files = True),
+    },
+)
+EOF
+
+  cat > a/BUILD <<'EOF'
+load(":a.bzl", "a")
+
+a(
+    name = "a",
+    src = "source_dir",
+)
+EOF
+
+  bazel build //a:a || fail "build failed"
+  expect_symlink bazel-bin/a/a.link
+}
+
 function test_symlink_file_to_directory_created_from_symlink_action() {
   mkdir -p a
   cat > a/a.bzl <<'EOF'


### PR DESCRIPTION
### Description

Treat source directories as directories in analysis by carrying a directory bit on SourceArtifact instead of classifying all source artifacts as files.

This fixes two related bugs:
- source directories now report File.is_directory == True
- ctx.actions.symlink(target_file=...) now accepts source directories with declare_directory() outputs

### Motivation

Fixes #12954
Fixes #26705

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
