### PR TITLE
fix Javac non-determinism

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/JavaLibraryBuildRequest.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/JavaLibraryBuildRequest.java
@@ -177,12 +177,14 @@ public final class JavaLibraryBuildRequest {
     if (optionsParser.getTargetLabel() != null) {
       depsBuilder.setTargetLabel(optionsParser.getTargetLabel());
     }
+    depsBuilder.setWorkDir(workDir);
     this.dependencyModule = depsBuilder.build();
     this.sourceGenDir =
         deriveDirectory(optionsParser.getTargetLabel(), optionsParser.getOutputJar(), "_sources");
 
     AnnotationProcessingModule.Builder processingBuilder = AnnotationProcessingModule.builder();
     processingBuilder.setSourceGenDir(sourceGenDir);
+    processingBuilder.setWorkDir(workDir);
     if (optionsParser.getManifestProtoPath() != null) {
       processingBuilder.setManifestProtoPath(asPath(optionsParser.getManifestProtoPath()));
     }

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/DependencyModule.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/DependencyModule.java
@@ -31,6 +31,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.sun.tools.javac.code.Symbol.PackageSymbol;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -88,6 +89,7 @@ public final class DependencyModule {
   private final FixMessage fixMessage;
   private final Set<String> exemptGenerators;
   private final Set<PackageSymbol> packages;
+  private final Path workDir;
 
   DependencyModule(
       StrictJavaDeps strictJavaDeps,
@@ -99,7 +101,8 @@ public final class DependencyModule {
       String targetLabel,
       Path outputDepsProtoFile,
       FixMessage fixMessage,
-      Set<String> exemptGenerators) {
+      Set<String> exemptGenerators,
+      Path workDir) {
     this.strictJavaDeps = strictJavaDeps;
     this.fixDepsTool = fixDepsTool;
     this.directJars = directJars;
@@ -113,6 +116,29 @@ public final class DependencyModule {
     this.fixMessage = fixMessage;
     this.exemptGenerators = exemptGenerators;
     this.packages = new HashSet<>();
+    this.workDir = workDir != null ? workDir : Path.of("");
+  }
+
+  /** Returns the sandbox working directory that output paths are relativized against. */
+  public Path getWorkDir() {
+    return workDir;
+  }
+
+  /**
+   * Strips the sandbox working directory prefix from {@code path} and returns a deterministic,
+   * exec-root-relative path string for use in the deps proto.
+   *
+   * <p>Without stripping, multiplex worker sandboxing embeds a non-deterministic slot number (e.g.
+   * {@code __sandbox/1088/_main/...}) in the output. {@code path} is left unchanged if it is not
+   * under {@code workDir} (including when {@code workDir} is empty). {@link Path#toString} uses the
+   * platform separator (`\` on Windows), but the proto must always use `/`.
+   */
+  public static String stripWorkDir(Path workDir, Path path) {
+    Path relative =
+        !workDir.toString().isEmpty() && path.startsWith(workDir)
+            ? workDir.relativize(path)
+            : path;
+    return relative.toString().replace(File.separatorChar, '/');
   }
 
   /** Returns a plugin to be enabled in the compiler. */
@@ -340,6 +366,7 @@ public final class DependencyModule {
     private boolean strictClasspathMode = false;
     private FixMessage fixMessage = new DefaultFixMessage();
     private final Set<String> exemptGenerators = new LinkedHashSet<>(SJD_EXEMPT_PROCESSORS);
+    private Path workDir = Path.of("");
 
     private static class DefaultFixMessage implements FixMessage {
       @Override
@@ -376,7 +403,14 @@ public final class DependencyModule {
           targetLabel,
           outputDepsProtoFile,
           fixMessage,
-          exemptGenerators);
+          exemptGenerators,
+          workDir);
+    }
+
+    @CanIgnoreReturnValue
+    public Builder setWorkDir(Path workDir) {
+      this.workDir = workDir;
+      return this;
     }
 
     /**

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/ImplicitDependencyExtractor.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/ImplicitDependencyExtractor.java
@@ -37,15 +37,18 @@ public class ImplicitDependencyExtractor {
   private final Map<Path, Deps.Dependency> depsMap;
 
   private final Set<Path> platformJars;
+  private final Path workDir;
 
   /**
    * ImplicitDependencyExtractor does not guarantee any ordering of the reported dependencies.
    * Clients should preserve the original classpath ordering if trying to minimize their classpaths
    * using this information.
    */
-  public ImplicitDependencyExtractor(Map<Path, Deps.Dependency> depsMap, Set<Path> platformJars) {
+  public ImplicitDependencyExtractor(
+      Map<Path, Deps.Dependency> depsMap, Set<Path> platformJars, Path workDir) {
     this.depsMap = depsMap;
     this.platformJars = platformJars;
+    this.workDir = workDir;
   }
 
   /**
@@ -104,7 +107,7 @@ public class ImplicitDependencyExtractor {
           path,
           Deps.Dependency.newBuilder()
               .setKind(completed ? Deps.Dependency.Kind.IMPLICIT : Deps.Dependency.Kind.INCOMPLETE)
-              .setPath(path.toString())
+              .setPath(DependencyModule.stripWorkDir(workDir, path))
               .build());
     }
   }

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
@@ -59,7 +59,6 @@ import com.sun.tools.javac.util.Log.WriterKind;
 import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Names;
 import com.sun.tools.javac.util.Position;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UncheckedIOException;
@@ -156,7 +155,9 @@ public final class StrictJavaDepsPlugin extends BlazeJavaCompilerPlugin {
     errWriter = log.getWriter(WriterKind.ERROR);
     implicitDependencyExtractor =
         new ImplicitDependencyExtractor(
-            dependencyModule.getImplicitDependenciesMap(), dependencyModule.getPlatformJars());
+            dependencyModule.getImplicitDependenciesMap(),
+            dependencyModule.getPlatformJars(),
+            dependencyModule.getWorkDir());
     checkingTreeScanner = context.get(CheckingTreeScanner.class);
     if (checkingTreeScanner == null) {
       checkingTreeScanner =
@@ -250,6 +251,7 @@ public final class StrictJavaDepsPlugin extends BlazeJavaCompilerPlugin {
   private static class CheckingTreeScanner extends TreePathScanner<Void, Void> {
 
     private final ImmutableSet<Path> directJars;
+    private final DependencyModule dependencyModule;
 
     /** Strict deps diagnostics. */
     private final List<SjdDiagnostic> diagnostics;
@@ -288,6 +290,7 @@ public final class StrictJavaDepsPlugin extends BlazeJavaCompilerPlugin {
         JavaFileManager fileManager,
         Names names) {
       this.directJars = dependencyModule.directJars();
+      this.dependencyModule = dependencyModule;
       this.diagnostics = diagnostics;
       this.missingTargets = missingTargets;
       this.directDependenciesMap = dependencyModule.getExplicitDependenciesMap();
@@ -360,11 +363,9 @@ public final class StrictJavaDepsPlugin extends BlazeJavaCompilerPlugin {
         // Also update the dependency proto
         Dependency dep =
             Dependency.newBuilder()
-                // Path.toString uses the platform separator (`\` on Windows), but the proto must
-                // use the same separator as in the arguments.
-                //
                 // An empty path is OK in the cases we produce it. See readJarOwnerFromManifest.
-                .setPath(jar.pathOrEmpty().toString().replace(File.separatorChar, '/'))
+                .setPath(
+                    DependencyModule.stripWorkDir(dependencyModule.getWorkDir(), jar.pathOrEmpty()))
                 .setKind(Dependency.Kind.EXPLICIT)
                 .build();
         directDependenciesMap.put(jar.pathOrEmpty(), dep);

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/processing/AnnotationProcessingModule.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/processing/AnnotationProcessingModule.java
@@ -35,11 +35,12 @@ public class AnnotationProcessingModule {
   public static class Builder {
     private Path sourceGenDir;
     private Path manifestProto;
+    private Path workDir;
 
     private Builder() {}
 
     public AnnotationProcessingModule build() {
-      return new AnnotationProcessingModule(sourceGenDir, manifestProto);
+      return new AnnotationProcessingModule(sourceGenDir, manifestProto, workDir);
     }
 
     public void setSourceGenDir(Path sourceGenDir) {
@@ -49,23 +50,42 @@ public class AnnotationProcessingModule {
     public void setManifestProtoPath(Path manifestProto) {
       this.manifestProto = manifestProto.toAbsolutePath();
     }
+
+    public void setWorkDir(Path workDir) {
+      this.workDir = workDir;
+    }
   }
 
   private final boolean enabled;
   private final Path sourceGenDir;
   private final Path manifestProto;
+  private final Path workDir;
 
   public boolean isGenerated(Path path) {
     return path.startsWith(sourceGenDir);
   }
 
   public Path stripSourceRoot(Path path) {
-    return path.startsWith(sourceGenDir) ? sourceGenDir.relativize(path) : path;
+    if (isGenerated(path)) {
+      return sourceGenDir.relativize(path);
+    }
+    // Strip the sandbox working directory prefix to produce deterministic exec-root-relative paths.
+    // Without this, multiplex worker sandboxing embeds a non-deterministic slot number
+    // (e.g. __sandbox/751/_main/...) in the manifest proto output.
+    return stripPrefix(path, workDir);
   }
 
-  private AnnotationProcessingModule(Path sourceGenDir, Path manifestProto) {
+  /** Returns {@code path} relativized against {@code prefix} if it is under it, else unchanged. */
+  private static Path stripPrefix(Path path, Path prefix) {
+    return !prefix.toString().isEmpty() && path.startsWith(prefix)
+        ? prefix.relativize(path)
+        : path;
+  }
+
+  private AnnotationProcessingModule(Path sourceGenDir, Path manifestProto, Path workDir) {
     this.sourceGenDir = sourceGenDir;
     this.manifestProto = manifestProto;
+    this.workDir = workDir != null ? workDir : Path.of("");
     this.enabled = sourceGenDir != null && manifestProto != null;
   }
 

--- a/src/java_tools/buildjar/javatests/com/google/devtools/build/buildjar/BUILD
+++ b/src/java_tools/buildjar/javatests/com/google/devtools/build/buildjar/BUILD
@@ -21,3 +21,14 @@ java_test(
         "//third_party:truth",
     ],
 )
+
+java_test(
+    name = "JavacWorkDirStrippingTest",
+    srcs = ["JavacWorkDirStrippingTest.java"],
+    deps = [
+        "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins:dependency",
+        "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins:processing",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)

--- a/src/java_tools/buildjar/javatests/com/google/devtools/build/buildjar/JavacWorkDirStrippingTest.java
+++ b/src/java_tools/buildjar/javatests/com/google/devtools/build/buildjar/JavacWorkDirStrippingTest.java
@@ -1,0 +1,86 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.buildjar;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.build.buildjar.javac.plugins.dependency.DependencyModule;
+import com.google.devtools.build.buildjar.javac.plugins.processing.AnnotationProcessingModule;
+import java.nio.file.Path;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests that the per-invocation worker-sandbox prefix is stripped from output paths, so that jdeps
+ * and annotation-processing manifest outputs are deterministic across sandbox slots (see #29468).
+ */
+@RunWith(JUnit4.class)
+public class JavacWorkDirStrippingTest {
+
+  @Test
+  public void stripWorkDir_stripsSandboxPrefix() {
+    Path workDir = Path.of("/exec/__sandbox/751/_main");
+    Path source = workDir.resolve("src/com/example/Foo.java");
+    assertThat(DependencyModule.stripWorkDir(workDir, source))
+        .isEqualTo("src/com/example/Foo.java");
+  }
+
+  @Test
+  public void stripWorkDir_isDeterministicAcrossSlots() {
+    Path slot1 = Path.of("/exec/__sandbox/751/_main");
+    Path slot2 = Path.of("/exec/__sandbox/1088/_main");
+    assertThat(DependencyModule.stripWorkDir(slot1, slot1.resolve("libfoo.jar")))
+        .isEqualTo(DependencyModule.stripWorkDir(slot2, slot2.resolve("libfoo.jar")));
+  }
+
+  @Test
+  public void stripWorkDir_leavesPathOutsideWorkDirUnchanged() {
+    Path workDir = Path.of("/exec/__sandbox/751/_main");
+    Path outside = Path.of("/other/location/libfoo.jar");
+    assertThat(DependencyModule.stripWorkDir(workDir, outside)).isEqualTo(outside.toString());
+  }
+
+  @Test
+  public void stripWorkDir_leavesPathUnchangedForEmptyWorkDir() {
+    Path path = Path.of("src/com/example/Foo.java");
+    assertThat(DependencyModule.stripWorkDir(Path.of(""), path)).isEqualTo(path.toString());
+  }
+
+  @Test
+  public void stripSourceRoot_stripsWorkDirPrefix() {
+    Path workDir = Path.of("/exec/__sandbox/751/_main");
+    AnnotationProcessingModule module = module(workDir, workDir.resolve("_sourcegenfiles"));
+    Path source = workDir.resolve("src/com/example/Foo.java");
+    assertThat(module.stripSourceRoot(source).toString()).isEqualTo("src/com/example/Foo.java");
+  }
+
+  @Test
+  public void stripSourceRoot_stripsSourceGenDirForGeneratedFiles() {
+    Path workDir = Path.of("/exec/__sandbox/751/_main");
+    Path sourceGenDir = workDir.resolve("_sourcegenfiles");
+    AnnotationProcessingModule module = module(workDir, sourceGenDir);
+    Path generated = sourceGenDir.resolve("com/example/Gen.java");
+    assertThat(module.stripSourceRoot(generated).toString()).isEqualTo("com/example/Gen.java");
+  }
+
+  private static AnnotationProcessingModule module(Path workDir, Path sourceGenDir) {
+    AnnotationProcessingModule.Builder builder = AnnotationProcessingModule.builder();
+    builder.setSourceGenDir(sourceGenDir);
+    builder.setManifestProtoPath(Path.of("/tmp/manifest.proto"));
+    builder.setWorkDir(workDir);
+    return builder.build();
+  }
+}


### PR DESCRIPTION
### Description

Fix non-deterministic `_manifest_proto` output in Javac compilation actions when using
multiplex worker sandboxing.

`AnnotationProcessingModule` now receives the `workDir` (the per-invocation sandbox slot
path, e.g. `__sandbox/751/_main`) and strips it from source file paths before writing them
to the manifest proto. This produces exec-root-relative paths (`src/com/example/Foo.java`)
instead of sandbox-absolute paths (`__sandbox/751/_main/src/com/example/Foo.java`).

This also fixes the same issue for `.jdeps` files.

### Motivation
 Fixes #29468

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
