### PR TITLE
docs: Fix flag name rendering in versioned pages

### DIFF
--- a/docs/versions/8.0.1/reference/flag-cheatsheet.mdx
+++ b/docs/versions/8.0.1/reference/flag-cheatsheet.mdx
@@ -23,7 +23,7 @@ The following flags are meant to be set explicitly on the command line.
 
   <tr>
     <td>
-      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--config">--config</a></code></h3>
+      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--config">`--config`</a></code></h3>
     </td>
     <td>
 
@@ -37,7 +37,7 @@ be selected with <code>--config=<strong>&lt;group&gt;</strong></code>.
 
   <tr>
     <td>
-      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--keep_going">--keep_going</a></code></h3>
+      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--keep_going">`--keep_going`</a></code></h3>
     </td>
     <td>
 
@@ -49,7 +49,7 @@ By default, Bazel fails eagerly.
 
   <tr>
     <td>
-      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--remote_download_outputs">--remote_download_outputs</a></code></h3>
+      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--remote_download_outputs">`--remote_download_outputs`</a></code></h3>
     </td>
     <td>
 
@@ -70,7 +70,7 @@ and intermediate artifacts that are necessary for local actions.
 
   <tr>
     <td>
-      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--stamp">--stamp</a></code></h3>
+      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--stamp">`--stamp`</a></code></h3>
     </td>
     <td>
 
@@ -96,7 +96,7 @@ The following flags can help you better understand Bazel build or test errors.
 
   <tr>
     <td>
-       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--announce_rc">--announce_rc</a></code></h3>
+       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--announce_rc">`--announce_rc`</a></code></h3>
     </td>
     <td>
 
@@ -109,7 +109,7 @@ machine-defined, or project-defined <strong>.bazelrc</strong> files.
 
   <tr>
     <td>
-      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--auto_output_filter">--auto_output_filter</a></code></h3>
+      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--auto_output_filter">`--auto_output_filter`</a></code></h3>
     </td>
     <td>
 
@@ -124,7 +124,7 @@ command line. To disable all filtering, set
 
   <tr>
     <td>
-      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--sandbox_debug">--sandbox_debug</a></code></h3>
+      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--sandbox_debug">`--sandbox_debug`</a></code></h3>
     </td>
     <td>
 
@@ -147,7 +147,7 @@ builds by default and what gets sandboxed, see our
 
   <tr>
     <td>
-      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--subcommands">--subcommands (-s)</a></code></h3>
+      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--subcommands">`--subcommands (-s)`</a></code></h3>
     </td>
     <td>
 
@@ -170,7 +170,7 @@ a server restart. Toggle these flags with caution.
 
   <tr>
     <td>
-       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--bazelrc">--bazelrc</a></code></h3>
+       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--bazelrc">`--bazelrc`</a></code></h3>
     </td>
     <td>
 
@@ -193,7 +193,7 @@ the .bazelrc file&gt;</strong></code>.
 
   <tr>
     <td>
-    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/8.0.1/docs/user-manual#host-jvm-args">--host_jvm_args</a></code></h3>
+    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/8.0.1/docs/user-manual#host-jvm-args">`--host_jvm_args`</a></code></h3>
     </td>
     <td>
 
@@ -226,7 +226,7 @@ For example, the following limits the Bazel heap size to <strong>3</strong>GB:
 
   <tr>
     <td>
-    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--output_base">--output_base</a></code></h3>
+    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--output_base">`--output_base`</a></code></h3>
     </td>
     <td>
 
@@ -257,7 +257,7 @@ The following flags are related to Bazel test
 
   <tr>
     <td>
-       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--java_debug">--java_debug</a></code></h3>
+       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--java_debug">`--java_debug`</a></code></h3>
     </td>
     <td>
 
@@ -269,7 +269,7 @@ Causes Java tests to wait for a debugger connection before being executed.
 
   <tr>
     <td>
-    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--runs_per_test">--runs_per_test</a></code></h3>
+    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--runs_per_test">`--runs_per_test`</a></code></h3>
     </td>
     <td>
 
@@ -283,7 +283,7 @@ flaky tests and see whether a fix causes a test to pass consistently.
 
   <tr>
     <td>
-    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--test_output">--test_output</a></code></h3>
+    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--test_output">`--test_output`</a></code></h3>
     </td>
     <td>
 
@@ -308,7 +308,7 @@ The following flags are related to Bazel run.
 
   <tr>
     <td>
-        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--run_under">--run_under</a></code></h3>
+        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--run_under">`--run_under`</a></code></h3>
     </td>
     <td>
 
@@ -333,7 +333,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--disk_cache">--disk_cache</a></code></h3>
+       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--disk_cache">`--disk_cache`</a></code></h3>
     </td>
     <td>
 
@@ -350,7 +350,7 @@ up Bazel builds by adding
 
   <tr>
     <td>
-    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--jobs">--jobs</a></code></h3>
+    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--jobs">`--jobs`</a></code></h3>
     </td>
     <td>
 
@@ -365,7 +365,7 @@ cluster executes more jobs than you have cores locally.
 
   <tr>
     <td>
-    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--local_resources">--local_resources</a></code></h3>
+    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--local_resources">`--local_resources`</a></code></h3>
     </td>
     <td>
 
@@ -382,7 +382,7 @@ Limits how much CPU or RAM is consumed by locally running actions.
 
   <tr>
     <td>
-    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--sandbox_base">--sandbox_base</a></code></h3>
+    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--sandbox_base">`--sandbox_base`</a></code></h3>
     </td>
     <td>
 
@@ -412,7 +412,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--flaky_test_attempts">--flaky_test_attempts</a></code></h3>
+       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--flaky_test_attempts">`--flaky_test_attempts`</a></code></h3>
     </td>
     <td>
 
@@ -427,7 +427,7 @@ the test summary.
 
   <tr>
     <td>
-    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--remote_cache">--remote_cache</a></code></h3>
+    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--remote_cache">`--remote_cache`</a></code></h3>
     </td>
     <td>
 
@@ -440,7 +440,7 @@ speed up Bazel builds. It can be combined with a local disk cache.
 
   <tr>
     <td>
-    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--remote_download_regex">--remote_download_regex</a></code></h3>
+    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--remote_download_regex">`--remote_download_regex`</a></code></h3>
     </td>
     <td>
 
@@ -454,7 +454,7 @@ patterns may be specified by repeating this flag.
 
   <tr>
     <td>
-     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--remote_executor">--remote_executor</a></code></h3>
+     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--remote_executor">`--remote_executor`</a></code></h3>
     </td>
     <td>
 
@@ -468,7 +468,7 @@ a remote execution service. You'll often need to Add
 
   <tr>
     <td>
-     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--remote_instance_name">--remote_instance_name</a></code></h3>
+     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--remote_instance_name">`--remote_instance_name`</a></code></h3>
     </td>
     <td>
 
@@ -480,7 +480,7 @@ The value to pass as <code>instance_name</code> in the remote execution API.
 
   <tr>
     <td>
-    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/8.0.1/docs/user-manual#show-timestamps">--show-timestamps</a></code></h3>
+    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/8.0.1/docs/user-manual#show-timestamps">`--show-timestamps`</a></code></h3>
     </td>
     <td>
 
@@ -494,7 +494,7 @@ quickly understand what step took how long.
 
   <tr>
     <td>
-    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--spawn_strategy">--spawn_strategy</a></code></h3>
+    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/8.0.1/reference/command-line-reference#flag--spawn_strategy">`--spawn_strategy`</a></code></h3>
     </td>
     <td>
 

--- a/docs/versions/8.1.1/reference/flag-cheatsheet.mdx
+++ b/docs/versions/8.1.1/reference/flag-cheatsheet.mdx
@@ -23,7 +23,7 @@ The following flags are meant to be set explicitly on the command line.
 
   <tr>
     <td>
-      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--config">--config</a></code></h3>
+      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--config">`--config`</a></code></h3>
     </td>
     <td>
 
@@ -37,7 +37,7 @@ be selected with <code>--config=<strong>&lt;group&gt;</strong></code>.
 
   <tr>
     <td>
-      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--keep_going">--keep_going</a></code></h3>
+      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--keep_going">`--keep_going`</a></code></h3>
     </td>
     <td>
 
@@ -49,7 +49,7 @@ By default, Bazel fails eagerly.
 
   <tr>
     <td>
-      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--remote_download_outputs">--remote_download_outputs</a></code></h3>
+      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--remote_download_outputs">`--remote_download_outputs`</a></code></h3>
     </td>
     <td>
 
@@ -70,7 +70,7 @@ and intermediate artifacts that are necessary for local actions.
 
   <tr>
     <td>
-      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--stamp">--stamp</a></code></h3>
+      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--stamp">`--stamp`</a></code></h3>
     </td>
     <td>
 
