### PR TITLE
Fix dotd file validation failure being cached

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
@@ -42,6 +42,7 @@ import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import com.google.devtools.common.options.OptionsProvider;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.SortedMap;
 import javax.annotation.Nullable;
@@ -205,6 +206,54 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
     }
   }
 
+  /**
+   * A spawn cache store that is delayed until after output validation succeeds.
+   */
+  public interface DeferredSpawnCacheStore extends Closeable {
+    void store() throws ExecException, InterruptedException, IOException;
+
+    @Override
+    void close();
+  }
+
+  private static final class DeferredSpawnCacheStores implements Closeable {
+    private final ArrayList<DeferredSpawnCacheStore> stores = new ArrayList<>();
+
+    synchronized void add(DeferredSpawnCacheStore store) {
+      stores.add(store);
+    }
+
+    void flush() throws ExecException, InterruptedException, IOException {
+      ArrayList<DeferredSpawnCacheStore> storesToFlush;
+      synchronized (this) {
+        storesToFlush = new ArrayList<>(stores);
+        stores.clear();
+      }
+      for (int i = 0; i < storesToFlush.size(); i++) {
+        try (DeferredSpawnCacheStore store = storesToFlush.get(i)) {
+          store.store();
+        } catch (ExecException | InterruptedException | IOException e) {
+          for (int j = i + 1; j < storesToFlush.size(); j++) {
+            storesToFlush.get(j).close();
+          }
+          throw e;
+        }
+      }
+    }
+
+    @Override
+    public void close() {
+      ArrayList<DeferredSpawnCacheStore> storesToClose;
+      synchronized (this) {
+        storesToClose = new ArrayList<>(stores);
+        stores.clear();
+      }
+      for (DeferredSpawnCacheStore store : storesToClose) {
+        store.close();
+      }
+    }
+  }
+
   /** Enum for --subcommands flag */
   public enum ShowSubcommands {
     TRUE(true, false), PRETTY_PRINT(true, true), FALSE(false, false);
@@ -239,6 +288,8 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
   private final SyscallCache syscallCache;
   private final ThreadStateReceiver threadStateReceiverForMetrics;
   private final boolean fileSystemSupportsInputDiscovery;
+  private final DeferredSpawnCacheStores deferredSpawnCacheStores;
+  private final boolean ownsDeferredSpawnCacheStores;
 
   private ActionExecutionContext(
       Executor executor,
@@ -256,7 +307,9 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
       DiscoveredModulesPruner discoveredModulesPruner,
       SyscallCache syscallCache,
       ThreadStateReceiver threadStateReceiverForMetrics,
-      boolean fileSystemSupportsInputDiscovery) {
+      boolean fileSystemSupportsInputDiscovery,
+      DeferredSpawnCacheStores deferredSpawnCacheStores,
+      boolean ownsDeferredSpawnCacheStores) {
     this.inputMetadataProvider = inputMetadataProvider;
     this.actionInputPrefetcher = actionInputPrefetcher;
     this.actionKeyContext = actionKeyContext;
@@ -276,6 +329,8 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
     this.discoveredModulesPruner = discoveredModulesPruner;
     this.syscallCache = syscallCache;
     this.fileSystemSupportsInputDiscovery = fileSystemSupportsInputDiscovery;
+    this.deferredSpawnCacheStores = deferredSpawnCacheStores;
+    this.ownsDeferredSpawnCacheStores = ownsDeferredSpawnCacheStores;
   }
 
   public ActionExecutionContext(
@@ -309,7 +364,9 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         discoveredModulesPruner,
         syscallCache,
         threadStateReceiverForMetrics,
-        /* fileSystemSupportsInputDiscovery= */ false);
+        /* fileSystemSupportsInputDiscovery= */ false,
+        new DeferredSpawnCacheStores(),
+        /* ownsDeferredSpawnCacheStores= */ true);
   }
 
   public static ActionExecutionContext forInputDiscovery(
@@ -344,7 +401,9 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         discoveredModulesPruner,
         syscalls,
         threadStateReceiverForMetrics,
-        fileSystemSupportsInputDiscovery);
+        fileSystemSupportsInputDiscovery,
+        new DeferredSpawnCacheStores(),
+        /* ownsDeferredSpawnCacheStores= */ true);
   }
 
   public ActionInputPrefetcher getActionInputPrefetcher() {
@@ -536,14 +595,33 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
     return threadStateReceiverForMetrics;
   }
 
