### PR TITLE
Remove experimental from remote_downloader flags

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -155,7 +155,8 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
   public abstract void setRemoteCache(String value);
 
   @Option(
-      name = "experimental_remote_downloader",
+      name = "remote_downloader",
+      oldName = "experimental_remote_downloader",
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
@@ -169,7 +170,8 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
   public abstract void setRemoteDownloader(String value);
 
   @Option(
-      name = "experimental_remote_downloader_local_fallback",
+      name = "remote_downloader_local_fallback",
+      oldName = "experimental_remote_downloader_local_fallback",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
@@ -179,7 +181,8 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
   public abstract void setRemoteDownloaderLocalFallback(boolean value);
 
   @Option(
-      name = "experimental_remote_downloader_propagate_credentials",
+      name = "remote_downloader_propagate_credentials",
+      oldName = "experimental_remote_downloader_propagate_credentials",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},

--- a/src/test/shell/bazel/remote/remote_downloader_test.sh
+++ b/src/test/shell/bazel/remote/remote_downloader_test.sh
@@ -100,7 +100,7 @@ EOF
   # Build using the remote downloader
   bazel build \
       --remote_cache=grpc://localhost:${worker_port} \
-      --experimental_remote_downloader=grpc://localhost:${worker_port} \
+      --remote_downloader=grpc://localhost:${worker_port} \
       //:test >& $TEST_log \
       || fail "Failed to build with remote downloader"
 
@@ -153,7 +153,7 @@ EOF
   # The build should fail due to checksum mismatch
   bazel build \
       --remote_cache=grpc://localhost:${worker_port} \
-      --experimental_remote_downloader=grpc://localhost:${worker_port} \
+      --remote_downloader=grpc://localhost:${worker_port} \
       //:check >& $TEST_log \
       && fail "Expected build to fail due to checksum mismatch"
 
@@ -207,7 +207,7 @@ EOF
 
   bazel build \
       --remote_cache=grpc://localhost:${worker_port} \
-      --experimental_remote_downloader=grpc://localhost:${worker_port} \
+      --remote_downloader=grpc://localhost:${worker_port} \
       //:test >& $TEST_log \
       || fail "Failed first build with canonical_id"
 
@@ -244,7 +244,7 @@ EOF
   # and re-download the file
   bazel build \
       --remote_cache=grpc://localhost:${worker_port} \
-      --experimental_remote_downloader=grpc://localhost:${worker_port} \
+      --remote_downloader=grpc://localhost:${worker_port} \
       //:test >& $TEST_log \
       || fail "Failed to build with new canonical_id"
 
@@ -298,7 +298,7 @@ EOF
   # First build - should download from the origin
   bazel build \
       --remote_cache=grpc://localhost:${worker_port} \
-      --experimental_remote_downloader=grpc://localhost:${worker_port} \
+      --remote_downloader=grpc://localhost:${worker_port} \
       //:test >& $TEST_log \
       || fail "Failed first build"
 
@@ -312,7 +312,7 @@ EOF
   # (no HTTP server running, so it would fail if trying to re-download)
   bazel build \
       --remote_cache=grpc://localhost:${worker_port} \
-      --experimental_remote_downloader=grpc://localhost:${worker_port} \
+      --remote_downloader=grpc://localhost:${worker_port} \
       //:test >& $TEST_log \
       || fail "Failed second build - should have used cache"
 


### PR DESCRIPTION
This has been around for 6 years and seems well supported in the
community.
