### PR TITLE
Replace `tag._sort_key` field with `module_ctx.tag_sort_key()` method

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionContext.java
@@ -161,6 +161,29 @@ public class ModuleExtensionContext extends StarlarkBaseExternalContext {
   }
 
   @StarlarkMethod(
+      name = "tag_sort_key",
+      doc =
+          """
+          Returns an opaque <code>sort_key</code> object for the given tag, which can be compared \
+          with other <code>sort_key</code> objects to determine the relative order of tags, even \
+          across tag classes. Tags are ordered by their position within a module file and by the \
+          BFS ordering of modules in the dependency graph. This can be used with \
+          <code>sorted()</code> to recover the original order of tags: \
+          <code>sorted(tags, key=lambda tag: module_ctx.tag_sort_key(tag))</code>
+          """,
+      parameters = {
+        @Param(
+            name = "tag",
+            doc =
+                "A tag obtained from <a"
+                    + " href=\"../builtins/bazel_module.html#tags\">bazel_module.tags</a>.",
+            allowedTypes = {@ParamType(type = TypeCheckedTag.class)})
+      })
+  public Object getTagSortKey(TypeCheckedTag tag) {
+    return tag.getSortKey();
+  }
+
+  @StarlarkMethod(
       name = "is_isolated",
       doc =
           "Whether this particular usage of the extension had <code>isolate = True</code> "

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModule.java
@@ -57,12 +57,6 @@ public class StarlarkBazelModule implements StarlarkValue {
           object has a field for each tag class of the extension, and the value of the field is a \
           list containing an object for each tag instance. This "tag instance" object in turn has \
           a field for each attribute of the tag class.
-          <p>Tag instance objects have a <code>_sort_key</code> field that returns an opaque value \
-          that can be compared with other sort keys to determine the relative order of tags, even \
-          across tag classes. Tags are ordered by their position within a module file and by the \
-          BFS ordering of modules in the dependency graph. This can be used with \
-          <code>sorted()</code> to recover the original order of tags: \
-          <code>sorted(tags, key=lambda tag: tag._sort_key)</code>.
           <p>When passed as positional arguments to <code>print()</code> or <code>fail()</code>, \
           tag instance objects turn into a meaningful string representation of the form "'install' \
           tag at /home/user/workspace/MODULE.bazel:3:4". This can be used to construct error \

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTag.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTag.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.bazel.repository.AttributeUtils;
 import com.google.devtools.build.lib.packages.LabelConverter;
 import com.google.devtools.build.lib.server.FailureDetails.ExternalDeps.Code;
@@ -44,8 +43,7 @@ public class TypeCheckedTag implements Structure {
    * classes within a module file and across modules in BFS order.
    */
   @StarlarkBuiltin(name = "sort_key", documented = false)
-  private record SortKey(int moduleIndex, int tagIndex)
-      implements StarlarkValue, Comparable<SortKey> {
+  record SortKey(int moduleIndex, int tagIndex) implements StarlarkValue, Comparable<SortKey> {
     private static final Comparator<SortKey> COMPARATOR =
         Comparator.comparingInt(SortKey::moduleIndex).thenComparingInt(SortKey::tagIndex);
 
@@ -69,8 +67,6 @@ public class TypeCheckedTag implements Structure {
       printer.append("<sort_key module=%d tag=%d>".formatted(moduleIndex, tagIndex));
     }
   }
-
-  private static final String SORT_KEY = "_sort_key";
 
   private final TagClass tagClass;
   private final ImmutableList<Object> attrValues;
@@ -144,9 +140,6 @@ public class TypeCheckedTag implements Structure {
   public Object getValue(String name) throws EvalException {
     Integer attrIndex = tagClass.attributeIndices().get(name);
     if (attrIndex == null) {
-      if (name.equals(SORT_KEY)) {
-        return sortKey;
-      }
       return null;
     }
     return attrValues.get(attrIndex);
@@ -154,10 +147,11 @@ public class TypeCheckedTag implements Structure {
 
   @Override
   public ImmutableCollection<String> getFieldNames() {
-    return ImmutableSet.<String>builderWithExpectedSize(tagClass.attributeIndices().size() + 1)
-        .addAll(tagClass.attributeIndices().keySet())
-        .add(SORT_KEY)
-        .build();
+    return tagClass.attributeIndices().keySet();
+  }
+
+  public Object getSortKey() {
+    return sortKey;
   }
 
   @Nullable

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -2827,7 +2827,7 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
         "    tags += module.tags.foo",
         "    tags += module.tags.bar",
         "    tags += module.tags.baz",
-        "  ids = [tag.id for tag in sorted(tags, key=lambda tag: tag._sort_key)]",
+        "  ids = [tag.id for tag in sorted(tags, key=lambda tag: ctx.tag_sort_key(tag))]",
         "  data_repo(name='ext_data',data=str(ids))",
         "foo = tag_class(attrs = {'id': attr.int()})",
         "bar = tag_class(attrs = {'id': attr.int()})",

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTagTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTagTest.java
@@ -67,7 +67,7 @@ public class TypeCheckedTagTest {
             "root module",
             /* moduleIndex= */ 0,
             /* tagIndex= */ 0);
-    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo", "_sort_key");
+    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo");
     assertThat(getattr(typeCheckedTag, "foo")).isEqualTo(StarlarkInt.of(3));
     assertThat(typeCheckedTag.isDevDependency()).isTrue();
   }
@@ -88,7 +88,7 @@ public class TypeCheckedTagTest {
             "root module",
             /* moduleIndex= */ 0,
             /* tagIndex= */ 0);
-    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo", "_sort_key");
+    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo");
     assertThat(getattr(typeCheckedTag, "foo"))
         .isEqualTo(
             StarlarkList.immutableOf(
@@ -111,7 +111,7 @@ public class TypeCheckedTagTest {
             "root module",
             /* moduleIndex= */ 0,
             /* tagIndex= */ 0);
-    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo", "_sort_key");
+    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo");
     assertThat(getattr(typeCheckedTag, "foo")).isEqualTo(Starlark.NONE);
     assertThat(typeCheckedTag.isDevDependency()).isTrue();
   }
@@ -129,7 +129,7 @@ public class TypeCheckedTagTest {
             "root module",
             /* moduleIndex= */ 0,
             /* tagIndex= */ 0);
-    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo", "_sort_key");
+    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo");
     assertThat(getattr(typeCheckedTag, "foo"))
         .isEqualTo(
             Dict.builder()
@@ -154,7 +154,7 @@ public class TypeCheckedTagTest {
             "root module",
             /* moduleIndex= */ 0,
             /* tagIndex= */ 0);
-    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo", "bar", "quux", "_sort_key");
+    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo", "bar", "quux");
     assertThat(getattr(typeCheckedTag, "foo")).isEqualTo("fooValue");
     assertThat(getattr(typeCheckedTag, "bar")).isEqualTo(StarlarkInt.of(3));
     assertThat(getattr(typeCheckedTag, "quux"))
@@ -218,47 +218,10 @@ public class TypeCheckedTagTest {
 
   @Test
   public void sortKey() throws Exception {
-    TypeCheckedTag module1Tag1 =
-        TypeCheckedTag.create(
-            createTagClass(attr("foo", Type.STRING).build()),
-            buildTag("tag_name").addAttr("foo", "value1").build(),
-            /* labelConverter= */ null,
-            "root module",
-            /* moduleIndex= */ 1,
-            /* tagIndex= */ 1);
-    TypeCheckedTag module2Tag1 =
-        TypeCheckedTag.create(
-            createTagClass(attr("foo", Type.STRING).build()),
-            buildTag("tag_name").addAttr("foo", "value2").build(),
-            /* labelConverter= */ null,
-            "root module",
-            /* moduleIndex= */ 2,
-            /* tagIndex= */ 1);
-    TypeCheckedTag module1Tag2 =
-        TypeCheckedTag.create(
-            createTagClass(attr("foo", Type.STRING).build()),
-            buildTag("tag_name").addAttr("foo", "value3").build(),
-            /* labelConverter= */ null,
-            "root module",
-            /* moduleIndex= */ 1,
-            /* tagIndex= */ 2);
-    TypeCheckedTag module2Tag2 =
-        TypeCheckedTag.create(
-            createTagClass(attr("foo", Type.STRING).build()),
-            buildTag("tag_name").addAttr("foo", "value4").build(),
-            /* labelConverter= */ null,
-            "root module",
-            /* moduleIndex= */ 2,
-            /* tagIndex= */ 2);
-
-    @SuppressWarnings("unchecked") // We know that _sort_key is a Comparable.
-    var keyM1T1 = (Comparable<Object>) getattr(module1Tag1, "_sort_key");
-    @SuppressWarnings("unchecked") // We know that _sort_key is a Comparable.
-    var keyM2T1 = (Comparable<Object>) getattr(module2Tag1, "_sort_key");
-    @SuppressWarnings("unchecked") // We know that _sort_key is a Comparable.
-    var keyM1T2 = (Comparable<Object>) getattr(module1Tag2, "_sort_key");
-    @SuppressWarnings("unchecked") // We know that _sort_key is a Comparable.
-    var keyM2T2 = (Comparable<Object>) getattr(module2Tag2, "_sort_key");
+    var keyM1T1 = new TypeCheckedTag.SortKey(1, 1);
+    var keyM2T1 = new TypeCheckedTag.SortKey(2, 1);
+    var keyM1T2 = new TypeCheckedTag.SortKey(1, 2);
+    var keyM2T2 = new TypeCheckedTag.SortKey(2, 2);
 
     assertThat(keyM1T1).isLessThan(keyM2T1);
     assertThat(keyM2T1).isGreaterThan(keyM1T1);
@@ -266,18 +229,5 @@ public class TypeCheckedTagTest {
     assertThat(keyM1T2).isGreaterThan(keyM1T1);
     assertThat(keyM2T1).isLessThan(keyM2T2);
     assertThat(keyM2T2).isGreaterThan(keyM2T1);
-  }
-
-  @Test
-  public void sortKeyIsInFieldNames() throws Exception {
-    TypeCheckedTag typeCheckedTag =
-        TypeCheckedTag.create(
-            createTagClass(attr("foo", Type.INTEGER).build()),
-            buildTag("tag_name").addAttr("foo", StarlarkInt.of(3)).build(),
-            /* labelConverter= */ null,
-            "root module",
-            /* moduleIndex= */ 0,
-            /* tagIndex= */ 0);
-    assertThat(typeCheckedTag.getFieldNames()).contains("_sort_key");
   }
 }


### PR DESCRIPTION
### Description

Replaces the implicit `tag._sort_key` field introduced in https://github.com/bazelbuild/bazel/pull/27883 with an explicit method `module_ctx.tag_sort_key(tag)`. The implicit field can unintentionally break users who are iterating through all available fields using e.g. `dir(tag)`.

### Motivation

Fixes https://github.com/bazelbuild/rules_rust/issues/3962

### Build API Changes

This does affect the Build API, and is not backwards compatible; but `tag._sort_key` was introduced earlier on HEAD, and hasn't been backported to a release branch yet.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Added the `module_ctx.tag_sort_key(tag)` method, which returns an opaque object for the given tag that can be compared to derive the order in which tags from different classes appear in the MODULE.bazel file.