### PR TITLE
Add `add_prefix` attribute to `git_repository`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
@@ -76,6 +76,11 @@ public class GitRepoSpecBuilder {
   }
 
   @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setAddPrefix(String addPrefix) {
+    return setAttr("add_prefix", addPrefix);
+  }
+
+  @CanIgnoreReturnValue
   public GitRepoSpecBuilder setRemotePatches(ImmutableMap<String, String> remotePatches) {
     return setAttr("remote_patches", remotePatches);
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -293,6 +293,7 @@ public class IndexRegistry implements Registry {
     Map<String, String> patches;
     int patchStrip;
     String stripPrefix;
+    String addPrefix;
   }
 
   /**
@@ -583,6 +584,7 @@ public class IndexRegistry implements Registry {
         .setInitSubmodules(sourceJson.initSubmodules)
         .setVerbose(sourceJson.verbose)
         .setStripPrefix(sourceJson.stripPrefix)
+        .setAddPrefix(sourceJson.addPrefix)
         .setRemoteModuleFile(
             new RemoteFile(
                 moduleFileChecksum.toSubresourceIntegrity(), ImmutableList.of(moduleFileUrl)))

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -337,7 +337,8 @@ public class IndexRegistryTest extends FoundationTestCase {
             "patches": {
                 "foo.patch": "sha256-totallyarealhash"
             },
-            "patch_strip": 1
+            "patch_strip": 1,
+            "add_prefix": "addedSubfolder"
         }
         """);
     server.serve("/modules/foo/1.0/MODULE.bazel", "module(name = \"foo\", version = \"1.0\")");
@@ -374,6 +375,7 @@ public class IndexRegistryTest extends FoundationTestCase {
                         server.getUrl() + "/modules/foo/1.0/patches/foo.patch",
                         "sha256-totallyarealhash"))
                 .setRemotePatchStrip(1)
+                .setAddPrefix("addedSubfolder")
                 .build());
   }
 

--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -116,9 +116,9 @@ function do_git_repository_test() {
   local shallow_since=""
   local add_prefix=""
   local add_prefix_path=""
-  [ $# -ge 2 ] && [ -n ${2:-} ] && strip_prefix="strip_prefix=\"$2\","
-  [ $# -ge 3 ] && [ -n ${3:-} ] && shallow_since="shallow_since=\"$3\","
-  [ $# -ge 4 ] && [ -n ${4:-} ] && add_prefix="add_prefix=\"$4\"," && add_prefix_path=$4
+  [ $# -ge 2 ] && [ -n "${2:-}" ] && strip_prefix="strip_prefix=\"$2\","
+  [ $# -ge 3 ] && [ -n "${3:-}" ] && shallow_since="shallow_since=\"$3\","
+  [ $# -ge 4 ] && [ -n "${4:-}" ] && add_prefix="add_prefix=\"$4\"," && add_prefix_path="${4}"
   # Create a workspace that clones the repository at the first commit.
   cat >> MODULE.bazel <<EOF
 git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
@@ -256,8 +256,8 @@ function do_git_repository_test_with_build() {
   local add_prefix=""
   local add_prefix_path=""
   local tag=""
-  [ $# -ge 3 ] && [ -n ${3:-} ] && strip_prefix="strip_prefix=\"$3\","
-  [ $# -ge 4 ] && [ -n ${4:-} ] && add_prefix="add_prefix=\"$4\"," && add_prefix_path="$4/"
+  [ $# -ge 3 ] && [ -n "${3:-}" ] && strip_prefix="strip_prefix=\"$3\","
+  [ $# -ge 4 ] && [ -n "${4:-}" ] && add_prefix="add_prefix=\"$4\"," && add_prefix_path="$4/"
   [ "$1" != "" ] && tag="tag = \"$1\","
 
   # Create a workspace that clones the repository at the first commit.

--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -116,9 +116,9 @@ function do_git_repository_test() {
   local shallow_since=""
   local add_prefix=""
   local add_prefix_path=""
-  [ $# -ge 2 ] && [ -n $2 ] && strip_prefix="strip_prefix=\"$2\","
-  [ $# -ge 3 ] && [ -n $3 ] && shallow_since="shallow_since=\"$3\","
-  [ $# -ge 4 ] && [ -n $4 ] && add_prefix="add_prefix=\"$4\"," && add_prefix_path=$4
+  [ $# -ge 2 ] && [ -n ${2:-} ] && strip_prefix="strip_prefix=\"$2\","
+  [ $# -ge 3 ] && [ -n ${3:-} ] && shallow_since="shallow_since=\"$3\","
+  [ $# -ge 4 ] && [ -n ${4:-} ] && add_prefix="add_prefix=\"$4\"," && add_prefix_path=$4
   # Create a workspace that clones the repository at the first commit.
   cat >> MODULE.bazel <<EOF
 git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
@@ -156,6 +156,20 @@ function test_git_repository() {
 
 function test_git_repository_add_prefix() {
   do_git_repository_test "52f9a3f87a2dd17ae0e5847bbae9734f09354afd" "" "" "add/a/prefix"
+}
+
+function test_git_repository_add_prefix_prevent_uproot() {
+      cat >> MODULE.bazel <<EOF
+git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+git_repository(
+    name = "pluto",
+    remote = "does-not-matter",
+    tag = "1-build",
+    add_prefix = "../uplevel/attempt",
+)
+EOF
+  bazel build @pluto >& $TEST_log && fail "Build succeeded"
+  expect_log "escaped the base directory"
 }
 
 function test_git_repository_strip_prefix() {
@@ -242,8 +256,8 @@ function do_git_repository_test_with_build() {
   local add_prefix=""
   local add_prefix_path=""
   local tag=""
-  [ $# -ge 3 ] && [ -n $3 ] && strip_prefix="strip_prefix=\"$3\","
-  [ $# -ge 4 ] && [ -n $4 ] && add_prefix="add_prefix=\"$4\"," && add_prefix_path="$4/"
+  [ $# -ge 3 ] && [ -n ${3:-} ] && strip_prefix="strip_prefix=\"$3\","
+  [ $# -ge 4 ] && [ -n ${4:-} ] && add_prefix="add_prefix=\"$4\"," && add_prefix_path="$4/"
   [ "$1" != "" ] && tag="tag = \"$1\","
 
   # Create a workspace that clones the repository at the first commit.

--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -114,8 +114,11 @@ function do_git_repository_test() {
   local commit_hash="$1"
   local strip_prefix=""
   local shallow_since=""
-  [ $# -eq 2 ] && strip_prefix="strip_prefix=\"$2\","
-  [ $# -eq 3 ] && shallow_since="shallow_since=\"$3\","
+  local add_prefix=""
+  local add_prefix_path=""
+  [ $# -ge 2 ] && [ -n $2 ] && strip_prefix="strip_prefix=\"$2\","
+  [ $# -ge 3 ] && [ -n $3 ] && shallow_since="shallow_since=\"$3\","
+  [ $# -ge 4 ] && [ -n $4 ] && add_prefix="add_prefix=\"$4\"," && add_prefix_path=$4
   # Create a workspace that clones the repository at the first commit.
   cat >> MODULE.bazel <<EOF
 git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
@@ -124,6 +127,7 @@ git_repository(
     remote = "$pluto_repo_dir",
     commit = "$commit_hash",
     $strip_prefix
+    $add_prefix
     $shallow_since
 )
 EOF
@@ -131,7 +135,7 @@ EOF
   cat > planets/BUILD <<EOF
 genrule(
     name = "planet-info",
-    srcs = ["@pluto//:pluto"],
+    srcs = ["@pluto//${add_prefix_path}:pluto"],
     outs = ["planet-info.txt"],
     cmd = "cp \$< \$@",
 )
@@ -142,12 +146,16 @@ EOF
   cat bazel-bin/planets/planet-info.txt > $TEST_log
   expect_log "Pluto is a dwarf planet"
 
-  git_repos_count=$(find $(bazel info output_base)/external/+git_repository+pluto -type d -name .git | wc -l)
-  assert_equals $git_repos_count 0
+  git_repos_count=$(find -L $(bazel info output_base)/external/+git_repository+pluto -type d -name .git | wc -l)
+  assert_equals 0 $git_repos_count
 }
 
 function test_git_repository() {
   do_git_repository_test "52f9a3f87a2dd17ae0e5847bbae9734f09354afd"
+}
+
+function test_git_repository_add_prefix() {
+  do_git_repository_test "52f9a3f87a2dd17ae0e5847bbae9734f09354afd" "" "" "add/a/prefix"
 }
 
 function test_git_repository_strip_prefix() {
@@ -156,11 +164,18 @@ function test_git_repository_strip_prefix() {
   do_git_repository_test "dbf9236251a9ea01b7a2eb563ca8e911060fc97c" "pluto"
 }
 
+function test_git_repository_add_and_strip_prefix() {
+  # Same as above, this commit has a 'pluto' subdirectory. The added prefix
+  # 'subfolder' is added, and the 'pluto' prefix is stripped.
+  do_git_repository_test "dbf9236251a9ea01b7a2eb563ca8e911060fc97c" "pluto" "" "subfolder"
+}
+
 function test_git_repository_shallow_since() {
     # This date is the previous day before the commit was made.
     # We need the revious day, because git adds current time to the specified date.
     do_git_repository_test "52f9a3f87a2dd17ae0e5847bbae9734f09354afd" "" "2015-07-15"
 }
+
 function test_git_repository_with_build_file() {
   do_git_repository_test_with_build "0-initial" "build_file"
 }
@@ -173,6 +188,10 @@ function test_git_repository_with_build_file_strip_prefix_default_branch() {
   do_git_repository_test_with_build "" "build_file" "pluto"
 }
 
+function test_git_repository_with_build_file_add_prefix() {
+  do_git_repository_test_with_build "0-initial" "build_file" "" "add/prefix"
+}
+
 function test_git_repository_with_build_file_content() {
   do_git_repository_test_with_build "0-initial" "build_file_content"
 }
@@ -183,6 +202,10 @@ function test_git_repository_with_build_file_content_strip_prefix() {
 
 function test_git_repository_with_build_file_content_strip_prefix_default_branch() {
   do_git_repository_test_with_build "" "build_file_content" "pluto"
+}
+
+function test_git_repository_with_build_file_content_add_prefix() {
+  do_git_repository_test_with_build "0-initial" "build_file_content" "" "add/prefix"
 }
 
 # Test cloning a Git repository using the git_repository rule with a BUILD file.
@@ -216,8 +239,11 @@ function test_git_repository_with_build_file_content_strip_prefix_default_branch
 function do_git_repository_test_with_build() {
   local pluto_repo_dir=$(get_pluto_repo)
   local strip_prefix=""
+  local add_prefix=""
+  local add_prefix_path=""
   local tag=""
-  [ $# -eq 3 ] && strip_prefix="strip_prefix=\"$3\","
+  [ $# -ge 3 ] && [ -n $3 ] && strip_prefix="strip_prefix=\"$3\","
+  [ $# -ge 4 ] && [ -n $4 ] && add_prefix="add_prefix=\"$4\"," && add_prefix_path="$4/"
   [ "$1" != "" ] && tag="tag = \"$1\","
 
   # Create a workspace that clones the repository at the first commit.
@@ -231,6 +257,7 @@ git_repository(
     $tag
     build_file = "//:pluto.BUILD",
     $strip_prefix
+    $add_prefix
 )
 EOF
 
@@ -240,7 +267,7 @@ EOF
     cat > pluto.BUILD <<EOF
 filegroup(
     name = "pluto",
-    srcs = ["info"],
+    srcs = ["${add_prefix_path}info"],
     visibility = ["//visibility:public"],
 )
 EOF
@@ -252,10 +279,11 @@ git_repository(
     remote = "$pluto_repo_dir",
     $tag
     $strip_prefix
+    $add_prefix
     build_file_content = """
 filegroup(
     name = "pluto",
-    srcs = ["info"],
+    srcs = ["${add_prefix_path}info"],
     visibility = ["//visibility:public"],
 )"""
 )
@@ -281,8 +309,8 @@ EOF
       expect_log "Pluto is a dwarf planet"
   fi
 
-  git_repos_count=$(find $(bazel info output_base)/external/+git_repository+pluto -type d -name .git | wc -l)
-  assert_equals $git_repos_count 0
+  git_repos_count=$(find -L $(bazel info output_base)/external/+git_repository+pluto -type d -name .git | wc -l)
+  assert_equals 0 $git_repos_count
 }
 
 # Test cloning a Git repository that has a submodule using the

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -41,6 +41,8 @@ def _clone_or_update_repo(ctx):
         fail("At most one of commit, tag, or branch may be provided")
 
     root = ctx.path(".")
+    if ctx.attr.add_prefix:
+        root = root.get_child(ctx.attr.add_prefix)
     directory = str(root)
     if ctx.attr.strip_prefix:
         directory = root.get_child(".tmp_git_root")
@@ -119,6 +121,15 @@ _common_attrs = {
     "strip_prefix": attr.string(
         default = "",
         doc = "A directory prefix to strip from the extracted files.",
+    ),
+    "add_prefix": attr.string(
+        default = "",
+        doc = """Destination directory relative to the repository directory.
+
+The git repo will be cloned into this directory, after applying `strip_prefix`
+(if any) to the file paths within the repo. For example, file
+`foo-1.2.3/src/foo.h` will be cloned to `bar/src/foo.h` if `add_prefix = "bar"`
+and `strip_prefix = "foo-1.2.3"`.""",
     ),
     "patches": attr.label_list(
         default = [],
@@ -232,10 +243,13 @@ def _git_repository_implementation(ctx):
             integrity = ctx.attr.remote_module_file_integrity,
         )
 
+    dot_git_path = ".git"
     if ctx.attr.strip_prefix:
-        ctx.delete(ctx.path(".tmp_git_root/.git"))
-    else:
-        ctx.delete(ctx.path(".git"))
+        dot_git_path = ".tmp_git_root/.git"
+    if ctx.attr.add_prefix:
+        dot_git_path = "%s/%s" % (ctx.attr.add_prefix, dot_git_path)
+    ctx.delete(ctx.path(dot_git_path))
+
     if ctx.attr.commit:
         return ctx.repo_metadata(reproducible = True)
     return ctx.repo_metadata(attrs_for_reproducibility = _update_git_attrs(ctx.attr, _common_attrs.keys(), update))

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -40,12 +40,10 @@ def _clone_or_update_repo(ctx):
         (ctx.attr.commit and ctx.attr.branch)):
         fail("At most one of commit, tag, or branch may be provided")
 
-    root = ctx.path(".")
-    if ctx.attr.add_prefix:
-        root = root.get_child(ctx.attr.add_prefix)
-    directory = str(root)
+    checkout_path = _checkout_path(ctx)
+    directory = str(checkout_path)
     if ctx.attr.strip_prefix:
-        directory = root.get_child(".tmp_git_root")
+        directory = str(checkout_path.get_child(".tmp_git_root"))
 
     git_ = git_repo(ctx, directory)
 
@@ -54,12 +52,31 @@ def _clone_or_update_repo(ctx):
         if not ctx.path(dest_link).exists:
             fail("strip_prefix at {} does not exist in repo".format(ctx.attr.strip_prefix))
         for item in ctx.path(dest_link).readdir():
-            ctx.symlink(item, root.get_child(item.basename))
+            ctx.symlink(item, checkout_path.get_child(item.basename))
 
     if ctx.attr.shallow_since:
         return {"commit": git_.commit, "shallow_since": git_.shallow_since}
     else:
         return {"commit": git_.commit}
+
+def _checkout_path(ctx):
+    """
+    Returns the path where the git repository will be checked out.
+
+    The path returned will be the repository directory. If `add_prefix` is set,
+    the additional prefix subdirectory path is appended to the repository
+    directory. If the directory escapes the "root" repository, eg. an uplevel
+    reference '..', the method will fail.
+    """
+    root = ctx.path(".")
+    if ctx.attr.add_prefix:
+        add_prefix_root = root.get_child(ctx.attr.add_prefix)
+        if not str(add_prefix_root).startswith(str(root)):
+            fail(
+                "add_prefix '%s' escaped the base directory of '%s': '%s'"
+                % (ctx.attr.add_prefix, str(root), str(add_prefix_root)))
+        return add_prefix_root
+    return root
 
 def _update_git_attrs(orig, keys, override):
     result = update_attrs(orig, keys, override)
@@ -243,12 +260,11 @@ def _git_repository_implementation(ctx):
             integrity = ctx.attr.remote_module_file_integrity,
         )
 
-    dot_git_path = ".git"
+    checkout_path = _checkout_path(ctx)
+    dot_git_path = checkout_path.get_child(".git")
     if ctx.attr.strip_prefix:
-        dot_git_path = ".tmp_git_root/.git"
-    if ctx.attr.add_prefix:
-        dot_git_path = "%s/%s" % (ctx.attr.add_prefix, dot_git_path)
-    ctx.delete(ctx.path(dot_git_path))
+        dot_git_path = checkout_path.get_child(".tmp_git_root/.git")
+    ctx.delete(dot_git_path)
 
     if ctx.attr.commit:
         return ctx.repo_metadata(reproducible = True)


### PR DESCRIPTION


<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->
Similar to `http_archive`'s `add_prefix` attribute, this allows git repos to be cloned into a given subdirectory.

Fixes #25453

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

See #25453 . This also further aligns the attributes of `http_archive` with `git_repository`

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

> 1. Has this been discussed in a design doc or issue? (Please link it)

See #25453

> 2. Is the change backward compatible?

Yes - an attribute is added.  It is optional to use.

> 3. If it's a breaking change, what is the migration plan?

N/A

### Checklist

- [X] I have added tests for the new use cases (if any).
- [X] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES[NEW]: Add `add_prefix` attribute to `git_repository` to allow cloning repositories into a given subdirectory prefix
