### PR TITLE
test-encyclopedia: fix link to JUnit schema

### DIFF
--- a/site/en/reference/test-encyclopedia.md
+++ b/site/en/reference/test-encyclopedia.md
@@ -456,7 +456,7 @@ The initial environment block shall be composed as follows:
       Location to which test actions should write a test result XML output file.
       Otherwise, Bazel generates a default XML output file wrapping the test log
       as part of the test action. The XML schema is based on the
-      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd"
+      <a href="https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd"
         class="external">JUnit test result schema</a>.</td>
     <td>optional</td>
   </tr>


### PR DESCRIPTION
The current link is broken, point to JUnit.xsd
on GitHub instead.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description

This updates a broken link to the JUnit schema in the test-encyclopeda to point to https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd

### Motivation

The [current link](https://windyroad.com.au/dl/Open%20Source/JUnit.xsd) is broken.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
