### PR TITLE
Update release documentation for GitHub "Latest" badge behavior

### DIFF
--- a/docs/release/index.mdx
+++ b/docs/release/index.mdx
@@ -21,7 +21,7 @@ information about Bazel's release model.
 | Bazel 5 | Deprecated | [5.4.1](https://github.com/bazelbuild/bazel/releases/tag/5.4.1) | Jan 2025 |
 | Bazel 4 | Deprecated | [4.2.4](https://github.com/bazelbuild/bazel/releases/tag/4.2.4) | Jan 2024 |
 
-All Bazel LTS releases can be found on the [release page](https://github.com/bazelbuild/bazel/releases) on GitHub.
+All Bazel LTS releases can be found on the [release page](https://github.com/bazelbuild/bazel/releases) on GitHub. The "Latest" badge on GitHub always points to the highest semantic version, even if a maintenance patch for an older version is released more recently.
 
 ## Release versioning {#bazel-versioning}
 

--- a/site/en/release/index.md
+++ b/site/en/release/index.md
@@ -25,7 +25,7 @@ information about Bazel's release model.
 | Bazel 4 | Deprecated | [4.2.4](https://github.com/bazelbuild/bazel/releases/tag/4.2.4) | Jan 2024 |
 
 All Bazel LTS releases can be found on the [release
-page](https://github.com/bazelbuild/bazel/releases){: .external} on GitHub.
+page](https://github.com/bazelbuild/bazel/releases){: .external} on GitHub. The "Latest" badge on GitHub always points to the highest semantic version, even if a maintenance patch for an older version is released more recently.
 
 ## Release versioning {:#bazel-versioning}
 


### PR DESCRIPTION
This PR updates the release documentation to clarify that the GitHub "Latest" badge always points to the highest semantic version, reflecting the changes made in the release deployment script.