@@ -96,7 +96,7 @@ The following flags can help you better understand Bazel build or test errors.
 
   <tr>
     <td>
-       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--announce_rc">--announce_rc</a></code></h3>
+       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--announce_rc">`--announce_rc`</a></code></h3>
     </td>
     <td>
 
@@ -109,7 +109,7 @@ machine-defined, or project-defined <strong>.bazelrc</strong> files.
 
   <tr>
     <td>
-      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--auto_output_filter">--auto_output_filter</a></code></h3>
+      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--auto_output_filter">`--auto_output_filter`</a></code></h3>
     </td>
     <td>
 
@@ -124,7 +124,7 @@ command line. To disable all filtering, set
 
   <tr>
     <td>
-      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--sandbox_debug">--sandbox_debug</a></code></h3>
+      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--sandbox_debug">`--sandbox_debug`</a></code></h3>
     </td>
     <td>
 
@@ -147,7 +147,7 @@ builds by default and what gets sandboxed, see our
 
   <tr>
     <td>
-      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--subcommands">--subcommands (-s)</a></code></h3>
+      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--subcommands">`--subcommands (-s)`</a></code></h3>
     </td>
     <td>
 
@@ -170,7 +170,7 @@ a server restart. Toggle these flags with caution.
 
   <tr>
     <td>
-       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--bazelrc">--bazelrc</a></code></h3>
+       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--bazelrc">`--bazelrc`</a></code></h3>
     </td>
     <td>
 
@@ -193,7 +193,7 @@ the .bazelrc file&gt;</strong></code>.
 
   <tr>
     <td>
-    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/8.1.1/docs/user-manual#host-jvm-args">--host_jvm_args</a></code></h3>
+    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/8.1.1/docs/user-manual#host-jvm-args">`--host_jvm_args`</a></code></h3>
     </td>
     <td>
 
@@ -226,7 +226,7 @@ For example, the following limits the Bazel heap size to <strong>3</strong>GB:
 
   <tr>
     <td>
-    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--output_base">--output_base</a></code></h3>
+    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--output_base">`--output_base`</a></code></h3>
     </td>
     <td>
 
@@ -257,7 +257,7 @@ The following flags are related to Bazel test
 
   <tr>
     <td>
-       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--java_debug">--java_debug</a></code></h3>
+       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--java_debug">`--java_debug`</a></code></h3>
     </td>
     <td>
 
@@ -269,7 +269,7 @@ Causes Java tests to wait for a debugger connection before being executed.
 
   <tr>
     <td>
-    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--runs_per_test">--runs_per_test</a></code></h3>
+    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--runs_per_test">`--runs_per_test`</a></code></h3>
     </td>
     <td>
 
@@ -283,7 +283,7 @@ flaky tests and see whether a fix causes a test to pass consistently.
 
   <tr>
     <td>
-    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--test_output">--test_output</a></code></h3>
+    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--test_output">`--test_output`</a></code></h3>
     </td>
     <td>
 
@@ -308,7 +308,7 @@ The following flags are related to Bazel run.
 
   <tr>
     <td>
-        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--run_under">--run_under</a></code></h3>
+        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--run_under">`--run_under`</a></code></h3>
     </td>
     <td>
 
@@ -333,7 +333,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--disk_cache">--disk_cache</a></code></h3>
+       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--disk_cache">`--disk_cache`</a></code></h3>
     </td>
     <td>
 
@@ -350,7 +350,7 @@ up Bazel builds by adding
 
   <tr>
     <td>
-    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--jobs">--jobs</a></code></h3>
+    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--jobs">`--jobs`</a></code></h3>
     </td>
     <td>
 
@@ -365,7 +365,7 @@ cluster executes more jobs than you have cores locally.
 
   <tr>
     <td>
-    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--local_resources">--local_resources</a></code></h3>
+    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--local_resources">`--local_resources`</a></code></h3>
     </td>
     <td>
 
@@ -382,7 +382,7 @@ Limits how much CPU or RAM is consumed by locally running actions.
 
   <tr>
     <td>
-    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--sandbox_base">--sandbox_base</a></code></h3>
+    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--sandbox_base">`--sandbox_base`</a></code></h3>
     </td>
     <td>
 
@@ -412,7 +412,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--flaky_test_attempts">--flaky_test_attempts</a></code></h3>
+       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--flaky_test_attempts">`--flaky_test_attempts`</a></code></h3>
     </td>
     <td>
 
@@ -427,7 +427,7 @@ the test summary.
 
   <tr>
     <td>
-    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--remote_cache">--remote_cache</a></code></h3>
+    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--remote_cache">`--remote_cache`</a></code></h3>
     </td>
     <td>
 
@@ -440,7 +440,7 @@ speed up Bazel builds. It can be combined with a local disk cache.
 
   <tr>
     <td>
-    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--remote_download_regex">--remote_download_regex</a></code></h3>
+    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--remote_download_regex">`--remote_download_regex`</a></code></h3>
     </td>
     <td>
 
@@ -454,7 +454,7 @@ patterns may be specified by repeating this flag.
 
   <tr>
     <td>
-     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--remote_executor">--remote_executor</a></code></h3>
+     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--remote_executor">`--remote_executor`</a></code></h3>
     </td>
     <td>
 
@@ -468,7 +468,7 @@ a remote execution service. You'll often need to Add
 
   <tr>
     <td>
-     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--remote_instance_name">--remote_instance_name</a></code></h3>
+     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--remote_instance_name">`--remote_instance_name`</a></code></h3>
     </td>
     <td>
 
@@ -480,7 +480,7 @@ The value to pass as <code>instance_name</code> in the remote execution API.
 
   <tr>
     <td>
-    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/8.1.1/docs/user-manual#show-timestamps">--show-timestamps</a></code></h3>
+    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/8.1.1/docs/user-manual#show-timestamps">`--show-timestamps`</a></code></h3>
     </td>
     <td>
 
@@ -494,7 +494,7 @@ quickly understand what step took how long.
 
   <tr>
     <td>
-    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--spawn_strategy">--spawn_strategy</a></code></h3>
+    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/8.1.1/reference/command-line-reference#flag--spawn_strategy">`--spawn_strategy`</a></code></h3>
     </td>
     <td>
 

--- a/docs/versions/8.2.1/reference/flag-cheatsheet.mdx
+++ b/docs/versions/8.2.1/reference/flag-cheatsheet.mdx
@@ -23,7 +23,7 @@ The following flags are meant to be set explicitly on the command line.
 
   <tr>
     <td>
-      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--config">--config</a></code></h3>
+      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--config">`--config`</a></code></h3>
     </td>
     <td>
 
@@ -37,7 +37,7 @@ be selected with <code>--config=<strong>&lt;group&gt;</strong></code>.
 
   <tr>
     <td>
-      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--keep_going">--keep_going</a></code></h3>
+      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--keep_going">`--keep_going`</a></code></h3>
     </td>
     <td>
 
@@ -49,7 +49,7 @@ By default, Bazel fails eagerly.
 
   <tr>
     <td>
-      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--remote_download_outputs">--remote_download_outputs</a></code></h3>
+      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--remote_download_outputs">`--remote_download_outputs`</a></code></h3>
     </td>
     <td>
 
@@ -70,7 +70,7 @@ and intermediate artifacts that are necessary for local actions.
 
   <tr>
     <td>
-      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--stamp">--stamp</a></code></h3>
+      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--stamp">`--stamp`</a></code></h3>
     </td>
     <td>
 
@@ -96,7 +96,7 @@ The following flags can help you better understand Bazel build or test errors.
 
   <tr>
     <td>
-       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--announce_rc">--announce_rc</a></code></h3>
+       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--announce_rc">`--announce_rc`</a></code></h3>
     </td>
     <td>
 
@@ -109,7 +109,7 @@ machine-defined, or project-defined <strong>.bazelrc</strong> files.
 
   <tr>
     <td>
-      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--auto_output_filter">--auto_output_filter</a></code></h3>
+      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--auto_output_filter">`--auto_output_filter`</a></code></h3>
     </td>
     <td>
 
@@ -124,7 +124,7 @@ command line. To disable all filtering, set
 
   <tr>
     <td>
-      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--sandbox_debug">--sandbox_debug</a></code></h3>
+      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--sandbox_debug">`--sandbox_debug`</a></code></h3>
     </td>
     <td>
 
@@ -147,7 +147,7 @@ builds by default and what gets sandboxed, see our
 
   <tr>
     <td>
-      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--subcommands">--subcommands (-s)</a></code></h3>
+      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--subcommands">`--subcommands (-s)`</a></code></h3>
     </td>
     <td>
 
@@ -170,7 +170,7 @@ a server restart. Toggle these flags with caution.
 
   <tr>
     <td>
-       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--bazelrc">--bazelrc</a></code></h3>
+       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--bazelrc">`--bazelrc`</a></code></h3>
     </td>
     <td>
 
