### PR TITLE
downloader: fix opaque file URI names

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.auth.Credentials;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
@@ -515,9 +516,7 @@ public class DownloadManager {
     if (!type.isPresent()) {
       return output;
     }
-    String basename =
-        MoreObjects.firstNonNull(
-            Strings.emptyToNull(PathFragment.create(url.getPath()).getBaseName()), "temp");
+    String basename = MoreObjects.firstNonNull(Strings.emptyToNull(getUrlBaseName(url)), "temp");
     if (!type.get().isEmpty()) {
       String suffix = "." + type.get();
       if (!basename.endsWith(suffix)) {
@@ -530,17 +529,35 @@ public class DownloadManager {
   }
 
   /**
-   * Deterimine the list of filenames to look for in the distdirs. Note that an output name may be
-   * specified that is unrelated to the primary URL. This happens, e.g., when the paramter output is
-   * specified in ctx.download.
+   * Determine the list of filenames to look for in the distdirs. Note that an output name may be
+   * specified that is unrelated to the primary URL. This happens, e.g., when the parameter output
+   * is specified in ctx.download.
    */
-  private static ImmutableSet<String> getCandidateFileNames(URI url, Path destination) {
-    String urlBaseName = PathFragment.create(url.getPath()).getBaseName();
+  @VisibleForTesting
+  static ImmutableSet<String> getCandidateFileNames(URI url, Path destination) {
+    String urlBaseName = getUrlBaseName(url);
     if (!Strings.isNullOrEmpty(urlBaseName) && !urlBaseName.equals(destination.getBaseName())) {
       return ImmutableSet.of(urlBaseName, destination.getBaseName());
     } else {
       return ImmutableSet.of(destination.getBaseName());
     }
+  }
+
+  private static String getUrlBaseName(URI url) {
+    String path = url.getPath();
+    if (path == null && url.isOpaque()) {
+      // Match URL#getPath() behavior for opaque file URIs such as file:../archive.tgz.
+      String rawPath = url.getRawSchemeSpecificPart();
+      int queryStart = rawPath.indexOf('?');
+      if (queryStart != -1) {
+        rawPath = rawPath.substring(0, queryStart);
+      }
+      path =
+          rawPath.isEmpty()
+              ? ""
+              : URI.create(url.getScheme() + ":" + rawPath).getSchemeSpecificPart();
+    }
+    return path == null ? "" : PathFragment.create(path).getBaseName();
   }
 
   private static class CacheProgress implements ExtendedEventHandler.FetchProgress {

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -178,6 +178,121 @@ public class HttpDownloaderTest {
   }
 
   @Test
+  public void downloadFromOpaqueFileUrl_withExplicitOutput() throws Exception {
+    Downloader downloader = mock(Downloader.class);
+    DownloadManager downloadManager =
+        new DownloadManager(downloadCache, downloader, httpDownloader, eventHandler);
+    byte[] data = "content".getBytes(UTF_8);
+    doAnswer(
+            (Answer<Void>)
+                invocationOnMock -> {
+                  Path output = invocationOnMock.getArgument(5, Path.class);
+                  try (OutputStream outputStream = output.getOutputStream()) {
+                    ByteStreams.copy(new ByteArrayInputStream(data), outputStream);
+                  }
+                  return null;
+                })
+        .when(downloader)
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq("testRepo"));
+
+    Path result =
+        download(
+            downloadManager,
+            ImmutableList.of(URI.create("file:../vendored_lodash-4.17.21.tgz")),
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            Optional.empty(),
+            "testCanonicalId",
+            Optional.empty(),
+            fs.getPath(workingDir.newFile().getAbsolutePath()),
+            ImmutableMap.of(),
+            "testRepo");
+
+    assertThat(new String(ByteStreams.toByteArray(result.getInputStream()), UTF_8))
+        .isEqualTo("content");
+  }
+
+  @Test
+  public void downloadFromOpaqueFileUrl_withType() throws Exception {
+    Downloader downloader = mock(Downloader.class);
+    DownloadManager downloadManager =
+        new DownloadManager(downloadCache, downloader, httpDownloader, eventHandler);
+    byte[] data = "content".getBytes(UTF_8);
+    doAnswer(
+            (Answer<Void>)
+                invocationOnMock -> {
+                  Path output = invocationOnMock.getArgument(5, Path.class);
+                  try (OutputStream outputStream = output.getOutputStream()) {
+                    ByteStreams.copy(new ByteArrayInputStream(data), outputStream);
+                  }
+                  return null;
+                })
+        .when(downloader)
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq("testRepo"));
+
+    Path result =
+        download(
+            downloadManager,
+            ImmutableList.of(URI.create("file:../vendored_lodash-4.17.21.tgz")),
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            Optional.empty(),
+            "testCanonicalId",
+            Optional.of("tgz"),
+            fs.getPath(workingDir.newFolder().getAbsolutePath()),
+            ImmutableMap.of(),
+            "testRepo");
+
+    assertThat(result.getBaseName()).isEqualTo("vendored_lodash-4.17.21.tgz");
+    assertThat(new String(ByteStreams.toByteArray(result.getInputStream()), UTF_8))
+        .isEqualTo("content");
+  }
+
+  @Test
+  public void downloadFromOpaqueFileUrl_withEscapedQuestionMarkAndType() throws Exception {
+    Downloader downloader = mock(Downloader.class);
+    DownloadManager downloadManager =
+        new DownloadManager(downloadCache, downloader, httpDownloader, eventHandler);
+    byte[] data = "content".getBytes(UTF_8);
+    doAnswer(
+            (Answer<Void>)
+                invocationOnMock -> {
+                  Path output = invocationOnMock.getArgument(5, Path.class);
+                  try (OutputStream outputStream = output.getOutputStream()) {
+                    ByteStreams.copy(new ByteArrayInputStream(data), outputStream);
+                  }
+                  return null;
+                })
+        .when(downloader)
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq("testRepo"));
+
+    Path result =
+        download(
+            downloadManager,
+            ImmutableList.of(URI.create("file:../foo%3Fbar.tgz")),
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            Optional.empty(),
+            "testCanonicalId",
+            Optional.of("tgz"),
+            fs.getPath(workingDir.newFolder().getAbsolutePath()),
+            ImmutableMap.of(),
+            "testRepo");
+
+    assertThat(result.getBaseName()).isEqualTo("foo_bar.tgz");
+    assertThat(new String(ByteStreams.toByteArray(result.getInputStream()), UTF_8))
+        .isEqualTo("content");
+  }
+
+  @Test
+  public void getCandidateFileNames_opaqueFileUrlWithEscapedQuestionMark() {
+    assertThat(
+            DownloadManager.getCandidateFileNames(
+                URI.create("file:../foo%3Fbar.tgz"), fs.getPath("/tmp/foo_bar.tgz")))
+        .containsExactly("foo?bar.tgz", "foo_bar.tgz");
+  }
+
+  @Test
   public void downloadFrom2UrlsFirstOk() throws IOException, InterruptedException {
     try (ServerSocket server1 = new ServerSocket(0, 1, InetAddress.getByName(null));
         ServerSocket server2 = new ServerSocket(0, 1, InetAddress.getByName(null))) {


### PR DESCRIPTION
Fix a Bazel 9.1.0 regression where repository_ctx.download
could crash on opaque file URIs such as file:../archive.tgz. The
URL-to-URI migration changed basename extraction because URI.getPath()
returns null for these inputs, unlike URL#getPath(). DownloadManager
then passed null to PathFragment.create while building distdir
candidate names.

Reuse one basename helper for download destinations and distdir
lookups, falling back to the scheme-specific part for opaque URIs.
Add regression coverage for the explicit-output and typed-download
paths.

Fixes #29393.
