### PR TITLE
Fix dead link to JUnit XML test result schema

### DIFF
--- a/docs/reference/test-encyclopedia.mdx
+++ b/docs/reference/test-encyclopedia.mdx
@@ -453,7 +453,7 @@ The initial environment block shall be composed as follows:
       Location to which test actions should write a test result XML output file.
       Otherwise, Bazel generates a default XML output file wrapping the test log
       as part of the test action. The XML schema is based on the
-      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd"
+      <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd"
         class="external">JUnit test result schema</a>.
     </td>
     <td>optional</td>

--- a/docs/versions/7.6.1/reference/test-encyclopedia.mdx
+++ b/docs/versions/7.6.1/reference/test-encyclopedia.mdx
@@ -446,7 +446,7 @@ The initial environment block shall be composed as follows:
       Location to which test actions should write a test result XML output file.
       Otherwise, Bazel generates a default XML output file wrapping the test log
       as part of the test action. The XML schema is based on the
-      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd">
+      <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd">
         JUnit test result schema
       </a>
     </td>

--- a/docs/versions/7.7.1/reference/test-encyclopedia.mdx
+++ b/docs/versions/7.7.1/reference/test-encyclopedia.mdx
@@ -442,7 +442,7 @@ The initial environment block shall be composed as follows:
   </tr>
   <tr>
     <td><code>XML_OUTPUT_FILE</code></td>
-    <td>Location to which test actions should write a test result XML output file. Otherwise, Bazel generates a default XML output file wrapping the test log as part of the test action. The XML schema is based on the <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd" class="external">JUnit test result schema</a>.</td>
+    <td>Location to which test actions should write a test result XML output file. Otherwise, Bazel generates a default XML output file wrapping the test log as part of the test action. The XML schema is based on the <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd" class="external">JUnit test result schema</a>.</td>
     <td>optional</td>
   </tr>
   <tr>

--- a/docs/versions/8.0.1/reference/test-encyclopedia.mdx
+++ b/docs/versions/8.0.1/reference/test-encyclopedia.mdx
@@ -446,7 +446,7 @@ The initial environment block shall be composed as follows:
       Location to which test actions should write a test result XML output file.
       Otherwise, Bazel generates a default XML output file wrapping the test log
       as part of the test action. The XML schema is based on the
-      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd"
+      <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd"
         class="external">JUnit test result schema</a>.
     </td>
     <td>optional</td>

--- a/docs/versions/8.1.1/reference/test-encyclopedia.mdx
+++ b/docs/versions/8.1.1/reference/test-encyclopedia.mdx
@@ -446,7 +446,7 @@ The initial environment block shall be composed as follows:
       Location to which test actions should write a test result XML output file.
       Otherwise, Bazel generates a default XML output file wrapping the test log
       as part of the test action. The XML schema is based on the
-      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd"
+      <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd"
         class="external">JUnit test result schema</a>.
     </td>
     <td>optional</td>

--- a/docs/versions/8.2.1/reference/test-encyclopedia.mdx
+++ b/docs/versions/8.2.1/reference/test-encyclopedia.mdx
@@ -446,7 +446,7 @@ The initial environment block shall be composed as follows:
       Location to which test actions should write a test result XML output file.
       Otherwise, Bazel generates a default XML output file wrapping the test log
       as part of the test action. The XML schema is based on the
-      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd"
+      <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd"
         class="external">JUnit test result schema</a>.
     </td>
     <td>optional</td>

--- a/docs/versions/8.3.1/reference/test-encyclopedia.mdx
+++ b/docs/versions/8.3.1/reference/test-encyclopedia.mdx
@@ -446,7 +446,7 @@ The initial environment block shall be composed as follows:
       Location to which test actions should write a test result XML output file.
       Otherwise, Bazel generates a default XML output file wrapping the test log
       as part of the test action. The XML schema is based on the
-      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd" class="external">JUnit test result schema</a>.
+      <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd" class="external">JUnit test result schema</a>.
     </td>
     <td>optional</td>
   </tr>

--- a/docs/versions/8.4.2/reference/test-encyclopedia.mdx
+++ b/docs/versions/8.4.2/reference/test-encyclopedia.mdx
@@ -446,7 +446,7 @@ The initial environment block shall be composed as follows:
       Location to which test actions should write a test result XML output file.
       Otherwise, Bazel generates a default XML output file wrapping the test log
       as part of the test action. The XML schema is based on the
-      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd"
+      <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd"
         class="external">JUnit test result schema</a>.
     </td>
     <td>optional</td>

