### PR TITLE
Fix Windows UNC path case-sensitivity resolution

### DIFF
--- a/src/main/native/windows/file.cc
+++ b/src/main/native/windows/file.cc
@@ -67,9 +67,11 @@ wstring AddUncPrefixMaybe(const wstring& path) {
 }
 
 wstring RemoveUncPrefixMaybe(const wstring& path) {
+  if (path.compare(0, 8, L"\\\\?\\UNC\\") == 0 || path.compare(0, 8, L"\\\\?\\unc\\") == 0) {
+    return wstring(L"\\\\") + path.substr(8);
+  }
   return bazel::windows::HasUncPrefix(path.c_str()) ? path.substr(4) : path;
 }
-
 bool IsAbsoluteNormalizedWindowsPath(const wstring& p) {
   if (p.empty()) {
     return false;


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->
This PR updates the path resolution logic on Windows to correctly handle mapped network drives and UNC paths. Previously, JoinPath and workspace directory computations (like those involving GetCanonicalCwd) would fail or return an invalid/empty path when encountering these network locations, causing the build to fail.
### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->
Fix #28607 

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x ] I have added tests for the new use cases (if any).
- [ x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Fixed an issue on Windows where Bazel would fail to resolve workspace paths when running from or depending on mapped network drives and UNC paths.
