### PR TITLE
Update starlark type system issue reference

### DIFF
--- a/docs/rules/language.mdx
+++ b/docs/rules/language.mdx
@@ -55,7 +55,7 @@ Starlark in Bazel at HEAD is incrementally adding support for type annotations
 with a syntax inspired by [PEP 484](https://peps.python.org/pep-0484/).
 
 - Starlark type annotations are under active development. The progress is
-  tracked on [issue#22935](https://github.com/bazelbuild/bazel/issues/22935).
+  tracked on [issue#27370](https://github.com/bazelbuild/bazel/issues/27370).
 - The specification is incrementally extended: [starlark-with-types/spec.md](https://github.com/bazelbuild/starlark/blob/starlark-with-types/spec.md)
 - Initial proposal: [SEP-001 Bootstrapping Starlark types](https://docs.google.com/document/d/1Sid7EAbBd_w_T7D94Li_f_bK3zMTztFbzIMvcpzo1wY/edit?tab=t.0#heading=h.5mcn15i0e1ch)
 


### PR DESCRIPTION
Point to https://github.com/bazelbuild/bazel/issues/27370, which has superseded https://github.com/bazelbuild/bazel/issues/22935.

RELNOTES: None