### PR TITLE
Improve Starlark test coverage

### DIFF
--- a/src/test/java/net/starlark/java/eval/testdata/abs.star
+++ b/src/test/java/net/starlark/java/eval/testdata/abs.star
@@ -1,0 +1,42 @@
+# abs
+
+assert_eq(abs(0), 0)
+assert_eq(abs(1), 1)
+assert_eq(abs(-1), 1)
+assert_eq(abs(123), 123)
+assert_eq(abs(-123), 123)
+assert_eq(type(abs(-7)), "int")
+assert_eq(type(abs(7)), "int")
+
+# big ints
+big = 1 << 100
+assert_eq(abs(big), big)
+assert_eq(abs(-big), big)
+assert_eq(abs(-(1 << 63)), 1 << 63)
+assert_eq(abs(-(1 << 31)), 1 << 31)
+assert_eq(abs(-2147483648), 2147483648)
+assert_eq(abs(-9223372036854775808), 9223372036854775808)
+
+# float
+assert_eq(abs(0.0), 0.0)
+assert_eq(abs(-0.0), 0.0)
+assert_eq(abs(1.5), 1.5)
+assert_eq(abs(-1.5), 1.5)
+assert_eq(abs(-3.14), 3.14)
+assert_eq(type(abs(1.0)), "float")
+assert_eq(type(abs(-1.0)), "float")
+
+inf = float("+inf")
+neginf = float("-inf")
+nan = float("nan")
+assert_eq(abs(inf), inf)
+assert_eq(abs(neginf), inf)
+assert_eq(str(abs(nan)), "nan")
+
+assert_fails(lambda: abs(True), "got value of type 'bool', want 'int or float'")
+assert_fails(lambda: abs(False), "got value of type 'bool', want 'int or float'")
+assert_fails(lambda: abs("1"), "got value of type 'string', want 'int or float'")
+assert_fails(lambda: abs(None), "got value of type 'NoneType', want 'int or float'")
+assert_fails(lambda: abs([1]), "got value of type 'list', want 'int or float'")
+assert_fails(lambda: abs(), "missing 1 required positional argument: x")
+assert_fails(lambda: abs(1, 2), "accepts no more than 1 positional argument")

--- a/src/test/java/net/starlark/java/eval/testdata/bool.star
+++ b/src/test/java/net/starlark/java/eval/testdata/bool.star
@@ -1,0 +1,52 @@
+# bool
+
+assert_eq(bool(), False)
+
+assert_eq(bool(True), True)
+assert_eq(bool(False), False)
+assert_eq(type(bool(True)), "bool")
+assert_eq(type(bool(0)), "bool")
+assert_eq(type(bool()), "bool")
+
+assert_eq(bool(None), False)
+
+assert_eq(bool(0), False)
+assert_eq(bool(1), True)
+assert_eq(bool(-1), True)
+assert_eq(bool(1 << 100), True)
+assert_eq(bool(-(1 << 100)), True)
+
+assert_eq(bool(0.0), False)
+assert_eq(bool(-0.0), False)
+assert_eq(bool(0.5), True)
+assert_eq(bool(-0.5), True)
+assert_eq(bool(float("inf")), True)
+assert_eq(bool(float("-inf")), True)
+assert_eq(bool(float("nan")), True)
+
+assert_eq(bool(""), False)
+assert_eq(bool(" "), True)
+assert_eq(bool("0"), True)
+assert_eq(bool("False"), True)
+
+assert_eq(bool([]), False)
+assert_eq(bool([0]), True)
+assert_eq(bool([False]), True)
+assert_eq(bool(()), False)
+assert_eq(bool((0,)), True)
+assert_eq(bool({}), False)
+assert_eq(bool({0: 0}), True)
+assert_eq(bool(set()), False)
+assert_eq(bool(set([0])), True)
+
+assert_eq(bool(range(0)), False)
+assert_eq(bool(range(0, 0)), False)
+assert_eq(bool(range(1)), True)
+assert_eq(bool(range(-5, 5)), True)
+
+assert_eq(bool(struct()), True)
+assert_eq(bool(struct(a = 1)), True)
+
+assert_eq(sorted([1, 0, 2, 0, 3], key = bool), [0, 0, 1, 2, 3])
+
+assert_fails(lambda: bool(1, 2), "accepts no more than 1 positional argument")

