### PR TITLE
Fix platform flag transition reset

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
@@ -124,6 +124,19 @@ public abstract class PlatformOptions extends FragmentOptions {
   public abstract void setExtraToolchains(List<String> value);
 
   @Option(
+      name = "platform_in_output_dir_starlark_flags",
+      converter = CommaSeparatedOptionListConverter.class,
+      defaultValue = "",
+      documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      help =
+          "An allowlist of Starlark flags (as labels) that platforms may set via "
+              + "their flags attribute. When a transition changes the platform, "
+              + "these flags will be included in the transition outputs so that "
+              + "stale values from a previous platform are properly cleaned up.")
+  public List<String> platformInOutputDirStarlarkFlags;
+
+  @Option(
       name = "toolchain_resolution_debug",
       defaultValue = "-.*", // By default, exclude everything.
       converter = RegexFilter.RegexFilterConverter.class,

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BUILD
@@ -480,6 +480,7 @@ java_library(
     name = "starlark_transition_cache",
     srcs = ["StarlarkTransitionCache.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/analysis:platform_options",
         ":build_options",
         ":core_options",
         ":scope",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/OutputPathMnemonicComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/OutputPathMnemonicComputer.java
@@ -300,7 +300,21 @@ public final class OutputPathMnemonicComputer {
     //   notion of trimming a Starlark option: 'null' or non-existent justs means set to default.
     ImmutableSet<String> chosenStarlarkOptions =
         diff.getChangedStarlarkOptions().stream().map(Label::toString).collect(toImmutableSet());
-    return hashChosenOptions(toOptions, chosenNativeOptions, chosenStarlarkOptions);
+    String fragment = hashChosenOptions(toOptions, chosenNativeOptions, chosenStarlarkOptions);
+    System.err.println(
+      "DEBUG_OUTPUT_PATH_DIFF toChecksum="
+        + toOptions.checksum().substring(0, 12)
+        + " baselineChecksum="
+        + baselineOptions.checksum().substring(0, 12)
+        + " native="
+        + chosenNativeOptions
+        + " starlark="
+        + chosenStarlarkOptions
+        + " starlarkValues="
+        + toOptions.getStarlarkOptions()
+        + " fragment="
+        + fragment);
+    return fragment;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkTransitionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkTransitionCache.java
@@ -18,6 +18,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.analysis.PlatformOptions;
 import com.google.devtools.build.lib.analysis.config.StarlarkDefinedConfigTransition.Settings;
 import com.google.devtools.build.lib.analysis.config.transitions.ConfigurationTransition;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionUtil;
@@ -27,10 +28,14 @@ import com.google.devtools.build.lib.analysis.starlark.StarlarkTransition;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkTransition.StarlarkTransitionVisitor;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkTransition.TransitionException;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
+import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.events.StoredEventHandler;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
 /**
@@ -48,6 +53,9 @@ import javax.annotation.Nullable;
  * cache saves most of that work, reducing analysis phase CPU time by 17%.
  */
 public final class StarlarkTransitionCache {
+
+  private static final Label PLATFORMS_OPTION =
+      Label.createUnvalidated(LabelConstants.COMMAND_LINE_OPTION_PACKAGE_IDENTIFIER, "platforms");
 
   private Cache<Key, Value> cache = Caffeine.newBuilder().softValues().build();
 
@@ -75,27 +83,95 @@ public final class StarlarkTransitionCache {
    * flag mapped to this alias.
    */
   public ImmutableSet<Label> getAllStarlarkBuildSettings(
-      ConfigurationTransition root, ImmutableMap<String, Label> flagsAliases) {
+      ConfigurationTransition root,
+      BuildOptions fromOptions,
+      ImmutableMap<String, Label> flagsAliases)
+      throws TransitionException {
     var cachedValue = starlarkBuildSettingsCache.getIfPresent(root);
-    if (cachedValue != null) {
-      return cachedValue;
+    if (cachedValue == null) {
+      ImmutableSet.Builder<Label> keyBuilder = new ImmutableSet.Builder<>();
+      try {
+        root.visit(
+            (StarlarkTransitionVisitor)
+                transition ->
+                    keyBuilder.addAll(
+                        StarlarkTransition.getRelevantStarlarkSettingsFromTransition(
+                            transition, flagsAliases, Settings.INPUTS_AND_OUTPUTS)));
+      } catch (TransitionException e) {
+        // Not actually thrown in the visitor, but declared.
+      }
+
+      cachedValue = keyBuilder.build();
+      starlarkBuildSettingsCache.put(root, cachedValue);
     }
 
-    ImmutableSet.Builder<Label> keyBuilder = new ImmutableSet.Builder<>();
+    ImmutableSet<Label> platformOutputSettings = getPlatformOutputSettings(root, fromOptions);
+    if (platformOutputSettings.isEmpty()) {
+      return cachedValue;
+    }
+    return ImmutableSet.<Label>builder()
+        .addAll(cachedValue)
+        .addAll(platformOutputSettings)
+        .build();
+  }
+
+  private static ImmutableSet<Label> getPlatformOutputSettings(
+      ConfigurationTransition root, BuildOptions fromOptions) throws TransitionException {
+    PlatformOptions platformOptions = fromOptions.get(PlatformOptions.class);
+    if (platformOptions == null || platformOptions.platformInOutputDirStarlarkFlags.isEmpty()) {
+      return ImmutableSet.of();
+    }
+
+    AtomicBoolean transitionOutputsPlatforms = new AtomicBoolean(false);
     try {
       root.visit(
           (StarlarkTransitionVisitor)
-              transition ->
-                  keyBuilder.addAll(
-                      StarlarkTransition.getRelevantStarlarkSettingsFromTransition(
-                          transition, flagsAliases, Settings.INPUTS_AND_OUTPUTS)));
+              transition -> {
+                if (transition.outputsPlatformOption()) {
+                  transitionOutputsPlatforms.set(true);
+                }
+              });
     } catch (TransitionException e) {
       // Not actually thrown in the visitor, but declared.
     }
 
-    ImmutableSet<Label> result = keyBuilder.build();
-    starlarkBuildSettingsCache.put(root, result);
-    return result;
+    CoreOptions coreOptions = fromOptions.get(CoreOptions.class);
+    boolean affectedByPlatformTransition =
+        coreOptions != null
+        && (coreOptions
+            .affectedByStarlarkTransition
+            .contains("//command_line_option:platforms")
+          || platformOptions.platformInOutputDirStarlarkFlags.stream()
+            .anyMatch(coreOptions.affectedByStarlarkTransition::contains));
+
+    if (!transitionOutputsPlatforms.get() && !affectedByPlatformTransition) {
+      return ImmutableSet.of();
+    }
+
+    ImmutableSet.Builder<Label> result = ImmutableSet.builder();
+    for (String rawFlag : platformOptions.platformInOutputDirStarlarkFlags) {
+      try {
+        result.add(Label.parseCanonical(rawFlag));
+      } catch (LabelSyntaxException e) {
+        throw new TransitionException(
+            String.format(
+                "Invalid label in --platform_in_output_dir_starlark_flags: %s", rawFlag),
+            e);
+      }
+    }
+      ImmutableSet<Label> platformOutputSettings = result.build();
+      System.err.println(
+        "DEBUG_PLATFORM_CLEANUP_SETTINGS transition="
+          + root
+          + " outputsPlatforms="
+          + transitionOutputsPlatforms.get()
+          + " affectedByPlatforms="
+          + affectedByPlatformTransition
+          + " allowlisted="
+          + platformOutputSettings
+          + " fromStarlark="
+          + fromOptions.getStarlarkOptions());
+      return platformOutputSettings;
   }
 
   /** Adds the default values for a transition's input build settings to its input build options. */
@@ -103,14 +179,19 @@ public final class StarlarkTransitionCache {
       BuildOptions fromOptions,
       ImmutableMap<String, Label> flagsAliases,
       ConfigurationTransition transition,
-      StarlarkBuildSettingsDetailsValue details) {
-    if (details.buildSettingToDefault().isEmpty() && details.customExecScopeValues().isEmpty()) {
+      StarlarkBuildSettingsDetailsValue details,
+      ImmutableSet<Label> platformOutputSettings)
+      throws TransitionException {
+    if (details.buildSettingToDefault().isEmpty()
+        && details.customExecScopeValues().isEmpty()
+        && platformOutputSettings.isEmpty()) {
       // No need to traverse the transition to find its Starlark flag inputs. There are none.
       return fromOptions;
     }
 
     BuildOptions.Builder optionsWithDefaults = null;
-    for (Label maybeAliasSetting : getAllStarlarkBuildSettings(transition, flagsAliases)) {
+    for (Label maybeAliasSetting :
+        getAllStarlarkBuildSettings(transition, fromOptions, flagsAliases)) {
       // details will only have the defaults of the actual setting so must unalias
       Label setting = details.aliasToActual().getOrDefault(maybeAliasSetting, maybeAliasSetting);
       if (!fromOptions.getStarlarkOptions().containsKey(maybeAliasSetting)) {
@@ -183,12 +264,25 @@ public final class StarlarkTransitionCache {
 
     ImmutableMap<String, Label> flagsAliases =
         fromOptions.get(CoreOptions.class).getCommandLineFlagAliasesMap();
+    ImmutableSet<Label> platformOutputSettings = getPlatformOutputSettings(transition, fromOptions);
 
     // All code below here only executes on a cache miss and thus should rely only on values that
     // are part of the above cache key or constants that exist throughout the lifetime of the
     // Blaze server instance.
     BuildOptions adjustedOptions =
-        addDefaultStarlarkOptions(fromOptions, flagsAliases, transition, details);
+      addDefaultStarlarkOptions(
+        fromOptions, flagsAliases, transition, details, platformOutputSettings);
+    if (!platformOutputSettings.isEmpty()) {
+      System.err.println(
+          "DEBUG_PLATFORM_CLEANUP_TRANSITION transition="
+              + transition
+              + " allowlisted="
+              + platformOutputSettings
+              + " before="
+              + fromOptions.getStarlarkOptions()
+              + " adjusted="
+              + adjustedOptions.getStarlarkOptions());
+    }
     // TODO(bazel-team): Add safety-check that this never mutates fromOptions.
     StoredEventHandler handlerWithErrorStatus = new StoredEventHandler();
     Map<String, BuildOptions> result =
@@ -206,7 +300,10 @@ public final class StarlarkTransitionCache {
     if (handlerWithErrorStatus.hasErrors()) {
       throw new TransitionException("Errors encountered while applying Starlark transition");
     }
-    result = StarlarkTransition.validate(transition, details, flagsAliases, result);
+    result =
+      StarlarkTransition.validate(
+        transition, details, flagsAliases, result, platformOutputSettings);
+    result = markPlatformCleanupAffectedFlags(result, platformOutputSettings);
     // If the transition errored (like bad Starlark code), this method already exited with an
     // exception so the results won't go into the cache. We still want to collect non-error events
     // like print() output.
@@ -214,6 +311,56 @@ public final class StarlarkTransitionCache {
         !handlerWithErrorStatus.isEmpty() ? handlerWithErrorStatus : null;
     cache.put(cacheKey, new Value(result, nonErrorEvents));
     return result;
+  }
+
+  private static Map<String, BuildOptions> markPlatformCleanupAffectedFlags(
+      Map<String, BuildOptions> transitionResult, ImmutableSet<Label> platformOutputSettings) {
+    if (platformOutputSettings.isEmpty()) {
+      return transitionResult;
+    }
+
+    ImmutableMap.Builder<String, BuildOptions> updatedResult = ImmutableMap.builder();
+    for (Map.Entry<String, BuildOptions> entry : transitionResult.entrySet()) {
+      BuildOptions options = entry.getValue();
+      CoreOptions coreOptions = options.get(CoreOptions.class);
+      if (coreOptions == null) {
+        updatedResult.put(entry);
+        continue;
+      }
+
+      ArrayList<String> affectedOptions = new ArrayList<>(coreOptions.affectedByStarlarkTransition);
+      boolean changed = false;
+      if (!affectedOptions.contains("//command_line_option:platforms")) {
+        affectedOptions.add("//command_line_option:platforms");
+        changed = true;
+      }
+      for (Label setting : platformOutputSettings) {
+        String settingName = setting.toString();
+        if (!affectedOptions.contains(settingName)) {
+          affectedOptions.add(settingName);
+          changed = true;
+        }
+      }
+
+      if (!changed) {
+        updatedResult.put(entry);
+        continue;
+      }
+
+      BuildOptions updatedOptions = options.clone();
+      updatedOptions.get(CoreOptions.class).affectedByStarlarkTransition = affectedOptions;
+      System.err.println(
+          "DEBUG_PLATFORM_CLEANUP_MARK transition="
+              + entry.getKey()
+              + " allowlisted="
+              + platformOutputSettings
+              + " affectedBy="
+              + affectedOptions
+              + " starlark="
+              + updatedOptions.getStarlarkOptions());
+      updatedResult.put(entry.getKey(), updatedOptions);
+    }
+    return updatedResult.buildOrThrow();
   }
 
   public void clear() {

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyProducer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyProducer.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.lib.analysis.config.transitions.BaselineOptions
 import com.google.devtools.build.lib.analysis.platform.PlatformValue;
 import com.google.devtools.build.lib.analysis.test.TestConfiguration;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.skyframe.BuildOptionsScopeFunction.BuildOptionsScopeFunctionException;
 import com.google.devtools.build.lib.skyframe.BuildOptionsScopeValue;
 import com.google.devtools.build.lib.skyframe.config.BuildConfigurationKey;
@@ -156,11 +157,80 @@ public final class BuildConfigurationKeyProducer<C>
     }
     Optional<ParsedFlagsValue> parsedFlags = targetPlatformValue.parsedFlags();
     if (parsedFlags.isPresent()) {
-      this.postPlatformProcessedOptions = parsedFlags.get().mergeWith(options).getOptions();
+      try {
+        BuildOptions mergedOptions = parsedFlags.get().mergeWith(options).getOptions();
+        this.postPlatformProcessedOptions =
+            cleanupAllowlistedPlatformFlags(options, mergedOptions, parsedFlags.get());
+      } catch (OptionsParsingException e) {
+        sink.acceptOptionsParsingError(e);
+        return runAfter;
+      }
       return this::findBuildOptionsScopes;
     } else {
       return this::mergeFromPlatformMapping;
     }
+  }
+
+  private static BuildOptions cleanupAllowlistedPlatformFlags(
+      BuildOptions prePlatformOptions,
+      BuildOptions postPlatformOptions,
+      ParsedFlagsValue parsedFlags)
+      throws OptionsParsingException {
+    PlatformOptions platformOptions = prePlatformOptions.get(PlatformOptions.class);
+    if (platformOptions == null || platformOptions.platformInOutputDirStarlarkFlags.isEmpty()) {
+      return postPlatformOptions;
+    }
+
+    CoreOptions coreOptions = prePlatformOptions.get(CoreOptions.class);
+    if (coreOptions == null
+        || !coreOptions
+            .affectedByStarlarkTransition
+            .contains("//command_line_option:platforms")) {
+      return postPlatformOptions;
+    }
+
+    var platformSetFlags = parsedFlags.parsingResult().getStarlarkOptions().keySet();
+    BuildOptions.Builder cleanedOptions = null;
+    ArrayList<Label> removedFlags = new ArrayList<>();
+    for (String rawFlag : platformOptions.platformInOutputDirStarlarkFlags) {
+      Label flag;
+      try {
+        flag = Label.parseCanonical(rawFlag);
+      } catch (LabelSyntaxException e) {
+        throw new OptionsParsingException(
+            String.format(
+                "Invalid label in --platform_in_output_dir_starlark_flags: %s", rawFlag),
+            e);
+      }
+
+      if (platformSetFlags.contains(flag.toString())
+          || !postPlatformOptions.getStarlarkOptions().containsKey(flag)) {
+        continue;
+      }
+
+      if (cleanedOptions == null) {
+        cleanedOptions = postPlatformOptions.toBuilder();
+      }
+      cleanedOptions.removeStarlarkOption(flag);
+      removedFlags.add(flag);
+    }
+
+    BuildOptions cleanedBuildOptions =
+        cleanedOptions == null ? postPlatformOptions : cleanedOptions.build();
+    System.err.println(
+        "DEBUG_PLATFORM_CLEANUP_POST_PLATFORM pre="
+            + prePlatformOptions.getStarlarkOptions()
+            + " merged="
+            + postPlatformOptions.getStarlarkOptions()
+            + " platformSet="
+            + platformSetFlags
+            + " removed="
+            + removedFlags
+            + " result="
+            + cleanedBuildOptions.getStarlarkOptions()
+            + " affectedBy="
+            + coreOptions.affectedByStarlarkTransition);
+    return cleanedBuildOptions;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/TransitionApplier.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/TransitionApplier.java
@@ -115,10 +115,17 @@ final class TransitionApplier
   }
 
   private StateMachine handleStarlarkTransition(Tasks tasks) throws InterruptedException {
-    ImmutableSet<Label> starlarkBuildSettings =
-        transitionCache.getAllStarlarkBuildSettings(
-            transition,
-            fromConfiguration.getOptions().get(CoreOptions.class).getCommandLineFlagAliasesMap());
+    ImmutableSet<Label> starlarkBuildSettings;
+    try {
+      starlarkBuildSettings =
+          transitionCache.getAllStarlarkBuildSettings(
+              transition,
+              fromConfiguration.getOptions(),
+              fromConfiguration.getOptions().get(CoreOptions.class).getCommandLineFlagAliasesMap());
+    } catch (TransitionException e) {
+      sink.acceptTransitionError(e);
+      return runAfter;
+    }
     Set<Label> hostFlags = new HashSet<>();
 
     // If the transition is the exec transition, we want to look up the host flag declared by

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
@@ -779,6 +779,8 @@ public final class FunctionTransitionUtil {
     if (toOptions == null && changedStarlarkOptions.isEmpty()) {
       return fromOptions;
     }
+    // DEBUG INSTRUMENTATION
+    System.err.println("DEBUG_TRANSITION [" + starlarkTransition + "] changedStarlark=" + changedStarlarkOptions + " fromStarlark=" + fromOptions.getStarlarkOptions() + " fromChecksum=" + fromOptions.checksum().substring(0,12));
     // Note that rebuilding also calls FragmentOptions.getNormalized() to guarantee --define,
     // --features, and similar flags are consistently ordered.
     toOptions =

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTransition.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTransition.java
@@ -42,6 +42,8 @@ public abstract class StarlarkTransition implements ConfigurationTransition {
 
   private static final Label STAMP_SETTING =
       Label.createUnvalidated(LabelConstants.COMMAND_LINE_OPTION_PACKAGE_IDENTIFIER, "stamp");
+  private static final Label PLATFORMS_OPTION =
+      Label.createUnvalidated(LabelConstants.COMMAND_LINE_OPTION_PACKAGE_IDENTIFIER, "platforms");
 
   private final StarlarkDefinedConfigTransition starlarkDefinedConfigTransition;
 
@@ -75,6 +77,10 @@ public abstract class StarlarkTransition implements ConfigurationTransition {
   // Get the outputs of the starlark transition as a set of canonicalized Labels.
   private ImmutableSet<Label> getOutputs() {
     return starlarkDefinedConfigTransition.getOutputsCanonicalizedToGiven().keySet();
+  }
+
+  public boolean outputsPlatformOption() {
+    return getOutputs().contains(PLATFORMS_OPTION);
   }
 
   @Override
@@ -147,6 +153,16 @@ public abstract class StarlarkTransition implements ConfigurationTransition {
       ImmutableMap<String, Label> flagsAliases,
       Map<String, BuildOptions> toOptions)
       throws TransitionException {
+    return validate(root, details, flagsAliases, toOptions, ImmutableSet.of());
+  }
+
+  public static Map<String, BuildOptions> validate(
+      ConfigurationTransition root,
+      StarlarkBuildSettingsDetailsValue details,
+      ImmutableMap<String, Label> flagsAliases,
+      Map<String, BuildOptions> toOptions,
+      ImmutableSet<Label> platformOutputSettings)
+      throws TransitionException {
     // Collect settings that are inputs or outputs of the transition together with their types.
     // Output setting values will be validated and removed if set to their default.
     // Raw means these have not been unaliased.
@@ -160,10 +176,13 @@ public abstract class StarlarkTransition implements ConfigurationTransition {
             transition -> {
               ImmutableSet<Label> inputAndOutputSettings =
                   getRelevantStarlarkSettingsFromTransition(
-                      transition, flagsAliases, Settings.INPUTS_AND_OUTPUTS);
+                      transition,
+                      flagsAliases,
+                      Settings.INPUTS_AND_OUTPUTS,
+                      platformOutputSettings);
               ImmutableSet<Label> outputSettings =
                   getRelevantStarlarkSettingsFromTransition(
-                      transition, flagsAliases, Settings.OUTPUTS);
+                      transition, flagsAliases, Settings.OUTPUTS, platformOutputSettings);
               for (Label setting : inputAndOutputSettings) {
                 rawInputAndOutputSettingsBuilder.add(setting);
                 if (!outputSettings.contains(setting)) {
@@ -216,6 +235,21 @@ public abstract class StarlarkTransition implements ConfigurationTransition {
       }
       // Keep the same instance if we didn't do anything to maintain reference equality later on.
       options = cleanedOptions != null ? cleanedOptions.build() : options;
+      if (!platformOutputSettings.isEmpty()) {
+        System.err.println(
+            "DEBUG_PLATFORM_CLEANUP_VALIDATE transition="
+                + root
+                + " splitKey="
+                + entry.getKey()
+                + " allowlisted="
+                + platformOutputSettings
+                + " inputOnly="
+                + inputOnlySettings
+                + " before="
+                + entry.getValue().getStarlarkOptions()
+                + " after="
+                + options.getStarlarkOptions());
+      }
       cleanedOptionMap.put(entry.getKey(), options);
     }
     return cleanedOptionMap.buildOrThrow();
@@ -329,6 +363,15 @@ public abstract class StarlarkTransition implements ConfigurationTransition {
 
   public static ImmutableSet<Label> getRelevantStarlarkSettingsFromTransition(
       StarlarkTransition transition, ImmutableMap<String, Label> flagsAliases, Settings settings) {
+    return getRelevantStarlarkSettingsFromTransition(
+        transition, flagsAliases, settings, ImmutableSet.of());
+  }
+
+  public static ImmutableSet<Label> getRelevantStarlarkSettingsFromTransition(
+      StarlarkTransition transition,
+      ImmutableMap<String, Label> flagsAliases,
+      Settings settings,
+      ImmutableSet<Label> platformOutputSettings) {
     if (transition.isExecTransition()) {
       // Ignore flag aliases for exec transitions. Starlark flags will provide their exec
       // transition semantics in the flag definition.
@@ -342,6 +385,11 @@ public abstract class StarlarkTransition implements ConfigurationTransition {
         addLabelIfRelevant(result, flagsAliases, transition.getInputs());
         addLabelIfRelevant(result, flagsAliases, transition.getOutputs());
       }
+    }
+    if (!platformOutputSettings.isEmpty()
+        && transition.outputsPlatformOption()
+        && (settings == Settings.OUTPUTS || settings == Settings.INPUTS_AND_OUTPUTS)) {
+      result.addAll(platformOutputSettings);
     }
     return result.build();
   }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/BaselineOptionsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/BaselineOptionsFunction.java
@@ -106,6 +106,8 @@ public final class BaselineOptionsFunction implements SkyFunction {
       }
     }
 
+    // DEBUG: log baseline starlark options
+    System.err.println("DEBUG_BASELINE platform=" + (key.newPlatform() != null ? key.newPlatform() : "null") + " starlarkOptions=" + remappedAdjustedBaselineOptions.getStarlarkOptions() + " checksum=" + remappedAdjustedBaselineOptions.checksum().substring(0,12));
     return BaselineOptionsValue.create(remappedAdjustedBaselineOptions);
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

This change highlights an impractical fix for https://github.com/bazelbuild/bazel/issues/29319.

The problem appears to be that transitionning to a platform without flags does not undo nor reset flag transitions applied by a previous platform transition.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

Yes, it introduces a whitelist flag listing flags that platform transitions are allowed to transition upon. That is, flags that can be mentionned in a platform definition.

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->
