### PR TITLE
Implement basic exec graph log parser

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -263,6 +263,7 @@ tasks:
       - "//src/java_tools/..."
       - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/..."
+      - "//src/tools/execgraph/..."
       - "//src/tools/execlog/..."
       - "//src/tools/one_version/..."
       - "//src/tools/singlejar/..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -264,6 +264,7 @@ tasks:
       - "//src/java_tools/..."
       - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/..."
+      - "//src/tools/execgraph/..."
       - "//src/tools/execlog/..."
       - "//src/tools/one_version/..."
       - "//src/tools/singlejar/..."

--- a/src/BUILD
+++ b/src/BUILD
@@ -437,6 +437,7 @@ filegroup(
         "//src/test/tools/test_repos:srcs",
         "//src/tools/bzlmod:srcs",
         "//src/tools/diskcache:srcs",
+        "//src/tools/execgraph:srcs",
         "//src/tools/execlog:srcs",
         "//src/tools/launcher:srcs",
         "//src/tools/one_version:srcs",

--- a/src/tools/execgraph/BUILD
+++ b/src/tools/execgraph/BUILD
@@ -1,0 +1,22 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    default_visibility = ["//:__pkg__"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]) + [
+        "//src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph:srcs",
+        "//src/tools/execgraph/test/main/java/com/google/devtools/build/execgraph:srcs",
+    ],
+    visibility = ["//src:__subpackages__"],
+)
+
+java_binary(
+    name = "parser",
+    main_class = "com.google.devtools.build.execgraph.ExecGraphParser",
+    visibility = ["//visibility:public"],
+    runtime_deps = ["//src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph:parser"],
+)

--- a/src/tools/execgraph/README.md
+++ b/src/tools/execgraph/README.md
@@ -1,0 +1,57 @@
+# Execution Graph Log Parser
+
+This tool is used to inspect and parse the Bazel execution graph log. The log is
+a zstd-compressed stream of length-delimited `execution_graph.Node` protos (see
+`src/main/protobuf/execution_graph.proto`).
+
+To generate the execution graph log, run e.g.:
+
+        bazel build \
+            --experimental_enable_execution_graph_log \
+            --experimental_execution_graph_log_path=/tmp/exec_graph.log :hello_world
+
+Then build the parser and run it:
+
+        bazel build src/tools/execgraph:parser
+        bazel-bin/src/tools/execgraph/parser --log_path=/tmp/exec_graph.log
+
+This will simply print the log contents to stdout in text form.
+
+To output results to a file, use `--output_path`:
+
+        bazel-bin/src/tools/execgraph/parser --log_path=/tmp/exec_graph.log \
+            --output_path=/tmp/exec_graph.log.txt
+
+To limit the output to a certain runner, use `--restrict_to_runner` option.
+For example,
+
+        bazel-bin/src/tools/execgraph/parser --log_path=/tmp/exec_graph.log \
+            --restrict_to_runner="linux-sandbox"
+
+Will limit the output to those nodes that were ran in the linux sandbox.
+
+
+Note that because Bazel is nondeterministic, different runs of the same build
+may produce logs where nodes are in a different order. To achieve a more
+meaningful textual diff, use the parser to convert both files at the same time:
+
+        bazel-bin/src/tools/execgraph/parser --log_path=/tmp/exec_graph1.log \
+                                             --log_path=/tmp/exec_graph2.log \
+                                             --output_path=/tmp/exec_graph1.log.txt \
+                                             --output_path=/tmp/exec_graph2.log.txt
+
+This will convert `/tmp/exec_graph1.log` to text as-is, but will reorder
+`/tmp/exec_graph2.log` to match the order of nodes found in
+`/tmp/exec_graph1.log`. Nodes are matched if their description is the same.
+Nodes that are not found in `/tmp/exec_graph1.log` are put at the end of
+`/tmp/exec_graph2.log.txt`. Note that descriptions are not guaranteed to be
+unique -- a single action can emit several nodes with the same description (for
+example, retries or actions that issue multiple spawns) -- so matching is
+best-effort when descriptions repeat.
+
+Note that this reordering makes it easier to see differences using text-based
+diffing tools, but may break the logical sequence of nodes in
+`/tmp/exec_graph2.log.txt`.
+
+For large log files, you might need to increase the JVM heap size. To do so,
+pass a corresponding `--jvm_flag`, for example `--jvm_flag=-Xmx4g` for 4GB of heap.