+  public void deferSpawnCacheStore(DeferredSpawnCacheStore store) {
+    deferredSpawnCacheStores.add(store);
+  }
+
+  /**
+   * Stores spawn cache entries that were deferred until action output validation and finalization
+   * succeeded.
+   */
+  public void flushDeferredSpawnCacheStores()
+      throws ExecException, InterruptedException, IOException {
+    deferredSpawnCacheStores.flush();
+  }
+
   @Override
   public void close() throws IOException {
-    // Ensure that we close both fileOutErr and actionFileSystem even if one throws.
+    // Ensure that we close all resources even if one throws.
     try {
       fileOutErr.close();
     } finally {
-      if (actionFileSystem instanceof Closeable closeable) {
-        closeable.close();
+      try {
+        if (actionFileSystem instanceof Closeable closeable) {
+          closeable.close();
+        }
+      } finally {
+        if (ownsDeferredSpawnCacheStores) {
+          deferredSpawnCacheStores.close();
+        }
       }
     }
   }
@@ -566,7 +644,9 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         discoveredModulesPruner,
         syscallCache,
         threadStateReceiverForMetrics,
-        fileSystemSupportsInputDiscovery);
+        fileSystemSupportsInputDiscovery,
+        deferredSpawnCacheStores,
+        /* ownsDeferredSpawnCacheStores= */ false);
   }
 
   /**
@@ -620,7 +700,9 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         discoveredModulesPruner,
         syscallCache,
         threadStateReceiverForMetrics,
-        fileSystemSupportsInputDiscovery);
+        fileSystemSupportsInputDiscovery,
+        deferredSpawnCacheStores,
+        /* ownsDeferredSpawnCacheStores= */ false);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
@@ -42,6 +42,7 @@ import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import com.google.devtools.common.options.OptionsProvider;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.SortedMap;
 import javax.annotation.Nullable;
@@ -205,6 +206,54 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
     }
   }
 
+  /**
+   * A spawn cache store that is delayed until after output validation succeeds.
+   */
+  public interface DeferredSpawnCacheStore extends Closeable {
+    void store() throws ExecException, InterruptedException, IOException;
+
+    @Override
+    void close();
+  }
+
+  private static final class DeferredSpawnCacheStores implements Closeable {
+    private final ArrayList<DeferredSpawnCacheStore> stores = new ArrayList<>();
+
+    synchronized void add(DeferredSpawnCacheStore store) {
+      stores.add(store);
+    }
+
+    void flush() throws ExecException, InterruptedException, IOException {
+      ArrayList<DeferredSpawnCacheStore> storesToFlush;
+      synchronized (this) {
+        storesToFlush = new ArrayList<>(stores);
+        stores.clear();
+      }
+      for (int i = 0; i < storesToFlush.size(); i++) {
+        try (DeferredSpawnCacheStore store = storesToFlush.get(i)) {
+          store.store();
+        } catch (ExecException | InterruptedException | IOException e) {
+          for (int j = i + 1; j < storesToFlush.size(); j++) {
+            storesToFlush.get(j).close();
+          }
+          throw e;
+        }
+      }
+    }
+
+    @Override
+    public void close() {
+      ArrayList<DeferredSpawnCacheStore> storesToClose;
+      synchronized (this) {
+        storesToClose = new ArrayList<>(stores);
+        stores.clear();
+      }
+      for (DeferredSpawnCacheStore store : storesToClose) {
+        store.close();
+      }
+    }
+  }
+
   /** Enum for --subcommands flag */
   public enum ShowSubcommands {
     TRUE(true, false), PRETTY_PRINT(true, true), FALSE(false, false);
@@ -240,6 +289,8 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
   private final ThreadStateReceiver threadStateReceiverForMetrics;
   private final boolean fileSystemSupportsInputDiscovery;
   private final boolean bustCaches;
+  private final DeferredSpawnCacheStores deferredSpawnCacheStores;
+  private final boolean ownsDeferredSpawnCacheStores;
 
   private ActionExecutionContext(
       Executor executor,
@@ -258,7 +309,9 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
       SyscallCache syscallCache,
       ThreadStateReceiver threadStateReceiverForMetrics,
       boolean fileSystemSupportsInputDiscovery,
-      boolean bustCaches) {
+      boolean bustCaches,
+      DeferredSpawnCacheStores deferredSpawnCacheStores,
+      boolean ownsDeferredSpawnCacheStores) {
     this.inputMetadataProvider = inputMetadataProvider;
     this.actionInputPrefetcher = actionInputPrefetcher;
     this.actionKeyContext = actionKeyContext;
@@ -279,6 +332,8 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
     this.syscallCache = syscallCache;
     this.fileSystemSupportsInputDiscovery = fileSystemSupportsInputDiscovery;
     this.bustCaches = bustCaches;
+    this.deferredSpawnCacheStores = deferredSpawnCacheStores;
+    this.ownsDeferredSpawnCacheStores = ownsDeferredSpawnCacheStores;
   }
 
   public ActionExecutionContext(
@@ -313,7 +368,9 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         syscallCache,
         threadStateReceiverForMetrics,
         /* fileSystemSupportsInputDiscovery= */ false,
-        /* bustCaches= */ false);
+        /* bustCaches= */ false,
+        new DeferredSpawnCacheStores(),
+        /* ownsDeferredSpawnCacheStores= */ true);
   }
 
   public ActionExecutionContext(
@@ -349,7 +406,9 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         syscallCache,
         threadStateReceiverForMetrics,
         /* fileSystemSupportsInputDiscovery= */ false,
-        bustCaches);
+        bustCaches,
+        new DeferredSpawnCacheStores(),
+        /* ownsDeferredSpawnCacheStores= */ true);
   }
 
   public static ActionExecutionContext forInputDiscovery(
@@ -385,7 +444,9 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         syscalls,
         threadStateReceiverForMetrics,
         fileSystemSupportsInputDiscovery,
-        /* bustCaches= */ false);
+        /* bustCaches= */ false,
+        new DeferredSpawnCacheStores(),
+        /* ownsDeferredSpawnCacheStores= */ true);
   }
 
   public boolean bustCaches() {
@@ -581,14 +642,33 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
     return threadStateReceiverForMetrics;
   }
 