@@ -193,7 +193,7 @@ the .bazelrc file&gt;</strong></code>.
 
   <tr>
     <td>
-    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/8.2.1/docs/user-manual#host-jvm-args">--host_jvm_args</a></code></h3>
+    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/8.2.1/docs/user-manual#host-jvm-args">`--host_jvm_args`</a></code></h3>
     </td>
     <td>
 
@@ -226,7 +226,7 @@ For example, the following limits the Bazel heap size to <strong>3</strong>GB:
 
   <tr>
     <td>
-    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--output_base">--output_base</a></code></h3>
+    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--output_base">`--output_base`</a></code></h3>
     </td>
     <td>
 
@@ -257,7 +257,7 @@ The following flags are related to Bazel test
 
   <tr>
     <td>
-       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--java_debug">--java_debug</a></code></h3>
+       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--java_debug">`--java_debug`</a></code></h3>
     </td>
     <td>
 
@@ -269,7 +269,7 @@ Causes Java tests to wait for a debugger connection before being executed.
 
   <tr>
     <td>
-    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--runs_per_test">--runs_per_test</a></code></h3>
+    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--runs_per_test">`--runs_per_test`</a></code></h3>
     </td>
     <td>
 
@@ -283,7 +283,7 @@ flaky tests and see whether a fix causes a test to pass consistently.
 
   <tr>
     <td>
-    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--test_output">--test_output</a></code></h3>
+    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--test_output">`--test_output`</a></code></h3>
     </td>
     <td>
 
@@ -308,7 +308,7 @@ The following flags are related to Bazel run.
 
   <tr>
     <td>
-        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--run_under">--run_under</a></code></h3>
+        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--run_under">`--run_under`</a></code></h3>
     </td>
     <td>
 
@@ -333,7 +333,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--disk_cache">--disk_cache</a></code></h3>
+       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--disk_cache">`--disk_cache`</a></code></h3>
     </td>
     <td>
 
@@ -350,7 +350,7 @@ up Bazel builds by adding
 
   <tr>
     <td>
-    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--jobs">--jobs</a></code></h3>
+    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--jobs">`--jobs`</a></code></h3>
     </td>
     <td>
 
@@ -365,7 +365,7 @@ cluster executes more jobs than you have cores locally.
 
   <tr>
     <td>
-    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--local_resources">--local_resources</a></code></h3>
+    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--local_resources">`--local_resources`</a></code></h3>
     </td>
     <td>
 
@@ -382,7 +382,7 @@ Limits how much CPU or RAM is consumed by locally running actions.
 
   <tr>
     <td>
-    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--sandbox_base">--sandbox_base</a></code></h3>
+    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--sandbox_base">`--sandbox_base`</a></code></h3>
     </td>
     <td>
 
@@ -412,7 +412,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--flaky_test_attempts">--flaky_test_attempts</a></code></h3>
+       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--flaky_test_attempts">`--flaky_test_attempts`</a></code></h3>
     </td>
     <td>
 
@@ -427,7 +427,7 @@ the test summary.
 
   <tr>
     <td>
-    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--remote_cache">--remote_cache</a></code></h3>
+    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--remote_cache">`--remote_cache`</a></code></h3>
     </td>
     <td>
 
@@ -440,7 +440,7 @@ speed up Bazel builds. It can be combined with a local disk cache.
 
   <tr>
     <td>
-    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--remote_download_regex">--remote_download_regex</a></code></h3>
+    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--remote_download_regex">`--remote_download_regex`</a></code></h3>
     </td>
     <td>
 
@@ -454,7 +454,7 @@ patterns may be specified by repeating this flag.
 
   <tr>
     <td>
-     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--remote_executor">--remote_executor</a></code></h3>
+     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--remote_executor">`--remote_executor`</a></code></h3>
     </td>
     <td>
 
@@ -468,7 +468,7 @@ a remote execution service. You'll often need to Add
 
   <tr>
     <td>
-     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--remote_instance_name">--remote_instance_name</a></code></h3>
+     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--remote_instance_name">`--remote_instance_name`</a></code></h3>
     </td>
     <td>
 
@@ -480,7 +480,7 @@ The value to pass as <code>instance_name</code> in the remote execution API.
 
   <tr>
     <td>
-    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/8.2.1/docs/user-manual#show-timestamps">--show-timestamps</a></code></h3>
+    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/8.2.1/docs/user-manual#show-timestamps">`--show-timestamps`</a></code></h3>
     </td>
     <td>
 
@@ -494,7 +494,7 @@ quickly understand what step took how long.
 
   <tr>
     <td>
-    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--spawn_strategy">--spawn_strategy</a></code></h3>
+    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/8.2.1/reference/command-line-reference#flag--spawn_strategy">`--spawn_strategy`</a></code></h3>
     </td>
     <td>
 

--- a/docs/versions/8.3.1/reference/flag-cheatsheet.mdx
+++ b/docs/versions/8.3.1/reference/flag-cheatsheet.mdx
@@ -23,7 +23,7 @@ The following flags are meant to be set explicitly on the command line.
 
   <tr>
     <td>
-      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--config">--config</a></code></h3>
+      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--config">`--config`</a></code></h3>
     </td>
     <td>
 
@@ -37,7 +37,7 @@ be selected with <code>--config=<strong>&lt;group&gt;</strong></code>.
 
   <tr>
     <td>
-      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--keep_going">--keep_going</a></code></h3>
+      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--keep_going">`--keep_going`</a></code></h3>
     </td>
     <td>
 
@@ -49,7 +49,7 @@ By default, Bazel fails eagerly.
 
   <tr>
     <td>
-      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--remote_download_outputs">--remote_download_outputs</a></code></h3>
+      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--remote_download_outputs">`--remote_download_outputs`</a></code></h3>
     </td>
     <td>
 
@@ -70,7 +70,7 @@ and intermediate artifacts that are necessary for local actions.
 
   <tr>
     <td>
-      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--stamp">--stamp</a></code></h3>
+      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--stamp">`--stamp`</a></code></h3>
     </td>
     <td>
 
@@ -96,7 +96,7 @@ The following flags can help you better understand Bazel build or test errors.
 
   <tr>
     <td>
-       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--announce_rc">--announce_rc</a></code></h3>
+       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--announce_rc">`--announce_rc`</a></code></h3>
     </td>
     <td>
 
@@ -109,7 +109,7 @@ machine-defined, or project-defined <strong>.bazelrc</strong> files.
 
   <tr>
     <td>
-      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--auto_output_filter">--auto_output_filter</a></code></h3>
+      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--auto_output_filter">`--auto_output_filter`</a></code></h3>
     </td>
     <td>
 
@@ -124,7 +124,7 @@ command line. To disable all filtering, set
 
   <tr>
     <td>
-      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--sandbox_debug">--sandbox_debug</a></code></h3>
+      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--sandbox_debug">`--sandbox_debug`</a></code></h3>
     </td>
     <td>
 
@@ -147,7 +147,7 @@ builds by default and what gets sandboxed, see our
 
   <tr>
     <td>
-      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--subcommands">--subcommands (-s)</a></code></h3>
+      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--subcommands">`--subcommands (-s)`</a></code></h3>
     </td>
     <td>
 
@@ -170,7 +170,7 @@ a server restart. Toggle these flags with caution.
 
   <tr>
     <td>
-       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--bazelrc">--bazelrc</a></code></h3>
+       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--bazelrc">`--bazelrc`</a></code></h3>
     </td>
     <td>
 
@@ -193,7 +193,7 @@ the .bazelrc file&gt;</strong></code>.
 
   <tr>
     <td>
-    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/8.3.1/docs/user-manual#host-jvm-args">--host_jvm_args</a></code></h3>
+    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/8.3.1/docs/user-manual#host-jvm-args">`--host_jvm_args`</a></code></h3>
     </td>
     <td>
 
@@ -226,7 +226,7 @@ For example, the following limits the Bazel heap size to <strong>3</strong>GB:
 
   <tr>
     <td>
-    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--output_base">--output_base</a></code></h3>
+    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--output_base">`--output_base`</a></code></h3>
     </td>
     <td>
 
@@ -257,7 +257,7 @@ The following flags are related to Bazel test
 
   <tr>
     <td>
-       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--java_debug">--java_debug</a></code></h3>
+       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--java_debug">`--java_debug`</a></code></h3>
     </td>
     <td>
 
@@ -269,7 +269,7 @@ Causes Java tests to wait for a debugger connection before being executed.
 
   <tr>
     <td>
-    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--runs_per_test">--runs_per_test</a></code></h3>
+    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--runs_per_test">`--runs_per_test`</a></code></h3>
     </td>
     <td>
 
@@ -283,7 +283,7 @@ flaky tests and see whether a fix causes a test to pass consistently.
 
   <tr>
     <td>
-    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--test_output">--test_output</a></code></h3>
+    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--test_output">`--test_output`</a></code></h3>
     </td>
     <td>
 
