### PR TITLE
Pass action args when spilling run_shell command to file

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -648,7 +648,11 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       if (helperScript == null) {
         builder.setShellCommand(shExecutable, command, pad);
       } else {
-        builder.setShellCommand(shExecutable, helperScript.getExecPathString(), pad);
+        // Invoke the script directly (e.g. `bash script.sh`) rather than via
+        // `bash -c script.sh`, so that any user-provided arguments become the
+        // script's positional parameters instead of those of the wrapping
+        // shell. No padding is needed since `$0` is now naturally the script.
+        builder.setShellCommand(constructor.asExecArgv(helperScript), /* pad= */ false);
         builder.addInput(helperScript);
       }
     } else if (commandUnchecked instanceof Sequence<?> commandList) {

--- a/src/test/shell/bazel/starlark_rule_test.sh
+++ b/src/test/shell/bazel/starlark_rule_test.sh
@@ -138,4 +138,40 @@ EOF
   rm BUILD bin.sh foo.bzl
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/29365
+function test_run_shell_passes_arguments_when_command_spills_to_script() {
+  mkdir -p test
+  cat > test/BUILD <<'EOF'
+load(":echo.bzl", "echo")
+
+echo(name = "echo")
+EOF
+
+  cat > test/echo.bzl <<'EOF'
+def _echo_impl(ctx):
+    out_file = ctx.actions.declare_file("%s.txt" % ctx.attr.name)
+
+    # A command long enough (>64000 bytes on non-Windows) to be spilled to a
+    # helper script by Bazel.
+    padding = "a" * 70000
+    ctx.actions.run_shell(
+        inputs = [],
+        outputs = [out_file],
+        command = "set -euo pipefail; echo {} $1 > {}".format(padding, out_file.path),
+        arguments = ["arg"],
+    )
+    return [DefaultInfo(files = depset([out_file]))]
+
+echo = rule(
+    implementation = _echo_impl,
+    attrs = {},
+)
+EOF
+
+  bazel build //test:echo &> $TEST_log \
+      || fail "Expected //test:echo to build, but it failed"
+  out_file="$(bazel info bazel-bin)/test/echo.txt"
+  assert_contains "arg$" "$out_file"
+}
+
 run_suite "Starlark rule definition tests"


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description


### Motivation
Fixes #29365

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
