### PR TITLE
bzlmod: respect lockfile-anchored source.json hash for yanked-version status

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -627,10 +627,6 @@ public class IndexRegistry implements Registry {
   @Override
   public Optional<YankedVersionsValue> tryGetYankedVersionsFromLockfile(
       ModuleKey selectedModuleKey) {
-    if (knownFileHashesMode == KnownFileHashesMode.USE_IMMUTABLE_AND_UPDATE) {
-      // Yanked version information is inherently mutable, so always refresh it when requested.
-      return Optional.empty();
-    }
     String yankedInfo = previouslySelectedYankedVersions.get(selectedModuleKey);
     if (yankedInfo != null) {
       // The module version was selected when the lockfile was created, but known to be yanked
@@ -645,13 +641,22 @@ public class IndexRegistry implements Registry {
     if (knownFileHashes.containsKey(getSourceJsonUrl(selectedModuleKey))) {
       // If the source.json hash is recorded in the lockfile, we know that the module was selected
       // when the lockfile was created. Since it does not appear in the list of selected yanked
-      // versions recorded in the lockfile, it must not have been yanked at that time. We do not
-      // refresh yanked versions information.
-      // Rationale: This ensures that builds with --lockfile_mode=update or error are reproducible
-      // and do not fail due to changes in the set of yanked versions. Furthermore, it avoids
+      // versions recorded in the lockfile, it must not have been yanked at that time.
+      //
+      // Rationale (reproducibility): builds with --lockfile_mode=update or error are reproducible
+      // and do not fail due to changes in the set of yanked versions. Furthermore, this avoids
       // refetching yanked versions for all modules every time the user modifies or adds a
       // dependency. If the selected version for a module changes, yanked version information is
       // always refreshed.
+      //
+      // Rationale (security): metadata.json is fetched without integrity verification (the file is
+      // by design mutable). A registry that becomes hostile after the lockfile has pinned a
+      // legitimate selection must not be able to silently force re-selection of that module by
+      // marking the previously-selected version as yanked. The lockfile's source.json hash anchor
+      // is therefore treated as ground truth for the yanked status of the previously-selected
+      // version regardless of --lockfile_mode. Users who want to refresh yanked-version status for
+      // an already-anchored version must do so explicitly (for example, by removing the entry from
+      // the lockfile and re-running module resolution).
       return Optional.of(YankedVersionsValue.NONE_YANKED);
     }
     // The lockfile does not contain sufficient information to determine the "yanked" status of the

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -80,7 +80,11 @@ public class IndexRegistry implements Registry {
     USE_AND_UPDATE,
     /**
      * Use file hashes from the lockfile if available and add hashes for new files to the lockfile.
-     * Always revalidate mutable registry information.
+     * Always revalidate mutable registry information, with one exception for security: if the
+     * lockfile already records a {@code source.json} hash for a previously-selected module version,
+     * that anchor is treated as ground truth that the version was not yanked at lockfile-creation
+     * time and the freshly-fetched (unauthenticated) {@code metadata.json} is not allowed to flip
+     * the version's yanked status. See {@link #tryGetYankedVersionsFromLockfile} for details.
      */
     USE_IMMUTABLE_AND_UPDATE,
     /**

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -522,6 +522,78 @@ public class IndexRegistryTest extends FoundationTestCase {
                 "red-pill 1.0 is yanked due to CVE-2000-101, please upgrade to 2.0"));
   }
 
+  /**
+   * Under {@code --lockfile_mode=refresh} (i.e. {@code KnownFileHashesMode.USE_IMMUTABLE_AND_UPDATE}),
+   * a module version whose source.json hash is already anchored in the lockfile must be treated as
+   * not-yanked without consulting the registry's mutable, integrity-unverified metadata.json. This
+   * prevents a hostile registry from flipping a previously-pinned version's yanked bit and forcing
+   * a re-resolution to a fallback version that has no lockfile anchor.
+   */
+  @Test
+  public void testTryGetYankedVersionsFromLockfile_refreshMode_anchoredSourceJson_returnsNoneYanked()
+      throws Exception {
+    server.start();
+    String registryUrl = server.getUrl();
+    Registry registry =
+        registryFactory.createRegistry(
+            registryUrl,
+            LockfileMode.REFRESH,
+            ImmutableMap.of(
+                registryUrl + "/modules/red-pill/1.0/source.json",
+                Optional.of(sha256("source.json content placeholder"))),
+            ImmutableMap.of(),
+            Optional.empty(),
+            ImmutableSet.of());
+    assertThat(registry.tryGetYankedVersionsFromLockfile(createModuleKey("red-pill", "1.0")))
+        .hasValue(YankedVersionsValue.NONE_YANKED);
+  }
+
+  /**
+   * Under refresh mode, a module that has no source.json hash anchor in the lockfile must fall
+   * through to a fresh (unauthenticated) registry fetch. Newly-introduced dependencies preserve
+   * their existing behavior.
+   */
+  @Test
+  public void testTryGetYankedVersionsFromLockfile_refreshMode_unanchored_returnsEmpty()
+      throws Exception {
+    server.start();
+    Registry registry =
+        registryFactory.createRegistry(
+            server.getUrl(),
+            LockfileMode.REFRESH,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            Optional.empty(),
+            ImmutableSet.of());
+    assertThat(registry.tryGetYankedVersionsFromLockfile(createModuleKey("red-pill", "1.0")))
+        .isEmpty();
+  }
+
+  /**
+   * Under refresh mode, the {@code previouslySelectedYankedVersions} short-circuit must continue
+   * to surface the lockfile-recorded yanked info (so that a version known to be yanked at
+   * lockfile-creation time stays yanked even if the user explicitly allowed it via
+   * {@code --allow_yanked_versions}).
+   */
+  @Test
+  public void testTryGetYankedVersionsFromLockfile_refreshMode_previouslyYanked_returnsYankedInfo()
+      throws Exception {
+    server.start();
+    Registry registry =
+        registryFactory.createRegistry(
+            server.getUrl(),
+            LockfileMode.REFRESH,
+            ImmutableMap.of(),
+            ImmutableMap.of(createModuleKey("red-pill", "1.0"), "yanked-at-lockfile-time"),
+            Optional.empty(),
+            ImmutableSet.of());
+    assertThat(registry.tryGetYankedVersionsFromLockfile(createModuleKey("red-pill", "1.0")))
+        .hasValue(
+            YankedVersionsValue.create(
+                Optional.of(
+                    ImmutableMap.of(Version.parse("1.0"), "yanked-at-lockfile-time"))));
+  }
+
   @Test
   public void testArchiveWithExplicitType() throws Exception {
     server.serve(


### PR DESCRIPTION
## Summary

`IndexRegistry.tryGetYankedVersionsFromLockfile` currently special-cases `KnownFileHashesMode.USE_IMMUTABLE_AND_UPDATE` (i.e. `--lockfile_mode=refresh`) and unconditionally returns `Optional.empty()`, forcing a fresh fetch of `metadata.json` for every previously-resolved module.

`metadata.json` is intentionally fetched without integrity verification — `IndexRegistry.getYankedVersions` calls `grabJson(..., useChecksum=false)` because the file is by design mutable. Combined with the unconditional refresh, this means a registry that becomes hostile *after* the lockfile has pinned a legitimate selection (a malicious mirror, a compromised custom registry, or a registry-side PR review bypass) can silently force re-selection of an anchored module by marking the previously-selected version as yanked.

In refresh mode the resulting build error pushes the user toward `bazel mod tidy`, which re-resolves to the next-best non-yanked version. **That fallback version typically has no `source.json` hash anchor in the lockfile yet, so the registry can serve an arbitrary `source.json` for it (with any attacker-chosen integrity).** The metadata.json poisoning therefore turns into a silent dependency downgrade — and, in the worst case, into supply-chain code execution if the attacker also serves a backdoored archive matching the integrity they declared.

## Fix

Treat the lockfile's `source.json` hash anchor as ground truth for the yanked status of the previously-selected version regardless of `--lockfile_mode`. Users who want to refresh yanked-version status for an already-anchored version do so explicitly (e.g. by removing the entry from the lockfile and re-running module resolution). Newly introduced dependencies — which lack a lockfile anchor — continue to trigger a fresh fetch of yanked-version data exactly as before.

The `previouslySelectedYankedVersions` short-circuit is preserved so that versions known to be yanked at lockfile-creation time stay yanked.

## Why this is safe

- `--lockfile_mode=update` (USE_AND_UPDATE) and `--lockfile_mode=error` (ENFORCE) already fall through to the same `knownFileHashes.containsKey(getSourceJsonUrl(...))` check, so the new behavior matches what those modes do today.
- `--lockfile_mode=refresh` users still see fresh yanked-version data for any module that was *not* previously anchored in the lockfile (new deps, removed-and-re-added deps, deps whose selected version changed).
- The legitimate use case for refresh mode — picking up new yanked-version notices for currently-resolved deps — can still be exercised by removing the affected lockfile entries and re-running resolution; doing so requires the user to consciously trust the registry's claim.

## Threat model and impact

This is being filed via Google OSS-VRP in parallel; the PR description here intentionally focuses on the defect and fix, not on the exploit chain.