### PR TITLE
Add a header for chunk writes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -17,6 +17,7 @@ import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static com.google.devtools.build.lib.remote.util.DigestUtil.isOldStyleDigestFunction;
 import static java.lang.String.format;
 
+import build.bazel.remote.execution.v2.ChunkingFunction;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.DigestFunction;
 import com.google.bytestream.ByteStreamGrpc;
@@ -308,10 +309,18 @@ final class ByteStreamUploader {
     }
 
     private ByteStreamStub bsAsyncStub(Channel channel) {
-      return ByteStreamGrpc.newStub(channel)
-          .withInterceptors(
-              TracingMetadataUtils.attachMetadataInterceptor(context.getRequestMetadata()))
-          .withCallCredentials(callCredentialsProvider.getCallCredentials());
+      ByteStreamStub stub =
+          ByteStreamGrpc.newStub(channel)
+              .withInterceptors(
+                  TracingMetadataUtils.attachMetadataInterceptor(context.getRequestMetadata()))
+              .withCallCredentials(callCredentialsProvider.getCallCredentials());
+      ChunkingFunction.Value chunkingFunction = context.getChunkingFunction();
+      if (chunkingFunction != null) {
+        stub =
+            stub.withInterceptors(
+                TracingMetadataUtils.attachChunkedHeaderInterceptor(chunkingFunction));
+      }
+      return stub;
     }
 
     private ListenableFuture<Long> query() {

--- a/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobUploader.java
@@ -102,9 +102,13 @@ public class ChunkedBlobUploader {
       return;
     }
 
+    // Mark only the individual chunk uploads with the chunking function. FindMissingDigests and
+    // SpliceBlob continue to use the original context because the header applies only to
+    // ByteStream Write calls.
+    RemoteActionExecutionContext chunkContext = context.chunked(chunkingFunction);
     ImmutableSet<Digest> missingDigests =
         getFromFuture(grpcCacheClient.findMissingDigests(context, chunkDigests));
-    uploadMissingChunks(context, missingDigests, chunkDigests, file);
+    uploadMissingChunks(chunkContext, missingDigests, chunkDigests, file);
     getFromFuture(grpcCacheClient.spliceBlob(context, blobDigest, chunkDigests, chunkingFunction));
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteActionExecutionContext.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.common;
 
+import build.bazel.remote.execution.v2.ChunkingFunction;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -73,6 +74,7 @@ public class RemoteActionExecutionContext {
   private final NetworkTime networkTime;
   private final CachePolicy writeCachePolicy;
   private final CachePolicy readCachePolicy;
+  @Nullable private final ChunkingFunction.Value chunkingFunction;
 
   private RemoteActionExecutionContext(
       @Nullable Spawn spawn,
@@ -85,7 +87,8 @@ public class RemoteActionExecutionContext {
         requestMetadata,
         networkTime,
         CachePolicy.ANY_CACHE,
-        CachePolicy.ANY_CACHE);
+        CachePolicy.ANY_CACHE,
+        /* chunkingFunction= */ null);
   }
 
   private RemoteActionExecutionContext(
@@ -95,12 +98,31 @@ public class RemoteActionExecutionContext {
       NetworkTime networkTime,
       CachePolicy writeCachePolicy,
       CachePolicy readCachePolicy) {
+    this(
+        spawn,
+        spawnExecutionContext,
+        requestMetadata,
+        networkTime,
+        writeCachePolicy,
+        readCachePolicy,
+        /* chunkingFunction= */ null);
+  }
+
+  private RemoteActionExecutionContext(
+      @Nullable Spawn spawn,
+      @Nullable SpawnExecutionContext spawnExecutionContext,
+      RequestMetadata requestMetadata,
+      NetworkTime networkTime,
+      CachePolicy writeCachePolicy,
+      CachePolicy readCachePolicy,
+      @Nullable ChunkingFunction.Value chunkingFunction) {
     this.spawn = spawn;
     this.spawnExecutionContext = spawnExecutionContext;
     this.requestMetadata = requestMetadata;
     this.networkTime = networkTime;
     this.writeCachePolicy = writeCachePolicy;
     this.readCachePolicy = readCachePolicy;
+    this.chunkingFunction = chunkingFunction;
   }
 
   public RemoteActionExecutionContext withWriteCachePolicy(CachePolicy writeCachePolicy) {
@@ -110,7 +132,8 @@ public class RemoteActionExecutionContext {
         requestMetadata,
         networkTime,
         writeCachePolicy,
-        readCachePolicy);
+        readCachePolicy,
+        chunkingFunction);
   }
 
   public RemoteActionExecutionContext withReadCachePolicy(CachePolicy readCachePolicy) {
@@ -120,7 +143,29 @@ public class RemoteActionExecutionContext {
         requestMetadata,
         networkTime,
         writeCachePolicy,
-        readCachePolicy);
+        readCachePolicy,
+        chunkingFunction);
+  }
+
+  /**
+   * Returns a context that marks ByteStream Write calls as carrying a chunk produced by {@code
+   * chunkingFunction}. The server can use this to skip re-chunking the uploaded data.
+   */
+  public RemoteActionExecutionContext chunked(ChunkingFunction.Value chunkingFunction) {
+    return new RemoteActionExecutionContext(
+        spawn,
+        spawnExecutionContext,
+        requestMetadata,
+        networkTime,
+        writeCachePolicy,
+        readCachePolicy,
+        chunkingFunction);
+  }
+
+  /** Returns the chunking function to signal on ByteStream Write calls, or {@code null}. */
+  @Nullable
+  public ChunkingFunction.Value getChunkingFunction() {
+    return chunkingFunction;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/util/TracingMetadataUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/TracingMetadataUtils.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.util;
 
+import build.bazel.remote.execution.v2.ChunkingFunction;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.bazel.remote.execution.v2.ToolDetails;
 import com.google.common.annotations.VisibleForTesting;
@@ -43,6 +44,14 @@ public class TracingMetadataUtils {
   @VisibleForTesting
   public static final Metadata.Key<RequestMetadata> METADATA_KEY =
       ProtoUtils.keyForProto(RequestMetadata.getDefaultInstance());
+
+  /**
+   * gRPC header attached to ByteStream Write calls for content-defined chunks. The value names the
+   * chunking function used to produce the uploaded chunk.
+   */
+  public static final Metadata.Key<String> CHUNKED_HEADER_KEY =
+      Metadata.Key.of(
+          "build.bazel.remote.execution.v2.chunked", Metadata.ASCII_STRING_MARSHALLER);
 
   public static RequestMetadata buildMetadata(
       String buildRequestId, String commandId, String actionId) {
@@ -117,6 +126,16 @@ public class TracingMetadataUtils {
 
   public static ClientInterceptor attachMetadataInterceptor(RequestMetadata requestMetadata) {
     return MetadataUtils.newAttachHeadersInterceptor(headersFromRequestMetadata(requestMetadata));
+  }
+
+  /** Returns an interceptor that attaches the chunked header to outgoing calls. */
+  public static ClientInterceptor attachChunkedHeaderInterceptor(
+      ChunkingFunction.Value chunkingFunction) {
+    Metadata metadata = new Metadata();
+    // The chunk size is already in the ByteStream resource digest, and the
+    // parent blob mapping is sent by SpliceBlob.
+    metadata.put(CHUNKED_HEADER_KEY, chunkingFunction.name());
+    return MetadataUtils.newAttachHeadersInterceptor(metadata);
   }
 
   private static Metadata newMetadataForHeaders(List<Entry<String, String>> headers) {

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 
+import build.bazel.remote.execution.v2.ChunkingFunction;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.RequestMetadata;
@@ -1140,6 +1141,93 @@ public class ByteStreamUploaderTest {
             }));
 
     uploadBlob(uploader, context, digest, chunker);
+  }
+
+  @Test
+  public void chunkedHeaderIsAttachedOnlyForChunkedContext() throws Exception {
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(
+            () -> new FixedBackoff(1, 0), (e) -> Result.TRANSIENT_FAILURE, retryService);
+    ByteStreamUploader uploader =
+        new ByteStreamUploader(
+            INSTANCE_NAME,
+            referenceCountedChannel,
+            CallCredentialsProvider.NO_CREDENTIALS,
+            retrier,
+            /* maximumOpenFiles= */ -1,
+            /* digestFunction= */ DigestFunction.Value.SHA256);
+
+    List<String> chunkedHeaderValues = Collections.synchronizedList(new ArrayList<>());
+    serviceRegistry.addService(
+        ServerInterceptors.intercept(
+            new ByteStreamImplBase() {
+              @Override
+              public StreamObserver<WriteRequest> write(
+                  StreamObserver<WriteResponse> streamObserver) {
+                return new StreamObserver<WriteRequest>() {
+                  private long committedSize;
+
+                  @Override
+                  public void onNext(WriteRequest writeRequest) {
+                    committedSize += writeRequest.getData().size();
+                  }
+
+                  @Override
+                  public void onError(Throwable throwable) {
+                    fail("onError should never be called.");
+                  }
+
+                  @Override
+                  public void onCompleted() {
+                    WriteResponse response =
+                        WriteResponse.newBuilder().setCommittedSize(committedSize).build();
+                    streamObserver.onNext(response);
+                    streamObserver.onCompleted();
+                  }
+                };
+              }
+            },
+            new ServerInterceptor() {
+              @Override
+              public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                  ServerCall<ReqT, RespT> call,
+                  Metadata metadata,
+                  ServerCallHandler<ReqT, RespT> next) {
+                chunkedHeaderValues.add(metadata.get(TracingMetadataUtils.CHUNKED_HEADER_KEY));
+                return next.startCall(call, metadata);
+              }
+            }));
+
+    byte[] regularBlob = new byte[CHUNK_SIZE];
+    byte[] fastCdcChunk = new byte[CHUNK_SIZE];
+    Arrays.fill(fastCdcChunk, (byte) 1);
+    byte[] repMaxCdcChunk = new byte[CHUNK_SIZE];
+    Arrays.fill(repMaxCdcChunk, (byte) 2);
+
+    Digest regularDigest = DIGEST_UTIL.compute(regularBlob);
+    uploadBlob(
+        uploader,
+        context,
+        regularDigest,
+        Chunker.builder().setInput(regularBlob).setChunkSize(CHUNK_SIZE).build());
+
+    Digest fastCdcDigest = DIGEST_UTIL.compute(fastCdcChunk);
+    uploadBlob(
+        uploader,
+        context.chunked(ChunkingFunction.Value.FAST_CDC_2020),
+        fastCdcDigest,
+        Chunker.builder().setInput(fastCdcChunk).setChunkSize(CHUNK_SIZE).build());
+
+    Digest repMaxCdcDigest = DIGEST_UTIL.compute(repMaxCdcChunk);
+    uploadBlob(
+        uploader,
+        context.chunked(ChunkingFunction.Value.REP_MAX_CDC),
+        repMaxCdcDigest,
+        Chunker.builder().setInput(repMaxCdcChunk).setChunkSize(CHUNK_SIZE).build());
+
+    assertThat(chunkedHeaderValues)
+        .containsExactly(null, "FAST_CDC_2020", "REP_MAX_CDC")
+        .inOrder();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobUploaderTest.java
@@ -25,12 +25,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import build.bazel.remote.execution.v2.ChunkingFunction;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.chunking.FastCdcChunker;
 import com.google.devtools.build.lib.remote.chunking.FastCdcChunkingConfig;
+import com.google.devtools.build.lib.remote.chunking.RepMaxCdcChunkingConfig;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.Blob;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
@@ -99,6 +102,50 @@ public class ChunkedBlobUploaderTest {
         new ChunkedBlobUploader(grpcCacheClient, combinedCache, config, DIGEST_UTIL);
 
     assertThat(uploader.getChunkingThreshold()).isEqualTo(512 * 4);
+  }
+
+  @Test
+  public void uploadChunked_repMaxCdc_marksChunkUploadsWithChunkingFunction() throws Exception {
+    ChunkedBlobUploader repMaxUploader =
+        new ChunkedBlobUploader(
+            grpcCacheClient,
+            combinedCache,
+            new RepMaxCdcChunkingConfig(/* minChunkSize= */ 1024, /* horizonSize= */ 0),
+            DIGEST_UTIL);
+    RemoteActionExecutionContext context =
+        RemoteActionExecutionContext.create(RequestMetadata.getDefaultInstance());
+    Path file = execRoot.getRelative("rep-max.txt");
+    byte[] data = new byte[4096];
+    new Random(42).nextBytes(data);
+    writeFile(file, data);
+    Digest blobDigest = DIGEST_UTIL.compute(data);
+
+    when(grpcCacheClient.findMissingDigests(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              List<Digest> digests = invocation.getArgument(1);
+              return immediateFuture(ImmutableSet.copyOf(digests));
+            });
+    List<RemoteActionExecutionContext> uploadContexts = new ArrayList<>();
+    when(combinedCache.uploadBlob(any(), any(Digest.class), any(Blob.class)))
+        .thenAnswer(
+            invocation -> {
+              uploadContexts.add(invocation.getArgument(0));
+              return immediateVoidFuture();
+            });
+    when(grpcCacheClient.spliceBlob(any(), any(), any(), any())).thenReturn(immediateVoidFuture());
+
+    repMaxUploader.uploadChunked(context, blobDigest, file);
+
+    assertThat(uploadContexts).isNotEmpty();
+    for (RemoteActionExecutionContext uploadContext : uploadContexts) {
+      assertThat(uploadContext.getChunkingFunction())
+          .isEqualTo(ChunkingFunction.Value.REP_MAX_CDC);
+    }
+    verify(grpcCacheClient).findMissingDigests(eq(context), any());
+    verify(grpcCacheClient)
+        .spliceBlob(
+            eq(context), eq(blobDigest), any(), eq(ChunkingFunction.Value.REP_MAX_CDC));
   }
 
   @Test


### PR DESCRIPTION
If the chunking threshold were to be < the max chunk size, which can be helpful for data de-duplication in many cases, it's critical for the remote cache server to understand if a blob is a whole blob, or a chunked blob already. This prevents any servers that do active chunking from re-chunking an already chunked blob. Since cut points are content defined, it can be beneficial to run anything > the min chunk size through the chunker.

### What this does
This change marks CAS uploads produced by `ChunkedBlobUploader` as content-defined chunks by attaching `build.bazel.remote.execution.v2.chunked: true` to the underlying ByteStream Write RPCs. ChunkedBlobUploader now derives a chunked `RemoteActionExecutionContext` for per-chunk uploads, and `ByteStreamUploader` attaches the chunked header only when that context flag is set.

### Why a gRPC header instead of RequestMetadata:
RequestMetadata describes the Bazel action/tool invocation for tracing, attribution, and request identity; whether a ByteStream Write payload is already a content-defined chunk is transport-level CAS upload behavior, not action identity. The signal is needed specifically on ByteStream Write calls and should be visible to cache servers or intermediaries that handle those writes without requiring them to reinterpret action metadata. Putting this in RequestMetadata would overload a stable cross-API tracing proto with cache-write behavior, and would require a remote-apis proto change before Bazel could send the signal. A request header is a better fit because it is per-RPC, optional, backwards-compatible, and can be ignored safely by servers that do not understand it.