### PR TITLE
Escape darwin-sandbox profile path strings

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
@@ -20,6 +20,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.escape.CharEscaperBuilder;
+import com.google.common.escape.Escaper;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -55,6 +57,9 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
   /** Path to the {@code sandbox-exec} system tool to use. */
   @VisibleForTesting
   static String sandboxExecBinary = "/usr/bin/sandbox-exec";
+
+  private static final Escaper SANDBOX_PROFILE_STRING_ESCAPER =
+      new CharEscaperBuilder().addEscape('\\', "\\\\").addEscape('"', "\\\"").toEscaper();
 
   // Since checking if sandbox is supported is expensive, we remember what we've checked.
   private static Boolean isSupported = null;
@@ -284,10 +289,10 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
       out.println("(allow file-write*");
       for (Path path : writableDirs) {
-        out.println("    (subpath \"" + path.getPathString() + "\")");
+        out.println("    (subpath \"" + sandboxProfileString(path) + "\")");
       }
       if (statisticsPath != null) {
-        out.println("    (literal \"" + statisticsPath.getPathString() + "\")");
+        out.println("    (literal \"" + sandboxProfileString(statisticsPath) + "\")");
       }
       out.println(")");
 
@@ -296,11 +301,15 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
         // The sandbox configuration file is not part of a cache key and sandbox-exec doesn't care
         // about ordering of paths in expressions, so it's fine if the iteration order is random.
         for (Path inaccessiblePath : inaccessiblePaths) {
-          out.println("    (subpath \"" + inaccessiblePath + "\")");
+          out.println("    (subpath \"" + sandboxProfileString(inaccessiblePath) + "\")");
         }
         out.println(")");
       }
     }
+  }
+
+  private static String sandboxProfileString(Path path) {
+    return SANDBOX_PROFILE_STRING_ESCAPER.escape(path.getPathString());
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunnerTest.java
@@ -59,6 +59,9 @@ public final class DarwinSandboxedSpawnRunnerTest extends SandboxedSpawnRunnerTe
   /** Path to the base of the sandbox to pass to the spawn runner. */
   private Path sandboxBase;
 
+  /** Copy of the most recent generated sandbox profile passed to the mock {@code sandbox-exec}. */
+  private Path lastSandboxProfile;
+
   /** Location of the real {@code sandbox-exec} binary; saved while the test is running. */
   private String oldSandboxExec;
 
@@ -76,13 +79,19 @@ public final class DarwinSandboxedSpawnRunnerTest extends SandboxedSpawnRunnerTe
     sandboxBase = execRoot.getRelative("sandbox");
     sandboxBase.createDirectory();
 
-    // The mock sandbox-exec just executes the given command and returns its output.
+    lastSandboxProfile = execRoot.getRelative("last-sandbox-profile.sb");
+
+    // The mock sandbox-exec captures the generated profile and then executes the given command.
     Path sandboxExec = execRoot.getRelative("sandbox-exec");
-    FileSystemUtils.writeContentAsLatin1(sandboxExec,
+    FileSystemUtils.writeContentAsLatin1(
+        sandboxExec,
         "#!/bin/sh\n"
-        + "shift\n"  // Skip -f flag.
-        + "shift\n"  // Skip target of -f flag.
-        + "exec \"$@\"\n");  // Remaining arguments are the process-wrapper's ones.
+            + "cp \"$2\" '"
+            + lastSandboxProfile.getPathString()
+            + "'\n"
+            + "shift\n" // Skip -f flag.
+            + "shift\n" // Skip target of -f flag.
+            + "exec \"$@\"\n"); // Remaining arguments are the process-wrapper's ones.
     sandboxExec.setExecutable(true);
     oldSandboxExec = DarwinSandboxedSpawnRunner.sandboxExecBinary;
     DarwinSandboxedSpawnRunner.sandboxExecBinary = sandboxExec.toString();
@@ -141,5 +150,26 @@ public final class DarwinSandboxedSpawnRunnerTest extends SandboxedSpawnRunnerTe
           .asList()
           .containsExactly("--foo", "--bar");
     }
+  }
+
+  @Test
+  public void testSandboxProfileEscapesWritablePathStrings() throws Exception {
+    DarwinSandboxedSpawnRunner runner =
+        new DarwinSandboxedSpawnRunner(commandEnvironment, sandboxBase, treeDeleter);
+    Spawn spawn =
+        new SpawnBuilder("/bin/sh", "-c", "exit 0")
+            .withEnvironment("TEST_TMPDIR", "foo\\bar\") (regex \".*")
+            .build();
+    FileOutErr fileOutErr =
+        new FileOutErr(testRoot.getChild("stdout"), testRoot.getChild("stderr"));
+    SpawnExecutionContextForTesting policy =
+        new SpawnExecutionContextForTesting(spawn, fileOutErr, Duration.ofMinutes(1));
+
+    SpawnResult spawnResult = runner.exec(spawn, policy);
+
+    assertThat(spawnResult.status()).isEqualTo(Status.SUCCESS);
+    String sandboxProfile = FileSystemUtils.readContent(lastSandboxProfile, StandardCharsets.UTF_8);
+    assertThat(sandboxProfile).doesNotContain("(regex \".*\")");
+    assertThat(sandboxProfile).contains("foo\\\\bar\\\") (regex \\\".*");
   }
 }


### PR DESCRIPTION
Fixes #29427.

This escapes backslashes and double quotes before writing filesystem paths into generated `darwin-sandbox` profile string literals. Without escaping, writable path data can terminate a `(subpath "...")` literal and inject additional sandbox policy forms.

The change applies the escaping to writable paths, inaccessible paths, and the process-wrapper statistics path.

Tests added:
- `DarwinSandboxedSpawnRunnerTest#testSandboxProfileEscapesWritablePathStrings` verifies that a writable path containing backslashes and a `") (regex ".*` payload is emitted as escaped string data instead of additional sandbox policy.