### PR TITLE
Add support for archived tree path mapping.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
@@ -83,6 +83,7 @@ public final class StrippingPathMapper implements PathMapper {
   public static final String GUID = "8eb2ad5a-85d4-435b-858f-5c192e91997d";
 
   private static final String FIXED_CONFIG_SEGMENT = "cfg";
+  private static final String ARCHIVED_TREE_ARTIFACTS_SEGMENT = ":archived_tree_artifacts";
 
   private final PathFragment outputRoot;
   private final String mnemonic;
@@ -159,11 +160,9 @@ public final class StrippingPathMapper implements PathMapper {
 
   @Override
   public int computeExecPathLengthDiff(DerivedArtifact artifact) {
-    String unmappedPath = artifact.getExecPathString();
-    // bazel-out/k8-fastbuild/... is mapped to bazel-out/${FIXED_CONFIG_SEGMENT}/...
-    int firstSlash = outputRoot.getPathString().length() + 1;
-    int secondSlash = unmappedPath.indexOf('/', firstSlash + 1);
-    return (secondSlash - firstSlash) - FIXED_CONFIG_SEGMENT.length();
+    PathFragment execPath = artifact.getExecPath();
+    int configIndex = getConfigSegmentIndex(execPath);
+    return execPath.getSegment(configIndex).length() - FIXED_CONFIG_SEGMENT.length();
   }
 
   @Override
@@ -280,21 +279,23 @@ public final class StrippingPathMapper implements PathMapper {
      * <p>Supports strings with multiple output paths in arbitrary places. For example
      * "/path/to/compiler bazel-out/x86-fastbuild/foo src/my.src -Dbazel-out/arm-opt/bar".
      *
+     * <p>Also supports special archived tree artifact paths containing colons (e.g.,
+     * "bazel-out/:archived_tree_artifacts/k8-fastbuild/...").
+     *
      * <p>Doesn't strip paths that would be non-existent without config prefixes. For example, these
      * are unchanged: "bazel-out/x86-fastbuild", "bazel-out;foo", "/path/to/compiler bazel-out".
      *
      * @param outputRoot root segment of output paths (e.g. "bazel-out")
      */
     private static Pattern stripPathsPattern(String outputRoot) {
-      // Match "bazel-out" followed by a slash followed by any combination of word characters, "_",
-      // and "-", followed by another slash. This would miss substrings like
-      // "bazel-out/k8-fastbuild". But those don't represent actual outputs (all outputs would have
-      // to have names beneath that path). So we're not trying to replace those.
-      return Pattern.compile(outputRoot + "/[\\w_-]+/");
+      // Match "bazel-out" followed by a slash, an optional ":archived_tree_artifacts/" prefix group
+      // captured in group 1, followed by the configuration segment (any combination of word
+      // characters, "_", and "-"), and another slash.
+      return Pattern.compile(outputRoot + "/(" + ARCHIVED_TREE_ARTIFACTS_SEGMENT + "/)?[\\w_-]+/");
     }
 
-    public String strip(String str) {
-      return pattern.matcher(str).replaceAll(outputRoot + "/" + FIXED_CONFIG_SEGMENT + "/");
+    String strip(String str) {
+      return pattern.matcher(str).replaceAll(outputRoot + "/$1" + FIXED_CONFIG_SEGMENT + "/");
     }
   }
 
@@ -313,6 +314,29 @@ public final class StrippingPathMapper implements PathMapper {
   /** Private utility method: Is this a strippable path? */
   private static boolean isOutputPath(PathFragment pathFragment, PathFragment outputRoot) {
     return pathFragment.startsWith(outputRoot);
+  }
+
+  /**
+   * Returns whether the given execution path belongs to an archived tree artifact.
+   *
+   * <p>Archived tree artifacts are compressed directory outputs stored in zip format that prepend a
+   * virtual directory prefix segment {@value #ARCHIVED_TREE_ARTIFACTS_SEGMENT} immediately after
+   * the output root (e.g., {@code bazel-out/:archived_tree_artifacts/k8-fastbuild/...}).
+   */
+  private static boolean isArchivedTreeArtifactPath(PathFragment execPath) {
+    return execPath.segmentCount() > 2
+        && execPath.getSegment(1).equals(ARCHIVED_TREE_ARTIFACTS_SEGMENT);
+  }
+
+  /**
+   * Returns the segment index inside the execution path where the configuration prefix is located.
+   *
+   * <p>For standard output artifacts, the configuration segment is at index 1 (e.g. {@code
+   * bazel-out/k8-fastbuild/bin/...}). For archived tree artifacts, the configuration segment is
+   * shifted to index 2 due to the injected virtual prefix directory.
+   */
+  private static int getConfigSegmentIndex(PathFragment execPath) {
+    return isArchivedTreeArtifactPath(execPath) ? 2 : 1;
   }
 
   /**
@@ -338,10 +362,12 @@ public final class StrippingPathMapper implements PathMapper {
       if (!isOutputPath(input, outputRoot)) {
         continue;
       }
+      PathFragment execPath = input.getExecPath();
+      int configIndex = getConfigSegmentIndex(execPath);
+      // Extract root-relative path after the configuration segment.
       // For "bazel-out/k8-fastbuild/bin/foo/bar", get "bin/foo/bar".
-      if (!rootRelativePaths
-          .computeIfAbsent(input.getExecPath().subFragment(2), k -> input)
-          .equals(input)) {
+      PathFragment rootRelativePath = execPath.subFragment(configIndex + 1);
+      if (!rootRelativePaths.computeIfAbsent(rootRelativePath, k -> input).equals(input)) {
         return false;
       }
     }
@@ -352,11 +378,12 @@ public final class StrippingPathMapper implements PathMapper {
    * Strips the configuration prefix from an output artifact's exec path.
    */
   private static PathFragment strip(PathFragment execPath) {
+    int configIndex = getConfigSegmentIndex(execPath);
     return execPath
-        .subFragment(0, 1)
+        .subFragment(0, configIndex)
         // Keep the config segment, but replace it with a fixed string to improve cacheability while
         // still preserving the general segment structure of the execpath.
         .getRelative(FIXED_CONFIG_SEGMENT)
-        .getRelative(execPath.subFragment(2));
+        .getRelative(execPath.subFragment(configIndex + 1));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnInputExpander.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnInputExpander.java
@@ -107,8 +107,11 @@ public final class SpawnInputExpander {
         ArchivedTreeArtifact archivedTreeArtifact =
             expandArchivedTreeArtifacts ? null : treeArtifactValue.getArchivedArtifact();
         if (archivedTreeArtifact != null) {
-          // TODO(bazel-team): Add path mapping support for archived tree artifacts.
-          addMapping(inputMap, location, archivedTreeArtifact, baseDirectory);
+          addMapping(
+              inputMap,
+              mapForRunfiles(pathMapper, root, location),
+              archivedTreeArtifact,
+              baseDirectory);
         } else if (treeArtifactValue.getChildren().isEmpty()) {
           addMapping(inputMap, mapForRunfiles(pathMapper, root, location), artifact, baseDirectory);
         } else {

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
@@ -310,4 +310,80 @@ public class PathMappersTest extends BuildViewTestCase {
     assertThat(pathMapper.map(PathFragment.create("bazel-out/k8-fastbuild-ST-12345/bin/pkg/file")))
         .isEqualTo(PathFragment.create("bazel-out/pm-k8-fastbuild-ST-12345/bin/pkg/file"));
   }
+
+  @Test
+  public void starlarkRule_archivedTreePaths() throws Exception {
+    String outDir = analysisMock.getProductName() + "-out";
+    scratch.file("defs/BUILD");
+    scratch.file(
+        "defs/defs.bzl",
+        """
+        def my_rule_impl(ctx):
+            out = ctx.actions.declare_file(ctx.label.name)
+            args = ctx.actions.args()
+            args.add(out)
+            args.add("--input")
+            args.add("%1$s/k8-fastbuild/bin/pkg/standard.js")
+            args.add("--input")
+            args.add("%1$s/:archived_tree_artifacts/k8-fastbuild/bin/pkg/tree.zip")
+            ctx.actions.run(
+                executable = ctx.executable.tool.path,
+                arguments = [args],
+                outputs = [out],
+                tools = [ctx.executable.tool],
+                mnemonic = "Android",  # Using a supported mnemonic to enable path-stripping.
+                execution_requirements = {"supports-path-mapping": "1"},
+            )
+            return DefaultInfo(files = depset([out]))
+        my_rule = rule(
+            implementation = my_rule_impl,
+            attrs = {
+                "tool": attr.label(
+                    default = "//foo:script",
+                    cfg = "exec",
+                    executable = True,
+                ),
+            },
+        )
+        """
+            .formatted(outDir));
+    scratch.file(
+        "foo/BUILD",
+        """
+        load('//test_defs:foo_binary.bzl', 'foo_binary')
+        foo_binary(
+            name = 'script',
+            srcs = ['script.sh'],
+            visibility = ['//visibility:public'],
+        )
+        """);
+    scratch.file(
+        "BUILD",
+        """
+        load("//defs:defs.bzl", "my_rule")
+        my_rule(name = "my_rule")
+        """);
+
+    ConfiguredTarget configuredTarget = getConfiguredTarget("//:my_rule");
+    Artifact outputArtifact =
+        configuredTarget.getProvider(FileProvider.class).getFilesToBuild().toList().get(0);
+    SpawnAction action = (SpawnAction) getGeneratingAction(outputArtifact);
+    Spawn spawn =
+        action.getSpawn(
+            new ActionExecutionContextBuilder()
+                .setMetadataProvider(new FakeActionInputFileCache())
+                .build());
+
+    assertThat(spawn.getPathMapper().isNoop()).isFalse();
+
+    assertThat(spawn.getArguments())
+        .containsExactly(
+            "%s/cfg/bin/foo/script".formatted(outDir),
+            "%s/cfg/bin/my_rule".formatted(outDir),
+            "--input",
+            "%s/cfg/bin/pkg/standard.js".formatted(outDir),
+            "--input",
+            "%s/:archived_tree_artifacts/cfg/bin/pkg/tree.zip".formatted(outDir))
+        .inOrder();
+  }
 }

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -50,6 +50,7 @@ function set_up() {
   start_worker
 
   add_rules_java "MODULE.bazel"
+  add_rules_shell "MODULE.bazel"
   mkdir -p src/main/java/com/example
   cat > src/main/java/com/example/BUILD <<'EOF'
 load("@rules_java//java:java_binary.bzl", "java_binary")
@@ -1192,6 +1193,100 @@ EOF
   expect_not_log 'INFO: From Action pkg/my_rule_file'
   expect_log_n 'Hello, stderr!' 2
   expect_log_n 'Hello, stdout!' 2
+}
+
+function test_path_stripping_archived_tree_artifacts() {
+  if is_windows; then
+    echo "Skipping test_path_stripping_archived_tree_artifacts on Windows as it requires sandboxing"
+    return
+  fi
+
+  local -r pkg="${FUNCNAME[0]}"
+  mkdir -p "$pkg"
+  cat > "$pkg/defs.bzl" <<EOF
+def _tree_gen_impl(ctx):
+    out = ctx.actions.declare_directory(ctx.label.name)
+    ctx.actions.run_shell(
+        outputs = [out],
+        command = "mkdir -p " + out.path,
+        mnemonic = "GenerateArchiveTree",
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+tree_gen = rule(
+    implementation = _tree_gen_impl,
+)
+
+def _consume_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name + ".out")
+    args = ctx.actions.args()
+    args.add(out)
+    args.add_all(ctx.files.srcs, expand_directories = False)
+    ctx.actions.run(
+        inputs = ctx.files.srcs,
+        outputs = [out],
+        executable = ctx.executable.tool,
+        arguments = [args],
+        mnemonic = "ConsumeArchiveTree",
+        execution_requirements = {"supports-path-mapping": ""},
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+consume = rule(
+    implementation = _consume_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "tool": attr.label(
+            default = "//$pkg:tool",
+            cfg = "exec",
+            executable = True,
+        ),
+    },
+)
+EOF
+
+  cat > "$pkg/BUILD" <<EOF
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load(":defs.bzl", "tree_gen", "consume")
+
+tree_gen(name = "my_tree")
+
+sh_binary(
+    name = "tool",
+    srcs = ["tool.sh"],
+)
+
+consume(
+    name = "my_consume",
+    srcs = [":my_tree"],
+)
+EOF
+
+  cat > "$pkg/tool.sh" <<'EOF'
+#!/bin/bash
+touch "$1"
+EOF
+  chmod +x "$pkg/tool.sh"
+
+
+  bazel build -c fastbuild \
+    --remote_cache=grpc://localhost:${worker_port} \
+    --archived_tree_artifact_mnemonics_filter=GenerateArchiveTree \
+    --experimental_output_paths=strip \
+    "//$pkg:my_consume" &> $TEST_log || fail "build failed unexpectedly"
+
+  expect_log 'linux-sandbox'
+  expect_not_log 'remote cache hit'
+
+  bazel build -c opt \
+    --remote_cache=grpc://localhost:${worker_port} \
+    --archived_tree_artifact_mnemonics_filter=GenerateArchiveTree \
+    --experimental_output_paths=strip \
+    "//$pkg:my_consume" &> $TEST_log || fail "build failed unexpectedly"
+
+  expect_log '1 remote cache hit'
+
+  rm -rf "$pkg"
 }
 
 run_suite "path mapping tests"

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -1289,4 +1289,101 @@ EOF
   rm -rf "$pkg"
 }
 
+function test_path_stripping_archived_tree_runfiles() {
+  if is_windows; then
+    echo "Skipping test_path_stripping_archived_tree_runfiles on Windows as it requires sandboxing"
+    return
+  fi
+
+  stop_worker
+  start_worker
+
+  local -r pkg="${FUNCNAME[0]}"
+  mkdir -p "$pkg"
+
+  cat > "$pkg/defs.bzl" <<EOF
+def _tree_gen_impl(ctx):
+    out = ctx.actions.declare_directory(ctx.label.name)
+    ctx.actions.run_shell(
+        outputs = [out],
+        command = "mkdir -p " + out.path,
+        mnemonic = "GenerateArchiveTree",
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+tree_gen = rule(
+    implementation = _tree_gen_impl,
+)
+
+def _consume_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name + ".out")
+    args = ctx.actions.args()
+    args.add(out)
+    ctx.actions.run(
+        inputs = ctx.files.srcs,
+        outputs = [out],
+        executable = ctx.executable.tool,
+        arguments = [args],
+        mnemonic = "ConsumeArchiveTree",
+        execution_requirements = {"supports-path-mapping": ""},
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+consume = rule(
+    implementation = _consume_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "tool": attr.label(
+            default = "//$pkg:my_binary",
+            cfg = "exec",
+            executable = True,
+        ),
+    },
+)
+EOF
+
+  cat > "$pkg/BUILD" <<EOF
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load(":defs.bzl", "tree_gen", "consume")
+
+tree_gen(name = "my_tree")
+
+sh_binary(
+    name = "my_binary",
+    srcs = ["my_binary.sh"],
+    data = [":my_tree"],
+)
+
+consume(
+    name = "my_consume",
+    srcs = [":my_tree"],
+)
+EOF
+
+  cat > "$pkg/my_binary.sh" <<'EOF'
+#!/bin/bash
+touch "$1"
+EOF
+  chmod +x "$pkg/my_binary.sh"
+
+  bazel build -c fastbuild \
+    --remote_cache=grpc://localhost:${worker_port} \
+    --archived_tree_artifact_mnemonics_filter=GenerateArchiveTree \
+    --experimental_output_paths=strip \
+    "//$pkg:my_consume" &> $TEST_log || fail "build failed unexpectedly"
+
+  expect_log 'linux-sandbox'
+  expect_not_log 'remote cache hit'
+
+  bazel build -c opt \
+    --remote_cache=grpc://localhost:${worker_port} \
+    --archived_tree_artifact_mnemonics_filter=GenerateArchiveTree \
+    --experimental_output_paths=strip \
+    "//$pkg:my_consume" &> $TEST_log || fail "build failed unexpectedly"
+
+  expect_log '1 remote cache hit'
+
+  rm -rf "$pkg"
+}
+
 run_suite "path mapping tests"


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
This PR enables output path mapping (config stripping) for `ArchivedTreeArtifact`s. 

`ArchivedTreeArtifact`s are compressed `.zip` container directories generated for remote transfer that inject a virtual prefix segment (`:archived_tree_artifacts`) immediately after the output root (e.g. `bazel-out/:archived_tree_artifacts/k8-fastbuild/bin/...`).

Previously, `StrippingPathMapper` hardcoded the configuration segment location at segment index `1` and the root-relative path at segment index `2`. This caused Bazel to strip the `:archived_tree_artifacts` prefix instead of the configuration prefix, leading to incorrect string length calculations and path translations.                                                                                                                                                       
                                                                                                                                                                                                      

We resolved this by:
1.  Introducing a dynamic `getConfigSegmentIndex(execPath)` method that shifts the configuration segment index from `1` to `2` when the `:archived_tree_artifacts` prefix is present.
3.  Consolidating the string-stripping regex pattern inside `StringStripper` into a single, pattern using an optional capturing group `(:archived_tree_artifacts/)?`.
4. Adding unit and integration tests to cover the newly added functionality.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Enabled output path mapping (config stripping) support for `ArchivedTreeArtifact`s to improve action caching under `--experimental_output_paths=strip`.