--- a/docs/versions/8.5.1/reference/test-encyclopedia.mdx
+++ b/docs/versions/8.5.1/reference/test-encyclopedia.mdx
@@ -446,7 +446,7 @@ The initial environment block shall be composed as follows:
       Location to which test actions should write a test result XML output file.
       Otherwise, Bazel generates a default XML output file wrapping the test log
       as part of the test action. The XML schema is based on the
-      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd"
+      <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd"
         class="external">JUnit test result schema</a>.
     </td>
     <td>optional</td>

--- a/docs/versions/8.6.0/reference/test-encyclopedia.mdx
+++ b/docs/versions/8.6.0/reference/test-encyclopedia.mdx
@@ -454,7 +454,7 @@ The initial environment block shall be composed as follows:
       Location to which test actions should write a test result XML output file.
       Otherwise, Bazel generates a default XML output file wrapping the test log
       as part of the test action. The XML schema is based on the
-      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd"
+      <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd"
         class="external">JUnit test result schema</a>.
     </td>
     <td>optional</td>

--- a/docs/versions/8.7.0/reference/test-encyclopedia.mdx
+++ b/docs/versions/8.7.0/reference/test-encyclopedia.mdx
@@ -453,7 +453,7 @@ The initial environment block shall be composed as follows:
       Location to which test actions should write a test result XML output file.
       Otherwise, Bazel generates a default XML output file wrapping the test log
       as part of the test action. The XML schema is based on the
-      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd"
+      <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd"
         class="external">JUnit test result schema</a>.
     </td>
     <td>optional</td>

--- a/docs/versions/9.0.0/reference/test-encyclopedia.mdx
+++ b/docs/versions/9.0.0/reference/test-encyclopedia.mdx
@@ -446,7 +446,7 @@ The initial environment block shall be composed as follows:
       Location to which test actions should write a test result XML output file.
       Otherwise, Bazel generates a default XML output file wrapping the test log
       as part of the test action. The XML schema is based on the
-      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd"
+      <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd"
         class="external">JUnit test result schema</a>.
     </td>
     <td>optional</td>

--- a/docs/versions/9.1.0/reference/test-encyclopedia.mdx
+++ b/docs/versions/9.1.0/reference/test-encyclopedia.mdx
@@ -453,7 +453,7 @@ The initial environment block shall be composed as follows:
     <td>Location to which test actions should write a test result XML output file.
       Otherwise, Bazel generates a default XML output file wrapping the test log
       as part of the test action. The XML schema is based on the
-      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd"
+      <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd"
         class="external">JUnit test result schema</a>.</td>
     <td>optional</td>
   </tr>

--- a/site/en/reference/test-encyclopedia.md
+++ b/site/en/reference/test-encyclopedia.md
@@ -456,7 +456,7 @@ The initial environment block shall be composed as follows:
       Location to which test actions should write a test result XML output file.
       Otherwise, Bazel generates a default XML output file wrapping the test log
       as part of the test action. The XML schema is based on the
-      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd"
+      <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd"
         class="external">JUnit test result schema</a>.</td>
     <td>optional</td>
   </tr>

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/model/AntXmlResultWriter.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/model/AntXmlResultWriter.java
@@ -25,8 +25,8 @@ import javax.annotation.Nullable;
 /**
  * Writes the JUnit test nodes and their results into Ant-JUnit XML. Ant-JUnit XML is not a
  * standardized format. For this implementation the
- * <a href="http://windyroad.com.au/dl/Open%20Source/JUnit.xsd">XML schema</a> that is generally
- * referred to as the best available source was used as a reference.
+ * <a href="https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd">XML schema</a> that is
+ * generally referred to as the best available source was used as a reference.
  */
 public final class AntXmlResultWriter implements XmlResultWriter {
   private static final String JUNIT_ELEMENT_TESTSUITES = "testsuites";


### PR DESCRIPTION
### Description
The cited schema URL https://windyroad.com.au/dl/Open%20Source/JUnit.xsd returns 404.
Replace it with the canonical home of the same schema on GitHub, pinned to tag 1.0.0: https://github.com/windyroad/JUnit-Schema/blob/1.0.0/JUnit.xsd

Updated:
- `site/en/reference/test-encyclopedia.md` and its current and versioned `docs/` mirrors,
- the Javadoc of `AntXmlResultWriter`.

### Motivation
Restore a working pointer to the JUnit XML test result schema that Bazel's Ant-JUnit XML writer is modelled after.

### Build API Changes
No

### Checklist
- [ ] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes
RELNOTES: None
