### PR TITLE
docs: clarify GitHub "Latest" badge behavior for releases

### DIFF
--- a/docs/release/index.mdx
+++ b/docs/release/index.mdx
@@ -21,7 +21,7 @@ information about Bazel's release model.
 | Bazel 5 | Deprecated | [5.4.1](https://github.com/bazelbuild/bazel/releases/tag/5.4.1) | Jan 2025 |
 | Bazel 4 | Deprecated | [4.2.4](https://github.com/bazelbuild/bazel/releases/tag/4.2.4) | Jan 2024 |
 
-All Bazel LTS releases can be found on the [release page](https://github.com/bazelbuild/bazel/releases) on GitHub.
+All Bazel LTS releases can be found on the [release page](https://github.com/bazelbuild/bazel/releases) on GitHub. The "Latest" badge on GitHub always points to the highest semantic version, ensuring it reflects the most recent major release rather than the most recently published maintenance patch.
 
 ## Release versioning {#bazel-versioning}
 


### PR DESCRIPTION
This PR updates the release documentation to clarify that the "Latest" badge on the GitHub releases page always points to the highest semantic version. This aligns the documentation with the recent changes to the release scripts that prevent maintenance patches from hijacking the "Latest" badge.