+  public void deferSpawnCacheStore(DeferredSpawnCacheStore store) {
+    deferredSpawnCacheStores.add(store);
+  }
+
+  /**
+   * Stores spawn cache entries that were deferred until action output validation and finalization
+   * succeeded.
+   */
+  public void flushDeferredSpawnCacheStores()
+      throws ExecException, InterruptedException, IOException {
+    deferredSpawnCacheStores.flush();
+  }
+
   @Override
   public void close() throws IOException {
-    // Ensure that we close both fileOutErr and actionFileSystem even if one throws.
+    // Ensure that we close all resources even if one throws.
     try {
       fileOutErr.close();
     } finally {
-      if (actionFileSystem instanceof Closeable closeable) {
-        closeable.close();
+      try {
+        if (actionFileSystem instanceof Closeable closeable) {
+          closeable.close();
+        }
+      } finally {
+        if (ownsDeferredSpawnCacheStores) {
+          deferredSpawnCacheStores.close();
+        }
       }
     }
   }
@@ -612,7 +692,9 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         syscallCache,
         threadStateReceiverForMetrics,
         fileSystemSupportsInputDiscovery,
-        bustCaches);
+        bustCaches,
+        deferredSpawnCacheStores,
+        /* ownsDeferredSpawnCacheStores= */ false);
   }
 
   /**
@@ -667,7 +749,9 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
         syscallCache,
         threadStateReceiverForMetrics,
         fileSystemSupportsInputDiscovery,
-        bustCaches);
+        bustCaches,
+        deferredSpawnCacheStores,
+        /* ownsDeferredSpawnCacheStores= */ false);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionMetadata.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionMetadata.java
@@ -133,4 +133,17 @@ public interface ActionExecutionMetadata extends ActionAnalysisMetadata {
   default boolean allowsStrategyRegexpMatching() {
     return true;
   }
+
+  /**
+   * Returns true if successful spawn results should only be stored in spawn caches after the owning
+   * action has completed successfully, including output validation.
+   *
+   * <p>This is for actions that validate spawn outputs after the spawn has completed and must not
+   * publish the spawn result if that validation rejects the action. Actions that run multiple
+   * cacheable spawns or overwrite spawn outputs before returning should leave this false unless the
+   * outputs for every deferred spawn remain available and unchanged until action completion.
+   */
+  default boolean shouldDeferSpawnCacheStore() {
+    return false;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionMetadata.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionMetadata.java
@@ -141,4 +141,17 @@ public interface ActionExecutionMetadata extends ActionAnalysisMetadata {
   default boolean allowsStrategyRegexpMatching() {
     return true;
   }
+
+  /**
+   * Returns true if successful spawn results should only be stored in spawn caches after the owning
+   * action has completed successfully, including output validation.
+   *
+   * <p>This is for actions that validate spawn outputs after the spawn has completed and must not
+   * publish the spawn result if that validation rejects the action. Actions that run multiple
+   * cacheable spawns or overwrite spawn outputs before returning should leave this false unless the
+   * outputs for every deferred spawn remain available and unchanged until action completion.
+   */
+  default boolean shouldDeferSpawnCacheStore() {
+    return false;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -22,6 +22,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.actions.ActionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
+import com.google.devtools.build.lib.actions.ActionExecutionContext.DeferredSpawnCacheStore;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
@@ -127,7 +128,10 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
     }
     SpawnResult spawnResult;
     ExecException ex = null;
-    try (CacheHandle cacheHandle = cache.lookup(spawn, context)) {
+    CacheHandle cacheHandle = null;
+    boolean closeCacheHandle = true;
+    try {
+      cacheHandle = cache.lookup(spawn, context);
       if (cacheHandle.hasResult()) {
         spawnResult = Preconditions.checkNotNull(cacheHandle.getResult());
       } else {
@@ -152,7 +156,25 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
                     startTime,
                     spawnIdentifier));
         if (cacheHandle.willStore()) {
-          cacheHandle.store(spawnResult);
+          if (spawn.getResourceOwner().shouldDeferSpawnCacheStore()) {
+            CacheHandle cacheHandleForStore = cacheHandle;
+            SpawnResult spawnResultForStore = spawnResult;
+            actionExecutionContext.deferSpawnCacheStore(
+                new DeferredSpawnCacheStore() {
+                  @Override
+                  public void store() throws ExecException, InterruptedException, IOException {
+                    cacheHandleForStore.store(spawnResultForStore);
+                  }
+
+                  @Override
+                  public void close() {
+                    cacheHandleForStore.close();
+                  }
+                });
+            closeCacheHandle = false;
+          } else {
+            cacheHandle.store(spawnResult);
+          }
         }
       }
     } catch (InterruptedIOException e) {
@@ -168,6 +190,10 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
       ex = e;
       spawnResult = e.getSpawnResult();
       // Log the Spawn and re-throw.
+    } finally {
+      if (closeCacheHandle && cacheHandle != null) {
+        cacheHandle.close();
+      }
     }
 
     SpawnLogContext spawnLogContext = actionExecutionContext.getContext(SpawnLogContext.class);

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.actions.ActionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
+import com.google.devtools.build.lib.actions.ActionExecutionContext.DeferredSpawnCacheStore;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Priority;
@@ -292,6 +293,17 @@ public interface SpawnRunner {
 
     /** Returns the environment of the Bazel client. */
     ImmutableMap<String, String> getClientEnv();
+
+    /**
+     * Defers a spawn cache store until after the owning {@link ActionExecutionMetadata} completes
+     * successfully.
+     */
+    default void deferSpawnCacheStore(DeferredSpawnCacheStore store)
+        throws ExecException, InterruptedException, IOException {
+      try (store) {
+        store.store();
+      }
+    }
   }
 
   /** Partial implementation of {@link SpawnExecutionContext}. */
@@ -362,6 +374,11 @@ public interface SpawnRunner {
     @Override
     public final ImmutableMap<String, String> getClientEnv() {
       return actionExecutionContext.getClientEnv();
+    }
+
+    @Override
+    public final void deferSpawnCacheStore(DeferredSpawnCacheStore store) {
+      actionExecutionContext.deferSpawnCacheStore(store);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.actions.ActionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
+import com.google.devtools.build.lib.actions.ActionExecutionContext.DeferredSpawnCacheStore;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Priority;
@@ -297,6 +298,17 @@ public interface SpawnRunner {
     default boolean bustCaches() {
       return false;
     }
+
+    /**
+     * Defers a spawn cache store until after the owning {@link ActionExecutionMetadata} completes
+     * successfully.
+     */
+    default void deferSpawnCacheStore(DeferredSpawnCacheStore store)
+        throws ExecException, InterruptedException, IOException {
+      try (store) {
+        store.store();
+      }
+    }
   }
 
   /** Partial implementation of {@link SpawnExecutionContext}. */
@@ -372,6 +384,11 @@ public interface SpawnRunner {
     @Override
     public final ImmutableMap<String, String> getClientEnv() {
       return actionExecutionContext.getClientEnv();
+    }
+
+    @Override
+    public final void deferSpawnCacheStore(DeferredSpawnCacheStore store) {
+      actionExecutionContext.deferSpawnCacheStore(store);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1449,15 +1449,9 @@ public class RemoteExecutionService {
         var unused = updateKnownMissingCasDigests(knownMissingCasDigests, metadata);
       }
 
-      // When downloading outputs from just remotely executed action, the action result comes from
-      // Execution response which means, if disk cache is enabled, action result hasn't been
-      // uploaded to it. Upload action result to disk cache here so next build could hit it.
-      if (useDiskCache() && result.executeResponse != null) {
-        getFromFuture(
-            combinedCache.uploadActionResult(
-                context.withWriteCachePolicy(CachePolicy.DISK_CACHE_ONLY),
-                action.getActionKey(),
-                result.actionResult));
+      if (shouldUploadActionResultToDiskCache(result)
+          && !action.getSpawn().getResourceOwner().shouldDeferSpawnCacheStore()) {
+        uploadActionResultToDiskCache(action, result);
       }
     }
 
@@ -1466,6 +1460,27 @@ public class RemoteExecutionService {
     }
 
     return null;
+  }
+
+  boolean shouldUploadActionResultToDiskCache(RemoteActionResult result) {
+    // When downloading outputs from a remotely executed action, the action result comes from the
+    // execution response, so the disk cache doesn't have the action result yet. Callers may still
+    // delay the upload until the owning action validates the spawn result.
+    return useDiskCache() && result.executeResponse != null && result.success();
+  }
+
+  void uploadActionResultToDiskCache(RemoteAction action, RemoteActionResult result)
+      throws IOException, InterruptedException {
+    if (!shouldUploadActionResultToDiskCache(result)) {
+      return;
+    }
+    getFromFuture(
+        combinedCache.uploadActionResult(
+            action
+                .getRemoteActionExecutionContext()
+                .withWriteCachePolicy(CachePolicy.DISK_CACHE_ONLY),
+            action.getActionKey(),
+            result.actionResult));
   }
 
   /** An ongoing local execution of a spawn. */

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1462,15 +1462,9 @@ public class RemoteExecutionService {
         var unused = updateKnownMissingCasDigests(knownMissingCasDigests, metadata);
       }
 
-      // When downloading outputs from just remotely executed action, the action result comes from
-      // Execution response which means, if disk cache is enabled, action result hasn't been
-      // uploaded to it. Upload action result to disk cache here so next build could hit it.
-      if (useDiskCache() && result.executeResponse != null) {
-        getFromFuture(
-            combinedCache.uploadActionResult(
-                context.withWriteCachePolicy(CachePolicy.DISK_CACHE_ONLY),
-                action.getActionKey(),
-                result.actionResult));
+      if (shouldUploadActionResultToDiskCache(result)
+          && !action.getSpawn().getResourceOwner().shouldDeferSpawnCacheStore()) {
+        uploadActionResultToDiskCache(action, result);
       }
     }
 
@@ -1479,6 +1473,27 @@ public class RemoteExecutionService {
     }
 
     return null;
+  }
+
+  boolean shouldUploadActionResultToDiskCache(RemoteActionResult result) {
+    // When downloading outputs from a remotely executed action, the action result comes from the
+    // execution response, so the disk cache doesn't have the action result yet. Callers may still
+    // delay the upload until the owning action validates the spawn result.
+    return useDiskCache() && result.executeResponse != null && result.success();
+  }
+
+  void uploadActionResultToDiskCache(RemoteAction action, RemoteActionResult result)
+      throws IOException, InterruptedException {
+    if (!shouldUploadActionResultToDiskCache(result)) {
+      return;
+    }
+    getFromFuture(
+        combinedCache.uploadActionResult(
+            action
+                .getRemoteActionExecutionContext()
+                .withWriteCachePolicy(CachePolicy.DISK_CACHE_ONLY),
+            action.getActionKey(),
+            result.actionResult));
   }
 
   /** An ongoing local execution of a spawn. */

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -35,6 +35,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.devtools.build.lib.actions.ActionExecutionContext.DeferredSpawnCacheStore;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
@@ -487,6 +488,21 @@ public class RemoteSpawnRunner implements SpawnRunner {
     try (SilentCloseable c = Profiler.instance().profile(REMOTE_DOWNLOAD, "download outputs")) {
       inMemoryOutput = remoteExecutionService.downloadOutputs(action, result);
     }
+    if (spawn.getResourceOwner().shouldDeferSpawnCacheStore()
+        && remoteExecutionService.shouldUploadActionResultToDiskCache(result)) {
+      action
+          .getSpawnExecutionContext()
+          .deferSpawnCacheStore(
+              new DeferredSpawnCacheStore() {
+                @Override
+                public void store() throws IOException, InterruptedException {
+                  remoteExecutionService.uploadActionResultToDiskCache(action, result);
+                }
+
+                @Override
+                public void close() {}
+              });
+    }
 
     fetchTime.stop();
     totalTime.stop();
@@ -693,8 +709,22 @@ public class RemoteSpawnRunner implements SpawnRunner {
         && uploadLocalResults
         && Objects.equals(result.status(), Status.SUCCESS)
         && result.exitCode() == 0) {
-      remoteExecutionService.uploadOutputs(
-          action, result, () -> {}, remoteOptions.getGuardAgainstConcurrentChanges());
+      if (spawn.getResourceOwner().shouldDeferSpawnCacheStore()) {
+        context.deferSpawnCacheStore(
+            new DeferredSpawnCacheStore() {
+              @Override
+              public void store() throws ExecException, InterruptedException {
+                remoteExecutionService.uploadOutputs(
+                    action, result, () -> {}, remoteOptions.getGuardAgainstConcurrentChanges());
+              }
+
+              @Override
+              public void close() {}
+            });
+      } else {
+        remoteExecutionService.uploadOutputs(
+            action, result, () -> {}, remoteOptions.getGuardAgainstConcurrentChanges());
+      }
     }
     return result;
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -35,6 +35,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.devtools.build.lib.actions.ActionExecutionContext.DeferredSpawnCacheStore;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
@@ -500,6 +501,21 @@ public class RemoteSpawnRunner implements SpawnRunner {
     try (SilentCloseable c = Profiler.instance().profile(REMOTE_DOWNLOAD, "download outputs")) {
       inMemoryOutput = remoteExecutionService.downloadOutputs(action, result);
     }
+    if (spawn.getResourceOwner().shouldDeferSpawnCacheStore()
+        && remoteExecutionService.shouldUploadActionResultToDiskCache(result)) {
+      action
+          .getSpawnExecutionContext()
+          .deferSpawnCacheStore(
+              new DeferredSpawnCacheStore() {
+                @Override
+                public void store() throws IOException, InterruptedException {
+                  remoteExecutionService.uploadActionResultToDiskCache(action, result);
+                }
+
+                @Override
+                public void close() {}
+              });
+    }
 
     fetchTime.stop();
     totalTime.stop();
@@ -706,8 +722,22 @@ public class RemoteSpawnRunner implements SpawnRunner {
         && uploadLocalResults
         && Objects.equals(result.status(), Status.SUCCESS)
         && result.exitCode() == 0) {
-      remoteExecutionService.uploadOutputs(
-          action, result, () -> {}, remoteOptions.getGuardAgainstConcurrentChanges());
+      if (spawn.getResourceOwner().shouldDeferSpawnCacheStore()) {
+        context.deferSpawnCacheStore(
+            new DeferredSpawnCacheStore() {
+              @Override
+              public void store() throws ExecException, InterruptedException {
+                remoteExecutionService.uploadOutputs(
+                    action, result, () -> {}, remoteOptions.getGuardAgainstConcurrentChanges());
+              }
+
+              @Override
+              public void close() {}
+            });
+      } else {
+        remoteExecutionService.uploadOutputs(
+            action, result, () -> {}, remoteOptions.getGuardAgainstConcurrentChanges());
+      }
     }
     return result;
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -1674,6 +1674,11 @@ public class CppCompileAction extends AbstractAction
     return featureConfiguration.isEnabled(CppRuleClasses.PARSE_SHOWINCLUDES);
   }
 
+  @Override
+  public boolean shouldDeferSpawnCacheStore() {
+    return getDotdFile() != null || shouldParseShowIncludes();
+  }
+
   /** Dynamically compute the dependencies of a compilation using C++20 modules. */
   private ImmutableSet<Artifact> computeUsedCpp20Modules(
       ActionExecutionContext actionExecutionContext) throws ActionExecutionException {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -1679,6 +1679,11 @@ public class CppCompileAction extends AbstractAction
     return featureConfiguration.isEnabled(CppRuleClasses.PARSE_SHOWINCLUDES);
   }
 
+  @Override
+  public boolean shouldDeferSpawnCacheStore() {
+    return getDotdFile() != null || shouldParseShowIncludes();
+  }
+
   /** Dynamically compute the dependencies of a compilation using C++20 modules. */
   private ImmutableSet<Artifact> computeUsedCpp20Modules(
       ActionExecutionContext actionExecutionContext) throws ActionExecutionException {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -64,6 +64,7 @@ import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.CachedActionEvent;
 import com.google.devtools.build.lib.actions.DiscoveredModulesPruner;
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.Executor;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FilesetOutputTree;
@@ -1290,9 +1291,6 @@ public final class SkyframeActionExecutor {
         ExtendedEventHandler eventHandler, ActionResult actionResult)
         throws ActionExecutionException, InterruptedException {
       boolean outputAlreadyDumped = false;
-      if (actionResult != ActionResult.EMPTY) {
-        eventHandler.post(new ActionResultReceivedEvent(action, actionResult));
-      }
 
       // Action terminated fine, now report the output.
       // The .showOutput() method is not necessarily a quick check: in its
@@ -1343,6 +1341,23 @@ public final class SkyframeActionExecutor {
                 Code.ACTION_FINALIZATION_FAILURE);
           }
         }
+
+        try {
+          actionExecutionContext.flushDeferredSpawnCacheStores();
+        } catch (ExecException e) {
+          throw ActionExecutionException.fromExecException(e, action);
+        } catch (IOException e) {
+          throw ActionExecutionException.fromExecException(
+              new EnvironmentalExecException(
+                  e,
+                  FailureDetail.newBuilder()
+                      .setMessage("Exec failed due to IOException")
+                      .setSpawn(
+                          FailureDetails.Spawn.newBuilder()
+                              .setCode(FailureDetails.Spawn.Code.EXEC_IO_EXCEPTION))
+                      .build()),
+              action);
+        }
       } catch (ActionExecutionException actionException) {
         // Success in execution but failure in completion.
         reportActionExecution(
@@ -1378,6 +1393,10 @@ public final class SkyframeActionExecutor {
         primaryOutputMetadata = outputMetadataStore.getOutputMetadata(primaryOutput);
       } catch (IOException e) {
         throw new IllegalStateException("Metadata already obtained for " + primaryOutput, e);
+      }
+
+      if (actionResult != ActionResult.EMPTY) {
+        eventHandler.post(new ActionResultReceivedEvent(action, actionResult));
       }
 
       reportActionExecution(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -64,6 +64,7 @@ import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.CachedActionEvent;
 import com.google.devtools.build.lib.actions.DiscoveredModulesPruner;
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.Executor;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FilesetOutputTree;
@@ -1373,6 +1374,23 @@ public final class SkyframeActionExecutor {
                 fileOutErr,
                 Code.ACTION_FINALIZATION_FAILURE);
           }
+        }
+
+        try {
+          actionExecutionContext.flushDeferredSpawnCacheStores();
+        } catch (ExecException e) {
+          throw ActionExecutionException.fromExecException(e, action);
+        } catch (IOException e) {
+          throw ActionExecutionException.fromExecException(
+              new EnvironmentalExecException(
+                  e,
+                  FailureDetail.newBuilder()
+                      .setMessage("Exec failed due to IOException")
+                      .setSpawn(
+                          FailureDetails.Spawn.newBuilder()
+                              .setCode(FailureDetails.Spawn.Code.EXEC_IO_EXCEPTION))
+                      .build()),
+              action);
         }
       } catch (ActionExecutionException actionException) {
         // Success in execution but failure in completion.

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -138,6 +138,94 @@ EOF
     || fail "Build failed but should have succeeded"
 }
 
+function test_dotd_validation_failure_not_stored_in_disk_cache() {
+  add_rules_cc "MODULE.bazel"
+
+  local pkg="dotd_cache_validation"
+  local cache="${TEST_TMPDIR}/disk_cache"
+  mkdir -p "${pkg}/dep1" "${pkg}/dep2"
+
+  cat > "${pkg}/BUILD" <<'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "f",
+    srcs = ["f.cc"],
+    deps = ["//dotd_cache_validation/dep1:dep1_h"],
+)
+EOF
+  cat > "${pkg}/dep1/BUILD" <<'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "dep1_h",
+    hdrs = [
+        "some_inc.h",
+        "other_inc.h",
+    ],
+    strip_include_prefix = ".",
+    visibility = ["//visibility:public"],
+)
+EOF
+  cat > "${pkg}/dep2/BUILD" <<'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "dep2_h",
+    hdrs = ["some_inc.h"],
+    strip_include_prefix = ".",
+    visibility = ["//visibility:public"],
+)
+EOF
+  cat > "${pkg}/f.cc" <<'EOF'
+#include "some_inc.h"
+#include "other_inc.h"
+
+int f() {
+  return SOME_INC + OTHER_INC;
+}
+EOF
+  echo "#define SOME_INC 1" > "${pkg}/dep1/some_inc.h"
+  echo "#define OTHER_INC 10" > "${pkg}/dep1/other_inc.h"
+  echo "#define SOME_INC 2" > "${pkg}/dep2/some_inc.h"
+
+  bazel build --spawn_strategy=local --disk_cache="${cache}" "//${pkg}:f" &>"$TEST_log" \
+    || fail "initial build failed"
+  [[ -e "bazel-bin/${pkg}/dep1/_virtual_includes/dep1_h/some_inc.h" ]] \
+    || fail "expected initial virtual include for dep1"
+
+  cat > "${pkg}/BUILD" <<'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "f",
+    srcs = ["f.cc"],
+    deps = [
+        "//dotd_cache_validation/dep1:dep1_h",
+        "//dotd_cache_validation/dep2:dep2_h",
+    ],
+)
+EOF
+  cat > "${pkg}/dep1/BUILD" <<'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "dep1_h",
+    hdrs = ["other_inc.h"],
+    strip_include_prefix = ".",
+    visibility = ["//visibility:public"],
+)
+EOF
+
+  bazel build --spawn_strategy=local --disk_cache="${cache}" "//${pkg}:f" &>"$TEST_log" \
+    && fail "incremental build should fail from stale virtual include" || true
+  expect_log "undeclared inclusion(s) in rule '//${pkg}:f'"
+
+  bazel clean &>"$TEST_log" || fail "clean failed"
+  bazel build --spawn_strategy=local --disk_cache="${cache}" "//${pkg}:f" &>"$TEST_log" \
+    || fail "clean rebuild should not replay the failed dotd validation from disk cache"
+}
+
 function test_tree_artifact_headers_are_invalidated() {
   add_rules_shell "MODULE.bazel"
   add_rules_cc "MODULE.bazel"

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -49,6 +49,94 @@ EOF
     || fail "Build failed but should have succeeded"
 }
 
