### PR TITLE
Add --incompatible_external_symlink

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
@@ -395,6 +395,19 @@ public abstract class BuildRequestOptions extends OptionsBase {
   public abstract boolean getIncompatibleSkipGenfilesSymlink();
 
   @Option(
+      name = "incompatible_external_symlink",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          """
+          If set to true, Bazel creates an `external` convenience symlink in the workspace root
+          pointing to the external repository directory.
+          """)
+  public abstract boolean getIncompatibleExternalSymlink();
+
+  @Option(
       name = "target_pattern_file",
       defaultValue = "",
       documentationCategory = OptionDocumentationCategory.GENERIC_INPUTS,

--- a/src/main/java/com/google/devtools/build/lib/buildtool/OutputDirectoryLinksUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/OutputDirectoryLinksUtils.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.analysis.config.SymlinkDefinition;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.ConvenienceSymlink;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.ConvenienceSymlink.Action;
 import com.google.devtools.build.lib.buildtool.BuildRequestOptions.ConvenienceSymlinksMode;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /** Static utilities for managing output directory symlinks. */
 public final class OutputDirectoryLinksUtils {
@@ -54,9 +56,12 @@ public final class OutputDirectoryLinksUtils {
    * <p>The order of the result indicates precedence for {@link PathPrettyPrinter}.
    */
   private static ImmutableList<SymlinkDefinition> getAllLinkDefinitions(
-      Iterable<SymlinkDefinition> symlinkDefinitions) {
+      Iterable<SymlinkDefinition> symlinkDefinitions, @Nullable Path externalPath) {
     ImmutableList.Builder<SymlinkDefinition> builder = ImmutableList.builder();
     builder.addAll(STANDARD_LINK_DEFINITIONS);
+    if (externalPath != null) {
+      builder.add(externalSymlink(externalPath));
+    }
     builder.addAll(symlinkDefinitions);
     return builder.build();
   }
@@ -100,6 +105,10 @@ public final class OutputDirectoryLinksUtils {
       String productName) {
     Path execRoot = directories.getExecRoot(workspaceName);
     Path outputPath = directories.getOutputPath(workspaceName);
+    Path externalPath =
+        buildRequestOptions.getIncompatibleExternalSymlink()
+            ? directories.getOutputBase().getRelative(LabelConstants.EXTERNAL_REPOSITORY_LOCATION)
+            : null;
     String symlinkPrefix = buildRequestOptions.getSymlinkPrefix(productName);
     ConvenienceSymlinksMode mode = buildRequestOptions.getExperimentalConvenienceSymlinks();
     if (NO_CREATE_SYMLINKS_PREFIX.equals(symlinkPrefix)) {
@@ -116,7 +125,7 @@ public final class OutputDirectoryLinksUtils {
     RepositoryName repositoryName = RepositoryName.MAIN;
     boolean logOnly = mode == ConvenienceSymlinksMode.LOG_ONLY;
 
-    for (SymlinkDefinition symlink : getAllLinkDefinitions(symlinkDefinitions)) {
+    for (SymlinkDefinition symlink : getAllLinkDefinitions(symlinkDefinitions, externalPath)) {
       String linkName = symlink.getLinkName(symlinkPrefix, workspaceBaseName);
       if (!createdLinks.add(linkName)) {
         // already created a link by this name
@@ -183,16 +192,22 @@ public final class OutputDirectoryLinksUtils {
   public static void removeOutputDirectoryLinks(
       Iterable<SymlinkDefinition> symlinkDefinitions,
       Path workspace,
+      Path outputBase,
       EventHandler eventHandler,
-      String symlinkPrefix) {
+      String symlinkPrefix,
+      boolean includeExternalSymlink) {
     if (NO_CREATE_SYMLINKS_PREFIX.equals(symlinkPrefix)) {
       return;
     }
     List<String> failures = new ArrayList<>();
 
     String workspaceBaseName = workspace.getBaseName();
+    Path externalPath =
+        includeExternalSymlink
+            ? outputBase.getRelative(LabelConstants.EXTERNAL_REPOSITORY_LOCATION)
+            : null;
 
-    for (SymlinkDefinition link : getAllLinkDefinitions(symlinkDefinitions)) {
+    for (SymlinkDefinition link : getAllLinkDefinitions(symlinkDefinitions, externalPath)) {
       removeLink(
           workspace,
           link.getLinkName(symlinkPrefix, workspaceBaseName),
@@ -361,6 +376,25 @@ public final class OutputDirectoryLinksUtils {
               return ImmutableSet.of(execRoot);
             }
           });
+
+  private static SymlinkDefinition externalSymlink(Path externalPath) {
+    return new SymlinkDefinition() {
+      @Override
+      public String getLinkName(String symlinkPrefix, String workspaceBaseName) {
+        return LabelConstants.EXTERNAL_REPOSITORY_LOCATION.getPathString();
+      }
+
+      @Override
+      public ImmutableSet<Path> getLinkPaths(
+          BuildRequestOptions buildRequestOptions,
+          Set<BuildConfigurationValue> targetConfigs,
+          RepositoryName repositoryName,
+          Path outputPath,
+          Path execRoot) {
+        return ImmutableSet.of(externalPath);
+      }
+    };
+  }
 
   static final SymlinkCreationResult EMPTY_SYMLINK_CREATION_RESULT =
       new SymlinkCreationResult(ImmutableList.of(), ImmutableMap.of());

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CleanCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CleanCommand.java
@@ -137,12 +137,16 @@ public final class CleanCommand implements BlazeCommand {
     env.getEventBus().post(new CleanStartingEvent(options));
 
     try {
+      BuildRequestOptions buildRequestOptions = options.getOptions(BuildRequestOptions.class);
       String symlinkPrefix =
-          options
-              .getOptions(BuildRequestOptions.class)
-              .getSymlinkPrefix(env.getRuntime().getProductName());
+          buildRequestOptions.getSymlinkPrefix(env.getRuntime().getProductName());
       return actuallyClean(
-          env, env.getOutputBase(), cleanOptions.getExpunge(), async, symlinkPrefix);
+          env,
+          env.getOutputBase(),
+          cleanOptions.getExpunge(),
+          async,
+          symlinkPrefix,
+          buildRequestOptions.getIncompatibleExternalSymlink());
     } catch (CleanException e) {
       env.getReporter().handle(Event.error(e.getMessage()));
       return BlazeCommandResult.failureDetail(e.getFailureDetail());
@@ -214,7 +218,12 @@ public final class CleanCommand implements BlazeCommand {
   }
 
   private static BlazeCommandResult actuallyClean(
-      CommandEnvironment env, Path outputBase, boolean expunge, boolean async, String symlinkPrefix)
+      CommandEnvironment env,
+      Path outputBase,
+      boolean expunge,
+      boolean async,
+      String symlinkPrefix,
+      boolean includeExternalSymlink)
       throws CleanException, InterruptedException {
     BlazeRuntime runtime = env.getRuntime();
 
@@ -299,8 +308,10 @@ public final class CleanCommand implements BlazeCommand {
     OutputDirectoryLinksUtils.removeOutputDirectoryLinks(
         runtime.getRuleClassProvider().getSymlinkDefinitions(),
         env.getWorkspace(),
+        outputBase,
         env.getReporter(),
-        symlinkPrefix);
+        symlinkPrefix,
+        includeExternalSymlink);
 
     // shutdown on expunge cleans
     if (expunge) {

--- a/src/test/java/com/google/devtools/build/lib/buildtool/ConvenienceSymlinkTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/ConvenienceSymlinkTest.java
@@ -35,6 +35,7 @@ import com.google.devtools.build.lib.analysis.config.transitions.TransitionFacto
 import com.google.devtools.build.lib.analysis.util.MockRule;
 import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
 import com.google.devtools.build.lib.buildtool.util.TestRuleModule;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.exec.FileWriteStrategy;
@@ -293,6 +294,20 @@ public final class ConvenienceSymlinkTest extends BuildIntegrationTestCase {
 
   private Path getOutputPath() {
     return getBlazeWorkspace().getDirectories().getOutputPath(TestConstants.WORKSPACE_NAME);
+  }
+
+  private Path getExternalPath() {
+    return getOutputBase().getRelative(LabelConstants.EXTERNAL_REPOSITORY_LOCATION);
+  }
+
+  private Path getCleanExternalLinkPath() throws IOException {
+    Path externalLink = getWorkspace().getChild("external");
+    if (externalLink.isSymbolicLink()) {
+      externalLink.delete();
+    } else if (externalLink.exists(Symlinks.NOFOLLOW)) {
+      externalLink.deleteTree();
+    }
+    return externalLink;
   }
 
   /** Gets a mapping from the workspace-relative paths of symlinks to the paths they point to. */
@@ -801,6 +816,98 @@ public final class ConvenienceSymlinkTest extends BuildIntegrationTestCase {
     buildTarget("//target:target");
 
     assertThat(getWorkspace().getChild("prefix-genfiles").isSymbolicLink()).isTrue();
+  }
+
+  @Test
+  public void externalLink_omittedWithoutIncompatibleFlag() throws Exception {
+    Path externalLink = getCleanExternalLinkPath();
+
+    write("target/BUILD", "basic_rule(name='target')");
+    buildTarget("//target:target");
+
+    assertThat(externalLink.exists(Symlinks.NOFOLLOW)).isFalse();
+  }
+
+  @Test
+  public void externalLink_presentWithIncompatibleFlag() throws Exception {
+    addOptions("--incompatible_external_symlink");
+    Path externalLink = getCleanExternalLinkPath();
+
+    write("target/BUILD", "basic_rule(name='target')");
+    buildTarget("//target:target");
+
+    assertThat(externalLink.isSymbolicLink()).isTrue();
+    assertThat(externalLink.readSymbolicLink()).isEqualTo(getExternalPath().asFragment());
+  }
+
+  @Test
+  public void externalLink_doesNotReplaceExistingDirectoryWithIncompatibleFlag() throws Exception {
+    addOptions("--incompatible_external_symlink");
+
+    Path externalDirectory = getWorkspace().getChild("external");
+    externalDirectory.createDirectoryAndParents();
+    write("external/source.txt", "existing source");
+
+    write("target/BUILD", "basic_rule(name='target')");
+    buildTarget("//target:target");
+
+    assertThat(externalDirectory.isDirectory(Symlinks.NOFOLLOW)).isTrue();
+    assertThat(getWorkspace().getRelative("external/source.txt").isFile()).isTrue();
+  }
+
+  @Test
+  public void externalLink_doesNotReplaceExistingFileWithIncompatibleFlag() throws Exception {
+    addOptions("--incompatible_external_symlink");
+    Path externalPath = getCleanExternalLinkPath();
+    FileSystemUtils.writeIsoLatin1(externalPath, "existing source");
+
+    write("target/BUILD", "basic_rule(name='target')");
+    buildTarget("//target:target");
+
+    assertThat(externalPath.isFile(Symlinks.NOFOLLOW)).isTrue();
+    assertThat(new String(FileSystemUtils.readContentAsLatin1(externalPath)))
+        .isEqualTo("existing source\n");
+  }
+
+  @Test
+  public void externalLink_replacesExistingSymlinkWithIncompatibleFlag() throws Exception {
+    addOptions("--incompatible_external_symlink");
+    Path manualExternal = getOutputBase().getRelative("manual-external");
+    manualExternal.createDirectoryAndParents();
+    Path externalLink = getCleanExternalLinkPath();
+    externalLink.createSymbolicLink(manualExternal);
+
+    write("target/BUILD", "basic_rule(name='target')");
+    buildTarget("//target:target");
+
+    assertThat(externalLink.isSymbolicLink()).isTrue();
+    assertThat(externalLink.readSymbolicLink()).isEqualTo(getExternalPath().asFragment());
+  }
+
+  @Test
+  public void externalLink_replacesBrokenSymlinkWithIncompatibleFlag() throws Exception {
+    addOptions("--incompatible_external_symlink");
+    Path externalLink = getCleanExternalLinkPath();
+    externalLink.createSymbolicLink(getOutputBase().getRelative("missing-external"));
+
+    write("target/BUILD", "basic_rule(name='target')");
+    buildTarget("//target:target");
+
+    assertThat(externalLink.isSymbolicLink()).isTrue();
+    assertThat(externalLink.readSymbolicLink()).isEqualTo(getExternalPath().asFragment());
+  }
+
+  @Test
+  public void externalLink_notManagedWithoutIncompatibleFlag() throws Exception {
+    Path manualExternal = getOutputBase().getRelative("manual-external");
+    manualExternal.createDirectoryAndParents();
+    Path externalLink = getCleanExternalLinkPath();
+    externalLink.createSymbolicLink(manualExternal);
+
+    write("target/BUILD", "basic_rule(name='target')");
+    buildTarget("//target:target");
+
+    assertThat(externalLink.readSymbolicLink()).isEqualTo(manualExternal.asFragment());
   }
 
   @Test


### PR DESCRIPTION
This flag enables automatic creation of an `external` symlink in the
root of the repo. This symlink is commonly created for debugging
binaries, where external code requires that path to exist at debug time,
and for compile_commands style tooling which require the same paths that
existed at compile time to exist for tooling.
