### PR TITLE
[9.2.0] Fix JVM crash from VerifyException in GrpcCacheClient.onNext() (https://github.com/bazelbuild/bazel/pull/29316)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -42,7 +42,6 @@ import com.google.bytestream.ByteStreamProto.ReadResponse;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
 import com.google.common.base.Preconditions;
-import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.flogger.GoogleLogger;
@@ -483,8 +482,11 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
                 .setReadOffset(rawOut.getCount())
                 .build(),
             new ClientResponseObserver<ReadRequest, ReadResponse>() {
+              private volatile ClientCallStreamObserver<ReadRequest> requestStream;
+
               @Override
               public void beforeStart(ClientCallStreamObserver<ReadRequest> requestStream) {
+                this.requestStream = requestStream;
                 future.addListener(
                     () -> {
                       if (future.isCancelled()) {
@@ -500,8 +502,13 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
                 try {
                   data.writeTo(out);
                 } catch (IOException e) {
-                  // Cancel the call.
-                  throw new VerifyException(e);
+                  // The output stream was likely closed due to cancellation (e.g. dynamic execution
+                  // choosing the local branch).
+                  if (requestStream != null) {
+                    requestStream.cancel("output stream closed", e);
+                  }
+                  future.setException(e);
+                  return;
                 }
                 // reset the stall backoff because we've made progress or been kept alive
                 progressiveBackoff.reset();


### PR DESCRIPTION
### Description
When a remote cache blob download is cancelled (e.g. dynamic execution choosing the local branch), the output stream is closed via a directExecutor() listener on the download future (CombinedCache#downloadFile). A pending onNext() callback can still be drained afterwards via DelayedClientCall's pending-callback path, which, unlike the normal StreamObserver path, does not convert RuntimeExceptions into onError(). The onNext() handler writes to the closed output stream, then catches the IOException, and throws VerifyException, which escapes to the gRPC executor's worker thread and hits Bazel's default uncaught exception handler.

Replace the throw with graceful error handling: cancel the gRPC stream via the stored requestStream reference and propagate the error through the SettableFuture. In the common case (future already cancelled by dynamic execution), setException is a no-op and the build continues using the local branch.

### Motivation
Fixes #22930

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #29316.

PiperOrigin-RevId: 901186846
Change-Id: Id9d9ca1bd824c0d4c62d69f05b6c9dbf606ab3ec

Commit https://github.com/bazelbuild/bazel/commit/588172a3307f09674ca0615e57e2cd3aa6acb1f2