### PR TITLE
[9.2.0] Fix ArtifactFactory.getPathFromSourceExecPath for external repos (https://github.com/bazelbuild/bazel/pull/29657)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
@@ -112,7 +112,6 @@ public class ArtifactFactory implements ArtifactResolver {
       return unwrapCacheObject(execPath, pathToSourceArtifact.get(execPath));
     }
 
-    @SuppressWarnings("unchecked")
     private Entry computeEntry(
         PathFragment execPath, BiFunction<PathFragment, Entry, Entry> computeFunction) {
       return unwrapCacheObject(
@@ -660,10 +659,27 @@ public class ArtifactFactory implements ArtifactResolver {
   public Path getPathFromSourceExecPath(Path execRoot, PathFragment execPath) {
     Preconditions.checkState(
         !execPath.startsWith(derivedPathPrefix), "%s is derived: %s", execPath, derivedPathPrefix);
+
+    Pair<RepositoryName, PathFragment> repo =
+        RepositoryName.fromPathFragment(execPath, siblingRepositoryLayout);
+    RepositoryName repositoryName = RepositoryName.MAIN;
+    PathFragment repositoryRelativePath = execPath;
+    if (repo != null) {
+      repositoryName = repo.getFirst();
+      repositoryRelativePath = repo.getSecond();
+    }
+
     Root sourceRoot =
-        packageRoots.getRootForPackage(PackageIdentifier.create(RepositoryName.MAIN, execPath));
+        packageRoots.getRootForPackage(
+            PackageIdentifier.create(repositoryName, repositoryRelativePath));
+    if (sourceRoot == null) {
+      sourceRoot =
+          findSourceRoot(
+              execPath, /* baseExecPath= */ null, /* baseRoot= */ null, RepositoryName.MAIN);
+    }
+
     if (sourceRoot != null) {
-      return sourceRoot.getRelative(execPath);
+      return sourceRoot.getRelative(repositoryRelativePath);
     }
     return execRoot.getRelative(execPath);
   }

--- a/src/test/java/com/google/devtools/build/lib/actions/ArtifactFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ArtifactFactoryTest.java
@@ -131,6 +131,40 @@ public class ArtifactFactoryTest {
   }
 
   @Test
+  public void testGetPathFromSourceExecPath_inExternalRepo() throws Exception {
+    Root externalRoot = Root.fromPath(scratch.dir("/external/alien"));
+    Path sourceFile = scratch.file("/external/alien/pkg/header.h", "");
+    ImmutableMap<PackageIdentifier, Root> packageRoots =
+        ImmutableMap.of(
+            PackageIdentifier.create("alien", PathFragment.create("pkg")), externalRoot);
+    artifactFactory.setPackageRoots(packageRoots::get);
+
+    Path path =
+        artifactFactory.getPathFromSourceExecPath(
+            execRoot, PathFragment.create("external/alien/pkg/header.h"));
+
+    assertThat(path).isEqualTo(sourceFile);
+    assertThat(path.isFile()).isTrue();
+  }
+
+  @Test
+  public void testGetPathFromSourceExecPath_externalRepoPackageDirectory() throws Exception {
+    Root externalRoot = Root.fromPath(scratch.dir("/external/alien"));
+    Path packageDirectory = scratch.dir("/external/alien/pkg");
+    ImmutableMap<PackageIdentifier, Root> packageRoots =
+        ImmutableMap.of(
+            PackageIdentifier.create("alien", PathFragment.create("pkg")), externalRoot);
+    artifactFactory.setPackageRoots(packageRoots::get);
+
+    Path path =
+        artifactFactory.getPathFromSourceExecPath(
+            execRoot, PathFragment.create("external/alien/pkg"));
+
+    assertThat(path).isEqualTo(packageDirectory);
+    assertThat(path.isDirectory()).isTrue();
+  }
+
+  @Test
   public void testResolveArtifact_noDerived_derivedRoot() throws Exception {
     assertThat(
             artifactFactory.resolveSourceArtifact(


### PR DESCRIPTION
This function is only called for include scanning, which isn't used
widely externally today. Previously if a source file was from an
external repo it would not be correctly found by this function, which
assumed all source files are relative to the workspace.

Closes #29657.

PiperOrigin-RevId: 924751755
Change-Id: Ifadb17823a3247b98cbeea13c98e31b05de8e19e

Commit https://github.com/bazelbuild/bazel/commit/a11ca574c706141a2d6baa345f5085b7a5bbe394