### PR TITLE
Fix ArtifactFactory.getPathFromSourceExecPath for external repos

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
@@ -661,10 +661,25 @@ public class ArtifactFactory implements ArtifactResolver {
   public Path getPathFromSourceExecPath(Path execRoot, PathFragment execPath) {
     Preconditions.checkState(
         !execPath.startsWith(derivedPathPrefix), "%s is derived: %s", execPath, derivedPathPrefix);
+
+    Pair<RepositoryName, PathFragment> repo =
+        RepositoryName.fromPathFragment(execPath, siblingRepositoryLayout);
+    RepositoryName repositoryName = RepositoryName.MAIN;
+    PathFragment repositoryRelativePath = execPath;
+    if (repo != null) {
+      repositoryName = repo.getFirst();
+      repositoryRelativePath = repo.getSecond();
+    }
+
     Root sourceRoot =
-        packageRoots.getRootForPackage(PackageIdentifier.create(RepositoryName.MAIN, execPath));
+        packageRoots.getRootForPackage(PackageIdentifier.create(repositoryName, repositoryRelativePath));
+    if (sourceRoot == null) {
+      sourceRoot = findSourceRoot(
+        execPath, /* baseExecPath= */ null, /* baseRoot= */ null, RepositoryName.MAIN);
+    }
+
     if (sourceRoot != null) {
-      return sourceRoot.getRelative(execPath);
+      return sourceRoot.getRelative(repositoryRelativePath);
     }
     return execRoot.getRelative(execPath);
   }

--- a/src/test/java/com/google/devtools/build/lib/actions/ArtifactFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ArtifactFactoryTest.java
@@ -131,6 +131,40 @@ public class ArtifactFactoryTest {
   }
 
   @Test
+  public void testGetPathFromSourceExecPath_inExternalRepo() throws Exception {
+    Root externalRoot = Root.fromPath(scratch.dir("/external/alien"));
+    Path sourceFile = scratch.file("/external/alien/pkg/header.h", "");
+    Map<PackageIdentifier, Root> packageRoots =
+        ImmutableMap.of(
+            PackageIdentifier.create("alien", PathFragment.create("pkg")), externalRoot);
+    artifactFactory.setPackageRoots(packageRoots::get);
+
+    Path path =
+        artifactFactory.getPathFromSourceExecPath(
+            execRoot, PathFragment.create("external/alien/pkg/header.h"));
+
+    assertThat(path).isEqualTo(sourceFile);
+    assertThat(path.isFile()).isTrue();
+  }
+
+  @Test
+  public void testGetPathFromSourceExecPath_externalRepoPackageDirectory() throws Exception {
+    Root externalRoot = Root.fromPath(scratch.dir("/external/alien"));
+    Path packageDirectory = scratch.dir("/external/alien/pkg");
+    Map<PackageIdentifier, Root> packageRoots =
+        ImmutableMap.of(
+            PackageIdentifier.create("alien", PathFragment.create("pkg")), externalRoot);
+    artifactFactory.setPackageRoots(packageRoots::get);
+
+    Path path =
+        artifactFactory.getPathFromSourceExecPath(
+            execRoot, PathFragment.create("external/alien/pkg"));
+
+    assertThat(path).isEqualTo(packageDirectory);
+    assertThat(path.isDirectory()).isTrue();
+  }
+
+  @Test
   public void testResolveArtifact_noDerived_derivedRoot() throws Exception {
     assertThat(
             artifactFactory.resolveSourceArtifact(


### PR DESCRIPTION
This function is only called for include scanning, which isn't used
widely externally today. Previously if a source file was from an
external repo it would not be correctly found by this function, which
assumed all source files are relative to the workspace.
