### PR TITLE
[9.2.0] BazelOutputService: Fix UnsupportedOperationException in batchStatJob (https://github.com/bazelbuild/bazel/pull/29422)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
@@ -397,8 +397,15 @@ public class FilesystemValueChecker {
               ActionOutputMetadataStore.fileArtifactValueFromArtifact(
                   artifact, stat, xattrProviderOverrider.getXattrProvider(syscallCache), tsgm);
           if (newData.couldBeModifiedSince(lastKnownData)) {
-            modifiedOutputsReceiver.reportModifiedOutputFile(
-                stat != null ? stat.getLastChangeTime() : -1, artifact);
+            long maybeModifiedTime = -1;
+            if (stat != null) {
+              try {
+                maybeModifiedTime = stat.getLastChangeTime();
+              } catch (UnsupportedOperationException ignored) {
+                // Not all filesystems support change time; falling back to -1.
+              }
+            }
+            modifiedOutputsReceiver.reportModifiedOutputFile(maybeModifiedTime, artifact);
             dirtyKeys.add(key);
           }
         } catch (IOException e) {


### PR DESCRIPTION
### Description

BazelOutputServiceSymlink etc. throws UnsupportedOperationException in e.g. getLastChangeTime(). Those objects are only created by batchStatter so the only place that code path is called is in batchStatJob() in FilesystemValueChecker.java. Catch the UnsupportedOperationException there.

### Motivation

Fixes #29405

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #29422.

PiperOrigin-RevId: 907531973
Change-Id: Ifb7491913016c577d55f2159856d4812a04bc633

Commit https://github.com/bazelbuild/bazel/commit/4d8f19c39f52be661e28f3aecb2ed4c19978268b