--- a/src/test/java/net/starlark/java/eval/testdata/enumerate.star
+++ b/src/test/java/net/starlark/java/eval/testdata/enumerate.star
@@ -1,0 +1,41 @@
+# enumerate
+
+assert_eq(enumerate([24, 21, 84]), [(0, 24), (1, 21), (2, 84)])
+assert_eq(enumerate([]), [])
+assert_eq(enumerate(["only"]), [(0, "only")])
+
+assert_eq(enumerate(list = [10, 20]), [(0, 10), (1, 20)])
+assert_eq(enumerate([10, 20], 0), [(0, 10), (1, 20)])
+assert_eq(enumerate([10, 20], start = 0), [(0, 10), (1, 20)])
+
+assert_eq(enumerate(["a", "b", "c"], 1), [(1, "a"), (2, "b"), (3, "c")])
+assert_eq(enumerate(["a", "b"], start = 100), [(100, "a"), (101, "b")])
+assert_eq(enumerate(["a", "b"], -1), [(-1, "a"), (0, "b")])
+assert_eq(enumerate([], 42), [])
+
+big = (1 << 31) - 2
+assert_eq(enumerate(["x", "y"], big), [(big, "x"), (big + 1, "y")])
+assert_fails(
+    lambda: enumerate([1], 1 << 40),
+    "got 1099511627776 for start, want value in signed 32-bit range",
+)
+
+assert_eq(enumerate(()), [])
+assert_eq(enumerate((10, 20, 30)), [(0, 10), (1, 20), (2, 30)])
+assert_eq(enumerate(range(3)), [(0, 0), (1, 1), (2, 2)])
+assert_eq(enumerate("abc".elems()), [(0, "a"), (1, "b"), (2, "c")])
+assert_eq(enumerate({"a": 1, "b": 2}), [(0, "a"), (1, "b")])
+assert_eq(enumerate({}), [])
+
+result = enumerate([1, 2])
+assert_eq(type(result), "list")
+assert_eq(type(result[0]), "tuple")
+result.append((2, 99))
+assert_eq(result, [(0, 1), (1, 2), (2, 99)])
+
+assert_fails(lambda: enumerate("abc"), "type 'string' is not iterable")
+assert_fails(lambda: enumerate(1), "type 'int' is not iterable")
+assert_fails(lambda: enumerate(None), "type 'NoneType' is not iterable")
+assert_fails(lambda: enumerate([1], "x"), "got value of type 'string', want 'int'")
+assert_fails(lambda: enumerate([1], 1.5), "got value of type 'float', want 'int'")
+assert_fails(lambda: enumerate(), "missing 1 required positional argument: list")

--- a/src/test/java/net/starlark/java/eval/testdata/hash.star
+++ b/src/test/java/net/starlark/java/eval/testdata/hash.star
@@ -1,0 +1,28 @@
+# hash
+
+assert_eq(hash(""), 0)
+assert_eq(hash("a"), 97)
+assert_eq(hash("ab"), 3105)
+assert_eq(hash("abc"), 96354)
+assert_eq(hash("A"), 65)
+
+assert_eq(hash("hello world"), hash("hello world"))
+
+s1 = "x" + "yz"
+s2 = "xyz"
+assert_eq(hash(s1), hash(s2))
+
+assert_(hash("foo") != hash("bar"))
+assert_(hash("a") != hash("b"))
+
+assert_eq(type(hash("anything")), "int")
+
+assert_fails(lambda: hash(1), "got value of type 'int', want 'string'")
+assert_fails(lambda: hash(1.5), "got value of type 'float', want 'string'")
+assert_fails(lambda: hash(True), "got value of type 'bool', want 'string'")
+assert_fails(lambda: hash(None), "got value of type 'NoneType', want 'string'")
+assert_fails(lambda: hash(["a"]), "got value of type 'list', want 'string'")
+assert_fails(lambda: hash(("a",)), "got value of type 'tuple', want 'string'")
+assert_fails(lambda: hash({"a": 1}), "got value of type 'dict', want 'string'")
+assert_fails(lambda: hash(), "missing 1 required positional argument: value")
+assert_fails(lambda: hash("a", "b"), "accepts no more than 1 positional argument")

