### PR TITLE
[8.7.0] Add try-import-if-bazel-version support in bazelrc files

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,6 +13,7 @@ module(
 # Bazel module dependencies
 # =========================================
 
+
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "grpc", version = "1.66.0.bcr.2", repo_name = "com_github_grpc_grpc")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,6 @@ module(
 # Bazel module dependencies
 # =========================================
 
-
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "grpc", version = "1.66.0.bcr.2", repo_name = "com_github_grpc_grpc")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -247,7 +247,7 @@
   "moduleExtensions": {
     "//:repositories.bzl%async_profiler_repos": {
       "general": {
-        "bzlTransitiveDigest": "S2oY3E+wIbtWB8ITVoYCFEaBvuGWXukUQc1JGK2TvEI=",
+        "bzlTransitiveDigest": "Ww9wnb5bUrfiGxZWrHzhCg0D43FYaQKad1cb0xSJZZg=",
         "usagesDigest": "sZRrbFQKw5lxsXhOehwC65S9w1JIcd3gp3/ji8P+J2A=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -382,6 +382,11 @@
             "",
             "platforms",
             "platforms"
+          ],
+          [
+            "",
+            "re2",
+            "re2+"
           ],
           [
             "",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -41,6 +41,7 @@ DIST_ARCHIVE_REPOS = [get_canonical_repo_name(repo) for repo in [
     "grpc-java",
     "io_bazel_skydoc",
     "platforms",
+    "re2",
     "rules_cc",
     "rules_go",
     "rules_graalvm",

--- a/site/en/run/bazelrc.md
+++ b/site/en/run/bazelrc.md
@@ -82,13 +82,60 @@ rules as the Bourne shell.
 
 #### Imports {:#imports}
 
-Lines that start with `import` or `try-import` are special: use these to load
-other "rc" files. To specify a path that is relative to the workspace root,
-write `import %workspace%/path/to/bazelrc`.
+Lines that start with `import`, `try-import` or `try-import-if-bazel-version`
+are special: use these to load other "rc" files. To specify a path that is
+relative to the workspace root, write `import %workspace%/path/to/bazelrc`.
 
-The difference between `import` and `try-import` is that Bazel fails if the
-`import`'ed file is missing (or can't be read), but not so for a `try-import`'ed
-file.
+The difference between the various import statements is as follows:
+
+*   `import` - Bazel will fail if the `imported`'ed file is missing (or can't be
+    read)
+*   `try-import` - An attempt to import the file will be made, but unlike
+    `import`, Bazel will NOT fail if the file is missing (or can't be read).
+*   `try-import-if-bazel-version` - Similar to `try-import`, but an additional
+    condition on the current Bazel version is checked before attempting to do
+    the import. See below for the syntax.
+
+Conditional Bazel version imports can be useful if a project needs to work under
+several Bazel versions or during the transition from one Bazel version to
+another. Different flags may be needed for different Bazel versions since flags
+may be deprecated, removed or introduced in each release. To check which version
+of Bazel you have, run `bazel --version`. The following conditional checks are
+supported and require valid semantic versions:
+
+```none
+# Strictly greater than: used for post-release targeting
+try-import-if-bazel-version >7.0.0 %workspace%/configs/post_v7.rc
+
+# Greater than or equal to: commonly used for feature introduction
+try-import-if-bazel-version >=6.0.0 %workspace%/configs/features.rc
+
+# Strictly less than: used for deprecated flags removed in newer versions
+try-import-if-bazel-version <7.0.0 %workspace%/configs/legacy.rc
+
+# Less than or equal to: caps configuration to a specific version
+try-import-if-bazel-version <=5.4.0 %workspace%/configs/v5_fixes.rc
+
+# Exact match: hotfix for a specific broken release
+try-import-if-bazel-version ==6.3.2 %workspace%/configs/hotfix_6.3.2.rc
+
+# Not equal to: excludes broken version from standard config
+try-import-if-bazel-version !=7.0.1 %workspace%/configs/standard.rc
+```
+
+An additional tilde operator provides ranges for patch, minor, and major version
+changes:
+
+```none
+# Equivalent to >=1.2.3 <1.3.0
+try-import-if-bazel-version ~1.2.3 %workspace%/configs/1.2.3_flags.rc
+
+# Equivalent to >=1.2.0 <1.3.0 (Same as 1.2.x)
+try-import-if-bazel-version ~1.2 %workspace%/configs/1.2_flags.rc
+
+# Equivalent to >=1.0.0 <2.0.0 (Same as 1.x)
+try-import-if-bazel-version ~1 %workspace%/configs/v1_flags.rc
+```
 
 Import precedence:
 

--- a/src/main/cpp/BUILD
+++ b/src/main/cpp/BUILD
@@ -179,6 +179,7 @@ cc_library(
     deps = [
         ":blaze_util",
         ":rc_file",
+        ":sem_ver",
         ":startup_options",
         ":workspace_layout",
         "//src/main/cpp/util",
@@ -245,6 +246,7 @@ cc_library(
     ],
     deps = [
         ":blaze_util",
+        ":sem_ver",
         ":workspace_layout",
         "//src/main/cpp/util",
         "//src/main/cpp/util:logging",
@@ -256,6 +258,22 @@ cc_library(
         "@abseil-cpp//absl/strings:str_format",
         "@abseil-cpp//absl/strings:string_view",
         "@abseil-cpp//absl/types:span",
+        "@re2",
+    ],
+)
+
+cc_library(
+    name = "sem_ver",
+    srcs = ["sem_ver.cc"],
+    hdrs = ["sem_ver.h"],
+    visibility = [
+        "//src:__pkg__",
+        "//src/test/cpp:__pkg__",
+    ],
+    deps = [
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:string_view",
+        "@re2",
     ],
 )
 

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1463,9 +1463,7 @@ void PrintBazelLeaf() {
   printf("%s\n", leaf.c_str());
 }
 
-void PrintVersionInfo(const string &self_path, const string &product_name) {
-  string build_label;
-  ExtractBuildLabel(self_path, &build_label);
+void PrintVersionInfo(const string& build_label, const string& product_name) {
   printf("%s %s\n", product_name.c_str(), build_label.c_str());
 }
 
@@ -1475,7 +1473,8 @@ static void RunLauncher(const string &self_path,
                         const StartupOptions &startup_options,
                         const OptionProcessor &option_processor,
                         const WorkspaceLayout &workspace_layout,
-                        const string &workspace, LoggingInfo *logging_info) {
+                        const string &workspace, const string &build_label,
+                        LoggingInfo *logging_info) {
   blaze_server = new BlazeServer(startup_options);
 
   const std::optional<DurationMillis> command_wait_duration =
@@ -1546,8 +1545,6 @@ static void RunLauncher(const string &self_path,
                  option_processor, startup_options, logging_info,
                  extract_data_duration, command_wait_duration, blaze_server);
   } else {
-    string build_label;
-    ExtractBuildLabel(self_path, &build_label);
     RunClientServerMode(server_exe, server_exe_args, server_dir,
                         workspace_layout, workspace, option_processor,
                         startup_options, logging_info, extract_data_duration,
@@ -1571,8 +1568,16 @@ int Main(int argc, const char *const *argv, WorkspaceLayout *workspace_layout,
     return blaze_exit_code::SUCCESS;
   }
 
+  // Extract build_label to be used in two places:
+  // 1) PrintVersionInfo()
+  // 2) Resolving conditional bazel imports in .bazelrc files (eg. import rc
+  //    file if bazel version >=8).
+  string build_label;
+  ExtractBuildLabel(self_path, &build_label);
+  option_processor->SetBuildLabel(build_label);
+
   if (argc == 2 && strcmp(argv[1], "--version") == 0) {
-    PrintVersionInfo(self_path, option_processor->GetLowercaseProductName());
+    PrintVersionInfo(build_label, option_processor->GetLowercaseProductName());
     return blaze_exit_code::SUCCESS;
   }
 
@@ -1648,7 +1653,8 @@ int Main(int argc, const char *const *argv, WorkspaceLayout *workspace_layout,
   PrepareDirectories(startup_options);
 
   RunLauncher(self_path, archive_contents, install_md5, *startup_options,
-              *option_processor, *workspace_layout, workspace, &logging_info);
+              *option_processor, *workspace_layout, workspace, build_label,
+              &logging_info);
   return 0;
 }
 

--- a/src/main/cpp/blaze.h
+++ b/src/main/cpp/blaze.h
@@ -24,7 +24,7 @@ namespace blaze {
 
 // Prints client version information to standard output, e.g. when invoking the
 // client with "--version".
-void PrintVersionInfo(const std::string& self_path,
+void PrintVersionInfo(const std::string& build_label,
                       const std::string& product_name);
 
 int Main(int argc, const char *const *argv, WorkspaceLayout* workspace_layout,

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <utility>
@@ -28,6 +29,7 @@
 #include "src/main/cpp/blaze_util.h"
 #include "src/main/cpp/blaze_util_platform.h"
 #include "src/main/cpp/option_processor-internal.h"
+#include "src/main/cpp/sem_ver.h"
 #include "src/main/cpp/util/file_platform.h"
 #include "src/main/cpp/util/logging.h"
 #include "src/main/cpp/util/path.h"
@@ -421,12 +423,14 @@ blaze_exit_code::ExitCode OptionProcessor::GetRcFiles(
   // that don't point to real files.
   rc_files = internal::DedupeBlazercPaths(rc_files);
 
+  const std::optional<SemVer>& sem_ver = SemVer::Parse(build_label_);
   std::set<std::string> read_files_canonical_paths;
   // Parse these potential files, in priority order;
   for (const std::string& top_level_bazelrc_path : rc_files) {
     std::unique_ptr<RcFile> parsed_rc;
-    blaze_exit_code::ExitCode parse_rcfile_exit_code = ParseRcFile(
-        workspace_layout, workspace, top_level_bazelrc_path, &parsed_rc, error);
+    blaze_exit_code::ExitCode parse_rcfile_exit_code =
+        ParseRcFile(workspace_layout, workspace, top_level_bazelrc_path,
+                    build_label_, sem_ver, &parsed_rc, error);
     if (parse_rcfile_exit_code != blaze_exit_code::SUCCESS) {
       return parse_rcfile_exit_code;
     }
@@ -467,19 +471,32 @@ blaze_exit_code::ExitCode OptionProcessor::GetRcFiles(
 blaze_exit_code::ExitCode ParseRcFile(const WorkspaceLayout* workspace_layout,
                                       const std::string& workspace,
                                       const std::string& rc_file_path,
+                                      const std::string& build_label,
+                                      const std::optional<SemVer>& sem_ver,
                                       std::unique_ptr<RcFile>* result_rc_file,
                                       std::string* error) {
   assert(!rc_file_path.empty());
   assert(result_rc_file != nullptr);
 
   RcFile::ParseError parse_error;
-  std::unique_ptr<RcFile> parsed_file = RcFile::Parse(
-      rc_file_path, workspace_layout, workspace, &parse_error, error);
+  std::unique_ptr<RcFile> parsed_file =
+      RcFile::Parse(rc_file_path, workspace_layout, workspace, build_label,
+                    sem_ver, &parse_error, error);
   if (parsed_file == nullptr) {
     return internal::ParseErrorToExitCode(parse_error);
   }
   *result_rc_file = std::move(parsed_file);
   return blaze_exit_code::SUCCESS;
+}
+
+blaze_exit_code::ExitCode ParseRcFile(const WorkspaceLayout* workspace_layout,
+                                      const std::string& workspace,
+                                      const std::string& rc_file_path,
+                                      std::unique_ptr<RcFile>* result_rc_file,
+                                      std::string* error) {
+  return ParseRcFile(workspace_layout, workspace, rc_file_path,
+                      /*build_label=*/"", /*sem_ver=*/std::nullopt,
+                      result_rc_file, error);
 }
 
 blaze_exit_code::ExitCode OptionProcessor::ParseOptions(

--- a/src/main/cpp/option_processor.h
+++ b/src/main/cpp/option_processor.h
@@ -117,6 +117,16 @@ class OptionProcessor {
   // the failure. Otherwise, the server will handle any required logging.
   void PrintStartupOptionsProvenanceMessage() const;
 
+  // Sets the build label.
+  void SetBuildLabel(const std::string& build_label) {
+    build_label_ = build_label;
+  }
+
+  // Parse the files in `blazercs` and return all options that need to be passed
+  // to the server. The options are returned in the order they should be appear
+  // on the command line (later options have precedence over earlier ones).
+  static std::vector<BlazercOption> GetBlazercOptions(
+      const std::string& cwd, const std::vector<RcFile*>& blazercs);
   // Constructs all synthetic command args that should be passed to the
   // server to configure blazerc options and client environment.
   static std::vector<std::string> GetBlazercAndEnvCommandArgs(
@@ -159,9 +169,20 @@ class OptionProcessor {
   // Path to the system-wide bazelrc configuration file.
   // This is configurable for testing purposes only.
   const std::string system_bazelrc_path_;
+
+  // Build label for Bazel.
+  std::string build_label_;
 };
 
 // Parses and returns the contents of the rc file.
+blaze_exit_code::ExitCode ParseRcFile(const WorkspaceLayout* workspace_layout,
+                                      const std::string& workspace,
+                                      const std::string& rc_file_path,
+                                      const std::string& build_label,
+                                      const std::optional<SemVer>& sem_ver,
+                                      std::unique_ptr<RcFile>* result_rc_file,
+                                      std::string* error);
+
 blaze_exit_code::ExitCode ParseRcFile(const WorkspaceLayout* workspace_layout,
                                       const std::string& workspace,
                                       const std::string& rc_file_path,

--- a/src/main/cpp/option_processor.h
+++ b/src/main/cpp/option_processor.h
@@ -122,11 +122,7 @@ class OptionProcessor {
     build_label_ = build_label;
   }
 
-  // Parse the files in `blazercs` and return all options that need to be passed
-  // to the server. The options are returned in the order they should be appear
-  // on the command line (later options have precedence over earlier ones).
-  static std::vector<BlazercOption> GetBlazercOptions(
-      const std::string& cwd, const std::vector<RcFile*>& blazercs);
+
   // Constructs all synthetic command args that should be passed to the
   // server to configure blazerc options and client environment.
   static std::vector<std::string> GetBlazercAndEnvCommandArgs(

--- a/src/main/cpp/rc_file.h
+++ b/src/main/cpp/rc_file.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include "src/main/cpp/sem_ver.h"
 #include "src/main/cpp/workspace_layout.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/functional/function_ref.h"
@@ -43,8 +44,15 @@ class RcFile {
   enum class ParseError { NONE, UNREADABLE_FILE, INVALID_FORMAT, IMPORT_LOOP };
   static std::unique_ptr<RcFile> Parse(
       const std::string& filename, const WorkspaceLayout* workspace_layout,
-      const std::string& workspace, ParseError* error, std::string* error_text,
-      ReadFileFn read_file = &ReadFileDefault,
+      const std::string& workspace, const std::string& build_label,
+      const std::optional<SemVer>& sem_ver, ParseError* error,
+      std::string* error_text, ReadFileFn read_file = &ReadFileDefault,
+      CanonicalizePathFn canonicalize_path = &CanonicalizePathDefault);
+
+  static std::unique_ptr<RcFile> Parse(
+      const std::string& filename, const WorkspaceLayout* workspace_layout,
+      const std::string& workspace, ParseError* error,
+      std::string* error_text, ReadFileFn read_file = &ReadFileDefault,
       CanonicalizePathFn canonicalize_path = &CanonicalizePathDefault);
 
   // Movable and copyable.
@@ -66,13 +74,18 @@ class RcFile {
   RcFile() = default;
 
   // Recursive call to parse a file and its imports.
-  ParseError ParseFile(const std::string& filename,
-                       const std::string& workspace,
-                       const WorkspaceLayout& workspace_layout,
-                       ReadFileFn read_file,
-                       CanonicalizePathFn canonicalize_path,
-                       std::vector<std::string>& import_stack,
-                       std::string* error_text);
+  ParseError ParseFile(
+      const std::string& filename, const std::string& workspace,
+      const WorkspaceLayout& workspace_layout, const std::string& build_label,
+      const std::optional<SemVer>& sem_ver, ReadFileFn read_file,
+      CanonicalizePathFn canonicalize_path,
+      std::vector<std::string>& import_stack, std::string* error_text);
+
+  ParseError ParseFile(
+      const std::string& filename, const std::string& workspace,
+      const WorkspaceLayout& workspace_layout, ReadFileFn read_file,
+      CanonicalizePathFn canonicalize_path,
+      std::vector<std::string>& import_stack, std::string* error_text);
 
   static bool ReadFileDefault(const std::string& filename,
                               std::string* contents, std::string* error_msg);
@@ -85,6 +98,18 @@ class RcFile {
   // All options parsed from the file.
   OptionMap options_;
 };
+
+// Checks if the build label passes the given comparison operation and
+// condition. An empty return (nullopt) indicates a failure and error_text will
+// be filled.
+//
+// Eg. The following values would evaluate to true since 8.4.5 >= 5.4.0
+//  - build_label=8.4.5
+//  - op='>='
+//  - compare_version=5.4.0
+std::optional<bool> BazelVersionMatchesCondition(
+    const SemVer& build_label, absl::string_view op,
+    const std::string& compare_version, std::string* error_text);
 
 }  // namespace blaze
 

--- a/src/main/cpp/sem_ver.cc
+++ b/src/main/cpp/sem_ver.cc
@@ -1,0 +1,152 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/main/cpp/sem_ver.h"
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
+#include "re2/re2.h"
+
+namespace blaze {
+namespace {
+// Semantic version regex copied verbatim from
+// https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+const LazyRE2 kSemverRe = {R"(^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$)"};
+}  // namespace
+
+std::optional<SemVer> SemVer::Parse(const std::string& v) {
+  int major;
+  int minor;
+  int patch;
+  std::string prerelease;
+  std::string buildmetadata;
+  if (RE2::FullMatch(v, *kSemverRe, &major, &minor, &patch, &prerelease,
+                     &buildmetadata)) {
+    return SemVer(major, minor, patch, prerelease, buildmetadata);
+  }
+  return std::nullopt;
+}
+
+SemVer SemVer::NextMajorVersion() const {
+  return SemVer(major_ + 1, 0, 0, "", "");
+}
+
+SemVer SemVer::NextMinorVersion() const {
+  return SemVer(major_, minor_ + 1, 0, "", "");
+}
+
+int SemVer::Compare(const SemVer& other) const {
+  auto major_diff = major_ - other.major_;
+  if (major_diff != 0) {
+    return major_diff;
+  }
+  auto minor_diff = minor_ - other.minor_;
+  if (minor_diff != 0) {
+    return minor_diff;
+  }
+  auto patch_diff = patch_ - other.patch_;
+  if (patch_diff != 0) {
+    return patch_diff;
+  }
+  return ComparePrerelease(prerelease_, other.prerelease_);
+}
+
+// Adapted from golang's implementation.
+// https://cs.opensource.google/go/x/mod/+/refs/tags/v0.30.0:semver/semver.go;l=339;bpv=1
+int SemVer::ComparePrerelease(absl::string_view x,
+                                         absl::string_view y) {
+  if (x == y) {
+    return 0;
+  }
+  // A larger set of pre-release fields has a higher precedence than a smaller
+  // set.
+  if (x.empty()) {
+    return 1;
+  }
+  if (y.empty()) {
+    return -1;
+  }
+
+  // Examine each dot-separated part.
+  const std::vector<absl::string_view> xv = absl::StrSplit(x, '.');
+  const std::vector<absl::string_view> yv = absl::StrSplit(y, '.');
+  std::size_t i = 0;
+  while (i != xv.size() && i != yv.size()) {
+    auto part_x = xv[i];
+    auto part_y = yv[i];
+    i++;
+    if (part_x != part_y) {
+      int ix;
+      int iy;
+      bool is_numeric_x = absl::SimpleAtoi(part_x, &ix);
+      bool is_numeric_y = absl::SimpleAtoi(part_y, &iy);
+
+      if (is_numeric_x != is_numeric_y) {
+        // Numeric identifiers always have lower precedence than non-numeric
+        // identifiers.
+        if (is_numeric_x) {
+          return -1;
+        }
+        return 1;
+      }
+
+      if (is_numeric_x) {  // Both parts are numbers.
+        if (ix < iy) {
+          return -1;
+        }
+        return 1;
+      }
+
+      // Lexicographic ordering.
+      if (part_x < part_y) {
+        return -1;
+      }
+      return 1;
+    }
+  }
+  // A larger set of pre-release fields has a higher precedence than a smaller
+  // set.
+  if (i == xv.size()) {  // We ran out of x parts.
+    return -1;
+  }
+  return 1;
+}
+
+bool SemVer::operator==(const SemVer& other) const {
+  return Compare(other) == 0;
+}
+
+bool SemVer::operator<(const SemVer& other) const { return Compare(other) < 0; }
+
+bool SemVer::operator!=(const SemVer& other) const {
+  return Compare(other) != 0;
+}
+
+bool SemVer::operator>(const SemVer& other) const { return Compare(other) > 0; }
+
+bool SemVer::operator<=(const SemVer& other) const {
+  return Compare(other) <= 0;
+}
+
+bool SemVer::operator>=(const SemVer& other) const {
+  return Compare(other) >= 0;
+}
+
+}  // namespace blaze

--- a/src/main/cpp/sem_ver.h
+++ b/src/main/cpp/sem_ver.h
@@ -1,0 +1,76 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BAZEL_SRC_MAIN_CPP_SEMVER_H_
+#define BAZEL_SRC_MAIN_CPP_SEMVER_H_
+
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "absl/strings/string_view.h"
+
+namespace blaze {
+
+// Represents a semantic version.
+class SemVer {
+ public:
+  // Parse a string into a SemVer. Must be a valid semantic version string per
+  // semver.org, otherwise, returns nullopt.
+  static std::optional<SemVer> Parse(const std::string& v);
+
+  // Returns a new SemVer with the next major version.  Eg. 8.3.4 -> 9.0.0.
+  SemVer NextMajorVersion() const;
+
+  // Returns a new SemVer with the next minor version. Eg. 8.3.4 -> 8.4.0.
+  SemVer NextMinorVersion() const;
+
+  bool operator==(const SemVer& other) const;
+
+  bool operator<(const SemVer& other) const;
+
+  bool operator!=(const SemVer& other) const;
+
+  bool operator>(const SemVer& other) const;
+
+  bool operator<=(const SemVer& other) const;
+
+  bool operator>=(const SemVer& other) const;
+
+ private:
+  // Private constructor - use Parse() instead.
+  explicit SemVer(int major, int minor, int patch, std::string prerelease,
+                  std::string buildmetadata)
+      : major_(major),
+        minor_(minor),
+        patch_(patch),
+        prerelease_(std::move(prerelease)),
+        buildmetadata_(std::move(buildmetadata)) {};
+
+  // Comparator for SemVer.
+  [[nodiscard]] int Compare(const SemVer& other) const;
+
+  // Comparator function for prerelease strings.
+  static int ComparePrerelease(absl::string_view x, absl::string_view y);
+
+  // The individual semantic version parts.
+  int major_;
+  int minor_;
+  int patch_;
+  std::string prerelease_;
+  std::string buildmetadata_;
+};
+
+}  // namespace blaze
+#endif  // BAZEL_SRC_MAIN_CPP_SEMVER_H_

--- a/src/test/cpp/BUILD
+++ b/src/test/cpp/BUILD
@@ -64,8 +64,20 @@ cc_test(
     deps = [
         "//src/main/cpp:blaze_util",
         "//src/main/cpp:option_processor",
+        "//src/main/cpp:sem_ver",
         "//src/main/cpp:workspace_layout",
         "//src/main/cpp/util",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "sem_ver_test",
+    size = "small",
+    srcs = ["sem_ver_test.cc"],
+    deps = [
+        "//src/main/cpp:sem_ver",
+        "@abseil-cpp//absl/strings:str_format",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <optional>
 #if defined(_WIN32)
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -25,9 +26,9 @@
 
 #include "src/main/cpp/bazel_startup_options.h"
 #include "src/main/cpp/blaze_util_platform.h"
-#include "src/main/cpp/option_processor-internal.h"
 #include "src/main/cpp/option_processor.h"
 #include "src/main/cpp/rc_file.h"
+#include "src/main/cpp/sem_ver.h"
 #include "src/main/cpp/util/file.h"
 #include "src/main/cpp/util/file_platform.h"
 #include "src/main/cpp/util/path.h"
@@ -39,9 +40,11 @@
 namespace blaze {
 using ::testing::ContainsRegex;
 using ::testing::ElementsAre;
+using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::IsEmpty;
 using ::testing::MatchesRegex;
+using ::testing::Optional;
 using ::testing::Pointee;
 
 #if defined(_WIN32) || defined(__CYGWIN__)
@@ -618,7 +621,7 @@ class BlazercImportTest : public ParseOptionsTest {
           "startup --io_nice_level=4",
         imported_rc_path, 0755));
 
-    // Add startup flags the imported bazelrc.
+    // Add startup flags to the imported bazelrc.
     std::string workspace_rc;
     ASSERT_TRUE(SetUpWorkspaceRcFile(
         "startup --max_idle_secs=42\n" +
@@ -848,6 +851,121 @@ TEST_F(BlazercImportTest, BazelRcTryImportDoesNotFallBackToLiteralPlaceholder) {
   ParseOptionsAndCheckOutput(args, blaze_exit_code::SUCCESS, "", "");
 }
 
+TEST_F(BlazercImportTest, SuccessfulTryImportIfBazelVersion) {
+  const std::string imported_rc_path =
+      blaze_util::JoinPath(workspace_, "myimportedbazelrc");
+  ASSERT_TRUE(
+      blaze_util::MakeDirectories(blaze_util::Dirname(imported_rc_path), 0755));
+  ASSERT_TRUE(blaze_util::WriteFile("startup --max_idle_secs=123\n",
+                                    imported_rc_path, 0755));
+
+  option_processor_->SetBuildLabel("8.4.2");
+  // Add startup flags to the imported bazelrc.
+  std::string workspace_rc;
+  ASSERT_TRUE(
+      SetUpWorkspaceRcFile("startup --max_idle_secs=42\n"
+                           "try-import-if-bazel-version >=8.4.2 " +
+                               imported_rc_path + "\n",
+                           &workspace_rc));
+
+  const std::vector<std::string> args = {"bazel", "build"};
+  ParseOptionsAndCheckOutput(args, blaze_exit_code::SUCCESS, "", "");
+
+  EXPECT_EQ(123, option_processor_->GetParsedStartupOptions()->max_idle_secs);
+}
+
+TEST_F(BlazercImportTest, TryImportVersionSkippedIfBuildVersionInvalid) {
+  const std::string imported_rc_path =
+      blaze_util::JoinPath(workspace_, "myimportedbazelrc");
+  ASSERT_TRUE(
+      blaze_util::MakeDirectories(blaze_util::Dirname(imported_rc_path), 0755));
+  ASSERT_TRUE(blaze_util::WriteFile("startup --max_idle_secs=123\n",
+                                    imported_rc_path, 0755));
+
+  // On dev builds, no_version is the build label.
+  option_processor_->SetBuildLabel("no_version");
+  // Add startup flags to the imported bazelrc.
+  std::string workspace_rc;
+  ASSERT_TRUE(
+      SetUpWorkspaceRcFile("startup --max_idle_secs=42\n"
+                           "try-import-if-bazel-version >=8.4.2 " +
+                               imported_rc_path + "\n",
+                           &workspace_rc));
+
+  const std::vector<std::string> args = {"bazel", "build"};
+  ParseOptionsAndCheckOutput(args, blaze_exit_code::SUCCESS, "", "");
+
+  // The try-import-if-bazel-version does NOT get processed.
+  EXPECT_EQ(42, option_processor_->GetParsedStartupOptions()->max_idle_secs);
+}
+
+TEST_F(BlazercImportTest, TryImportVersionSkippedIfComparisonFails) {
+  const std::string imported_rc_path =
+      blaze_util::JoinPath(workspace_, "myimportedbazelrc");
+  ASSERT_TRUE(
+      blaze_util::MakeDirectories(blaze_util::Dirname(imported_rc_path), 0755));
+  ASSERT_TRUE(blaze_util::WriteFile("startup --max_idle_secs=123\n",
+                                    imported_rc_path, 0755));
+
+  // Old version that does not pass the condition >=8.4.2
+  option_processor_->SetBuildLabel("5.4.0");
+  // Add startup flags to the imported bazelrc.
+  std::string workspace_rc;
+  ASSERT_TRUE(
+      SetUpWorkspaceRcFile("startup --max_idle_secs=42\n"
+                           "try-import-if-bazel-version >=8.4.2 " +
+                               imported_rc_path + "\n",
+                           &workspace_rc));
+
+  const std::vector<std::string> args = {"bazel", "build"};
+  ParseOptionsAndCheckOutput(args, blaze_exit_code::SUCCESS, "", "");
+
+  // The try-import-if-bazel-version does NOT get processed.
+  EXPECT_EQ(42, option_processor_->GetParsedStartupOptions()->max_idle_secs);
+}
+
+TEST_F(BlazercImportTest, TryImportVersionSkippedIfFileDoesNotExist) {
+  option_processor_->SetBuildLabel("8.4.2");
+  // Add startup flags to the imported bazelrc.
+  std::string workspace_rc;
+  ASSERT_TRUE(
+      SetUpWorkspaceRcFile("startup --max_idle_secs=42\n"
+                           "try-import-if-bazel-version >=8.4.2 "
+                           "non-existent/file.rc\n",
+                           &workspace_rc));
+
+  const std::vector<std::string> args = {"bazel", "build"};
+  // The Parse does NOT fail if the file is missing.
+  ParseOptionsAndCheckOutput(args, blaze_exit_code::SUCCESS, "", "");
+}
+
+TEST_F(BlazercImportTest, TryImportVersionInvalidCondition) {
+  option_processor_->SetBuildLabel("8.4.2");
+  std::string workspace_rc;
+  ASSERT_TRUE(SetUpWorkspaceRcFile(
+      "try-import-if-bazel-version ^8.4.2 /unused/path\n", &workspace_rc));
+
+  const std::vector<std::string> args = {"bazel", "build"};
+  ParseOptionsAndCheckOutput(
+      args, blaze_exit_code::BAD_ARGV,
+      "Invalid version condition in config file.*Condition '\\^8.4.2'", "");
+}
+
+TEST_F(BlazercImportTest, TryImportVersionInvalidConditionSemanticVersion) {
+  option_processor_->SetBuildLabel("8.4.2");
+  std::string workspace_rc;
+  ASSERT_TRUE(SetUpWorkspaceRcFile(
+      "try-import-if-bazel-version ==no_version /unused/path\n",
+      &workspace_rc));
+
+  const std::vector<std::string> args = {"bazel", "build"};
+  ParseOptionsAndCheckOutput(
+      args, blaze_exit_code::BAD_ARGV,
+      "Invalid import declaration in config file.*Could not parse version "
+      "'no_version' as a valid semantic version",
+      "");
+}
+
 #if defined(_WIN32)
 TEST_F(BlazercImportTest,
        BazelRcTryImportDoesNotFailForInvalidPosixPathOnWindows) {
@@ -971,5 +1089,150 @@ TEST_F(ParseOptionsTest, ImportingStandardRcBeforeItIsLoadedCausesAWarning) {
       "unnecessarily imported earlier.\n");
 }
 #endif  // !defined(_WIN32) && !defined(__CYGWIN__)
+
+TEST(BazelVersionMatchesCondition_Tilde, VersionFullSemanticVersion) {
+  std::string error_text;
+  // ~1.2.3 => >=1.2.3 <1.3.0
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse("1.2.4").value(), "~",
+                                           "1.2.3", &error_text),
+              Optional(true));
+  EXPECT_THAT(
+      BazelVersionMatchesCondition(SemVer::Parse("1.2.3-prerelease").value(),
+                                   "~", "1.2.3", &error_text),
+      Optional(false));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse("1.2.2").value(), "~",
+                                           "1.2.3", &error_text),
+              Optional(false));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse("1.3.0").value(), "~",
+                                           "1.2.3", &error_text),
+              Optional(false));
+}
+
+TEST(BazelVersionMatchesCondition_Tilde, VersionMajorMinorVersion) {
+  std::string error_text;
+  // ~1.2 => >=1.2.0 <1.3.0
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse("1.2.4").value(), "~",
+                                           "1.2", &error_text),
+              Optional(true));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse("1.2.0").value(), "~",
+                                           "1.2", &error_text),
+              Optional(true));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse("1.1.9").value(), "~",
+                                           "1.2", &error_text),
+              Optional(false));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse("1.3.0").value(), "~",
+                                           "1.2", &error_text),
+              Optional(false));
+}
+
+TEST(BazelVersionMatchesCondition_Tilde, VersionMajorVersion) {
+  std::string unused_error_text;
+  // ~1 => >=1.0.0 <2.0.0
+  const std::string compare_version = "1";
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse("1.0.0").value(), "~",
+                                           compare_version, &unused_error_text),
+              Optional(true));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse("1.2.4").value(), "~",
+                                           compare_version, &unused_error_text),
+              Optional(true));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse("1.9.9").value(), "~",
+                                           compare_version, &unused_error_text),
+              Optional(true));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse("2.0.0").value(), "~",
+                                           compare_version, &unused_error_text),
+              Optional(false));
+}
+
+TEST(BazelVersionMatchesCondition_Tilde, VersionPrerelease) {
+  std::string unused_error_text;
+  const std::string compare_version = "1.2.3-beta.2";
+  // ~1.2.3-beta.2 => >=1.2.3-beta.2 <1.3.0
+  EXPECT_THAT(
+      BazelVersionMatchesCondition(SemVer::Parse("1.2.3-beta.2").value(), "~",
+                                   compare_version, &unused_error_text),
+      Optional(true));
+  EXPECT_THAT(
+      BazelVersionMatchesCondition(SemVer::Parse("1.2.3-beta.3").value(), "~",
+                                   compare_version, &unused_error_text),
+      Optional(true));
+  EXPECT_THAT(
+      BazelVersionMatchesCondition(SemVer::Parse("1.2.3-alpha.42").value(), "~",
+                                   compare_version, &unused_error_text),
+      Optional(false));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse("1.3.0").value(), "~",
+                                           compare_version, &unused_error_text),
+              Optional(false));
+}
+
+TEST(BazelVersionMatchesCondition_Tilde, VersionInvalid) {
+  std::string error_text;
+  // Invalid because prefixed with 'v'.
+  const std::string compare_version = "v1.2.3";
+  EXPECT_THAT(
+      BazelVersionMatchesCondition(SemVer::Parse("1.2.3-beta.2").value(), "~",
+                                   compare_version, &error_text),
+      Eq(std::nullopt));
+  EXPECT_THAT(error_text, HasSubstr("Could not parse the tilde range version"));
+}
+
+TEST(BazelVersionMatchesCondition, AllComparisonOperators) {
+  std::string unused_error_text;
+  std::string build_label = "8.4.2";
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse(build_label).value(),
+                                           ">", "8.4.0", &unused_error_text),
+              Optional(true));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse(build_label).value(),
+                                           ">", "8.5.0", &unused_error_text),
+              Optional(false));
+
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse(build_label).value(),
+                                           ">=", "8.4.2", &unused_error_text),
+              Optional(true));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse(build_label).value(),
+                                           ">=", "8.5.0", &unused_error_text),
+              Optional(false));
+
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse(build_label).value(),
+                                           "<", "8.5.0", &unused_error_text),
+              Optional(true));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse(build_label).value(),
+                                           "<", "1.0.0", &unused_error_text),
+              Optional(false));
+
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse(build_label).value(),
+                                           "<=", "8.4.2", &unused_error_text),
+              Optional(true));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse(build_label).value(),
+                                           "<=", "8.4.1", &unused_error_text),
+              Optional(false));
+
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse(build_label).value(),
+                                           "==", "8.4.2", &unused_error_text),
+              Optional(true));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse(build_label).value(),
+                                           "==", "8.4.2-prerelease",
+                                           &unused_error_text),
+              Optional(false));
+
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse(build_label).value(),
+                                           "!=", "8.4.2-prerelease",
+                                           &unused_error_text),
+              Optional(true));
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse(build_label).value(),
+                                           "!=", "8.4.2", &unused_error_text),
+              Optional(false));
+}
+
+TEST(BazelVersionMatchesCondition, InvalidCompareVersion) {
+  std::string error_text;
+  // Invalid because of 'v' prefix (not a valid semantic version).
+  EXPECT_THAT(BazelVersionMatchesCondition(SemVer::Parse("8.4.2").value(), ">",
+                                           "v8.4.2", &error_text),
+              Eq(std::nullopt));
+  EXPECT_THAT(
+      error_text,
+      HasSubstr(
+          "Could not parse version 'v8.4.2' as a valid semantic version."));
+}
 
 }  // namespace blaze

