### PR TITLE
Fix LTO backend actions ignoring toolchain execution platform constraints

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
@@ -1141,6 +1141,12 @@ public class CcStarlarkInternal implements StarlarkValue {
             allowedTypes = {@ParamType(type = Artifact.class), @ParamType(type = NoneType.class)}),
         @Param(name = "outputs", positional = false, named = true),
         @Param(name = "env", positional = false, named = true),
+        @Param(
+            name = "toolchain_type",
+            positional = false,
+            named = true,
+            allowedTypes = {@ParamType(type = String.class), @ParamType(type = NoneType.class)},
+            defaultValue = "None"),
       })
   public void createLtoBackendAction(
       StarlarkActionFactory actions,
@@ -1151,8 +1157,14 @@ public class CcStarlarkInternal implements StarlarkValue {
       Object allBitcodeFiles,
       Object imports,
       Sequence<?> outputs,
-      Dict<?, ?> env)
+      Dict<?, ?> env,
+      Object toolchainType)
       throws EvalException {
+    RuleContext ruleContext = actions.getRuleContext();
+    ActionOwner actionOwner =
+        toolchainType instanceof String s
+            ? CppCompileActionBuilder.getActionOwner(ruleContext, s)
+            : ruleContext.getActionOwner();
     FeatureConfiguration featureConfiguration =
         featureConfigurationForStarlark.getFeatureConfiguration();
     BitcodeFiles bitcodeFiles =
@@ -1161,8 +1173,8 @@ public class CcStarlarkInternal implements StarlarkValue {
             : new BitcodeFiles(Depset.cast(allBitcodeFiles, Artifact.class, "bitcode_files"));
     LtoBackendAction action =
         LtoBackendArtifacts.createLtoBackendActionForStarlark(
-            actions.getRuleContext().getActionOwner(),
-            actions.getRuleContext().getConfiguration(),
+            actionOwner,
+            ruleContext.getConfiguration(),
             featureConfiguration,
             buildVariables,
             usePic,
@@ -1172,7 +1184,7 @@ public class CcStarlarkInternal implements StarlarkValue {
             ImmutableSet.copyOf(Sequence.cast(outputs, Artifact.class, "outputs")),
             ActionEnvironment.create(
                 ImmutableMap.copyOf(Dict.cast(env, String.class, String.class, "env"))));
-    actions.getRuleContext().registerAction(action);
+    ruleContext.registerAction(action);
   }
 
   @StarlarkMethod(
@@ -1222,6 +1234,12 @@ public class CcStarlarkInternal implements StarlarkValue {
               @ParamType(type = NoneType.class)
             }),
         @Param(name = "env", positional = false, named = true),
+        @Param(
+            name = "toolchain_type",
+            positional = false,
+            named = true,
+            allowedTypes = {@ParamType(type = String.class), @ParamType(type = NoneType.class)},
+            defaultValue = "None"),
       })
   public void createLtoBackendActionTemplate(
       StarlarkActionFactory actions,
@@ -1234,8 +1252,14 @@ public class CcStarlarkInternal implements StarlarkValue {
       Object bitcodeFileObj,
       Object objectFileObj,
       Object dwoFileObj,
-      Dict<?, ?> env)
+      Dict<?, ?> env,
+      Object toolchainType)
       throws EvalException {
+    RuleContext ruleContext = actions.getRuleContext();
+    ActionOwner actionOwner =
+        toolchainType instanceof String s
+            ? CppCompileActionBuilder.getActionOwner(ruleContext, s)
+            : ruleContext.getActionOwner();
     FeatureConfiguration featureConfiguration =
         featureConfigurationForStarlark.getFeatureConfiguration();
     BitcodeFiles bitcodeFiles =
@@ -1255,8 +1279,8 @@ public class CcStarlarkInternal implements StarlarkValue {
             buildVariables,
             usePic,
             bitcodeFiles,
-            actions.getRuleContext().getActionOwner());
-    actions.getRuleContext().registerAction(actionTemplate);
+            actionOwner);
+    ruleContext.registerAction(actionTemplate);
   }
 
   @StarlarkMethod(

--- a/src/test/java/com/google/devtools/build/lib/analysis/AutoExecGroupsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/AutoExecGroupsTest.java
@@ -2089,6 +2089,81 @@ public class AutoExecGroupsTest extends BuildViewTestCase {
   }
 
   @Test
+  public void ccCommonLink_ltoBackendCompileActionExecutesOnCorrectPlatform() throws Exception {
+    scratch.file(
+        "test/defs.bzl",
+        "load('@rules_cc//cc/common:cc_info.bzl', 'CcInfo')",
+        "load('@rules_cc//cc/common:cc_common.bzl', 'cc_common')",
+        "def _use_cpp_toolchain():",
+        "   return [",
+        "      config_common.toolchain_type('"
+            + TestConstants.CPP_TOOLCHAIN_TYPE
+            + "', mandatory = False),",
+        "   ]",
+        "def _impl(ctx):",
+        "  cc_toolchain = ctx.toolchains['" + TestConstants.CPP_TOOLCHAIN_TYPE + "'].cc",
+        "  feature_configuration = cc_common.configure_features(",
+        "      ctx = ctx,",
+        "      cc_toolchain = cc_toolchain,",
+        "      requested_features = ctx.features,",
+        "      unsupported_features = ctx.disabled_features,",
+        "  )",
+        "  linking_outputs = cc_common.link(",
+        "    name = ctx.label.name,",
+        "    actions = ctx.actions,",
+        "    feature_configuration = feature_configuration,",
+        "    cc_toolchain = cc_toolchain,",
+        "    linking_contexts = [dep[CcInfo].linking_context for dep in ctx.attr.deps if"
+            + " CcInfo in dep]",
+        "  )",
+        "  return []",
+        "custom_rule = rule(",
+        "  implementation = _impl,",
+        "  attrs = {",
+        "    'deps': attr.label_list(),",
+        "    'srcs': attr.label_list(allow_files = ['.cc']),",
+        "  },",
+        "  toolchains = ['//rule:toolchain_type_2'] + _use_cpp_toolchain(),",
+        "  fragments = ['cpp']",
+        ")");
+    scratch.file(
+        "test/BUILD",
+        """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+        load("//test:defs.bzl", "custom_rule")
+
+        cc_library(
+            name = "dep",
+            srcs = ["dep.cc"],
+        )
+
+        custom_rule(
+            name = "custom_rule_name",
+            srcs = ["custom.cc"],
+            deps = ["dep"],
+        )
+        """);
+    useConfiguration("--incompatible_auto_exec_groups", "--features=thin_lto");
+    AnalysisMock.get()
+        .ccSupport()
+        .setupCcToolchainConfig(
+            mockToolsConfig,
+            CcToolchainConfig.builder()
+                .withFeatures(CppRuleClasses.THIN_LTO, CppRuleClasses.SUPPORTS_START_END_LIB)
+                .withToolchainTargetConstraints("@@//platforms:constraint_1")
+                .withToolchainExecConstraints("@@//platforms:constraint_1"));
+
+    ImmutableList<Action> ltoBackendActions =
+        getActions("//test:custom_rule_name", "CcLtoBackendCompile");
+
+    assertThat(ltoBackendActions).isNotEmpty();
+    for (Action action : ltoBackendActions) {
+      assertThat(action.getOwner().getExecutionPlatform().label())
+          .isEqualTo(Label.parseCanonical("//platforms:platform_1"));
+    }
+  }
+
+  @Test
   public void ccCommonLink_linkstampCompileActionExecutesOnFirstPlatform() throws Exception {
     scratch.file(
         "bazel_internal/test_rules/cc/defs.bzl",


### PR DESCRIPTION
### Description

Add an optional `toolchain_type` parameter to both `cc_internal.create_lto_backend_action` and
`cc_internal.create_lto_backend_action_template`.

### Motivation

When auto_exec_groups is enabled (the default), CcLtoBackendCompile and LtoBackendActionTemplate actions are created with an ActionOwner resolved from the DEFAULT exec group, which does not include any toolchain types in its ToolchainContextKey. This causes these actions to be scheduled on an arbitrary execution platform that satisfies only rule-level exec_compatible_with constraints, ignoring the CC toolchain's exec_compatible_with entirely.

In contrast, CppCompile and CppLink actions correctly resolve their ActionOwner through the auto exec group keyed by the CC toolchain type (via CppCompileActionBuilder.getActionOwner), which includes the toolchain type in platform resolution and thus respects the toolchain's exec_compatible_with constraints.

This manifests as a cross-compilation failure in mixed-architecture RBE setups: when a CC toolchain is constrained to arm64 workers, the compile and link actions correctly run on arm64, but LTO backend compile actions escape to x86_64 workers. The x86_64 worker's clang then produces x86_64 objects that the arm64 linker rejects:

  ld.lld: error: ...hello.pic.o is incompatible with elf64-littleaarch64

The fix adds an optional `toolchain_type` parameter to both `cc_internal.create_lto_backend_action` and
`cc_internal.create_lto_backend_action_template`. When provided, it resolves the ActionOwner through the toolchain-aware auto exec group (using the same CppCompileActionBuilder.getActionOwner helper as CppCompile actions). The parameter defaults to None for backwards compatibility with existing rules_cc versions.

A [corresponding rules_cc change](https://github.com/bazelbuild/rules_cc/pull/709) is needed to pass `toolchain_type` to these APIs.

### Build API Changes

This adds a new optional arg to two cc_internal functions, intended to be used through rules_cc.  This has not been discussed anywhere before this PR.  The change is backwards compatible.  This area of code goes away with the eventual starlarkification of rules_cc.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Fixed an issue where ThinLTO backend compile actions could be scheduled on the wrong execution platform when using auto exec groups with remote execution, causing cross-compilation failures.