### PR TITLE
Implement `isinstance()` in Starlark interpreter

### DIFF
--- a/src/main/java/net/starlark/java/eval/Eval.java
+++ b/src/main/java/net/starlark/java/eval/Eval.java
@@ -43,6 +43,7 @@ import net.starlark.java.syntax.Identifier;
 import net.starlark.java.syntax.IfStatement;
 import net.starlark.java.syntax.IndexExpression;
 import net.starlark.java.syntax.IntLiteral;
+import net.starlark.java.syntax.IsInstanceExpression;
 import net.starlark.java.syntax.LambdaExpression;
 import net.starlark.java.syntax.ListExpression;
 import net.starlark.java.syntax.LoadStatement;
@@ -573,8 +574,7 @@ final class Eval {
       case CAST:
         return eval(fr, ((CastExpression) expr).getValue());
       case ISINSTANCE:
-        fr.setErrorLocation(expr.getStartLocation());
-        throw new EvalException("isinstance() is not yet supported");
+        return evalIsInstance(fr, (IsInstanceExpression) expr);
       case IDENTIFIER:
         return evalIdentifier(fr, (Identifier) expr);
       case INDEX:
@@ -799,6 +799,11 @@ final class Eval {
       fr.setErrorLocation(loc);
       throw ex;
     }
+  }
+
+  private static Object evalIsInstance(StarlarkThread.Frame fr, IsInstanceExpression isInstance) throws EvalException, InterruptedException {
+    Object evaluatedValue = eval(fr, isInstance.getValue());
+    return TypeChecker.isValueSubtypeOf(evaluatedValue, isInstance.getStarlarkType());
   }
 
   private static Object evalIdentifier(StarlarkThread.Frame fr, Identifier id)

--- a/src/main/java/net/starlark/java/syntax/IsInstanceExpression.java
+++ b/src/main/java/net/starlark/java/syntax/IsInstanceExpression.java
@@ -14,12 +14,16 @@
 
 package net.starlark.java.syntax;
 