@@ -308,7 +308,7 @@ The following flags are related to Bazel run.
 
   <tr>
     <td>
-        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--run_under">--run_under</a></code></h3>
+        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--run_under">`--run_under`</a></code></h3>
     </td>
     <td>
 
@@ -333,7 +333,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--disk_cache">--disk_cache</a></code></h3>
+       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--disk_cache">`--disk_cache`</a></code></h3>
     </td>
     <td>
 
@@ -350,7 +350,7 @@ up Bazel builds by adding
 
   <tr>
     <td>
-    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--jobs">--jobs</a></code></h3>
+    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--jobs">`--jobs`</a></code></h3>
     </td>
     <td>
 
@@ -365,7 +365,7 @@ cluster executes more jobs than you have cores locally.
 
   <tr>
     <td>
-    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--local_resources">--local_resources</a></code></h3>
+    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--local_resources">`--local_resources`</a></code></h3>
     </td>
     <td>
 
@@ -382,7 +382,7 @@ Limits how much CPU or RAM is consumed by locally running actions.
 
   <tr>
     <td>
-    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--sandbox_base">--sandbox_base</a></code></h3>
+    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--sandbox_base">`--sandbox_base`</a></code></h3>
     </td>
     <td>
 
@@ -412,7 +412,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--flaky_test_attempts">--flaky_test_attempts</a></code></h3>
+       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--flaky_test_attempts">`--flaky_test_attempts`</a></code></h3>
     </td>
     <td>
 
@@ -427,7 +427,7 @@ the test summary.
 
   <tr>
     <td>
-    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--remote_cache">--remote_cache</a></code></h3>
+    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--remote_cache">`--remote_cache`</a></code></h3>
     </td>
     <td>
 
@@ -440,7 +440,7 @@ speed up Bazel builds. It can be combined with a local disk cache.
 
   <tr>
     <td>
-    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--remote_download_regex">--remote_download_regex</a></code></h3>
+    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--remote_download_regex">`--remote_download_regex`</a></code></h3>
     </td>
     <td>
 
@@ -454,7 +454,7 @@ patterns may be specified by repeating this flag.
 
   <tr>
     <td>
-     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--remote_executor">--remote_executor</a></code></h3>
+     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--remote_executor">`--remote_executor`</a></code></h3>
     </td>
     <td>
 
@@ -468,7 +468,7 @@ a remote execution service. You'll often need to Add
 
   <tr>
     <td>
-     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--remote_instance_name">--remote_instance_name</a></code></h3>
+     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--remote_instance_name">`--remote_instance_name`</a></code></h3>
     </td>
     <td>
 
@@ -480,7 +480,7 @@ The value to pass as <code>instance_name</code> in the remote execution API.
 
   <tr>
     <td>
-    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/8.3.1/docs/user-manual#show-timestamps">--show-timestamps</a></code></h3>
+    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/8.3.1/docs/user-manual#show-timestamps">`--show-timestamps`</a></code></h3>
     </td>
     <td>
 
@@ -494,7 +494,7 @@ quickly understand what step took how long.
 
   <tr>
     <td>
-    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--spawn_strategy">--spawn_strategy</a></code></h3>
+    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/8.3.1/reference/command-line-reference#flag--spawn_strategy">`--spawn_strategy`</a></code></h3>
     </td>
     <td>
 

--- a/docs/versions/8.4.2/reference/flag-cheatsheet.mdx
+++ b/docs/versions/8.4.2/reference/flag-cheatsheet.mdx
@@ -23,7 +23,7 @@ The following flags are meant to be set explicitly on the command line.
 
   <tr>
     <td>
-      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--config">--config</a></code></h3>
+      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--config">`--config`</a></code></h3>
     </td>
     <td>
 
@@ -37,7 +37,7 @@ be selected with <code>--config=<strong>&lt;group&gt;</strong></code>.
 
   <tr>
     <td>
-      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--keep_going">--keep_going</a></code></h3>
+      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--keep_going">`--keep_going`</a></code></h3>
     </td>
     <td>
 
@@ -49,7 +49,7 @@ By default, Bazel fails eagerly.
 
   <tr>
     <td>
-      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--remote_download_outputs">--remote_download_outputs</a></code></h3>
+      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--remote_download_outputs">`--remote_download_outputs`</a></code></h3>
     </td>
     <td>
 
@@ -70,7 +70,7 @@ and intermediate artifacts that are necessary for local actions.
 
   <tr>
     <td>
-      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--stamp">--stamp</a></code></h3>
+      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--stamp">`--stamp`</a></code></h3>
     </td>
     <td>
 
@@ -96,7 +96,7 @@ The following flags can help you better understand Bazel build or test errors.
 
   <tr>
     <td>
-       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--announce_rc">--announce_rc</a></code></h3>
+       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--announce_rc">`--announce_rc`</a></code></h3>
     </td>
     <td>
 
@@ -109,7 +109,7 @@ machine-defined, or project-defined <strong>.bazelrc</strong> files.
 
   <tr>
     <td>
-      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--auto_output_filter">--auto_output_filter</a></code></h3>
+      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--auto_output_filter">`--auto_output_filter`</a></code></h3>
     </td>
     <td>
 
@@ -124,7 +124,7 @@ command line. To disable all filtering, set
 
   <tr>
     <td>
-      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--sandbox_debug">--sandbox_debug</a></code></h3>
+      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--sandbox_debug">`--sandbox_debug`</a></code></h3>
     </td>
     <td>
 
@@ -147,7 +147,7 @@ builds by default and what gets sandboxed, see our
 
   <tr>
     <td>
-      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--subcommands">--subcommands (-s)</a></code></h3>
+      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--subcommands">`--subcommands (-s)`</a></code></h3>
     </td>
     <td>
 
@@ -170,7 +170,7 @@ a server restart. Toggle these flags with caution.
 
   <tr>
     <td>
-       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--bazelrc">--bazelrc</a></code></h3>
+       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--bazelrc">`--bazelrc`</a></code></h3>
     </td>
     <td>
 
@@ -193,7 +193,7 @@ the .bazelrc file&gt;</strong></code>.
 
   <tr>
     <td>
-    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/8.4.2/docs/user-manual#host-jvm-args">--host_jvm_args</a></code></h3>
+    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/8.4.2/docs/user-manual#host-jvm-args">`--host_jvm_args`</a></code></h3>
     </td>
     <td>
 
@@ -226,7 +226,7 @@ For example, the following limits the Bazel heap size to <strong>3</strong>GB:
 
   <tr>
     <td>
-    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--output_base">--output_base</a></code></h3>
+    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--output_base">`--output_base`</a></code></h3>
     </td>
     <td>
 
@@ -257,7 +257,7 @@ The following flags are related to Bazel test
 
   <tr>
     <td>
-       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--java_debug">--java_debug</a></code></h3>
+       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--java_debug">`--java_debug`</a></code></h3>
     </td>
     <td>
 
@@ -269,7 +269,7 @@ Causes Java tests to wait for a debugger connection before being executed.
 
   <tr>
     <td>
-    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--runs_per_test">--runs_per_test</a></code></h3>
+    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--runs_per_test">`--runs_per_test`</a></code></h3>
     </td>
     <td>
 
@@ -283,7 +283,7 @@ flaky tests and see whether a fix causes a test to pass consistently.
 
   <tr>
     <td>
-    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--test_output">--test_output</a></code></h3>
+    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--test_output">`--test_output`</a></code></h3>
     </td>
     <td>
 
@@ -308,7 +308,7 @@ The following flags are related to Bazel run.
 
   <tr>
     <td>
-        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--run_under">--run_under</a></code></h3>
+        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--run_under">`--run_under`</a></code></h3>
     </td>
     <td>
 
@@ -333,7 +333,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--disk_cache">--disk_cache</a></code></h3>
+       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--disk_cache">`--disk_cache`</a></code></h3>
     </td>
     <td>
 
@@ -350,7 +350,7 @@ up Bazel builds by adding
 
   <tr>
     <td>
-    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--jobs">--jobs</a></code></h3>
+    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--jobs">`--jobs`</a></code></h3>
     </td>
     <td>
 
@@ -365,7 +365,7 @@ cluster executes more jobs than you have cores locally.
 
   <tr>
     <td>
-    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--local_resources">--local_resources</a></code></h3>
+    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--local_resources">`--local_resources`</a></code></h3>
     </td>
     <td>
 
@@ -382,7 +382,7 @@ Limits how much CPU or RAM is consumed by locally running actions.
 
   <tr>
     <td>
-    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--sandbox_base">--sandbox_base</a></code></h3>
+    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--sandbox_base">`--sandbox_base`</a></code></h3>
     </td>
     <td>
 
@@ -412,7 +412,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--flaky_test_attempts">--flaky_test_attempts</a></code></h3>
+       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--flaky_test_attempts">`--flaky_test_attempts`</a></code></h3>
     </td>
     <td>
 