--- a/src/tools/execgraph/README.md
+++ b/src/tools/execgraph/README.md
@@ -22,13 +22,13 @@ To output results to a file, use `--output_path`:
         bazel-bin/src/tools/execgraph/parser --log_path=/tmp/exec_graph.log \
             --output_path=/tmp/exec_graph.log.txt
 
-To limit the output to a certain runner, use `--restrict_to_runner` option.
+To limit the output to a certain runner, use the `--restrict_to_runner` option.
 For example,
 
         bazel-bin/src/tools/execgraph/parser --log_path=/tmp/exec_graph.log \
             --restrict_to_runner="linux-sandbox"
 
-Will limit the output to those nodes that were ran in the linux sandbox.
+will limit the output to those nodes that were run in the linux sandbox.
 
 
 Note that because Bazel is nondeterministic, different runs of the same build

--- a/src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph/BUILD
+++ b/src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph/BUILD
@@ -1,0 +1,28 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    default_visibility = ["//:__subpackages__"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//src:__subpackages__"],
+)
+
+java_library(
+    name = "parser",
+    srcs = [
+        "ExecGraphParser.java",
+        "ParserOptions.java",
+    ],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/util/io:io-proto",
+        "//src/main/java/com/google/devtools/common/options",
+        "//src/main/protobuf:execution_graph_java_proto",
+        "//third_party:guava",
+        "//third_party:jsr305",
+        "@zstd-jni",
+    ],
+)

--- a/src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph/ExecGraphParser.java
+++ b/src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph/ExecGraphParser.java
@@ -202,36 +202,37 @@ public final class ExecGraphParser {
       System.exit(1);
     }
 
