### PR TITLE
[8.7.0] Add `strip_components` to `extract`/`download_and_extract` `http_arch…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunction.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -101,7 +102,13 @@ public abstract class CompressedTarFunction implements Decompressor {
           continue;
         }
 
-        Path filePath = descriptor.destinationPath().getRelative(entryPath.getPathFragment());
+        PathFragment strippedRelativePath = entryPath.getPathFragment();
+        strippedRelativePath = strippedRelativePath.stripComponents(descriptor.stripComponents());
+        if (Objects.equals(strippedRelativePath, PathFragment.EMPTY_FRAGMENT)) {
+          continue;
+        }
+
+        Path filePath = descriptor.destinationPath().getRelative(strippedRelativePath);
         filePath.getParentDirectory().createDirectoryAndParents();
         if (entry.isDirectory()) {
           filePath.createDirectoryAndParents();

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorDescriptor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorDescriptor.java
@@ -33,6 +33,7 @@ public record DecompressorDescriptor(
     Path archivePath,
     Path destinationPath,
     Optional<String> prefix,
+    int stripComponents,
     ImmutableMap<String, String> renameFiles) {
   public DecompressorDescriptor {
     requireNonNull(context, "context");
@@ -45,6 +46,7 @@ public record DecompressorDescriptor(
   public static Builder builder() {
     return new AutoBuilder_DecompressorDescriptor_Builder()
         .setContext("")
+        .setStripComponents(0)
         .setRenameFiles(ImmutableMap.of());
   }
 
@@ -60,8 +62,22 @@ public record DecompressorDescriptor(
 
     public abstract Builder setPrefix(String prefix);
 
+    public abstract Builder setStripComponents(int stripComponents);
+
     public abstract Builder setRenameFiles(Map<String, String> renameFiles);
 
-    public abstract DecompressorDescriptor build();
+    public abstract DecompressorDescriptor autoBuild();
+
+    public DecompressorDescriptor build() {
+      DecompressorDescriptor d = autoBuild();
+      if (d.stripComponents() < 0) {
+        throw new IllegalArgumentException("'strip_components' must be non-negative");
+      }
+      if (d.stripComponents() != 0 && d.prefix().isPresent() && !d.prefix().get().isEmpty()) {
+        throw new IllegalArgumentException(
+            "Only one of 'strip_prefix' or 'strip_components' can be set");
+      }
+      return d;
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/ZipDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/ZipDecompressor.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -95,8 +96,12 @@ public class ZipDecompressor implements Decompressor {
         if (entryPath.skip()) {
           continue;
         }
-        extractZipEntry(
-            reader, entry, destinationDirectory, entryPath.getPathFragment(), prefix, symlinks);
+        PathFragment pathFragment =
+            entryPath.getPathFragment().stripComponents(descriptor.stripComponents());
+        if (Objects.equals(pathFragment, PathFragment.EMPTY_FRAGMENT)) {
+          continue;
+        }
+        extractZipEntry(reader, entry, destinationDirectory, pathFragment, prefix, symlinks);
       }
 
       if (prefix.isPresent() && !foundPrefix) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -262,7 +262,7 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
 
   // There is no unregister(). We don't have that many futures in each repository and it just
   // introduces the failure mode of erroneously unregistering async work that's not done.
-  protected final void registerAsyncTask(AsyncTask task) {
+  private final void registerAsyncTask(AsyncTask task) {
     asyncTasks.add(task);
   }
 
@@ -927,7 +927,8 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
                 be used to strip it from extracted files.
 
                 <p>For compatibility, this parameter may also be used under the deprecated name
-                <code>stripPrefix</code>.
+                <code>stripPrefix</code>. Only one of <code>strip_prefix</code> or
+                <code>strip_components</code> can be used.
                 """),
         @Param(
             name = "allow_fail",
@@ -993,6 +994,16 @@ the same path on case-insensitive filesystems.
             positional = false,
             named = true,
             defaultValue = "''"),
+        @Param(
+            name = "strip_components",
+            positional = false,
+            named = true,
+            defaultValue = "0",
+            doc =
+"""
+Strip the given number of leading components from file paths on extraction. Only one of
+<code>strip_components</code> or <code>strip_prefix</code> can be used.
+"""),
       })
   public StructImpl downloadAndExtract(
       Object url,
@@ -1007,9 +1018,12 @@ the same path on case-insensitive filesystems.
       String integrity,
       Dict<?, ?> renameFiles, // <String, String> expected
       String oldStripPrefix,
+      StarlarkInt stripComponentsI,
       StarlarkThread thread)
       throws RepositoryFunctionException, InterruptedException, EvalException {
     stripPrefix = renamedStripPrefix("download_and_extract", stripPrefix, oldStripPrefix);
+    int stripComponents = Starlark.toInt(stripComponentsI, "strip_components");
+    validateStripping("download_and_extract", stripPrefix, stripComponents);
     ImmutableMap<URI, Map<String, List<String>>> authHeaders =
         getAuthHeaders(getAuthContents(authUnchecked, "auth"));
 
@@ -1111,6 +1125,7 @@ the same path on case-insensitive filesystems.
               .setArchivePath(downloadedPath)
               .setDestinationPath(outputPath.getPath())
               .setPrefix(stripPrefix)
+              .setStripComponents(stripComponents)
               .setRenameFiles(renameFilesMap)
               .build());
       env.getListener().post(new ExtractProgress(outputPath.getPath().toString()));
@@ -1208,7 +1223,8 @@ the same path on case-insensitive filesystems.
                 used to strip it from extracted files.
 
                 <p>For compatibility, this parameter may also be used under the deprecated name
-                <code>stripPrefix</code>.
+                <code>stripPrefix</code>. Only one of <code>strip_prefix</code> or
+                <code>strip_components</code> can be set.
                 """),
         @Param(
             name = "rename_files",
@@ -1239,6 +1255,16 @@ the same path on case-insensitive filesystems.
             positional = false,
             named = true,
             defaultValue = "''"),
+        @Param(
+            name = "strip_components",
+            positional = false,
+            named = true,
+            defaultValue = "0",
+            doc =
+"""
+Strip the given number of leading components from file paths on extraction. Only one of
+<code>strip_components</code> or <code>strip_prefix</code> can be set.
+"""),
       })
   public void extract(
       Object archive,
@@ -1247,9 +1273,12 @@ the same path on case-insensitive filesystems.
       Dict<?, ?> renameFiles, // <String, String> expected
       String watchArchive,
       String oldStripPrefix,
+      StarlarkInt stripComponentsI,
       StarlarkThread thread)
       throws RepositoryFunctionException, InterruptedException, EvalException {
     stripPrefix = renamedStripPrefix("extract", stripPrefix, oldStripPrefix);
+    int stripComponents = Starlark.toInt(stripComponentsI, "strip_components");
+    validateStripping("extract", stripPrefix, stripComponents);
     StarlarkPath archivePath = getPath(archive);
 
     if (!archivePath.exists()) {
@@ -1287,6 +1316,7 @@ the same path on case-insensitive filesystems.
             .setArchivePath(archivePath.getPath())
             .setDestinationPath(outputPath.getPath())
             .setPrefix(stripPrefix)
+            .setStripComponents(stripComponents)
             .setRenameFiles(renameFilesMap)
             .build());
     env.getListener().post(new ExtractProgress(outputPath.getPath().toString()));
@@ -1338,6 +1368,22 @@ the same path on case-insensitive filesystems.
         "%s() got multiple values for parameter 'strip_prefix' (via compatibility alias"
             + " 'stripPrefix')",
         method);
+  }
+
+  private static void validateStripping(String method, String stripPrefix, int stripComponents)
+      throws EvalException {
+    if (stripComponents < 0) {
+      throw Starlark.errorf(
+          "%s() has an invalid argument for 'strip_components': %d. Must be non-negative.",
+          method, stripComponents);
+    }
+
+    if (!stripPrefix.isEmpty() && stripComponents > 0) {
+      throw Starlark.errorf(
+          "%s() got multiple strip values. Only one of 'strip_prefix' or 'strip_components' can be"
+              + " set",
+          method);
+    }
   }
 
   @StarlarkMethod(

--- a/src/main/java/com/google/devtools/build/lib/vfs/PathFragment.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/PathFragment.java
@@ -584,7 +584,7 @@ public abstract sealed class PathFragment
    * @param beginIndex the beginning index, inclusive.
    * @param endIndex the ending index, exclusive.
    * @return the specified sub fragment, never null.
-   * @exception IndexOutOfBoundsException if the <code>beginIndex</code> is negative, or <code>
+   * @throws IndexOutOfBoundsException if the <code>beginIndex</code> is negative, or <code>
    *     endIndex</code> is larger than the length of this <code>String</code> object, or <code>
    *     beginIndex</code> is larger than <code>endIndex</code>.
    */
@@ -643,6 +643,21 @@ public abstract sealed class PathFragment
       endi = Math.max(endi, driveStrLength);
     }
     return makePathFragment(normalizedPath.substring(starti, endi), driveStrLength);
+  }
+
+  /** Strip <code>numComponents</code> leading components from file names on extraction. */
+  public PathFragment stripComponents(int numComponents) {
+    if (numComponents == 0) {
+      return this;
+    }
+    if (numComponents < 0) {
+      throw new IllegalArgumentException(
+          String.format("Invalid number of components (%d)", numComponents));
+    }
+    if (numComponents >= this.segmentCount()) {
+      return EMPTY_FRAGMENT;
+    }
+    return this.subFragment(numComponents);
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunctionTest.java
@@ -67,6 +67,19 @@ public class CompressedTarFunctionTest {
   }
 
   /**
+   * Test decompressing a tar.gz file with hard link file and symbolic link file inside and
+   * stripping the first component.
+   */
+  @Test
+  public void testDecompressWithStripComponents() throws Exception {
+    DecompressorDescriptor.Builder descriptorBuilder =
+        archiveDescriptor.createDescriptorBuilder().setStripComponents(1);
+    Path outputDir = decompress(descriptorBuilder.build());
+
+    archiveDescriptor.assertOutputFiles(outputDir, INNER_FOLDER_NAME);
+  }
+
+  /**
    * Test decompressing a tar.gz file, with some entries being renamed during the extraction
    * process.
    */
@@ -95,6 +108,24 @@ public class CompressedTarFunctionTest {
         archiveDescriptor
             .createDescriptorBuilder()
             .setPrefix(ROOT_FOLDER_NAME)
+            .setRenameFiles(renameFiles);
+    Path outputDir = decompress(descriptorBuilder.build());
+
+    Path innerDir = outputDir.getRelative(INNER_FOLDER_NAME);
+    assertThat(innerDir.getRelative("renamedFile").exists()).isTrue();
+  }
+
+  /** Test that entry renaming is applied prior to component stripping. */
+  @Test
+  public void testDecompressWithRenamedFilesAndStripComponents() throws Exception {
+    String innerDirName = ROOT_FOLDER_NAME + "/" + INNER_FOLDER_NAME;
+
+    HashMap<String, String> renameFiles = new HashMap<>();
+    renameFiles.put(innerDirName + "/hardLinkFile", innerDirName + "/renamedFile");
+    DecompressorDescriptor.Builder descriptorBuilder =
+        archiveDescriptor
+            .createDescriptorBuilder()
+            .setStripComponents(1)
             .setRenameFiles(renameFiles);
     Path outputDir = decompress(descriptorBuilder.build());
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/ZipDecompressorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/ZipDecompressorTest.java
@@ -56,14 +56,28 @@ public class ZipDecompressorTest {
   }
 
   /**
-   * Test decompressing a tar.gz file with hard link file and symbolic link file inside and
-   * stripping a prefix
+   * Test decompressing a zip file with hard link file and symbolic link file inside and stripping a
+   * prefix
    */
   @Test
   public void testDecompressWithPrefix() throws Exception {
     TestArchiveDescriptor archiveDescriptor = new TestArchiveDescriptor(ARCHIVE_NAME, "out", false);
     DecompressorDescriptor.Builder descriptorBuilder =
         archiveDescriptor.createDescriptorBuilder().setPrefix(ROOT_FOLDER_NAME);
+    Path outputDir = decompress(descriptorBuilder.build());
+
+    archiveDescriptor.assertOutputFiles(outputDir, INNER_FOLDER_NAME);
+  }
+
+  /**
+   * Test decompressing a zip file with hard link file and symbolic link file inside and stripping a
+   * component
+   */
+  @Test
+  public void testDecompressWithStripComponents() throws Exception {
+    TestArchiveDescriptor archiveDescriptor = new TestArchiveDescriptor(ARCHIVE_NAME, "out", false);
+    DecompressorDescriptor.Builder descriptorBuilder =
+        archiveDescriptor.createDescriptorBuilder().setStripComponents(1);
     Path outputDir = decompress(descriptorBuilder.build());
 
     archiveDescriptor.assertOutputFiles(outputDir, INNER_FOLDER_NAME);
@@ -99,6 +113,25 @@ public class ZipDecompressorTest {
         archiveDescriptor
             .createDescriptorBuilder()
             .setPrefix(ROOT_FOLDER_NAME)
+            .setRenameFiles(renameFiles);
+    Path outputDir = decompress(descriptorBuilder.build());
+
+    Path innerDir = outputDir.getRelative(INNER_FOLDER_NAME);
+    assertThat(innerDir.getRelative("renamedFile").exists()).isTrue();
+  }
+
+  /** Test that entry renaming is applied prior to stripping components. */
+  @Test
+  public void testDecompressWithRenamedFilesAndStripComponents() throws Exception {
+    TestArchiveDescriptor archiveDescriptor = new TestArchiveDescriptor(ARCHIVE_NAME, "out", false);
+    String innerDirName = ROOT_FOLDER_NAME + "/" + INNER_FOLDER_NAME;
+
+    HashMap<String, String> renameFiles = new HashMap<>();
+    renameFiles.put(innerDirName + "/hardLinkFile", innerDirName + "/renamedFile");
+    DecompressorDescriptor.Builder descriptorBuilder =
+        archiveDescriptor
+            .createDescriptorBuilder()
+            .setStripComponents(1)
             .setRenameFiles(renameFiles);
     Path outputDir = decompress(descriptorBuilder.build());
 

--- a/src/test/java/com/google/devtools/build/lib/vfs/PathFragmentTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/PathFragmentTest.java
@@ -381,6 +381,25 @@ public final class PathFragmentTest {
   }
 
   @Test
+  public void testStripComponents() {
+    PathFragment pathFragmentStripZero = create("/foo/bar/baz");
+    assertThat(pathFragmentStripZero.stripComponents(0)).isSameInstanceAs(pathFragmentStripZero);
+
+    assertThat(create("/foo/bar/baz").stripComponents(0).getPathString()).isEqualTo("/foo/bar/baz");
+    assertThat(create("/foo/bar/baz").stripComponents(1).getPathString()).isEqualTo("bar/baz");
+    assertThat(create("/foo/bar/baz").stripComponents(2).getPathString()).isEqualTo("baz");
+    assertThat(create("/foo/bar/baz").stripComponents(3).getPathString()).isEqualTo("");
+    assertThat(create("/foo/bar/baz").stripComponents(4).getPathString()).isEqualTo("");
+
+    PathFragment pathFragmentStripAll = create("/foo/bar/baz");
+    assertThat(pathFragmentStripAll.stripComponents(3)).isSameInstanceAs(EMPTY_FRAGMENT);
+    assertThat(pathFragmentStripAll.stripComponents(4)).isSameInstanceAs(EMPTY_FRAGMENT);
+
+    PathFragment pathFragment = create("/foo/bar/baz");
+    assertThrows(IllegalArgumentException.class, () -> pathFragment.stripComponents(-2));
+  }
+
+  @Test
   public void testStartsWith() {
     PathFragment foobar = create("/foo/bar");
     PathFragment foobarRelative = create("foo/bar");

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -865,6 +865,13 @@ http_archive(
     strip_prefix = "x/y/z",
     build_file = "@//:x.BUILD",
 )
+http_archive(
+    name = "x2",
+    url = "http://127.0.0.1:$nc_port/x.tar.gz",
+    sha256 = "$sha256",
+    strip_components = 3,
+    build_file = "@//:x.BUILD",
+)
 EOF
   cat > x.BUILD <<EOF
 genrule(
@@ -876,8 +883,10 @@ genrule(
 EOF
   touch BUILD
 
-  bazel build @x//:catter &> $TEST_log || fail "Build failed"
+  bazel build @x//:catter &> $TEST_log || fail "Build x failed"
   assert_contains "abc" bazel-genfiles/external/+_repo_rules+x/catter.out
+  bazel build @x2//:catter &> $TEST_log || fail "Build x2 failed"
+  assert_contains "abc" bazel-genfiles/external/+_repo_rules+x2/catter.out
 }
 
 function test_prefix_stripping_zip() {
@@ -896,6 +905,13 @@ http_archive(
     strip_prefix = "x/y/z",
     build_file = "@//:x.BUILD",
 )
+http_archive(
+    name = "x2",
+    url = "http://127.0.0.1:$nc_port/x.zip",
+    sha256 = "$sha256",
+    strip_components = 3,
+    build_file = "@//:x.BUILD",
+)
 EOF
   cat > x.BUILD <<EOF
 genrule(
@@ -907,8 +923,10 @@ genrule(
 EOF
   touch BUILD
 
-  bazel build @x//:catter &> $TEST_log || fail "Build failed"
+  bazel build @x//:catter &> $TEST_log || fail "Build x failed"
   assert_contains "abc" bazel-genfiles/external/+_repo_rules+x/catter.out
+  bazel build @x2//:catter &> $TEST_log || fail "Build x2 failed"
+  assert_contains "abc" bazel-genfiles/external/+_repo_rules+x2/catter.out
 }
 
 function test_prefix_stripping_existing_repo() {
@@ -935,10 +953,18 @@ http_archive(
     sha256 = "$sha256",
     strip_prefix = "x/y/z",
 )
+http_archive(
+    name = "x2",
+    url = "http://127.0.0.1:$nc_port/x.zip",
+    sha256 = "$sha256",
+    strip_components = 3,
+)
 EOF
 
-  bazel build @x//:catter &> $TEST_log || fail "Build failed"
+  bazel build @x//:catter &> $TEST_log || fail "Build x failed"
   assert_contains "abc" bazel-genfiles/external/+_repo_rules+x/catter.out
+  bazel build @x2//:catter &> $TEST_log || fail "Build x2 failed"
+  assert_contains "abc" bazel-genfiles/external/+_repo_rules+x2/catter.out
 }
 
 function test_adding_prefix_zip() {
@@ -989,6 +1015,14 @@ http_archive(
     add_prefix = "x",
     build_file = "@//:ws.BUILD",
 )
+http_archive(
+    name = "ws2",
+    url = "http://127.0.0.1:$nc_port/z.zip",
+    sha256 = "$sha256",
+    strip_components = 1,
+    add_prefix = "x",
+    build_file = "@//:ws.BUILD",
+)
 EOF
   cat > ws.BUILD <<EOF
 genrule(
@@ -1000,8 +1034,10 @@ genrule(
 EOF
   touch BUILD
 
-  bazel build @ws//:catter &> $TEST_log || fail "Build failed"
+  bazel build @ws//:catter &> $TEST_log || fail "Build ws failed"
   assert_contains "abc" bazel-genfiles/external/+_repo_rules+ws/catter.out
+  bazel build @ws2//:catter &> $TEST_log || fail "Build ws2 failed"
+  assert_contains "abc" bazel-genfiles/external/+_repo_rules+ws2/catter.out
 }
 
 function test_moving_build_file() {

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -138,7 +138,7 @@
   "moduleExtensions": {
     "@@pybind11_bazel+//:python_configure.bzl%extension": {
       "general": {
-        "bzlTransitiveDigest": "D2/qWHU6yQFwRG7Bb+caqrYMha5avsASao2vERrxK24=",
+        "bzlTransitiveDigest": "VhEtmxw1yzb9rBZVsKTdti7p+nDM/Fv1p9TmKdO45+Q=",
         "usagesDigest": "fycyB39YnXIJkfWCIXLUKJMZzANcuLy9ZE73hRucjFk=",
         "recordedFileInputs": {
           "@@pybind11_bazel+//MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
@@ -172,7 +172,7 @@
     },
     "@@rules_fuzzing+//fuzzing/private:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "4LouzhF/yT117s7peGnNs9ROomiJXC6Zl5R0oI21jho=",
+        "bzlTransitiveDigest": "CYUiFDCnL2VGx3uotIu/VuGabgObnZra2zzRUJCX0sU=",
         "usagesDigest": "wy6ISK6UOcBEjj/mvJ/S3WeXoO67X+1llb9yPyFtPgc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -255,7 +255,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "nvW/NrBXlAmiQw99EMGKkLaD2KbNp2mQDlxdfpr+0Ls=",
+        "bzlTransitiveDigest": "03Qju4tW0vE+0RBuZGuV2A4Hx6AiSkdNahYvworx2aM=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -319,7 +319,7 @@
     },
     "@@rules_python+//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "uqu5jBgLGZcXPcpYhJ6vSaSM70lh6XfI7hXr2Wb5GVw=",
+        "bzlTransitiveDigest": "lFXtGLhTWi+586Hk5wxd2is/yHXqyHDL7B2EAPLG4qA=",
         "usagesDigest": "OLoIStnzNObNalKEMRq99FqenhPGLFZ5utVLV4sz7OI=",
         "recordedFileInputs": {
           "@@rules_python+//tools/publish/requirements_darwin.txt": "2994136eab7e57b083c3de76faf46f70fad130bc8e7360a7fed2b288b69e79dc",

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -152,6 +152,9 @@ def _http_archive_impl(ctx):
     if ctx.attr.build_file and ctx.attr.build_file_content:
         fail("Only one of build_file and build_file_content can be provided.")
 
+    if ctx.attr.strip_prefix and ctx.attr.strip_components:
+        fail("Only one of strip_prefix and strip_components can be provided.")
+
     source_urls = _get_source_urls(ctx)
     download_info = ctx.download_and_extract(
         source_urls,
@@ -159,6 +162,7 @@ def _http_archive_impl(ctx):
         ctx.attr.sha256,
         ctx.attr.type,
         ctx.attr.strip_prefix,
+        strip_components = ctx.attr.strip_components,
         canonical_id = ctx.attr.canonical_id or get_default_canonical_id(ctx, source_urls),
         auth = get_auth(ctx, source_urls),
         integrity = ctx.attr.integrity,
@@ -301,7 +305,16 @@ Note that if there are files outside of this directory, they will be
 discarded and inaccessible (e.g., a top-level license file). This includes
 files/directories that start with the prefix but are not in the directory
 (e.g., `foo-lib-1.2.3.release-notes`). If the specified prefix does not
-match a directory in the archive, Bazel will return an error.""",
+match a directory in the archive, Bazel will return an error.
+
+Only one of `strip_prefix` and `strip_components` can be set.""",
+    ),
+    "strip_components": attr.int(
+        default = 0,
+        doc = """Strip the given number of leading components from file paths
+        on extraction.
+
+        Only one of `strip_components` and `strip_prefix` can be set.""",
     ),
     "add_prefix": attr.string(
         default = "",


### PR DESCRIPTION
…… (https://github.com/bazelbuild/bazel/pull/29281)

Add `strip_components` to `extract`/`download_and_extract` `http_archive`

### Description

The `strip_components` attribute functions similar to `tar --strip-components`:

> Strip NUMBER leading components from file names on extraction.

This is an alternative to the existing `strip_prefix` attribute, which required knowing the exact prefix to be stripped. Only one of the two attributes (`strip_prefix`, `strip_components`) can be set at one time.

### Motivation
See #28879

### Build API Changes

> 1. Has this been discussed in a design doc or issue? (Please link it)

See #28879

> 2. Is the change backward compatible?

Yes

> 3. If it's a breaking change, what is the migration plan?

N/A - this is not a breaking change.

### Checklist

- [X] I have added tests for the new use cases (if any).
- [X] I have updated the documentation (if applicable).

### Release Notes

RELNOTES[NEW]: Adds the `strip_components` attribute to `extract`/`download_and_extract`/`http_archive` to allow stripping of path components when extracting files.

Closes #29281.

Fixes https://github.com/bazelbuild/bazel/issues/28879

PiperOrigin-RevId: 902961227
Change-Id: I3fda77ec42c3d052f6655e42c8b57ec27667c758
