### PR TITLE
buildeventservice: use fresh environment for BES credential helper

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -306,7 +306,7 @@ public final class GoogleAuthUtils {
       // Fallback to .netrc if it exists.
       try {
         fallbackCredentials =
-            newCredentialsFromNetrc(credentialHelperEnvironment.clientEnvironment(), fileSystem);
+            newCredentialsFromNetrc(credentialHelperEnvironment.clientEnvironment().get(), fileSystem);
       } catch (IOException e) {
         // TODO(yannic): Make this fail the build.
         credentialHelperEnvironment.eventReporter().handle(Event.warn(e.getMessage()));
@@ -422,7 +422,7 @@ public final class GoogleAuthUtils {
     CredentialHelperProvider.Builder builder = CredentialHelperProvider.builder();
     for (AuthAndTLSOptions.CredentialHelperOption helper : helpers) {
       Optional<String> scope = helper.scope();
-      Path path = pathFactory.create(environment.clientEnvironment(), helper.path());
+      Path path = pathFactory.create(environment.clientEnvironment().get(), helper.path());
       if (scope.isPresent()) {
         builder.add(scope.get(), path);
       } else {

--- a/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelper.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharStreams;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
@@ -161,11 +162,12 @@ public final class CredentialHelper {
     Preconditions.checkNotNull(environment);
     Preconditions.checkNotNull(args);
 
-    return new SubprocessBuilder(environment.clientEnvironment())
+    ImmutableMap<String, String> clientEnv = environment.clientEnvironment().get();
+    return new SubprocessBuilder(clientEnv)
         .setArgv(ImmutableList.<String>builder().add(path.getPathString()).add(args).build())
         .setWorkingDirectory(
             environment.workspacePath() != null ? environment.workspacePath().getPathFile() : null)
-        .setEnv(environment.clientEnvironment())
+        .setEnv(clientEnv)
         .setTimeoutMillis(environment.helperExecutionTimeout().toMillis())
         .start();
   }

--- a/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelperEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelperEnvironment.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.vfs.Path;
 import java.time.Duration;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
@@ -32,14 +33,13 @@ import javax.annotation.Nullable;
  *     outside a workspace.
  *     <p>If available, it will be used as the working directory when invoking the helper
  *     subprocess. Otherwise, the working directory is inherited from the Bazel server process.
- * @param clientEnvironment Returns the environment from the Bazel client.
- *     <p>Passed as environment variables to the subprocess.
+ * @param clientEnvironment Supplies the environment from the Bazel client.
  * @param helperExecutionTimeout Returns the execution timeout for the helper subprocess.
  */
 public record CredentialHelperEnvironment(
     Reporter eventReporter,
     @Nullable Path workspacePath,
-    ImmutableMap<String, String> clientEnvironment,
+    Supplier<ImmutableMap<String, String>> clientEnvironment,
     Duration helperExecutionTimeout) {
   public CredentialHelperEnvironment {
     requireNonNull(eventReporter, "eventReporter");
@@ -64,10 +64,11 @@ public record CredentialHelperEnvironment(
     public abstract Builder setWorkspacePath(@Nullable Path path);
 
     /**
-     * Sets the environment from the Bazel client to pass as environment variables to the
-     * subprocess.
+     * Sets the supplier of the client environment to pass as environment variables to the
+     * subprocess. The supplier is called each time a subprocess is spawned.
      */
-    public abstract Builder setClientEnvironment(ImmutableMap<String, String> environment);
+    public abstract Builder setClientEnvironment(
+        Supplier<ImmutableMap<String, String>> environment);
 
     /** Sets the execution timeout for the helper subprocess. */
     public abstract Builder setHelperExecutionTimeout(Duration timeout);

--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -448,7 +448,7 @@ public class BazelRepositoryModule extends BlazeModule {
             CredentialHelperEnvironment.newBuilder()
                 .setEventReporter(env.getReporter())
                 .setWorkspacePath(env.getWorkspace())
-                .setClientEnvironment(env.getClientEnv())
+                .setClientEnvironment(env::getClientEnv)
                 .setHelperExecutionTimeout(authAndTlsOptions.getCredentialHelperTimeout())
                 .build();
         CredentialHelperProvider credentialHelperProvider =

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModule.java
@@ -80,6 +80,21 @@ public class BazelBuildEventServiceModule
   private BuildEventServiceClient client;
   private BackendConfig config;
 
+  /**
+   * Client environment of the most recently started command.
+   *
+   * <p>A cached {@link BuildEventServiceClient} can outlive the command that created it, so its
+   * credential helper must not capture a per-command {@link CommandEnvironment}. Instead it reads
+   * the environment through {@link #latestClientEnv()}, which {@link #getBesClient} refreshes at the
+   * start of every command (including when a cached client is returned). {@code volatile} because
+   * the helper may run on a gRPC I/O thread.
+   */
+  private volatile ImmutableMap<String, String> latestClientEnv = ImmutableMap.of();
+
+  private ImmutableMap<String, String> latestClientEnv() {
+    return latestClientEnv;
+  }
+
   private CredentialModule credentialModule;
 
   @Override
@@ -118,6 +133,9 @@ public class BazelBuildEventServiceModule
       BuildEventServiceOptions besOptions,
       AuthAndTLSOptions authAndTLSOptions)
       throws IOException {
+    // Refresh for every command, including when a cached client is returned below, so credential
+    // helpers observe the current command's environment (e.g. a rotated auth token).
+    latestClientEnv = env.getClientEnv();
     BackendConfig newConfig = BackendConfig.create(besOptions, authAndTLSOptions);
     if (client == null || !Objects.equals(config, newConfig)) {
       clearBesClient();
@@ -129,7 +147,7 @@ public class BazelBuildEventServiceModule
               CredentialHelperEnvironment.newBuilder()
                   .setEventReporter(env.getReporter())
                   .setWorkspacePath(env.getWorkspace())
-                  .setClientEnvironment(env.getClientEnv())
+                  .setClientEnvironment(this::latestClientEnv)
                   .setHelperExecutionTimeout(authAndTLSOptions.getCredentialHelperTimeout())
                   .build(),
               credentialModule.getCredentialCache(),
@@ -183,6 +201,8 @@ public class BazelBuildEventServiceModule
     }
     this.client = null;
     this.config = null;
+    // Do not reset latestClientEnv here: an in-flight credential lookup on a gRPC I/O thread may
+    // call the supplier after clearBesClient() returns, and an empty map would give it no PATH/HOME.
   }
 
   private static final ImmutableSet<String> ALLOWED_COMMANDS =

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -601,7 +601,7 @@ public final class RemoteModule extends BlazeModule {
               CredentialHelperEnvironment.newBuilder()
                   .setEventReporter(env.getReporter())
                   .setWorkspacePath(env.getWorkspace())
-                  .setClientEnvironment(env.getClientEnv())
+                  .setClientEnvironment(env::getClientEnv)
                   .setHelperExecutionTimeout(authAndTlsOptions.getCredentialHelperTimeout())
                   .build(),
               credentialModule.getCredentialCache(),

--- a/src/test/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtilsTest.java
@@ -124,7 +124,7 @@ public class GoogleAuthUtilsTest {
         CredentialHelperEnvironment.newBuilder()
             .setEventReporter(new Reporter(EventBusEventHandler.createWithNewEventBus()))
             .setWorkspacePath(workspace)
-            .setClientEnvironment(ImmutableMap.of("PATH", pathValue.getPathString()))
+            .setClientEnvironment(() -> ImmutableMap.of("PATH", pathValue.getPathString()))
             .setHelperExecutionTimeout(Duration.ZERO)
             .build();
     CommandLinePathFactory commandLinePathFactory =

--- a/src/test/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelperTest.java
@@ -78,7 +78,7 @@ public class CredentialHelperTest {
         CredentialHelperEnvironment.newBuilder()
             .setEventReporter(reporter)
             .setWorkspacePath(fs.getPath(TEST_WORKSPACE_PATH))
-            .setClientEnvironment(ImmutableMap.copyOf(clientEnv))
+            .setClientEnvironment(() -> ImmutableMap.copyOf(clientEnv))
             .setHelperExecutionTimeout(timeout)
             .build(),
         URI.create(uri));

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModuleTest.java
@@ -89,12 +89,16 @@ import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.Server;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
 import io.grpc.Status;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.util.MutableHandlerRegistry;
 import java.io.BufferedOutputStream;
+import java.util.Collections;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -907,6 +911,60 @@ public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTest
         .containsExactly(
             TestConstants.PRODUCT_NAME + " is crashing: Crashed: (java.lang.OutOfMemoryError) ");
     assertAndClearBugReporterStoredCrash(OutOfMemoryError.class);
+  }
+  
+  @Test
+  public void getBesClient_credentialHelperUsesStaleClientEnvAfterTokenRotation() throws Exception {
+    // Write a credential helper that reads MY_TOKEN from its env and returns it as a header.
+    Path helperPath = tmpFolder.newFile("cred_helper.sh").toPath();
+    Files.writeString(
+        helperPath,
+        """
+        #!/usr/bin/env bash
+        cat /dev/stdin > /dev/null
+        echo "{\\"headers\\":{\\"x-my-token\\":[\\"$MY_TOKEN\\"]}}"
+        """);
+    helperPath.toFile().setExecutable(true);
+
+    // Intercept headers arriving at the fake BES server.
+    List<String> observedTokens = new ArrayList<>();
+    var headerInterceptor = new ServerInterceptor() {
+      @Override
+      public <Req, Resp> ServerCall.Listener<Req> interceptCall(
+          ServerCall<Req, Resp> call, Metadata headers, ServerCallHandler<Req, Resp> next) {
+        String token = headers.get(
+            Metadata.Key.of("x-my-token", Metadata.ASCII_STRING_MARSHALLER));
+        if (token != null) {
+          observedTokens.add(token);
+        }
+        return next.startCall(call, headers);
+      }
+    };
+    serviceRegistry.addService(
+        ServerInterceptors.intercept(
+            buildEventService,
+            new TracingMetadataUtils.ServerHeadersInterceptor(),
+            headerInterceptor));
+
+    // Build 1: token-1 in client env.
+    addOptions(
+        "--bes_backend=inprocess",
+        "--bes_upload_mode=WAIT_FOR_UPLOAD_COMPLETE",
+        "--credential_helper=" + helperPath,
+        "--credential_helper_cache_duration=0s",   // disable caching so helper is called every RPC
+        "--client_env=MY_TOKEN=token-1");
+    runBuildWithOptions();
+    afterBuildCommand();
+    observedTokens.clear();
+
+    // Build 2: same config, token rotated to token-2.
+    addOptions("--client_env=MY_TOKEN=token-2");
+    runBuildWithOptions();
+    afterBuildCommand();
+
+    assertThat(observedTokens).isNotEmpty();
+    assertThat(observedTokens).containsExactlyElementsIn(
+        Collections.nCopies(observedTokens.size(), "token-2"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -456,7 +456,7 @@ public final class RemoteModuleTest {
             CredentialHelperEnvironment.newBuilder()
                 .setEventReporter(new Reporter(EventBusEventHandler.createWithNewEventBus()))
                 .setWorkspacePath(fileSystem.getPath("/workspace"))
-                .setClientEnvironment(ImmutableMap.of("NETRC", netrc))
+                .setClientEnvironment(() -> ImmutableMap.of("NETRC", netrc))
                 .setHelperExecutionTimeout(Duration.ZERO)
                 .build(),
             credentialCache,


### PR DESCRIPTION
When the BES backend config is unchanged across builds,
BazelBuildEventServiceModule reuses the existing gRPC client. Before,
the CredentialHelperCredentials object baked into that client held a
frozen CredentialHelperEnvironment (and thus a frozen clientEnv) from
the first build, causing credential helper subprocesses to see the old
environment on subsequent builds.

Known limitations not addressed here:
- The netrc fallback credentials (newCredentialsFromNetrc) and the
  credential helper binary path (pathFactory.create) are both resolved
  eagerly when the Credentials object is first constructed. If NETRC,
  HOME, or PATH changes between builds, those values remain stale until
  the backend config changes and a new client is built.
- The eventReporter and workspacePath fields in CredentialHelperEnvironment
  are likewise snapshotted from the first build's CommandEnvironment.

Fixes #29714

AI-Assisted: Claude
