### PR TITLE
Fix stamp=false configs getting incorrect ST-hash when baseline has stamp=true

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/OutputPathMnemonicComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/OutputPathMnemonicComputer.java
@@ -290,10 +290,17 @@ public final class OutputPathMnemonicComputer {
     // Note: getFirst only excludes options trimmed between baselineOptions to toOptions and this is
     //   considered OK as a given Rule should not be being built with options of different
     //   trimmings. See longform note in {@link ConfiguredTargetKey} for details.
+    //
+    // Exclude --stamp when its value in toOptions is the default (false). A config with stamp=false
+    // should have the same output path regardless of what the top-level baseline's stamp value is.
+    // Configs with stamp=true still get a distinct hash to avoid collisions with unstamped configs.
+    CoreOptions toCoreOptions = toOptions.get(CoreOptions.class);
+    boolean targetStampIsDefault = toCoreOptions == null || !toCoreOptions.getStampBinaries();
     ImmutableSet<String> chosenNativeOptions =
         diff.getFirst().keySet().stream()
             .map(OptionDefinition::getOptionName)
             .filter(optionName -> !explicitInOutputPathOptions.contains(optionName))
+            .filter(optionName -> !(optionName.equals("stamp") && targetStampIsDefault))
             .collect(toImmutableSet());
     // Note: getChangedStarlarkOptions includes all changed options, added options and removed
     //   options between baselineOptions and toOptions. This is necessary since there is no current

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTransitionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTransitionTest.java
@@ -1009,6 +1009,48 @@ public class StarlarkTransitionTest extends BuildViewTestCase {
   }
 
   @Test
+  public void stampTransitionOutput_depConfigSameRegardlessOfStampFlag() throws Exception {
+    scratch.file(
+        "test/defs.bzl",
+        """
+        def _stamp_output_impl(settings, attr):
+            return {"//command_line_option:stamp": False}
+
+        stamp_output_transition = transition(
+            implementation = _stamp_output_impl,
+            inputs = [],
+            outputs = ["//command_line_option:stamp"],
+        )
+
+        example = rule(
+          implementation = lambda ctx: None,
+          attrs = {"dep": attr.label(cfg = stamp_output_transition)},
+        )
+        """);
+    scratch.file(
+        "test/BUILD",
+        """
+        load(":defs.bzl", "example")
+        example(name = "depends_on_stamp_output", dep = ":dep")
+        filegroup(name = "dep", srcs = [])
+        """);
+
+    useConfiguration("--stamp=true");
+    var depWithStampTrue =
+        getDirectPrerequisite(
+            getConfiguredTarget("//test:depends_on_stamp_output"), "//test:dep");
+    var configWithStampTrue = getConfiguration(depWithStampTrue);
+
+    useConfiguration("--stamp=false");
+    var depWithStampFalse =
+        getDirectPrerequisite(
+            getConfiguredTarget("//test:depends_on_stamp_output"), "//test:dep");
+    var configWithStampFalse = getConfiguration(depWithStampFalse);
+
+    assertThat(configWithStampTrue).isEqualTo(configWithStampFalse);
+  }
+
+  @Test
   public void stampTransitionOutput_stampSettingMarkerAppliedIfStampFlag(
       @TestParameter boolean stampFlag) throws Exception {
     scratch.file(


### PR DESCRIPTION
## Problem

When a Starlark transition explicitly sets `--stamp=false`, the resulting dep configuration should be identical regardless of whether the top-level build passed `--stamp`. It currently isn't.

With `--stamp=true`, the baseline configuration also has `stamp=true`. A transition that then sets `stamp=false` creates a diff (`stamp=false` vs baseline `stamp=true`) that contributes to the ST-hash, giving the dep a different output path mnemonic than in a build without `--stamp`. Since the dep always produces the same (unstamped) output, this difference is spurious — it causes unnecessary rebuilds when toggling `--stamp`.

## Fix

In `OutputPathMnemonicComputer.computeNameFragmentWithDiff`, exclude `--stamp` from the ST-hash when the transitioned config's stamp value is the default (`false`). Configs with `stamp=true` still get a distinct hash since they genuinely produce different (stamped) outputs.

## Test

Added `stampTransitionOutput_depConfigSameRegardlessOfStampFlag` to `StarlarkTransitionTest`: builds a target with a `stamp=false` output transition twice — once with `--stamp=true` and once with `--stamp=false` — and asserts the dep's `BuildConfigurationValue` is equal in both cases.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)