--- a/src/test/java/net/starlark/java/eval/testdata/repr.star
+++ b/src/test/java/net/starlark/java/eval/testdata/repr.star
@@ -1,0 +1,69 @@
+# repr
+
+assert_eq(repr(None), "None")
+assert_eq(repr(True), "True")
+assert_eq(repr(False), "False")
+
+assert_eq(repr(0), "0")
+assert_eq(repr(42), "42")
+assert_eq(repr(-7), "-7")
+assert_eq(repr(1 << 64), "18446744073709551616")
+assert_eq(repr(-(1 << 64)), "-18446744073709551616")
+
+assert_eq(repr(0.0), "0.0")
+assert_eq(repr(-0.0), "-0.0")
+assert_eq(repr(1.0), "1.0")
+assert_eq(repr(-1.5), "-1.5")
+assert_eq(repr(float("+inf")), "+inf")
+assert_eq(repr(float("-inf")), "-inf")
+assert_eq(repr(float("nan")), "nan")
+
+assert_eq(repr(""), '""')
+assert_eq(repr("abc"), '"abc"')
+assert_eq(repr('it\'s "ok"'), '"it\'s \\"ok\\""')
+assert_eq(repr("a\\b"), '"a\\\\b"')
+assert_eq(repr("a\nb"), '"a\\nb"')
+assert_eq(repr("a\tb"), '"a\\tb"')
+assert_eq(repr("a\rb"), '"a\\rb"')
+# Source uses octal escapes (Starlark has no \x escape); repr output uses \xNN.
+assert_eq(repr("\0"), '"\\x00"')
+assert_eq(repr("\1\037"), '"\\x01\\x1f"')
+
+assert_eq(type(repr(123)), "string")
+assert_eq(type(repr(None)), "string")
+
+assert_eq(repr(()), "()")
+assert_eq(repr((1,)), "(1,)")
+assert_eq(repr((1, 2)), "(1, 2)")
+assert_eq(repr((1, "x", None)), '(1, "x", None)')
+
+assert_eq(repr([]), "[]")
+assert_eq(repr([1]), "[1]")
+assert_eq(repr([1, 2, 3]), "[1, 2, 3]")
+assert_eq(repr(["a", "b"]), '["a", "b"]')
+
+assert_eq(repr({}), "{}")
+assert_eq(repr({1: 2}), "{1: 2}")
+assert_eq(repr({"a": 1, "b": 2}), '{"a": 1, "b": 2}')
+
+assert_eq(repr(set()), "set()")
+assert_eq(repr(set([1])), "set([1])")
+assert_eq(repr(set([1, 2, 3])), "set([1, 2, 3])")
+
+assert_eq(repr(range(3)), "range(0, 3)")
+assert_eq(repr(range(1, 5)), "range(1, 5)")
+assert_eq(repr(range(0, 10, 2)), "range(0, 10, 2)")
+
+assert_eq(repr([(1, 2), (3, 4)]), "[(1, 2), (3, 4)]")
+assert_eq(repr({"a": [1, 2]}), '{"a": [1, 2]}')
+assert_eq(repr([{"a": 1}, {"b": 2}]), '[{"a": 1}, {"b": 2}]')
+assert_eq(repr([None, True, False, 0, ""]), '[None, True, False, 0, ""]')
+
+def myfn():
+    pass
+
+assert_eq(repr(myfn), "<function myfn>")
+assert_eq(repr(lambda: 0), "<function lambda>")
+
+assert_fails(lambda: repr(), "missing 1 required positional argument: x")
+assert_fails(lambda: repr(1, 2), "accepts no more than 1 positional argument")

--- a/src/test/java/net/starlark/java/eval/testdata/string_case.star
+++ b/src/test/java/net/starlark/java/eval/testdata/string_case.star
@@ -1,0 +1,34 @@
+# str.lower / str.upper
+
+assert_eq("HELLO".lower(), "hello")
+assert_eq("hello".lower(), "hello")
+assert_eq("HeLlO".lower(), "hello")
+assert_eq("".lower(), "")
+assert_eq("Hello World!".lower(), "hello world!")
+
+assert_eq("hello".upper(), "HELLO")
+assert_eq("HELLO".upper(), "HELLO")
+assert_eq("HeLlO".upper(), "HELLO")
+assert_eq("".upper(), "")
+assert_eq("Hello World!".upper(), "HELLO WORLD!")
+
+assert_eq("123 ABC abc!?".lower(), "123 abc abc!?")
+assert_eq("123 ABC abc!?".upper(), "123 ABC ABC!?")
+assert_eq("  ".lower(), "  ")
+assert_eq("\t\n".upper(), "\t\n")
+
+# ASCII-only: non-ASCII letters pass through unchanged.
+assert_eq("café".upper(), "CAFé")
+assert_eq("CAFÉ".lower(), "cafÉ")
+assert_eq("naïve".upper(), "NAïVE")
+assert_eq("ÄÖÜß".lower(), "ÄÖÜß")
+assert_eq("äöüß".upper(), "äöüß")
+
+assert_eq(type("Hi".lower()), "string")
+assert_eq(type("Hi".upper()), "string")
+
+assert_eq("abcxyz".upper().lower(), "abcxyz")
+assert_eq("ABCXYZ".lower().upper(), "ABCXYZ")
+
+assert_fails(lambda: "abc".lower("x"), "lower\\(\\) got unexpected positional argument")
+assert_fails(lambda: "abc".upper("x"), "upper\\(\\) got unexpected positional argument")