-    if (options.logPath == null || options.logPath.isEmpty()) {
+    if (options.getLogPath() == null || options.getLogPath().isEmpty()) {
       System.err.println("--log_path needs to be specified.");
       System.exit(1);
     }
-    if (options.outputPath != null && options.outputPath.size() > options.logPath.size()) {
+    if (options.getOutputPath() != null
+        && options.getOutputPath().size() > options.getLogPath().size()) {
       System.err.println("Too many --output_path values.");
       System.exit(1);
     }
 
-    String logPath = options.logPath.get(0);
+    String logPath = options.getLogPath().get(0);
     String secondPath = null;
     String output1 = null;
     String output2 = null;
 
-    if (options.logPath.size() > 1) {
-      if (options.logPath.size() > 2) {
+    if (options.getLogPath().size() > 1) {
+      if (options.getLogPath().size() > 2) {
         System.err.println("Too many --log_path: at most two files are currently supported.");
         System.exit(1);
       }
-      secondPath = options.logPath.get(1);
-      if (options.outputPath == null || options.outputPath.size() != 2) {
+      secondPath = options.getLogPath().get(1);
+      if (options.getOutputPath() == null || options.getOutputPath().size() != 2) {
         System.err.println(
             "Exactly two --output_path values expected, one for each of --log_path values.");
         System.exit(1);
       }
-      output1 = options.outputPath.get(0);
-      output2 = options.outputPath.get(1);
+      output1 = options.getOutputPath().get(0);
+      output2 = options.getOutputPath().get(1);
     } else {
-      if (options.outputPath != null && !options.outputPath.isEmpty()) {
-        output1 = options.outputPath.get(0);
+      if (options.getOutputPath() != null && !options.getOutputPath().isEmpty()) {
+        output1 = options.getOutputPath().get(0);
       }
     }
 
@@ -241,7 +242,7 @@ public final class ExecGraphParser {
     }
 
     try (MessageInputStream<Node> input = getMessageInputStream(logPath)) {
-      FilteredStream parser = new FilteredStream(input, options.restrictToRunner);
+      FilteredStream parser = new FilteredStream(input, options.getRestrictToRunner());
 
       if (output1 == null) {
         output(parser, System.out, golden);
@@ -255,7 +256,7 @@ public final class ExecGraphParser {
     if (secondPath != null) {
       try (MessageInputStream<Node> file2 = getMessageInputStream(secondPath);
           OutputStream output = new FileOutputStream(output2)) {
-        MessageInputStream<Node> parser = new FilteredStream(file2, options.restrictToRunner);
+        MessageInputStream<Node> parser = new FilteredStream(file2, options.getRestrictToRunner());
         // OrderedStream will read the whole golden on initialization,
         // so it is safe to close after.
         parser = new OrderedStream(golden, parser);

--- a/src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph/ExecGraphParser.java
+++ b/src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph/ExecGraphParser.java
@@ -1,0 +1,266 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.execgraph;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.github.luben.zstd.ZstdInputStream;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.devtools.build.lib.actions.ExecutionGraph.Node;
+import com.google.devtools.build.lib.util.io.MessageInputStream;
+import com.google.devtools.build.lib.util.io.MessageInputStreamWrapper.BinaryInputStreamWrapper;
+import com.google.devtools.common.options.OptionsParser;
+import java.io.BufferedWriter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import javax.annotation.Nullable;
+
+/**
+ * A tool to inspect and parse the Bazel execution graph log (written by
+ * {@code --experimental_enable_execution_graph_log}).
+ *
+ * <p>The log is a zstd-compressed stream of length-delimited {@code execution_graph.Node} protos.
+ */
+public final class ExecGraphParser {
+  private ExecGraphParser() {}
+
+  private static final String DELIMITER =
+      "\n---------------------------------------------------------\n";
+
+  @VisibleForTesting
+  static MessageInputStream<Node> getMessageInputStream(String path) throws IOException {
+    // The execution graph log is always a zstd-compressed stream of length-delimited Node protos.
+    return new BinaryInputStreamWrapper<>(
+        new ZstdInputStream(new FileInputStream(path)), Node.getDefaultInstance());
+  }
+
+  @VisibleForTesting
+  static class FilteredStream implements MessageInputStream<Node> {
+    final MessageInputStream<Node> in;
+    final String restrictToRunner;
+
+    FilteredStream(MessageInputStream<Node> in, String restrictToRunner) {
+      this.in = in;
+      this.restrictToRunner = restrictToRunner;
+    }
+
+    @Override
+    @Nullable
+    public Node read() throws IOException {
+      Node node;
+      while ((node = in.read()) != null) {
+        if (restrictToRunner == null || restrictToRunner.equals(node.getRunner())) {
+          return node;
+        }
+      }
+      return null;
+    }
+
+    @Override
+    public void close() throws IOException {
+      in.close();
+    }
+  }
+
+  @Nullable
+  static String getKey(Node node) {
+    // Nodes don't list their outputs, so the human-readable description is the most stable key for
+    // matching the same node across two builds.
+    String description = node.getDescription();
+    return description.isEmpty() ? null : description;
+  }
+
+  @VisibleForTesting
+  static class OrderedStream implements MessageInputStream<Node> {
+
+    public static class Golden {
+      // A map of positions of nodes in the first file.
+      // Key: the node's description.
+      // Value: the position of the node in the file (e.g., 0th, 1st etc).
+      private final Map<String, Integer> positions;
+      private int index;
+
+      public Golden() {
+        positions = new HashMap<>();
+        index = 0;
+      }
+
+      public void addNode(Node node) {
+        String key = getKey(node);
+        if (key != null) {
+          positions.put(key, index++);
+        }
+      }
+
+      public int positionFor(Node node) {
+        String key = getKey(node);
+        if (key != null && positions.containsKey(key)) {
+          return positions.get(key);
+        }
+        return -1;
+      }
+    }
+
+    private static class Element {
+      public int position;
+      public Node element;
+
+      public Element(int position, Node element) {
+        this.position = position;
+        this.element = element;
+      }
+    }
+
+    private final MessageInputStream<Node> in;
+    private final Golden golden;
+
+    OrderedStream(Golden golden, MessageInputStream<Node> in) throws IOException {
+      this.in = in;
+      this.golden = golden;
+      processInputFile();
+    }
+
+    // nodes from input that appear in golden, indexed by their position in the golden.
+    PriorityQueue<Element> sameNodes;
+    // nodes in input that are not in the golden, in order received.
+    Queue<Node> uniqueNodes;
+
+    private void processInputFile() throws IOException {
+      sameNodes = new PriorityQueue<>((e1, e2) -> (e1.position - e2.position));
+      uniqueNodes = new ArrayDeque<>();
+
+      Node node;
+      while ((node = in.read()) != null) {
+        int position = golden.positionFor(node);
+        if (position >= 0) {
+          sameNodes.add(new Element(position, node));
+        } else {
+          uniqueNodes.add(node);
+        }
+      }
+    }
+
+    @Override
+    public Node read() {
+      if (sameNodes.isEmpty()) {
+        return uniqueNodes.poll();
+      }
+      return sameNodes.remove().element;
+    }
+
+    @Override
+    public void close() throws IOException {
+      in.close();
+    }
+  }
+
+  public static void output(
+      MessageInputStream<Node> in, OutputStream outStream, OrderedStream.Golden golden)
+      throws IOException {
+    PrintWriter out =
+        new PrintWriter(new BufferedWriter(new OutputStreamWriter(outStream, UTF_8)), true);
+    Node node;
+    while ((node = in.read()) != null) {
+      out.println(node);
+      out.println(DELIMITER);
+      if (golden != null) {
+        golden.addNode(node);
+      }
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    OptionsParser op = OptionsParser.builder().optionsClasses(ParserOptions.class).build();
+    op.parseAndExitUponError(args);
+
+    ParserOptions options = op.getOptions(ParserOptions.class);
+    List<String> remainingArgs = op.getResidue();
+
+    if (!remainingArgs.isEmpty()) {
+      System.err.println("Unexpected options: " + String.join(" ", remainingArgs));
+      System.exit(1);
+    }
+
+    if (options.logPath == null || options.logPath.isEmpty()) {
+      System.err.println("--log_path needs to be specified.");
+      System.exit(1);
+    }
+    if (options.outputPath != null && options.outputPath.size() > options.logPath.size()) {
+      System.err.println("Too many --output_path values.");
+      System.exit(1);
+    }
+
+    String logPath = options.logPath.get(0);
+    String secondPath = null;
+    String output1 = null;
+    String output2 = null;
+
+    if (options.logPath.size() > 1) {
+      if (options.logPath.size() > 2) {
+        System.err.println("Too many --log_path: at most two files are currently supported.");
+        System.exit(1);
+      }
+      secondPath = options.logPath.get(1);
+      if (options.outputPath == null || options.outputPath.size() != 2) {
+        System.err.println(
+            "Exactly two --output_path values expected, one for each of --log_path values.");
+        System.exit(1);
+      }
+      output1 = options.outputPath.get(0);
+      output2 = options.outputPath.get(1);
+    } else {
+      if (options.outputPath != null && !options.outputPath.isEmpty()) {
+        output1 = options.outputPath.get(0);
+      }
+    }
+
+    OrderedStream.Golden golden = null;
+    if (secondPath != null) {
+      golden = new OrderedStream.Golden();
+    }
+
+    try (MessageInputStream<Node> input = getMessageInputStream(logPath)) {
+      FilteredStream parser = new FilteredStream(input, options.restrictToRunner);
+
+      if (output1 == null) {
+        output(parser, System.out, golden);
+      } else {
+        try (OutputStream output = new FileOutputStream(output1)) {
+          output(parser, output, golden);
+        }
+      }
+    }
+
+    if (secondPath != null) {
+      try (MessageInputStream<Node> file2 = getMessageInputStream(secondPath);
+          OutputStream output = new FileOutputStream(output2)) {
+        MessageInputStream<Node> parser = new FilteredStream(file2, options.restrictToRunner);
+        // OrderedStream will read the whole golden on initialization,
+        // so it is safe to close after.
+        parser = new OrderedStream(golden, parser);
+        output(parser, output, null);
+      }
+    }
+  }
+}

--- a/src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph/ParserOptions.java
+++ b/src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph/ParserOptions.java
@@ -1,0 +1,63 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.execgraph;
+
+import com.google.devtools.common.options.Option;
+import com.google.devtools.common.options.OptionDocumentationCategory;
+import com.google.devtools.common.options.OptionEffectTag;
+import com.google.devtools.common.options.OptionsBase;
+import java.util.List;
+
+/** Options for the execution graph log parser. */
+public class ParserOptions extends OptionsBase {
+  @Option(
+      name = "log_path",
+      defaultValue = "null",
+      category = "logging",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      allowMultiple = true,
+      help =
+          "Location of the log file to parse. If a second value is specified, both files will be"
+              + " converted. The first log will be processed as-is. The nodes in the second log"
+              + " will be reordered to match the first. A node will be matched if the first file"
+              + " contains a node with the same description. Any nodes that cannot be matched to"
+              + " the first file will appear at the end of the log. Note that this reordering"
+              + " fascilitates easier text-based comparisons, but may break any logical order of"
+              + " the nodes.")
+  public List<String> logPath;
+
+  @Option(
+      name = "output_path",
+      defaultValue = "null",
+      category = "logging",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      allowMultiple = true,
+      help =
+          "Location where to put the output(s). If left empty, the log will be output to stdout."
+              + " If two log paths are specified, needs to be specified and have exactly two"
+              + " paths.")
+  public List<String> outputPath;
+
+  @Option(
+      name = "restrict_to_runner",
+      defaultValue = "null",
+      category = "logging",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "If set, only output the nodes that used the given runner.")
+  public String restrictToRunner;
+}

--- a/src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph/ParserOptions.java
+++ b/src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph/ParserOptions.java
@@ -18,10 +18,12 @@ import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
 import com.google.devtools.common.options.OptionsBase;
+import com.google.devtools.common.options.OptionsClass;
 import java.util.List;
 
 /** Options for the execution graph log parser. */
-public class ParserOptions extends OptionsBase {
+@OptionsClass
+public abstract class ParserOptions extends OptionsBase {
   @Option(
       name = "log_path",
       defaultValue = "null",
@@ -37,7 +39,9 @@ public class ParserOptions extends OptionsBase {
               + " the first file will appear at the end of the log. Note that this reordering"
               + " fascilitates easier text-based comparisons, but may break any logical order of"
               + " the nodes.")
-  public List<String> logPath;
+  public abstract List<String> getLogPath();
+
+  public abstract void setLogPath(List<String> value);
 
   @Option(
       name = "output_path",
@@ -50,7 +54,9 @@ public class ParserOptions extends OptionsBase {
           "Location where to put the output(s). If left empty, the log will be output to stdout."
               + " If two log paths are specified, needs to be specified and have exactly two"
               + " paths.")
-  public List<String> outputPath;
+  public abstract List<String> getOutputPath();
+
+  public abstract void setOutputPath(List<String> value);
 
   @Option(
       name = "restrict_to_runner",
@@ -59,5 +65,7 @@ public class ParserOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help = "If set, only output the nodes that used the given runner.")
-  public String restrictToRunner;
+  public abstract String getRestrictToRunner();
+
+  public abstract void setRestrictToRunner(String value);
 }

--- a/src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph/ParserOptions.java
+++ b/src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph/ParserOptions.java
@@ -37,11 +37,9 @@ public abstract class ParserOptions extends OptionsBase {
               + " will be reordered to match the first. A node will be matched if the first file"
               + " contains a node with the same description. Any nodes that cannot be matched to"
               + " the first file will appear at the end of the log. Note that this reordering"
-              + " fascilitates easier text-based comparisons, but may break any logical order of"
+              + " facilitates easier text-based comparisons, but may break any logical order of"
               + " the nodes.")
   public abstract List<String> getLogPath();
-
-  public abstract void setLogPath(List<String> value);
 
   @Option(
       name = "output_path",
@@ -56,8 +54,6 @@ public abstract class ParserOptions extends OptionsBase {
               + " paths.")
   public abstract List<String> getOutputPath();
 
-  public abstract void setOutputPath(List<String> value);
-
   @Option(
       name = "restrict_to_runner",
       defaultValue = "null",
@@ -66,6 +62,4 @@ public abstract class ParserOptions extends OptionsBase {
       effectTags = {OptionEffectTag.UNKNOWN},
       help = "If set, only output the nodes that used the given runner.")
   public abstract String getRestrictToRunner();
-
-  public abstract void setRestrictToRunner(String value);
 }

--- a/src/tools/execgraph/test/main/java/com/google/devtools/build/execgraph/BUILD
+++ b/src/tools/execgraph/test/main/java/com/google/devtools/build/execgraph/BUILD
@@ -1,0 +1,32 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = 1,
+    default_visibility = [
+        "//javatests/com/google/devtools/build/lib:__subpackages__",
+        "//src/test/java/com/google/devtools/build/lib:__subpackages__",
+    ],
+)
+
+filegroup(
+    name = "srcs",
+    testonly = 0,
+    srcs = glob(["**"]),
+    visibility = ["//src:__subpackages__"],
+)
+
+java_test(
+    name = "ExecGraphParserTest",
+    size = "small",
+    srcs = ["ExecGraphParserTest.java"],
+    test_class = "com.google.devtools.build.execgraph.ExecGraphParserTest",
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/util/io:io-proto",
+        "//src/main/protobuf:execution_graph_java_proto",
+        "//src/tools/execgraph/src/main/java/com/google/devtools/build/execgraph:parser",
+        "//third_party:junit4",
+        "//third_party:truth",
+        "@zstd-jni",
+    ],
+)

--- a/src/tools/execgraph/test/main/java/com/google/devtools/build/execgraph/ExecGraphParserTest.java
+++ b/src/tools/execgraph/test/main/java/com/google/devtools/build/execgraph/ExecGraphParserTest.java
@@ -1,0 +1,233 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.execgraph;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.github.luben.zstd.ZstdOutputStream;
+import com.google.devtools.build.execgraph.ExecGraphParser.FilteredStream;
+import com.google.devtools.build.execgraph.ExecGraphParser.OrderedStream;
+import com.google.devtools.build.lib.actions.ExecutionGraph.Node;
+import com.google.devtools.build.lib.util.io.MessageInputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Testing ExecGraphParser */
+@RunWith(JUnit4.class)
+public final class ExecGraphParserTest {
+
+  @Test
+  public void readsZstdCompressedNodes() throws Exception {
+    var path = Files.createTempFile("execgraph", ".tmp");
+    try (var out = new ZstdOutputStream(Files.newOutputStream(path))) {
+      Node.newBuilder().setDescription("action a").setMnemonic("Javac").build().writeDelimitedTo(out);
+      Node.newBuilder().setDescription("action b").setMnemonic("CppCompile").build()
+          .writeDelimitedTo(out);
+    }
+
+    try (var stream = ExecGraphParser.getMessageInputStream(path.toString())) {
+      assertThat(stream.read())
+          .isEqualTo(Node.newBuilder().setDescription("action a").setMnemonic("Javac").build());
+      assertThat(stream.read())
+          .isEqualTo(
+              Node.newBuilder().setDescription("action b").setMnemonic("CppCompile").build());
+      assertThat(stream.read()).isNull();
+    }
+  }
+
+  @Test
+  public void readEmpty() throws Exception {
+    FilteredStream p = new FilteredStream(new FakeStream(new ArrayList<Node>()), null);
+    assertThat(p.read()).isNull();
+  }
+
+  @Test
+  public void readEmptyWithRunner() throws Exception {
+    FilteredStream p = new FilteredStream(new FakeStream(new ArrayList<Node>()), "local");
+    assertThat(p.read()).isNull();
+  }
+
+  @Test
+  public void readSingleNode() throws Exception {
+    Node e = Node.newBuilder().setRunner("runs").setDescription("command").build();
+    FilteredStream p = new FilteredStream(new FakeStream(Arrays.asList(e)), null);
+    assertThat(p.read()).isEqualTo(e);
+    assertThat(p.read()).isNull();
+  }
+
+  @Test
+  public void readSingleNodeRunnerMatch() throws Exception {
+    Node e = Node.newBuilder().setRunner("runs").setDescription("command").build();
+    FilteredStream p = new FilteredStream(new FakeStream(Arrays.asList(e)), "runs");
+    assertThat(p.read()).isEqualTo(e);
+    assertThat(p.read()).isNull();
+  }
+
+  @Test
+  public void readSingleNodeRunnerNoMatch() throws Exception {
+    Node e = Node.newBuilder().setRunner("runs").setDescription("command").build();
+    FilteredStream p = new FilteredStream(new FakeStream(Arrays.asList(e)), "run");
+    assertThat(p.read()).isNull();
+  }
+
+  @Test
+  public void readManyMatches() throws Exception {
+    Node e = Node.newBuilder().setRunner("run1").setDescription("com1").build();
+    Node e2 = Node.newBuilder().setRunner("r").setDescription("com2").build();
+    Node e3 = Node.newBuilder().setRunner("run1").setDescription("com3").build();
+    Node e4 = Node.newBuilder().setRunner("run1").setDescription("com4").build();
+    Node e5 = Node.newBuilder().setRunner("ru").setDescription("com5").build();
+    FilteredStream p = new FilteredStream(new FakeStream(Arrays.asList(e, e2, e3, e4, e5)), "run1");
+    assertThat(p.read()).isEqualTo(e);
+    assertThat(p.read()).isEqualTo(e3);
+    assertThat(p.read()).isEqualTo(e4);
+    assertThat(p.read()).isNull();
+  }
+
+  @Test
+  public void readManyButNoMatch() throws Exception {
+    Node e = Node.newBuilder().setRunner("run1").setDescription("com1").build();
+    Node e2 = Node.newBuilder().setRunner("r").setDescription("com2").build();
+    Node e3 = Node.newBuilder().setRunner("run1").setDescription("com3").build();
+    FilteredStream p = new FilteredStream(new FakeStream(Arrays.asList(e, e2, e3)), "none");
+    assertThat(p.read()).isNull();
+  }
+
+  @Test
+  public void readManyNoMatcher() throws Exception {
+    Node e = Node.newBuilder().setRunner("run1").setDescription("com1").build();
+    Node e2 = Node.newBuilder().setRunner("r").setDescription("com2").build();
+    Node e3 = Node.newBuilder().setRunner("run1").setDescription("com3").build();
+    FilteredStream p = new FilteredStream(new FakeStream(Arrays.asList(e, e2, e3)), null);
+    assertThat(p.read()).isEqualTo(e);
+    assertThat(p.read()).isEqualTo(e2);
+    assertThat(p.read()).isEqualTo(e3);
+    assertThat(p.read()).isNull();
+  }
+
+  private static class FakeStream implements MessageInputStream<Node> {
+    List<Node> inputs;
+    int i;
+
+    public FakeStream(List<Node> ex) {
+      this.inputs = ex;
+      i = 0;
+    }
+
+    @Override
+    public Node read() {
+      if (i >= inputs.size()) {
+        return null;
+      }
+      return inputs.get(i++);
+    }
+
+    @Override
+    public void close() {}
+  }
+
+  public static FakeStream fakeParserFromStrings(List<String> strings) {
+    ArrayList<Node> ins = new ArrayList<>(strings.size());
+    for (String s : strings) {
+      ins.add(Node.newBuilder().setDescription(s).setMnemonic(s).build());
+    }
+    return new FakeStream(ins);
+  }
+
+  public static OrderedStream.Golden getGolden(List<String> keys) {
+    OrderedStream.Golden result = new OrderedStream.Golden();
+    for (String s : keys) {
+      result.addNode(Node.newBuilder().setDescription(s).build());
+    }
+    return result;
+  }
+
+  public void test(List<String> golden, List<String> input, List<String> expectedOutput)
+      throws Exception {
+    OrderedStream p = new OrderedStream(getGolden(golden), fakeParserFromStrings(input));
+
+    List<String> got = new ArrayList<>();
+
+    Node node;
+    while ((node = p.read()) != null) {
+      got.add(node.getDescription());
+    }
+
+    assertThat(got).containsExactlyElementsIn(expectedOutput).inOrder();
+  }
+
+  @Test
+  public void reorderSimple() throws Exception {
+    test(Arrays.asList("a", "b"), Arrays.asList("b", "a"), Arrays.asList("a", "b"));
+  }
+
+  @Test
+  public void noReorderSimple() throws Exception {
+    test(Arrays.asList("a", "b"), Arrays.asList("a", "b"), Arrays.asList("a", "b"));
+  }
+
+  @Test
+  public void extraElement1() throws Exception {
+    test(Arrays.asList("a", "b"), Arrays.asList("c", "b", "a"), Arrays.asList("a", "b", "c"));
+  }
+
+  @Test
+  public void reorderExtraElement2() throws Exception {
+    test(Arrays.asList("a", "b"), Arrays.asList("b", "c", "a"), Arrays.asList("a", "b", "c"));
+  }
+
+  @Test
+  public void reorderMissingElement2() throws Exception {
+    test(Arrays.asList("a", "b"), Arrays.asList("b"), Arrays.asList("b"));
+  }
+
+  @Test
+  public void reorderLongMisc() throws Exception {
+    test(
+        Arrays.asList("a", "b", "c", "d"),
+        Arrays.asList("y", "c", "b", "d", "x"),
+        Arrays.asList("b", "c", "d", "y", "x"));
+  }
+
+  @Test
+  public void reorderNothingThere() throws Exception {
+    test(
+        Arrays.asList("a", "b", "c", "d"),
+        Arrays.asList("x", "y", "z"),
+        Arrays.asList("x", "y", "z"));
+  }
+
+  @Test
+  public void reorderPreservesInformation() throws Exception {
+    List<String> golden = Arrays.asList("a", "b");
+
+    // Include extra fields not present in golden.
+    Node a = Node.newBuilder().setDescription("a").setMnemonic("acom").build();
+    Node b = Node.newBuilder().setDescription("b").setMnemonic("bcom").build();
+    Node c = Node.newBuilder().setDescription("c").setMnemonic("ccom").build();
+    MessageInputStream<Node> input = new FakeStream(Arrays.asList(c, b, a));
+
+    OrderedStream p = new OrderedStream(getGolden(golden), input);
+
+    assertThat(p.read()).isEqualTo(a);
+    assertThat(p.read()).isEqualTo(b);
+    assertThat(p.read()).isEqualTo(c);
+    assertThat(p.read()).isNull();
+  }
+}

--- a/src/tools/execgraph/test/main/java/com/google/devtools/build/execgraph/ExecGraphParserTest.java
+++ b/src/tools/execgraph/test/main/java/com/google/devtools/build/execgraph/ExecGraphParserTest.java
@@ -36,8 +36,15 @@ public final class ExecGraphParserTest {
   public void readsZstdCompressedNodes() throws Exception {
     var path = Files.createTempFile("execgraph", ".tmp");
     try (var out = new ZstdOutputStream(Files.newOutputStream(path))) {
-      Node.newBuilder().setDescription("action a").setMnemonic("Javac").build().writeDelimitedTo(out);
-      Node.newBuilder().setDescription("action b").setMnemonic("CppCompile").build()
+      Node.newBuilder()
+          .setDescription("action a")
+          .setMnemonic("Javac")
+          .build()
+          .writeDelimitedTo(out);
+      Node.newBuilder()
+          .setDescription("action b")
+          .setMnemonic("CppCompile")
+          .build()
           .writeDelimitedTo(out);
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description

Provide a simple tool to parse/convert generated execution graph log files ([`--experimental_execution_graph_log_path`](https://bazel.build/advanced/performance/build-performance-metrics#execution-graph-log)) into text files in a very similar manner to the [existing execution log parser tool](https://github.com/alexander-scott/bazel/tree/master/src/tools/execlog).

### Motivation

I would like an easy means to make the generated execution graph log files human readable. The execution log files already have a way, why not also for the execution graph log?

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Provide a tool to parse and covert generated execution graph log files.
