### PR TITLE
Expose IncompatiblePlatformProvider to starlark rules

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -704,6 +704,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/packages:provider",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform",
+        "//src/main/java/net/starlark/java/eval",
         "//third_party:guava",
         "//third_party:jsr305",
     ],

--- a/src/main/java/com/google/devtools/build/lib/analysis/IncompatiblePlatformProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/IncompatiblePlatformProvider.java
@@ -18,6 +18,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.analysis.platform.ConstraintCollection;
 import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
@@ -27,6 +28,9 @@ import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.starlarkbuildapi.platform.IncompatiblePlatformProviderApi;
 import java.util.Comparator;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Sequence;
+import net.starlark.java.eval.Starlark;
 
 /**
  * Provider instance for the {@code target_compatible_with} attribute.
@@ -50,11 +54,13 @@ import javax.annotation.Nullable;
  *     this provider to be present.
  *     <p>This may be null. If it is null, then at least one of {@code
  *     getConstraintsResponsibleForIncompatibility()} and {@code
- *     getConfigSettingsResponsibleForIncompatibility()} is guaranteed to be non-null. It will have
- *     at least one element in it if it is not null.
+ *     getConfigSettingsResponsibleForIncompatibility()} is guaranteed to be non-null. The
+ *     constraints list may be empty when a Starlark rule directly marks its target incompatible
+ *     without identifying specific constraint values.
  * @param constraintsResponsibleForIncompatibility Returns the constraints that the target platform
  *     didn't satisfy.
- *     <p>This may be null. It will have at least one element in it if it is not null.
+ *     <p>This may be null. It may be empty when a Starlark rule directly marks its target
+ *     incompatible without identifying specific constraint values.
  *     <p>The list is sorted based on the stringified label of each constraint.
  * @param configSettingsResponsibleForIncompatibility Returns the config_settings that didn't match.
  *     <p>This may be null. It will have at least one element in it if it is not null.
@@ -72,9 +78,54 @@ public record IncompatiblePlatformProvider(
   public static final String STARLARK_NAME = "IncompatiblePlatformProvider";
 
   /** Provider singleton constant. */
-  public static final BuiltinProvider<IncompatiblePlatformProvider> PROVIDER =
-      new BuiltinProvider<IncompatiblePlatformProvider>(
-          STARLARK_NAME, IncompatiblePlatformProvider.class) {};
+  public static final Provider PROVIDER = new Provider();
+
+  /** Provider class for {@link IncompatiblePlatformProvider} objects. */
+  public static class Provider extends BuiltinProvider<IncompatiblePlatformProvider>
+      implements IncompatiblePlatformProviderApi.IncompatiblePlatformProviderApiProvider {
+    private Provider() {
+      super(STARLARK_NAME, IncompatiblePlatformProvider.class);
+    }
+
+    @Override
+    public IncompatiblePlatformProviderApi constructor(Object constraints) throws EvalException {
+      ImmutableList<ConstraintValueInfo> constraintList =
+          constraints == Starlark.NONE
+              ? ImmutableList.of()
+              : ImmutableList.copyOf(
+                  Sequence.cast(constraints, ConstraintValueInfo.class, "constraints"));
+      try {
+        ConstraintCollection.validateConstraints(constraintList);
+      } catch (ConstraintCollection.DuplicateConstraintException e) {
+        throw Starlark.errorf("%s", e.getMessage());
+      }
+      return new IncompatiblePlatformProvider(
+          /* targetPlatform= */ null,
+          /* targetsResponsibleForIncompatibility= */ null,
+          sortAndDeduplicateConstraints(constraintList),
+          /* configSettingsResponsibleForIncompatibility= */ null);
+    }
+  }
+
+  /** Returns this provider with {@code targetPlatform} filled in if it was not already known. */
+  public IncompatiblePlatformProvider withTargetPlatform(@Nullable Label targetPlatform) {
+    if (this.targetPlatform != null || targetPlatform == null) {
+      return this;
+    }
+    return new IncompatiblePlatformProvider(
+        targetPlatform,
+        targetsResponsibleForIncompatibility,
+        constraintsResponsibleForIncompatibility,
+        configSettingsResponsibleForIncompatibility);
+  }
+
+  private static ImmutableList<ConstraintValueInfo> sortAndDeduplicateConstraints(
+      ImmutableList<ConstraintValueInfo> constraints) {
+    return constraints.stream()
+        .sorted(Comparator.comparing(ConstraintValueInfo::label))
+        .distinct()
+        .collect(toImmutableList());
+  }
 
   @Override
   public BuiltinProvider<IncompatiblePlatformProvider> getProvider() {
@@ -112,11 +163,7 @@ public record IncompatiblePlatformProvider(
 
     // Deduplicate and sort the list of incompatible constraints. Doing it here means that everyone
     // inspecting this provider doesn't have to deal with it.
-    constraints =
-        constraints.stream()
-            .sorted(Comparator.comparing(ConstraintValueInfo::label))
-            .distinct()
-            .collect(toImmutableList());
+    constraints = sortAndDeduplicateConstraints(constraints);
 
     configSettings =
         configSettings.stream()

--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleConfiguredTargetBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleConfiguredTargetBuilder.java
@@ -195,6 +195,9 @@ public final class RuleConfiguredTargetBuilder {
       if (ruleContext.getConfiguration().hasFragment(TestConfiguration.class)) {
         if (runfilesSupport != null) {
           add(TestProvider.class, initializeTestProvider(filesToRunProvider));
+        } else if (providersBuilder.contains(IncompatiblePlatformProvider.PROVIDER.getKey())) {
+          // Incompatible test targets never run, so they don't need real runfiles. The empty
+          // TestProvider is wired up by StarlarkRuleConfiguredTargetUtil for this case.
         } else {
           if (!allowAnalysisFailures) {
             throw new IllegalStateException("Test rules must have runfiles");

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
@@ -317,11 +317,16 @@ public class TopLevelConstraintSemantics {
       @Nullable Label targetPlatform,
       @Nullable ImmutableList<ConstraintValueInfo> constraints,
       @Nullable ImmutableList<Label> configSettings) {
+    if ((constraints == null || constraints.isEmpty())
+        && (configSettings == null || configSettings.isEmpty())) {
+      return " target was marked incompatible";
+    }
+
     StringJoiner reasons = new StringJoiner(" and");
-    if (constraints != null) {
+    if (constraints != null && !constraints.isEmpty()) {
       reasons.add(formatConstraintIncompatibility(targetPlatform, constraints));
     }
-    if (configSettings != null) {
+    if (configSettings != null && !configSettings.isEmpty()) {
       reasons.add(formatConfigSettingIncompatibility(configSettings));
     }
     return reasons.toString();
@@ -330,7 +335,9 @@ public class TopLevelConstraintSemantics {
   private static String formatConstraintIncompatibility(
       @Nullable Label targetPlatform, ImmutableList<ConstraintValueInfo> constraints) {
     String message =
-        String.format(" target platform (%s) didn't satisfy constraint", targetPlatform);
+        targetPlatform == null
+            ? " target platform didn't satisfy constraint"
+            : String.format(" target platform (%s) didn't satisfy constraint", targetPlatform);
     if (constraints.size() == 1) {
       return message + " " + constraints.get(0).label();
     }

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkGlobalsImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkGlobalsImpl.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.analysis.starlark;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.ActionsProvider;
 import com.google.devtools.build.lib.analysis.DefaultInfo;
+import com.google.devtools.build.lib.analysis.IncompatiblePlatformProvider;
 import com.google.devtools.build.lib.analysis.MaterializedDepsInfo;
 import com.google.devtools.build.lib.analysis.OutputGroupInfo;
 import com.google.devtools.build.lib.analysis.RunEnvironmentInfo;
@@ -103,6 +104,7 @@ public final class StarlarkGlobalsImpl implements StarlarkGlobals {
     env.put("DefaultInfo", DefaultInfo.PROVIDER);
     env.put("RunEnvironmentInfo", RunEnvironmentInfo.PROVIDER);
     env.put("MaterializedDepsInfo", MaterializedDepsInfo.PROVIDER);
+    env.put("IncompatiblePlatformProvider", IncompatiblePlatformProvider.PROVIDER);
 
     return env.buildOrThrow();
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleConfiguredTargetUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleConfiguredTargetUtil.java
@@ -20,6 +20,7 @@ import com.google.devtools.build.lib.analysis.ActionsProvider;
 import com.google.devtools.build.lib.analysis.CachingAnalysisEnvironment;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.DefaultInfo;
+import com.google.devtools.build.lib.analysis.IncompatiblePlatformProvider;
 import com.google.devtools.build.lib.analysis.MaterializedDepsInfo;
 import com.google.devtools.build.lib.analysis.RequiredConfigFragmentsProvider;
 import com.google.devtools.build.lib.analysis.RuleConfiguredTargetBuilder;
@@ -29,9 +30,14 @@ import com.google.devtools.build.lib.analysis.Runfiles;
 import com.google.devtools.build.lib.analysis.RunfilesProvider;
 import com.google.devtools.build.lib.analysis.RunfilesSupport;
 import com.google.devtools.build.lib.analysis.StarlarkProviderValidationUtil;
+import com.google.devtools.build.lib.analysis.test.TestActionBuilder;
+import com.google.devtools.build.lib.analysis.test.TestConfiguration;
+import com.google.devtools.build.lib.analysis.test.TestProvider;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.packages.AdvertisedProviderSet;
 import com.google.devtools.build.lib.packages.Info;
 import com.google.devtools.build.lib.packages.Provider;
@@ -214,8 +220,10 @@ public final class StarlarkRuleConfiguredTargetUtil {
       try {
         // Check all artifacts have actions. Despite signature, must be done after build().
         StarlarkProviderValidationUtil.validateArtifacts(context);
-        // Check all advertised providers were created.
-        checkDeclaredProviders(ct, advertisedProviders);
+        if (ct.get(IncompatiblePlatformProvider.PROVIDER) == null) {
+          // Check all advertised providers were created.
+          checkDeclaredProviders(ct, advertisedProviders);
+        }
       } catch (EvalException ex) {
         context.ruleError("\n" + implLoc(context) + ": " + ex.getMessage());
         return null;
@@ -288,6 +296,17 @@ public final class StarlarkRuleConfiguredTargetUtil {
       }
     }
 
+    if (declaredProviders.containsKey(IncompatiblePlatformProvider.PROVIDER.getKey())) {
+      if (declaredProviders.size() != 1) {
+        throw Starlark.errorf(
+            "IncompatiblePlatformProvider must be the only provider returned by a rule "
+                + "implementation function, but got %s",
+            declaredProviders.keySet());
+      }
+      addEmptyProvidersForIncompatibleTarget(context, builder, declaredProviders);
+      return;
+    }
+
     var runEnvironmentInfo =
         (RunEnvironmentInfo) declaredProviders.get(RunEnvironmentInfo.PROVIDER.getKey());
     if (runEnvironmentInfo != null
@@ -328,6 +347,32 @@ public final class StarlarkRuleConfiguredTargetUtil {
           isDefaultExecutableCreated,
           runEnvironmentInfo);
     }
+  }
+
+  private static void addEmptyProvidersForIncompatibleTarget(
+      RuleContext context,
+      RuleConfiguredTargetBuilder builder,
+      Map<Provider.Key, Info> declaredProviders) {
+    var provider =
+        (IncompatiblePlatformProvider)
+            declaredProviders.get(IncompatiblePlatformProvider.PROVIDER.getKey());
+    builder.addStarlarkDeclaredProvider(
+        provider.withTargetPlatform(getTargetPlatformLabel(context)));
+
+    builder.setFilesToBuild(NestedSetBuilder.emptySet(Order.STABLE_ORDER));
+    builder.addProvider(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY));
+
+    if (TargetUtils.isTestRule(context.getTarget())
+        && context.getConfiguration().hasFragment(TestConfiguration.class)) {
+      builder.addProvider(
+          TestProvider.class, new TestProvider(TestActionBuilder.createEmptyTestParams()));
+    }
+  }
+
+  @Nullable
+  private static Label getTargetPlatformLabel(RuleContext context) {
+    var toolchainContext = context.getToolchainContext();
+    return toolchainContext == null ? null : toolchainContext.targetPlatform().label();
   }
 
   // Returns an EvalException whose message has a location as the prefix. The exception is intended

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/IncompatiblePlatformProviderApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/IncompatiblePlatformProviderApi.java
@@ -15,7 +15,15 @@
 package com.google.devtools.build.lib.starlarkbuildapi.platform;
 
 import com.google.devtools.build.docgen.annot.DocCategory;
+import com.google.devtools.build.docgen.annot.StarlarkConstructor;
+import com.google.devtools.build.lib.starlarkbuildapi.core.ProviderApi;
+import net.starlark.java.annot.Param;
+import net.starlark.java.annot.ParamType;
 import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.NoneType;
+import net.starlark.java.eval.Sequence;
 import net.starlark.java.eval.StarlarkValue;
 
 /** Targets that are incompatible with the target platform. */
@@ -25,6 +33,43 @@ import net.starlark.java.eval.StarlarkValue;
         "A provider for targets that are incompatible with the target platform. See "
             + "<a href='${link platforms#detecting-incompatible-targets-using-bazel-cquery}'>"
             + "Detecting incompatible targets using <code>bazel cquery</code></a> for more "
-            + "information.",
+            + "information."
+            + "<p>Returning an instance of this provider from a rule's implementation function "
+            + "marks the target as incompatible with the current platform, in the same way that "
+            + "the <code>target_compatible_with</code> attribute does. This allows rules to make "
+            + "incompatibility decisions based on dynamic logic that can't easily be expressed "
+            + "via constraints.</p>",
     category = DocCategory.PROVIDER)
-public interface IncompatiblePlatformProviderApi extends StarlarkValue {}
+public interface IncompatiblePlatformProviderApi extends StarlarkValue {
+
+  /** Provider for {@link IncompatiblePlatformProviderApi}. */
+  @StarlarkBuiltin(name = "Provider", documented = false, doc = "")
+  interface IncompatiblePlatformProviderApiProvider extends ProviderApi {
+
+    @StarlarkMethod(
+        name = "IncompatiblePlatformProvider",
+        doc =
+            "Constructs an <code>IncompatiblePlatformProvider</code>. Returning this provider "
+                + "from a rule's implementation function marks the target as incompatible with "
+                + "the current platform.",
+        parameters = {
+          @Param(
+              name = "constraints",
+              allowedTypes = {
+                @ParamType(type = Sequence.class, generic1 = ConstraintValueInfoApi.class),
+                @ParamType(type = NoneType.class),
+              },
+              named = true,
+              positional = false,
+              defaultValue = "None",
+              doc =
+                  "An optional list of <a href='ConstraintValueInfo.html'>"
+                      + "<code>ConstraintValueInfo</code></a> instances that the target platform "
+                      + "did not satisfy, used for explanatory error messages when an incompatible "
+                      + "target is explicitly requested on the command line."),
+        },
+        selfCall = true)
+    @StarlarkConstructor
+    IncompatiblePlatformProviderApi constructor(Object constraints) throws EvalException;
+  }
+}

--- a/src/test/shell/integration/target_compatible_with_test.sh
+++ b/src/test/shell/integration/target_compatible_with_test.sh
@@ -718,6 +718,169 @@ EOF
   expect_log 'ERROR: Build did NOT complete successfully'
 }
 
+# Validates that a Starlark rule's implementation function can mark its target
+# as incompatible by returning IncompatiblePlatformProvider. Targets that do
+# this should behave just like target_compatible_with.
+function test_starlark_returns_incompatible_platform_provider() {
+  cat > target_skipping/rules.bzl <<'EOF'
+def _conditional_rule_impl(ctx):
+    if ctx.attr.is_incompatible:
+        return [IncompatiblePlatformProvider(
+            constraints = [ctx.attr._foo2[platform_common.ConstraintValueInfo]],
+        )]
+    out = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(out, "compatible")
+    return [DefaultInfo(files = depset([out]))]
+
+conditional_rule = rule(
+    implementation = _conditional_rule_impl,
+    attrs = {
+        "is_incompatible": attr.bool(),
+        "deps": attr.label_list(),
+        "_foo2": attr.label(default = "//target_skipping:foo2"),
+    },
+)
+
+def _no_constraint_rule_impl(ctx):
+    return [IncompatiblePlatformProvider()]
+
+no_constraint_rule = rule(
+    implementation = _no_constraint_rule_impl,
+)
+
+AdvertisedInfo = provider()
+
+def _advertised_rule_impl(ctx):
+    return [IncompatiblePlatformProvider()]
+
+advertised_rule = rule(
+    implementation = _advertised_rule_impl,
+    provides = [AdvertisedInfo],
+)
+
+def _output_group_rule_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name + ".out")
+    ctx.actions.write(out, "unused")
+    return [
+        IncompatiblePlatformProvider(),
+        OutputGroupInfo(extra = depset([out])),
+    ]
+
+output_group_rule = rule(
+    implementation = _output_group_rule_impl,
+)
+EOF
+
+  cat >> target_skipping/BUILD <<'EOF'
+load(
+    "//target_skipping:rules.bzl",
+    "advertised_rule",
+    "conditional_rule",
+    "no_constraint_rule",
+    "output_group_rule",
+)
+
+conditional_rule(
+    name = "dynamic_incompatible",
+    is_incompatible = True,
+)
+
+conditional_rule(
+    name = "dynamic_compatible",
+    is_incompatible = False,
+)
+
+# A target that consumes a dynamically-incompatible target via deps. It should
+# become indirectly incompatible.
+conditional_rule(
+    name = "consumer_of_incompatible",
+    is_incompatible = False,
+    deps = [":dynamic_incompatible"],
+)
+
+no_constraint_rule(
+    name = "always_incompatible_no_constraint",
+)
+
+advertised_rule(
+    name = "advertised_incompatible",
+)
+
+output_group_rule(
+    name = "output_group_incompatible",
+)
+EOF
+
+  cd target_skipping || fail "couldn't cd into workspace"
+
+  # --skip_incompatible_explicit_targets applies
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:foo1_bar1_platform \
+    --platforms=@//target_skipping:foo1_bar1_platform \
+    --skip_incompatible_explicit_targets \
+    //target_skipping:dynamic_compatible \
+    //target_skipping:dynamic_incompatible \
+    //target_skipping:consumer_of_incompatible \
+    //target_skipping:always_incompatible_no_constraint \
+    //target_skipping:advertised_incompatible &> "${TEST_log}" \
+    || fail "Bazel failed unexpectedly."
+  expect_log '//target_skipping:dynamic_compatible up-to-date'
+  expect_log 'Target //target_skipping:dynamic_incompatible was skipped'
+  expect_log 'Target //target_skipping:consumer_of_incompatible was skipped'
+  expect_log 'Target //target_skipping:always_incompatible_no_constraint was skipped'
+  expect_log 'Target //target_skipping:advertised_incompatible was skipped'
+
+  # IncompatiblePlatformProvider is a terminal result: rules cannot also return
+  # OutputGroupInfo or any other provider.
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:foo1_bar1_platform \
+    --platforms=@//target_skipping:foo1_bar1_platform \
+    //target_skipping:output_group_incompatible &> "${TEST_log}" \
+    && fail "Bazel passed unexpectedly."
+  expect_log 'IncompatiblePlatformProvider must be the only provider returned'
+  expect_log 'OutputGroupInfo'
+  expect_log 'ERROR: Build did NOT complete successfully'
+
+  # Explicitly requesting just the incompatible target should fail with a
+  # message that mentions the responsible constraint.
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:foo1_bar1_platform \
+    --platforms=@//target_skipping:foo1_bar1_platform \
+    //target_skipping:dynamic_incompatible &> "${TEST_log}" \
+    && fail "Bazel passed unexpectedly."
+  expect_log 'ERROR:.* Target //target_skipping:dynamic_incompatible is incompatible and cannot be built, but was explicitly requested'
+  expect_log "didn't satisfy constraint //target_skipping:foo2"
+  expect_log 'ERROR: Build did NOT complete successfully'
+
+  # Explicitly requesting the consumer should also error and surface the
+  # dependency chain back to the dynamically-incompatible dep.
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:foo1_bar1_platform \
+    --platforms=@//target_skipping:foo1_bar1_platform \
+    //target_skipping:consumer_of_incompatible &> "${TEST_log}" \
+    && fail "Bazel passed unexpectedly."
+  expect_log 'ERROR:.* Target //target_skipping:consumer_of_incompatible is incompatible and cannot be built, but was explicitly requested'
+  expect_log '//target_skipping:consumer_of_incompatible '
+  expect_log '//target_skipping:dynamic_incompatible '
+  expect_log 'ERROR: Build did NOT complete successfully'
+
+  # A rule that returns IncompatiblePlatformProvider with no constraints should
+  # also be marked incompatible when explicitly requested.
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:foo1_bar1_platform \
+    --platforms=@//target_skipping:foo1_bar1_platform \
+    //target_skipping:always_incompatible_no_constraint &> "${TEST_log}" \
+    && fail "Bazel passed unexpectedly."
+  expect_log 'ERROR:.* Target //target_skipping:always_incompatible_no_constraint is incompatible and cannot be built, but was explicitly requested'
+  expect_log 'target was marked incompatible'
+  expect_log 'ERROR: Build did NOT complete successfully'
+}
+
 # Validates that rules with custom providers are skipped when incompatible.
 # This is valuable because we use providers to convey incompatibility.
 function test_dependencies_with_providers() {


### PR DESCRIPTION
This allows rules to return the IncompatiblePlatformProvider to mark the
target as incompatible.

Fixes https://github.com/bazelbuild/bazel/issues/12419
