### PR TITLE
BazelOutputService: Fix UnsupportedOperationException in batchStatJob

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
@@ -397,8 +397,14 @@ public class FilesystemValueChecker {
               ActionOutputMetadataStore.fileArtifactValueFromArtifact(
                   artifact, stat, xattrProviderOverrider.getXattrProvider(syscallCache), tsgm);
           if (newData.couldBeModifiedSince(lastKnownData)) {
-            modifiedOutputsReceiver.reportModifiedOutputFile(
-                stat != null ? stat.getLastChangeTime() : -1, artifact);
+            long maybeModifiedTime = -1;
+            if (stat != null) {
+              try {
+                maybeModifiedTime = stat.getLastChangeTime();
+              } catch (UnsupportedOperationException e) {
+              }
+            }
+            modifiedOutputsReceiver.reportModifiedOutputFile(maybeModifiedTime, artifact);
             dirtyKeys.add(key);
           }
         } catch (IOException e) {


### PR DESCRIPTION
### Description

BazelOutputServiceSymlink etc. throws UnsupportedOperationException in e.g. getLastChangeTime(). Those objects are only created by batchStatter so the only place that code path is called is in batchStatJob() in FilesystemValueChecker.java. Catch the UnsupportedOperationException there.

### Motivation

Fixes #29405

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
