### PR TITLE
[9.1.1] Invalidate unresolved symlink info after deletion in the RAFS (https://github.com/bazelbuild/bazel/pull/29495)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/PathCanonicalizer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/PathCanonicalizer.java
@@ -174,6 +174,8 @@ final class PathCanonicalizer {
   /** Removes cached information for a path prefix. */
   void clearPrefix(PathFragment pathPrefix) {
     Node node = getRootNode(pathPrefix);
+    NonSymlinkNode parent = null;
+    String parentSegment = null;
     Iterator<String> segments = pathPrefix.segments().iterator();
     boolean hasNext = segments.hasNext();
 
@@ -183,7 +185,10 @@ final class PathCanonicalizer {
 
       switch (node) {
         case SymlinkNode symlinkNode -> {
-          // Path prefix not in trie.
+          // Invalidate all intermediate symlinks.
+          if (parent != null) {
+            parent.remove(parentSegment);
+          }
           return;
         }
         case NonSymlinkNode nonSymlinkNode -> {
@@ -191,6 +196,8 @@ final class PathCanonicalizer {
             // Found the path prefix.
             nonSymlinkNode.remove(segment);
           } else {
+            parent = nonSymlinkNode;
+            parentSegment = segment;
             node = nonSymlinkNode.get(segment);
           }
         }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -354,6 +354,7 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
 
   @Override
   public boolean delete(PathFragment path) throws IOException {
+    PathFragment originalPath = path;
     try {
       path = resolveSymbolicLinksForParent(path);
     } catch (FileNotFoundException ignored) {
@@ -363,7 +364,7 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
 
     // No action implementations call renameTo concurrently with other filesystem operations, so
     // there's no risk of a race condition below.
-    pathCanonicalizer.clearPrefix(path);
+    pathCanonicalizer.clearPrefix(originalPath);
 
     boolean deleted = localFs.getPath(path).delete();
     if (isOutput(path)) {

--- a/src/test/java/com/google/devtools/build/lib/remote/PathCanonicalizerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/PathCanonicalizerTest.java
@@ -225,6 +225,19 @@ public final class PathCanonicalizerTest {
   }
 
   @Test
+  public void testClearPathDescendingThroughSymlinkInvalidatesIt() throws Exception {
+    createSymlink("/a/b", "/d");
+    createNonSymlink("/d/c");
+    assertSuccess("/a/b/c", "/d/c");
+
+    fs.getPath(pathFragment("/a/b")).delete();
+    createNonSymlink("/a/b/c");
+    canonicalizer.clearPrefix(pathFragment("/a/b/c"));
+
+    assertSuccess("/a/b/c", "/a/b/c");
+  }
+
+  @Test
   public void testSymlinkSelfLoop() throws Exception {
     createSymlink("/a/b", "/a/b");
     assertFailure(FileSymlinkLoopException.class, "/a/b");

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -2664,4 +2664,53 @@ EOF
   bazel run "${FLAGS[@]}" //:foo >& $TEST_log || fail "Failed to run //:foo"
 }
 
+function test_symlink_output_replaced_by_subpackage() {
+  # Regression test for https://github.com/bazelbuild/bazel/issues/29480.
+  add_rules_shell "MODULE.bazel"
+  mkdir -p tools
+  cat > tools/wrapper_script.sh <<'EOF'
+#!/bin/bash
+echo hello
+EOF
+  chmod +x tools/wrapper_script.sh
+
+  cat > tools/BUILD <<'EOF'
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+sh_binary(
+    name = "bazel_wrapper",
+    srcs = ["wrapper_script.sh"],
+)
+EOF
+
+  bazel build \
+      --remote_cache=grpc://localhost:${worker_port} \
+      //tools:bazel_wrapper >& $TEST_log \
+      || fail "Failed first build of //tools:bazel_wrapper"
+
+  [[ -L bazel-bin/tools/bazel_wrapper ]] \
+      || fail "Expected bazel-bin/tools/bazel_wrapper to be a symlink"
+
+  # Move the sh_binary into a same-named subpackage. The output that was
+  # previously a symlinked file at .../tools/bazel_wrapper must now become a
+  # directory at .../tools/bazel_wrapper/ which contains the new outputs.
+  mkdir -p tools/bazel_wrapper
+  cat > tools/bazel_wrapper/BUILD <<'EOF'
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+sh_binary(
+    name = "bazel_wrapper",
+    srcs = ["//tools:wrapper_script.sh"],
+)
+EOF
+  cat > tools/BUILD <<'EOF'
+exports_files(["wrapper_script.sh"])
+EOF
+
+  bazel build \
+      --remote_cache=grpc://localhost:${worker_port} \
+      //tools/bazel_wrapper:bazel_wrapper >& $TEST_log \
+      || fail "Failed second build after moving sh_binary to a subpackage"
+}
+
 run_suite "Build without the Bytes tests"


### PR DESCRIPTION
### Description
When a path is deleted while using the RemoteActionFileSystem, cached symlink resolutions have to be invalidated for the original path and all intermediate resolved paths, not just the final resolved path.

### Motivation
Fixes #29480

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #29495.

PiperOrigin-RevId: 922882682
Change-Id: I59fadf42357d56b141e9a1406787cf13ce36bf33

Commit https://github.com/bazelbuild/bazel/commit/2e29213d00f444e8b324e99703d5b8e6398dc6b9