### PR TITLE
Fix sandbox policy injection via unescaped paths in darwin-sandbox

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
@@ -255,6 +255,14 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     };
   }
 
+  /** Escapes quotes and backslashes for Apple SBPL Scheme string literals. */
+  private static String escapeSchemeString(String s) {
+    if (s == null) {
+      return "";
+    }
+    return s.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
   private static void writeConfig(
       Path sandboxConfigPath,
       Set<Path> writableDirs,
@@ -284,10 +292,10 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
       out.println("(allow file-write*");
       for (Path path : writableDirs) {
-        out.println("    (subpath \"" + path.getPathString() + "\")");
+        out.println("    (subpath \"" + escapeSchemeString(path.getPathString()) + "\")");
       }
       if (statisticsPath != null) {
-        out.println("    (literal \"" + statisticsPath.getPathString() + "\")");
+        out.println("    (literal \"" + escapeSchemeString(statisticsPath.getPathString()) + "\")");
       }
       out.println(")");
 
@@ -296,7 +304,7 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
         // The sandbox configuration file is not part of a cache key and sandbox-exec doesn't care
         // about ordering of paths in expressions, so it's fine if the iteration order is random.
         for (Path inaccessiblePath : inaccessiblePaths) {
-          out.println("    (subpath \"" + inaccessiblePath + "\")");
+          out.println("    (subpath \"" + escapeSchemeString(inaccessiblePath.toString()) + "\")");
         }
         out.println(")");
       }


### PR DESCRIPTION
## Summary

Fix for #29427 - Escape quote and backslash characters in path strings before writing them into Apple SBPL sandbox configuration files.

## Problem

The `writeConfig()` method in `DarwinSandboxedSpawnRunner.java` writes path strings directly into double-quoted SBPL string literals without escaping metacharacters. A workspace directory containing quote characters can inject arbitrary sandbox policy directives, breaking sandbox containment.

**Affected versions:** Regression between Bazel 6.5.0 and 7.0.0. Confirmed in 7.0.0, 7.7.0, 8.4.0, 9.1.0.

## Fix

Added `escapeSchemeString()` helper that escapes backslash and quote characters in path strings before interpolation into SBPL config. Applied to all three dynamic path insertion points in `writeConfig()`:
- Writable directory paths (line 287)
- Statistics path (line 290)
- Inaccessible paths (line 299)

## Impact

Without this fix, an attacker with control over workspace directory names can escape the Bazel sandbox on macOS, enabling writes to arbitrary filesystem locations.

## Testing

The fix is minimal and targeted - it only adds escaping to string interpolation. It does not change any sandbox policy logic or path resolution behavior.

Fixes #29427
