### PR TITLE
bind starlark debug server to loopback by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkdebug/module/StarlarkDebuggerModule.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdebug/module/StarlarkDebuggerModule.java
@@ -40,7 +40,11 @@ public final class StarlarkDebuggerModule extends BlazeModule {
     boolean enabled = buildOptions != null && buildOptions.debugStarlark;
     if (enabled) {
       initializeDebugging(
-          env, buildOptions.debugServerPort, buildOptions.verboseLogs, buildOptions.resetAnalysis);
+          env,
+          buildOptions.debugServerPort,
+          buildOptions.debugServerAddress,
+          buildOptions.verboseLogs,
+          buildOptions.resetAnalysis);
     } else {
       disableDebugging();
     }
@@ -69,13 +73,17 @@ public final class StarlarkDebuggerModule extends BlazeModule {
   }
 
   private static void initializeDebugging(
-      CommandEnvironment env, int debugPort, boolean verboseLogs, boolean resetAnalysis) {
+      CommandEnvironment env,
+      int debugPort,
+      String debugAddress,
+      boolean verboseLogs,
+      boolean resetAnalysis) {
     try {
       DebugCallback callback =
           resetAnalysis ? getBreakpointInvalidatingCallback(env) : DebugCallback.noop();
       StarlarkDebugServer server =
           StarlarkDebugServer.createAndWaitForConnection(
-              env.getReporter(), debugPort, verboseLogs, callback);
+              env.getReporter(), debugPort, debugAddress, verboseLogs, callback);
       Debug.setDebugger(server);
       // we need to block otherwise the build (i.e. analysis) may start and the request to set
       // breakpoints may lose the race to delete skyframe nodes

--- a/src/main/java/com/google/devtools/build/lib/starlarkdebug/module/StarlarkDebuggerOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdebug/module/StarlarkDebuggerOptions.java
@@ -45,6 +45,17 @@ public final class StarlarkDebuggerOptions extends OptionsBase {
   public int debugServerPort;
 
   @Option(
+      name = "experimental_skylark_debug_server_address",
+      defaultValue = "",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {OptionEffectTag.EXECUTION},
+      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+      help =
+          "The address on which the Starlark debug server will listen for connections. Defaults"
+              + " to the loopback interface; set this explicitly to allow non-local clients.")
+  public String debugServerAddress;
+
+  @Option(
       name = "experimental_skylark_debug_verbose_logging",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugServer.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugServer.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.starlarkdebugging.StarlarkDebuggingProtos;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -36,14 +37,30 @@ public final class StarlarkDebugServer implements Debug.Debugger {
    * debug server socket and blocks waiting for an incoming connection.
    *
    * @param port the port on which the server should listen for connections
+   * @param listenAddress the address on which the server should listen for connections; if null
+   *     or empty, loopback is used
    * @param verboseLogging if true, debug-level events will be logged
    * @throws IOException if an I/O error occurs while opening the socket or waiting for a connection
    */
   public static StarlarkDebugServer createAndWaitForConnection(
-      EventHandler eventHandler, int port, boolean verboseLogging, DebugCallback callback)
+      EventHandler eventHandler,
+      int port,
+      @Nullable String listenAddress,
+      boolean verboseLogging,
+      DebugCallback callback)
       throws IOException {
-    ServerSocket serverSocket = new ServerSocket(port, /* backlog */ 1);
+    ServerSocket serverSocket = createServerSocket(port, listenAddress);
     return createAndWaitForConnection(eventHandler, serverSocket, verboseLogging, callback);
+  }
+
+  @VisibleForTesting
+  static ServerSocket createServerSocket(int port, @Nullable String listenAddress)
+      throws IOException {
+    InetAddress address =
+        listenAddress == null || listenAddress.isEmpty()
+            ? InetAddress.getLoopbackAddress()
+            : InetAddress.getByName(listenAddress);
+    return new ServerSocket(port, /* backlog */ 1, address);
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugServerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugServerTest.java
@@ -128,6 +128,20 @@ public class StarlarkDebugServerTest {
   }
 
   @Test
+  public void testCreateServerSocketDefaultsToLoopback() throws Exception {
+    try (ServerSocket serverSocket = StarlarkDebugServer.createServerSocket(0, "")) {
+      assertThat(serverSocket.getInetAddress().isLoopbackAddress()).isTrue();
+    }
+  }
+
+  @Test
+  public void testCreateServerSocketHonorsExplicitAddress() throws Exception {
+    try (ServerSocket serverSocket = StarlarkDebugServer.createServerSocket(0, "0.0.0.0")) {
+      assertThat(serverSocket.getInetAddress().isAnyLocalAddress()).isTrue();
+    }
+  }
+
+  @Test
   public void testStartDebuggingResponseReceived() throws Exception {
     DebugEvent response =
         client.sendRequestAndWaitForResponse(


### PR DESCRIPTION
## Summary
- bind the Starlark debug server to the loopback interface by default instead of inheriting the JVM wildcard bind
- add `--experimental_skylark_debug_server_address` for explicit non-local debugger binds
- cover the new binding behavior with focused unit tests

## Why
`StarlarkDebugServer` currently creates a plain `ServerSocket(port)`, which binds all interfaces by default. That makes accidental non-local exposure possible whenever `--experimental_skylark_debug` is enabled. Defaulting to loopback keeps the common local-debugging workflow intact while making broader exposure an explicit choice.

## User impact
local debugging continues to work without extra flags.
users who intentionally attach from another host now need to pass `--experimental_skylark_debug_server_address=<addr>`.

## Validation
- `git diff --check`
- `/tmp/bazelisk test --test_output=errors //src/test/java/com/google/devtools/build/lib/starlarkdebug/server:StarlarkDebugServerTest //src/test/java/com/google/devtools/build/lib/starlarkdebug/server:StarlarkDebugIntegrationTest`
  - started successfully from a fresh Bazelisk/Bazel 9.0.0 setup
  - still running locally while this draft PR is being opened because the first cold build pulls and compiles a large toolchain graph
