### PR TITLE
Add support for unknown flag names in flag_alias

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -635,7 +635,12 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
             Profiler.instance().profile(ProfilerTask.BZLMOD, "compute main repo mapping")) {
           RepositoryMapping mainRepoMapping =
               env.getSkyframeExecutor().getMainRepoMapping(reporter);
-          optionsParser = optionsParser.toBuilder().withConversionContext(mainRepoMapping).build();
+          optionsParser =
+              optionsParser
+                  .toBuilder()
+                  .allowUnknownOptions(false)
+                  .withConversionContext(mainRepoMapping)
+                  .build();
           // Collect MODULE.bazel flag_alias(name = "foo", starlark_flag = "//bar") entries, so when
           // builds set "--foo=1", that maps to "--//bar=1". Inject this as an implicit
           // "--flag_alias=foo=//bar" flag. This is because select()s and configuration transitions
@@ -673,10 +678,15 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
                   runtime, workspace, command, commandAnnotation, optionsParser, invocationPolicy);
           ImmutableList.Builder<OptionAndRawValue> invocationPolicyFlagListBuilder =
               ImmutableList.builder();
-          // Do not handle any events since this is the second time we parse the options.
+          // Do not replay events unless this parse fails, since this is the second time we parse
+          // the options.
+          StoredEventHandler reparseEventHandler = new StoredEventHandler();
           earlyExitCode =
               optionHandler.parseOptions(
-                  args, ExtendedEventHandler.NOOP, invocationPolicyFlagListBuilder);
+                  args, reparseEventHandler, invocationPolicyFlagListBuilder);
+          if (!earlyExitCode.isSuccess()) {
+            reparseEventHandler.replayOn(reporter);
+          }
           env.setInvocationPolicyFlags(invocationPolicyFlagListBuilder.build());
         }
         if (!earlyExitCode.isSuccess()) {
@@ -939,6 +949,9 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
         OptionsParser.builder()
             .optionsData(optionsData)
             .skipStarlarkOptionPrefixes()
+            // MODULE.bazel flag_alias() entries are only known after module resolution. Defer
+            // unknown long options during the first parse so they can be resolved on the reparse.
+            .allowUnknownOptions(annotation.buildPhase().analyzes())
             .allowResidue(annotation.allowResidue())
             .withAliasFlag(CoreOptionConverters.BLAZE_ALIASING_FLAG)
             .build();

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -131,6 +131,7 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.Label.LabelInterner;
 import com.google.devtools.build.lib.cmdline.Label.PackageContext;
 import com.google.devtools.build.lib.cmdline.Label.RepoContext;
+import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -3323,17 +3324,16 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     EvaluationResult<BazelDepGraphValue> evalResult =
         evaluate(
             ImmutableList.of(BazelDepGraphValue.KEY), false, DEFAULT_THREAD_COUNT, eventHandler);
-    var bzlmodDepGraph = evalResult.get(BazelDepGraphValue.KEY).getDepGraph();
+    BazelDepGraphValue bzlmodDepGraphValue = evalResult.get(BazelDepGraphValue.KEY);
+    var bzlmodDepGraph = bzlmodDepGraphValue.getDepGraph();
     LinkedHashMap<String, String> aliasesMap = new LinkedHashMap<>();
     var rootModule = bzlmodDepGraph.entrySet().iterator().next().getValue();
     for (var module : bzlmodDepGraph.entrySet()) {
       ImmutableMap<String, String> flagAliases = module.getValue().getFlagAliases();
+      RepositoryMapping repoMapping = bzlmodDepGraphValue.getFullRepoMapping(module.getKey());
       for (var flagAlias : flagAliases.entrySet()) {
-        aliasesMap.put(
-            flagAlias.getKey(),
-            flagAlias.getValue().startsWith("//")
-                ? module.getKey().getCanonicalRepoNameWithoutVersion() + flagAlias.getValue()
-                : flagAlias.getValue());
+        String aliasValue = canonicalizeModuleFlagAliasValue(repoMapping, flagAlias.getValue());
+        aliasesMap.put(flagAlias.getKey(), aliasValue);
       }
       if (!module.getValue().getName().equals("rules_python")) {
         continue;
@@ -3363,6 +3363,21 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     }
 
     return ImmutableMap.copyOf(aliasesMap);
+  }
+
+  private static String canonicalizeModuleFlagAliasValue(
+      RepositoryMapping repoMapping, String aliasValue) {
+    try {
+      return Label.parseWithPackageContext(
+              aliasValue,
+              PackageContext.of(
+                  PackageIdentifier.create(repoMapping.contextRepo(), PathFragment.EMPTY_FRAGMENT),
+                  repoMapping))
+          .getUnambiguousCanonicalForm();
+    } catch (LabelSyntaxException e) {
+      throw new IllegalStateException(
+          String.format("Invalid MODULE.bazel flag_alias label %s", aliasValue), e);
+    }
   }
 
   public RepositoryMapping getMainRepoMapping(ExtendedEventHandler eventHandler)

--- a/src/main/java/com/google/devtools/common/options/OptionsParser.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParser.java
@@ -208,6 +208,15 @@ public class OptionsParser implements OptionsParsingResult {
       return this;
     }
 
+    /**
+     * Sets whether unknown long options should be preserved as skipped options for a later parse.
+     */
+    @CanIgnoreReturnValue
+    public Builder allowUnknownOptions(boolean allowUnknownOptions) {
+      this.implBuilder.allowUnknownOptions(allowUnknownOptions);
+      return this;
+    }
+
     /** Sets whether the parser should ignore user options. If true, returns no user options. */
     @CanIgnoreReturnValue
     public Builder ignoreUserOptions() {

--- a/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
@@ -62,6 +62,7 @@ class OptionsParserImpl {
     private ArgsPreProcessor argsPreProcessor = args -> args;
     private final ArrayList<String> skippedPrefixes = new ArrayList<>();
     private boolean ignoreInternalOptions = true;
+    private boolean allowUnknownOptions = false;
     @Nullable private String aliasFlag = null;
     @Nullable private Object conversionContext = null;
     private final Map<String, String> aliases = new HashMap<>();
@@ -91,6 +92,15 @@ class OptionsParserImpl {
     @CanIgnoreReturnValue
     public Builder ignoreInternalOptions(boolean ignoreInternalOptions) {
       this.ignoreInternalOptions = ignoreInternalOptions;
+      return this;
+    }
+
+    /**
+     * Sets whether unknown long options should be preserved as skipped options for a later parse.
+     */
+    @CanIgnoreReturnValue
+    public Builder allowUnknownOptions(boolean allowUnknownOptions) {
+      this.allowUnknownOptions = allowUnknownOptions;
       return this;
     }
 
@@ -128,6 +138,7 @@ class OptionsParserImpl {
           this.argsPreProcessor,
           this.skippedPrefixes,
           this.ignoreInternalOptions,
+          this.allowUnknownOptions,
           this.aliasFlag,
           this.conversionContext,
           this.aliases);
@@ -184,6 +195,7 @@ class OptionsParserImpl {
   private final ArgsPreProcessor argsPreProcessor;
   private final List<String> skippedPrefixes;
   private final boolean ignoreInternalOptions;
+  private final boolean allowUnknownOptions;
   @Nullable private final String aliasFlag;
   @Nullable private final Object conversionContext;
 
@@ -219,6 +231,7 @@ class OptionsParserImpl {
       ArgsPreProcessor argsPreProcessor,
       List<String> skippedPrefixes,
       boolean ignoreInternalOptions,
+      boolean allowUnknownOptions,
       @Nullable String aliasFlag,
       @Nullable Object conversionContext,
       Map<String, String> aliases) {
@@ -226,6 +239,7 @@ class OptionsParserImpl {
     this.argsPreProcessor = argsPreProcessor;
     this.skippedPrefixes = skippedPrefixes;
     this.ignoreInternalOptions = ignoreInternalOptions;
+    this.allowUnknownOptions = allowUnknownOptions;
     this.aliasFlag = aliasFlag;
     this.conversionContext = conversionContext;
     this.flagAliasMappings = aliases;
@@ -250,7 +264,8 @@ class OptionsParserImpl {
             .withAliasFlag(aliasFlag)
             .withAliases(flagAliasMappings)
             .withConversionContext(conversionContext)
-            .ignoreInternalOptions(ignoreInternalOptions);
+            .ignoreInternalOptions(ignoreInternalOptions)
+            .allowUnknownOptions(allowUnknownOptions);
     for (String skippedPrefix : skippedPrefixes) {
       builder.skippedPrefix(skippedPrefix);
     }
@@ -799,6 +814,21 @@ class OptionsParserImpl {
 
     // Do not recognize internal options, which are treated as if they did not exist.
     if (lookupResult == null || shouldIgnoreOption(lookupResult.definition)) {
+      if (allowUnknownOptions && arg.startsWith("--")) {
+        return new ParsedOptionDescriptionOrIgnoredArgs(
+            Optional.of(
+                ParsedOptionDescription.newParsedOptionDescription(
+                    skippedArgsDefinition,
+                    commandLineForm.toString(),
+                    commandLineForm.toString(),
+                    new OptionInstanceOrigin(
+                        priority,
+                        sourceFunction.apply(skippedArgsDefinition),
+                        implicitDependent,
+                        expandedFrom),
+                    conversionContext)),
+            Optional.empty());
+      }
       String suggestion;
       // Do not offer suggestions for short-form options.
       if (arg.startsWith("--")) {

--- a/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
+++ b/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
@@ -2535,6 +2535,32 @@ public final class OptionsParserTest {
   }
 
   @Test
+  public void allowUnknownOptions_skipsUnknownLongOptions() throws Exception {
+    OptionsParser parser =
+        OptionsParser.builder().optionsClasses(ExampleFoo.class).allowUnknownOptions(true).build();
+
+    parser.parse("--unknown_option=1", "--foo=bar");
+
+    assertThat(parser.getSkippedArgs()).containsExactly("--unknown_option=1");
+    assertThat(parser.getOptions(ExampleFoo.class).getFoo()).isEqualTo("bar");
+    assertThat(
+            parser.asCompleteListOfParsedOptions().stream()
+                .map(ParsedOptionDescription::getCommandLineForm))
+        .containsExactly("--foo=bar");
+  }
+
+  @Test
+  public void allowUnknownOptions_canBeDisabledOnRebuiltParser() throws Exception {
+    OptionsParser parser =
+        OptionsParser.builder().optionsClasses(ExampleFoo.class).allowUnknownOptions(true).build();
+    parser.parse("--unknown_option=1");
+
+    OptionsParser strictParser = parser.toBuilder().allowUnknownOptions(false).build();
+
+    assertThrows(OptionsParsingException.class, () -> strictParser.parse("--unknown_option=1"));
+  }
+
+  @Test
   public void fallbackOptions_optionsParsingEquivalently() throws OptionsParsingException {
     OpaqueOptionsData fallbackData =
         OptionsParser.getFallbackOptionsData(

--- a/src/test/shell/integration/platform_based_flags_test.sh
+++ b/src/test/shell/integration/platform_based_flags_test.sh
@@ -652,4 +652,56 @@ EOF
   expect_log "//${pkg}:show: value = \"alt\""
 }
 
+function test_module_flag_alias_for_unknown_flag() {
+  # Only bazel supports modules.
+  is_bazel || return 0
+
+  local -r pkg="$FUNCNAME"
+  mkdir -p "$pkg"
+
+  cat > "$pkg/rules.bzl" <<EOF
+BuildSettingInfo = provider(fields = ["value"])
+
+def _sample_flag_impl(ctx):
+    return BuildSettingInfo(value = ctx.build_setting_value)
+
+sample_flag = rule(
+    implementation = _sample_flag_impl,
+    build_setting = config.string(flag = True),
+)
+
+def _show_sample_flag_impl(ctx):
+    value = ctx.attr.flag[BuildSettingInfo].value
+    print("%s: value = \"%s\"" % (ctx.label, value))
+
+show_sample_flag = rule(
+    implementation = _show_sample_flag_impl,
+    attrs = {
+        "flag": attr.label(providers = [BuildSettingInfo]),
+    },
+)
+EOF
+
+  cat > "$pkg/BUILD" <<EOF
+load(":rules.bzl", "sample_flag", "show_sample_flag")
+
+sample_flag(
+    name = "my_flag",
+    build_setting_default = "default",
+)
+
+show_sample_flag(
+    name = "show",
+    flag = ":my_flag",
+)
+EOF
+
+  cat >> MODULE.bazel <<EOF
+flag_alias(name = "myflag", starlark_flag = "//$pkg:my_flag")
+EOF
+
+  bazel build --myflag=custom_value //$pkg:show &> $TEST_log || fail "bazel failed"
+  expect_log "//${pkg}:show: value = \"custom_value\""
+}
+
 run_suite "Tests for platform based flags"


### PR DESCRIPTION
Previously only native flag names could be used in flag_alias
definitions in the MODULE.bazel. Now any string can. This requires
deferring the unknown values until the aliases have been registered
