### PR TITLE
[9.1.1] Use released bazel_ci_rules 2.0.0.

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -348,6 +348,8 @@ tasks:
       - "-//src/test/shell/bazel:bazel_spawnstats_test"
       - "-//src/test/shell/integration:bazel_hardened_sandboxed_worker_test"
       - "-//src/test/shell/integration:test_test"
+      - "-//src/test/tools:linux-sandbox_test"
+      - "-//src/test/tools:daemonize_test"
     include_json_profile:
       - build
       - test

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -359,6 +359,8 @@ tasks:
       - "-//src/test/shell/bazel:bazel_spawnstats_test"
       - "-//src/test/shell/integration:bazel_hardened_sandboxed_worker_test"
       - "-//src/test/shell/integration:test_test"
+      - "-//src/test/tools:linux-sandbox_test"
+      - "-//src/test/tools:daemonize_test"
     include_json_profile:
       - build
       - test

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -430,12 +430,6 @@ bazel_dep(name = "bazel_ci_rules", version = "2.0.0")
 bazel_dep(name = "rules_fuzzing", version = "0.6.0")
 bazel_dep(name = "wabt", version = "1.0.37")
 
-git_override(
-    module_name = "bazel_ci_rules",
-    remote = "https://github.com/bazelbuild/continuous-integration.git",
-    commit = "0fd2a39dee6b4faf8804762eaa589f5c2ae85d1c",
-    strip_prefix = "rules",
-)
 
 rbe = use_extension("@bazel_ci_rules//:rbe_config.bzl", "rbe_config_extension")
 rbe.config(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -426,16 +426,23 @@ use_repo(
 # Other Bazel testing dependencies
 # =========================================
 
-bazel_dep(name = "bazel_ci_rules", version = "1.0.0")
+bazel_dep(name = "bazel_ci_rules", version = "2.0.0")
 bazel_dep(name = "rules_fuzzing", version = "0.6.0")
 bazel_dep(name = "wabt", version = "1.0.37")
 
-rbe_preconfig = use_repo_rule("@bazel_ci_rules//:rbe_repo.bzl", "rbe_preconfig")
-
-rbe_preconfig(
-    name = "rbe_ubuntu2404",
-    toolchain = "ubuntu2404",
+git_override(
+    module_name = "bazel_ci_rules",
+    remote = "https://github.com/bazelbuild/continuous-integration.git",
+    commit = "0fd2a39dee6b4faf8804762eaa589f5c2ae85d1c",
+    strip_prefix = "rules",
 )
+
+rbe = use_extension("@bazel_ci_rules//:rbe_config.bzl", "rbe_config_extension")
+rbe.config(
+    name = "rbe_ubuntu2404",
+    preset = "ubuntu2404",
+)
+use_repo(rbe, "rbe_ubuntu2404")
 
 list_source_repository = use_repo_rule("//src/test/shell/bazel:list_source_repository.bzl", "list_source_repository")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -28,8 +28,8 @@
     "https://bcr.bazel.build/modules/apple_support/1.24.5/MODULE.bazel": "692784f32ee3175cc1ced78f4262a0d4b7110c89793cd0b63f950af2d9cc6bdc",
     "https://bcr.bazel.build/modules/apple_support/1.24.5/source.json": "e81e4f6557a879aaaa104e84255710a02862b9380b12bd72e4a58bff32c70116",
     "https://bcr.bazel.build/modules/apple_support/1.8.1/MODULE.bazel": "500f7aa32c008222e360dc9a158c248c2dbaeb3b6246c19e7269981dbd61e29b",
-    "https://bcr.bazel.build/modules/bazel_ci_rules/1.0.0/MODULE.bazel": "0f92c944b9c466066ed484cfc899cf43fca765df78caca18984c62479f7925eb",
-    "https://bcr.bazel.build/modules/bazel_ci_rules/1.0.0/source.json": "3405a2a7f9f827a44934b01470faeac1b56fb1304955c98ee9fcd03ad2ca5dcc",
+    "https://bcr.bazel.build/modules/apple_support/2.3.0/MODULE.bazel": "d48f824ae8eeea5f837eb3038cef3615075d996d3e82eb9187192c2820605a81",
+    "https://bcr.bazel.build/modules/apple_support/2.3.0/source.json": "d99b0a50918c4484856d773026b2fd60a694668c70fc0e19d592786dc7e5e469",
     "https://bcr.bazel.build/modules/bazel_features/1.0.0/MODULE.bazel": "d7f022dc887efb96e1ee51cec7b2e48d41e36ff59a6e4f216c40e4029e1585bf",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
@@ -423,6 +423,21 @@
               "urls": [
                 "https://github.com/async-profiler/async-profiler/releases/download/v4.1/async-profiler-4.1-macos.zip"
               ]
+            }
+          }
+        }
+      }
+    },
+    "@@bazel_ci_rules+//:rbe_config.bzl%rbe_config_extension": {
+      "general": {
+        "bzlTransitiveDigest": "9+l/EBrynYwo8/gokt6U/+ZoE2tIACzH5rOoPfI01wE=",
+        "usagesDigest": "HujAq5EGA+Tlz7DHoDf3wQuuXcobfsrLb9WdkQry/+A=",
+        "recordedInputs": [],
+        "generatedRepoSpecs": {
+          "rbe_ubuntu2404": {
+            "repoRuleId": "@@bazel_ci_rules+//:rbe_config.bzl%_rbe_config",
+            "attributes": {
+              "preset_name": "ubuntu2404"
             }
           }
         }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -30,6 +30,8 @@
     "https://bcr.bazel.build/modules/apple_support/1.8.1/MODULE.bazel": "500f7aa32c008222e360dc9a158c248c2dbaeb3b6246c19e7269981dbd61e29b",
     "https://bcr.bazel.build/modules/apple_support/2.3.0/MODULE.bazel": "d48f824ae8eeea5f837eb3038cef3615075d996d3e82eb9187192c2820605a81",
     "https://bcr.bazel.build/modules/apple_support/2.3.0/source.json": "d99b0a50918c4484856d773026b2fd60a694668c70fc0e19d592786dc7e5e469",
+    "https://bcr.bazel.build/modules/bazel_ci_rules/2.0.0/MODULE.bazel": "96dc6d2eac255b530a645cbf9102064ea997cae7b22acbe34fcc976f3dd53cbf",
+    "https://bcr.bazel.build/modules/bazel_ci_rules/2.0.0/source.json": "b6948e739190180af80dd91ceb9e3fb2b0c0160ecbf81177de2130475b54b516",
     "https://bcr.bazel.build/modules/bazel_features/1.0.0/MODULE.bazel": "d7f022dc887efb96e1ee51cec7b2e48d41e36ff59a6e4f216c40e4029e1585bf",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",


### PR DESCRIPTION
Closes https://github.com/bazelbuild/bazel/pull/29661.

PiperOrigin-RevId: 922138625
Change-Id: I7cbbc213cafdda874f836265608a01c8a3c676c2

Commit https://github.com/bazelbuild/bazel/commit/1a04a7b58cb55b80f4968fe5485fab55dca8f608 and https://github.com/bazelbuild/bazel/commit/c7268b24d2b33abb1de8baa12bc86b4513e58cb8