### PR TITLE
docs: sync --test_summary description with current behavior

### DIFF
--- a/site/en/docs/user-manual.md
+++ b/site/en/docs/user-manual.md
@@ -1559,14 +1559,19 @@ failing status.
 
 Specifies how the test result summary should be displayed.
 
-*   `short` prints the results of each test along with the name of
-    the file containing the test output if the test failed. This is the default
-    value.
-*   `terse` like `short`, but even shorter: only print
-    information about tests which did not pass.
-*   `detailed` prints each individual test case that failed, not
-    only each test. The names of test output files are omitted.
-*   `none` does not print test summary.
+*   `short` lists all tests that ran to completion, along with the name of
+    the file containing the test output if the test failed. This is the
+    default value.
+*   `short_uncached` like `short`, but omits tests whose results were cached.
+*   `terse` lists only failed and flaky tests.
+*   `detailed` lists all tests that ran to completion and prints each
+    individual test case (passed, skipped, and failed). The names of test
+    output files are omitted.
+*   `detailed_uncached` like `detailed`, but omits tests whose results were
+    cached.
+*   `testcase` prints a summary at test-case resolution without detailed
+    information about failed test cases.
+*   `none` does not print a test summary.
 
 #### `--test_output={{ "<var>" }}output_style{{ "</var>" }}` {:#test-output}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

sync --test_summary description with current behavior

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

The user-manual.md description of --test_summary became stale after two upstream changes that updated the @Option help= string in ExecutionOptions.java but not this page:

  * c75fda99e7 / #19099 (cherry-picked to 6.4 as #19505): made --test_summary=detailed print passed and skipped test cases in addition to failed ones.
  * 42196f5fff / #28341 (in 8.6 and 9.1): added the short_uncached and detailed_uncached values.

The 'testcase' value has also been a public TestSummaryFormat enum constant for years without ever being documented here.

Resync the prose with the help= string and the TestSummaryFormat javadoc so the documented behavior matches what bazel actually does.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
