### PR TITLE
Add timeout param to ctx.actions.run

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
@@ -161,7 +161,7 @@ public final class Spawns {
    */
   public static Duration getTimeout(Spawn spawn, Duration defaultTimeout) throws ExecException {
     String timeoutStr = spawn.getExecutionInfo().get(ExecutionRequirements.TIMEOUT);
-    if (timeoutStr == null) {
+    if (timeoutStr == null || timeoutStr.isEmpty()) {
       return defaultTimeout == null ? Duration.ZERO : defaultTimeout;
     }
     try {

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -50,6 +50,7 @@ import com.google.devtools.build.lib.actions.CommandLines;
 import com.google.devtools.build.lib.actions.CommandLines.CommandLineAndParamFileInfo;
 import com.google.devtools.build.lib.actions.CommandLines.ExpandedCommandLines;
 import com.google.devtools.build.lib.actions.ExecException;
+import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.ParamFileInfo;
 import com.google.devtools.build.lib.actions.PathMapper;
@@ -86,6 +87,7 @@ import com.google.errorprone.annotations.CompileTimeConstant;
 import com.google.errorprone.annotations.ForOverride;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -930,6 +932,22 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     @CanIgnoreReturnValue
     public Builder setExecutionInfo(Map<String, String> info) {
       this.executionInfo = ImmutableMap.copyOf(info);
+      return this;
+    }
+
+    /**
+     * Sets the timeout for the spawned action. A non-null, non-zero value adds {@link
+     * ExecutionRequirements#TIMEOUT} to the execution info, overriding any previously set value.
+     */
+    @CanIgnoreReturnValue
+    public Builder setTimeout(Duration timeout) {
+      if (timeout != null && !timeout.isZero()) {
+        this.executionInfo =
+            ImmutableMap.<String, String>builderWithExpectedSize(this.executionInfo.size() + 1)
+                .putAll(this.executionInfo)
+                .put(ExecutionRequirements.TIMEOUT, Long.toString(timeout.toSeconds()))
+                .buildKeepingLast();
+      }
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -81,6 +81,7 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.SymlinkTargetType;
 import com.google.protobuf.GeneratedMessage;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -418,7 +419,8 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       Object execGroupUnchecked,
       Object shadowedActionUnchecked,
       Object resourceSetUnchecked,
-      Object toolchainUnchecked)
+      Object toolchainUnchecked,
+      Object timeoutUnchecked)
       throws EvalException, InterruptedException {
     context.checkMutable("actions.run");
     execGroupUnchecked = context.maybeOverrideExecGroup(execGroupUnchecked);
@@ -469,6 +471,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
         shadowedActionUnchecked,
         resourceSetUnchecked,
         toolchainUnchecked,
+        timeoutUnchecked,
         builder);
   }
 
@@ -613,7 +616,8 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       Object execGroupUnchecked,
       Object shadowedActionUnchecked,
       Object resourceSetUnchecked,
-      Object toolchainUnchecked)
+      Object toolchainUnchecked,
+      Object timeoutUnchecked)
       throws EvalException, InterruptedException {
     context.checkMutable("actions.run_shell");
     execGroupUnchecked = context.maybeOverrideExecGroup(execGroupUnchecked);
@@ -682,6 +686,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
         shadowedActionUnchecked,
         resourceSetUnchecked,
         toolchainUnchecked,
+        timeoutUnchecked,
         builder);
   }
 
@@ -734,6 +739,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       Object shadowedActionUnchecked,
       Object resourceSetUnchecked,
       Object toolchainUnchecked,
+      Object timeoutUnchecked,
       StarlarkAction.Builder builder)
       throws EvalException {
     if (inputs instanceof Sequence) {
@@ -853,6 +859,17 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       builder.setResources(
           StarlarkActionResourceSetBuilder.create(
               (StarlarkCallable) resourceSetUnchecked, mnemonic, getSemantics()));
+    }
+
+    // Resolve timeout from action-level parameter.
+    if (timeoutUnchecked != Starlark.NONE) {
+      int timeoutSecs = ((StarlarkInt) timeoutUnchecked).toInt("timeout");
+      if (timeoutSecs < 0) {
+        throw Starlark.errorf("'timeout' must be a non-negative integer, got %d", timeoutSecs);
+      }
+      if (timeoutSecs > 0) {
+        builder.setTimeout(Duration.ofSeconds(timeoutSecs));
+      }
     }
 
     // Always register the action

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -27,6 +27,7 @@ import net.starlark.java.eval.NoneType;
 import net.starlark.java.eval.Sequence;
 import net.starlark.java.eval.StarlarkCallable;
 import net.starlark.java.eval.StarlarkFunction;
+import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.StarlarkValue;
 
@@ -611,6 +612,21 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
                     + " `toolchain` and `exec_group` parameters are both set, `exec_group` will be"
                     + " used. An error is raised in case the `exec_group` doesn't specify the same"
                     + " toolchain.</p>"),
