### PR TITLE
{r,m}ctx.download*: report size of downloaded file

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -542,8 +542,10 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
   private StructImpl calculateDownloadResult(Optional<Checksum> checksum, Path downloadedPath)
       throws InterruptedException, RepositoryFunctionException {
     Checksum finalChecksum;
+    long size;
     try {
       finalChecksum = calculateChecksum(checksum, downloadedPath);
+      size = downloadedPath.getFileSize();
     } catch (IOException e) {
       throw new RepositoryFunctionException(
           new IOException(
@@ -559,6 +561,7 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
     if (finalChecksum.getKeyType() == KeyType.SHA256) {
       out.put("sha256", finalChecksum.toString());
     }
+    out.put("size_bytes", StarlarkInt.of(size));
     return StarlarkInfo.create(StructProvider.STRUCT, out.buildOrThrow(), Location.BUILTIN);
   }
 
@@ -679,7 +682,8 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
 Downloads a file to the output path for the provided url and returns a struct \
 containing <code>success</code>, a flag which is <code>true</code> if the \
 download completed successfully, and if successful, a hash of the file \
-with the fields <code>sha256</code> and <code>integrity</code>. If the value \
+with the fields <code>sha256</code> and <code>integrity</code>, as well as \
+<code>size_bytes</code>, which contains the size of the downloaded file in bytes as an integer. If the value \
 of the <code>success</code> field is false, the <code>error</code> field will be set \
 with a message indicating why the download failed. The message in the <code>error</code> \
 field is for debugging purposes only and should not be relied upon as a stable API (the \
@@ -901,7 +905,8 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
 Downloads a file to the output path for the provided url, extracts it, and returns a \
 struct containing <code>success</code>, a flag which is <code>true</code> if the \
 download completed successfully, and if successful, a hash of the file with the \
-fields <code>sha256</code> and <code>integrity</code>. If the value \
+fields <code>sha256</code> and <code>integrity</code>, as well as the <code>size_bytes</code> \
+of the downloaded file in bytes as an integer. If the value \
 of the <code>success</code> field is false, the <code>error</code> field will be set \
 with a message indicating why the download failed. The message in the <code>error</code> \
 field is for debugging purposes only and should not be relied upon as a stable API (the \

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContextTest.java
@@ -347,6 +347,8 @@ public class StarlarkBaseExternalContextTest {
               "sha256-"
                   + Base64.getEncoder()
                       .encodeToString(HexFormat.of().parseHex(SHA256_EMPTY_GZ_FILE)));
+      assertThat(struct.getValue("size_bytes", StarlarkInt.class))
+          .isEqualTo(StarlarkInt.of(emptyTarGzBytes.length));
     }
   }
 
@@ -408,6 +410,8 @@ public class StarlarkBaseExternalContextTest {
               "sha256-"
                   + Base64.getEncoder()
                       .encodeToString(HexFormat.of().parseHex(SHA256_EMPTY_GZ_FILE)));
+      assertThat(struct.getValue("size_bytes", StarlarkInt.class))
+          .isEqualTo(StarlarkInt.of(emptyTarGzBytes.length));
     }
   }
 


### PR DESCRIPTION
### Description

Adds a new structure field `size_bytes` in the return value of `rctx.download` (and friends) containing the file size of the downloaded file.

### Motivation

This is a useful piece of metadata Bazel provides to repository rules and module extensions. Motivation for adding this: I need the ability to annotate BUILD files with sizes of downloaded files in rules_runfiles_group (https://github.com/hermeticbuild/rules_runfiles_group). This makes it possible to merge runfiles groups based on their "weight", which may include actual file sizes of *_import targets (java_import, cc_import, ...).

### Build API Changes

It does affect the Build API, but is backwards compatible (adding a new field).
Existing users will not be impacted.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES[NEW]: {r,m}ctx.download* report the size of downloaded files
RELNOTES: Addition to the user-facing Build API
