### PR TITLE
 build: pin peter-evans/repository-dispatch to commit SHA

### DIFF
--- a/.github/workflows/trigger-docs-update.yml
+++ b/.github/workflows/trigger-docs-update.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger build of bazel-docs
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           repository: bazel-contrib/bazel-docs
           # Fine-grained PAT (https://github.com/settings/personal-access-tokens/new), which needs


### PR DESCRIPTION
Pin `peter-evans/repository-dispatch` to full commit SHA instead of mutable
  `v4` tag. This workflow has access to `secrets.BAZEL_DOC_TRIGGER_TOKEN`
  (a fine-grained PAT with write access to bazel-contrib/bazel-docs).

  Pinning to SHA ensures immutability and prevents supply chain attacks
  via tag manipulation of the third-party action.

  Ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions