### PR TITLE
fix: validate TEST_SRCDIR in SandboxStash to prevent path traversal outside sandboxExecRoot

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxStash.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxStash.java
@@ -470,8 +470,43 @@ public class SandboxStash {
     return isTestAction(mnemonic) && outputs.files().size() == 1;
   }
 
+  /**
+   * Validates that an environment variable value used to construct a host filesystem path does not
+   * contain path traversal sequences or absolute path components. This prevents action-environment
+   * values from escaping the sandbox exec root when used in {@code Path.getRelative()} and
+   * subsequent {@code renameTo()} calls that are executed by the Bazel server JVM itself (not the
+   * sandboxed child process).
+   *
+   * @param envVarName the name of the environment variable, for error messages.
+   * @param value the value to validate.
+   * @return the validated value.
+   * @throws IllegalArgumentException if the value contains traversal or absolute path components.
+   */
+  private static String validateEnvPathComponent(String envVarName, @Nullable String value) {
+    if (value == null) {
+      return "";
+    }
+    PathFragment fragment = PathFragment.create(value);
+    if (fragment.isAbsolute()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Action environment variable %s must not be an absolute path, got: %s",
+              envVarName, value));
+    }
+    if (fragment.containsUplevelReferences()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Action environment variable %s must not contain '..' path traversal, got: %s",
+              envVarName, value));
+    }
+    return value;
+  }
+
   private static String getCurrentRunfilesDir(Map<String, String> environment) {
-    return environment.get("TEST_WORKSPACE") + "/" + environment.get(TEST_SRCDIR);
+    String workspace =
+        validateEnvPathComponent("TEST_WORKSPACE", environment.get("TEST_WORKSPACE"));
+    String srcDir = validateEnvPathComponent(TEST_SRCDIR, environment.get(TEST_SRCDIR));
+    return workspace + "/" + srcDir;
   }
 
   private ImmutableList<Path> sortStashesByMatchingTargetSegments(


### PR DESCRIPTION
Fixes #29476

## Summary

SandboxStash.getCurrentRunfilesDir() constructs a host filesystem path from action-environment values TEST_WORKSPACE and TEST_SRCDIR without validation:

`java
private static String getCurrentRunfilesDir(Map<String, String> environment) {
    return environment.get(TEST_WORKSPACE) + / + environment.get(TEST_SRCDIR);
}
`

The result is passed to Path.getRelative() and used as the destination of a enameTo() call at SandboxStash.java:151. With sufficient ../ segments in TEST_SRCDIR, the destination resolves outside sandboxExecRoot.

Critically, the enameTo() is performed by the **Bazel server JVM**, not the sandboxed child process. The sandbox isolates the child, but here the server itself performs the file operation using attacker-controlled env values.

This only triggers with --reuse_sandbox_directories which is **default: true**.

## Root Cause

This is the same class of issue that motivated stripping TMPDIR in PosixLocalEnvProvider (#3296). The fix was partial -- TMPDIR was sanitized but TEST_SRCDIR (and TEST_WORKSPACE) were missed.

## Fix

Added alidateEnvPathComponent() that rejects:
- Absolute paths (e.g., /etc/passwd)
- Path traversal sequences (e.g., ../../_stash_escape)

Applied to both TEST_SRCDIR and TEST_WORKSPACE in getCurrentRunfilesDir() before the values reach getRelative().

Uses PathFragment.isAbsolute() and PathFragment.containsUplevelReferences() which are existing Bazel path utilities, ensuring consistency with the rest of the codebase.

## Testing

The validation throws IllegalArgumentException for malicious values, which is caught by the existing IOException handler in 	akeStashedSandboxInternal() and stashSandboxInternal(), causing sandbox reuse to be safely disabled rather than allowing the traversal.

**Reproduction from #29476:**
`python
sh_test(
    name = exploit,
    srcs = [exploit.sh],
    env = {TEST_SRCDIR: ../../../../../../_stash_escape},
)
`

Before fix: _stash_escape directory created outside sandbox by Bazel server JVM.
After fix: IllegalArgumentException thrown, sandbox reuse turned off, no escape.

## Related

- #29457 -- sister issue (TEST_TMPDIR via getWritableDirs()), same class
- #3296 -- prior fix that sanitized TMPDIR in PosixLocalEnvProvider
- #28515 -- hermetic linux-sandbox symlink following

/cc @iancha1992