--- a/src/test/cpp/sem_ver_test.cc
+++ b/src/test/cpp/sem_ver_test.cc
@@ -1,0 +1,97 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include "src/main/cpp/sem_ver.h"
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "absl/strings/str_format.h"
+#include "googletest/include/gtest/gtest.h"
+
+namespace blaze {
+
+TEST(SemVerTest, ComparisonOperators) {
+  // Adapted from
+  // https://cs.opensource.google/go/x/mod/+/refs/tags/v0.30.0:semver/semver_test.go;l=19
+  // This list of semantic version strings are in order of precedence.
+
+  // clang-format off: preserve one test version per line.
+  std::vector<std::string> test_versions = {
+    "1.0.0-alpha",
+    "1.0.0-alpha.1",
+    "1.0.0-alpha.beta",
+    "1.0.0-beta",
+    "1.0.0-beta.2",
+    "1.0.0-beta.11",
+    "1.0.0-rc.1",
+    "1.0.0",
+    "1.2.0",
+    "1.2.3-456",
+    "1.2.3-456.789",
+    "1.2.3-456-789",
+    "1.2.3-456a",
+    "1.2.3-pre",
+    "1.2.3-pre.1",
+    "1.2.3-zzz",
+    "1.2.3",
+  };
+  // clang-format on
+
+  // Double loop over the test versions.  The index of each indicates the
+  // precedence and the expected value.
+  for (std::size_t i = 0; i < test_versions.size(); i++) {
+    for (std::size_t j = 0; j < test_versions.size(); j++) {
+      const std::string& is = test_versions[i];
+      const std::string& js = test_versions[j];
+
+      auto iv = SemVer::Parse(is);
+      auto jv = SemVer::Parse(js);
+      ASSERT_TRUE(iv.has_value()) << is;
+      ASSERT_TRUE(jv.has_value()) << js;
+
+      auto message = absl::StrFormat("comparing '%s' with '%s'", is, js);
+      if (is == js) {
+        EXPECT_TRUE(iv == jv) << message;
+        EXPECT_FALSE(iv != jv) << message;
+      } else if (i < j) {
+        EXPECT_TRUE(iv < jv) << message;
+        EXPECT_FALSE(iv >= jv) << message;
+      } else {
+        EXPECT_TRUE(iv > jv) << message;
+        EXPECT_FALSE(iv <= jv) << message;
+      }
+    }
+  }
+}
+
+TEST(SemVerTest, NextMajorVersion) {
+  EXPECT_EQ(SemVer::Parse("0.0.0")->NextMajorVersion(), SemVer::Parse("1.0.0"));
+  EXPECT_EQ(SemVer::Parse("8.0.0")->NextMajorVersion(), SemVer::Parse("9.0.0"));
+  EXPECT_EQ(SemVer::Parse("8.2.4")->NextMajorVersion(), SemVer::Parse("9.0.0"));
+  EXPECT_EQ(SemVer::Parse("8.2.4-beta")->NextMajorVersion(),
+            SemVer::Parse("9.0.0"));
+}
+
+TEST(SemVerTest, NextMinorVersion) {
+  EXPECT_EQ(SemVer::Parse("0.0.0")->NextMinorVersion(), SemVer::Parse("0.1.0"));
+  EXPECT_EQ(SemVer::Parse("8.0.0")->NextMinorVersion(), SemVer::Parse("8.1.0"));
+  EXPECT_EQ(SemVer::Parse("8.2.4")->NextMinorVersion(), SemVer::Parse("8.3.0"));
+  EXPECT_EQ(SemVer::Parse("8.2.4-beta")->NextMinorVersion(),
+            SemVer::Parse("8.3.0"));
+}
+
+}  // namespace blaze


### PR DESCRIPTION
This PR cherry-picks the commit d61a021aa63739f28ae1ba9f00ecf0c05e3edd09 to the release-8.7.0 branch and resolves conflicts.

In `.bazelrc` files, you can now conditionally import .rc files based on the current bazel version.

For example:

```
# Use new feature flags available in 6.0:
try-import-if-bazel-version >=6.0.0 %workspace%/configs/features.rc

# Use legacy flags in older versions:
try-import-if-bazel-version <7.0.0 %workspace%/configs/legacy.rc
```

The format is:
`try-import-if-bazel-version <conditional-operator><version> <config-file>`

`conditional-operator` can take one of 7 different operators:

1) `>`
2) `>=`
3) `<`
4) `<=`
5) `==`
6) `!=`
7) `~`

The tilde (~) operator follows the semantics of npm's tilde ranges: https://docs.npmjs.com/cli/v6/using-npm/semver#tilde-ranges-123-12-1

The implementation follows the proposal by meteorcloudy@ in https://github.com/bazelbuild/bazel/issues/24043#issuecomment-3502702961 with the exception that the comparison operator and the version string are joined together (no space inbetween).

Fixes https://github.com/bazelbuild/bazel/issues/24043

Closes https://github.com/bazelbuild/bazel/pull/27675.

PiperOrigin-RevId: 840844695
Change-Id: Ibd10cb8c3fc1b2a23faa90fa4a94cba862e5d7a9