### PR TITLE
fix(docs): Fix the link to the `ExpandedDirectory` page in the doc of the `map_directory` action

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -96,7 +96,7 @@ arguments:
       create actions.</li>
   <li><code>input_directories</code> (keyword-only): A dictionary mapping from the string keys of
       the <code>input_directories</code> argument of <code>actions.map_directory()</code> to their
-      values' corresponding <a href='../builtins/File.html'><code>ExpandedDirectory</code></a>
+      values' corresponding <a href='../builtins/ExpandedDirectory.html'><code>ExpandedDirectory</code></a>
       objects.</li>
   <li><code>output_directories</code> (keyword-only): The value of the
       <code>output_directories</code> argument of <code>actions.map_directory()</code>; a


### PR DESCRIPTION
### Description

Fix the link to the `ExpandedDirectory` page in the doc of the [map_directory](https://bazel.build/rules/lib/builtins/actions#map_directory) action for the `implementation` parameter.

### Motivation

No

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [X] I have updated the documentation (if applicable).