--- a/src/test/java/net/starlark/java/eval/testdata/string_join.star
+++ b/src/test/java/net/starlark/java/eval/testdata/string_join.star
@@ -1,0 +1,43 @@
+# str.join
+
+assert_eq("-".join(["a", "b", "c"]), "a-b-c")
+assert_eq(", ".join(["a", "b", "c"]), "a, b, c")
+assert_eq("".join(["a", "b", "c"]), "abc")
+assert_eq("/".join(["a"]), "a")
+assert_eq("/".join([]), "")
+assert_eq("/".join([""]), "")
+assert_eq("/".join(["", ""]), "/")
+assert_eq("/".join(["", "", ""]), "//")
+
+assert_eq(" -> ".join(["a", "b", "c"]), "a -> b -> c")
+assert_eq("".join([]), "")
+
+assert_eq("|".join(("a", "b", "c")), "a|b|c")
+assert_eq("|".join({"a": 1, "b": 2, "c": 3}), "a|b|c")
+assert_eq("|".join({}), "")
+assert_eq("|".join([x for x in ["a", "b", "c"]]), "a|b|c")
+assert_eq("|".join("abc".elems()), "a|b|c")
+
+assert_eq(type("-".join(["a", "b"])), "string")
+
+assert_fails(
+    lambda: ",".join(["a", 1, "c"]),
+    "expected string for sequence element 1, got '1' of type int",
+)
+assert_fails(
+    lambda: ",".join([None]),
+    "expected string for sequence element 0, got 'None' of type NoneType",
+)
+assert_fails(
+    lambda: ",".join(["a", "b", ["c"]]),
+    "expected string for sequence element 2, got .* of type list",
+)
+assert_fails(
+    lambda: ",".join([True]),
+    "expected string for sequence element 0, got 'True' of type bool",
+)
+
+assert_fails(lambda: ",".join(1), "got value of type 'int', want 'iterable'")
+assert_fails(lambda: ",".join(None), "got value of type 'NoneType', want 'iterable'")
+assert_fails(lambda: ",".join("abc"), "got value of type 'string', want 'iterable'")
+assert_fails(lambda: ",".join(), "missing 1 required positional argument: elements")

