### PR TITLE
docs: add mention of hello-cli C++ example

### DIFF
--- a/site/en/start/cpp.md
+++ b/site/en/start/cpp.md
@@ -409,4 +409,4 @@ start. Here are some more resources to continue learning with Bazel:
 *   To learn more about Bazel's other rules, see this [reference
     guide](https://bazel.build/rules).
 
-Happy building!
+Happy building!\n\n## Other C++ Examples {:#other-examples}\n\nThe `bazelbuild/examples` repository contains other C++ examples. For instance, the `examples/cpp/` directory contains a `hello-world` and a `hello-cli` example that demonstrate basic C++ targets.


### PR DESCRIPTION
This PR adds a mention of the new hello-cli C++ example to the C++ tutorial, as part of the automated documentation synchronization test.