### PR TITLE
build: pin actions/checkout to commit SHA in community-review-labeler…

### DIFF
--- a/.github/workflows/community-review-labeler.yml
+++ b/.github/workflows/community-review-labeler.yml
@@ -19,7 +19,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout master branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: master
 


### PR DESCRIPTION
 Pin `actions/checkout` to full commit SHA instead of mutable `v6` tag.

  This workflow has `pull-requests: write` permission and access to
  `secrets.GITHUB_TOKEN`. Pinning to SHA ensures immutability and prevents
  supply chain attacks via tag manipulation.

  Ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions