### PR TITLE
[9.1.1] Partially revert PR #27877

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -425,7 +425,7 @@ public class BazelRepositoryModule extends BlazeModule {
       }
       try {
         UrlRewriter rewriter =
-            UrlRewriter.getDownloaderUrlRewriter(env.getWorkspace(), repoOptions.downloaderConfigs);
+            UrlRewriter.getDownloaderUrlRewriter(env.getWorkspace(), repoOptions.downloaderConfig);
         downloadManager.setUrlRewriter(rewriter);
       } catch (UrlRewriterParseException e) {
         // It's important that the build stops ASAP, because this config file may be required for

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -277,7 +277,6 @@ public class RepositoryOptions extends OptionsBase {
   @Option(
       name = "downloader_config",
       oldName = "experimental_downloader_config",
-      allowMultiple = true,
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
@@ -289,7 +288,7 @@ public class RepositoryOptions extends OptionsBase {
               + "against, and one to use as a substitute URL, with back-references starting from "
               + "`$1`. It is possible for multiple `rewrite` directives for the same URL to be "
               + "given, and in this case multiple URLs will be returned.")
-  public List<PathFragment> downloaderConfigs;
+  public PathFragment downloaderConfig;
 
   @Option(
       name = "ignore_dev_dependency",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
@@ -82,17 +82,21 @@ public class UrlRewriter {
   /**
    * Obtain a new {@code UrlRewriter} configured with the specified config file.
    *
-   * @param configPaths Paths to the config file to use. May be null.
+   * @param configPath Path to the config file to use. May be null.
    */
   public static UrlRewriter getDownloaderUrlRewriter(
-      Path workspaceRoot, @Nullable List<PathFragment> configPaths)
+      Path workspaceRoot, @Nullable PathFragment configPath)
       throws UrlRewriterParseException {
     // "empty" UrlRewriter shouldn't alter auth headers
-    if (configPaths == null
-        || configPaths.isEmpty()
-        || configPaths.stream().anyMatch(PathFragment::isEmpty)) {
+    if (configPath == null || configPath.isEmpty()) {
       return new UrlRewriter(ImmutableList.of(""), ImmutableList.of(new StringReader("")));
     }
+
+    // 9.1.1 and 9.2.0+ only: #27877 was accidentially cherry-picked into 9.1.0, breaking users
+    // who relied on the fact that --downloader_config was not a repeatable flag.
+    // Instead of reverting the whole change, we do a bare-minimum "revert" here and feed the
+    // singular flag value as a singleton list into the rest of the logic.
+    ImmutableList<PathFragment> configPaths = ImmutableList.of(configPath);
 
     // There have been reports (eg. https://github.com/bazelbuild/bazel/issues/22104) that
     // there are occasional errors when `configFile` can't be found, and when this happens


### PR DESCRIPTION
PR #27877 was accidentally cherry-picked into 9.1.0, breaking users who relied on the fact that `--downloader_config` was not a repeatable flag. This commit makes the flag non-repeatable again.

Work towards #29605

RELNOTES: `--downloader_config` was accidentally made a repeatable flag in 9.1.0, which was a backwards-incompatible change. This has been reverted in 9.1.1.