+import javax.annotation.Nullable;
+
 /** Syntax node for isinstance() expressions. */
 public final class IsInstanceExpression extends Expression {
   private final int startOffset;
   private final Expression value;
   private final Expression type;
   private final int rparenOffset;
+  // Set by type tagging.
+  @Nullable private StarlarkType starlarkType;
 
   IsInstanceExpression(
       FileLocations locs, int startOffset, Expression value, Expression type, int rparenOffset) {
@@ -46,6 +50,15 @@ public final class IsInstanceExpression extends Expression {
 
   public Expression getType() {
     return type;
+  }
+
+  @Nullable
+  public StarlarkType getStarlarkType() {
+    return starlarkType;
+  }
+
+  public void setStarlarkType(@Nullable StarlarkType starlarkType) {
+    this.starlarkType = starlarkType;
   }
 
   @Override

--- a/src/main/java/net/starlark/java/syntax/Resolver.java
+++ b/src/main/java/net/starlark/java/syntax/Resolver.java
@@ -917,11 +917,11 @@ public final class Resolver extends NodeVisitor {
 
   @Override
   public void visit(IsInstanceExpression node) {
-    // TODO: #27848 - Restrict the types that can be used on the RHS of isinstance(); e.g. `list` or
-    // `list | tuple` (or aliases resolving to those!) are allowed, but `list[int]` isn't,  since a
-    // list can subsequently be mutated to add a non-int element. Probably needs to be done in
-    // TypeTagger.
-    errorf(node, "isinstance() is not yet supported");
+    if (!options.resolveTypeSyntax()) {
+      errorf(node, "Using isinstance() requires enabling resolveTypeSyntax");
+    }
+    visit(node.getValue());
+    visit(node.getType());
   }
 
   @Override

--- a/src/main/java/net/starlark/java/syntax/TypeChecker.java
+++ b/src/main/java/net/starlark/java/syntax/TypeChecker.java
@@ -23,13 +23,17 @@ import static java.util.stream.Collectors.joining;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.FormatMethod;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nullable;
 import net.starlark.java.spelling.SpellChecker;
+import net.starlark.java.syntax.Resolver.Binding;
 
 /**
  * A visitor for validating that expressions and statements respect the types of the symbols
@@ -256,8 +260,10 @@ public final class TypeChecker extends NodeVisitor {
       case COMPREHENSION -> {
         return inferComprehension((Comprehension) expr);
       }
+      case ISINSTANCE -> {
+        return Types.BOOL;
+      }
       default -> {
-        // TODO: #28037 - support isinstance expressions.
         errorf(expr, "UNSUPPORTED: cannot typecheck %s expression", expr.kind());
         return Types.ANY;
       }
@@ -1303,11 +1309,129 @@ public final class TypeChecker extends NodeVisitor {
     if (usesTypeSyntax()) {
       // Check type constraints in the condition.
       infer(node.getCondition());
+
+      var condition = node.getCondition();
+      if (condition instanceof IsInstanceExpression isInstanceExpression
+          && isInstanceExpression.getValue() instanceof Identifier identifier && identifier.getBinding() != null) {
+        // Narrow type in then block for `if isinstance(...)`
+        visitBlockWithNarrowedType(node.getThenBlock(), identifier.getBinding(),
+            isInstanceExpression.getStarlarkType());
+        if (node.getElseBlock() != null) {
+          var type = Objects.requireNonNull(typeTable.getType(identifier.getBinding()));
+          var narrowedType = Types.subtract(type, isInstanceExpression.getStarlarkType());
+          visitBlockWithNarrowedType(node.getElseBlock(), identifier.getBinding(), narrowedType);
+        }
+        return;
+      } else if (node.getElseBlock() != null
+          && condition instanceof UnaryOperatorExpression unaryOperatorExpression
+          && unaryOperatorExpression.getOperator() == TokenKind.NOT
+          && unaryOperatorExpression.getX() instanceof IsInstanceExpression isInstanceExpression
+          && isInstanceExpression.getValue() instanceof Identifier identifier && identifier.getBinding() != null) {
+        // Narrow type in else block for `if not isinstance(...)`
+        var type = Objects.requireNonNull(typeTable.getType(identifier.getBinding()));
+        var narrowedType = Types.subtract(type, isInstanceExpression.getStarlarkType());
+        visitBlockWithNarrowedType(node.getThenBlock(), identifier.getBinding(), narrowedType);
+        visitBlockWithNarrowedType(node.getElseBlock(), identifier.getBinding(),
+            isInstanceExpression.getStarlarkType());
+        return;
+      } else if (condition instanceof BinaryOperatorExpression binaryOperatorExpression
+          && binaryOperatorExpression.getOperator() == TokenKind.OR
+          && binaryOperatorExpression.getX() instanceof IsInstanceExpression isInstanceExpression
+          && isInstanceExpression.getValue() instanceof Identifier identifier
+          && identifier.getBinding() != null) {
+        // Narrow type in then block for `if isinstance(x, ...) or isinstance(x, ...) or ...
+        // where each `isinstance` checks the same identifier
+        var types = ImmutableSet.<StarlarkType>builder();
+        types.add(Objects.requireNonNull(isInstanceExpression.getStarlarkType()));
+        var binding = identifier.getBinding();
+
+        var current = binaryOperatorExpression.getY();
+        while (true) {
+          if (current instanceof IsInstanceExpression currentIsInstance
+              && currentIsInstance.getValue() instanceof Identifier currentIdentifier
+              && binding.equals(currentIdentifier.getBinding())) {
+            types.add(Objects.requireNonNull(currentIsInstance.getStarlarkType()));
+            var narrowedType = Types.union(types.build());
+            visitBlockWithNarrowedType(node.getThenBlock(), binding, narrowedType);
+            break;
+          } else if (current instanceof BinaryOperatorExpression currentBinaryExpression
+              && currentBinaryExpression.getOperator() == TokenKind.OR
+              && currentBinaryExpression.getX() instanceof IsInstanceExpression currentIsInstance
+              && currentIsInstance.getValue() instanceof Identifier currentIdentifier
+              && binding.equals(currentIdentifier.getBinding())) {
+            types.add(Objects.requireNonNull(currentIsInstance.getStarlarkType()));
+            current = currentBinaryExpression.getY();
+          } else {
+            visitBlock(node.getThenBlock());
+            break;
+          }
+        }
+      } else if (condition instanceof BinaryOperatorExpression binaryOperatorExpression
+          && binaryOperatorExpression.getOperator() == TokenKind.AND
+          && binaryOperatorExpression.getX() instanceof IsInstanceExpression isInstanceExpression
+          && isInstanceExpression.getValue() instanceof Identifier identifier
+          && identifier.getBinding() != null) {
+        // Narrow types in then block for `if isinstance(x, ...) and isinstance(y, ...) and ...`
+        // where each `isinstance` checks a different identifier
+        var types = new HashMap<Binding, StarlarkType>();
+        types.put(identifier.getBinding(), Objects.requireNonNull(isInstanceExpression.getStarlarkType()));
+
+        var current = binaryOperatorExpression.getY();
+        while (true) {
+          if (current instanceof IsInstanceExpression currentIsInstance
+              && currentIsInstance.getValue() instanceof Identifier currentIdentifier
+              && !types.containsKey(currentIdentifier.getBinding())) {
+            types.put(currentIdentifier.getBinding(), Objects.requireNonNull(currentIsInstance.getStarlarkType()));
+            visitBlockWithNarrowedTypes(node.getThenBlock(), ImmutableMap.copyOf(types));
+            break;
+          } else if (current instanceof BinaryOperatorExpression currentBinaryExpression
+              && currentBinaryExpression.getOperator() == TokenKind.AND
+              && currentBinaryExpression.getX() instanceof IsInstanceExpression currentIsInstance
+              && currentIsInstance.getValue() instanceof Identifier currentIdentifier
+              && !types.containsKey(currentIdentifier.getBinding())) {
+            types.put(identifier.getBinding(), Objects.requireNonNull(currentIsInstance.getStarlarkType()));
+            current = currentBinaryExpression.getY();
+          } else {
+            visitBlock(node.getThenBlock());
+            break;
+          }
+        }
+      } else {
+        visitBlock(node.getThenBlock());
+      }
+
+      if (node.getElseBlock() != null) {
+        visitBlock(node.getElseBlock());
+      }
+      return;
     }
     // Visit then/else blocks even in untyped code; they may contain nested typed def statements.
     visitBlock(node.getThenBlock());
     if (node.getElseBlock() != null) {
       visitBlock(node.getElseBlock());
+    }
+  }
+
+  private void visitBlockWithNarrowedType(ImmutableList<Statement> block, Binding binding, StarlarkType narrowedType) {
+    visitBlockWithNarrowedTypes(block, ImmutableMap.of(binding, narrowedType));
+  }
+
+  private void visitBlockWithNarrowedTypes(ImmutableList<Statement> block, ImmutableMap<Binding, StarlarkType> narrowedType) {
+    var nonNarrowedTypes = new HashMap<Binding, StarlarkType>();
+    for (var entry : narrowedType.entrySet()) {
+      var binding = entry.getKey();
+      StarlarkType nonNarrowedType = typeTable.getType(binding);
+      // We intersect the types here to avoid accidently widening the type, this could happen in code like this:
+      // a: int = 5
+      // if isinstance(a, int | str):
+      typeTable.setInferredType(binding, Types.intersect(nonNarrowedType, entry.getValue()));
+      nonNarrowedTypes.put(binding, nonNarrowedType);
+    }
+
+    visitBlock(block);
+
+    for (var entry : nonNarrowedTypes.entrySet()) {
+      typeTable.setInferredType(entry.getKey(), entry.getValue());
     }
   }
 

--- a/src/main/java/net/starlark/java/syntax/TypeTagger.java
+++ b/src/main/java/net/starlark/java/syntax/TypeTagger.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import net.starlark.java.spelling.SpellChecker;
 import net.starlark.java.syntax.Resolver.Scope;
+import net.starlark.java.syntax.Types.AbstractCollectionType;
 
 /**
  * A visitor for tagging the data structures of a resolved file with type information.
@@ -507,6 +508,24 @@ public final class TypeTagger extends NodeVisitor {
     setUsesTypeSyntax();
     cast.setStarlarkType(extractType(cast.getType()));
     super.visit(cast);
+  }
+
+  @Override
+  public void visit(IsInstanceExpression isInstance) {
+    StarlarkType type = extractType(isInstance.getType());
+    if (type instanceof AbstractCollectionType collectionType && !collectionType.getElementType().equals(Types.ANY)) {
+      errorf(isInstance.getType(), "Parameterized types are not allowed in isinstance()");
+      return;
+    }
+
+    if (type.equals(Types.ANY)) {
+      errorf(isInstance.getType(), "'Any' is not allowed in isinstance()");
+      return;
+    }
+
+    isInstance.setStarlarkType(type);
+
+    super.visit(isInstance);
   }
 
   @Override

--- a/src/main/java/net/starlark/java/syntax/Types.java
+++ b/src/main/java/net/starlark/java/syntax/Types.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -665,6 +666,31 @@ public final class Types {
     public boolean hasSetField() {
       return getTypes().stream().allMatch(StarlarkType::hasSetField);
     }
+  }
+
+  public static StarlarkType intersect(StarlarkType... types) {
+    Preconditions.checkArgument(types.length > 0, "Cannot create intersection of zero types");
+
+    if (types.length == 1) {
+      return types[0];
+    }
+
+    var unfoldedTypes = new HashSet<>(unfoldUnion(types[0]));
+    for (var type : types) {
+      unfoldedTypes.retainAll(unfoldUnion(type));
+    }
+
+    if (unfoldedTypes.isEmpty()) {
+      return Types.NEVER;
+    }
+
+    return Types.union(ImmutableSet.copyOf(unfoldedTypes));
+  }
+
+  public static StarlarkType subtract(StarlarkType typeToSubtractFrom, StarlarkType typeToSubtract) {
+    var toSubtractFrom = new HashSet<>(unfoldUnion(typeToSubtractFrom));
+    toSubtractFrom.removeAll(unfoldUnion(typeToSubtract));
+    return Types.union(ImmutableSet.copyOf(toSubtractFrom));
   }
 
   public static ListType list(StarlarkType elementType) {

--- a/src/test/java/net/starlark/java/eval/EvaluationTest.java
+++ b/src/test/java/net/starlark/java/eval/EvaluationTest.java
@@ -908,10 +908,23 @@ public final class EvaluationTest {
         .testEval("z", "42");
   }
 
-  // TODO(b/350661266): resolve types in isinstance().
   @Test
-  public void isinstanceExpression_notYetSupported() throws Exception {
-    ev.setFileOptions(FileOptions.builder().allowTypeSyntax(true).build());
-    ev.new Scenario().testIfExactError("isinstance() is not yet supported", "isinstance(x, list)");
+  public void isinstanceExpression_evaluates() throws Exception {
+    ev.setFileOptions(FileOptions.builder().allowTypeSyntax(true).resolveTypeSyntax(true).build());
+    var semantics = StarlarkSemantics.builder().setBool(StarlarkSemantics.EXPERIMENTAL_STARLARK_DYNAMIC_TYPE_CHECKING, true).build();
+    ev.new Scenario(semantics)
+        .setUp(
+            """
+            xs = [1, 2, 3]
+            ys = (1, 2, 3)
+            a = isinstance(xs, list)
+            b = isinstance(xs, tuple)
+            c = isinstance(xs, list | tuple)
+            d = isinstance(ys, list | tuple)
+            """)
+        .testExpression("a", Boolean.TRUE)
+        .testExpression("b", Boolean.FALSE)
+        .testExpression("c", Boolean.TRUE)
+        .testExpression("d", Boolean.TRUE);
   }
 }

--- a/src/test/java/net/starlark/java/eval/StaticTypeCheckTest.java
+++ b/src/test/java/net/starlark/java/eval/StaticTypeCheckTest.java
@@ -442,4 +442,24 @@ public final class StaticTypeCheckTest {
         "_: str = my_type_value.bar()");
     assertInvalid("'my_type_value' is not callable; got type 'MyType'", "_: str = my_type_value()");
   }
+
+  @Test
+  public void isinstance_narrows_types() {
+    assertValid(
+        """
+        def f(x: int | str) -> int:
+            if isinstance(x, int):
+                return x + 1
+            return 0
+        """);
+
+    assertInvalid(
+        "operator '+' cannot be applied to types 'int|str' and 'int'",
+        """
+        def f(x: int | str) -> int:
+            if isinstance(x, int):
+                return x + 1
+            return x + 1
+        """);
+  }
 }

--- a/src/test/java/net/starlark/java/syntax/ResolverTest.java
+++ b/src/test/java/net/starlark/java/syntax/ResolverTest.java
@@ -807,13 +807,18 @@ public class ResolverTest {
     assertContainsError(badFile.errors(), "name 'b' is not defined");
   }
 
-  // TODO: #27848 - Resolve types in isinstance().
   @Test
-  public void testIsInstanceExpression_notYetSupported() throws Exception {
+  public void testIsInstanceExpression_valueAndType_areResolved() throws Exception {
     options.allowTypeSyntax(true);
-    StarlarkFile badFile = resolveFile("isinstance(x, list)");
+    options.resolveTypeSyntax(true);
+
+    StarlarkFile goodFile = resolveFile("isinstance(pre, pre)");
+    assertThat(goodFile.ok()).isTrue();
+
+    StarlarkFile badFile = resolveFile("isinstance(a, b)");
     assertThat(badFile.ok()).isFalse();
-    assertContainsError(badFile.errors(), "isinstance() is not yet supported");
+    assertContainsError(badFile.errors(), "name 'a' is not defined");
+    assertContainsError(badFile.errors(), "name 'b' is not defined");
   }
 
   // checkBindings verifies the binding (scope and index) of each identifier.

--- a/src/test/java/net/starlark/java/syntax/TypeCheckerTest.java
+++ b/src/test/java/net/starlark/java/syntax/TypeCheckerTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ObjectArrays;
 import java.util.Objects;
 import net.starlark.java.syntax.Resolver.Module;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -2207,6 +2208,95 @@ public final class TypeCheckerTest {
             else:
                 '123' + 456
         """);
+  }
+
+  @Test
+  public void if_statement_isinstance_narrows_types() throws Exception {
+    assertValid(
+        """
+            def f(x: int | str) -> int:
+                if isinstance(x, int):
+                    return x + 1
+                else:
+                    return 0
+            """);
+
+    assertInvalid(
+        "operator '+' cannot be applied to types 'str' and 'int'",
+        """
+            def f(x: int | str) -> int:
+                if isinstance(x, int):
+                    return x + 1
+                else:
+                    return x + 1
+            """);
+
+    assertValid(
+        """
+            def g(x: int | str) -> int:
+                if not isinstance(x, int):
+                    a = "" + x
+                    return 0
+                else:
+                    return x + 1
+            """);
+
+    assertValid(
+        """
+            def f(x: int | str | float) -> int | float:
+              if isinstance(x, int) or isinstance(x, float):
+                return x
+              return 0
+            """);
+
+    assertInvalid("operator '+' cannot be applied to types 'int|str' and 'int|str'",
+        """
+            def f(x: int | str, y: int | str) -> int:
+              if isinstance(x, int) or isinstance(y, int):
+                return x + y
+              return 0
+            """);
+
+    assertValid(
+        """
+            def f(x: int | str, y: int | str) -> int:
+              if isinstance(x, int) and isinstance(y, int):
+                return x + y
+              return 0
+            """);
+
+    assertInvalid("f() declares return type 'int' but may return 'int|str'",
+        """
+            def f(x: int | str) -> int:
+              if isinstance(x, str) and isinstance(x, int):
+                return x
+              return 0
+            """);
+  }
+
+  @Test
+  public void isinstance_does_not_accidentally_widen_type() throws Exception {
+    assertValid(
+        """
+            def f(x: int) -> int:
+              if isinstance(x, int | str):
+                return x + 1
+              return x
+            """);
+  }
+
+  @Ignore("disabled until type alias resolving is implemented in Resolver and TypeTagger")
+  @Test
+  public void isinstance_works_with_typealiases() throws Exception {
+    assertValid(
+        """
+            type a = int
+            def f(x: int | str) -> int:
+              if isinstance(x, a):
+                return x
+              return 0
+            """
+    );
   }
 
   @Test

--- a/src/test/java/net/starlark/java/syntax/TypeTaggerTest.java
+++ b/src/test/java/net/starlark/java/syntax/TypeTaggerTest.java
@@ -721,4 +721,24 @@ public class TypeTaggerTest {
     loader = importName -> TestUtils.LoadableModule.of();
     assertInvalid("module '//x:x.bzl' does not contain symbol 'x'", "load('//x:x.bzl', 'x')");
   }
+
+  @Test
+  public void isinstance_parameterizedTypesMustUseAny() throws Exception {
+    assertInvalid("Parameterized types are not allowed in isinstance()",
+        """
+            def f(x: int | list[int]) -> int:
+              if isinstance(x, list[int]):
+                return 0
+              return 0
+            """);
+
+    tagFile(
+        """
+            def f(x: int | list[int]) -> int:
+              if isinstance(x, list[Any]):
+                return 0
+              return 0
+            """
+    );
+  }
 }

--- a/src/test/java/net/starlark/java/syntax/TypesTest.java
+++ b/src/test/java/net/starlark/java/syntax/TypesTest.java
@@ -425,4 +425,10 @@ public class TypesTest {
         .isEqualTo(
             "(bool, /, a: int, b: [float], *args: int, c: None, d: [Any], **kwargs: int) -> bool");
   }
+
+  @Test
+  public void intersect() {
+    assertThat(Types.intersect(Types.union(Types.INT, Types.STR), Types.union(Types.INT, Types.FLOAT))).isEqualTo(Types.INT);
+    assertThat(Types.intersect(Types.INT, Types.STR)).isEqualTo(Types.NEVER);
+  }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->
This PR actually implements `isinstance()` in Starlark. Until now, `isinstance()` was only reserved in the lexer and parser but could not actually be used.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->
Closes #27848.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

This should probably only be released together with all the other type system changes.

### Open questions

These are questions that are still open from my side that I would like to get input on.

#### Should `isinstance()` require enabling type checking?

Currently, for this implementation work correctly it requires that the user either uses static or dynamic type checking as otherwise the `TypeTagger` is not run. The `TypeTagger` is responsible for resolving the `Expression` in the `IsInstanceExpression` to a `StarlarkType` (similar to `CastExpression`s). If the `TypeTagger` is never run the code currently throws a `NullPointerException` in `Eval#evalIsInstance()` because it expects the `IsInstanceExpression` to have a `StarlarkType`. This should probably be caught by the `Resolver` but it currently does not have access to the information of whether the user has enabled type checking. Another option would be to add an explicit check in `evalIsInstance()` and throw an error there. Alternatively, to avoid this problem entirely, we could just always run the `TypeTagger`. But I'm not sure if this may cause other issues.

#### More complex type narrowing logic?

I only implemented a basic matching against a few (in my opinion) common patterns of using `isinstance()` instead of a full evaluation of all possible combinations of `and`, `or` and `not` together with `isinstance()`. I don't think the more advanced cases warrant the additional complexity.

The code for this pattern matching is currently not really nice as it uses long conditional chains. The conditions cannot really be factored out because the `IsInstanceExpression` and `Identifier` are both needed in the body of the if block. IntelliJ suggests using a switch statement instead of the if-else chain, however that makes the code even more unreadable in my opinion.

#### Type aliases

As far as I could tell, type aliases are not yet resolved in the `TypeTagger` and as such they don't work in `isinstance()`. I added a unit test that tests type aliases in `isinstance()` but it is annotated with `@Ignore` for now.