### PR TITLE
[9.2.0] Support for toolchains aspects wildcard "*" (https://github.com/bazelbuild/bazel/pull/29415)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/AspectResolutionHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AspectResolutionHelpers.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.packages.AdvertisedProviderSet;
 import com.google.devtools.build.lib.packages.Aspect;
 import com.google.devtools.build.lib.packages.AspectClass;
 import com.google.devtools.build.lib.packages.AspectDefinition;
+import com.google.devtools.build.lib.packages.AspectPropagationEdgesSupplier;
 import com.google.devtools.build.lib.packages.AspectPropagationEdgesSupplier.FixedListSupplier;
 import com.google.devtools.build.lib.packages.AspectPropagationEdgesSupplier.FunctionSupplier;
 import com.google.devtools.build.lib.packages.Attribute;
@@ -128,7 +129,9 @@ public final class AspectResolutionHelpers {
 
   private static <T> boolean propagatesTo(
       T edge, Aspect aspect, ImmutableMultimap<Aspect, T> computedEdges) {
-    return computedEdges.containsEntry(aspect, edge) || computedEdges.containsEntry(aspect, "*");
+    return computedEdges.containsEntry(aspect, edge)
+        || computedEdges.containsEntry(aspect, "*")
+        || computedEdges.containsEntry(aspect, AspectPropagationEdgesSupplier.ALL_TOOLCHAINS);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkToolchainContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkToolchainContext.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkList;
 import net.starlark.java.eval.StarlarkSemantics;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.StarlarkValue;
@@ -52,6 +53,11 @@ public abstract class StarlarkToolchainContext implements ToolchainContextApi {
             StarlarkThread starlarkThread, StarlarkSemantics semantics, Object key) {
           return false;
         }
+
+        @Override
+        public StarlarkList<Label> toolchainTypes() {
+          return StarlarkList.empty();
+        }
       };
 
   public static ToolchainContextApi create(
@@ -71,6 +77,11 @@ public abstract class StarlarkToolchainContext implements ToolchainContextApi {
   protected abstract Function<Label, ResolvedToolchainData> resolveToolchainFunc();
 
   protected abstract ImmutableSet<Label> resolvedToolchainTypeLabels();
+
+  @Override
+  public StarlarkList<Label> toolchainTypes() {
+    return StarlarkList.immutableCopyOf(resolvedToolchainTypeLabels());
+  }
 
   @Override
   public boolean isImmutable() {

--- a/src/main/java/com/google/devtools/build/lib/packages/AspectPropagationEdgesSupplier.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/AspectPropagationEdgesSupplier.java
@@ -45,6 +45,8 @@ import net.starlark.java.eval.StarlarkThread;
  */
 public sealed interface AspectPropagationEdgesSupplier<T> {
 
+  Label ALL_TOOLCHAINS = Label.parseCanonicalUnchecked("//__toolchains_aspects__:all");
+
   public static final AspectPropagationEdgesSupplier<String> DEFAULT_ATTR_ASPECTS_SUPPLIER =
       new FixedListSupplier<>(ImmutableSet.of());
 
@@ -221,8 +223,16 @@ public sealed interface AspectPropagationEdgesSupplier<T> {
     Sequence<String> toolchainsAspects =
         Sequence.cast(rawToolchainsAspects, String.class, "toolchains_aspects");
 
+    if (toolchainsAspects.size() == 1 && Objects.equals(toolchainsAspects.get(0), "*")) {
+      return ImmutableSet.of(ALL_TOOLCHAINS);
+    }
+
     ImmutableSet.Builder<Label> parsedLabels = new ImmutableSet.Builder<>();
     for (String input : toolchainsAspects) {
+      if (Objects.equals(input, "*")) {
+        // This is already handled if the list has a single '*' item in it
+        throw new EvalException("'*' must be the only item in 'toolchains_aspects' list");
+      }
       try {
         Label label = labelConverter.convert(input);
         parsedLabels.add(label);

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/ToolchainContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/ToolchainContextApi.java
@@ -15,7 +15,10 @@
 package com.google.devtools.build.lib.starlarkbuildapi.platform;
 
 import com.google.devtools.build.docgen.annot.DocCategory;
+import com.google.devtools.build.lib.cmdline.Label;
 import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.Sequence;
 import net.starlark.java.eval.StarlarkIndexable;
 import net.starlark.java.eval.StarlarkValue;
 
@@ -35,4 +38,8 @@ import net.starlark.java.eval.StarlarkValue;
             + " target. It can be accessed by"
             + " <code>ctx.rule.toolchains[\"//pkg:my_toolchain_type\"]</code> and it returns the"
             + " list of providers resulted from applying the aspects on these toolchain targets. ")
-public interface ToolchainContextApi extends StarlarkValue, StarlarkIndexable.Threaded {}
+public interface ToolchainContextApi extends StarlarkValue, StarlarkIndexable.Threaded {
+
+  @StarlarkMethod(name = "toolchain_types", doc = "Returns the resolved toolchain type labels.")
+  Sequence<Label> toolchainTypes();
+}

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/BUILD
@@ -174,6 +174,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/analysis:toolchain_collection",
         "//src/main/java/com/google/devtools/build/lib/analysis:toolchain_context",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:dependency_evaluation_exception",
+        "//src/main/java/com/google/devtools/build/lib/analysis/config:toolchain_type_requirement",
         "//src/main/java/com/google/devtools/build/lib/analysis/producers",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/packages",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainsForTargetsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainsForTargetsTest.java
@@ -35,6 +35,7 @@ import com.google.devtools.build.lib.analysis.TargetAndConfiguration;
 import com.google.devtools.build.lib.analysis.ToolchainCollection;
 import com.google.devtools.build.lib.analysis.ToolchainContext;
 import com.google.devtools.build.lib.analysis.config.DependencyEvaluationException;
+import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
 import com.google.devtools.build.lib.analysis.constraints.IncompatibleTargetChecker.IncompatibleTargetException;
 import com.google.devtools.build.lib.analysis.producers.DependencyContext;
@@ -342,6 +343,11 @@ public final class ToolchainsForTargetsTest extends AnalysisTestCase {
     assertThat(toolchainCollection)
         .defaultToolchainContext()
         .hasResolvedToolchain("//toolchains:toolchain_1_impl");
+    Label toolchainType = Label.parseCanonicalUnchecked("//toolchain:test_toolchain");
+    assertThat(toolchainCollection)
+        .defaultToolchainContext()
+        .toolchainTypes()
+        .containsExactly(toolchainType, ToolchainTypeRequirement.create(toolchainType));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/starlark/BUILD
@@ -269,6 +269,7 @@ java_test(
         "//src/main/java/net/starlark/java/syntax",
         "//src/test/java/com/google/devtools/build/lib/analysis/testing",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
+        "//src/test/java/com/google/devtools/build/lib/events:testutil",
         "//src/test/java/com/google/devtools/build/lib/starlark/util",
         "//src/test/java/com/google/devtools/build/lib/testutil",
         "//src/test/java/com/google/devtools/build/lib/testutil:JunitUtils",

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkAspectsToolchainPropagationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkAspectsToolchainPropagationTest.java
@@ -2624,6 +2624,64 @@ var_supplier(
   }
 
   @Test
+  public void toolchainTypesFunc_wildcardEnumeratesResolvedToolchains(
+      @TestParameter boolean autoExecGroups) throws Exception {
+    scratch.file(
+        "test/defs.bzl",
+        """
+        AspectInfo = provider()
+
+        def _impl(target, ctx):
+          res = ['my_aspect on ' + str(target.label)]
+          for toolchain_type in ctx.rule.toolchains.toolchain_types():
+            if AspectInfo in ctx.rule.toolchains[toolchain_type]:
+              res.extend(ctx.rule.toolchains[toolchain_type][AspectInfo].res)
+          return [AspectInfo(res = res)]
+
+        toolchain_aspect = aspect(
+          implementation = _impl,
+          toolchains_aspects = ['*'],
+        )
+
+        def _rule_impl(ctx):
+          pass
+
+        r1 = rule(
+          implementation = _rule_impl,
+          toolchains = ['//rule:toolchain_type_1', '//rule:toolchain_type_2'],
+        )
+        """);
+    scratch.file(
+        "test/BUILD",
+        """
+        load('//test:defs.bzl', 'r1')
+        r1(name = 't1')
+        """);
+    useConfiguration(
+        "--extra_toolchains=//toolchain:foo_toolchain,//toolchain:foo_toolchain_with_provider",
+        "--incompatible_auto_exec_groups=" + autoExecGroups);
+
+    var analysisResult = update(ImmutableList.of("//test:defs.bzl%toolchain_aspect"), "//test:t1");
+
+    var aspectKeys = getAspectKeys("//test:defs.bzl%toolchain_aspect");
+    assertThat(aspectKeys)
+        .containsExactly(
+            "//test:defs.bzl%toolchain_aspect on //test:t1",
+            "//test:defs.bzl%toolchain_aspect on //toolchain:foo",
+            "//test:defs.bzl%toolchain_aspect on //toolchain:foo_with_provider");
+
+    ConfiguredAspect configuredAspect =
+        Iterables.getOnlyElement(analysisResult.getAspectsMap().values());
+    assertThat(
+            getStarlarkProvider(configuredAspect, "//test:defs.bzl", "AspectInfo")
+                .getValue("res", Sequence.class))
+        .containsExactly(
+            "my_aspect on @@//test:t1",
+            "my_aspect on @@//toolchain:foo",
+            "my_aspect on @@//toolchain:foo_with_provider");
+  }
+
+  @Test
   public void toolchainTypesFunc_propagateToSelectedTypes(@TestParameter boolean autoExecGroups)
       throws Exception {
     scratch.file(

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -55,6 +55,7 @@ import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.events.NullEventHandler;
+import com.google.devtools.build.lib.events.util.EventCollectionApparatus.FailFastException;
 import com.google.devtools.build.lib.packages.AdvertisedProviderSet;
 import com.google.devtools.build.lib.packages.Aspect;
 import com.google.devtools.build.lib.packages.AspectClass;
@@ -5626,6 +5627,50 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         .containsExactly(
             Label.parseCanonicalUnchecked("//toolchains:type1"),
             Label.parseCanonicalUnchecked("//toolchains:type2"));
+  }
+
+  @Test
+  public void testAspectWithWildcardToolchainsAspects_parsesCorrectly() throws Exception {
+    evalAndExport(
+        ev,
+        """
+        def _aspect_impl(target, ctx):
+            return []
+        my_aspect = aspect(
+            implementation = _aspect_impl,
+            toolchains_aspects = ["*"]
+        )
+        """);
+
+    StarlarkDefinedAspect aspect = (StarlarkDefinedAspect) ev.lookup("my_aspect");
+    var toolchainsAspects = aspect.getToolchainsAspects();
+
+    assertThat(toolchainsAspects).isInstanceOf(FixedListSupplier.class);
+    assertThat(((FixedListSupplier<Label>) toolchainsAspects).getList()).hasSize(1);
+  }
+
+  @Test
+  public void testAspectWithWildcardToolchainsAspects_mixedWithLabels_fails() throws Exception {
+    reporter.removeHandler(failFastHandler);
+
+    FailFastException failFastException =
+        assertThrows(
+            FailFastException.class,
+            () ->
+                evalAndExport(
+                    ev,
+                    """
+                    def _aspect_impl(target, ctx):
+                        return []
+                    my_aspect = aspect(
+                        implementation = _aspect_impl,
+                        toolchains_aspects = ["*", "//toolchains:type1"]
+                    )
+                    """));
+
+    assertThat(failFastException)
+        .hasMessageThat()
+        .contains("'*' must be the only item in 'toolchains_aspects' list");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
@@ -4279,6 +4279,34 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testNoToolchainContext_toolchainTypesEmpty() throws Exception {
+    // Build setting rules do not have a toolchain context, as they are part of the configuration.
+    scratch.file(
+        "test/BUILD",
+        """
+        load(':rule.bzl', 'sample_setting')
+        toolchain_type(name = 'toolchain_type')
+        sample_setting(
+            name = 'test',
+            build_setting_default = True,
+        )
+        """);
+    scratch.file(
+        "test/rule.bzl",
+        """
+        def _sample_impl(ctx):
+            if ctx.toolchains.toolchain_types():
+                fail('Toolchain context should be empty')
+        sample_setting = rule(
+            implementation = _sample_impl,
+            build_setting = config.bool(flag = True),
+        )
+        """);
+    getConfiguredTarget("//test:test");
+    assertNoEvents();
+  }
+
+  @Test
   public void testTemplateExpansionComputedSubstitution() throws Exception {
     scratch.file(
         "test/rules.bzl",


### PR DESCRIPTION
### Description
This adds support for "*" in toolchains_aspects the same way as attr_aspects does.

Disclaimer, all of it was produced by codex AI.

Fixes #29258

### Motivation
This allows for generic aspects to not know in advance all the toolchains it would have to interact with throughout the build graph and focus solely on the providers they would provide

### Build API Changes

This changes allows for toolchain_types to be iterated on where applicable as a sequence such as `for toolchain_type in ctx.rule.toolchains.toolchain_types():`

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #29415.

PiperOrigin-RevId: 912642236
Change-Id: I96fd9753f3e77710c10718222d44c5c140cae002

Commit https://github.com/bazelbuild/bazel/commit/009ea69934c0c87ff15336cd923183c44de4b031