@@ -427,7 +427,7 @@ the test summary.
 
   <tr>
     <td>
-    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--remote_cache">--remote_cache</a></code></h3>
+    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--remote_cache">`--remote_cache`</a></code></h3>
     </td>
     <td>
 
@@ -440,7 +440,7 @@ speed up Bazel builds. It can be combined with a local disk cache.
 
   <tr>
     <td>
-    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--remote_download_regex">--remote_download_regex</a></code></h3>
+    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--remote_download_regex">`--remote_download_regex`</a></code></h3>
     </td>
     <td>
 
@@ -454,7 +454,7 @@ patterns may be specified by repeating this flag.
 
   <tr>
     <td>
-     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--remote_executor">--remote_executor</a></code></h3>
+     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--remote_executor">`--remote_executor`</a></code></h3>
     </td>
     <td>
 
@@ -468,7 +468,7 @@ a remote execution service. You'll often need to Add
 
   <tr>
     <td>
-     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--remote_instance_name">--remote_instance_name</a></code></h3>
+     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--remote_instance_name">`--remote_instance_name`</a></code></h3>
     </td>
     <td>
 
@@ -480,7 +480,7 @@ The value to pass as <code>instance_name</code> in the remote execution API.
 
   <tr>
     <td>
-    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/8.4.2/docs/user-manual#show-timestamps">--show-timestamps</a></code></h3>
+    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/8.4.2/docs/user-manual#show-timestamps">`--show-timestamps`</a></code></h3>
     </td>
     <td>
 
@@ -494,7 +494,7 @@ quickly understand what step took how long.
 
   <tr>
     <td>
-    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--spawn_strategy">--spawn_strategy</a></code></h3>
+    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/8.4.2/reference/command-line-reference#flag--spawn_strategy">`--spawn_strategy`</a></code></h3>
     </td>
     <td>
 

--- a/docs/versions/8.5.1/reference/flag-cheatsheet.mdx
+++ b/docs/versions/8.5.1/reference/flag-cheatsheet.mdx
@@ -23,7 +23,7 @@ The following flags are meant to be set explicitly on the command line.
 
   <tr>
     <td>
-      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--config">--config</a></code></h3>
+      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--config">`--config`</a></code></h3>
     </td>
     <td>
 
@@ -37,7 +37,7 @@ be selected with <code>--config=<strong>&lt;group&gt;</strong></code>.
 
   <tr>
     <td>
-      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--keep_going">--keep_going</a></code></h3>
+      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--keep_going">`--keep_going`</a></code></h3>
     </td>
     <td>
 
@@ -49,7 +49,7 @@ By default, Bazel fails eagerly.
 
   <tr>
     <td>
-      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--remote_download_outputs">--remote_download_outputs</a></code></h3>
+      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--remote_download_outputs">`--remote_download_outputs`</a></code></h3>
     </td>
     <td>
 
@@ -70,7 +70,7 @@ and intermediate artifacts that are necessary for local actions.
 
   <tr>
     <td>
-      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--stamp">--stamp</a></code></h3>
+      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--stamp">`--stamp`</a></code></h3>
     </td>
     <td>
 
@@ -96,7 +96,7 @@ The following flags can help you better understand Bazel build or test errors.
 
   <tr>
     <td>
-       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--announce_rc">--announce_rc</a></code></h3>
+       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--announce_rc">`--announce_rc`</a></code></h3>
     </td>
     <td>
 
@@ -109,7 +109,7 @@ machine-defined, or project-defined <strong>.bazelrc</strong> files.
 
   <tr>
     <td>
-      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--auto_output_filter">--auto_output_filter</a></code></h3>
+      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--auto_output_filter">`--auto_output_filter`</a></code></h3>
     </td>
     <td>
 
@@ -124,7 +124,7 @@ command line. To disable all filtering, set
 
   <tr>
     <td>
-      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--sandbox_debug">--sandbox_debug</a></code></h3>
+      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--sandbox_debug">`--sandbox_debug`</a></code></h3>
     </td>
     <td>
 
@@ -147,7 +147,7 @@ builds by default and what gets sandboxed, see our
 
   <tr>
     <td>
-      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--subcommands">--subcommands (-s)</a></code></h3>
+      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--subcommands">`--subcommands (-s)`</a></code></h3>
     </td>
     <td>
 
@@ -170,7 +170,7 @@ a server restart. Toggle these flags with caution.
 
   <tr>
     <td>
-       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--bazelrc">--bazelrc</a></code></h3>
+       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--bazelrc">`--bazelrc`</a></code></h3>
     </td>
     <td>
 
@@ -193,7 +193,7 @@ the .bazelrc file&gt;</strong></code>.
 
   <tr>
     <td>
-    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/8.5.1/docs/user-manual#host-jvm-args">--host_jvm_args</a></code></h3>
+    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/8.5.1/docs/user-manual#host-jvm-args">`--host_jvm_args`</a></code></h3>
     </td>
     <td>
 
@@ -226,7 +226,7 @@ For example, the following limits the Bazel heap size to <strong>3</strong>GB:
 
   <tr>
     <td>
-    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--output_base">--output_base</a></code></h3>
+    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--output_base">`--output_base`</a></code></h3>
     </td>
     <td>
 
@@ -257,7 +257,7 @@ The following flags are related to Bazel test
 
   <tr>
     <td>
-       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--java_debug">--java_debug</a></code></h3>
+       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--java_debug">`--java_debug`</a></code></h3>
     </td>
     <td>
 
@@ -269,7 +269,7 @@ Causes Java tests to wait for a debugger connection before being executed.
 
   <tr>
     <td>
-    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--runs_per_test">--runs_per_test</a></code></h3>
+    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--runs_per_test">`--runs_per_test`</a></code></h3>
     </td>
     <td>
 
@@ -283,7 +283,7 @@ flaky tests and see whether a fix causes a test to pass consistently.
 
   <tr>
     <td>
-    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--test_output">--test_output</a></code></h3>
+    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--test_output">`--test_output`</a></code></h3>
     </td>
     <td>
 
@@ -308,7 +308,7 @@ The following flags are related to Bazel run.
 
   <tr>
     <td>
-        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--run_under">--run_under</a></code></h3>
+        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--run_under">`--run_under`</a></code></h3>
     </td>
     <td>
 
@@ -333,7 +333,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--disk_cache">--disk_cache</a></code></h3>
+       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--disk_cache">`--disk_cache`</a></code></h3>
     </td>
     <td>
 
@@ -350,7 +350,7 @@ up Bazel builds by adding
 
   <tr>
     <td>
-    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--jobs">--jobs</a></code></h3>
+    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--jobs">`--jobs`</a></code></h3>
     </td>
     <td>
 
@@ -365,7 +365,7 @@ cluster executes more jobs than you have cores locally.
 
   <tr>
     <td>
-    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--local_resources">--local_resources</a></code></h3>
+    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--local_resources">`--local_resources`</a></code></h3>
     </td>
     <td>
 
@@ -382,7 +382,7 @@ Limits how much CPU or RAM is consumed by locally running actions.
 
   <tr>
     <td>
-    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--sandbox_base">--sandbox_base</a></code></h3>
+    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--sandbox_base">`--sandbox_base`</a></code></h3>
     </td>
     <td>
 
@@ -412,7 +412,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--flaky_test_attempts">--flaky_test_attempts</a></code></h3>
+       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--flaky_test_attempts">`--flaky_test_attempts`</a></code></h3>
     </td>
     <td>
 
@@ -427,7 +427,7 @@ the test summary.
 
   <tr>
     <td>
-    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--remote_cache">--remote_cache</a></code></h3>
+    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--remote_cache">`--remote_cache`</a></code></h3>
     </td>
     <td>
 
@@ -440,7 +440,7 @@ speed up Bazel builds. It can be combined with a local disk cache.
 
   <tr>
     <td>
-    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--remote_download_regex">--remote_download_regex</a></code></h3>
+    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--remote_download_regex">`--remote_download_regex`</a></code></h3>
     </td>
     <td>
 
@@ -454,7 +454,7 @@ patterns may be specified by repeating this flag.
 
   <tr>
     <td>
-     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--remote_executor">--remote_executor</a></code></h3>
+     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--remote_executor">`--remote_executor`</a></code></h3>
     </td>
     <td>
 
@@ -468,7 +468,7 @@ a remote execution service. You'll often need to Add
 
   <tr>
     <td>
-     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--remote_instance_name">--remote_instance_name</a></code></h3>
+     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--remote_instance_name">`--remote_instance_name`</a></code></h3>
     </td>
     <td>
 
@@ -480,7 +480,7 @@ The value to pass as <code>instance_name</code> in the remote execution API.
 
   <tr>
     <td>
