### PR TITLE
[9.1.1] Fix crash on --remote_default_exec_properties with the same key.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -33,6 +33,7 @@ import com.google.devtools.common.options.OptionEffectTag;
 import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.OptionsParsingException;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -813,9 +814,15 @@ public final class RemoteOptions extends CommonRemoteOptions {
    * specified. Use this method instead of directly accessing the field.
    */
   public ImmutableSortedMap<String, String> getRemoteDefaultExecProperties() {
-    return remoteDefaultExecProperties != null
-        ? ImmutableSortedMap.copyOf(remoteDefaultExecProperties)
-        : ImmutableSortedMap.of();
+    if (remoteDefaultExecProperties == null) {
+      return ImmutableSortedMap.of();
+    }
+    // Don't use `ImmutableSortedMap.copyOf` directly because it crashes on duplicate keys.
+    var map = new HashMap<String, String>();
+    for (Map.Entry<String, String> entry : remoteDefaultExecProperties) {
+      map.put(entry.getKey(), entry.getValue());
+    }
+    return ImmutableSortedMap.copyOf(map);
   }
 
   /** An enum for specifying different modes for printing remote execution messages. */

--- a/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
@@ -50,6 +50,18 @@ public class RemoteOptionsTest {
   }
 
   @Test
+  public void testRemoteDefaultExecPropertiesWithDuplicates() throws Exception {
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteDefaultExecProperties =
+        Arrays.asList(
+            Maps.immutableEntry("foo", "bar"),
+            Maps.immutableEntry("qux", "quux"),
+            Maps.immutableEntry("foo", "baz"));
+    SortedMap<String, String> properties = options.getRemoteDefaultExecProperties();
+    assertThat(properties).isEqualTo(ImmutableSortedMap.of("foo", "baz", "qux", "quux"));
+  }
+
+  @Test
   public void testRemoteTimeoutOptionsConverterWithoutUnit() {
     try {
       int seconds = 60;


### PR DESCRIPTION
Fixes #29145.

PiperOrigin-RevId: 891705887
Change-Id: I11af19001aebf818b746bd671c9a25f12a25979b

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/bbf284d000880eb96020b8c7ea43104ffaf69fa5
