### PR TITLE
Represent negative literals as a single literal AST node

### DIFF
--- a/src/main/java/net/starlark/java/syntax/FloatLiteral.java
+++ b/src/main/java/net/starlark/java/syntax/FloatLiteral.java
@@ -14,30 +14,23 @@
 package net.starlark.java.syntax;
 
 /**
- * Syntax node for a non-negative float literal. (Negative floats are parsed as a {@link
- * UnaryOperatorExpression} operating on a positive {@link FloatLiteral} argument.)
+ * Syntax node for a float literal.
  */
-// TODO: #28385 - consider optimizing negative float literals to be FloatLiteral.
 public final class FloatLiteral extends Expression {
-  private final String raw;
   private final int tokenOffset;
+  private final int endOffset;
   private final double value;
 
-  FloatLiteral(FileLocations locs, String raw, int tokenOffset, double value) {
+  FloatLiteral(FileLocations locs, int tokenOffset, int endOffset, double value) {
     super(locs, Kind.FLOAT_LITERAL);
-    this.raw = raw;
     this.tokenOffset = tokenOffset;
+    this.endOffset = endOffset;
     this.value = value;
   }
 
   /** Returns the value denoted by this literal. */
   public double getValue() {
     return value;
-  }
-
-  /** Returns the raw source text of the literal. */
-  public String getRaw() {
-    return raw;
   }
 
   @Override
@@ -47,7 +40,7 @@ public final class FloatLiteral extends Expression {
 
   @Override
   public int getEndOffset() {
-    return tokenOffset + raw.length();
+    return endOffset;
   }
 
   @Override

--- a/src/main/java/net/starlark/java/syntax/IntLiteral.java
+++ b/src/main/java/net/starlark/java/syntax/IntLiteral.java
@@ -17,13 +17,11 @@ import java.math.BigInteger;
 import javax.annotation.Nullable;
 
 /**
- * Syntax node for a non-negative int literal. (Negative integers are parsed as a {@link
- * UnaryOperatorExpression} operating on a positive {@link IntLiteral} argument.)
+ * Syntax node for an int literal.
  */
-// TODO: #28385 - consider optimizing negative integer literals to be IntLiteral.
 public final class IntLiteral extends Expression {
-  private final String raw;
   private final int tokenOffset;
+  private final int endOffset;
   private final Number value; // = Integer | Long | BigInteger
 
   /**
@@ -32,10 +30,10 @@ public final class IntLiteral extends Expression {
    * <p>{@code value} must be either an Integer or Long or BigInteger, and the smallest type capable
    * of exactly representing the number must be used.
    */
-  IntLiteral(FileLocations locs, String raw, int tokenOffset, Number value) {
+  IntLiteral(FileLocations locs, int tokenOffset, int endOffset, Number value) {
     super(locs, Kind.INT_LITERAL);
-    this.raw = raw;
     this.tokenOffset = tokenOffset;
+    this.endOffset = endOffset;
     this.value = value;
   }
 
@@ -56,11 +54,6 @@ public final class IntLiteral extends Expression {
     return value instanceof Integer intValue ? intValue : null;
   }
 
-  /** Returns the raw source text of the literal. */
-  public String getRaw() {
-    return raw;
-  }
-
   @Override
   public int getStartOffset() {
     return tokenOffset;
@@ -68,7 +61,7 @@ public final class IntLiteral extends Expression {
 
   @Override
   public int getEndOffset() {
-    return tokenOffset + raw.length();
+    return endOffset;
   }
 
   @Override

--- a/src/main/java/net/starlark/java/syntax/Parser.java
+++ b/src/main/java/net/starlark/java/syntax/Parser.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.FormatMethod;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -691,7 +692,7 @@ final class Parser {
       case INT:
         {
           IntLiteral literal =
-              new IntLiteral(locs, token.getRaw(), token.start, (Number) token.value);
+              new IntLiteral(locs, token.start, token.end, (Number) token.value);
           nextToken();
           return literal;
         }
@@ -699,7 +700,7 @@ final class Parser {
       case FLOAT:
         {
           FloatLiteral literal =
-              new FloatLiteral(locs, token.getRaw(), token.start, (double) token.value);
+              new FloatLiteral(locs, token.start, token.end, (double) token.value);
           nextToken();
           return literal;
         }
@@ -756,13 +757,40 @@ final class Parser {
           return makeErrorExpression(lparenOffset, end);
         }
 
-      case MINUS:
+      case MINUS: {
+        int offset = nextToken();
+        Expression x = parsePrimaryWithSuffix();
+
+        // Optimize int and float literals to contain the negative value directly
+        // instead of being wrapped in a UnaryOperatorExpression
+        if (x instanceof IntLiteral intLiteral) {
+          Number negatedValue = switch (intLiteral.getValue()) {
+            case Integer intValue -> -intValue;
+            case Long longValue when longValue == Integer.MAX_VALUE + 1L -> (int) -longValue;
+            case Long longValue -> -longValue;
+            case BigInteger bigIntegerValue when bigIntegerValue.equals(
+                BigInteger.valueOf(Long.MIN_VALUE).negate()) ->
+                bigIntegerValue.negate().longValueExact();
+            case BigInteger bigIntegerValue -> bigIntegerValue.negate();
+            default -> throw new IllegalStateException(
+                "int literal does not contain an Integer, Long or BigInteger");
+          };
+          return new IntLiteral(intLiteral.locs, offset, intLiteral.getEndOffset(), negatedValue);
+        } else if (x instanceof FloatLiteral floatLiteral) {
+          return new FloatLiteral(floatLiteral.locs, offset, floatLiteral.getEndOffset(),
+              -floatLiteral.getValue());
+        }
+
+        return new UnaryOperatorExpression(locs, TokenKind.MINUS, offset, x);
+      }
+
       case PLUS:
       case TILDE:
         {
           TokenKind op = token.kind;
           int offset = nextToken();
           Expression x = parsePrimaryWithSuffix();
+
           return new UnaryOperatorExpression(locs, op, offset, x);
         }
 

--- a/src/main/java/net/starlark/java/syntax/TypeChecker.java
+++ b/src/main/java/net/starlark/java/syntax/TypeChecker.java
@@ -258,24 +258,14 @@ public final class TypeChecker extends NodeVisitor {
   }
 
   /**
-   * Returns the integer value of an expression if it's an integer value (or a unary expression
-   * negating an integer value) which can be exactly represented as a Java integer, or null
-   * otherwise (in particular, if the expression itself is null).
+   * Returns the integer value of an expression if it's an integer value which can be exactly
+   * represented as a Java integer, or null otherwise (in particular, if the expression itself is
+   * null).
    */
-  // TODO: #28037 - Consider allowing more complicated static expressions, e.g. binary operators on
-  // integers.
   @Nullable
   private static Integer getIntValueExact(@Nullable Expression expr) {
     if (expr instanceof IntLiteral intLiteral) {
       return intLiteral.getIntValueExact();
-    } else if (expr instanceof UnaryOperatorExpression unop
-        && unop.getOperator() == TokenKind.MINUS
-        && unop.getX() instanceof IntLiteral negatedIntLiteral) {
-      // We may want to simplify negative integer literals to be IntLiteral; see #28385.
-      Integer x = negatedIntLiteral.getIntValueExact();
-      if (x != null) {
-        return -x; // safe since x >= 0
-      }
     }
     return null;
   }

--- a/src/test/java/net/starlark/java/syntax/NodePrinterTest.java
+++ b/src/test/java/net/starlark/java/syntax/NodePrinterTest.java
@@ -231,7 +231,7 @@ public final class NodePrinterTest {
   public void unaryOperatorExpression() throws SyntaxError.Exception {
     assertExprPrettyMatches("not True", "not (True)");
     assertExprTostringMatches("not True", "not True");
-    assertExprPrettyMatches("-5", "-(5)");
+    assertExprPrettyMatches("-(5 + 3)", "-((5 + 3))");
     assertExprTostringMatches("-5", "-5");
   }
 

--- a/src/test/java/net/starlark/java/syntax/ParserTest.java
+++ b/src/test/java/net/starlark/java/syntax/ParserTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.testing.junit.testparameterinjector.TestParameter;
 import com.google.testing.junit.testparameterinjector.TestParameterInjector;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -216,16 +217,85 @@ public final class ParserTest {
   }
 
   @Test
-  public void testUnaryMinusExpr() throws Exception {
-    UnaryOperatorExpression e = (UnaryOperatorExpression) parseExpression("-5");
-    UnaryOperatorExpression e2 = (UnaryOperatorExpression) parseExpression("- 5");
+  public void testUnaryMinusForNonLiteral() throws Exception {
+    Expression expression = parseExpression("-(5 + 3)");
+    assertThat(expression).isInstanceOf(UnaryOperatorExpression.class);
+    UnaryOperatorExpression unaryExpression = (UnaryOperatorExpression) expression;
+    assertThat(unaryExpression.getOperator()).isEqualTo(TokenKind.MINUS);
+    assertThat(unaryExpression.getX()).isInstanceOf(BinaryOperatorExpression.class);
+    BinaryOperatorExpression binaryExpression = (BinaryOperatorExpression) unaryExpression.getX();
+    assertThat(binaryExpression.getX()).isInstanceOf(IntLiteral.class);
+    IntLiteral x = (IntLiteral) binaryExpression.getX();
+    assertThat(x.getValue()).isEqualTo(5);
+    assertThat(binaryExpression.getY()).isInstanceOf(IntLiteral.class);
+    IntLiteral y = (IntLiteral) binaryExpression.getY();
+    assertThat(y.getValue()).isEqualTo(3);
 
-    IntLiteral i = (IntLiteral) e.getX();
-    assertThat(i.getValue()).isEqualTo(5);
-    IntLiteral i2 = (IntLiteral) e2.getX();
-    assertThat(i2.getValue()).isEqualTo(5);
-    assertLocation(0, 2, e);
-    assertLocation(0, 3, e2);
+    assertLocation(0, 7, expression);
+  }
+
+  @Test
+  public void testUnaryMinusWithIntLiteralContainingInt() throws Exception {
+    Expression expression = parseExpression("-5");
+    assertThat(expression).isInstanceOf(IntLiteral.class);
+    IntLiteral intLiteral = (IntLiteral) expression;
+    assertThat(intLiteral.getValue()).isInstanceOf(Integer.class);
+    Integer integer = (Integer) intLiteral.getValue();
+    assertThat(integer).isEqualTo(-5);
+  }
+
+  @Test
+  public void testUnaryMinusWithIntLiteralLocation() throws Exception {
+    Expression expression = parseExpression("- 5");
+    assertLocation(0, 3, expression);
+  }
+
+  @Test
+  public void testUnaryMinusWithIntLiteralContainingLong() throws Exception {
+    Expression expression = parseExpression("-3000000000");
+    assertThat(expression).isInstanceOf(IntLiteral.class);
+    IntLiteral intLiteral = (IntLiteral) expression;
+    assertThat(intLiteral.getValue()).isInstanceOf(Long.class);
+    Long longValue = (Long) intLiteral.getValue();
+    assertThat(longValue).isEqualTo(-3_000_000_000L);
+  }
+
+  @Test
+  public void testUnaryMinusWithIntLiteralContainingBigInteger() throws Exception {
+    Expression expression = parseExpression("-10000000000000000000");
+    assertThat(expression).isInstanceOf(IntLiteral.class);
+    IntLiteral intLiteral = (IntLiteral) expression;
+    assertThat(intLiteral.getValue()).isInstanceOf(BigInteger.class);
+    BigInteger integer = (BigInteger) intLiteral.getValue();
+    assertThat(integer).isEqualTo(new BigInteger("-10000000000000000000"));
+  }
+
+  @Test
+  public void testUnaryMinusWithIntLiteralAndMinIntValue() throws Exception {
+    Expression expression = parseExpression(String.valueOf(Integer.MIN_VALUE));
+    assertThat(expression).isInstanceOf(IntLiteral.class);
+    IntLiteral intLiteral = (IntLiteral) expression;
+    assertThat(intLiteral.getValue()).isInstanceOf(Integer.class);
+    Integer integer = (Integer) intLiteral.getValue();
+    assertThat(integer).isEqualTo(Integer.MIN_VALUE);
+  }
+
+  @Test
+  public void testUnaryMinusWithIntLiteralAndMinLongValue() throws Exception {
+    Expression expression = parseExpression(String.valueOf(Long.MIN_VALUE));
+    assertThat(expression).isInstanceOf(IntLiteral.class);
+    IntLiteral intLiteral = (IntLiteral) expression;
+    assertThat(intLiteral.getValue()).isInstanceOf(Long.class);
+    Long longValue = (Long) intLiteral.getValue();
+    assertThat(longValue).isEqualTo(Long.MIN_VALUE);
+  }
+
+  @Test
+  public void testUnaryMinusWithFloatLiteral() throws Exception {
+    Expression expression = parseExpression("-5.0");
+    assertThat(expression).isInstanceOf(FloatLiteral.class);
+    FloatLiteral literal = (FloatLiteral) expression;
+    assertThat(literal.getValue()).isEqualTo(-5.0);
   }
 
   @Test


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

Represent negative int and float literals in Starlark as `IntLiteral` and `FloatLiteral` AST nodes containing negative values instead of wrapping `IntLiteral` or `FloatLiteral` in an `UnaryOperatorExpression`.

Fixes #28385.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

This allows simplifying the type checker and saves a bit of memory.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

Not sure.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

 I'm not sure if this change should be added to the release notes. I'd be happy to add release notes if necessary.

---

This is first contribution to bazel. Please let me know if I need to change anything/can improve something. As written above I'd like input on whether this is a Build API change and whether this change needs release notes.
