### PR TITLE
[9.2.0] don't fail test setup if `file` is not available (https://github.com/bazelbuild/bazel/pull/29260)

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -328,7 +328,7 @@ if [[ -n "$TEST_UNDECLARED_OUTPUTS_DIR" && -n "$TEST_UNDECLARED_OUTPUTS_MANIFEST
       # stat has different flags for different systems. -c is supported by GNU,
       # and -f by BSD (and thus OSX). Try both.
       file_size="$(stat -f%z "$undeclared_output" 2>/dev/null || stat -c%s "$undeclared_output" 2>/dev/null || echo "Could not stat $undeclared_output")"
-      file_type="$(file -L -b --mime-type "$undeclared_output")"
+      file_type="$(file -L -b --mime-type "$undeclared_output" || echo "Could not establish file type for $undeclared_output")"
 
       printf "$rel_path\t$file_size\t$file_type\n"
     done <<< "$undeclared_outputs" \


### PR DESCRIPTION
Update file type detection to handle errors gracefully.

Some executors or images might not have the `file` binary. This line seems non-critical.

An example build failure:
```
/buildbuddy-execroot/external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
/buildbuddy-execroot/external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
/buildbuddy-execroot/external/bazel_tools/tools/test/test-setup.sh: line 396: file: command not found
```

Closes #29260.

PiperOrigin-RevId: 898852344
Change-Id: Id7a4a44ad8a4c630ff46c90f5ce7fab92469d042

Commit https://github.com/bazelbuild/bazel/commit/18beb97fd555d2d7993655e71b1479e868611b42