### PR TITLE
docs: add hello-cli to C++ tutorial

### DIFF
--- a/docs/start/cpp.mdx
+++ b/docs/start/cpp.mdx
@@ -399,6 +399,7 @@ start. Here are some more resources to continue learning with Bazel:
 
 *   To keep focusing on C++, read about common [C++ build use
     cases](https://bazel.build/tutorials/cpp-use-cases).
+*   For a simple, self-contained C++ example, see the [`hello-cli`](https://github.com/bazelbuild/examples/tree/main/cpp) target in the `bazelbuild/examples` repository.
 *   To get started with building other applications with Bazel, see the
     tutorials for [Java](https://bazel.build/start/java), [Android
     application](https://bazel.build/start/android-app), or [iOS

--- a/site/en/start/cpp.md
+++ b/site/en/start/cpp.md
@@ -400,6 +400,7 @@ start. Here are some more resources to continue learning with Bazel:
 
 *   To keep focusing on C++, read about common [C++ build use
     cases](https://bazel.build/tutorials/cpp-use-cases).
+*   For a simple, self-contained C++ example, see the [`hello-cli`](https://github.com/bazelbuild/examples/tree/main/cpp) target in the `bazelbuild/examples` repository.
 *   To get started with building other applications with Bazel, see the
     tutorials for [Java](https://bazel.build/start/java), [Android
     application](https://bazel.build/start/android-app), or [iOS


### PR DESCRIPTION
This PR updates the C++ tutorial to include a link to the new `hello-cli` example target. This provides a simple, self-contained C++ example for new users.

This change is based on the new example added in https://github.com/bazelbuild/bazel/pull/29309.