### PR TITLE
add starlark debug server address flag

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkdebug/module/StarlarkDebuggerModule.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdebug/module/StarlarkDebuggerModule.java
@@ -40,7 +40,11 @@ public final class StarlarkDebuggerModule extends BlazeModule {
     boolean enabled = buildOptions != null && buildOptions.debugStarlark;
     if (enabled) {
       initializeDebugging(
-          env, buildOptions.debugServerPort, buildOptions.verboseLogs, buildOptions.resetAnalysis);
+          env,
+          buildOptions.debugServerPort,
+          buildOptions.debugServerAddress,
+          buildOptions.verboseLogs,
+          buildOptions.resetAnalysis);
     } else {
       disableDebugging();
     }
@@ -69,13 +73,17 @@ public final class StarlarkDebuggerModule extends BlazeModule {
   }
 
   private static void initializeDebugging(
-      CommandEnvironment env, int debugPort, boolean verboseLogs, boolean resetAnalysis) {
+      CommandEnvironment env,
+      int debugPort,
+      String debugAddress,
+      boolean verboseLogs,
+      boolean resetAnalysis) {
     try {
       DebugCallback callback =
           resetAnalysis ? getBreakpointInvalidatingCallback(env) : DebugCallback.noop();
       StarlarkDebugServer server =
           StarlarkDebugServer.createAndWaitForConnection(
-              env.getReporter(), debugPort, verboseLogs, callback);
+              env.getReporter(), debugPort, debugAddress, verboseLogs, callback);
       Debug.setDebugger(server);
       // we need to block otherwise the build (i.e. analysis) may start and the request to set
       // breakpoints may lose the race to delete skyframe nodes

--- a/src/main/java/com/google/devtools/build/lib/starlarkdebug/module/StarlarkDebuggerOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdebug/module/StarlarkDebuggerOptions.java
@@ -45,6 +45,17 @@ public final class StarlarkDebuggerOptions extends OptionsBase {
   public int debugServerPort;
 
   @Option(
+      name = "experimental_skylark_debug_server_address",
+      defaultValue = "",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {OptionEffectTag.EXECUTION},
+      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+      help =
+          "The address on which the Starlark debug server will listen for connections. Defaults"
+              + " to the loopback interface; set this explicitly to allow non-local clients.")
+  public String debugServerAddress;
+
+  @Option(
       name = "experimental_skylark_debug_verbose_logging",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/starlarkdebug/module/StarlarkDebuggerOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdebug/module/StarlarkDebuggerOptions.java
@@ -52,7 +52,8 @@ public final class StarlarkDebuggerOptions extends OptionsBase {
       metadataTags = {OptionMetadataTag.EXPERIMENTAL},
       help =
           "The address on which the Starlark debug server will listen for connections. Defaults"
-              + " to the loopback interface; set this explicitly to allow non-local clients.")
+              + " to the existing wildcard bind behavior. Set this to a loopback address to accept"
+              + " local clients only.")
   public String debugServerAddress;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugServer.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugServer.java
@@ -37,15 +37,15 @@ public final class StarlarkDebugServer implements Debug.Debugger {
    * debug server socket and blocks waiting for an incoming connection.
    *
    * @param port the port on which the server should listen for connections
-   * @param listenAddress the address on which the server should listen for connections; if null
-   *     or empty, loopback is used
+   * @param listenAddress the address on which the server should listen for connections; if empty,
+   *     the existing wildcard bind behavior is used
    * @param verboseLogging if true, debug-level events will be logged
    * @throws IOException if an I/O error occurs while opening the socket or waiting for a connection
    */
   public static StarlarkDebugServer createAndWaitForConnection(
       EventHandler eventHandler,
       int port,
-      @Nullable String listenAddress,
+      String listenAddress,
       boolean verboseLogging,
       DebugCallback callback)
       throws IOException {
@@ -54,13 +54,11 @@ public final class StarlarkDebugServer implements Debug.Debugger {
   }
 
   @VisibleForTesting
-  static ServerSocket createServerSocket(int port, @Nullable String listenAddress)
-      throws IOException {
-    InetAddress address =
-        listenAddress == null || listenAddress.isEmpty()
-            ? InetAddress.getLoopbackAddress()
-            : InetAddress.getByName(listenAddress);
-    return new ServerSocket(port, /* backlog */ 1, address);
+  static ServerSocket createServerSocket(int port, String listenAddress) throws IOException {
+    if (listenAddress.isEmpty()) {
+      return new ServerSocket(port, /* backlog */ 1);
+    }
+    return new ServerSocket(port, /* backlog */ 1, InetAddress.getByName(listenAddress));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugServer.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugServer.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.starlarkdebugging.StarlarkDebuggingProtos;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -36,14 +37,30 @@ public final class StarlarkDebugServer implements Debug.Debugger {
    * debug server socket and blocks waiting for an incoming connection.
    *
    * @param port the port on which the server should listen for connections
+   * @param listenAddress the address on which the server should listen for connections; if null
+   *     or empty, loopback is used
    * @param verboseLogging if true, debug-level events will be logged
    * @throws IOException if an I/O error occurs while opening the socket or waiting for a connection
    */
   public static StarlarkDebugServer createAndWaitForConnection(
-      EventHandler eventHandler, int port, boolean verboseLogging, DebugCallback callback)
+      EventHandler eventHandler,
+      int port,
+      @Nullable String listenAddress,
+      boolean verboseLogging,
+      DebugCallback callback)
       throws IOException {
-    ServerSocket serverSocket = new ServerSocket(port, /* backlog */ 1);
+    ServerSocket serverSocket = createServerSocket(port, listenAddress);
     return createAndWaitForConnection(eventHandler, serverSocket, verboseLogging, callback);
+  }
+
+  @VisibleForTesting
+  static ServerSocket createServerSocket(int port, @Nullable String listenAddress)
+      throws IOException {
+    InetAddress address =
+        listenAddress == null || listenAddress.isEmpty()
+            ? InetAddress.getLoopbackAddress()
+            : InetAddress.getByName(listenAddress);
+    return new ServerSocket(port, /* backlog */ 1, address);
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugServerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugServerTest.java
@@ -128,6 +128,20 @@ public class StarlarkDebugServerTest {
   }
 
   @Test
+  public void testCreateServerSocketDefaultsToLoopback() throws Exception {
+    try (ServerSocket serverSocket = StarlarkDebugServer.createServerSocket(0, "")) {
+      assertThat(serverSocket.getInetAddress().isLoopbackAddress()).isTrue();
+    }
+  }
+
+  @Test
+  public void testCreateServerSocketHonorsExplicitAddress() throws Exception {
+    try (ServerSocket serverSocket = StarlarkDebugServer.createServerSocket(0, "0.0.0.0")) {
+      assertThat(serverSocket.getInetAddress().isAnyLocalAddress()).isTrue();
+    }
+  }
+
+  @Test
   public void testStartDebuggingResponseReceived() throws Exception {
     DebugEvent response =
         client.sendRequestAndWaitForResponse(

--- a/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugServerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugServerTest.java
@@ -128,16 +128,16 @@ public class StarlarkDebugServerTest {
   }
 
   @Test
-  public void testCreateServerSocketDefaultsToLoopback() throws Exception {
+  public void testCreateServerSocketDefaultsToWildcardBind() throws Exception {
     try (ServerSocket serverSocket = StarlarkDebugServer.createServerSocket(0, "")) {
-      assertThat(serverSocket.getInetAddress().isLoopbackAddress()).isTrue();
+      assertThat(serverSocket.getInetAddress().isAnyLocalAddress()).isTrue();
     }
   }
 
   @Test
-  public void testCreateServerSocketHonorsExplicitAddress() throws Exception {
-    try (ServerSocket serverSocket = StarlarkDebugServer.createServerSocket(0, "0.0.0.0")) {
-      assertThat(serverSocket.getInetAddress().isAnyLocalAddress()).isTrue();
+  public void testCreateServerSocketHonorsExplicitLoopbackAddress() throws Exception {
+    try (ServerSocket serverSocket = StarlarkDebugServer.createServerSocket(0, "localhost")) {
+      assertThat(serverSocket.getInetAddress().isLoopbackAddress()).isTrue();
     }
   }
 


### PR DESCRIPTION
## Summary
- add `--experimental_skylark_debug_server_address` while preserving the existing default bind behavior
- bind the Starlark debug server to an explicit address only when the new flag is set
- cover both the default wildcard bind and an explicit loopback bind with focused unit tests

## Why
This introduces the configuration knob first without breaking existing cross-machine debugger workflows. Users and internal tools can opt into a specific address now, and callers that need remote debugger access can explicitly set a non-loopback address before any future default change.

## User impact
there is no behavior change by default.
users who want local-only debugger access can pass `--experimental_skylark_debug_server_address=localhost` or another loopback address.
users who intentionally attach from another host can continue relying on the current default for now, or set the required listen address explicitly.

## Validation
- `git diff --check`
- `/tmp/bazelisk test --test_output=errors //src/test/java/com/google/devtools/build/lib/starlarkdebug/server:StarlarkDebugServerTest //src/test/java/com/google/devtools/build/lib/starlarkdebug/server:StarlarkDebugIntegrationTest`
