### PR TITLE
fix: validate TEST_TMPDIR path traversal in getWritableDirs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -55,6 +55,7 @@ import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
@@ -363,6 +364,10 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
 
     String testTmpdir = env.get("TEST_TMPDIR");
     if (testTmpdir != null) {
+      // Validate that TEST_TMPDIR does not contain path traversal sequences.
+      // Unlike TMPDIR (sanitized by PosixLocalEnvProvider, see #3296),
+      // TEST_TMPDIR is passed through unvalidated from the action environment.
+      validateTestTmpdir(testTmpdir, sandboxExecRoot);
       addWritablePath(
           sandboxExecRoot,
           writablePaths,
@@ -431,6 +436,24 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
       }
     } else {
       throw new IOException(String.format(pathDoesNotExistErrorTemplate, path.getPathString()));
+    }
+  }
+
+  /**
+   * Validates that TEST_TMPDIR does not contain path traversal sequences.
+   *
+   * <p>Absolute TEST_TMPDIR values are legitimate (set via --test_tmpdir).
+   * The concern is '../' traversal in relative paths escaping sandboxExecRoot.
+   */
+  private static void validateTestTmpdir(String testTmpdir, Path sandboxExecRoot)
+      throws IOException {
+    PathFragment fragment = PathFragment.create(testTmpdir);
+    if (fragment.containsUplevelReferences()) {
+      throw new IOException(
+          String.format(
+              "TEST_TMPDIR must not contain '..' path traversal (it could escape the sandbox),"
+                  + " got: \"%s\" (sandboxExecRoot: %s)",
+              testTmpdir, sandboxExecRoot.getPathString()));
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
@@ -160,6 +160,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/util/io",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/protobuf:failure_details_java_proto",
         "//third_party:guava",
     ],


### PR DESCRIPTION
Fixes #29457

## Summary

`AbstractSandboxSpawnRunner.getWritableDirs()` reads `TEST_TMPDIR` from the action environment and passes it directly to `addWritablePath()` without validation. A malicious rule can set `TEST_TMPDIR` to a relative path containing `../` traversal sequences, causing the resolved path to escape the sandbox exec root.

## Root Cause

Same class of issue as #3296 (TMPDIR sanitization). The fix was partial -- `TMPDIR` was sanitized but `TEST_TMPDIR` was missed.

| Variable | Sanitized? | Risk |
|----------|-----------|------|
| `TMPDIR` | Yes | None (fixed in #3296) |
| `TEST_TMPDIR` | **No** | Traversal sequences can escape sandbox |

## Fix

Added `validateTestTmpdir()` using `PathFragment.containsUplevelReferences()` to reject `../` traversal before `addWritablePath()`. Absolute paths are allowed (legitimate via `--test_tmpdir`).

## Related

- #29476 / PR #29631 -- sister issue (TEST_SRCDIR)
- #3296 -- prior TMPDIR fix
- #28515 / PR #29645 -- symlink following fix
