### PR TITLE
Add --experimental_cc_permissive_artifact_extensions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.CommandLines.CommandLineAndParamFileInfo;
 import com.google.devtools.build.lib.actions.ParameterFile.ParameterFileType;
+import com.google.devtools.build.lib.analysis.BazelRuleAnalysisThreadContext;
 import com.google.devtools.build.lib.analysis.Expander;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.actions.SymlinkAction;
@@ -261,13 +262,23 @@ public class CcStarlarkInternal implements StarlarkValue {
       parameters = {
         @Param(name = "toolchain_config_info", positional = false, named = true),
         @Param(name = "tools_directory", positional = false, named = true),
-      })
+      },
+      useStarlarkThread = true)
   public CcToolchainFeatures ccToolchainFeatures(
-      StarlarkInfo ccToolchainConfigInfo, String toolsDirectoryPathString)
+      StarlarkInfo ccToolchainConfigInfo,
+      String toolsDirectoryPathString,
+      StarlarkThread thread)
       throws EvalException, RuleErrorException {
+    CppOptions cppOptions =
+        BazelRuleAnalysisThreadContext.fromOrFail(thread, "cc_toolchain_features")
+            .getRuleContext()
+            .getConfiguration()
+            .getOptions()
+            .get(CppOptions.class);
     return new CcToolchainFeatures(
         CcToolchainConfigInfo.PROVIDER.wrap(ccToolchainConfigInfo),
-        PathFragment.create(toolsDirectoryPathString));
+        PathFragment.create(toolsDirectoryPathString),
+        cppOptions.getExperimentalCcPermissiveArtifactExtensions());
   }
 
   @StarlarkMethod(

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainConfigInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainConfigInfo.java
@@ -76,7 +76,8 @@ public class CcToolchainConfigInfo {
     return featureBuilder.build();
   }
 
-  public ArtifactNamePatternMapper getArtifactNamePatterns() throws EvalException {
+  public ArtifactNamePatternMapper getArtifactNamePatterns(boolean permissiveArtifactExtensions)
+      throws EvalException {
     CcToolchainFeatures.ArtifactNamePatternMapper.Builder artifactNamePatternBuilder =
         new CcToolchainFeatures.ArtifactNamePatternMapper.Builder();
     for (StarlarkInfo artifactNamePattern :
@@ -85,7 +86,9 @@ public class CcToolchainConfigInfo {
             StarlarkInfo.class,
             "_artifact_name_patterns")) {
       CcToolchainFeaturesLib.artifactNamePatternFromStarlark(
-          artifactNamePattern, artifactNamePatternBuilder::addOverride);
+          artifactNamePattern,
+          artifactNamePatternBuilder::addOverride,
+          permissiveArtifactExtensions);
     }
     return artifactNamePatternBuilder.build();
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeatures.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeatures.java
@@ -1107,7 +1107,10 @@ public class CcToolchainFeatures implements StarlarkValue {
    * @param ccToolchainPath location of the cc_toolchain.
    * @throws EvalException if the configuration has logical errors.
    */
-  CcToolchainFeatures(CcToolchainConfigInfo ccToolchainConfigInfo, PathFragment ccToolchainPath)
+  CcToolchainFeatures(
+      CcToolchainConfigInfo ccToolchainConfigInfo,
+      PathFragment ccToolchainPath,
+      boolean permissiveArtifactExtensions)
       throws EvalException {
     // Build up the feature/action config graph.  We refer to features/action configs as
     // 'selectables'.
@@ -1148,7 +1151,8 @@ public class CcToolchainFeatures implements StarlarkValue {
 
     this.actionConfigsByActionName = actionConfigsByActionName.buildOrThrow();
 
-    this.artifactNamePatterns = ccToolchainConfigInfo.getArtifactNamePatterns();
+    this.artifactNamePatterns =
+        ccToolchainConfigInfo.getArtifactNamePatterns(permissiveArtifactExtensions);
 
     // Next, we build up all forward references for 'implies', 'requires', and 'provides' edges.
     ImmutableMultimap.Builder<CrosstoolSelectable, CrosstoolSelectable> implies =

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesLib.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesLib.java
@@ -454,6 +454,16 @@ public class CcToolchainFeaturesLib {
   @VisibleForTesting
   static void artifactNamePatternFromStarlark(
       StarlarkInfo artifactNamePatternStruct, ArtifactNamePatternAdder adder) throws EvalException {
+    artifactNamePatternFromStarlark(
+        artifactNamePatternStruct, adder, /* permissiveArtifactExtensions= */ false);
+  }
+
+  @VisibleForTesting
+  static void artifactNamePatternFromStarlark(
+      StarlarkInfo artifactNamePatternStruct,
+      ArtifactNamePatternAdder adder,
+      boolean permissiveArtifactExtensions)
+      throws EvalException {
     checkRightProviderType(artifactNamePatternStruct, "artifact_name_pattern");
     String categoryName =
         getMandatoryFieldFromStarlarkProvider(
@@ -479,7 +489,8 @@ public class CcToolchainFeaturesLib {
         Strings.nullToEmpty(
             getMandatoryFieldFromStarlarkProvider(
                 artifactNamePatternStruct, "extension", String.class));
-    if (!foundCategory.getAllowedExtensions().contains(extension)) {
+    if (!permissiveArtifactExtensions
+        && !foundCategory.getAllowedExtensions().contains(extension)) {
       throw infoError(
           artifactNamePatternStruct,
           "Unrecognized file extension '%s', allowed extensions are %s,"

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -1027,6 +1027,20 @@ public abstract class CppOptions extends FragmentOptions {
   public abstract boolean getExperimentalCcImplementationDeps();
 
   @Option(
+      name = "experimental_cc_permissive_artifact_extensions",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {
+        OptionEffectTag.LOADING_AND_ANALYSIS,
+      },
+      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+      help =
+          "If enabled, artifact_name_pattern declarations in cc_toolchain configuration may use"
+              + " any file extension for any artifact category, bypassing the hardcoded allow-list;"
+              + " experimental, behaviour may change.")
+  public abstract boolean getExperimentalCcPermissiveArtifactExtensions();
+
+  @Option(
       name = "experimental_cpp_modules",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -264,6 +264,7 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:host_linkopt",
         "//command_line_option:experimental_link_static_libraries_once",
         "//command_line_option:experimental_cc_implementation_deps",
+        "//command_line_option:experimental_cc_permissive_artifact_extensions",
         "//command_line_option:experimental_cpp_modules",
         "//command_line_option:start_end_lib",
         "//command_line_option:experimental_inmemory_dotd_files",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesTest.java
@@ -63,6 +63,13 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
   }
 
   private CcToolchainFeatures buildFeatures(String... content) throws Exception {
+    String packageName = setUpFeaturesRule(content);
+    ConfiguredTarget target = getConfiguredTarget("//" + packageName + ":f");
+    assertThat(target).isNotNull();
+    return (CcToolchainFeatures) getStarlarkProvider(target, "MyInfo").getValue("f");
+  }
+
+  private String setUpFeaturesRule(String... content) throws Exception {
     loadCcToolchainConfigLib();
     String packageName = "crosstool" + starlarkConfigCounter.getAndIncrement();
     scratch.overwriteFile(
@@ -120,9 +127,7 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
         "cc_toolchain_features(name = 'f', config = ':r')",
         "cc_toolchain_config_rule(name = 'r')");
 
-    ConfiguredTarget target = getConfiguredTarget("//" + packageName + ":f");
-    assertThat(target).isNotNull();
-    return (CcToolchainFeatures) getStarlarkProvider(target, "MyInfo").getValue("f");
+    return packageName;
   }
 
   /**
@@ -2054,5 +2059,53 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
     assertThat(
             toolchainFeatures.getArtifactNameExtensionForCategory(ArtifactCategory.STATIC_LIBRARY))
         .isEqualTo(".a");
+  }
+
+  @Test
+  public void testArtifactNamePattern_unrecognizedExtension_rejectedByDefault() throws Exception {
+    String packageName =
+        setUpFeaturesRule(
+            "artifact_name_patterns = [",
+            "    artifact_name_pattern(",
+            "        category_name = 'executable',",
+            "        prefix = '',",
+            "        extension = '.axf',",
+            "    ),",
+            "]");
+    reporter.removeHandler(failFastHandler);
+    assertThat(getConfiguredTarget("//" + packageName + ":f")).isNull();
+    assertContainsEvent("Unrecognized file extension '.axf'");
+  }
+
+  @Test
+  public void testArtifactNamePattern_permissiveFlag_allowsAxfForExecutable() throws Exception {
+    useConfiguration("--experimental_cc_permissive_artifact_extensions=true");
+    CcToolchainFeatures toolchainFeatures =
+        buildFeatures(
+            "artifact_name_patterns = [",
+            "    artifact_name_pattern(",
+            "        category_name = 'executable',",
+            "        prefix = '',",
+            "        extension = '.axf',",
+            "    ),",
+            "]");
+    assertThat(toolchainFeatures.getArtifactNameExtensionForCategory(ArtifactCategory.EXECUTABLE))
+        .isEqualTo(".axf");
+  }
+
+  @Test
+  public void testArtifactNamePattern_permissiveFlag_appliesAcrossCategories() throws Exception {
+    useConfiguration("--experimental_cc_permissive_artifact_extensions=true");
+    CcToolchainFeatures toolchainFeatures =
+        buildFeatures(
+            "artifact_name_patterns = [",
+            "    artifact_name_pattern(",
+            "        category_name = 'object_file',",
+            "        prefix = '',",
+            "        extension = '.weird',",
+            "    ),",
+            "]");
+    assertThat(toolchainFeatures.getArtifactNameExtensionForCategory(ArtifactCategory.OBJECT_FILE))
+        .isEqualTo(".weird");
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description

Adds a new experimental command-line flag `--experimental_cc_permissive_artifact_extensions` (default `false`). When enabled, the validation in `artifactNamePatternFromStarlark` that compares an `artifact_name_pattern` extension against `ArtifactCategory.allowedExtensions` is skipped, so cc_toolchain configurations can declare any file extension for any artifact category. Default behaviour is unchanged for toolchains that do not set the flag.

Fixes #29520.
Relates to #5920.

### Motivation

Motivation is explained in #29520:
> I work on a Bazel toolchain for a platform whose file extensions are private implementation details under NDA and cannot be  disclosed upstream. Declaring those extensions via cc_artifact_name_pattern is rejected by the validation against the hardcoded ArtifactCategory.allowedExtensions. Adding them to ArtifactCategory.java — the usual workaround — is closed to me by the same NDA.
>
> The same gap affects users on public platforms. The allow-list has grown one entry at a time (.exe, then .wasm), and requests for additional extensions like .axf (https://github.com/bazelbuild/bazel/issues/5920) have remained open for years.
>
> In my opinion, Bazel shouldn't try to enumerate every possible extension upstream — that's an open-ended task, especially if considering supporting proprietary or domain-specific platforms — and toolchain authors should be trusted to declare what's valid for their own toolchain

### Build API Changes

Yes — adds one new command-line flag.

1. Discussed in #29520 (this PR's tracking issue), #5920 (specific extension request). No separate design doc; the change is small, gated behind an experimental flag.
2. Backward compatible. Default is `false`; existing toolchains see no behaviour change.
3. Not a breaking change.

### Checklist
- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES[NEW]: `--experimental_cc_permissive_artifact_extensions`: when enabled, `artifact_name_pattern` declarations in `cc_toolchain` configuration accept any extension for any artifact category, bypassing the hardcoded allow-list in `ArtifactCategory.java`.