-    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/8.5.1/docs/user-manual#show-timestamps">--show-timestamps</a></code></h3>
+    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/8.5.1/docs/user-manual#show-timestamps">`--show-timestamps`</a></code></h3>
     </td>
     <td>
 
@@ -494,7 +494,7 @@ quickly understand what step took how long.
 
   <tr>
     <td>
-    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--spawn_strategy">--spawn_strategy</a></code></h3>
+    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/8.5.1/reference/command-line-reference#flag--spawn_strategy">`--spawn_strategy`</a></code></h3>
     </td>
     <td>
 

--- a/docs/versions/8.6.0/reference/flag-cheatsheet.mdx
+++ b/docs/versions/8.6.0/reference/flag-cheatsheet.mdx
@@ -22,7 +22,7 @@ The following flags are meant to be set explicitly on the command line.
 
   <tr>
     <td>
-      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--config">--config</a></code></h3>
+      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--config">`--config`</a></code></h3>
     </td>
     <td>
 
@@ -36,7 +36,7 @@ be selected with <code>--config=<strong>&lt;group&gt;</strong></code>.
 
   <tr>
     <td>
-      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--keep_going">--keep_going</a></code></h3>
+      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--keep_going">`--keep_going`</a></code></h3>
     </td>
     <td>
 
@@ -48,7 +48,7 @@ By default, Bazel fails eagerly.
 
   <tr>
     <td>
-      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--remote_download_outputs">--remote_download_outputs</a></code></h3>
+      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--remote_download_outputs">`--remote_download_outputs`</a></code></h3>
     </td>
     <td>
 
@@ -69,7 +69,7 @@ and intermediate artifacts that are necessary for local actions.
 
   <tr>
     <td>
-      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--stamp">--stamp</a></code></h3>
+      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--stamp">`--stamp`</a></code></h3>
     </td>
     <td>
 
@@ -96,7 +96,7 @@ The following flags can help you better understand Bazel build or test errors.
 
   <tr>
     <td>
-       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--announce_rc">--announce_rc</a></code></h3>
+       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--announce_rc">`--announce_rc`</a></code></h3>
     </td>
     <td>
 
@@ -109,7 +109,7 @@ machine-defined, or project-defined <strong>.bazelrc</strong> files.
 
   <tr>
     <td>
-      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--auto_output_filter">--auto_output_filter</a></code></h3>
+      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--auto_output_filter">`--auto_output_filter`</a></code></h3>
     </td>
     <td>
 
@@ -124,7 +124,7 @@ command line. To disable all filtering, set
 
   <tr>
     <td>
-      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--sandbox_debug">--sandbox_debug</a></code></h3>
+      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--sandbox_debug">`--sandbox_debug`</a></code></h3>
     </td>
     <td>
 
@@ -147,7 +147,7 @@ builds by default and what gets sandboxed, see our
 
   <tr>
     <td>
-      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--subcommands">--subcommands (-s)</a></code></h3>
+      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--subcommands">`--subcommands (-s)`</a></code></h3>
     </td>
     <td>
 
@@ -171,7 +171,7 @@ a server restart. Toggle these flags with caution.
 
   <tr>
     <td>
-       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--bazelrc">--bazelrc</a></code></h3>
+       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--bazelrc">`--bazelrc`</a></code></h3>
     </td>
     <td>
 
@@ -194,7 +194,7 @@ the .bazelrc file&gt;</strong></code>.
 
   <tr>
     <td>
-    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/8.6.0/docs/user-manual#host-jvm-args">--host_jvm_args</a></code></h3>
+    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/8.6.0/docs/user-manual#host-jvm-args">`--host_jvm_args`</a></code></h3>
     </td>
     <td>
 
@@ -227,7 +227,7 @@ For example, the following limits the Bazel heap size to <strong>3</strong>GB:
 
   <tr>
     <td>
-    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--output_base">--output_base</a></code></h3>
+    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--output_base">`--output_base`</a></code></h3>
     </td>
     <td>
 
@@ -259,7 +259,7 @@ The following flags are related to Bazel test
 
   <tr>
     <td>
-       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--java_debug">--java_debug</a></code></h3>
+       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--java_debug">`--java_debug`</a></code></h3>
     </td>
     <td>
 
@@ -271,7 +271,7 @@ Causes Java tests to wait for a debugger connection before being executed.
 
   <tr>
     <td>
-    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--runs_per_test">--runs_per_test</a></code></h3>
+    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--runs_per_test">`--runs_per_test`</a></code></h3>
     </td>
     <td>
 
@@ -285,7 +285,7 @@ flaky tests and see whether a fix causes a test to pass consistently.
 
   <tr>
     <td>
-    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--test_output">--test_output</a></code></h3>
+    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--test_output">`--test_output`</a></code></h3>
     </td>
     <td>
 
@@ -311,7 +311,7 @@ The following flags are related to Bazel run.
 
   <tr>
     <td>
-        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--run_under">--run_under</a></code></h3>
+        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--run_under">`--run_under`</a></code></h3>
     </td>
     <td>
 
@@ -337,7 +337,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--disk_cache">--disk_cache</a></code></h3>
+       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--disk_cache">`--disk_cache`</a></code></h3>
     </td>
     <td>
 
@@ -354,7 +354,7 @@ up Bazel builds by adding
 
   <tr>
     <td>
-    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--jobs">--jobs</a></code></h3>
+    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--jobs">`--jobs`</a></code></h3>
     </td>
     <td>
 
@@ -369,7 +369,7 @@ cluster executes more jobs than you have cores locally.
 
   <tr>
     <td>
-    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--local_resources">--local_resources</a></code></h3>
+    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--local_resources">`--local_resources`</a></code></h3>
     </td>
     <td>
 
@@ -386,7 +386,7 @@ Limits how much CPU or RAM is consumed by locally running actions.
 
   <tr>
     <td>
-    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--sandbox_base">--sandbox_base</a></code></h3>
+    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--sandbox_base">`--sandbox_base`</a></code></h3>
     </td>
     <td>
 
@@ -417,7 +417,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--flaky_test_attempts">--flaky_test_attempts</a></code></h3>
+       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--flaky_test_attempts">`--flaky_test_attempts`</a></code></h3>
     </td>
     <td>
 
@@ -432,7 +432,7 @@ the test summary.
 
   <tr>
     <td>
-    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--remote_cache">--remote_cache</a></code></h3>
+    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--remote_cache">`--remote_cache`</a></code></h3>
     </td>
     <td>
 
@@ -445,7 +445,7 @@ speed up Bazel builds. It can be combined with a local disk cache.
 
   <tr>
     <td>
-    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--remote_download_regex">--remote_download_regex</a></code></h3>
+    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--remote_download_regex">`--remote_download_regex`</a></code></h3>
     </td>
     <td>
 
@@ -459,7 +459,7 @@ patterns may be specified by repeating this flag.
 
   <tr>
     <td>
-     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--remote_executor">--remote_executor</a></code></h3>
+     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--remote_executor">`--remote_executor`</a></code></h3>
     </td>
     <td>
 
@@ -473,7 +473,7 @@ a remote execution service. You'll often need to Add
 
   <tr>
     <td>
-     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--remote_instance_name">--remote_instance_name</a></code></h3>
+     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--remote_instance_name">`--remote_instance_name`</a></code></h3>
     </td>
     <td>
 
@@ -485,7 +485,7 @@ The value to pass as <code>instance_name</code> in the remote execution API.
 
   <tr>
     <td>
-    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/8.6.0/docs/user-manual#show-timestamps">--show-timestamps</a></code></h3>
+    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/8.6.0/docs/user-manual#show-timestamps">`--show-timestamps`</a></code></h3>
     </td>
     <td>
 
@@ -499,7 +499,7 @@ quickly understand what step took how long.
 
   <tr>
     <td>
-    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--spawn_strategy">--spawn_strategy</a></code></h3>
+    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/8.6.0/reference/command-line-reference#flag--spawn_strategy">`--spawn_strategy`</a></code></h3>
     </td>
     <td>
 

--- a/docs/versions/9.0.0/reference/flag-cheatsheet.mdx
+++ b/docs/versions/9.0.0/reference/flag-cheatsheet.mdx
@@ -23,7 +23,7 @@ The following flags are meant to be set explicitly on the command line.
 
   <tr>
     <td>
-      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--config">--config</a></code></h3>
+      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--config">`--config`</a></code></h3>
     </td>
     <td>
 
@@ -37,7 +37,7 @@ be selected with <code>--config=<strong>&lt;group&gt;</strong></code>.
 
   <tr>
     <td>
-      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--keep_going">--keep_going</a></code></h3>
+      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--keep_going">`--keep_going`</a></code></h3>
     </td>
     <td>
 
@@ -49,7 +49,7 @@ By default, Bazel fails eagerly.
 
   <tr>
     <td>
