### PR TITLE
Add Stack Trace to BulkTransferException.getMessage() for Each Unique Exception Message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
@@ -194,7 +194,7 @@ public interface SpawnRunner {
             throw new EnvironmentalExecException(
                 bulkTransferException,
                 FailureDetail.newBuilder()
-                    .setMessage("Failed to fetch blobs because of a remote cache error.")
+                    .setMessage("Failed to fetch blobs because of a remote cache error")
                     .setSpawn(FailureDetails.Spawn.newBuilder().setCode(Code.REMOTE_CACHE_EVICTED))
                     .build());
           }

--- a/src/main/java/com/google/devtools/build/lib/remote/common/BulkTransferException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/BulkTransferException.java
@@ -13,19 +13,16 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.common;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
-
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ImportantOutputHandler.LostArtifacts;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -118,24 +115,27 @@ public class BulkTransferException extends IOException {
 
   @Override
   public String getMessage() {
-    // Only report unique messages to avoid flooding the user, e.g. in case a remote cache server is
-    // unavailable
-    // and causing several identical messages. Also sort the messages, for more deterministic
-    // result. All of this allows
-    // more efficient event deduplication when reporting the returned aggregated message.
-    List<String> uniqueSortedMessages =
-        Arrays.stream(super.getSuppressed())
-            .map(Throwable::getMessage)
-            .filter(Objects::nonNull)
-            .sorted()
-            .distinct()
-            .collect(toImmutableList());
+    Throwable[] exceptions = super.getSuppressed();
 
-    return switch (uniqueSortedMessages.size()) {
-      case 0 -> "Unknown error during bulk transfer";
-      case 1 -> Iterables.getOnlyElement(uniqueSortedMessages);
-      default ->
-          "Multiple errors during bulk transfer:\n" + Joiner.on("\n").join(uniqueSortedMessages);
-    };
+    if (exceptions.length == 0) {
+      return "Unknown error during bulk transfer";
+    } else if (exceptions.length == 1) {
+      return exceptions[0].getMessage();
+    } else {
+      StringBuilder sb = new StringBuilder();
+      sb.append("Multiple errors during bulk transfer:\n");
+      Set<String> uniqueMessages = new HashSet<>();
+      for (var e : exceptions) {
+        if (uniqueMessages.contains(e.getMessage())) {
+          continue;
+        }
+        uniqueMessages.add(e.getMessage());
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        e.printStackTrace(pw);
+        sb.append(sw).append("\n\n");
+      }
+      return sb.toString();
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/common/BulkTransferException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/BulkTransferException.java
@@ -120,7 +120,7 @@ public class BulkTransferException extends IOException {
     Set<String> uniqueMessages = new HashSet<>();
 
     for (var e : exceptions) {
-      if (uniqueMessages.contains(e.getMessage())) {
+      if (e.getMessage() == null || uniqueMessages.contains(e.getMessage())) {
         continue;
       }
       uniqueMessages.add(e.getMessage());

--- a/src/main/java/com/google/devtools/build/lib/remote/common/BulkTransferException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/BulkTransferException.java
@@ -116,26 +116,24 @@ public class BulkTransferException extends IOException {
   @Override
   public String getMessage() {
     Throwable[] exceptions = super.getSuppressed();
+    StringBuilder sb = new StringBuilder();
+    Set<String> uniqueMessages = new HashSet<>();
 
-    if (exceptions.length == 0) {
-      return "Unknown error during bulk transfer";
-    } else if (exceptions.length == 1) {
-      return exceptions[0].getMessage();
-    } else {
-      StringBuilder sb = new StringBuilder();
-      sb.append("Multiple errors during bulk transfer:\n");
-      Set<String> uniqueMessages = new HashSet<>();
-      for (var e : exceptions) {
-        if (uniqueMessages.contains(e.getMessage())) {
-          continue;
-        }
-        uniqueMessages.add(e.getMessage());
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        e.printStackTrace(pw);
-        sb.append(sw).append("\n\n");
+    for (var e : exceptions) {
+      if (uniqueMessages.contains(e.getMessage())) {
+        continue;
       }
-      return sb.toString();
+      uniqueMessages.add(e.getMessage());
+      StringWriter sw = new StringWriter();
+      PrintWriter pw = new PrintWriter(sw);
+      e.printStackTrace(pw);
+      sb.append(sw).append("\n\n");
+    }
+    if (uniqueMessages.size() == 0) {
+      return "Unknown error during bulk transfer";
+    } else {
+      return String.format("%d errors during bulk transfer (%d unique):\n\n", exceptions.length, uniqueMessages.size()) +
+              sb.toString();
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/common/BulkTransferExceptionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/common/BulkTransferExceptionTest.java
@@ -17,6 +17,8 @@ package com.google.devtools.build.lib.remote.common;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -24,28 +26,16 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class BulkTransferExceptionTest {
 
+  private static String stackTraceAsString(Throwable t) {
+    StringWriter sw = new StringWriter();
+    t.printStackTrace(new PrintWriter(sw));
+    return sw.toString();
+  }
+
   @Test
   public void shouldProvideGenericMessageIfNoAddedException() {
     BulkTransferException bulkTransferException = new BulkTransferException();
     assertThat(bulkTransferException.getMessage()).isEqualTo("Unknown error during bulk transfer");
-  }
-
-  @Test
-  public void shouldPreserveMessageAsIsFromSingleException() {
-    BulkTransferException bulkTransferException = new BulkTransferException();
-    bulkTransferException.add(new IOException("Failure Type A"));
-    assertThat(bulkTransferException.getMessage()).isEqualTo("Failure Type A");
-  }
-
-  @Test
-  public void shouldSortAndRemoveDuplicatesWhenAggregatingMessages() {
-    BulkTransferException bulkTransferException = new BulkTransferException();
-    bulkTransferException.add(new IOException("Failure Type B"));
-    bulkTransferException.add(new IOException("Failure Type A"));
-    bulkTransferException.add(new IOException("Failure Type B"));
-    assertThat(bulkTransferException.getMessage())
-        .isEqualTo(
-            "Multiple errors during bulk transfer:\n" + "Failure Type A\n" + "Failure Type B");
   }
 
   @Test
@@ -56,10 +46,47 @@ public class BulkTransferExceptionTest {
   }
 
   @Test
-  public void shouldIgnoreNullMessagesWhenGettingMessage() {
+  public void shouldReturnStackTraceFromSingleException() {
+    IOException cause = new IOException("Failure Type A");
     BulkTransferException bulkTransferException = new BulkTransferException();
-    bulkTransferException.add(new IOException("Failure Type A"));
-    bulkTransferException.add(new IOException());
-    assertThat(bulkTransferException.getMessage()).isEqualTo("Failure Type A");
+    bulkTransferException.add(cause);
+    String message = bulkTransferException.getMessage();
+    assertThat(message).isEqualTo("1 errors during bulk transfer (1 unique):\n\n" + stackTraceAsString(cause) + "\n\n");
+  }
+
+  @Test
+  public void shouldDeduplicateExceptionsWithSameMessage() {
+    IOException cause = new IOException("Failure Type A");
+    BulkTransferException bulkTransferException = new BulkTransferException();
+    bulkTransferException.add(cause);
+    bulkTransferException.add(cause);
+    bulkTransferException.add(cause);
+    String message = bulkTransferException.getMessage();
+    assertThat(message).startsWith("3 errors during bulk transfer (1 unique):\n\n");
+    assertThat(message.indexOf("Failure Type A")).isEqualTo(message.lastIndexOf("Failure Type A"));
+  }
+
+  @Test
+  public void shouldIncludeAllDistinctStackTracesWhenAggregating() {
+    IOException causeA = new IOException("Failure Type A");
+    IOException causeB = new IOException("Failure Type B");
+    BulkTransferException bulkTransferException = new BulkTransferException();
+    bulkTransferException.add(causeA);
+    bulkTransferException.add(causeB);
+    String message = bulkTransferException.getMessage();
+    assertThat(message).startsWith("2 errors during bulk transfer (2 unique):\n\n");
+    assertThat(message).contains(stackTraceAsString(causeA));
+    assertThat(message).contains(stackTraceAsString(causeB));
+  }
+
+  @Test
+  public void shouldIncludeCauseChainInStackTrace() {
+    IOException rootCause = new IOException("root: UNAVAILABLE");
+    IOException wrapping = new IOException("grpc: UNAVAILABLE", rootCause);
+    BulkTransferException bulkTransferException = new BulkTransferException();
+    bulkTransferException.add(wrapping);
+    String message = bulkTransferException.getMessage();
+    assertThat(message).contains("grpc: UNAVAILABLE");
+    assertThat(message).contains("root: UNAVAILABLE");
   }
 }


### PR DESCRIPTION
### Description
As the title says, this PR adds a stack trace to `BulkTransferException.getMessage()` for each unique exception message. This PR also fixes a minor punctuation issue relating to remote cache error reporting.

Sample remote cache error reporting using code from current head:
```
Failed to fetch blobs because of a remote cache error.: Multiple errors during bulk transfer:
java.io.IOException: io.grpc.StatusRuntimeException: UNAVAILABLE: io exception
java.io.IOException: No space left on device
```

Sample remote cache error reporting using code from PR:
```
Failed to fetch blobs because of a remote cache error: 5 errors during bulk transfer (2 unique):

java.io.IOException: io.grpc.StatusRuntimeException: UNAVAILABLE: io exception
	at com.google.devtools.build.lib.remote.GrpcCacheClient.fetchBlob(GrpcCacheClient.java:312)
	... 3 more
Caused by: io.grpc.StatusRuntimeException: UNAVAILABLE: io exception
	... 5 more
Caused by: java.io.IOException: Connection reset by peer
	... 9 more

java.io.IOException: No space left on device
	at java.io.FileOutputStream.writeBytes(Native Method)
	at java.io.FileOutputStream.write(FileOutputStream.java:347)
	... 2 more
```

### Motivation
The reason for adding the stack traces is to make it easier to debug any such errors.

Fixes #29029

### Build API Changes
No

### Checklist

- [x] I have added tests for the new use cases (if any)
- [x] I have updated the documentation (if applicable)

### Release Notes
RELNOTES: None