+        @Param(
+            name = "timeout",
+            allowedTypes = {
+              @ParamType(type = StarlarkInt.class),
+              @ParamType(type = NoneType.class),
+            },
+            defaultValue = "None",
+            named = true,
+            positional = false,
+            doc =
+                "Maximum duration of the action in seconds, or <code>None</code> for no timeout."
+                    + " If the action runs longer than this, it is killed and the build fails."
+                    + " Overrides any rule-level <code>timeout</code> attribute for this specific"
+                    + " action. Must be a non-negative integer; 0 is treated the same as"
+                    + " <code>None</code>."),
       })
   void run(
       Sequence<?> outputs,
@@ -628,7 +644,8 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
       Object execGroupUnchecked,
       Object shadowedAction,
       Object resourceSetUnchecked,
-      Object toolchainUnchecked)
+      Object toolchainUnchecked,
+      Object timeoutUnchecked)
       throws EvalException, InterruptedException;
 
   @StarlarkMethod(
@@ -854,6 +871,21 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
                     + " `toolchain` and `exec_group` parameters are both set, `exec_group` will be"
                     + " used. An error is raised in case the `exec_group` doesn't specify the same"
                     + " toolchain.</p>"),
+        @Param(
+            name = "timeout",
+            allowedTypes = {
+              @ParamType(type = StarlarkInt.class),
+              @ParamType(type = NoneType.class),
+            },
+            defaultValue = "None",
+            named = true,
+            positional = false,
+            doc =
+                "Maximum duration of the action in seconds, or <code>None</code> for no timeout."
+                    + " If the action runs longer than this, it is killed and the build fails."
+                    + " Overrides any rule-level <code>timeout</code> attribute for this specific"
+                    + " action. Must be a non-negative integer; 0 is treated the same as"
+                    + " <code>None</code>."),
       })
   void runShell(
       Sequence<?> outputs,
@@ -870,7 +902,8 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
       Object execGroupUnchecked,
       Object shadowedAction,
       Object resourceSetUnchecked,
-      Object toolchainUnchecked)
+      Object toolchainUnchecked,
+      Object timeoutUnchecked)
       throws EvalException, InterruptedException;
 
   @StarlarkMethod(

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
@@ -566,6 +566,65 @@ public final class SpawnActionTest extends BuildViewTestCase {
         .isEqualTo("ToolPoolMnemonic");
   }
 
+  @Test
+  public void testSetTimeout_addsToExecutionInfo() {
+    SpawnAction action =
+        builder()
+            .addOutput(destinationArtifact)
+            .setExecutable(PathFragment.create("/bin/cp"))
+            .setTimeout(java.time.Duration.ofSeconds(300))
+            .setMnemonic("Dummy")
+            .build(nullOwnerWithTargetConfig(), targetConfig);
+    assertThat(action.getExecutionInfo())
+        .containsEntry(
+            com.google.devtools.build.lib.actions.ExecutionRequirements.TIMEOUT, "300");
+  }
+
+  @Test
+  public void testSetTimeout_zeroDoesNotAddToExecutionInfo() {
+    SpawnAction action =
+        builder()
+            .addOutput(destinationArtifact)
+            .setExecutable(PathFragment.create("/bin/cp"))
+            .setTimeout(java.time.Duration.ZERO)
+            .setMnemonic("Dummy")
+            .build(nullOwnerWithTargetConfig(), targetConfig);
+    assertThat(action.getExecutionInfo())
+        .doesNotContainKey(
+            com.google.devtools.build.lib.actions.ExecutionRequirements.TIMEOUT);
+  }
+
+  @Test
+  public void testSetTimeout_nullDoesNotAddToExecutionInfo() {
+    SpawnAction action =
+        builder()
+            .addOutput(destinationArtifact)
+            .setExecutable(PathFragment.create("/bin/cp"))
+            .setTimeout(null)
+            .setMnemonic("Dummy")
+            .build(nullOwnerWithTargetConfig(), targetConfig);
+    assertThat(action.getExecutionInfo())
+        .doesNotContainKey(
+            com.google.devtools.build.lib.actions.ExecutionRequirements.TIMEOUT);
+  }
+
+  @Test
+  public void testSetTimeout_overridesExistingTimeout() {
+    SpawnAction action =
+        builder()
+            .addOutput(destinationArtifact)
+            .setExecutable(PathFragment.create("/bin/cp"))
+            .setExecutionInfo(
+                ImmutableMap.of(
+                    com.google.devtools.build.lib.actions.ExecutionRequirements.TIMEOUT, "100"))
+            .setTimeout(java.time.Duration.ofSeconds(300))
+            .setMnemonic("Dummy")
+            .build(nullOwnerWithTargetConfig(), targetConfig);
+    assertThat(action.getExecutionInfo())
+        .containsEntry(
+            com.google.devtools.build.lib.actions.ExecutionRequirements.TIMEOUT, "300");
+  }
+
   private ActionOwner nullOwnerWithTargetConfig() {
     return ActionOwner.create(
         ActionsTestUtil.NULL_ACTION_OWNER.getLabel(),

--- a/src/test/java/com/google/devtools/build/lib/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/starlark/BUILD
@@ -336,6 +336,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/actions:action_lookup_data",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:commandline_item",
+        "//src/main/java/com/google/devtools/build/lib/actions:execution_requirements",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/parameter_file_write_action",
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/substitution",

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
@@ -4314,4 +4314,57 @@ args.add_all(d, map_each = _map_each, uniquify = True)
     Dict<?, ?> dict = (Dict<?, ?>) ev.eval("{k: None for k in [DefaultInfo, p, DefaultInfo, p]}");
     assertThat(dict.size()).isEqualTo(2);
   }
+
+  @Test
+  public void testRunShellWithTimeout() throws Exception {
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+    ev.exec(
+        "ruleContext.actions.run_shell(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = ruleContext.files.srcs,",
+        "  mnemonic = 'DummyMnemonic',",
+        "  command = 'dummy_command',",
+        "  timeout = 120)");
+    SpawnAction action =
+        (SpawnAction)
+            Iterables.getOnlyElement(
+                ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
+    assertThat(action.getExecutionInfo())
+        .containsEntry(
+            com.google.devtools.build.lib.actions.ExecutionRequirements.TIMEOUT, "120");
+  }
+
+  @Test
+  public void testRunShellWithZeroTimeout() throws Exception {
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+    ev.exec(
+        "ruleContext.actions.run_shell(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = ruleContext.files.srcs,",
+        "  mnemonic = 'DummyMnemonic',",
+        "  command = 'dummy_command',",
+        "  timeout = 0)");
+    SpawnAction action =
+        (SpawnAction)
+            Iterables.getOnlyElement(
+                ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
+    assertThat(action.getExecutionInfo())
+        .doesNotContainKey(
+            com.google.devtools.build.lib.actions.ExecutionRequirements.TIMEOUT);
+  }
+
+  @Test
+  public void testRunShellWithNegativeTimeout() throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+    ev.checkEvalErrorContains(
+        "'timeout' must be a non-negative integer, got -1",
+        "ruleContext.actions.run_shell(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = ruleContext.files.srcs,",
+        "  mnemonic = 'DummyMnemonic',",
+        "  command = 'dummy_command',",
+        "  timeout = -1)");
+  }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->
Add timeout param to `ctx.actions.run` for RBE and local environment use.

- Add timeout parameter to `ctx.actions.run()` and `ctx.actions.run_shell()` Starlark API
- Add `SpawnAction.Builder.setTimeout(Duration)` that sets `ExecutionRequirements.TIMEOUT` in execution info
- Add empty-string guard to `Spawns.getTimeout()`
- Add unit tests for `setTimeout` and Starlark timeout parameter (positive, zero, null, negative, override)

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->
Some actions in a Remote Execution environment can take a long time and there is no way to split them up due to some third party application commands. The environment can have their own timeouts, but if a single action needs to be longer, it should be explicitly configured for that longer timeout.

### Build API Changes

Does this PR affect the Build API? Yes - Starlark API

If yes, please answer the following:
1. Has this been discussed in a design doc or issue? https://github.com/bazelbuild/bazel/issues/21142
2. Is the change backward compatible? Yes - additive to something the user does not have access to change.
3. If it's a breaking change, what is the migration plan? N/A

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES[NEW]: Add parameter `timeout` to `ctx.actions.{run,run_shell}` 
