### PR TITLE
Fix repo collisions when checking package traversals of source dirs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -2295,6 +2295,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/io:file_symlink_exception",
         "//src/main/java/com/google/devtools/build/lib/io:file_symlink_infinite_expansion_exception",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupValue.java
@@ -116,11 +116,6 @@ public abstract class PackageLookupValue implements SkyValue {
    */
   public abstract String getErrorMsg();
 
-  public static SkyKey key(PathFragment directory) {
-    Preconditions.checkArgument(!directory.isAbsolute(), directory);
-    return key(PackageIdentifier.createInMainRepo(directory));
-  }
-
   public static Key key(PackageIdentifier pkgIdentifier) {
     return Key.create(pkgIdentifier);
   }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunction.java
@@ -553,6 +553,9 @@ public final class RecursiveFilesystemTraversalFunction implements SkyFunction {
         rootInfo.type.exists() && !rootInfo.type.isFile(), "{%s} {%s}", traversal, rootInfo);
     var rootPath = traversal.root().getRootPart().asPath();
     RepositoryName repoName;
+    // The roots of external repositories are always children of the external directory, even if
+    // those are symlinks to other locations (e.g. in the case of a local_repository), so all other
+    // roots are part of the main repository.
     if (rootPath.startsWith(externalDirectory)) {
       checkState(
           rootPath.relativeTo(externalDirectory).isSingleSegment(),

--- a/src/main/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunction.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.skyframe;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -29,6 +30,8 @@ import com.google.devtools.build.lib.actions.FileStateValue.RegularFileStateValu
 import com.google.devtools.build.lib.actions.FileStateValue.RegularFileStateValueWithDigest;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.actions.HasDigest;
+import com.google.devtools.build.lib.cmdline.PackageIdentifier;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.io.FileSymlinkException;
@@ -155,17 +158,19 @@ public final class RecursiveFilesystemTraversalFunction implements SkyFunction {
   }
 
   /** Exception type thrown by {@link RecursiveFilesystemTraversalFunction#compute}. */
-  private static final class RecursiveFilesystemTraversalFunctionException extends
-      SkyFunctionException {
+  private static final class RecursiveFilesystemTraversalFunctionException
+      extends SkyFunctionException {
     RecursiveFilesystemTraversalFunctionException(RecursiveFilesystemTraversalException e) {
       super(e, Transience.PERSISTENT);
     }
   }
 
   private final SyscallCache syscallCache;
+  private final Path externalDirectory;
 
-  RecursiveFilesystemTraversalFunction(SyscallCache syscallCache) {
+  RecursiveFilesystemTraversalFunction(SyscallCache syscallCache, Path externalDirectory) {
     this.syscallCache = syscallCache;
+    this.externalDirectory = externalDirectory;
   }
 
   @Nullable
@@ -199,8 +204,8 @@ public final class RecursiveFilesystemTraversalFunction implements SkyFunction {
       if (rootInfo.type.isDirectory() && rootInfo.metadata instanceof TreeArtifactValue value) {
         ImmutableList.Builder<RecursiveFilesystemTraversalValue> traversalValues =
             ImmutableList.builderWithExpectedSize(value.getChildValues().size());
-        for (Map.Entry<TreeFileArtifact, FileArtifactValue> entry
-            : value.getChildValues().entrySet()) {
+        for (Map.Entry<TreeFileArtifact, FileArtifactValue> entry :
+            value.getChildValues().entrySet()) {
           RootedPath path =
               RootedPath.toRootedPath(traversal.root().getRootPart(), entry.getKey().getPath());
           traversalValues.add(
@@ -315,8 +320,9 @@ public final class RecursiveFilesystemTraversalFunction implements SkyFunction {
     @Override
     public String toString() {
       if (type.isSymlink()) {
-        return String.format("(%s: link_value=%s, real_path=%s)", type,
-            unresolvedSymlinkTarget.getPathString(), realPath);
+        return String.format(
+            "(%s: link_value=%s, real_path=%s)",
+            type, unresolvedSymlinkTarget.getPathString(), realPath);
       } else {
         return String.format("(%s: real_path=%s)", type, realPath);
       }
@@ -487,7 +493,9 @@ public final class RecursiveFilesystemTraversalFunction implements SkyFunction {
 
   private static final class PkgLookupResult {
     private enum Type {
-      CONFLICT, DIRECTORY, PKG
+      CONFLICT,
+      DIRECTORY,
+      PKG
     }
 
     private final PkgLookupResult.Type type;
@@ -504,7 +512,7 @@ public final class RecursiveFilesystemTraversalFunction implements SkyFunction {
       return new PkgLookupResult(PkgLookupResult.Type.DIRECTORY, traversal, rootInfo);
     }
 
-    /** Result for a package, i.e. a directory  with a BUILD file. */
+    /** Result for a package, i.e. a directory with a BUILD file. */
     static PkgLookupResult pkg(TraversalRequest traversal, FileInfo rootInfo) {
       return new PkgLookupResult(PkgLookupResult.Type.PKG, traversal, rootInfo);
     }
@@ -538,11 +546,23 @@ public final class RecursiveFilesystemTraversalFunction implements SkyFunction {
    *     a package is found, but under a different root than expected)
    */
   @Nullable
-  private static PkgLookupResult checkIfPackage(
+  private PkgLookupResult checkIfPackage(
       Environment env, TraversalRequest traversal, FileInfo rootInfo, SyscallCache syscallCache)
       throws IOException, InterruptedException, BuildFileNotFoundException {
     checkArgument(
         rootInfo.type.exists() && !rootInfo.type.isFile(), "{%s} {%s}", traversal, rootInfo);
+    var rootPath = traversal.root().getRootPart().asPath();
+    RepositoryName repoName;
+    if (rootPath.startsWith(externalDirectory)) {
+      checkState(
+          rootPath.relativeTo(externalDirectory).isSingleSegment(),
+          "%s is expected to be directly under %s",
+          rootPath,
+          externalDirectory);
+      repoName = RepositoryName.createUnvalidated(rootPath.getBaseName());
+    } else {
+      repoName = RepositoryName.MAIN;
+    }
     // PackageLookupFunction/dependencies can only throw IOException, BuildFileNotFoundException,
     // and RepositoryFetchException, and RepositoryFetchException is not in play here. Note that
     // run-of-the-mill circular symlinks will *not* throw here, and will trigger later errors during
@@ -550,7 +570,8 @@ public final class RecursiveFilesystemTraversalFunction implements SkyFunction {
     PackageLookupValue pkgLookup =
         (PackageLookupValue)
             env.getValueOrThrow(
-                PackageLookupValue.key(traversal.root().getRelativePart()),
+                PackageLookupValue.key(
+                    PackageIdentifier.create(repoName, traversal.root().getRelativePart())),
                 BuildFileNotFoundException.class,
                 IOException.class);
     if (env.valuesMissing()) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -131,6 +131,7 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.Label.LabelInterner;
 import com.google.devtools.build.lib.cmdline.Label.PackageContext;
 import com.google.devtools.build.lib.cmdline.Label.RepoContext;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -960,7 +961,9 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     map.put(SkyFunctions.ACTION_EXECUTION, newActionExecutionFunction());
     map.put(
         SkyFunctions.RECURSIVE_FILESYSTEM_TRAVERSAL,
-        new RecursiveFilesystemTraversalFunction(syscallCache));
+        new RecursiveFilesystemTraversalFunction(
+            syscallCache,
+            directories.getOutputBase().getRelative(LabelConstants.EXTERNAL_REPOSITORY_LOCATION)));
     map.put(
         SkyFunctions.ACTION_TEMPLATE_EXPANSION,
         new ActionTemplateExpansionFunction(actionKeyContext));

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1957,6 +1957,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        "//src/test/java/com/google/devtools/build/lib/analysis/util",
         "//src/test/java/com/google/devtools/build/lib/buildtool/util",
         "//third_party:guava",
         "//third_party:junit4",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunctionTest.java
@@ -44,6 +44,7 @@ import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.clock.BlazeClock;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.events.NullEventHandler;
 import com.google.devtools.build.lib.io.FileSymlinkCycleUniquenessFunction;
@@ -167,7 +168,9 @@ public final class RecursiveFilesystemTraversalFunctionTest extends FoundationTe
         new DirectoryListingStateFunction(externalFilesHelper, SyscallCache.NO_CACHE));
     skyFunctions.put(
         SkyFunctions.RECURSIVE_FILESYSTEM_TRAVERSAL,
-        new RecursiveFilesystemTraversalFunction(SyscallCache.NO_CACHE));
+        new RecursiveFilesystemTraversalFunction(
+            SyscallCache.NO_CACHE,
+            directories.getOutputBase().getRelative(LabelConstants.EXTERNAL_REPOSITORY_LOCATION)));
     skyFunctions.put(
         SkyFunctions.PACKAGE_LOOKUP,
         new PackageLookupFunction(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/SourceDirectoryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/SourceDirectoryIntegrationTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.BuildFailedException;
+import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
 import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.vfs.Path;
@@ -251,6 +252,51 @@ public final class SourceDirectoryIntegrationTest extends BuildIntegrationTestCa
     assertThrows(BuildFailedException.class, () -> buildTarget("//foo"));
     assertContainsEvent("infinite symlink expansion detected");
     assertContainsEvent("foo/dir/subdir/nested2");
+  }
+
+  /** Regression test for {@see https://github.com/bazelbuild/bazel/issues/29688}. */
+  @Test
+  public void crossingRepoPackageCollision_doesNotFail() throws Exception {
+    if (!AnalysisMock.get().isThisBazel()) {
+      return;
+    }
+    write("tools/docker/BUILD");
+
+    write(
+        "MODULE.bazel",
+        """
+        bazel_dep(name = "ext")
+        local_path_override(
+            module_name = "ext",
+            path = "ext",
+        )
+        """);
+    write("ext/MODULE.bazel", "module(name = 'ext')");
+    write(
+        "ext/BUILD",
+        """
+        filegroup(
+            name = "dir",
+            srcs = ["tools"],
+            visibility = ["//visibility:public"],
+        )
+        """);
+    Path extSourceDir = getWorkspace().getRelative("ext/tools");
+    extSourceDir.getRelative("docker").createDirectoryAndParents();
+    writeIsoLatin1(extSourceDir.getRelative("docker/data"), "content");
+
+    write(
+        "BUILD",
+        """
+        genrule(
+            name = "consume",
+            srcs = ["@ext//:dir"],
+            outs = ["consume.out"],
+            cmd = "touch $@",
+        )
+        """);
+
+    buildTarget("//:consume");
   }
 
   private static final String GENRULE_EVENT = "Executing genrule //foo:foo";


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
Checking for package traversals of source directories did not take the repo name into account, leading to false positives.

### Motivation
Fixes #29688 

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
