### PR TITLE
fix: validate TEST_TMPDIR in getWritableDirs to prevent sandbox escape via arbitrary bind mounts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -55,6 +55,7 @@ import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
@@ -363,6 +364,10 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
 
     String testTmpdir = env.get("TEST_TMPDIR");
     if (testTmpdir != null) {
+      // Validate that TEST_TMPDIR does not contain path traversal sequences.
+      // Unlike TMPDIR (sanitized by PosixLocalEnvProvider, see #3296),
+      // TEST_TMPDIR is passed through unvalidated from the action environment.
+      validateTestTmpdir(testTmpdir, sandboxExecRoot);
       addWritablePath(
           sandboxExecRoot,
           writablePaths,
@@ -431,6 +436,24 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
       }
     } else {
       throw new IOException(String.format(pathDoesNotExistErrorTemplate, path.getPathString()));
+    }
+  }
+
+  /**
+   * Validates that TEST_TMPDIR does not contain path traversal sequences.
+   *
+   * <p>Absolute TEST_TMPDIR values are legitimate (set via --test_tmpdir).
+   * The concern is '../' traversal in relative paths escaping sandboxExecRoot.
+   */
+  private static void validateTestTmpdir(String testTmpdir, Path sandboxExecRoot)
+      throws IOException {
+    PathFragment fragment = PathFragment.create(testTmpdir);
+    if (fragment.containsUplevelReferences()) {
+      throw new IOException(
+          String.format(
+              "TEST_TMPDIR must not contain '..' path traversal (it could escape the sandbox),"
+                  + " got: \"%s\" (sandboxExecRoot: %s)",
+              testTmpdir, sandboxExecRoot.getPathString()));
     }
   }
 


### PR DESCRIPTION
Fixes #29457

## Summary

`AbstractSandboxSpawnRunner.getWritableDirs()` reads `TEST_TMPDIR` from the action environment and passes it directly to `addWritablePath()` without validation. A malicious rule can set `TEST_TMPDIR` to a relative path containing `../` traversal sequences. When `addWritablePath()` resolves this via `sandboxExecRoot.getRelative()`, the resulting path escapes the sandbox exec root, and the directory gets added as a writable bind mount -- granting the sandboxed action write access to host directories outside the sandbox subtree.

## Root Cause

This is the same class of issue that motivated stripping `TMPDIR` in `PosixLocalEnvProvider` (#3296). The fix was partial -- `TMPDIR` was sanitized but `TEST_TMPDIR` was missed.

| Variable | Sanitized? | Risk |
|----------|-----------|------|
| `TMPDIR` | Yes -- stripped and replaced with safe value by `PosixLocalEnvProvider.rewriteLocalEnv()` | None (fixed in #3296) |
| `TEST_TMPDIR` | No -- used directly from action environment | **Traversal sequences can escape sandbox subtree** |

## Fix

Added `validateTestTmpdir()` that uses `PathFragment.containsUplevelReferences()` to reject `../` traversal sequences before the value reaches `addWritablePath()` and the bind mount infrastructure.

**Design note:** Absolute `TEST_TMPDIR` values are intentionally allowed. Bazel legitimately sets `TEST_TMPDIR` to an absolute path when the user specifies `--test_tmpdir` or when the tmp directory falls outside the exec root (see `StandaloneTestStrategy.createEnvironment()` and `TestPolicy.computeTestEnvironment()`). The security concern is specifically with traversal sequences in relative paths.

The validation throws `IOException`, which is the declared exception type for `getWritableDirs()`. This causes the sandbox setup to fail safely rather than granting the traversal.

## Testing

The validation throws `IOException` for malicious values, which propagates up through the existing error handling in `AbstractSandboxSpawnRunner.exec()` -> `UserExecException`, causing the action to fail with a clear error message.

**Reproduction from #29457:**
```python
sh_test(
    name = "exploit",
    srcs = ["exploit.sh"],
    env = {"TEST_TMPDIR": "../../escape"},
)
```

Before fix: `sandboxExecRoot.getRelative("../../escape")` resolves outside the sandbox and gets added as a writable bind mount.
After fix: `IOException` thrown, action fails safely.

## Related

- #29476 -- sister issue (`TEST_SRCDIR` via `SandboxStash.getCurrentRunfilesDir()`), fix in PR #29631
- #3296 -- prior fix that sanitized `TMPDIR` in `PosixLocalEnvProvider`
- #28515 -- hermetic linux-sandbox symlink following

/cc @iancha1992
