### PR TITLE
Fix :bazel_bootstrap_distfile_test and :bazel_bootstrap_distfile_tar_…

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -29,7 +29,7 @@ LIBRARY_JARS=$(find $ADDITIONAL_JARS -name '*.jar' | sort | grep -Fv JavaBuilder
 MAVEN_JARS=$(find "derived/maven" -name '*.jar' | sort | grep -Fv netty-tcnative | tr "\n" " ")
 LIBRARY_JARS="${LIBRARY_JARS} ${MAVEN_JARS}"
 
-ANNOTATION_PROCESSOR_FILES=$(echo src/main/java/com/google/devtools/common/options/processor/OptionsClassProcessor.java src/main/java/com/google/devtools/common/options/{Option.java,OptionMetadataTag.java,OptionEffectTag.java,OptionDocumentationCategory.java,OptionsClass.java,Converter.java,OptionsParsingException.java})
+ANNOTATION_PROCESSOR_FILES=$(echo src/main/java/com/google/devtools/common/options/processor/OptionsClassProcessor.java src/main/java/com/google/devtools/common/options/{Option.java,OptionMetadataTag.java,OptionEffectTag.java,OptionDocumentationCategory.java,OptionsClass.java,Converter.java,OptionsParsingException.java,processor/OptionProcessorException.java,processor/ProcessorUtils.java})
 ANNOTATION_PROCESSORS="com.google.devtools.common.options.processor.OptionsClassProcessor,com.google.auto.value.processor.AutoValueProcessor,com.google.auto.value.processor.AutoBuilderProcessor,com.google.auto.value.processor.AutoOneOfProcessor,com.google.auto.service.processor.AutoServiceProcessor"
 DIRS=$(echo src/{java_tools/singlejar/java/com/google/devtools/build/zip,main/java,tools/starlark/java} tools/java/runfiles ${OUTPUT_DIR}/src)
 # Exclude source files that are not needed for Bazel itself, which avoids dependencies like truth.

--- a/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
@@ -201,6 +201,7 @@ class OptionsParserImpl {
         allowMultiple = true,
         defaultValue = "null",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        metadataTags = {OptionMetadataTag.INTERNAL},
         effectTags = {OptionEffectTag.NO_OP},
         help = "Only used internally by OptionsParserImpl")
     public abstract List<String> getSkippedArgs();

--- a/src/main/java/com/google/devtools/common/options/processor/OptionsClassProcessor.java
+++ b/src/main/java/com/google/devtools/common/options/processor/OptionsClassProcessor.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.common.options.Converter;
-import com.google.devtools.common.options.Converters;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
@@ -74,9 +73,31 @@ public final class OptionsClassProcessor extends AbstractProcessor {
     return SourceVersion.latestSupported();
   }
 
+  // This method is necessary because when bootstrapping Bazel, we need to run the option class
+  // annotation processor so we need to build it first. But if we simply reference Converters, we
+  // also need all of its transitive dependencies, which is a lot. So instead reference it using
+  // reflection and report that no default converters are available during bootstrapping.
+  @Nullable
+  @SuppressWarnings("unchecked") // uses reflection, can't have generic arguments
+  private static Map<Class<?>, Converter<?>> getDefaultConverters() {
+    Class<?> converters;
+    try {
+      converters = Class.forName("com.google.devtools.common.options.Converters");
+    } catch (ClassNotFoundException e) {
+      return null;
+    }
+
+    try {
+      return (Map<Class<?>, Converter<?>>) converters.getField("DEFAULT_CONVERTERS").get(null);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
   @Override
   public synchronized void init(ProcessingEnvironment processingEnv) {
     super.init(processingEnv);
+
     typeUtils = processingEnv.getTypeUtils();
     elementUtils = processingEnv.getElementUtils();
     messager = processingEnv.getMessager();
@@ -89,10 +110,15 @@ public final class OptionsClassProcessor extends AbstractProcessor {
             .put(long.class, typeUtils.getPrimitiveType(TypeKind.LONG))
             .buildOrThrow();
 
+    Map<Class<?>, Converter<?>> defaultConverterMap = getDefaultConverters();
+    if (defaultConverterMap == null) {
+      defaultConverters = null;
+      return;
+    }
     ImmutableMap.Builder<TypeMirror, Converter<?>> converterMapBuilder =
         new ImmutableMap.Builder<>();
 
-    for (Map.Entry<Class<?>, Converter<?>> entry : Converters.DEFAULT_CONVERTERS.entrySet()) {
+    for (Map.Entry<Class<?>, Converter<?>> entry : defaultConverterMap.entrySet()) {
       Class<?> converterClass = entry.getKey();
       String typeName = converterClass.getCanonicalName();
       TypeElement typeElement = elementUtils.getTypeElement(typeName);
@@ -549,6 +575,11 @@ public final class OptionsClassProcessor extends AbstractProcessor {
   private void checkForDefaultConverter(
       ExecutableElement method, List<TypeMirror> acceptedConverterReturnTypes, String defaultValue)
       throws OptionProcessorException {
+    if (defaultConverters == null) {
+      // Bootstrapping. Do not do this check.
+      return;
+    }
+
     for (TypeMirror acceptedConverterReturnType : acceptedConverterReturnTypes) {
       Converter<?> converterInstance = findDefaultConverter(acceptedConverterReturnType);
       if (converterInstance == null) {


### PR DESCRIPTION
…test.

https://github.com/bazelbuild/bazel/commit/c96425607a6f6287065d2ee698b028f437d36f9a made it so that OptionsClassProcessor references a few more classes, so those new classes accordingly need to be added to the "built annotation processors" bootstrap step.

RELNOTES: None.
PiperOrigin-RevId: 902985271
Change-Id: Ief5d3daf7987381e66fc5a9485c03a0d6393295a