+function test_dotd_validation_failure_not_stored_in_disk_cache() {
+  add_rules_cc "MODULE.bazel"
+
+  local pkg="dotd_cache_validation"
+  local cache="${TEST_TMPDIR}/disk_cache"
+  mkdir -p "${pkg}/dep1" "${pkg}/dep2"
+
+  cat > "${pkg}/BUILD" <<'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "f",
+    srcs = ["f.cc"],
+    deps = ["//dotd_cache_validation/dep1:dep1_h"],
+)
+EOF
+  cat > "${pkg}/dep1/BUILD" <<'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "dep1_h",
+    hdrs = [
+        "some_inc.h",
+        "other_inc.h",
+    ],
+    strip_include_prefix = ".",
+    visibility = ["//visibility:public"],
+)
+EOF
+  cat > "${pkg}/dep2/BUILD" <<'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "dep2_h",
+    hdrs = ["some_inc.h"],
+    strip_include_prefix = ".",
+    visibility = ["//visibility:public"],
+)
+EOF
+  cat > "${pkg}/f.cc" <<'EOF'
+#include "some_inc.h"
+#include "other_inc.h"
+
+int f() {
+  return SOME_INC + OTHER_INC;
+}
+EOF
+  echo "#define SOME_INC 1" > "${pkg}/dep1/some_inc.h"
+  echo "#define OTHER_INC 10" > "${pkg}/dep1/other_inc.h"
+  echo "#define SOME_INC 2" > "${pkg}/dep2/some_inc.h"
+
+  bazel build --spawn_strategy=local --disk_cache="${cache}" "//${pkg}:f" &>"$TEST_log" \
+    || fail "initial build failed"
+  [[ -e "bazel-bin/${pkg}/dep1/_virtual_includes/dep1_h/some_inc.h" ]] \
+    || fail "expected initial virtual include for dep1"
+
+  cat > "${pkg}/BUILD" <<'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "f",
+    srcs = ["f.cc"],
+    deps = [
+        "//dotd_cache_validation/dep1:dep1_h",
+        "//dotd_cache_validation/dep2:dep2_h",
+    ],
+)
+EOF
+  cat > "${pkg}/dep1/BUILD" <<'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "dep1_h",
+    hdrs = ["other_inc.h"],
+    strip_include_prefix = ".",
+    visibility = ["//visibility:public"],
+)
+EOF
+
+  bazel build --spawn_strategy=local --disk_cache="${cache}" "//${pkg}:f" &>"$TEST_log" \
+    && fail "incremental build should fail from stale virtual include" || true
+  expect_log "undeclared inclusion(s) in rule '//${pkg}:f'"
+
+  bazel clean &>"$TEST_log" || fail "clean failed"
+  bazel build --spawn_strategy=local --disk_cache="${cache}" "//${pkg}:f" &>"$TEST_log" \
+    || fail "clean rebuild should not replay the failed dotd validation from disk cache"
+}
+
 function test_sibling_repository_layout_include_external_repo_output() {
   add_rules_java MODULE.bazel
   add_rules_cc "MODULE.bazel"


### PR DESCRIPTION
If you disable sandboxing, dotd file validation could fail for
non-hermetic reasons. One case of this is if you move a header from 1
target to another, both of which have `strip_include_prefix`, the header
would potentially be visible through both the new location, and a stale
`_virtual_includes` directory that is only not cleaned up because you
have sandboxing disabled. Previously bazel would cache this failure,
making it very hard to get out of the bad situation. Now bazel marks
that as a failure without caching the result of the compile (and dotd
file output)

This works by opting in to deferring the cache store until after the
post processing. This is the only place I know of that needs this,
although there was a similar case in the past with genrules that didn't
produce all of their declared outputs, fixed in a151116f7f671efea9a95f3e251561e53e535cca

Fixes https://github.com/bazelbuild/bazel/issues/28530
