### PR TITLE
Support path mapping collisions for identical files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1368,6 +1368,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:commandline_item",
         "//src/main/java/com/google/devtools/build/lib/actions:execution_requirements",
+        "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/actions:virtual_action_input",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:build_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:core_options",

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/ParameterFileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/ParameterFileWriteAction.java
@@ -201,10 +201,12 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
     // Since this depends on the consumer but the decision is only made at execution time, it is not
     // clear how to improve that situation. Actions that are prone to such collisions should avoid
     // depending on parameter files.
-    var pathMapper = PathMappers.create(this, getOutputPathsMode(), /* isStarlarkAction= */ false);
+    InputMetadataProvider inputMetadataProvider =
+        Preconditions.checkNotNull(ctx.getInputMetadataProvider());
+    var pathMapper =
+        PathMappers.create(
+            this, getOutputPathsMode(), /* isStarlarkAction= */ false, inputMetadataProvider);
     try {
-      InputMetadataProvider inputMetadataProvider =
-          Preconditions.checkNotNull(ctx.getInputMetadataProvider());
       arguments = commandLine.expand(inputMetadataProvider, pathMapper);
     } catch (CommandLineExpansionException e) {
       throw new UserExecException(

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/PathMappers.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/PathMappers.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.actions.CommandLineLimits;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
+import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
@@ -115,17 +116,23 @@ public final class PathMappers {
    * @param action the {@link AbstractAction} for which a {@link Spawn} is to be created
    * @param outputPathsMode the value of {@link CoreOptions#outputPathsMode}
    * @param isStarlarkAction whether the action is a Starlark action
+   * @param inputMetadataProvider if non-null, used to verify that colliding inputs (from different
+   *     configurations mapping to the same path) have identical file digests
    * @return a {@link PathMapper} that maps paths of the action's inputs and outputs. May be {@link
    *     PathMapper#NOOP} if path mapping is not applicable to the action.
    */
   public static PathMapper create(
-      AbstractAction action, OutputPathsMode outputPathsMode, boolean isStarlarkAction) {
+      AbstractAction action,
+      OutputPathsMode outputPathsMode,
+      boolean isStarlarkAction,
+      @Nullable InputMetadataProvider inputMetadataProvider) {
     if (getEffectiveOutputPathsMode(
             outputPathsMode, action.getMnemonic(), action.getExecutionInfo())
         != OutputPathsMode.STRIP) {
       return PathMapper.NOOP;
     }
-    return StrippingPathMapper.tryCreate(action, isStarlarkAction).orElse(PathMapper.NOOP);
+    return StrippingPathMapper.tryCreate(action, isStarlarkAction, inputMetadataProvider)
+        .orElse(PathMapper.NOOP);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -207,7 +207,11 @@ public class SpawnAction extends AbstractAction implements CommandAction {
   @Override
   public List<String> getArguments() throws CommandLineExpansionException, InterruptedException {
     return commandLines.allArguments(
-        PathMappers.create(this, outputPathsMode, this instanceof StarlarkAction));
+        PathMappers.create(
+            this,
+            outputPathsMode,
+            this instanceof StarlarkAction,
+            /* inputMetadataProvider= */ null));
   }
 
   @Override
@@ -371,7 +375,11 @@ public class SpawnAction extends AbstractAction implements CommandAction {
       boolean reportOutputs)
       throws CommandLineExpansionException, InterruptedException {
     PathMapper pathMapper =
-        PathMappers.create(this, outputPathsMode, this instanceof StarlarkAction);
+        PathMappers.create(
+            this,
+            outputPathsMode,
+            this instanceof StarlarkAction,
+            actionExecutionContext.getInputMetadataProvider());
     ExpandedCommandLines expandedCommandLines =
         commandLines.expand(
             actionExecutionContext.getInputMetadataProvider(),

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.analysis.actions;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.AbstractAction;
@@ -27,11 +28,15 @@ import com.google.devtools.build.lib.actions.CommandLine.SimpleArgChunk;
 import com.google.devtools.build.lib.actions.CommandLineItem;
 import com.google.devtools.build.lib.actions.CommandLineItem.ExceptionlessMapFn;
 import com.google.devtools.build.lib.actions.CommandLineItem.MapFn;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.VirtualActionInput;
 import com.google.devtools.build.lib.starlarkbuildapi.FileRootApi;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Objects;
@@ -127,16 +132,19 @@ public final class StrippingPathMapper implements PathMapper {
    *
    * @param action the action to potentially strip paths from
    * @param isStarlarkAction whether the action is a Starlark action
+   * @param inputMetadataProvider provider to verify colliding inputs have identical digests
    * @return a {@link StrippingPathMapper} if the action supports it, else {@link Optional#empty()}.
    */
-  static Optional<PathMapper> tryCreate(AbstractAction action, boolean isStarlarkAction) {
+  static Optional<PathMapper> tryCreate(
+      AbstractAction action,
+      boolean isStarlarkAction,
+      @Nullable InputMetadataProvider inputMetadataProvider) {
     PathFragment outputRoot = action.getPrimaryOutput().getExecPath().subFragment(0, 1);
-    // Additional artifacts to map are not part of the action's inputs, but may still lead to
-    // path collisions after stripping. It is thus important to include them in this check.
     if (isPathStrippable(
         Iterables.concat(
             action.getInputs().toList(), action.getAdditionalArtifactsForPathMapping().toList()),
-        outputRoot)) {
+        outputRoot,
+        inputMetadataProvider)) {
       return Optional.of(
           new StrippingPathMapper(
               action.getPrimaryOutput(), action.getMnemonic(), isStarlarkAction));
@@ -345,18 +353,18 @@ public final class StrippingPathMapper implements PathMapper {
    * <p>This is distinct from whether we <b>should</b> strip it. An action is stripped if a) the
    * action is explicitly supported (see {@link PathMappers#SUPPORTED_MNEMONICS}) and b) it's safe
    * to do that (for example, the action doesn't have two inputs in different configurations that
-   * would resolve to the same path if prefixes were removed).
+   * would resolve to the same path if prefixes were removed and have different content).
+   *
+   * <p>Collisions between inputs from different configurations that map to the same root-relative
+   * path are allowed if they have the same file digest.
    *
    * <p>This method checks b).
    */
-  private static boolean isPathStrippable(
-      Iterable<? extends ActionInput> actionInputs, PathFragment outputRoot) {
-    // For qualifying action types, check that no inputs or outputs would clash if config segments
-    // were removed, e.g. "bazel-out/k8-fastbuild/bin/foo" and
-    // "bazel-out/k8-fastbuild-ST-1234/bin/foo".
-    //
-    // A more clever algorithm could remap these with custom prefixes - "bazel-out/1/bin/foo" and
-    // "bazel-out/2/bin/foo" - if experience shows that would help.
+  @VisibleForTesting
+  static boolean isPathStrippable(
+      Iterable<? extends ActionInput> actionInputs,
+      PathFragment outputRoot,
+      @Nullable InputMetadataProvider inputMetadataProvider) {
     HashMap<PathFragment, ActionInput> rootRelativePaths = new HashMap<>();
     for (ActionInput input : actionInputs) {
       if (!isOutputPath(input, outputRoot)) {
@@ -367,16 +375,40 @@ public final class StrippingPathMapper implements PathMapper {
       // Extract root-relative path after the configuration segment.
       // For "bazel-out/k8-fastbuild/bin/foo/bar", get "bin/foo/bar".
       PathFragment rootRelativePath = execPath.subFragment(configIndex + 1);
-      if (!rootRelativePaths.computeIfAbsent(rootRelativePath, k -> input).equals(input)) {
+      ActionInput previous =
+          rootRelativePaths.computeIfAbsent(rootRelativePath, k -> input);
+      if (!previous.equals(input) && !haveSameDigest(previous, input, inputMetadataProvider)) {
         return false;
       }
     }
     return true;
   }
 
-  /*
-   * Strips the configuration prefix from an output artifact's exec path.
+  /**
+   * Returns true if the two inputs have the same file digest.
    */
+  private static boolean haveSameDigest(
+      ActionInput a, ActionInput b, @Nullable InputMetadataProvider inputMetadataProvider) {
+    if (inputMetadataProvider == null) {
+      return false;
+    }
+    try {
+      FileArtifactValue metadataA = inputMetadataProvider.getInputMetadata(a);
+      FileArtifactValue metadataB = inputMetadataProvider.getInputMetadata(b);
+      if (metadataA == null || metadataB == null) {
+        return false;
+      }
+      byte[] digestA = metadataA.getDigest();
+      byte[] digestB = metadataB.getDigest();
+      if (digestA == null || digestB == null) {
+        return false;
+      }
+      return Arrays.equals(digestA, digestB);
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
   private static PathFragment strip(PathFragment execPath) {
     int configIndex = getConfigSegmentIndex(execPath);
     return execPath

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
@@ -84,6 +84,7 @@ import java.io.IOException;
 import java.util.AbstractCollection;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.Iterator;
@@ -524,23 +525,11 @@ public final class MerkleTreeComputer {
       }
 
       PathFragment path = entry.getKey();
-      // The same path may appear multiple times if the inputs are outputs of shared actions or if
-      // identical inputs are not de-duplicated. Only stage the first one.
+      // The same path may appear multiple times if the inputs are outputs of shared actions,
+      // if identical inputs are not deduplicated or if path mapping maps artifacts from
+      // different configurations to the same path. Only stage the first one as we assume
+      // that the inputs have been validated before.
       if (lastEntry != null && path.equals(lastEntry.getKey())) {
-        var previousInput = lastEntry.getValue();
-        var currentInput = entry.getValue();
-        if (previousInput.equals(currentInput)) {
-          continue;
-        }
-        checkState(
-            previousInput instanceof Artifact previousArtifact
-                && currentInput instanceof Artifact currentArtifact
-                && new Artifact.OwnerlessArtifactWrapper(previousArtifact)
-                    .equals(new Artifact.OwnerlessArtifactWrapper(currentArtifact)),
-            "Duplicate paths are only allowed for distinct shared artifacts, got: %s and %s at %s",
-            previousInput,
-            currentInput,
-            path);
         continue;
       }
       lastEntry = entry;

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -1457,7 +1457,10 @@ public class CppCompileAction extends AbstractAction
       throws ActionExecutionException, InterruptedException {
     PathMapper pathMapper =
         PathMappers.create(
-            this, PathMappers.getOutputPathsMode(configuration), /* isStarlarkAction= */ false);
+            this,
+            PathMappers.getOutputPathsMode(configuration),
+            /* isStarlarkAction= */ false,
+            actionExecutionContext.getInputMetadataProvider());
 
     ArgumentsAndParamFileActionInput argumentsAndParamFileActionInput =
         getArgumentsForExecute(pathMapper);

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
@@ -92,6 +92,8 @@ final class HeaderDiscovery {
       // an action cache hit in that case, since even if it previously depended on the artifact
       // whose path changed, that is not taken into account by the action cache, and it will get an
       // action cache hit using the remaining un-renamed artifact.
+      // TODO: Consider using a multimap here so that header resolution depends on _all_ identical
+      // files, not just a single representative.
       if (a.isTreeArtifact()) {
         treeArtifacts.putIfAbsent(pathMapper.map(a.getExecPath()), (SpecialArtifact) a);
       } else {

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -22,8 +22,6 @@ import static java.util.stream.Collectors.joining;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -84,6 +82,7 @@ import com.google.protobuf.ExtensionRegistry;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -288,7 +287,10 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
     CustomCommandLine.Builder classpathLine = CustomCommandLine.builder();
     PathMapper pathMapper =
         PathMappers.create(
-            this, PathMappers.getOutputPathsMode(configuration), /* isStarlarkAction= */ false);
+            this,
+            PathMappers.getOutputPathsMode(configuration),
+            /* isStarlarkAction= */ false,
+            actionExecutionContext.getInputMetadataProvider());
 
     if (fallback) {
       classpathLine.addExecPaths("--classpath", transitiveInputs);
@@ -336,7 +338,10 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
       throws CommandLineExpansionException, InterruptedException {
     PathMapper pathMapper =
         PathMappers.create(
-            this, PathMappers.getOutputPathsMode(configuration), /* isStarlarkAction= */ false);
+            this,
+            PathMappers.getOutputPathsMode(configuration),
+            /* isStarlarkAction= */ false,
+            actionExecutionContext.getInputMetadataProvider());
     CommandLines.ExpandedCommandLines expandedCommandLines =
         getCommandLines()
             .expand(
@@ -744,19 +749,21 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
     }
 
     // For each of the action's generated inputs, revert its mapped path back to its original path.
-    BiMap<String, PathFragment> mappedToOriginalPath = HashBiMap.create();
+    HashMap<String, PathFragment> mappedToOriginalPath = new HashMap<>();
+    HashSet<String> originalPaths = new HashSet<>();
     for (Artifact actionInput :
         Iterables.concat(actionInputs.toList(), additionalArtifactsForPathMapping.toList())) {
       if (actionInput.isSourceArtifact()) {
         continue;
       }
       String mappedPath = pathMapper.getMappedExecPathString(actionInput);
+      originalPaths.add(actionInput.getExecPath().getPathString());
       PathFragment previousPath = mappedToOriginalPath.put(mappedPath, actionInput.getExecPath());
       if (previousPath != null && !previousPath.equals(actionInput.getExecPath())) {
-        throw new IllegalStateException(
-            String.format(
-                "Duplicate mapped path %s derived from %s and %s",
-                mappedPath, actionInput.getExecPath(), mappedToOriginalPath.get(mappedPath)));
+        // Multiple inputs from different configs map to the same path. This is allowed when they
+        // have identical content (checked by StrippingPathMapper.isPathStrippable). Pick any
+        // original path for jdeps rewriting.
+        mappedToOriginalPath.put(mappedPath, previousPath);
       }
     }
 
@@ -775,7 +782,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
       // we can leave it as is. For entirely unexpected paths, we still report an error.
       if (originalPath == null
           && pathOnExecutor.subFragment(0, 1).equals(outputRoot)
-          && !mappedToOriginalPath.containsValue(pathOnExecutor)) {
+          && !originalPaths.contains(pathOnExecutor.getPathString())) {
         throw new IllegalStateException(
             String.format(
                 "Missing original path for mapped path %s in %s%njdeps: %s%npath map: %s",

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLineTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLineTest.java
@@ -886,7 +886,7 @@ public final class StarlarkCustomCommandLineTest {
   private void verifyStrippedCommandLine(CommandLine commandLine, String... expected)
       throws CommandLineExpansionException, InterruptedException {
     verifyCommandLine(
-        PathMappers.create(action, CoreOptions.OutputPathsMode.STRIP, /* isStarlarkAction= */ true),
+        PathMappers.create(action, CoreOptions.OutputPathsMode.STRIP, /* isStarlarkAction= */ true, /* inputMetadataProvider= */ null),
         commandLine,
         expected);
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputerTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.remote.merkletree;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static org.junit.Assert.assertThrows;
 
 import build.bazel.remote.execution.v2.Digest;
 import com.google.common.collect.ImmutableClassToInstanceMap;
@@ -30,6 +31,7 @@ import com.google.devtools.build.lib.actions.DelegatingPairInputMetadataProvider
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FilesetOutputTree;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.RunfilesArtifactValue;
 import com.google.devtools.build.lib.actions.RunfilesTree;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -372,6 +374,62 @@ public class MerkleTreeComputerTest {
 
     // All threads share a single upload of the subtree.
     assertThat(ensureInputsPresentCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void duplicateMappedPath_sameDigest_succeeds() throws Exception {
+    // Two artifacts from different configurations that map to the same path with identical content.
+    var fastbuildRoot =
+        ArtifactRoot.asDerivedRoot(
+            execRoot, ArtifactRoot.RootType.OUTPUT, "outputs", "k8-fastbuild", "bin");
+    checkNotNull(fastbuildRoot.getRoot().asPath()).createDirectoryAndParents();
+    var stRoot =
+        ArtifactRoot.asDerivedRoot(
+            execRoot, ArtifactRoot.RootType.OUTPUT, "outputs", "k8-fastbuild-ST-1234", "bin");
+    checkNotNull(stRoot.getRoot().asPath()).createDirectoryAndParents();
+
+    Artifact artifact1 = ActionsTestUtil.createArtifact(fastbuildRoot, "pkg/foo.h");
+    Artifact artifact2 = ActionsTestUtil.createArtifact(stRoot, "pkg/foo.h");
+    artifact1.getPath().getParentDirectory().createDirectoryAndParents();
+    artifact2.getPath().getParentDirectory().createDirectoryAndParents();
+    FileSystemUtils.writeContentAsLatin1(artifact1.getPath(), "same content");
+    FileSystemUtils.writeContentAsLatin1(artifact2.getPath(), "same content");
+
+    FakeActionInputFileCache cache = new FakeActionInputFileCache();
+    FileArtifactValue metadata1 = FileArtifactValue.createForTesting(artifact1);
+    FileArtifactValue metadata2 = FileArtifactValue.createForTesting(artifact2);
+    cache.put(artifact1, metadata1);
+    cache.put(artifact2, metadata2);
+
+    // PathMapper that strips the config segment
+    PathMapper strippingMapper =
+        new PathMapper() {
+          @Override
+          public PathFragment map(PathFragment execPath) {
+            if (execPath.startsWith(PathFragment.create("outputs"))
+                && execPath.segmentCount() >= 3) {
+              return execPath
+                  .subFragment(0, 1)
+                  .getRelative("cfg")
+                  .getRelative(execPath.subFragment(2));
+            }
+            return execPath;
+          }
+        };
+
+    Spawn spawn =
+        new SpawnBuilder().withInputs(artifact1, artifact2).setPathMapper(strippingMapper).build();
+    var merkleTreeComputer = createMerkleTreeComputer(/* uploader= */ null);
+
+    // Should succeed without error — same digest allows the collision
+    var unused =
+        merkleTreeComputer.buildForSpawn(
+            spawn,
+            ImmutableSet.of(),
+            /* scrubber= */ null,
+            createSpawnExecutionContext(spawn, cache),
+            RemotePathResolver.createDefault(execRoot),
+            MerkleTreeComputer.BlobPolicy.KEEP);
   }
 
   private MerkleTreeComputer createMerkleTreeComputer(MerkleTreeUploader uploader) {

--- a/src/test/shell/integration/config_stripped_outputs_test.sh
+++ b/src/test/shell/integration/config_stripped_outputs_test.sh
@@ -538,4 +538,494 @@ EOF
   assert_paths_stripped "$TEST_log" "$pkg/_objs/main/main."
 }
 
+##############################################################################
+# Colliding-inputs tests.
+#
+# When path stripping maps inputs from different configurations onto the same
+# root-relative path, the build must still succeed as long as the colliding
+# files have identical content (verified by StrippingPathMapper.isPathStrippable).
+# The tests below cover C++ headers, Java JARs (full and reduced classpath),
+# and Starlark run_shell actions.
+##############################################################################
+
+# Test: C++ header collision.
+# Aim: Verify that CppCompile actions use stripped paths when two generated
+# headers from different configurations collide on the same root-relative path
+# but have identical content.
+# Case: A Starlark rule produces a header under a config transition.  Two
+# instances with different setting values generate identical "shared.h" files.
+# The cc_binary depending on both should compile with stripped paths.
+function test_identical_colliding_inputs_are_stripped() {
+  add_rules_cc MODULE.bazel
+  local -r pkg="third_party/${FUNCNAME[0]}"
+  mkdir -p "$pkg/rules"
+  cat > $pkg/rules/defs.bzl <<EOF
+SettingInfo = provider(fields = ["value"])
+
+def _setting_impl(ctx):
+    return SettingInfo(value = ctx.build_setting_value)
+
+my_setting = rule(
+    implementation = _setting_impl,
+    build_setting = config.string(),
+)
+
+def _transition_impl(settings, attr):
+    return {"//$pkg/rules:my_setting": attr.setting_value}
+
+_my_transition = transition(
+    implementation = _transition_impl,
+    inputs = [],
+    outputs = ["//$pkg/rules:my_setting"],
+)
+
+def _gen_identical_header_impl(ctx):
+    # Generate a header with content that does NOT depend on the config setting,
+    # so that outputs from different configurations are identical.
+    header = ctx.actions.declare_file("shared.h")
+    ctx.actions.write(header, "#define SHARED_VALUE 42\\n")
+    return [
+        DefaultInfo(files = depset([header])),
+    ]
+
+gen_identical_header = rule(
+    _gen_identical_header_impl,
+    cfg = _my_transition,
+    attrs = {
+        "setting_value": attr.string(),
+    },
+)
+EOF
+  cat > $pkg/rules/BUILD << 'EOF'
+load(":defs.bzl", "my_setting")
+
+my_setting(
+    name = "my_setting",
+    build_setting_default = "",
+)
+EOF
+
+  mkdir -p $pkg
+  cat > $pkg/BUILD <<EOF
+load("//$pkg/rules:defs.bzl", "gen_identical_header")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+gen_identical_header(
+    name = "header_a",
+    setting_value = "a",
+)
+gen_identical_header(
+    name = "header_b",
+    setting_value = "b",
+)
+cc_binary(
+    name = "main",
+    srcs = [
+        "main.cc",
+        ":header_a",
+        ":header_b",
+    ],
+    includes = ["."],
+)
+EOF
+  cat > $pkg/main.cc <<'EOF'
+#include "shared.h"
+int main() {
+  return SHARED_VALUE - 42;
+}
+EOF
+
+  bazel clean
+  bazel build -s \
+    --modify_execution_info=CppCompile=+supports-path-mapping \
+    "//$pkg:main" 2>"$TEST_log" \
+    || fail "Expected success"
+
+  # For "bazel-out/x86-fastbuild/bin/...", return "bazel-out".
+  output_path=$(bazel info | grep '^output_path:')
+  bazel_out="${output_path##*/}"
+
+  # The two shared.h files from different configs have identical content,
+  # so path mapping should be used (paths stripped) for the CppCompile action.
+  # The extension can be .pic.o or .o depending on the platform.
+  assert_paths_stripped "$TEST_log" "$pkg/_objs/main/main."
+
+}
+
+# Test: Java JAR collision (full classpath / getFullSpawn).
+# Aim: Verify that JavaCompileAction uses stripped paths when two JARs from
+# different configurations collide on the same root-relative path but have
+# identical content.
+# Case: A java_library is built under two different config transitions,
+# producing identical JARs.  A Starlark rule forwards both as JavaInfo deps
+# to a downstream java_binary, whose compilation should use stripped paths.
+# This exercises JavaCompileAction.getFullSpawn().
+function test_identical_colliding_java_inputs_are_stripped() {
+  local -r pkg="${FUNCNAME[0]}"
+  mkdir -p "$pkg/rules"
+  cat > $pkg/rules/defs.bzl <<EOF
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+
+SettingInfo = provider(fields = ["value"])
+
+def _setting_impl(ctx):
+    return SettingInfo(value = ctx.build_setting_value)
+
+my_setting = rule(
+    implementation = _setting_impl,
+    build_setting = config.string(),
+)
+
+def _transition_impl(settings, attr):
+    return {"//$pkg/rules:my_setting": attr.setting_value}
+
+_my_transition = transition(
+    implementation = _transition_impl,
+    inputs = [],
+    outputs = ["//$pkg/rules:my_setting"],
+)
+
+def _transitioned_java_dep_impl(ctx):
+    # Forward the JavaInfo from a java_library built under a config transition.
+    # Since the java_library doesn't depend on the custom setting, the JARs
+    # are identical across configurations.
+    return [ctx.attr.dep[JavaInfo]]
+
+transitioned_java_dep = rule(
+    _transitioned_java_dep_impl,
+    cfg = _my_transition,
+    attrs = {
+        "dep": attr.label(providers = [JavaInfo]),
+        "setting_value": attr.string(),
+    },
+    provides = [JavaInfo],
+)
+EOF
+  cat > $pkg/rules/BUILD << 'EOF'
+load(":defs.bzl", "my_setting")
+
+my_setting(
+    name = "my_setting",
+    build_setting_default = "",
+)
+EOF
+
+  mkdir -p $pkg
+  cat > $pkg/BUILD <<EOF
+load("@rules_java//java:java_binary.bzl", "java_binary")
+load("@rules_java//java:java_library.bzl", "java_library")
+load("//$pkg/rules:defs.bzl", "transitioned_java_dep")
+java_library(
+    name = "mylib",
+    srcs = ["MyLib.java"],
+)
+transitioned_java_dep(
+    name = "dep_a",
+    dep = ":mylib",
+    setting_value = "a",
+)
+transitioned_java_dep(
+    name = "dep_b",
+    dep = ":mylib",
+    setting_value = "b",
+)
+java_binary(
+    name = "mybin",
+    srcs = ["MyBin.java"],
+    main_class = "main.MyBin",
+    deps = [
+        ":dep_a",
+        ":dep_b",
+    ],
+)
+EOF
+  cat > $pkg/MyLib.java <<'EOF'
+package mylib;
+public class MyLib {
+  public static void runMyLib() {
+    System.out.println("MyLib checking in.");
+  }
+}
+EOF
+  cat > $pkg/MyBin.java <<'EOF'
+package main;
+import mylib.MyLib;
+public class MyBin {
+  public static void main(String[] argv) {
+    MyLib.runMyLib();
+  }
+}
+EOF
+
+  bazel clean
+  bazel build --experimental_output_paths=strip \
+    "//$pkg:mybin" -s 2>"$TEST_log" \
+    || fail "Expected success"
+
+  # For "bazel-out/x86-fastbuild/bin/...", return "bazel-out".
+  output_path=$(bazel info | grep '^output_path:')
+  bazel_out="${output_path##*/}"
+
+  # The two libmylib.jar files from different configs have identical content,
+  # so path mapping should be used (paths stripped) for the java_binary
+  # compilation.
+  assert_paths_stripped "$TEST_log" "bin/$pkg/mybin.jar"
+
+  # Verify that a .params file was used (ParameterFileWriteAction) and that
+  # it contains stripped paths for the classpath JAR.
+  local params_file="${bazel_out:0:5}-bin/$pkg/mybin.jar-0.params"
+  [[ -f "$params_file" ]] \
+    || fail "Expected params file to exist: $params_file"
+  grep -q "${bazel_out}/cfg/bin/$pkg/libmylib" "$params_file" \
+    || fail "Expected stripped libmylib path in params file: $(cat $params_file)"
+}
+
+# Test: Java JAR collision (reduced classpath / getReducedSpawn).
+# Aim: Same as test_identical_colliding_java_inputs_are_stripped, but with
+# classpath reduction enabled (--experimental_java_classpath=bazel).
+# Case: Identical setup to the previous test.  The difference is that this
+# exercises JavaCompileAction.getReducedSpawn() instead of getFullSpawn(),
+# ensuring stripped paths are also applied in the reduced-classpath code path.
+function test_identical_colliding_java_inputs_are_stripped_reduced_classpath() {
+  local -r pkg="${FUNCNAME[0]}"
+  mkdir -p "$pkg/rules"
+  cat > $pkg/rules/defs.bzl <<EOF
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+
+SettingInfo = provider(fields = ["value"])
+
+def _setting_impl(ctx):
+    return SettingInfo(value = ctx.build_setting_value)
+
+my_setting = rule(
+    implementation = _setting_impl,
+    build_setting = config.string(),
+)
+
+def _transition_impl(settings, attr):
+    return {"//$pkg/rules:my_setting": attr.setting_value}
+
+_my_transition = transition(
+    implementation = _transition_impl,
+    inputs = [],
+    outputs = ["//$pkg/rules:my_setting"],
+)
+
+def _transitioned_java_dep_impl(ctx):
+    return [ctx.attr.dep[JavaInfo]]
+
+transitioned_java_dep = rule(
+    _transitioned_java_dep_impl,
+    cfg = _my_transition,
+    attrs = {
+        "dep": attr.label(providers = [JavaInfo]),
+        "setting_value": attr.string(),
+    },
+    provides = [JavaInfo],
+)
+EOF
+  cat > $pkg/rules/BUILD << 'EOF'
+load(":defs.bzl", "my_setting")
+
+my_setting(
+    name = "my_setting",
+    build_setting_default = "",
+)
+EOF
+
+  mkdir -p $pkg
+  cat > $pkg/BUILD <<EOF
+load("@rules_java//java:java_binary.bzl", "java_binary")
+load("@rules_java//java:java_library.bzl", "java_library")
+load("//$pkg/rules:defs.bzl", "transitioned_java_dep")
+java_library(
+    name = "mylib",
+    srcs = ["MyLib.java"],
+)
+transitioned_java_dep(
+    name = "dep_a",
+    dep = ":mylib",
+    setting_value = "a",
+)
+transitioned_java_dep(
+    name = "dep_b",
+    dep = ":mylib",
+    setting_value = "b",
+)
+java_binary(
+    name = "mybin",
+    srcs = ["MyBin.java"],
+    main_class = "main.MyBin",
+    deps = [
+        ":dep_a",
+        ":dep_b",
+    ],
+)
+EOF
+  cat > $pkg/MyLib.java <<'EOF'
+package mylib;
+public class MyLib {
+  public static void runMyLib() {
+    System.out.println("MyLib checking in.");
+  }
+}
+EOF
+  cat > $pkg/MyBin.java <<'EOF'
+package main;
+import mylib.MyLib;
+public class MyBin {
+  public static void main(String[] argv) {
+    MyLib.runMyLib();
+  }
+}
+EOF
+
+  bazel clean
+  bazel build --experimental_output_paths=strip \
+    --experimental_java_classpath=bazel \
+    "//$pkg:mybin" -s 2>"$TEST_log" \
+    || fail "Expected success"
+
+  # For "bazel-out/x86-fastbuild/bin/...", return "bazel-out".
+  output_path=$(bazel info | grep '^output_path:')
+  bazel_out="${output_path##*/}"
+
+  # With classpath reduction, JavaCompileAction.getReducedSpawn() is used.
+  # The two libmylib.jar files from different configs have identical content,
+  # so path mapping should be used (paths stripped).
+  assert_paths_stripped "$TEST_log" "bin/$pkg/mybin.jar"
+
+  # Verify that a .params file was used (ParameterFileWriteAction) and that
+  # it contains stripped paths for the classpath JAR.
+  local params_file="${bazel_out:0:5}-bin/$pkg/mybin.jar-0.params"
+  [[ -f "$params_file" ]] \
+    || fail "Expected params file to exist: $params_file"
+  grep -q "${bazel_out}/cfg/bin/$pkg/libmylib" "$params_file" \
+    || fail "Expected stripped libmylib path in params file: $(cat $params_file)"
+}
+
+# Test: Starlark run_shell action collision.
+# Aim: Verify that SpawnAction uses stripped paths when two generated files
+# from different configurations collide on the same root-relative path but
+# have identical content.
+# Case: A Starlark rule generates an identical "data.txt" file under two
+# different config transitions.  A downstream Starlark run_shell action
+# concatenates both files.  This exercises SpawnAction.getSpawn() and checks
+# that the actual shell command line uses /cfg/ stripped paths.
+function test_identical_colliding_starlark_action_inputs_are_stripped() {
+  local -r pkg="${FUNCNAME[0]}"
+  mkdir -p "$pkg/rules"
+  cat > $pkg/rules/defs.bzl <<EOF
+SettingInfo = provider(fields = ["value"])
+
+def _setting_impl(ctx):
+    return SettingInfo(value = ctx.build_setting_value)
+
+my_setting = rule(
+    implementation = _setting_impl,
+    build_setting = config.string(),
+)
+
+def _transition_impl(settings, attr):
+    return {"//$pkg/rules:my_setting": attr.setting_value}
+
+_my_transition = transition(
+    implementation = _transition_impl,
+    inputs = [],
+    outputs = ["//$pkg/rules:my_setting"],
+)
+
+def _gen_identical_file_impl(ctx):
+    f = ctx.actions.declare_file("data.txt")
+    ctx.actions.write(f, "identical content\\n")
+    return [DefaultInfo(files = depset([f]))]
+
+gen_identical_file = rule(
+    _gen_identical_file_impl,
+    cfg = _my_transition,
+    attrs = {
+        "setting_value": attr.string(),
+    },
+)
+
+def _cat_impl(ctx):
+    inputs = ctx.files.srcs
+    output = ctx.actions.declare_file(ctx.attr.name + ".out")
+    out_args = ctx.actions.args()
+    out_args.add(output)
+    in_args = ctx.actions.args()
+    in_args.add_all(inputs)
+    ctx.actions.run_shell(
+        inputs = inputs,
+        outputs = [output],
+        arguments = [out_args, in_args],
+        command = "out=\$1; shift; cat \$@ > \$out",
+        execution_requirements = {"supports-path-mapping": "1"},
+    )
+    return [DefaultInfo(files = depset([output]))]
+
+cat_rule = rule(
+    _cat_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+    },
+)
+EOF
+  cat > $pkg/rules/BUILD << 'EOF'
+load(":defs.bzl", "my_setting")
+
+my_setting(
+    name = "my_setting",
+    build_setting_default = "",
+)
+EOF
+
+  mkdir -p $pkg
+  cat > $pkg/BUILD <<EOF
+load("//$pkg/rules:defs.bzl", "gen_identical_file", "cat_rule")
+gen_identical_file(
+    name = "file_a",
+    setting_value = "a",
+)
+gen_identical_file(
+    name = "file_b",
+    setting_value = "b",
+)
+cat_rule(
+    name = "combined",
+    srcs = [
+        ":file_a",
+        ":file_b",
+    ],
+)
+EOF
+
+  bazel clean
+  bazel build --experimental_output_paths=strip \
+    "//$pkg:combined" -s 2>"$TEST_log" \
+    || fail "Expected success"
+
+  # For "bazel-out/x86-fastbuild/bin/...", return "bazel-out".
+  output_path=$(bazel info | grep '^output_path:')
+  bazel_out="${output_path##*/}"
+
+  # The two data.txt files from different configs have identical content,
+  # so path mapping should be used (paths stripped) for the Starlark
+  # run_shell action (SpawnAction.getSpawn).
+  # Note: assert_paths_stripped uses xargs which chokes on single quotes
+  # in run_shell commands, so we check directly.
+  # Grep for the actual bash command line (not the SUBCOMMAND header).
+  local action_cmd
+  action_cmd=$(grep "bash.*combined.out" "$TEST_log" || true)
+  [[ -n "$action_cmd" ]] || fail "No bash command found for combined.out in $TEST_log"
+  echo "$action_cmd" | grep -q "${bazel_out}/cfg/bin/$pkg/combined.out" \
+    || fail "Expected combined.out with /cfg/ path in action: $action_cmd"
+  echo "$action_cmd" | grep -q "${bazel_out}/cfg/bin/$pkg/data.txt" \
+    || fail "Expected data.txt with /cfg/ path in action: $action_cmd"
+  # Verify no non-stripped config paths appear for our package's artifacts.
+  echo "$action_cmd" | grep -oE "${bazel_out}/[^ ')]+" | grep "$pkg" | while read -r path; do
+    echo "$path" | grep -q "/cfg/" \
+      || fail "Found non-stripped path for $pkg artifact: $path"
+  done
+}
+
 run_suite "Tests stripping config prefixes from output paths for better action caching"


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

As per https://bazelbuild.slack.com/archives/CA31HN1T3/p1778851259301539?thread_ts=1775817669.172489&cid=CA31HN1T3 discussion with @fmeum , This implements support for path collisions amongst mapped files as long as their content is the same.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

I hope this fixes two issues. One with silently colliding declared inputs, taking the first one. And another when the same file ends-up showing in the dependencies through two different transitions, in particular with discovered inputs, like cc rules do.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

Oddly enough, the change has minimal impact on the APIs. All it adds is an optional `@Nullable` `InputMetadataProvider` to PathMapper create() method.

### Checklist

- [X] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
