### PR TITLE
Add //tools:tools_for_bazel_subcommands filegroup to vendor mod tidy deps

### DIFF
--- a/site/en/external/vendor.md
+++ b/site/en/external/vendor.md
@@ -104,6 +104,22 @@ Note that vendoring all dependencies has a few **disadvantages**:
 
 Therefore, consider vendoring for specific targets first.
 
+### Vendor tools for Bazel subcommands {:#vendor-tools-for-subcommands}
+
+Some Bazel subcommands (such as `bazel mod tidy`) have implicit tool
+dependencies that are not reachable from user build targets, so they are
+**not** included by `bazel vendor //...`. To vendor those tools as well, add
+the `@bazel_tools//tools:tools_for_bazel_subcommands` filegroup to your
+vendor invocation:
+
+```none
+bazel vendor //... @bazel_tools//tools:tools_for_bazel_subcommands
+```
+
+This is required if you plan to run commands like `bazel mod tidy` in an
+offline/hermetic environment (for example with `--vendor_dir` and
+`--nofetch`).
+
 ## Configure vendor mode with VENDOR.bazel {:#configure-vendor-mode}
 
 You can control how given repos are handled with the VENDOR.bazel file located

--- a/src/test/py/bazel/bzlmod/bazel_vendor_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_vendor_test.py
@@ -873,6 +873,67 @@ class BazelVendorTest(test_base.TestBase):
     # Regression test for https://github.com/bazelbuild/bazel/issues/23300
     self.RunBazel(['vendor', '//foo/...', '--vendor_dir=vendor'])
 
