### PR TITLE
Don't consider external repos dirty if hardlink count changes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileStateValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileStateValue.java
@@ -127,8 +127,11 @@ public abstract class FileStateValue extends RegularFileValue implements HasDige
     } else if (statNoFollow.isSymbolicLink()) {
       return new SymlinkFileStateValue(path.readSymbolicLinkUnchecked());
     }
-    throw new InconsistentFilesystemException("according to stat, existing path " + path + " is "
-        + "neither a file nor directory nor symlink.");
+    throw new InconsistentFilesystemException(
+        "according to stat, existing path "
+            + path
+            + " is "
+            + "neither a file nor directory nor symlink.");
   }
 
   /**
@@ -222,6 +225,42 @@ public abstract class FileStateValue extends RegularFileValue implements HasDige
 
   @Nullable
   public abstract FileContentsProxy getContentsProxy();
+
+  /**
+   * Returns whether this value is equal to {@code other}, except that a change to ctime (last
+   * change time) only is permitted.
+   *
+   * <p>Use this rather than {@link #equals} when 1) hardlinks are involved, and 2) missing certain
+   * modifications in edge cases is acceptable.
+   */
+  public boolean equalsIgnoringChangeTime(FileStateValue other) {
+    if (this == other) {
+      return true;
+    }
+    if (getType() != other.getType()) {
+      return false;
+    }
+    return switch (getType()) {
+      case REGULAR_FILE, SPECIAL_FILE -> {
+        if (getSize() != other.getSize()) {
+          yield false;
+        }
+        // Prefer comparing digests, the most robust signal, when both values have one.
+        var thisDigest = getDigest();
+        var otherDigest = other.getDigest();
+        if (thisDigest != null && otherDigest != null) {
+          yield Arrays.equals(thisDigest, otherDigest);
+        }
+        var thisProxy = getContentsProxy();
+        var otherProxy = other.getContentsProxy();
+        if (thisProxy != null && otherProxy != null) {
+          yield !thisProxy.isModified(otherProxy);
+        }
+        yield equals(other);
+      }
+      default -> equals(other);
+    };
+  }
 
   @Nullable
   @Override

--- a/src/main/java/com/google/devtools/build/lib/skyframe/DirtinessCheckerUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/DirtinessCheckerUtils.java
@@ -148,7 +148,12 @@ public class DirtinessCheckerUtils {
       if (cacheable) {
         return SkyValueDirtinessChecker.DirtyResult.dirtyWithNewValue(newValue);
       }
-      if (fileType == FileType.EXTERNAL_REPO) {
+      // The hermetic Linux sandbox uses hardlinks to stage inputs, which affects ctimes. Don't
+      // report files as modified and trigger a refetch of the repo just due to that.
+      if (fileType == FileType.EXTERNAL_REPO
+          && !(oldValue instanceof FileStateValue oldFileState
+              && newValue instanceof FileStateValue newFileState
+              && newFileState.equalsIgnoringChangeTime(oldFileState))) {
         var repositoryName = externalFilesHelper.getExternalRepoName(rootedPath);
         if (repositoryName != null) {
           dirtyExternalRepos.putIfAbsent(repositoryName, rootedPath);

--- a/src/test/shell/bazel/bazel_hermetic_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_hermetic_sandboxing_test.sh
@@ -370,6 +370,43 @@ function test_other_artifacts() {
   assert_contains ".directory_artifact" "bazel-bin/examples/hermetic/other_artifacts.result"
 }
 
+# Test that hardlinking an external repo file into the sandbox doesn't trigger a refetch.
+# Regression test for https://github.com/bazelbuild/bazel/issues/29590: the hermetic Linux
+# sandbox hardlinks an action's inputs, which updates their ctime.
+function test_external_repo_not_refetched_after_hardlinking() {
+  cat >> MODULE.bazel <<'EOF'
+ext = use_repo_rule("//examples/hermetic:ext.bzl", "ext")
+ext(name = "ext")
+EOF
+  cat > examples/hermetic/ext.bzl <<'EOF'
+def _ext_impl(rctx):
+    print("FETCHING_EXT_REPO")
+    rctx.file("BUILD", "exports_files(['data.txt'])")
+    rctx.file("data.txt", "external data")
+ext = repository_rule(_ext_impl)
+EOF
+  cat >> examples/hermetic/BUILD <<'EOF'
+genrule(
+    name = "use_ext",
+    srcs = ["@ext//:data.txt"],
+    outs = ["use_ext.txt"],
+    cmd = "cat $(location @ext//:data.txt) > $@",
+)
+EOF
+
+  # The first build fetches the repo and runs the action, which hardlinks the external file into
+  # the hermetic sandbox and thereby updates its ctime.
+  bazel build examples/hermetic:use_ext &> $TEST_log \
+    || fail "Expected first build to succeed"
+  expect_log "FETCHING_EXT_REPO"
+
+  # The ctime change from hardlinking must not be treated as a modification, so the second build
+  # must not refetch the repo.
+  bazel build examples/hermetic:use_ext &> $TEST_log \
+    || fail "Expected second build to succeed"
+  expect_not_log "FETCHING_EXT_REPO"
+}
+
 # The test shouldn't fail if the environment doesn't support running it.
 check_sandbox_allowed || exit 0
 is_linux || exit 0


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
When checking external repos for external modifications, don't use ctime as it is sensitive to hardlink count changes (e.g. with `--experimental_use_hermetic_linux_sandbox`) and thus causes false positives.

### Motivation
Fixes #29590 

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: External repos are no longer refetched whenever they contribute inputs to an action using the hermetic Linux sandbox.
