### PR TITLE
[9.2.0] Truncate "Detecting cycles with roots" log to avoid huge java.log entries (https://github.com/bazelbuild/bazel/pull/29380)

### DIFF
--- a/src/main/java/com/google/devtools/build/skyframe/ParallelEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/ParallelEvaluator.java
@@ -57,6 +57,9 @@ import javax.annotation.Nullable;
  */
 public class ParallelEvaluator extends AbstractParallelEvaluator {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
+  private static final int MAX_CYCLE_ROOTS_TO_LOG = 100;
+
   private final UnnecessaryTemporaryStateDropperReceiver unnecessaryTemporaryStateDropperReceiver;
 
   public ParallelEvaluator(
@@ -540,7 +543,16 @@ public class ParallelEvaluator extends AbstractParallelEvaluator {
       }
     }
     if (!cycleRoots.isEmpty()) {
-      logger.atInfo().log("Detecting cycles with roots: %s", cycleRoots);
+      int cycleRootsSize = cycleRoots.size();
+      if (cycleRootsSize <= MAX_CYCLE_ROOTS_TO_LOG) {
+        logger.atInfo().log("Detecting cycles with roots: %s", cycleRoots);
+      } else {
+        logger.atInfo().log(
+            "Detecting cycles with roots (%d total, showing first %d): %s",
+            cycleRootsSize,
+            MAX_CYCLE_ROOTS_TO_LOG,
+            Iterables.limit(cycleRoots, MAX_CYCLE_ROOTS_TO_LOG));
+      }
       try (AutoProfiler p =
           GoogleAutoProfilerUtils.logged("Checking for Skyframe cycles", Duration.ofMillis(10))) {
         cycleDetector.checkForCycles(cycleRoots, result, evaluatorContext);


### PR DESCRIPTION
### Description

When a build has tens or hundreds of thousands of top-level keys, the full cycleRoots collection could be serialized into a single log line. Cap the logged sample at 100 entries and include the total count.

### Motivation
Our java.log grew to ~200MB in some cases due to this single log for builds with pre-selected targets.

### Build API Changes
No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #29380.

PiperOrigin-RevId: 906371168
Change-Id: I201375f98c81a311624b3082bf9fd029f36d1923

Commit https://github.com/bazelbuild/bazel/commit/b6088e335bab4a48e879028a042bf90992a8b54e