### PR TITLE
fix: use lstat() in CreateTarget to prevent symlink traversal outside sandbox_root

### DIFF
--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -130,9 +130,19 @@ static int CreateTarget(const char* path, bool is_directory) {
   }
 
   struct stat sb;
-  // If the path already exists...
+  // Use lstat() instead of stat() to avoid following symlinks.
+  // If a parent component under sandbox_root is a pre-seeded symlink,
+  // stat() would follow it and subsequent mkdir()/link() calls would
+  // operate outside sandbox_root. Using lstat() detects and rejects
+  // symlinks, preventing writes to arbitrary host paths.
+  // See https://github.com/bazelbuild/bazel/issues/28515
 
-  if (stat(path, &sb) == 0) {
+  if (lstat(path, &sb) == 0) {
+    if (S_ISLNK(sb.st_mode)) {
+      // Reject symlinks: following them could escape the sandbox root.
+      errno = ELOOP;
+      return -1;
+    }
     if (is_directory && S_ISDIR(sb.st_mode)) {
       // and it's a directory and supposed to be a directory, we're done here.
       return 0;
@@ -145,7 +155,7 @@ static int CreateTarget(const char* path, bool is_directory) {
       return -1;
     }
   } else {
-    // If stat failed because of any error other than "the path does not exist",
+    // If lstat failed because of any error other than "the path does not exist",
     // this is an error.
     if (errno != ENOENT) {
       return -1;


### PR DESCRIPTION
Fixes #28515

## Summary

`CreateTarget()` in `linux-sandbox-pid1.cc` uses `stat()` to check whether a path already exists before creating mount targets under `sandbox_root`. Since `stat()` follows symlinks, a pre-seeded symlink under `sandbox_root` causes subsequent `mkdir()`/`link()` calls to operate on the host filesystem outside `sandbox_root`.

This is a robustness/hardening issue: hermetic sandbox setup code runs before `pivot_root`/`chroot` and performs host filesystem operations. If `sandbox_root/<component>` is unexpectedly a symlink, mount target creation can write outside the intended sandbox directory.

## Root Cause

```c
// BEFORE (vulnerable): stat() follows symlinks
if (stat(path, &sb) == 0) {
    // sb reflects the TARGET of any symlink, not the symlink itself
    // mkdir/link will operate at the symlink target (outside sandbox_root)
}
```

## Fix

Two changes to `CreateTarget()`:

1. **Replaced `stat()` with `lstat()`** -- `lstat()` does not follow symlinks, so it reports the symlink itself rather than its target.

2. **Added explicit symlink rejection** -- if `lstat()` detects a symlink (`S_ISLNK`), `CreateTarget()` now returns `-1` with `errno = ELOOP`, preventing any further operations on the path.

```c
// AFTER (safe): lstat() does not follow symlinks
if (lstat(path, &sb) == 0) {
    if (S_ISLNK(sb.st_mode)) {
        // Reject symlinks: following them could escape the sandbox root.
        errno = ELOOP;
        return -1;
    }
    // ... normal directory/file handling
}
```

## Reproduction (from #28515)

```bash
proof_root="$(mktemp -d)"
sandbox_root="$proof_root/sandbox"
outside_root="$proof_root/outside"
mkdir -p "$sandbox_root"
ln -s "$outside_root" "$sandbox_root/mnt"
# Run linux-sandbox with hermetic mode -- CreateTarget will follow the symlink
# Before fix: "$outside_root/<something>" gets created on the host
# After fix: CreateTarget returns ELOOP, mount setup fails safely
```

## Related

- #29457 -- TEST_TMPDIR sandbox escape (fix in PR #29644)
- #29476 -- TEST_SRCDIR path traversal (fix in PR #29631)

/cc @meisterT
