### PR TITLE
Allow filtering instrumented classes in JacocoInstrumentationProcessor

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/instrumentation/JacocoInstrumentationProcessor.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/instrumentation/JacocoInstrumentationProcessor.java
@@ -34,6 +34,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
+import org.jacoco.core.runtime.WildcardMatcher;
 
 /** Instruments compiled java classes using Jacoco instrumentation library. */
 public final class JacocoInstrumentationProcessor {
@@ -48,14 +49,22 @@ public final class JacocoInstrumentationProcessor {
               + ": pathsForCoverageFile");
     }
 
-    return new JacocoInstrumentationProcessor(args.getFirst());
+    String coverageIncludes = args.size() >= 2 ? args.get(1) : "";
+    String coverageExcludes = args.size() >= 3 ? args.get(2) : "";
+
+    return new JacocoInstrumentationProcessor(args.getFirst(), coverageIncludes, coverageExcludes);
   }
 
   private Path instrumentedClassesDirectory;
   private final String coverageInformation;
+  private final WildcardMatcher includeMatcher;
+  private final WildcardMatcher excludeMatcher;
 
-  private JacocoInstrumentationProcessor(String coverageInfo) {
+  private JacocoInstrumentationProcessor(String coverageInfo, String coverageIncludes,
+      String coverageExcludes) {
     this.coverageInformation = coverageInfo;
+    this.includeMatcher = new WildcardMatcher(coverageIncludes.isBlank() ? "*" : coverageIncludes);
+    this.excludeMatcher = new WildcardMatcher(coverageExcludes);
   }
 
   /**
@@ -110,6 +119,12 @@ public final class JacocoInstrumentationProcessor {
             // it only once during recursive directory traversal while also mutating the directory.
             Path instrumentedCopy = file;
             Path absoluteUninstrumentedCopy = Path.of(file + ".uninstrumented");
+            Path relativeClassFile = root.relativize(file);
+            String className = relativeClassFile.toString().replace(".class", "");
+            if (!includeMatcher.matches(className) || excludeMatcher.matches(className)) {
+              return FileVisitResult.CONTINUE;
+            }
+
             Path uninstrumentedCopy =
                 instrumentedClassesDirectory.resolve(root.relativize(absoluteUninstrumentedCopy));
             Files.createDirectories(uninstrumentedCopy.getParent());

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
@@ -74,6 +74,8 @@ public final class JavaCompilationHelper {
   private boolean enableJspecify = true;
   private boolean enableDirectClasspath = true;
   private final String execGroup;
+  private ImmutableList<String> coverageIncludes;
+  private ImmutableList<String> coverageExcludes;
 
   public JavaCompilationHelper(
       RuleContext ruleContext,
@@ -102,6 +104,14 @@ public final class JavaCompilationHelper {
 
   public void enableJspecify(boolean enableJspecify) {
     this.enableJspecify = enableJspecify;
+  }
+
+  public void setCoverageIncludes(ImmutableList<String> coverageIncludes) {
+    this.coverageIncludes = coverageIncludes;
+  }
+
+  public void setCoverageExcludes(ImmutableList<String> coverageExcludes) {
+    this.coverageExcludes = coverageExcludes;
   }
 
   JavaTargetAttributes getAttributes() {
@@ -247,6 +257,8 @@ public final class JavaCompilationHelper {
     builder.setTargetLabel(label);
     Artifact coverageArtifact = maybeCreateCoverageArtifact(outputs.output());
     builder.setCoverageArtifact(coverageArtifact);
+    builder.setCoverageIncludes(coverageIncludes);
+    builder.setCoverageExcludes(coverageExcludes);
     BootClassPathInfo bootClassPathInfo = getBootclasspathOrDefault();
     builder.setBootClassPath(bootClassPathInfo);
     NestedSet<Artifact> classpath =

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
@@ -137,6 +137,8 @@ public final class JavaCompileActionBuilder {
   private final String execGroup;
   private ImmutableSet<Artifact> additionalOutputs = ImmutableSet.of();
   private Artifact coverageArtifact;
+  private ImmutableList<String> coverageIncludes;
+  private ImmutableList<String> coverageExcludes;
   private ImmutableSet<Artifact> sourceFiles = ImmutableSet.of();
   private ImmutableList<Artifact> sourceJars = ImmutableList.of();
   private StrictDepsMode strictJavaDeps = StrictDepsMode.ERROR;
@@ -326,6 +328,8 @@ public final class JavaCompileActionBuilder {
     if (coverageArtifact != null) {
       result.add("--post_processor");
       result.addExecPath(JACOCO_INSTRUMENTATION_PROCESSOR, coverageArtifact);
+      result.addDynamicString(String.join(":", coverageIncludes));
+      result.addDynamicString(String.join(":", coverageExcludes));
     }
     return result.build();
   }
@@ -452,6 +456,18 @@ public final class JavaCompileActionBuilder {
   @CanIgnoreReturnValue
   public JavaCompileActionBuilder setCoverageArtifact(Artifact coverageArtifact) {
     this.coverageArtifact = coverageArtifact;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public JavaCompileActionBuilder setCoverageIncludes(ImmutableList<String> coverageIncludes) {
+    this.coverageIncludes = coverageIncludes;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public JavaCompileActionBuilder setCoverageExcludes(ImmutableList<String> coverageExcludes) {
+    this.coverageExcludes = coverageExcludes;
     return this;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -201,7 +201,9 @@ public class JavaStarlarkCommon
       boolean enableJSpecify,
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
-      Sequence<?> additionalOutputs)
+      Sequence<?> additionalOutputs,
+      Sequence<?> coverageIncludes,
+      Sequence<?> coverageExcludes)
       throws EvalException,
           TypeException,
           RuleErrorException,
@@ -261,6 +263,10 @@ public class JavaStarlarkCommon
         Depset.cast(javaBuilderJvmFlags, String.class, "javabuilder_jvm_flags"));
     compilationHelper.enableJspecify(enableJSpecify);
     compilationHelper.enableDirectClasspath(enableDirectClasspath);
+    compilationHelper.setCoverageIncludes(
+        Sequence.cast(coverageIncludes, String.class, "coverage_includes").getImmutableList());
+    compilationHelper.setCoverageExcludes(
+        Sequence.cast(coverageExcludes, String.class, "coverage_excludes").getImmutableList());
     compilationHelper.createCompileAction(outputs);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
@@ -524,6 +524,8 @@ public interface JavaCommonApi<
         @Param(name = "enable_direct_classpath", defaultValue = "True", named = true),
         @Param(name = "additional_inputs", defaultValue = "[]", named = true),
         @Param(name = "additional_outputs", defaultValue = "[]", named = true),
+        @Param(name = "coverage_includes", defaultValue = "[]", named = true),
+        @Param(name = "coverage_excludes", defaultValue = "[]", named = true)
       })
   void createCompilationAction(
       StarlarkRuleContextT ctx,
@@ -553,7 +555,9 @@ public interface JavaCommonApi<
       boolean enableJSpecify,
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
-      Sequence<?> additionalOutputs)
+      Sequence<?> additionalOutputs,
+      Sequence<?> coverageIncludes,
+      Sequence<?> coverageExcludes)
       throws EvalException,
           TypeException,
           RuleErrorException,


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

This PR allows passing include and exclude lists to the `JacocoInstrumentationProcessor` to filter which classes get instrumented. The format and behavior is the same as used by [JaCoCo](https://www.jacoco.org/jacoco/trunk/doc/agent.html). Only classes in the include list get instrumented except if they are in the exclude list. The lists are lists of class names separated by `:`. The class names use `/` as a separator instead of `.`. `?` and `*` are supported as wildcards. If no options are given all classes will be included (again matching the behavior of JaCoCo).

Should I add tests for these changes? That would require refactoring the code a bit and moving the include/exclude logic into a separate method or class.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

Fixes #28209 and #21520 in combination with https://github.com/bazelbuild/rules_java/pull/356

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->


