### PR TITLE
Fix PatchUtil charAt OOB on truncated new mode / new file mode lines

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/PatchUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/PatchUtil.java
@@ -484,6 +484,10 @@ public class PatchUtil {
           // The line should look like: "new mode 100755" or "new file mode 100755"
           // 7 is the file permission for owner, which is at index 12 or 17
           int index = type == LineType.NEW_MODE ? 12 : 17;
+          if (line.length() <= index) {
+            throw new PatchFailedException(
+                "Truncated file mode at line " + (i + 1) + ": " + line);
+          }
           char c = line.charAt(index);
           if (c < '0' || c > '7') {
             throw new PatchFailedException(

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/PatchUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/PatchUtilTest.java
@@ -199,6 +199,38 @@ public final class PatchUtilTest {
   }
 
   @Test
+  public void testTruncatedNewFileModeRaisesPatchFailed() throws IOException {
+    // Regression test: a "new file mode" line shorter than 18 characters
+    // (the index PatchUtil.applyInternal reaches with charAt(17)) must
+    // produce a declared PatchFailedException, not an uncaught
+    // StringIndexOutOfBoundsException.
+    Path patchFile =
+        scratch.file(
+            "/root/patchfile",
+            "diff --git a/foo b/foo",
+            "new file mode 1");
+    PatchFailedException expected =
+        assertThrows(PatchFailedException.class, () -> PatchUtil.apply(patchFile, 1, root));
+    assertThat(expected).hasMessageThat().contains("Truncated file mode");
+  }
+
+  @Test
+  public void testTruncatedNewModeRaisesPatchFailed() throws IOException {
+    // Regression test: a "new mode" line shorter than 13 characters
+    // (the index PatchUtil.applyInternal reaches with charAt(12)) must
+    // produce a declared PatchFailedException, not an uncaught
+    // StringIndexOutOfBoundsException.
+    Path patchFile =
+        scratch.file(
+            "/root/patchfile",
+            "diff --git a/foo b/foo",
+            "new mode 1");
+    PatchFailedException expected =
+        assertThrows(PatchFailedException.class, () -> PatchUtil.apply(patchFile, 1, root));
+    assertThat(expected).hasMessageThat().contains("Truncated file mode");
+  }
+
+  @Test
   public void testGitFormatPatching() throws IOException, PatchFailedException {
     Path foo =
         scratch.file(


### PR DESCRIPTION
### Description

`PatchUtil.applyInternal` calls `line.charAt(12)` for `NEW_MODE` lines and `line.charAt(17)` for `NEW_FILE_MODE` lines without verifying the line is long enough. A patch file containing a truncated mode line — for example `new mode 1` or `new file mode 1` — passes the prefix-based line-type classification (because the classifier only checks `startsWith("new mode ")` / `startsWith("new file mode ")`) and then crashes in `charAt` with `StringIndexOutOfBoundsException`.

That exception is not declared on `PatchUtil.apply` (which throws `IOException` and `PatchFailedException`) and is not caught by the callers (`StarlarkRepositoryContext.patch`, `ModuleFileFunction.applyPatchesToModuleFile`). It propagates all the way up through Skyframe's `RepositoryFetchFunction` as `RuntimeException: Unrecoverable error...`, hits Bazel's top-level fatal handler, and causes:

```
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.RuntimeException: Unrecoverable error while evaluating node
  REPOSITORY_DIRECTORY:@@+crash_ext+crashrepo
Caused by: net.starlark.java.eval.Starlark$UncheckedEvalException:
  StringIndexOutOfBoundsException thrown during Starlark evaluation
Caused by: java.lang.StringIndexOutOfBoundsException:
  Index 12 out of bounds for length 10
    at java.base/java.lang.String.charAt(...)
    at com.google.devtools.build.lib.bazel.repository.decompressor
          .PatchUtil.applyInternal(PatchUtil.java:487)
```

The Bazel server daemon then exits. Confirmed end-to-end on Bazel 9.1.0 with a 35-byte patch supplied through a Bzlmod `module_extension` and reproduced on master HEAD.

### Reachability

`PatchUtil.apply` is reached from:

- `http_archive(patches=...)` / `git_repository(patches=...)`
- `single_version_override(patches=...)` in `MODULE.bazel`
- Bzlmod `source.json#patches` map (any module in any configured registry, including the Bazel Central Registry)
- `ctx.patch()` from any `repository_rule` / `module_extension`

All of these accept attacker-influenced patch content. A malicious or compromised module in a registry can ship a 35-byte patch that crashes every Bazel server that resolves it.

### Fix

Add a length guard before the `charAt(index)` so that a truncated mode line produces the declared `PatchFailedException` instead of an unchecked `StringIndexOutOfBoundsException`.

```java
case NEW_MODE, NEW_FILE_MODE -> {
    int index = type == LineType.NEW_MODE ? 12 : 17;
    if (line.length() <= index) {
        throw new PatchFailedException(
            "Truncated file mode at line " + (i + 1) + ": " + line);
    }
    char c = line.charAt(index);
    ...
}
```

### Tests added

Two new regression tests in `PatchUtilTest` covering both index sites:

- `testTruncatedNewFileModeRaisesPatchFailed` — `"new file mode 1"` (length 15) at the `charAt(17)` site.
- `testTruncatedNewModeRaisesPatchFailed` — `"new mode 1"` (length 10) at the `charAt(12)` site.

Both assert the call throws `PatchFailedException` with `"Truncated file mode"` in the message.

### How to reproduce on master before the fix

Workspace (3 files):

```
MODULE.bazel:
    module(name = "patchcrash", version = "0.0.0")
    crash = use_extension("//:crash.bzl", "crash_ext")
    use_repo(crash, "crashrepo")

crash.bzl:
    def _impl(ctx):
        ctx.file("BUILD.bazel", "")
        ctx.file("foo.txt", "line1\n")
        ctx.file("crash.patch", "diff --git a/foo b/foo\nnew mode 1\n")
        ctx.patch("crash.patch", strip = 1)
    _crashrule = repository_rule(implementation = _impl)
    def _ext_impl(ctx):
        _crashrule(name = "crashrepo")
    crash_ext = module_extension(implementation = _ext_impl)

BUILD.bazel:
    filegroup(name = "all", srcs = ["@crashrepo//:BUILD.bazel"])
```

Then `bazel build //:all` prints the FATAL crash above; the Bazel server PID is gone after the command exits.

With this patch applied the same input fails cleanly with a `Truncated file mode at line 2: new mode 1` error and the server stays alive.

### Notes

Found via Jazzer fuzzing of `PatchUtil.apply`.
