### PR TITLE
Detect stale runfiles on Windows when symlinks fall back to copies

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -186,6 +186,7 @@ java_library(
     name = "runfiles_tree_updater",
     srcs = ["RunfilesTreeUpdater.java"],
     deps = [
+        ":execution_options",
         ":symlink_tree_helper",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:runfiles_tree",

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -35,6 +35,7 @@ import com.google.devtools.common.options.EnumConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
+import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.OptionsBase;
 import com.google.devtools.common.options.OptionsClass;
 import com.google.devtools.common.options.OptionsParsingException;
@@ -74,6 +75,19 @@ public abstract class ExecutionOptions extends OptionsBase {
               + " value is \"remote,worker,sandboxed,local\". See"
               + " https://blog.bazel.build/2019/06/19/list-strategy.html for details.")
   public abstract List<String> getSpawnStrategy();
+
+  @Option(
+      name = "experimental_detect_stale_runfiles",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+      effectTags = {OptionEffectTag.EXECUTION},
+      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+      help =
+          "If true, verifies that runfiles entries are real symbolic links before reusing an"
+              + " existing runfiles directory based on manifest equality. Detects stale runfiles"
+              + " on Windows when symlink privileges are unavailable and the tree is materialized"
+              + " as copies. Has no effect on platforms that always use real symlinks.")
+  public abstract boolean getDetectStaleRunfiles();
 
   @Option(
       name = "genrule_strategy",

--- a/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.exec;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.RunfilesTree;
@@ -46,6 +47,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public class RunfilesTreeUpdater {
   private final Path execRoot;
   private final XattrProvider xattrProvider;
+  private final boolean detectStaleRunfiles;
 
   /**
    * Deduplicates multiple attempts to update the same runfiles tree.
@@ -59,12 +61,18 @@ public class RunfilesTreeUpdater {
       new ConcurrentHashMap<>();
 
   public static RunfilesTreeUpdater forCommandEnvironment(CommandEnvironment env) {
-    return new RunfilesTreeUpdater(env.getExecRoot(), env.getXattrProvider());
+    ExecutionOptions options = env.getOptions().getOptions(ExecutionOptions.class);
+    return new RunfilesTreeUpdater(
+        env.getExecRoot(),
+        env.getXattrProvider(),
+        options != null && options.getDetectStaleRunfiles());
   }
 
-  public RunfilesTreeUpdater(Path execRoot, XattrProvider xattrProvider) {
+  public RunfilesTreeUpdater(
+      Path execRoot, XattrProvider xattrProvider, boolean detectStaleRunfiles) {
     this.execRoot = execRoot;
     this.xattrProvider = xattrProvider;
+    this.detectStaleRunfiles = detectStaleRunfiles;
   }
 
   /** Creates or updates input runfiles trees for a spawn. */
@@ -120,18 +128,12 @@ public class RunfilesTreeUpdater {
       // implying the symlinks exist and are already up to date. If the output manifest is a
       // symbolic link, it is likely a symbolic link to the input manifest, so we cannot trust it as
       // an up-to-date check.
-      // On Windows, where symlinks may be silently replaced by copies, a previous run in SKIP mode
-      // could have resulted in an output manifest that is an identical copy of the input manifest,
-      // which we must not treat as up to date, but we also don't want to unnecessarily rebuild the
-      // runfiles directory all the time. Instead, check for the presence of the first runfile in
-      // the manifest. If it is present, we can be certain that the previous mode wasn't SKIP.
       if (tree.getSymlinksMode() == RunfileSymlinksMode.CREATE
           && !outputManifest.isSymbolicLink()
           && Arrays.equals(
               DigestUtils.getDigestWithManualFallback(outputManifest, xattrProvider),
               DigestUtils.getDigestWithManualFallback(inputManifest, xattrProvider))
-          && (OS.getCurrent() != OS.WINDOWS
-              || isRunfilesDirectoryPopulated(runfilesDir, outputManifest))) {
+          && runfilesDirIsFresh(runfilesDir, outputManifest)) {
         return;
       }
     } catch (IOException e) {
@@ -154,6 +156,16 @@ public class RunfilesTreeUpdater {
     }
   }
 
+  private boolean runfilesDirIsFresh(Path runfilesDir, Path outputManifest) {
+    if (detectStaleRunfiles) {
+      // Manifest equality only proves freshness when entries are real symlinks, not copies.
+      return runfilesUseRealSymlinks(runfilesDir, outputManifest);
+    }
+    // Legacy: only checks that the first runfile exists (doesn't catch copy-mode staleness).
+    return OS.getCurrent() != OS.WINDOWS
+        || isRunfilesDirectoryPopulated(runfilesDir, outputManifest);
+  }
+
   private static boolean isRunfilesDirectoryPopulated(Path runfilesDir, Path outputManifest) {
     String relativeRunfilePath;
     try (BufferedReader reader =
@@ -166,5 +178,43 @@ public class RunfilesTreeUpdater {
     }
     // The runfile could be a dangling symlink.
     return runfilesDir.getRelative(relativeRunfilePath).exists(Symlinks.NOFOLLOW);
+  }
+
+  /**
+   * Returns true if the runfiles directory is populated and its entries are real symlinks.
+   *
+   * <p>When the entries are real symlinks (Linux, or Windows with symlink privileges), the
+   * manifest-equality short-circuit in {@link #updateRunfilesTree} is sound: the symlinks
+   * auto-follow current source content. When they are content copies (Windows without symlink
+   * privileges, where {@code WindowsFileSystem.createSymbolicLink} silently falls back to {@code
+   * Files.copy}), the short-circuit is unsafe and the caller must re-sync.
+   *
+   * <p>Returns false when the directory is empty/missing (e.g. the previous run was SKIP) or when
+   * the first non-empty entry isn't a symlink, so the caller falls through to the create path.
+   *
+   * <p>Empty-file manifest entries (lines with only a path and no target) are skipped: they are
+   * always materialized as regular files even when the rest of the tree uses symlinks, so they
+   * can't be used to distinguish symlink-mode from copy-mode.
+   */
+  @VisibleForTesting
+  static boolean runfilesUseRealSymlinks(Path runfilesDir, Path outputManifest) {
+    String firstEntryPath = null;
+    try (BufferedReader reader =
+        new BufferedReader(new InputStreamReader(outputManifest.getInputStream(), ISO_8859_1))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        String[] parts = line.split(" ", -1);
+        if (parts.length >= 2 && !parts[1].isEmpty()) {
+          firstEntryPath = parts[0];
+          break;
+        }
+      }
+    } catch (IOException e) {
+      return false;
+    }
+    if (firstEntryPath == null) {
+      return false;
+    }
+    return runfilesDir.getRelative(firstEntryPath).isSymbolicLink();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.DosFileAttributes;
 import javax.annotation.Nullable;
 
@@ -86,7 +87,12 @@ public class WindowsFileSystem extends JavaIoFileSystem {
 
       if (!createSymbolicLinks && existingFile) {
         // If symlinks aren't enabled and the target is an existing file, fall back to a copy.
-        Files.copy(target, link);
+        // REPLACE_EXISTING: idempotent overwrite. COPY_ATTRIBUTES: propagates source mtime.
+        Files.copy(
+            target,
+            link,
+            StandardCopyOption.REPLACE_EXISTING,
+            StandardCopyOption.COPY_ATTRIBUTES);
       } else if (createSymbolicLinks
           && (existingFile || (!existingDirectory && type != SymlinkTargetType.DIRECTORY))) {
         // If symlinks are enabled and the target is not an existing or future directory, create a

--- a/src/test/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/exec/BUILD
@@ -56,6 +56,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/exec:execution_options",
         "//src/main/java/com/google/devtools/build/lib/exec:file_write_strategy",
         "//src/main/java/com/google/devtools/build/lib/exec:module_action_context_registry",
+        "//src/main/java/com/google/devtools/build/lib/exec:runfiles_tree_updater",
         "//src/main/java/com/google/devtools/build/lib/exec:single_build_file_cache",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_cache",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_exec_exception",

--- a/src/test/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdaterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdaterTest.java
@@ -1,0 +1,111 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.exec;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link RunfilesTreeUpdater#runfilesUseRealSymlinks}. */
+@RunWith(JUnit4.class)
+public final class RunfilesTreeUpdaterTest {
+
+  private final FileSystem fs = new InMemoryFileSystem(DigestHashFunction.SHA256);
+  private Path runfilesDir;
+  private Path outputManifest;
+
+  @Before
+  public void setUp() throws Exception {
+    runfilesDir = fs.getPath("/execroot/foo.runfiles");
+    runfilesDir.createDirectoryAndParents();
+    outputManifest = runfilesDir.getChild("MANIFEST");
+  }
+
+  private void writeManifest(String content) throws Exception {
+    FileSystemUtils.writeContent(outputManifest, UTF_8, content);
+  }
+
+  private Path createEntry(String relativePath) throws Exception {
+    Path entry = runfilesDir.getRelative(relativePath);
+    entry.getParentDirectory().createDirectoryAndParents();
+    return entry;
+  }
+
+  @Test
+  public void symlinkEntry_returnsTrue() throws Exception {
+    writeManifest("ws/foo /source/foo\n");
+    FileSystemUtils.ensureSymbolicLink(
+        createEntry("ws/foo"), PathFragment.create("/source/foo"));
+
+    assertThat(RunfilesTreeUpdater.runfilesUseRealSymlinks(runfilesDir, outputManifest)).isTrue();
+  }
+
+  @Test
+  public void regularFileEntry_returnsFalse() throws Exception {
+    writeManifest("ws/foo /source/foo\n");
+    FileSystemUtils.writeContent(createEntry("ws/foo"), UTF_8, "stale content");
+
+    assertThat(RunfilesTreeUpdater.runfilesUseRealSymlinks(runfilesDir, outputManifest)).isFalse();
+  }
+
+  @Test
+  public void skipsEmptyFileEntries() throws Exception {
+    // Empty-file entries (no target) are always regular files even in symlink mode — skip them.
+    writeManifest("ws/__init__.py \nws/foo /source/foo\n");
+    FileSystemUtils.createEmptyFile(createEntry("ws/__init__.py"));
+    FileSystemUtils.ensureSymbolicLink(
+        createEntry("ws/foo"), PathFragment.create("/source/foo"));
+
+    assertThat(RunfilesTreeUpdater.runfilesUseRealSymlinks(runfilesDir, outputManifest)).isTrue();
+  }
+
+  @Test
+  public void nothingToProbe_returnsFalse() throws Exception {
+    writeManifest("");
+    assertThat(RunfilesTreeUpdater.runfilesUseRealSymlinks(runfilesDir, outputManifest)).isFalse();
+
+    writeManifest("ws/__init__.py \nws/sub/__init__.py \n");
+    assertThat(RunfilesTreeUpdater.runfilesUseRealSymlinks(runfilesDir, outputManifest)).isFalse();
+
+    // Manifest doesn't exist on disk.
+    outputManifest.delete();
+    assertThat(RunfilesTreeUpdater.runfilesUseRealSymlinks(runfilesDir, outputManifest)).isFalse();
+  }
+
+  @Test
+  public void missingEntry_returnsFalse() throws Exception {
+    writeManifest("ws/foo /source/foo\n");
+
+    assertThat(RunfilesTreeUpdater.runfilesUseRealSymlinks(runfilesDir, outputManifest)).isFalse();
+  }
+
+  @Test
+  public void danglingSymlink_returnsTrue() throws Exception {
+    writeManifest("ws/foo /nonexistent/foo\n");
+    FileSystemUtils.ensureSymbolicLink(
+        createEntry("ws/foo"), PathFragment.create("/nonexistent/foo"));
+
+    assertThat(RunfilesTreeUpdater.runfilesUseRealSymlinks(runfilesDir, outputManifest)).isTrue();
+  }
+}

--- a/src/test/shell/integration/run_test.sh
+++ b/src/test/shell/integration/run_test.sh
@@ -147,17 +147,14 @@ EOF
 }
 
 function test_runfiles_updated_correctly_with_nobuild_runfile_links {
-  if is_windows; then
-    # TODO(laszlocsomor): fix this test on Windows, and enable it.
-    return
-  fi
   write_cc_source_files
 
   cat > cc/hello_kitty.txt <<EOF
 Hello, kitty.
 EOF
 
-  bazel run --nobuild_runfile_links //cc:kitty > output \
+  bazel run --nobuild_runfile_links \
+    --experimental_detect_stale_runfiles //cc:kitty > output \
     || fail "${PRODUCT_NAME} run failed."
   assert_contains "Hello, kitty" output || fail "Output is not OK."
 
@@ -166,7 +163,8 @@ EOF
 A pussycat.
 EOF
 
-  bazel run --nobuild_runfile_links //cc:kitty > output \
+  bazel run --nobuild_runfile_links \
+    --experimental_detect_stale_runfiles //cc:kitty > output \
     || fail "${PRODUCT_NAME} run failed."
   assert_contains "pussycat" output || fail "Output is not OK."
 }


### PR DESCRIPTION
### Description

Add `--experimental_detect_stale_runfiles` flag (default off). When enabled, `RunfilesTreeUpdater` probes the on-disk type of the first non-empty manifest entry before short-circuiting: if it's a real symlink the optimization applies; if it's a regular file (the `Files.copy` fallback on Windows without symlink privileges), the tree is re-synced.

Also hardens `WindowsFileSystem.createSymbolicLink`'s copy fallback with `REPLACE_EXISTING` and `COPY_ATTRIBUTES`.

This also fixes a test that has been skipped for windows until now.

### Motivation

On Windows without symlink privileges, `WindowsFileSystem.createSymbolicLink` silently falls back to `Files.copy`. The runfiles short-circuit in `RunfilesTreeUpdater` compares manifest digests to decide the tree is up to date, which is safe for real symlinks (which auto-follow source content), but not for copies, where byte-equal manifests say nothing about content freshness. The result is runfiles getting stale on every incremental build until `bazel clean`.

### Build API Changes

New experimental flag: `--experimental_detect_stale_runfiles` (boolean, default false). No breaking changes, as the behavior is identical to current master when the flag is off.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES[NEW]: New `--experimental_detect_stale_runfiles` flag detects stale
runfiles on Windows when symlink privileges are unavailable and the runfiles
tree is materialized as copies rather than symlinks.