-      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--remote_download_outputs">--remote_download_outputs</a></code></h3>
+      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--remote_download_outputs">`--remote_download_outputs`</a></code></h3>
     </td>
     <td>
 
@@ -70,7 +70,7 @@ and intermediate artifacts that are necessary for local actions.
 
   <tr>
     <td>
-      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--stamp">--stamp</a></code></h3>
+      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--stamp">`--stamp`</a></code></h3>
     </td>
     <td>
 
@@ -96,7 +96,7 @@ The following flags can help you better understand Bazel build or test errors.
 
   <tr>
     <td>
-       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--announce_rc">--announce_rc</a></code></h3>
+       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--announce_rc">`--announce_rc`</a></code></h3>
     </td>
     <td>
 
@@ -109,7 +109,7 @@ machine-defined, or project-defined <strong>.bazelrc</strong> files.
 
   <tr>
     <td>
-      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--auto_output_filter">--auto_output_filter</a></code></h3>
+      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--auto_output_filter">`--auto_output_filter`</a></code></h3>
     </td>
     <td>
 
@@ -124,7 +124,7 @@ command line. To disable all filtering, set
 
   <tr>
     <td>
-      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--sandbox_debug">--sandbox_debug</a></code></h3>
+      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--sandbox_debug">`--sandbox_debug`</a></code></h3>
     </td>
     <td>
 
@@ -147,7 +147,7 @@ builds by default and what gets sandboxed, see our
 
   <tr>
     <td>
-      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--subcommands">--subcommands (-s)</a></code></h3>
+      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--subcommands">`--subcommands (-s)`</a></code></h3>
     </td>
     <td>
 
@@ -170,7 +170,7 @@ a server restart. Toggle these flags with caution.
 
   <tr>
     <td>
-       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--bazelrc">--bazelrc</a></code></h3>
+       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--bazelrc">`--bazelrc`</a></code></h3>
     </td>
     <td>
 
@@ -193,7 +193,7 @@ the .bazelrc file&gt;</strong></code>.
 
   <tr>
     <td>
-    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/9.0.0/docs/user-manual#host-jvm-args">--host_jvm_args</a></code></h3>
+    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/9.0.0/docs/user-manual#host-jvm-args">`--host_jvm_args`</a></code></h3>
     </td>
     <td>
 
@@ -226,7 +226,7 @@ For example, the following limits the Bazel heap size to <strong>3</strong>GB:
 
   <tr>
     <td>
-    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--output_base">--output_base</a></code></h3>
+    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--output_base">`--output_base`</a></code></h3>
     </td>
     <td>
 
@@ -257,7 +257,7 @@ The following flags are related to Bazel test
 
   <tr>
     <td>
-       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--java_debug">--java_debug</a></code></h3>
+       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--java_debug">`--java_debug`</a></code></h3>
     </td>
     <td>
 
@@ -269,7 +269,7 @@ Causes Java tests to wait for a debugger connection before being executed.
 
   <tr>
     <td>
-    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--runs_per_test">--runs_per_test</a></code></h3>
+    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--runs_per_test">`--runs_per_test`</a></code></h3>
     </td>
     <td>
 
@@ -283,7 +283,7 @@ flaky tests and see whether a fix causes a test to pass consistently.
 
   <tr>
     <td>
-    <h3 id="flag-test-filter" data-text="test_filter"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--test_filter">--test_filter</a></code></h3>
+    <h3 id="flag-test-filter" data-text="test_filter"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--test_filter">`--test_filter`</a></code></h3>
     </td>
     <td>
 
@@ -300,7 +300,7 @@ debugging. This flag is often used in conjunction with
 
   <tr>
     <td>
-    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--test_output">--test_output</a></code></h3>
+    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--test_output">`--test_output`</a></code></h3>
     </td>
     <td>
 
@@ -325,7 +325,7 @@ The following flags are related to Bazel run.
 
   <tr>
     <td>
-        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--run_under">--run_under</a></code></h3>
+        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--run_under">`--run_under`</a></code></h3>
     </td>
     <td>
 
@@ -350,7 +350,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--disk_cache">--disk_cache</a></code></h3>
+       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--disk_cache">`--disk_cache`</a></code></h3>
     </td>
     <td>
 
@@ -367,7 +367,7 @@ up Bazel builds by adding
 
   <tr>
     <td>
-    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--jobs">--jobs</a></code></h3>
+    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--jobs">`--jobs`</a></code></h3>
     </td>
     <td>
 
@@ -382,7 +382,7 @@ cluster executes more jobs than you have cores locally.
 
   <tr>
     <td>
-    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--local_resources">--local_resources</a></code></h3>
+    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--local_resources">`--local_resources`</a></code></h3>
     </td>
     <td>
 
@@ -399,7 +399,7 @@ Limits how much CPU or RAM is consumed by locally running actions.
 
   <tr>
     <td>
-    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--sandbox_base">--sandbox_base</a></code></h3>
+    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--sandbox_base">`--sandbox_base`</a></code></h3>
     </td>
     <td>
 
@@ -429,7 +429,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--flaky_test_attempts">--flaky_test_attempts</a></code></h3>
+       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--flaky_test_attempts">`--flaky_test_attempts`</a></code></h3>
     </td>
     <td>
 
@@ -444,7 +444,7 @@ the test summary.
 
   <tr>
     <td>
-    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--remote_cache">--remote_cache</a></code></h3>
+    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--remote_cache">`--remote_cache`</a></code></h3>
     </td>
     <td>
 
@@ -457,7 +457,7 @@ speed up Bazel builds. It can be combined with a local disk cache.
 
   <tr>
     <td>
-    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--remote_download_regex">--remote_download_regex</a></code></h3>
+    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--remote_download_regex">`--remote_download_regex`</a></code></h3>
     </td>
     <td>
 
@@ -471,7 +471,7 @@ patterns may be specified by repeating this flag.
 
   <tr>
     <td>
-     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--remote_executor">--remote_executor</a></code></h3>
+     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--remote_executor">`--remote_executor`</a></code></h3>
     </td>
     <td>
 
@@ -485,7 +485,7 @@ a remote execution service. You'll often need to Add
 
   <tr>
     <td>
-     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--remote_instance_name">--remote_instance_name</a></code></h3>
+     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--remote_instance_name">`--remote_instance_name`</a></code></h3>
     </td>
     <td>
 
@@ -497,7 +497,7 @@ The value to pass as <code>instance_name</code> in the remote execution API.
 
   <tr>
     <td>
-    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/9.0.0/docs/user-manual#show-timestamps">--show_timestamps</a></code></h3>
+    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/9.0.0/docs/user-manual#show-timestamps">`--show_timestamps`</a></code></h3>
     </td>
     <td>
 
@@ -511,7 +511,7 @@ quickly understand what step took how long.
 
   <tr>
     <td>
-    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--spawn_strategy">--spawn_strategy</a></code></h3>
+    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/9.0.0/reference/command-line-reference#flag--spawn_strategy">`--spawn_strategy`</a></code></h3>
     </td>
     <td>
 

--- a/docs/versions/9.1.0/reference/flag-cheatsheet.mdx
+++ b/docs/versions/9.1.0/reference/flag-cheatsheet.mdx
@@ -45,7 +45,7 @@ The following flags are meant to be set explicitly on the command line.
 
   <tr>
     <td>
-      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--config">--config</a></code></h3>
+      <h3 id="flag-config" data-text="config"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--config">`--config`</a></code></h3>
     </td>
     <td>
 
@@ -59,7 +59,7 @@ be selected with <code>--config=<strong>&lt;group&gt;</strong></code>.
 
   <tr>
     <td>
-      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--keep_going">--keep_going</a></code></h3>
+      <h3 id="flag-keep-going" data-text="keep_going"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--keep_going">`--keep_going`</a></code></h3>
     </td>
     <td>
 
@@ -71,7 +71,7 @@ By default, Bazel fails eagerly.
 
   <tr>
     <td>
-      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--remote_download_outputs">--remote_download_outputs</a></code></h3>
+      <h3 id="flag-remote-download-outputs" data-text="remote_download_outputs"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--remote_download_outputs">`--remote_download_outputs`</a></code></h3>
     </td>
     <td>
 
@@ -92,7 +92,7 @@ and intermediate artifacts that are necessary for local actions.
 
   <tr>
     <td>
-      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--stamp">--stamp</a></code></h3>
+      <h3 id="flag-stamp" data-text="stamp"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--stamp">`--stamp`</a></code></h3>
     </td>
     <td>
 
@@ -119,7 +119,7 @@ The following flags can help you better understand Bazel build or test errors.
 
   <tr>
     <td>
-       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--announce_rc">--announce_rc</a></code></h3>
+       <h3 id="flag-announce-rc" data-text="announce_rc"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--announce_rc">`--announce_rc`</a></code></h3>
     </td>
     <td>
 
@@ -132,7 +132,7 @@ machine-defined, or project-defined <strong>.bazelrc</strong> files.
 
   <tr>
     <td>
