### PR TITLE
Improve performance of discovering undeclared outputs

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -323,15 +323,23 @@ if [[ -n "$TEST_UNDECLARED_OUTPUTS_DIR" && -n "$TEST_UNDECLARED_OUTPUTS_MANIFEST
     # For each file, write a tab-separated line with name (relative to
     # TEST_UNDECLARED_OUTPUTS_DIR), size, and mime type to the manifest. e.g.
     # foo.txt	9	text/plain
-    while read -r undeclared_output; do
-      rel_path="${undeclared_output#$TEST_UNDECLARED_OUTPUTS_DIR/}"
-      # stat has different flags for different systems. -c is supported by GNU,
-      # and -f by BSD (and thus OSX). Try both.
-      file_size="$(stat -f%z "$undeclared_output" 2>/dev/null || stat -c%s "$undeclared_output" 2>/dev/null || echo "Could not stat $undeclared_output")"
-      file_type="$(file -L -b --mime-type "$undeclared_output" || echo "Could not establish file type for $undeclared_output")"
 
-      printf "$rel_path\t$file_size\t$file_type\n"
-    done <<< "$undeclared_outputs" \
+    # stat has different flags for different systems. -c is supported by GNU,
+    # and -f by BSD (and thus OSX). Detect once.
+    if stat -f%z /dev/null >/dev/null 2>&1; then
+      stat_size_fmt='-f%z'
+    else
+      stat_size_fmt='-c%s'
+    fi
+
+    # Path length + "/" + 1 because 'cut' is 1 indexed
+    cut_prefix_len=$(( ${#TEST_UNDECLARED_OUTPUTS_DIR} + 2 ))
+
+    paste \
+      <(printf '%s\n' "$undeclared_outputs" | cut -c"${cut_prefix_len}"-) \
+      <(printf '%s\n' "$undeclared_outputs" | tr '\n' '\0' | xargs -0 stat "$stat_size_fmt" 2>/dev/null) \
+      <(printf '%s\n' "$undeclared_outputs" | tr '\n' '\0' \
+          | xargs -0 file -L -b --mime-type || awk '{print "Could not establish file type for " $0}' <<< "$undeclared_outputs") \
       > "$TEST_UNDECLARED_OUTPUTS_MANIFEST"
     if [[ ! -s "$TEST_UNDECLARED_OUTPUTS_MANIFEST" ]]; then
       rm "$TEST_UNDECLARED_OUTPUTS_MANIFEST"

--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -332,14 +332,12 @@ if [[ -n "$TEST_UNDECLARED_OUTPUTS_DIR" && -n "$TEST_UNDECLARED_OUTPUTS_MANIFEST
       stat_size_fmt='-c%s'
     fi
 
-    # Path length + "/" + 1 because 'cut' is 1 indexed
-    cut_prefix_len=$(( ${#TEST_UNDECLARED_OUTPUTS_DIR} + 2 ))
-
     paste \
-      <(printf '%s\n' "$undeclared_outputs" | cut -c"${cut_prefix_len}"-) \
-      <(printf '%s\n' "$undeclared_outputs" | tr '\n' '\0' | xargs -0 stat "$stat_size_fmt" 2>/dev/null) \
-      <(printf '%s\n' "$undeclared_outputs" | tr '\n' '\0' \
-          | xargs -0 file -L -b --mime-type || awk '{print "Could not establish file type for " $0}' <<< "$undeclared_outputs") \
+      <(printf '%s\n' "$undeclared_outputs" | sed "s|^$TEST_UNDECLARED_OUTPUTS_DIR/||") \
+      <(printf '%s\n' "$undeclared_outputs" | tr '\n' '\0' | xargs -0 stat $stat_size_fmt \
+          || awk '{print "Could not establish file size"}' <<< "$undeclared_outputs") \
+      <(printf '%s\n' "$undeclared_outputs" | tr '\n' '\0' | xargs -0 file -L -b --mime-type \
+          || awk '{print "Could not establish file type"}' <<< "$undeclared_outputs") \
       > "$TEST_UNDECLARED_OUTPUTS_MANIFEST"
     if [[ ! -s "$TEST_UNDECLARED_OUTPUTS_MANIFEST" ]]; then
       rm "$TEST_UNDECLARED_OUTPUTS_MANIFEST"


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description

Improve the performance of generating the undeclared test output manifest by converting repeated calls to `stat` and `file` into a single command using `paste` and `xargs` to generate the same output.

I believe the relevant behavior of `test-startup.sh` is covered by [test_wrapper_test.py](https://github.com/bazelbuild/bazel/blob/283fec5e2ab5eba6f619ef7bfc5fdf16ab56451c/src/test/py/bazel/test_wrapper_test.py#L557-L581)

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

Fixes https://github.com/bazelbuild/bazel/issues/29464

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