+  def testVendorToolsForBazelSubcommands(self):
+    # Regression test for https://github.com/bazelbuild/bazel/issues/29222:
+    # `bazel vendor //...` alone doesn't pull in tools needed by Bazel
+    # subcommands (e.g. buildozer for `bazel mod tidy`). Users must explicitly
+    # vendor @bazel_tools//tools:tools_for_bazel_subcommands for those
+    # subcommands to work under `--nofetch`.
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'ext = use_extension("//:extension.bzl", "ext")',
+            'use_repo(ext, "dep", "indirect_dep")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def _repo_impl(ctx):',
+            '    ctx.file("WORKSPACE")',
+            '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
+            'repo_rule = repository_rule(implementation=_repo_impl)',
+            '',
+            'def _ext_impl(ctx):',
+            '    repo_rule(name="dep")',
+            '    repo_rule(name="missing_dep")',
+            '    repo_rule(name="indirect_dep")',
+            '    return ctx.extension_metadata(',
+            '        root_module_direct_deps=["dep", "missing_dep"],',
+            '        root_module_direct_dev_deps=[],',
+            '    )',
+            '',
+            'ext = module_extension(implementation=_ext_impl)',
+        ],
+    )
+
+    # Vendor the main target set plus the tools filegroup so that
+    # `bazel mod tidy` (which invokes buildozer) can run offline.
+    self.RunBazel([
+        'vendor',
+        '--vendor_dir=vendor',
+        '//...',
+        '@bazel_tools//tools:tools_for_bazel_subcommands',
+    ])
+
+    # Run `bazel mod tidy` under `--nofetch`. Without the filegroup being
+    # vendored above, this would fail because buildozer can't be fetched.
+    self.RunBazel([
+        'mod',
+        'tidy',
+        '--vendor_dir=vendor',
+        '--nofetch',
+    ])
+
+    # Verify that mod tidy actually rewrote MODULE.bazel based on the
+    # extension's root_module_direct_deps metadata.
+    with open(self.Path('MODULE.bazel'), 'r', encoding='utf-8') as f:
+      contents = f.read()
+    self.assertIn('"dep"', contents)
+    self.assertIn('"missing_dep"', contents)
+    self.assertNotIn('"indirect_dep"', contents)
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/src/test/shell/bazel/bazel_tools_test.sh
+++ b/src/test/shell/bazel/bazel_tools_test.sh
@@ -39,4 +39,19 @@ function test_bzl_srcs() {
   done
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/29222
+# The filegroup @bazel_tools//tools:tools_for_bazel_subcommands must exist so
+# that users who run Bazel offline (e.g. with --vendor_dir and --nofetch) can
+# add it to `bazel vendor` to pick up implicit tool dependencies of Bazel
+# subcommands like `bazel mod tidy` (which needs buildozer).
+function test_tools_for_bazel_subcommands() {
+  local deps
+  deps=$(bazel query 'deps(@bazel_tools//tools:tools_for_bazel_subcommands)') \
+    || fail "expected target @bazel_tools//tools:tools_for_bazel_subcommands to exist"
+  # buildozer is required by `bazel mod tidy` (see BazelModTidyFunction).
+  if ! [[ "$deps" == *"buildozer"* ]]; then
+    fail "expected buildozer in deps of @bazel_tools//tools:tools_for_bazel_subcommands; got: $deps"
+  fi
+}
+
 run_suite "bazel_tools test suite"

--- a/src/test/shell/bazel/bazel_tools_test.sh
+++ b/src/test/shell/bazel/bazel_tools_test.sh
@@ -39,29 +39,4 @@ function test_bzl_srcs() {
   done
 }
 
-# Regression test for https://github.com/bazelbuild/bazel/issues/29222
-# The filegroup @bazel_tools//tools:tools_for_bazel_subcommands must exist so
-# that users who run Bazel offline (e.g. with --vendor_dir and --nofetch) can
-# add it to `bazel vendor` to pick up implicit tool dependencies of Bazel
-# subcommands like `bazel mod tidy` (which needs buildozer).
-function test_tools_for_bazel_subcommands() {
-  # 1. The target must exist and be a filegroup.
-  local kind
-  kind=$(bazel query 'kind(".*", @bazel_tools//tools:tools_for_bazel_subcommands)') \
-    || fail "expected target @bazel_tools//tools:tools_for_bazel_subcommands to exist"
-  if ! [[ "$kind" == *"filegroup rule"* ]]; then
-    fail "expected @bazel_tools//tools:tools_for_bazel_subcommands to be a filegroup; got: $kind"
-  fi
-
-  # 2. buildozer must be reachable via the filegroup so that `bazel vendor`
-  #    will pick it up. buildozer is required by `bazel mod tidy`
-  #    (see BazelModTidyFunction).
-  local deps
-  deps=$(bazel query 'deps(@bazel_tools//tools:tools_for_bazel_subcommands)') \
-    || fail "failed to query deps of @bazel_tools//tools:tools_for_bazel_subcommands"
-  if ! [[ "$deps" == *"buildozer"* ]]; then
-    fail "expected buildozer in deps of @bazel_tools//tools:tools_for_bazel_subcommands; got: $deps"
-  fi
-}
-
 run_suite "bazel_tools test suite"

--- a/src/test/shell/bazel/bazel_tools_test.sh
+++ b/src/test/shell/bazel/bazel_tools_test.sh
@@ -45,10 +45,20 @@ function test_bzl_srcs() {
 # add it to `bazel vendor` to pick up implicit tool dependencies of Bazel
 # subcommands like `bazel mod tidy` (which needs buildozer).
 function test_tools_for_bazel_subcommands() {
+  # 1. The target must exist and be a filegroup.
+  local kind
+  kind=$(bazel query 'kind(".*", @bazel_tools//tools:tools_for_bazel_subcommands)') \
+    || fail "expected target @bazel_tools//tools:tools_for_bazel_subcommands to exist"
+  if ! [[ "$kind" == *"filegroup rule"* ]]; then
+    fail "expected @bazel_tools//tools:tools_for_bazel_subcommands to be a filegroup; got: $kind"
+  fi
+
+  # 2. buildozer must be reachable via the filegroup so that `bazel vendor`
+  #    will pick it up. buildozer is required by `bazel mod tidy`
+  #    (see BazelModTidyFunction).
   local deps
   deps=$(bazel query 'deps(@bazel_tools//tools:tools_for_bazel_subcommands)') \
-    || fail "expected target @bazel_tools//tools:tools_for_bazel_subcommands to exist"
-  # buildozer is required by `bazel mod tidy` (see BazelModTidyFunction).
+    || fail "failed to query deps of @bazel_tools//tools:tools_for_bazel_subcommands"
   if ! [[ "$deps" == *"buildozer"* ]]; then
     fail "expected buildozer in deps of @bazel_tools//tools:tools_for_bazel_subcommands; got: $deps"
   fi

--- a/tools/BUILD.tools
+++ b/tools/BUILD.tools
@@ -41,7 +41,9 @@ filegroup(
 filegroup(
     name = "tools_for_bazel_subcommands",
     srcs = [
-        # Required by `bazel mod tidy` (see BazelModTidyFunction).
+        # Required by `bazel mod tidy`. Keep in sync with the label resolved
+        # in src/main/java/com/google/devtools/build/lib/bazel/bzlmod/
+        # BazelModTidyFunction.java (search for "buildozer.exe").
         "@buildozer_binary//:buildozer.exe",
     ],
 )

--- a/tools/BUILD.tools
+++ b/tools/BUILD.tools
@@ -29,3 +29,19 @@ filegroup(
         "//tools/test:bzl_srcs",
     ],
 )
+
+# Tools that Bazel subcommands (e.g. `bazel mod tidy`) depend on implicitly,
+# but that aren't in the transitive closure of user build targets. Users who
+# need to run these subcommands offline (e.g. with `--vendor_dir` and
+# `--nofetch`) should include this target in their `bazel vendor` invocation:
+#
+#   bazel vendor //... @bazel_tools//tools:tools_for_bazel_subcommands
+#
+# See https://github.com/bazelbuild/bazel/issues/29222.
+filegroup(
+    name = "tools_for_bazel_subcommands",
+    srcs = [
+        # Required by `bazel mod tidy` (see BazelModTidyFunction).
+        "@buildozer_binary//:buildozer.exe",
+    ],
+)


### PR DESCRIPTION
## Problem

`bazel vendor //...` does not vendor the implicit `@buildozer_binary` dependency of `bazel mod tidy`, so a subsequent `bazel mod tidy` run with `--vendor_dir` and `--nofetch` fails with:

```
ERROR: no such package '@@buildozer++buildozer_binary+buildozer_binary//':
no such package '@@buildozer+//': Vendored repository buildozer+ not found
under the vendor directory and fetching is disabled.
```

Users currently have to discover and pass the undiscoverable incantation `--repo=@@buildozer+ --repo=@@buildozer++buildozer_binary+buildozer_binary`.

See #29222 for the full discussion. @fmeum proposed the fix adopted here:

> We could add a target under `bazel_tools` that groups all such tools and that you could add to your vendor pattern list for this purpose.

The reporter confirmed this approach works for their use case.

## Fix

Add a new public filegroup `@bazel_tools//tools:tools_for_bazel_subcommands` that groups implicit tool dependencies of Bazel subcommands. Today it contains just `@buildozer_binary//:buildozer.exe` (required by `bazel mod tidy`); future subcommands that introduce implicit tool deps can be added here.

Users who run Bazel offline with `--vendor_dir` and `--nofetch` can opt in by including the target in their vendor invocation:

```
bazel vendor //... @bazel_tools//tools:tools_for_bazel_subcommands
```

This preserves the current behavior for users who don't run `bazel mod tidy` (no silent expansion of the transitive closure) while giving those who do run it a single, documented target to add to their vendor pattern.

## Testing

Added `test_tools_for_bazel_subcommands` in `src/test/shell/bazel/bazel_tools_test.sh` that queries the new filegroup and asserts buildozer is in its transitive dependencies.

## Release notes

```
Add `@bazel_tools//tools:tools_for_bazel_subcommands` filegroup that groups implicit tool dependencies of Bazel subcommands (e.g. buildozer for `bazel mod tidy`). Add this target to `bazel vendor` when working offline.
```

Fixes #29222