-      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--auto_output_filter">--auto_output_filter</a></code></h3>
+      <h3 id="flag-auto-output-filter" data-text="auto_output_filter"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--auto_output_filter">`--auto_output_filter`</a></code></h3>
     </td>
     <td>
 
@@ -147,7 +147,7 @@ command line. To disable all filtering, set
 
   <tr>
     <td>
-      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--sandbox_debug">--sandbox_debug</a></code></h3>
+      <h3 id="flag-sandbox-debug" data-text="sandbox_debug"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--sandbox_debug">`--sandbox_debug`</a></code></h3>
     </td>
     <td>
 
@@ -170,7 +170,7 @@ builds by default and what gets sandboxed, see our
 
   <tr>
     <td>
-      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--subcommands">--subcommands (-s)</a></code></h3>
+      <h3 id="flag-subcommands" data-text="subcommands"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--subcommands">`--subcommands (-s)`</a></code></h3>
     </td>
     <td>
 
@@ -194,7 +194,7 @@ a server restart. Toggle these flags with caution.
 
   <tr>
     <td>
-       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--bazelrc">--bazelrc</a></code></h3>
+       <h3 id="flag-bazelrc" data-text="bazelrc"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--bazelrc">`--bazelrc`</a></code></h3>
     </td>
     <td>
 
@@ -217,7 +217,7 @@ the .bazelrc file&gt;</strong></code>.
 
   <tr>
     <td>
-    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/9.1.0/docs/user-manual#host-jvm-args">--host_jvm_args</a></code></h3>
+    <h3 id="flag-host-jvm-args" data-text="host_jvm_args"><code><a href="https://bazel.build/versions/9.1.0/docs/user-manual#host-jvm-args">`--host_jvm_args`</a></code></h3>
     </td>
     <td>
 
@@ -250,7 +250,7 @@ For example, the following limits the Bazel heap size to <strong>3</strong>GB:
 
   <tr>
     <td>
-    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--output_base">--output_base</a></code></h3>
+    <h3 id="flag-output-base" data-text="output_base"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--output_base">`--output_base`</a></code></h3>
     </td>
     <td>
 
@@ -282,7 +282,7 @@ The following flags are related to Bazel test
 
   <tr>
     <td>
-       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--java_debug">--java_debug</a></code></h3>
+       <h3 id="flag-java-debug" data-text="java_debug"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--java_debug">`--java_debug`</a></code></h3>
     </td>
     <td>
 
@@ -294,7 +294,7 @@ Causes Java tests to wait for a debugger connection before being executed.
 
   <tr>
     <td>
-    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--runs_per_test">--runs_per_test</a></code></h3>
+    <h3 id="flag-runs-per-test" data-text="runs_per_test"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--runs_per_test">`--runs_per_test`</a></code></h3>
     </td>
     <td>
 
@@ -308,7 +308,7 @@ flaky tests and see whether a fix causes a test to pass consistently.
 
   <tr>
     <td>
-    <h3 id="flag-test-filter" data-text="test_filter"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--test_filter">--test_filter</a></code></h3>
+    <h3 id="flag-test-filter" data-text="test_filter"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--test_filter">`--test_filter`</a></code></h3>
     </td>
     <td>
 
@@ -325,7 +325,7 @@ debugging. This flag is often used in conjunction with
 
   <tr>
     <td>
-    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--test_output">--test_output</a></code></h3>
+    <h3 id="flag-test-output" data-text="test_output"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--test_output">`--test_output`</a></code></h3>
     </td>
     <td>
 
@@ -351,7 +351,7 @@ The following flags are related to Bazel run.
 
   <tr>
     <td>
-        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--run_under">--run_under</a></code></h3>
+        <h3 id="flag-run-under" data-text="run_under"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--run_under">`--run_under`</a></code></h3>
     </td>
     <td>
 
@@ -377,7 +377,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--disk_cache">--disk_cache</a></code></h3>
+       <h3 id="flag-disk-cache" data-text="disk_cache"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--disk_cache">`--disk_cache`</a></code></h3>
     </td>
     <td>
 
@@ -394,7 +394,7 @@ up Bazel builds by adding
 
   <tr>
     <td>
-    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--jobs">--jobs</a></code></h3>
+    <h3 id="flag-jobs" data-text="jobs"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--jobs">`--jobs`</a></code></h3>
     </td>
     <td>
 
@@ -409,7 +409,7 @@ cluster executes more jobs than you have cores locally.
 
   <tr>
     <td>
-    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--local_resources">--local_resources</a></code></h3>
+    <h3 id="flag-local-resources" data-text="local_resources"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--local_resources">`--local_resources`</a></code></h3>
     </td>
     <td>
 
@@ -426,7 +426,7 @@ Limits how much CPU or RAM is consumed by locally running actions.
 
   <tr>
     <td>
-    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--sandbox_base">--sandbox_base</a></code></h3>
+    <h3 id="flag-sandbox-base" data-text="sandbox_base"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--sandbox_base">`--sandbox_base`</a></code></h3>
     </td>
     <td>
 
@@ -457,7 +457,7 @@ options.
 
   <tr>
     <td>
-       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--flaky_test_attempts">--flaky_test_attempts</a></code></h3>
+       <h3 id="flag-flaky-test-attempts" data-text="flaky_test_attempts"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--flaky_test_attempts">`--flaky_test_attempts`</a></code></h3>
     </td>
     <td>
 
@@ -472,7 +472,7 @@ the test summary.
 
   <tr>
     <td>
-    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--remote_cache">--remote_cache</a></code></h3>
+    <h3 id="flag-remote-cache" data-text="remote_cache"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--remote_cache">`--remote_cache`</a></code></h3>
     </td>
     <td>
 
@@ -485,7 +485,7 @@ speed up Bazel builds. It can be combined with a local disk cache.
 
   <tr>
     <td>
-    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--remote_download_regex">--remote_download_regex</a></code></h3>
+    <h3 id="flag-remote-download-regex" data-text="remote_download_regex"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--remote_download_regex">`--remote_download_regex`</a></code></h3>
     </td>
     <td>
 
@@ -499,7 +499,7 @@ patterns may be specified by repeating this flag.
 
   <tr>
     <td>
-     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--remote_executor">--remote_executor</a></code></h3>
+     <h3 id="flag-remote-executor" data-text="remote_executor"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--remote_executor">`--remote_executor`</a></code></h3>
     </td>
     <td>
 
@@ -513,7 +513,7 @@ a remote execution service. You'll often need to Add
 
   <tr>
     <td>
-     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--remote_instance_name">--remote_instance_name</a></code></h3>
+     <h3 id="flag-remote-instance-name" data-text="remote_instance_name"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--remote_instance_name">`--remote_instance_name`</a></code></h3>
     </td>
     <td>
 
@@ -525,7 +525,7 @@ The value to pass as <code>instance_name</code> in the remote execution API.
 
   <tr>
     <td>
-    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/9.1.0/docs/user-manual#show-timestamps">--show_timestamps</a></code></h3>
+    <h3 id="flag-show-timestamps" data-text="show-timestamps"><code><a href="https://bazel.build/versions/9.1.0/docs/user-manual#show-timestamps">`--show_timestamps`</a></code></h3>
     </td>
     <td>
 
@@ -539,7 +539,7 @@ quickly understand what step took how long.
 
   <tr>
     <td>
-    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--spawn_strategy">--spawn_strategy</a></code></h3>
+    <h3 id="flag-spawn-strategy" data-text="spawn_strategy"><code><a href="https://bazel.build/versions/9.1.0/reference/command-line-reference#flag--spawn_strategy">`--spawn_strategy`</a></code></h3>
     </td>
     <td>
 


### PR DESCRIPTION
### Description
Follow up to https://github.com/bazelbuild/bazel/pull/29325
 
- Wrapped flag names in single backticks to fix rendering issue where like `--verbose` on the [flag cheatsheet](https://preview.bazel.build/reference/flag-cheatsheet) are rendered with an emdash (—) instead of double dashes (--) due to Mintlify's smart typography converting `--` in prose contexts
- Hyperlinks to the command-line reference are preserved
- This PR targets the flag cheatsheet page in versioned docs whereas https://github.com/bazelbuild/bazel/pull/29325 fixed the issue in HEAD
- Mintlify preview link (example version 8.6 docs): https://bazel-pr-29408.mintlify.app/versions/8.6.0/reference/flag-cheatsheet

### Motivation
Fixes https://github.com/bazel-contrib/bazel-docs/issues/366

### Build API Changes
No

### Checklist

- [ ] Verify on Mintlify [preview](https://bazel-pr-29408.mintlify.app/versions/8.6.0/reference/flag-cheatsheet) that flag names render with -- (not —)
- [ ] Verify flag names are still clickable links to the command-line reference
### Release Notes

N/A

RELNOTES: None
