### PR TITLE
[8.8.0] Disable sandbox tests on RBE

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -282,8 +282,8 @@ tasks:
       - "//src:bazel_nojdk.exe"
     include_json_profile:
       - build
-  rbe_ubuntu2004:
-    platform: ubuntu2004
+  rbe_ubuntu2404:
+    platform: ubuntu2404
     name: "RBE"
     build_flags:
       - "--config=remote"

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -336,6 +336,12 @@ tasks:
       - "-//src/test/shell/bazel:verify_workspace"
       # Disable some Android tests since we are moving Android rules out of the Bazel repo.
       - "-//src/test/shell/bazel:bazel_android_tools_test"
+      # Disable tests that fail on RBE due to sandboxing/mount restrictions
+      - "-//src/test/shell/integration:sandboxing_test"
+      - "-//src/test/java/com/google/devtools/build/lib/shell:CommandUsingLinuxSandboxTest"
+      - "-//src/test/shell/bazel:bazel_spawnstats_test"
+      - "-//src/test/shell/integration:bazel_hardened_sandboxed_worker_test"
+      - "-//src/test/shell/integration:test_test"
     include_json_profile:
       - build
       - test

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -362,6 +362,12 @@ tasks:
       - "-//src/test/shell/bazel:bazel_sandboxing_networking_test"
       # Disable some Android tests since we are moving Android rules out of the Bazel repo.
       - "-//src/test/shell/bazel:bazel_android_tools_test"
+      # Disable tests that fail on RBE due to sandboxing/mount restrictions
+      - "-//src/test/shell/integration:sandboxing_test"
+      - "-//src/test/java/com/google/devtools/build/lib/shell:CommandUsingLinuxSandboxTest"
+      - "-//src/test/shell/bazel:bazel_spawnstats_test"
+      - "-//src/test/shell/integration:bazel_hardened_sandboxed_worker_test"
+      - "-//src/test/shell/integration:test_test"
     include_json_profile:
       - build
       - test

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -305,8 +305,8 @@ tasks:
       - "//src:bazel_nojdk.exe"
     include_json_profile:
       - build
-  rbe_ubuntu2004:
-    platform: ubuntu2004
+  rbe_ubuntu2404:
+    platform: ubuntu2404
     name: "RBE"
     build_flags:
       - "--config=remote"

--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,7 @@ build:remote_shared --java_runtime_version=rbe_jdk
 build:remote_shared --tool_java_runtime_version=rbe_jdk
 
 # Configuration to build and test Bazel on RBE on Ubuntu 20.04
+common:ubuntu2404 --extra_toolchains=@rbe_ubuntu2404//java:all
 common:ubuntu2404 --extra_toolchains=@rbe_ubuntu2404//config:cc-toolchain
 common:ubuntu2404 --extra_execution_platforms=//:rbe_ubuntu2404_platform,//:rbe_ubuntu2404_highcpu_platform
 common:ubuntu2404 --host_platform=//:rbe_ubuntu2404_platform

--- a/.bazelrc
+++ b/.bazelrc
@@ -11,17 +11,15 @@ build:remote_shared --action_env=PATH=/bin:/usr/bin:/usr/local/bin
 build:remote_shared --java_runtime_version=rbe_jdk
 build:remote_shared --tool_java_runtime_version=rbe_jdk
 
-# Configuration to build and test Bazel on RBE on Ubuntu 18.04 with Java 11
-build:ubuntu2004 --extra_toolchains=@rbe_ubuntu2004//java:all
-build:ubuntu2004 --crosstool_top=@rbe_ubuntu2004//cc:toolchain
-build:ubuntu2004 --extra_toolchains=@rbe_ubuntu2004//config:cc-toolchain
-build:ubuntu2004 --extra_execution_platforms=//:rbe_ubuntu2004_platform,//:rbe_ubuntu2004_highcpu_platform
-build:ubuntu2004 --host_platform=//:rbe_ubuntu2004_platform
-build:ubuntu2004 --platforms=//:rbe_ubuntu2004_platform
-build:ubuntu2004 --config=remote_shared
+# Configuration to build and test Bazel on RBE on Ubuntu 20.04
+common:ubuntu2404 --extra_toolchains=@rbe_ubuntu2404//config:cc-toolchain
+common:ubuntu2404 --extra_execution_platforms=//:rbe_ubuntu2404_platform,//:rbe_ubuntu2404_highcpu_platform
+common:ubuntu2404 --host_platform=//:rbe_ubuntu2404_platform
+common:ubuntu2404 --platforms=//:rbe_ubuntu2404_platform
+common:ubuntu2404 --config=remote_shared
 
 # Alias
-build:remote --config=ubuntu2004
+common:remote --config=ubuntu2404
 
 build:macos --macos_minimum_os=10.13
 

--- a/BUILD
+++ b/BUILD
@@ -289,7 +289,7 @@ platform(
     ],
 )
 
-REMOTE_PLATFORMS = ("rbe_ubuntu2004",)
+REMOTE_PLATFORMS = ("rbe_ubuntu2404",)
 
 [
     platform(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -400,8 +400,8 @@ bazel_dep(name = "wabt", version = "1.0.37")
 rbe_preconfig = use_repo_rule("@bazel_ci_rules//:rbe_repo.bzl", "rbe_preconfig")
 
 rbe_preconfig(
-    name = "rbe_ubuntu2004",
-    toolchain = "ubuntu2004",
+    name = "rbe_ubuntu2404",
+    toolchain = "ubuntu2404",
 )
 
 list_source_repository = use_repo_rule("//src/test/shell/bazel:list_source_repository.bzl", "list_source_repository")


### PR DESCRIPTION
Those tests are failing since we migrated to ubuntu2404 for RBE

Fixes https://buildkite.com/bazel/bazel-bazel/builds/35546

PiperOrigin-RevId: 918287393
Change-Id: Ifa81d0d990a692d6aaa0f0363cd2fe2060645b48

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/bca5e06e6e5f4724c5f9226c6aaf6a91c273e3a0