--- a/src/test/java/net/starlark/java/eval/testdata/string_strip.star
+++ b/src/test/java/net/starlark/java/eval/testdata/string_strip.star
@@ -1,0 +1,69 @@
+# strip / lstrip / rstrip
+
+assert_eq("  abc  ".strip(), "abc")
+assert_eq("  abc  ".lstrip(), "abc  ")
+assert_eq("  abc  ".rstrip(), "  abc")
+
+assert_eq(" \t\n\rabc\t\n\r ".strip(), "abc")
+assert_eq("\013\014abc\013\014".strip(), "abc")
+assert_eq("\034\035\036\037abc\034\035\036\037".strip(), "abc")
+
+assert_eq("abc".strip(), "abc")
+assert_eq("abc".lstrip(), "abc")
+assert_eq("abc".rstrip(), "abc")
+
+assert_eq("   ".strip(), "")
+assert_eq("   ".lstrip(), "")
+assert_eq("   ".rstrip(), "")
+assert_eq(" \t\n\r ".strip(), "")
+
+assert_eq("".strip(), "")
+assert_eq("".lstrip(), "")
+assert_eq("".rstrip(), "")
+
+assert_eq("  a b  c  ".strip(), "a b  c")
+assert_eq("  a b  c  ".lstrip(), "a b  c  ")
+assert_eq("  a b  c  ".rstrip(), "  a b  c")
+
+assert_eq("   abc".strip(), "abc")
+assert_eq("   abc".lstrip(), "abc")
+assert_eq("   abc".rstrip(), "   abc")
+
+assert_eq("abc   ".strip(), "abc")
+assert_eq("abc   ".lstrip(), "abc   ")
+assert_eq("abc   ".rstrip(), "abc")
+
+assert_eq("  abc  ".strip(None), "abc")
+assert_eq("  abc  ".lstrip(None), "abc  ")
+assert_eq("  abc  ".rstrip(None), "  abc")
+
+# chars: any combination removed, NOT a prefix/suffix
+assert_eq("abcba".lstrip("ba"), "cba")
+assert_eq("abcbaa".rstrip("ab"), "abc")
+assert_eq("aabcbcbaa".strip("ab"), "cbc")
+
+assert_eq("xyzfoozyx".strip("xyz"), "foo")
+assert_eq("xyzfoozyx".strip("zyx"), "foo")
+assert_eq("xyzfoozyx".strip("yxz"), "foo")
+
+assert_eq("aaaaaXaaaa".strip("a"), "X")
+assert_eq("...path...".strip("."), "path")
+
+assert_eq("  abc  ".strip(""), "  abc  ")
+assert_eq("aaa".lstrip(""), "aaa")
+assert_eq("aaa".rstrip(""), "aaa")
+
+assert_eq("abcba".strip("abc"), "")
+assert_eq("abc".lstrip("abc"), "")
+assert_eq("abc".rstrip("abc"), "")
+
+assert_eq("aXbXa".strip("a"), "XbX")
+assert_eq("abXba".strip("ab"), "X")
+
+assert_eq("  a b c  ".strip(" "), "a b c")
+
+assert_fails(lambda: "abc".strip(1), "got value of type 'int', want 'string or NoneType'")
+assert_fails(lambda: "abc".lstrip(1), "got value of type 'int', want 'string or NoneType'")
+assert_fails(lambda: "abc".rstrip(1), "got value of type 'int', want 'string or NoneType'")
+assert_fails(lambda: "abc".strip(["a"]), "got value of type 'list', want 'string or NoneType'")
+assert_fails(lambda: "abc".strip("a", "b"), "accepts no more than 1 positional argument")

--- a/src/test/java/net/starlark/java/eval/testdata/zip.star
+++ b/src/test/java/net/starlark/java/eval/testdata/zip.star
@@ -1,0 +1,40 @@
+# zip
+
+assert_eq(zip(), [])
+
+assert_eq(zip([1, 2, 3]), [(1,), (2,), (3,)])
+assert_eq(zip(()), [])
+assert_eq(zip([]), [])
+assert_eq(zip(range(3)), [(0,), (1,), (2,)])
+
+assert_eq(zip([1, 2, 3], [4, 5, 6]), [(1, 4), (2, 5), (3, 6)])
+assert_eq(zip((1, 2), (3, 4), (5, 6)), [(1, 3, 5), (2, 4, 6)])
+
+assert_eq(zip([1, 2, 3], [4, 5]), [(1, 4), (2, 5)])
+assert_eq(zip([1], [2, 3], [4, 5, 6]), [(1, 2, 4)])
+assert_eq(zip([], [1, 2]), [])
+assert_eq(zip([1, 2], []), [])
+
+assert_eq(zip([1, 2], (3, 4)), [(1, 3), (2, 4)])
+assert_eq(zip({"a": 1, "b": 2}, [10, 20]), [("a", 10), ("b", 20)])
+assert_eq(zip("ab".elems(), "cd".elems()), [("a", "c"), ("b", "d")])
+assert_eq(zip(range(2), [3, 4, 5]), [(0, 3), (1, 4)])
+
+z = zip([1], [2])
+assert_eq(type(z), "list")
+assert_eq(type(z[0]), "tuple")
+
+src1 = [1, 2, 3]
+src2 = ["a", "b", "c"]
+out = zip(src1, src2)
+out.append(("d", 4))
+assert_eq(out, [(1, "a"), (2, "b"), (3, "c"), ("d", 4)])
+assert_eq(src1, [1, 2, 3])
+assert_eq(src2, ["a", "b", "c"])
+
+assert_fails(lambda: zip("ab"), "type 'string' is not iterable")
+assert_fails(lambda: zip([1, 2], "ab"), "type 'string' is not iterable")
+assert_fails(lambda: zip(1), "type 'int' is not iterable")
+assert_fails(lambda: zip([1, 2], 3), "type 'int' is not iterable")
+assert_fails(lambda: zip(None), "type 'NoneType' is not iterable")
+assert_fails(lambda: zip(args = [1, 2]), "got unexpected keyword argument 'args'")


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
Adds more extensive unit test coverage for built-in Starlark functions.

### Motivation
This will make it easier to optimize them or the entire Starlark interpreter without risking regressions.


### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
