### PR TITLE
docs: Special-case command line reference conversion

### DIFF
--- a/scripts/docs/BUILD
+++ b/scripts/docs/BUILD
@@ -97,6 +97,20 @@ py_test(
     ],
 )
 
+py_library(
+    name = "clr_converter",
+    srcs = ["clr_converter.py"],
+)
+
+py_test(
+    name = "clr_converter_test",
+    srcs = ["clr_converter_test.py"],
+    data = [":testdata"],
+    deps = [
+        ":clr_converter",
+    ],
+)
+
 py_binary(
     name = "docs2mdx",
     srcs = ["docs2mdx.py"],
@@ -104,6 +118,7 @@ py_binary(
         "//src/main/java/com/google/devtools/build/lib:__pkg__",
     ],
     deps = [
+        ":clr_converter",
         "//third_party/py/abseil",
         requirement("markdownify"),
     ],

--- a/scripts/docs/clr_converter.py
+++ b/scripts/docs/clr_converter.py
@@ -1,0 +1,691 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Converts command-line-reference HTML to MDX with ParamField components."""
+
+import dataclasses
+import html
+import html.parser
+import re
+
+
+@dataclasses.dataclass
+class _Option:
+  anchor_id: str = ""
+  flag_name: str = ""
+  value_type: str = ""
+  abbreviation: str = ""
+  default: str = ""
+  allow_multiple: bool = False
+  is_deprecated: bool = False
+  help_html: str = ""
+  expansion_flags: list = dataclasses.field(default_factory=list)
+  tags_html: str = ""
+
+
+@dataclasses.dataclass
+class _Section:
+  heading: str = ""
+  anchor: str = ""
+  inherits_html: str = ""
+  categories: list = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass
+class _Category:
+  description: str = ""
+  options: list = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass
+class _TagTable:
+  heading: str = ""
+  rows: list = dataclasses.field(default_factory=list)
+
+
+_REPLACED_JS_CHARACTERS = {
+    "{": "&lcub;",
+    "}": "&rcub;",
+}
+
+_REPLACED_CODE_CHARACTERS = {
+    "<": "&lt;",
+    ">": "&gt;",
+    **_REPLACED_JS_CHARACTERS,
+}
+
+
+def _escape_mdx(text):
+  for c, replacement in _REPLACED_JS_CHARACTERS.items():
+    text = text.replace(c, replacement)
+  return text
+
+
+def _escape_mdx_code(text):
+  # Escape $ so MDX doesn't parse it as a LaTeX math delimiter or,
+  # combined with {, as a JS template expression.
+  text = text.replace("$", "&#36;")
+  for c, replacement in _REPLACED_CODE_CHARACTERS.items():
+    text = text.replace(c, replacement)
+  return text
+
+
+class _CLRParser(html.parser.HTMLParser):
+  """Parses the command-line-reference HTML into structured data."""
+
+  def __init__(self):
+    super().__init__()
+    self.prefix_html = ""
+    self.commands_table_rows = []
+    self.sections = []
+    self.tag_tables = []
+
+    self._state = "PREFIX"
+    self._depth = 0
+    self._tag_stack = []
+
+    self._current_section = None
+    self._current_category = None
+    self._current_option = None
+    self._current_tag_table = None
+
+    self._in_dt = False
+    self._in_dd = False
+    self._in_h2 = False
+    self._in_h3 = False
+    self._in_commands_table = False
+    self._in_tag_table = False
+    self._in_table_row = False
+    self._table_cells = []
+    self._current_cell_html = ""
+    self._in_table_cell = False
+    self._in_dl = False
+    self._dl_text_buffer = ""
+    self._inherits_buffer = ""
+
+    self._dt_html = ""
+    self._dd_html = ""
+    self._heading_text = ""
+    self._heading_anchor = ""
+
+    self._prefix_parts = []
+    self._saw_commands_heading = False
+
+  def handle_starttag(self, tag, attrs):
+    attrs_dict = dict(attrs)
+
+    if self._state == "PREFIX":
+      if tag == "h2":
+        self._in_h2 = True
+        self._heading_text = ""
+        return
+      self._prefix_parts.append(self._rebuild_tag(tag, attrs))
+      return
+
+    if self._in_dt:
+      self._dt_html += self._rebuild_tag(tag, attrs)
+      return
+
+    if self._in_dd:
+      self._dd_html += self._rebuild_tag(tag, attrs)
+      return
+
+    if self._in_table_cell:
+      self._current_cell_html += self._rebuild_tag(tag, attrs)
+      return
+
+    if tag == "h2":
+      self._in_h2 = True
+      self._heading_text = ""
+      self._heading_anchor = ""
+      return
+
+    if tag == "h3":
+      self._in_h3 = True
+      self._heading_text = ""
+      return
+
+    if tag == "a" and self._in_h2:
+      name = attrs_dict.get("name", "")
+      if name:
+        self._heading_anchor = name
+      return
+
+    if tag == "table":
+      if self._in_h3 or (self._current_tag_table is not None):
+        self._in_tag_table = True
+      elif self._state == "COMMANDS_TABLE":
+        self._in_commands_table = True
+      return
+
+    if tag == "tr" and (self._in_commands_table or self._in_tag_table):
+      self._in_table_row = True
+      self._table_cells = []
+      return
+
+    if tag == "td" and self._in_table_row:
+      self._in_table_cell = True
+      self._current_cell_html = ""
+      cell_id = attrs_dict.get("id", "")
+      if cell_id:
+        self._current_cell_html += f'<span id="{cell_id}">'
+      return
+
+    if tag == "p" and self._current_section and not self._in_dl:
+      self._state = "INHERITS_P"
+      self._inherits_buffer = ""
+      return
+
+    if tag == "a" and self._state == "INHERITS_P":
+      self._inherits_buffer += self._rebuild_tag(tag, attrs)
+      return
+
+    if tag == "dl":
+      self._in_dl = True
+      self._dl_text_buffer = ""
+      return
+
+    if tag == "dt":
+      self._in_dt = True
+      self._dt_html = ""
+      anchor_id = attrs_dict.get("id", "")
+      self._current_option = _Option(anchor_id=anchor_id)
+      return
+
+    if tag == "dd":
+      self._in_dd = True
+      self._dd_html = ""
+      return
+
+    if tag == "p" and self._in_dl and not self._in_dt and not self._in_dd:
+      self._in_dd = True
+      self._dd_html = "<p>"
+      return
+
+  def handle_endtag(self, tag):
+    if self._state == "PREFIX":
+      if tag == "h2" and self._in_h2:
+        self._in_h2 = False
+        if self._heading_text.strip() == "Commands":
+          self.prefix_html = "".join(self._prefix_parts)
+          self._state = "COMMANDS_TABLE"
+        else:
+          self._prefix_parts.append(f"<h2>{self._heading_text}</h2>")
+        return
+      self._prefix_parts.append(f"</{tag}>")
+      return
+
+    if self._in_dt:
+      if tag == "dt":
+        self._in_dt = False
+        self._parse_dt(self._dt_html)
+        return
+      self._dt_html += f"</{tag}>"
+      return
+
+    if self._in_dd:
+      if tag == "dd":
+        self._in_dd = False
+        self._parse_dd(self._dd_html)
+        if self._current_option and self._current_category:
+          self._current_category.options.append(self._current_option)
+          self._current_option = None
+        return
+      self._dd_html += f"</{tag}>"
+      return
+
+    if self._in_table_cell:
+      if tag == "td":
+        self._in_table_cell = False
+        self._table_cells.append(self._current_cell_html)
+        return
+      self._current_cell_html += f"</{tag}>"
+      return
+
+    if tag == "tr" and self._in_table_row:
+      self._in_table_row = False
+      if self._in_commands_table:
+        self.commands_table_rows.append(self._table_cells)
+      elif self._in_tag_table and self._current_tag_table:
+        self._current_tag_table.rows.append(self._table_cells)
+      return
+
+    if tag == "a" and self._state == "INHERITS_P":
+      self._inherits_buffer += "</a>"
+      return
+
+    if tag == "p" and self._state == "INHERITS_P":
+      if self._current_section:
+        self._current_section.inherits_html = self._inherits_buffer
+      self._state = "BODY"
+      return
+
+    if tag == "table":
+      if self._in_commands_table:
+        self._in_commands_table = False
+        self._state = "BODY"
+      elif self._in_tag_table:
+        self._in_tag_table = False
+        if self._current_tag_table:
+          self.tag_tables.append(self._current_tag_table)
+          self._current_tag_table = None
+      return
+
+    if tag == "h2" and self._in_h2:
+      self._in_h2 = False
+      self._finish_current_section()
+      self._current_section = _Section(
+          heading=self._heading_text.strip(),
+          anchor=self._heading_anchor,
+      )
+      return
+
+    if tag == "h3" and self._in_h3:
+      self._in_h3 = False
+      heading = self._heading_text.strip()
+      if "Option" in heading and "Tag" in heading:
+        self._current_tag_table = _TagTable(heading=heading)
+      return
+
+    if tag == "dl":
+      self._in_dl = False
+      if self._current_category:
+        if self._current_section:
+          self._current_section.categories.append(self._current_category)
+        self._current_category = None
+      return
+
+    if tag == "p" and self._in_dl and not self._in_dt and not self._in_dd:
+      pass
+
+  def handle_data(self, data):
+    if self._state == "PREFIX":
+      if self._in_h2:
+        self._heading_text += data
+      else:
+        self._prefix_parts.append(html.escape(data).replace("&#x27;", "'"))
+      return
+
+    if self._in_h2 or self._in_h3:
+      self._heading_text += data
+      return
+
+    if self._in_dt:
+      self._dt_html += html.escape(data)
+      return
+
+    if self._in_dd:
+      self._dd_html += html.escape(data)
+      return
+
+    if self._in_table_cell:
+      self._current_cell_html += html.escape(data)
+      return
+
+    if self._in_dl and not self._in_dt and not self._in_dd:
+      stripped = data.strip().rstrip(":")
+      if stripped:
+        self._current_category = _Category(description=html.unescape(stripped))
+      return
+
+    if self._state == "INHERITS_P":
+      self._inherits_buffer += html.escape(data)
+      return
+
+  def handle_entityref(self, name):
+    text = f"&{name};"
+    if self._in_dt:
+      self._dt_html += text
+    elif self._in_dd:
+      self._dd_html += text
+    elif self._in_table_cell:
+      self._current_cell_html += text
+    elif self._state == "INHERITS_P":
+      self._inherits_buffer += text
+    elif self._state == "PREFIX" and not self._in_h2:
+      self._prefix_parts.append(text)
+
+  def handle_charref(self, name):
+    text = f"&#{name};"
+    if self._in_dt:
+      self._dt_html += text
+    elif self._in_dd:
+      self._dd_html += text
+    elif self._in_table_cell:
+      self._current_cell_html += text
+
+  def close(self):
+    super().close()
+    self._finish_current_section()
+
+  def _finish_current_section(self):
+    if self._current_category and self._current_section:
+      self._current_section.categories.append(self._current_category)
+      self._current_category = None
+    if self._current_section:
+      self.sections.append(self._current_section)
+      self._current_section = None
+
+  def _rebuild_tag(self, tag, attrs):
+    parts = [tag]
+    for k, v in attrs:
+      if v is None:
+        parts.append(k)
+      else:
+        parts.append(f'{k}="{v}"')
+    return "<" + " ".join(parts) + ">"
+
+  def _parse_dt(self, dt_html):
+    opt = self._current_option
+    if not opt:
+      return
+
+    flag_match = re.search(r'<a[^>]*>([^<]+)</a>', dt_html)
+    if flag_match:
+      opt.flag_name = flag_match.group(1)
+
+    code_match = re.search(r'<code[^>]*>(.*?)</code>', dt_html, re.DOTALL)
+    if code_match:
+      code_content = code_match.group(1)
+      after_a = re.split(r'</a>', code_content, maxsplit=1)
+      if len(after_a) > 1:
+        value_part = after_a[1].strip()
+        if value_part.startswith("="):
+          raw_type = html.unescape(value_part[1:]).strip()
+          if raw_type.startswith("<") and raw_type.endswith(">"):
+            raw_type = raw_type[1:-1]
+          opt.value_type = raw_type
+
+    after_code = re.split(r'</code>\s*', dt_html, maxsplit=1)
+    if len(after_code) > 1:
+      remainder = after_code[1]
+
+      abbrev_match = re.search(r'\[<code>(-\w)</code>\]', remainder)
+      if abbrev_match:
+        opt.abbreviation = abbrev_match.group(1)
+        remainder = remainder[abbrev_match.end():]
+
+      remainder = remainder.strip()
+      if "multiple uses are accumulated" in remainder:
+        opt.allow_multiple = True
+      elif remainder.startswith("default:"):
+        default_val = remainder[len("default:"):].strip()
+        default_val = html.unescape(default_val).strip('"')
+        opt.default = default_val
+
+    if not opt.value_type and not opt.flag_name.startswith("--[no]"):
+      opt.value_type = "void"
+    elif not opt.value_type and opt.flag_name.startswith("--[no]"):
+      opt.value_type = "boolean"
+
+  def _parse_dd(self, dd_html):
+    opt = self._current_option
+    if not opt:
+      return
+
+    parts = re.split(r'<p>', dd_html)
+    help_parts = []
+    for part in parts:
+      part_text = part.strip()
+      if not part_text:
+        continue
+      if part_text.startswith("Expands to:"):
+        exp_flags = re.findall(
+            r'<code><a[^>]*>([^<]+)</a></code>', part_text)
+        opt.expansion_flags = exp_flags
+      elif part_text.startswith("Tags:"):
+        opt.tags_html = "<p>" + part_text
+        if "deprecated" in part_text.lower():
+          if "metadata_tag_DEPRECATED" in part_text:
+            opt.is_deprecated = True
+      else:
+        help_parts.append(part_text.removesuffix("</p>"))
+
+    opt.help_html = "\n".join(help_parts)
+
+
+def _escape_mdx_outside_code(text):
+  """Escapes MDX-special characters outside of code spans and fenced blocks."""
+  # First split on fenced code blocks (``` ... ```), then within non-fenced
+  # segments split on inline backtick spans.
+  fenced_parts = re.split(r'(```[^`]*```)', text, flags=re.DOTALL)
+  result = []
+  for fi, fenced_part in enumerate(fenced_parts):
+    if fi % 2 == 1:
+      result.append(fenced_part)
+      continue
+    inline_parts = re.split(r'(`[^`]*`)', fenced_part)
+    for ii, inline_part in enumerate(inline_parts):
+      if ii % 2 == 0:
+        inline_part = _escape_mdx_code(inline_part)
+      result.append(inline_part)
+  return "".join(result)
+
+
+_PRE_CODE_RE = re.compile(
+    r'<pre><code>(.*?)</code></pre>', re.DOTALL)
+
+
+def _convert_pre_code_block(m):
+  content = html.unescape(m.group(1)).strip('\n')
+  return f'\n\n```\n{content}\n```\n\n'
+
+
+_ERRATA = [
+    ("`rewrite, allow, block'", "`rewrite, allow, block`"),
+]
+
+
+def _apply_known_errata(text):
+  for old, new in _ERRATA:
+    text = text.replace(old, new)
+  return text
+
+
+def _html_to_simple_md(html_content):
+  """Minimal HTML-to-markdown for option help text."""
+  text = html_content
+
+  # Fenced code blocks before inline code so <pre><code> isn't consumed
+  # by the inline pattern. Content is unescaped but not MDX-escaped since
+  # fenced blocks are literal in MDX.
+  text = _PRE_CODE_RE.sub(_convert_pre_code_block, text)
+
+  text = re.sub(r'<a\s+href="([^"]*)"[^>]*>([^<]*)</a>', r'[\2](\1)', text)
+  text = re.sub(r'<code>([^<]*)</code>', lambda m: '`' + m.group(1) + '`', text)
+  text = re.sub(r'<em>([^<]*)</em>', r'*\1*', text)
+  text = re.sub(r'<strong>([^<]*)</strong>', r'**\1**', text)
+  text = re.sub(r'<br\s*/?>', '\n', text)
+
+  text = re.sub(r'<li>\s*', '- ', text)
+  text = re.sub(r'</li>', '', text)
+  text = re.sub(r'</?[uo]l>', '', text)
+
+  text = re.sub(r'<p>', '\n\n', text)
+  text = re.sub(r'</p>', '', text)
+
+  text = re.sub(r'<[^>]+>', '', text)
+
+  text = html.unescape(text)
+  text = _apply_known_errata(text)
+  text = _escape_mdx_outside_code(text)
+  text = re.sub(r'\n{3,}', '\n\n', text)
+  return text.strip()
+
+
+def _escape_attr(value):
+  """Escapes a string for use inside a JSX attribute value."""
+  escaped = value.replace("&", "&amp;")
+  escaped = escaped.replace('"', "&quot;")
+  escaped = escaped.replace("<", "&lt;")
+  escaped = escaped.replace(">", "&gt;")
+  escaped = escaped.replace("{", "&lcub;")
+  escaped = escaped.replace("}", "&rcub;")
+  return escaped
+
+
+def _render_option(opt):
+  """Renders a single option as a ParamField component."""
+  attrs = [f'path="{_escape_attr(opt.flag_name)}"']
+
+  if opt.value_type:
+    attrs.append(f'type="{_escape_attr(opt.value_type)}"')
+
+  if opt.default and not opt.allow_multiple:
+    attrs.append(f'default="{_escape_attr(opt.default)}"')
+
+  if opt.is_deprecated:
+    attrs.append("deprecated")
+
+  attr_str = " ".join(attrs)
+  lines = [f"<ParamField {attr_str}>"]
+
+  if opt.abbreviation:
+    lines.append(f"  Short form: `{opt.abbreviation}`")
+    lines.append("")
+
+  help_md = _html_to_simple_md(opt.help_html)
+  if help_md:
+    for line in help_md.split("\n"):
+      lines.append(f"  {line}" if line.strip() else "")
+
+  if opt.allow_multiple:
+    lines.append("")
+    lines.append("  *May be used multiple times; values are accumulated.*")
+
+  if opt.expansion_flags:
+    lines.append("")
+    lines.append("  Expands to:")
+    for flag in opt.expansion_flags:
+      lines.append(f"  - `{_escape_mdx(flag)}`")
+
+  if opt.tags_html:
+    tags_md = _render_tags(opt.tags_html)
+    if tags_md:
+      lines.append("")
+      lines.append(f"  {tags_md}")
+
+  lines.append("</ParamField>")
+  return "\n".join(lines)
+
+
+def _render_tags(tags_html):
+  """Converts tags HTML to markdown."""
+  tag_links = re.findall(
+      r'<a\s+href="([^"]*)"><code>([^<]*)</code></a>', tags_html)
+  if not tag_links:
+    return ""
+  parts = [f"[`{name}`]({href})" for href, name in tag_links]
+  return "Tags: " + ", ".join(parts)
+
+
+def _render_commands_table(rows):
+  """Renders the commands table as markdown."""
+  lines = [
+      "## Commands",
+      "",
+      "| | |",
+      "| --- | --- |",
+  ]
+  for cells in rows:
+    if len(cells) >= 2:
+      cmd_md = re.sub(
+          r'<a\s+href="([^"]*)"><code>([^<]*)</code></a>',
+          lambda m: f"[`{m.group(2)}`]({m.group(1)})",
+          cells[0],
+      )
+      desc = html.unescape(re.sub(r'<[^>]+>', '', cells[1]))
+      lines.append(f"| {cmd_md} | {_escape_mdx(desc)} |")
+  return "\n".join(lines)
+
+
+def _render_tag_table(tag_table):
+  """Renders a tag description table as markdown."""
+  lines = [
+      f"### {tag_table.heading}",
+      "",
+      "| | |",
+      "| --- | --- |",
+  ]
+  for cells in tag_table.rows:
+    if len(cells) >= 2:
+      name_cell = cells[0]
+      span_match = re.search(r'<span id="([^"]*)">', name_cell)
+      code_match = re.search(r'<code>([^<]*)</code>', name_cell)
+      if span_match and code_match:
+        tag_id = span_match.group(1)
+        tag_name = code_match.group(1)
+        name_md = f'<span id="{tag_id}">`{tag_name}`</span>'
+      else:
+        name_md = re.sub(r'<[^>]+>', '', name_cell)
+      desc = html.unescape(re.sub(r'<[^>]+>', '', cells[1]))
+      lines.append(f"| {name_md} | {_escape_mdx(desc)} |")
+  return "\n".join(lines)
+
+
+def _render_section(section):
+  """Renders a section heading, inherits info, and all options."""
+  lines = [f"## {section.heading}"]
+  if section.anchor:
+    lines[0] = f'## {section.heading} {{#{section.anchor}}}'
+
+  if section.inherits_html:
+    inherits_md = re.sub(
+        r'<a\s+href="([^"]*)">([^<]*)</a>',
+        lambda m: f"[{m.group(2)}]({m.group(1)})",
+        section.inherits_html,
+    )
+    inherits_md = re.sub(r'<[^>]+>', '', inherits_md).strip()
+    if inherits_md:
+      lines.append("")
+      lines.append(inherits_md)
+
+  for cat in section.categories:
+    lines.append("")
+    if cat.description:
+      lines.append(cat.description)
+    lines.append("")
+    for opt in cat.options:
+      lines.append(_render_option(opt))
+      lines.append("")
+
+  return "\n".join(lines)
+
+
+def convert(html_content):
+  """Converts command-line-reference HTML to MDX with ParamField components.
+
+  Args:
+    html_content: str; the full HTML content of command-line-reference.html.
+
+  Returns:
+    The MDX content with ParamField components.
+  """
+  parser = _CLRParser()
+  parser.feed(html_content)
+  parser.close()
+
+  parts = []
+
+  parts.append(_render_commands_table(parser.commands_table_rows))
+  parts.append("")
+
+  for section in parser.sections:
+    parts.append(_render_section(section))
+    parts.append("")
+
+  for tag_table in parser.tag_tables:
+    parts.append(_render_tag_table(tag_table))
+    parts.append("")
+
+  return "\n".join(parts)

--- a/scripts/docs/clr_converter_test.py
+++ b/scripts/docs/clr_converter_test.py
@@ -1,0 +1,229 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from scripts.docs import clr_converter
+
+
+def _read_data_file(basename):
+  path = os.path.join(
+      os.getenv("TEST_SRCDIR"),
+      os.getenv("TEST_WORKSPACE"),
+      "scripts/docs/testdata",
+      basename)
+  with open(path, "rt", encoding="utf-8") as f:
+    return f.read()
+
+
+class ConvertTest(unittest.TestCase):
+
+  def test_full_conversion(self):
+    html_content = _read_data_file("clr_input.html")
+    expected = _read_data_file("clr_expected.mdx")
+    actual = clr_converter.convert(html_content)
+    self.assertEqual(actual, expected)
+
+  def test_boolean_option(self):
+    html_input = """
+    <h2>Commands</h2>
+    <table></table>
+    <h2>Options</h2>
+    <dl>Category:
+    <dt id="opts-flag--batch"><code><a href="#opts-flag--batch">--[no]batch</a></code> default: "false"</dt>
+    <dd><p>Run in batch mode.</p></dd>
+    </dl>
+    """
+    result = clr_converter.convert(html_input)
+    self.assertIn('path="--[no]batch"', result)
+    self.assertIn('type="boolean"', result)
+    self.assertIn('default="false"', result)
+
+  def test_typed_option(self):
+    html_input = """
+    <h2>Commands</h2>
+    <table></table>
+    <h2>Options</h2>
+    <dl>Category:
+    <dt id="opts-flag--jobs"><code><a href="#opts-flag--jobs">--jobs</a>=&lt;an integer&gt;</code> default: "auto"</dt>
+    <dd><p>Number of jobs.</p></dd>
+    </dl>
+    """
+    result = clr_converter.convert(html_input)
+    self.assertIn('path="--jobs"', result)
+    self.assertIn('type="an integer"', result)
+    self.assertIn('default="auto"', result)
+
+  def test_void_expansion_option(self):
+    html_input = """
+    <h2>Commands</h2>
+    <table></table>
+    <h2>Options</h2>
+    <dl>Category:
+    <dt id="opts-flag--debug"><code><a href="#opts-flag--debug">--debug</a></code></dt>
+    <dd>
+    <p>Enable debug mode.</p>
+    <p>Expands to:
+    <br/>&nbsp;&nbsp;<code><a href="#flag--verbose">--verbose</a></code>
+    </p></dd>
+    </dl>
+    """
+    result = clr_converter.convert(html_input)
+    self.assertIn('type="void"', result)
+    self.assertIn("Expands to:", result)
+    self.assertIn("`--verbose`", result)
+    self.assertNotIn("default=", result)
+
+  def test_allow_multiple_option(self):
+    html_input = """
+    <h2>Commands</h2>
+    <table></table>
+    <h2>Options</h2>
+    <dl>Category:
+    <dt id="opts-flag--rc"><code><a href="#opts-flag--rc">--rc</a>=&lt;path&gt;</code> multiple uses are accumulated</dt>
+    <dd><p>RC file location.</p></dd>
+    </dl>
+    """
+    result = clr_converter.convert(html_input)
+    self.assertIn("May be used multiple times", result)
+    self.assertNotIn("default=", result)
+
+  def test_deprecated_option(self):
+    html_input = """
+    <h2>Commands</h2>
+    <table></table>
+    <h2>Options</h2>
+    <dl>Category:
+    <dt id="opts-flag--old"><code><a href="#opts-flag--old">--[no]old</a></code> default: "false"</dt>
+    <dd><p>Old flag.</p>
+    <p>Tags:
+    <a href="#metadata_tag_DEPRECATED"><code>deprecated</code></a>
+    </p></dd>
+    </dl>
+    """
+    result = clr_converter.convert(html_input)
+    self.assertIn("deprecated", result)
+
+  def test_abbreviation(self):
+    html_input = """
+    <h2>Commands</h2>
+    <table></table>
+    <h2>Options</h2>
+    <dl>Category:
+    <dt id="opts-flag--jobs"><code><a href="#opts-flag--jobs">--jobs</a>=&lt;an integer&gt;</code> [<code>-j</code>] default: "8"</dt>
+    <dd><p>Number of jobs.</p></dd>
+    </dl>
+    """
+    result = clr_converter.convert(html_input)
+    self.assertIn("Short form: `-j`", result)
+
+  def test_inherits_from(self):
+    html_input = """
+    <h2>Commands</h2>
+    <table></table>
+    <h2><a name="build">Build Options</a></h2>
+    <p>Inherits all options from <a href="#common">common</a> and <a href="#test">test</a>.</p>
+    <dl>Cat:
+    <dt id="build-flag--f"><code><a href="#build-flag--f">--[no]f</a></code> default: "true"</dt>
+    <dd><p>A flag.</p></dd>
+    </dl>
+    """
+    result = clr_converter.convert(html_input)
+    self.assertIn("Inherits all options from [common](#common) and [test](#test)", result)
+    self.assertIn("{#build}", result)
+
+  def test_enum_type_escaping(self):
+    html_input = """
+    <h2>Commands</h2>
+    <table></table>
+    <h2>Options</h2>
+    <dl>Category:
+    <dt id="opts-flag--level"><code><a href="#opts-flag--level">--level</a>={0,1,2}</code> default: "0"</dt>
+    <dd><p>Set level.</p></dd>
+    </dl>
+    """
+    result = clr_converter.convert(html_input)
+    self.assertIn("&lcub;0,1,2&rcub;", result)
+
+  def test_quotes_in_type_description(self):
+    html_input = """
+    <h2>Commands</h2>
+    <table></table>
+    <h2>Options</h2>
+    <dl>Category:
+    <dt id="opts-flag--jobs"><code><a href="#opts-flag--jobs">--jobs</a>=&lt;an integer, or a keyword ("auto", "HOST_CPUS")&gt;</code> default: "auto"</dt>
+    <dd><p>Number of jobs.</p></dd>
+    </dl>
+    """
+    result = clr_converter.convert(html_input)
+    self.assertNotIn('("auto"', result)
+    self.assertIn("&quot;auto&quot;", result)
+
+  def test_angle_brackets_in_type_description(self):
+    html_input = """
+    <h2>Commands</h2>
+    <table></table>
+    <h2>Options</h2>
+    <dl>Category:
+    <dt id="opts-flag--mem"><code><a href="#opts-flag--mem">--mem</a>=&lt;an integer or "HOST_RAM", followed by [-|*]&lt;float&gt;&gt;</code> default: "0"</dt>
+    <dd><p>Memory limit.</p></dd>
+    </dl>
+    """
+    result = clr_converter.convert(html_input)
+    for line in result.split("\n"):
+      if "<ParamField" in line:
+        self.assertNotIn('*]<float', line)
+        self.assertIn("&lt;float&gt;", line)
+        break
+
+  def test_commands_table(self):
+    html_input = """
+    <h2>Commands</h2>
+    <table>
+    <tr>
+      <td><a href="#build"><code>build</code></a></td>
+      <td>Build targets.</td>
+    </tr>
+    </table>
+    <h2>Options</h2>
+    <dl>Cat:
+    <dt id="f"><code><a href="#f">--[no]f</a></code> default: "true"</dt>
+    <dd><p>Flag.</p></dd>
+    </dl>
+    """
+    result = clr_converter.convert(html_input)
+    self.assertIn("## Commands", result)
+    self.assertIn("[`build`](#build)", result)
+    self.assertIn("Build targets.", result)
+
+  def test_tag_tables(self):
+    html_input = """
+    <h2>Commands</h2>
+    <table></table>
+    <h3>Option Effect Tags</h3>
+    <table>
+    <tr>
+    <td id="effect_tag_FOO"><code>foo</code></td>
+    <td>Foo description.</td>
+    </tr>
+    </table>
+    """
+    result = clr_converter.convert(html_input)
+    self.assertIn("### Option Effect Tags", result)
+    self.assertIn('<span id="effect_tag_FOO">`foo`</span>', result)
+    self.assertIn("Foo description.", result)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/scripts/docs/docs2mdx.py
+++ b/scripts/docs/docs2mdx.py
@@ -22,6 +22,7 @@ import sys
 from absl import app
 from absl import flags
 import markdownify
+from scripts.docs import clr_converter
 
 
 FLAGS = flags.FLAGS
@@ -156,7 +157,13 @@ def _convert_file(src, dest):
 
 def _transform(path, content):
   content = _pre_markdown_transforms(content)
-  md = _html2md(content) if path.endswith(".html") else content
+  if path.endswith(".html"):
+    if os.path.basename(path) == "command-line-reference.html":
+      md = clr_converter.convert(content)
+    else:
+      md = _html2md(content)
+  else:
+    md = content
   return _post_markdown_transforms(md)
 
 

--- a/scripts/docs/testdata/clr_expected.mdx
+++ b/scripts/docs/testdata/clr_expected.mdx
@@ -1,0 +1,89 @@
+## Commands
+
+| | |
+| --- | --- |
+| [`build`](#build) | Builds the specified targets. |
+| [`test`](#test) | Builds and runs the specified test targets. |
+
+## Startup Options
+
+Options that appear before the command and are parsed by the client
+
+<ParamField path="--[no]batch" type="boolean" default="false" deprecated>
+  If set, Bazel will be run as just a client process without a server.
+
+  Tags: [`loses_incremental_state`](#effect_tag_LOSES_INCREMENTAL_STATE), [`deprecated`](#metadata_tag_DEPRECATED)
+</ParamField>
+
+<ParamField path="--connect_timeout_secs" type="an integer" default="30">
+  The amount of time the client waits for each attempt to connect to the server
+
+  Tags: [`bazel_internal_configuration`](#effect_tag_BAZEL_INTERNAL_CONFIGURATION)
+</ParamField>
+
+<ParamField path="--bazelrc" type="path">
+  The location of the user .bazelrc file.
+
+  *May be used multiple times; values are accumulated.*
+
+  Tags: [`changes_inputs`](#effect_tag_CHANGES_INPUTS)
+</ParamField>
+
+<ParamField path="--host_jvm_debug" type="void">
+  Convenience option to add some additional JVM startup flags.
+
+  Expands to:
+  - `--host_jvm_args=-agentlib:jdwp=transport=dt_socket,server=y,address=5005`
+</ParamField>
+
+<ParamField path="--digest_function" type="hash function" default="see description">
+  The hash function to use when computing file digests.
+
+  Tags: [`loses_incremental_state`](#effect_tag_LOSES_INCREMENTAL_STATE)
+</ParamField>
+
+<ParamField path="--io_nice_level" type="&lcub;-1,0,1,2,3,4,5,6,7&rcub;" default="-1">
+  Only on Linux; set a level from 0-7 for best-effort IO scheduling.
+
+  Tags: [`host_machine_resource_optimizations`](#effect_tag_HOST_MACHINE_RESOURCE_OPTIMIZATIONS)
+</ParamField>
+
+
+## Options Common to all Commands {#common_options}
+
+Verbosity options
+
+<ParamField path="--[no]verbose" type="boolean" default="false">
+  If true, enable verbose output.
+
+  Tags: [`affects_outputs`](#effect_tag_AFFECTS_OUTPUTS)
+</ParamField>
+
+
+## Build Options {#build}
+
+Inherits all options from [common_options](#common_options).
+
+Build-specific options
+
+<ParamField path="--jobs" type="an integer" default="auto">
+  Short form: `-j`
+
+  The number of concurrent jobs to run. Takes an integer, or "auto".
+
+  Tags: [`execution`](#effect_tag_EXECUTION)
+</ParamField>
+
+
+### Option Effect Tags
+
+| | |
+| --- | --- |
+| <span id="effect_tag_LOSES_INCREMENTAL_STATE">`loses_incremental_state`</span> | This option affects the incremental state. |
+| <span id="effect_tag_AFFECTS_OUTPUTS">`affects_outputs`</span> | This option affects the outputs. |
+
+### Option Metadata Tags
+
+| | |
+| --- | --- |
+| <span id="metadata_tag_DEPRECATED">`deprecated`</span> | This option is deprecated. |

--- a/scripts/docs/testdata/clr_input.html
+++ b/scripts/docs/testdata/clr_input.html
@@ -1,0 +1,115 @@
+<html devsite>
+<head>
+  <meta name="project_path" value="/_project.yaml">
+  <meta name="book_path" value="/_book.yaml">
+</head>
+<body>
+
+<h1 class="page-title">Command-Line Reference</h1>
+
+<pre>
+bazel [&lt;startup options&gt;] &lt;command&gt; [&lt;args&gt;]
+</pre>
+
+<h2>Option Syntax</h2>
+
+<p>
+Options can be passed to Bazel in different ways.
+</p>
+
+<h2>Commands</h2>
+<table>
+<tr>
+  <td><a href="#build"><code>build</code></a></td>
+  <td>Builds the specified targets.</td>
+</tr>
+<tr>
+  <td><a href="#test"><code>test</code></a></td>
+  <td>Builds and runs the specified test targets.</td>
+</tr>
+</table>
+
+<h2>Startup Options</h2>
+<dl>Options that appear before the command and are parsed by the client:
+<dt id="startup_options-flag--batch"><code id="batch"><a href="#startup_options-flag--batch">--[no]batch</a></code> default: "false"</dt>
+<dd>
+<p>If set, Bazel will be run as just a client process without a server.</p>
+<p>Tags:
+<a href="#effect_tag_LOSES_INCREMENTAL_STATE"><code>loses_incremental_state</code></a>, <a href="#metadata_tag_DEPRECATED"><code>deprecated</code></a>
+</p></dd>
+<dt id="startup_options-flag--connect_timeout_secs"><code id="connect_timeout_secs"><a href="#startup_options-flag--connect_timeout_secs">--connect_timeout_secs</a>=&lt;an integer&gt;</code> default: "30"</dt>
+<dd>
+<p>The amount of time the client waits for each attempt to connect to the server</p>
+<p>Tags:
+<a href="#effect_tag_BAZEL_INTERNAL_CONFIGURATION"><code>bazel_internal_configuration</code></a>
+</p></dd>
+<dt id="startup_options-flag--bazelrc"><code id="bazelrc"><a href="#startup_options-flag--bazelrc">--bazelrc</a>=&lt;path&gt;</code> multiple uses are accumulated</dt>
+<dd>
+<p>The location of the user .bazelrc file.</p>
+<p>Tags:
+<a href="#effect_tag_CHANGES_INPUTS"><code>changes_inputs</code></a>
+</p></dd>
+<dt id="startup_options-flag--host_jvm_debug"><code id="host_jvm_debug"><a href="#startup_options-flag--host_jvm_debug">--host_jvm_debug</a></code></dt>
+<dd>
+<p>Convenience option to add some additional JVM startup flags.</p>
+<p>Expands to:
+<br/>&nbsp;&nbsp;<code><a href="#flag--host_jvm_args">--host_jvm_args=-agentlib:jdwp=transport=dt_socket,server=y,address=5005</a></code>
+</p></dd>
+<dt id="startup_options-flag--digest_function"><code id="digest_function"><a href="#startup_options-flag--digest_function">--digest_function</a>=&lt;hash function&gt;</code> default: see description</dt>
+<dd>
+<p>The hash function to use when computing file digests.</p>
+<p>Tags:
+<a href="#effect_tag_LOSES_INCREMENTAL_STATE"><code>loses_incremental_state</code></a>
+</p></dd>
+<dt id="startup_options-flag--io_nice_level"><code id="io_nice_level"><a href="#startup_options-flag--io_nice_level">--io_nice_level</a>={-1,0,1,2,3,4,5,6,7}</code> default: "-1"</dt>
+<dd>
+<p>Only on Linux; set a level from 0-7 for best-effort IO scheduling.</p>
+<p>Tags:
+<a href="#effect_tag_HOST_MACHINE_RESOURCE_OPTIMIZATIONS"><code>host_machine_resource_optimizations</code></a>
+</p></dd>
+</dl>
+
+<h2><a name="common_options">Options Common to all Commands</a></h2>
+<dl>Verbosity options:
+<dt id="common_options-flag--verbose"><code id="verbose"><a href="#common_options-flag--verbose">--[no]verbose</a></code> default: "false"</dt>
+<dd>
+<p>If true, enable verbose output.</p>
+<p>Tags:
+<a href="#effect_tag_AFFECTS_OUTPUTS"><code>affects_outputs</code></a>
+</p></dd>
+</dl>
+
+<h2><a name="build">Build Options</a></h2>
+<p>Inherits all options from <a href="#common_options">common_options</a>.</p>
+
+<dl>Build-specific options:
+<dt id="build-flag--jobs"><code id="jobs"><a href="#build-flag--jobs">--jobs</a>=&lt;an integer&gt;</code> [<code>-j</code>] default: "auto"</dt>
+<dd>
+<p>The number of concurrent jobs to run. Takes an integer, or "auto".</p>
+<p>Tags:
+<a href="#effect_tag_EXECUTION"><code>execution</code></a>
+</p></dd>
+</dl>
+
+<h3>Option Effect Tags</h3>
+<table>
+<tr>
+<td id="effect_tag_LOSES_INCREMENTAL_STATE"><code>loses_incremental_state</code></td>
+<td>This option affects the incremental state.</td>
+</tr>
+<tr>
+<td id="effect_tag_AFFECTS_OUTPUTS"><code>affects_outputs</code></td>
+<td>This option affects the outputs.</td>
+</tr>
+</table>
+
+<h3>Option Metadata Tags</h3>
+<table>
+<tr>
+<td id="metadata_tag_DEPRECATED"><code>deprecated</code></td>
+<td>This option is deprecated.</td>
+</tr>
+</table>
+
+</body>
+</html>

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -291,7 +291,7 @@ public abstract class RepositoryOptions extends OptionsBase {
           This file consists of directives, one per line, that adjust how the
           Bazel downloader acts. The directives are: `allow`, `block`, `rewrite`,
           and `all_blocked_message`. The directives are applied in the order
-          `rewrite, allow, block'.
+          `rewrite, allow, block`.
 
           Comments are allowed and must be on their own line (no trailing comments)
           and preceded by a `#`. Example: `# evil.com is known to host malicious code`


### PR DESCRIPTION
Special-cases the command line reference conversion so the generated MDX is formatted in a usable way. Since the HTML is rather rigid and predictable, this is sufficient for the initial migration away from DevSite.

Eventually, the command line reference should be generated externally from e.g. proto so the generation mechanism is not tied to the bazel version.

RELNOTES: None
