### PR TITLE
docs: remove stale roadmap link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Build and test software of any size, quickly and reliably.
   * [Use the query command](https://bazel.build/reference/query)
   * [Extend Bazel](https://bazel.build/rules/concepts)
   * [Write tests](https://bazel.build/reference/test-encyclopedia)
-  * [Roadmap](https://bazel.build/community/roadmaps)
   * [Who is using Bazel?](https://bazel.build/community/users)
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
The roadmap page was retired from the unversioned narrative documentation on the master branch in commit 2e72f2f121 (chore: remove outdated roadmap) because the 2025 planning projection had become stale.

Context #29135 
