### PR TITLE
Fix grpc connection pool race condition

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java
@@ -39,6 +39,7 @@ import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
@@ -158,96 +159,101 @@ class GrpcRemoteExecutor implements RemoteExecutionClient {
                     // than a connection timeout. This is not an error condition and is thus handled
                     // outside of the retrier.
                     while (true) {
-                      final Iterator<Operation> replies;
-                      if (waitExecution.get()) {
-                        WaitExecutionRequest wr =
-                            WaitExecutionRequest.newBuilder()
-                                .setName(operation.get().getName())
-                                .build();
-                        replies =
-                            channel.withChannelBlocking(
-                                channel ->
-                                    execBlockingStub(context.getRequestMetadata(), channel)
-                                        .waitExecution(wr));
-                      } else {
-                        try (SilentCloseable c =
-                            Profiler.instance()
-                                .profile(ProfilerTask.REMOTE_EXECUTION, "send Execute request")) {
-                          replies =
-                              channel.withChannelBlocking(
-                                  channel ->
-                                      execBlockingStub(context.getRequestMetadata(), channel)
-                                          .execute(request));
-                        }
-                      }
-                      try {
-                        while (replies.hasNext()) {
-                          Operation o = replies.next();
-                          operation.set(o);
-                          waitExecution.set(!operation.get().getDone());
-
-                          // Update execution progress to the caller.
-                          //
-                          // After called `execute` above, the action is actually waiting for an
-                          // available
-                          // gRPC connection to be sent. Once we get a reply from server, we know
-                          // the
-                          // connection is up and indicate to the caller the fact by forwarding the
-                          // `operation`.
-                          //
-                          // The accurate execution status of the action relies on the server
-                          // implementation:
-                          //   1. Server can reply the accurate status in
-                          // `operation.metadata.stage`;
-                          //   2. Server may send a reply without metadata. In this case, we assume
-                          // the
-                          //      action is accepted by the server and will be executed ASAP;
-                          //   3. Server may execute the action silently and send a reply once it is
-                          // done.
-                          observer.onNext(o);
-
-                          ExecuteResponse r = getOperationResponse(o);
-                          if (r != null) {
-                            return r;
-                          }
-                        }
-                        // The operation completed successfully but without a result.
-                        if (!waitExecution.get()) {
-                          throw new IOException(
-                              String.format(
-                                  "Remote server error: execution request for %s terminated with no"
-                                      + " result.",
-                                  operation.get().getName()));
-                        }
-                      } catch (StatusRuntimeException e) {
-                        if (e.getStatus().getCode() == Code.NOT_FOUND) {
-                          // Operation was lost on the server. Retry Execute.
-                          waitExecution.set(false);
-                        }
-                        throw e;
-                      } finally {
-                        // The blocking streaming call closes correctly only when trailers and a
-                        // Status
-                        // are received from the server so that onClose() is called on this call's
-                        // CallListener. Under normal circumstances (no cancel/errors), these are
-                        // guaranteed to be sent by the server only if replies.hasNext() has been
-                        // called
-                        // after all replies from the stream have been consumed.
-                        try {
-                          while (replies.hasNext()) {
-                            replies.next();
-                          }
-                        } catch (StatusRuntimeException e) {
-                          // Cleanup: ignore exceptions, because the meaningful errors have already
-                          // been
-                          // propagated.
-                        }
+                      Optional<ExecuteResponse> response =
+                          channel.withChannelBlocking(
+                              channel ->
+                                  Optional.ofNullable(
+                                      handleOperationStream(
+                                          channel,
+                                          context,
+                                          request,
+                                          operation,
+                                          waitExecution,
+                                          observer)));
+                      if (response.isPresent()) {
+                        return response.get();
                       }
                     }
                   }),
           callCredentialsProvider);
     } catch (StatusRuntimeException e) {
       throw new IOException(e);
+    }
+  }
+
+  // The reply stream must be consumed here, while the pooled connection is still held, so the
+  // connection's concurrency permit is not released before the stream completes.
+  @Nullable
+  private ExecuteResponse handleOperationStream(
+      Channel channel,
+      RemoteActionExecutionContext context,
+      ExecuteRequest request,
+      AtomicReference<Operation> operation,
+      AtomicBoolean waitExecution,
+      OperationObserver observer)
+      throws IOException {
+    final Iterator<Operation> replies;
+    if (waitExecution.get()) {
+      WaitExecutionRequest wr =
+          WaitExecutionRequest.newBuilder().setName(operation.get().getName()).build();
+      replies = execBlockingStub(context.getRequestMetadata(), channel).waitExecution(wr);
+    } else {
+      try (SilentCloseable c =
+          Profiler.instance().profile(ProfilerTask.REMOTE_EXECUTION, "send Execute request")) {
+        replies = execBlockingStub(context.getRequestMetadata(), channel).execute(request);
+      }
+    }
+
+    try {
+      while (replies.hasNext()) {
+        Operation o = replies.next();
+        operation.set(o);
+        waitExecution.set(!operation.get().getDone());
+
+        // Update execution progress to the caller.
+        //
+        // After called `execute` above, the action is actually waiting for an available gRPC
+        // connection to be sent. Once we get a reply from server, we know the connection is up and
+        // indicate to the caller the fact by forwarding the `operation`.
+        //
+        // The accurate execution status of the action relies on the server implementation:
+        //   1. Server can reply the accurate status in `operation.metadata.stage`;
+        //   2. Server may send a reply without metadata. In this case, we assume the action is
+        //      accepted by the server and will be executed ASAP;
+        //   3. Server may execute the action silently and send a reply once it is done.
+        observer.onNext(o);
+
+        ExecuteResponse r = getOperationResponse(o);
+        if (r != null) {
+          return r;
+        }
+      }
+      // The operation completed successfully but without a result.
+      if (!waitExecution.get()) {
+        throw new IOException(
+            String.format(
+                "Remote server error: execution request for %s terminated with no result.",
+                operation.get().getName()));
+      }
+      return null;
+    } catch (StatusRuntimeException e) {
+      if (e.getStatus().getCode() == Code.NOT_FOUND) {
+        // Operation was lost on the server. Retry Execute.
+        waitExecution.set(false);
+      }
+      throw e;
+    } finally {
+      // The blocking streaming call closes correctly only when trailers and a Status are received
+      // from the server so that onClose() is called on this call's CallListener. Under normal
+      // circumstances (no cancel/errors), these are guaranteed to be sent by the server only if
+      // replies.hasNext() has been called after all replies from the stream have been consumed.
+      try {
+        while (replies.hasNext()) {
+          replies.next();
+        }
+      } catch (StatusRuntimeException e) {
+        // Cleanup: ignore exceptions, because the meaningful errors have already been propagated.
+      }
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutorTest.java
@@ -21,6 +21,7 @@ import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.ExecuteRequest;
 import build.bazel.remote.execution.v2.ExecuteResponse;
+import build.bazel.remote.execution.v2.ExecutionGrpc.ExecutionImplBase;
 import build.bazel.remote.execution.v2.ExecutionCapabilities;
 import build.bazel.remote.execution.v2.OutputFile;
 import build.bazel.remote.execution.v2.RequestMetadata;
@@ -43,11 +44,16 @@ import io.grpc.Server;
 import io.grpc.Status;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
 import io.reactivex.rxjava3.core.Single;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -507,5 +513,99 @@ public class GrpcRemoteExecutorTest {
 
     assertThat(executionService.getExecTimes()).isEqualTo(1);
     assertThat(executionService.getWaitTimes()).isEqualTo(MAX_RETRY_ATTEMPTS + 1);
+  }
+
+  @Test
+  public void executeRemotely_holdsChannelLeaseUntilExecuteStreamCompletes() throws Exception {
+    BlockingExecutionService blockingExecutionService = new BlockingExecutionService();
+    ExecutorService serverExecutor = Executors.newCachedThreadPool();
+    String fakeServerName = "blocking fake server for " + getClass() + "#" + System.nanoTime();
+    Server server =
+        InProcessServerBuilder.forName(fakeServerName)
+            .addService(blockingExecutionService)
+            .executor(serverExecutor)
+            .build()
+            .start();
+    AtomicInteger channelCreations = new AtomicInteger();
+    ReferenceCountedChannel channel =
+        new ReferenceCountedChannel(
+            new ChannelConnectionWithServerCapabilitiesFactory() {
+              @Override
+              public Single<ChannelConnectionWithServerCapabilities> create() {
+                channelCreations.incrementAndGet();
+                ManagedChannel ch =
+                    InProcessChannelBuilder.forName(fakeServerName)
+                        .intercept(TracingMetadataUtils.newExecHeadersInterceptor(remoteOptions))
+                        .build();
+                ServerCapabilities caps =
+                    ServerCapabilities.newBuilder()
+                        .setExecutionCapabilities(
+                            ExecutionCapabilities.newBuilder().setExecEnabled(true).build())
+                        .build();
+                return Single.just(
+                    new ChannelConnectionWithServerCapabilities(ch, Single.just(caps)));
+              }
+
+              @Override
+              public int maxConcurrency() {
+                return 1;
+              }
+            });
+    RemoteExecutionClient executor = createExecutionService(channel);
+    ExecutorService clientExecutor = Executors.newFixedThreadPool(2);
+
+    try {
+      Future<ExecuteResponse> first =
+          clientExecutor.submit(
+              () -> executor.executeRemotely(context, DUMMY_REQUEST, OperationObserver.NO_OP));
+      assertThat(blockingExecutionService.firstExecuteStarted.await(1, SECONDS)).isTrue();
+      assertThat(channelCreations.get()).isEqualTo(1);
+
+      Future<ExecuteResponse> second =
+          clientExecutor.submit(
+              () -> executor.executeRemotely(context, DUMMY_REQUEST, OperationObserver.NO_OP));
+      assertThat(blockingExecutionService.secondExecuteStarted.await(1, SECONDS)).isTrue();
+
+      assertThat(channelCreations.get()).isEqualTo(2);
+
+      blockingExecutionService.completeFirstExecute.countDown();
+      assertThat(second.get(1, SECONDS)).isEqualTo(DUMMY_RESPONSE);
+      assertThat(first.get(1, SECONDS)).isEqualTo(DUMMY_RESPONSE);
+    } finally {
+      blockingExecutionService.completeFirstExecute.countDown();
+      clientExecutor.shutdownNow();
+      executor.close();
+      server.shutdownNow();
+      server.awaitTermination();
+      serverExecutor.shutdownNow();
+    }
+  }
+
+  private static final class BlockingExecutionService extends ExecutionImplBase {
+    private final AtomicInteger executeTimes = new AtomicInteger();
+    private final CountDownLatch firstExecuteStarted = new CountDownLatch(1);
+    private final CountDownLatch secondExecuteStarted = new CountDownLatch(1);
+    private final CountDownLatch completeFirstExecute = new CountDownLatch(1);
+
+    @Override
+    public void execute(ExecuteRequest request, StreamObserver<Operation> responseObserver) {
+      int executeNumber = executeTimes.incrementAndGet();
+      if (executeNumber == 1) {
+        responseObserver.onNext(FakeExecutionService.ackOperation(request));
+        firstExecuteStarted.countDown();
+        try {
+          completeFirstExecute.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          responseObserver.onError(Status.CANCELLED.asRuntimeException());
+          return;
+        }
+      } else if (executeNumber == 2) {
+        secondExecuteStarted.countDown();
+      }
+
+      responseObserver.onNext(FakeExecutionService.doneOperation(request, DUMMY_RESPONSE));
+      responseObserver.onCompleted();
+    }
   }
 }


### PR DESCRIPTION
Previously calling `withChannelConnection` claimed and closed a
connection from the `dynamicConnectionPool` instantly, even if there
were still remote exec requests in flight. This mean the connection went
back into the pool and would be reused by bazel even if it already had
the maximum number of MAX_CONCURRENT_STREAMS in flight. The end result
is that when you set `--jobs=500` your number of concurrent remote exec
actions could still be gated by `MAX_CONCURRENT_STREAMS` over a single
connection.

This seems to race based on how quickly bazel ends up creating another
connection before it closes the first one.

Related: https://github.com/bazelbuild/bazel/issues/11801
