### PR TITLE
ci: fix linux-sandbox on Ubuntu 24.04

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -299,6 +299,8 @@ REMOTE_PLATFORMS = ("rbe_ubuntu2404",)
         exec_properties = {
             "dockerNetwork": "standard",
             "dockerPrivileged": "true",
+            "dockerRunAsRoot": "true",
+            "linuxIsolation": "OFF",
             "Pool": "default",
         },
         parents = ["@" + platform_name + "//config:platform"],

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -597,7 +597,7 @@ public class CombinedCache extends AbstractReferenceCounted {
         directExecutor());
   }
 
-  /** A reporter that reports download progresses. */
+  /** A reporter that reports download progress. */
   public static class DownloadProgressReporter {
     private static final Pattern PATTERN = Pattern.compile("^bazel-out/[^/]+/[^/]+/");
     private final boolean includeFile;


### PR DESCRIPTION
After the Ubuntu 24.04 RBE migration, linux-sandbox tests failed on RBE with CommandUsingLinuxSandboxTest reporting BadExitStatusException from the linux-sandbox wrapper:
```
com.google.devtools.build.lib.shell.BadExitStatusException: Process exited with status 1
```
The failing cases were the linux-sandbox echo test and the linux-sandbox execution-statistics tests. Update the Ubuntu 24.04 RBE platform to run actions as root with linuxIsolation=OFF while keeping dockerPrivileged enabled, preserving RBE coverage for linux-sandbox and nested sandboxing tests.

Fix a typo in a CombinedCache comment so changed-target CI selection includes the core remote cache package.