### PR TITLE
[9.2.0] Fix race in DynamicConnectionPool. (https://github.com/bazelbuild/bazel/pull/29693)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/grpc/DynamicConnectionPool.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/grpc/DynamicConnectionPool.java
@@ -82,16 +82,16 @@ public class DynamicConnectionPool implements ConnectionPool {
    * has available connections, and the number of factories is less than {@link #maxConnections}, it
    * will create a new {@link SharedConnectionFactory}.
    */
-  private SharedConnectionFactory nextAvailableFactory() {
+  private Single<SharedConnection> createConnection() {
     if (closed.get()) {
       throw new IllegalStateException("closed");
     }
 
     synchronized (this) {
       for (int times = 0; times < factories.size(); ++times) {
-        SharedConnectionFactory factory = nextFactory();
-        if (factory.numAvailableConnections() > 0) {
-          return factory;
+        Single<SharedConnection> connection = nextFactory().tryCreate();
+        if (connection != null) {
+          return connection;
         }
       }
 
@@ -99,19 +99,15 @@ public class DynamicConnectionPool implements ConnectionPool {
         SharedConnectionFactory factory =
             new SharedConnectionFactory(connectionFactory, maxConcurrencyPerConnection);
         factories.add(factory);
-        return factory;
+        return factory.tryCreate();
       } else {
-        return nextFactory();
+        return nextFactory().create();
       }
     }
   }
 
   @Override
   public Single<SharedConnection> create() {
-    return Single.defer(
-        () -> {
-          SharedConnectionFactory factory = nextAvailableFactory();
-          return factory.create();
-        });
+    return Single.defer(this::createConnection);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/grpc/SharedConnectionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/grpc/SharedConnectionFactory.java
@@ -123,24 +123,38 @@ public class SharedConnectionFactory implements ConnectionPool {
    */
   @Override
   public Single<SharedConnection> create() {
-    return tokenBucket
-        .acquireToken()
-        .flatMap(
-            token ->
-                acquireConnection()
-                    .doOnError(ignored -> tokenBucket.addToken(token))
-                    .doOnDispose(() -> tokenBucket.addToken(token))
-                    .map(
-                        conn ->
-                            new SharedConnection(
-                                conn,
-                                /* onClose= */ () -> tokenBucket.addToken(token),
-                                fatalErrorPredicate,
-                                /* onFatalError= */ () -> {
-                                  synchronized (this) {
-                                    connectionAsyncSubject = null;
-                                  }
-                                })));
+    return tokenBucket.acquireToken().flatMap(this::createWithToken);
+  }
+
+  /**
+   * Non-blocking variant of {@link #create()} that eagerly reserves a permit, returning {@code
+   * null} if the connection is at capacity. The returned {@link Single} must be subscribed, or the
+   * reserved permit leaks.
+   */
+  @Nullable
+  Single<SharedConnection> tryCreate() {
+    Integer token = tokenBucket.tryAcquireToken();
+    if (token == null) {
+      return null;
+    }
+    return Single.defer(() -> createWithToken(token));
+  }
+
+  private Single<SharedConnection> createWithToken(int token) {
+    return acquireConnection()
+        .doOnError(ignored -> tokenBucket.addToken(token))
+        .doOnDispose(() -> tokenBucket.addToken(token))
+        .map(
+            conn ->
+                new SharedConnection(
+                    conn,
+                    /* onClose= */ () -> tokenBucket.addToken(token),
+                    fatalErrorPredicate,
+                    /* onFatalError= */ () -> {
+                      synchronized (this) {
+                        connectionAsyncSubject = null;
+                      }
+                    }));
   }
 
   /** Returns current number of available connections. */

--- a/src/main/java/com/google/devtools/build/lib/remote/grpc/TokenBucket.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/grpc/TokenBucket.java
@@ -24,6 +24,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import javax.annotation.Nullable;
 
 /** A container for tokens which is used for rate limiting. */
 @ThreadSafe
@@ -53,6 +54,11 @@ public class TokenBucket<T> implements Closeable {
   /** Returns current number of tokens in the bucket. */
   public int size() {
     return tokens.size();
+  }
+
+  @Nullable
+  public T tryAcquireToken() {
+    return tokens.pollFirst();
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/remote/grpc/DynamicConnectionPoolTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/grpc/DynamicConnectionPoolTest.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.remote.grpc;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -24,6 +25,9 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -157,6 +161,39 @@ public class DynamicConnectionPoolTest {
 
     observer1.assertValue(conn -> conn.getUnderlyingConnection() == connection0).assertComplete();
     assertThat(connectionFactoryCreateTimes.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void create_concurrent_neverCollidesOnSameConnection() throws Exception {
+    int n = 200;
+    ConnectionFactory factory = mock(ConnectionFactory.class);
+    Connection connection = mock(Connection.class);
+    when(factory.create()).thenAnswer(invocation -> Single.just(connection));
+    DynamicConnectionPool pool =
+        new DynamicConnectionPool(factory, /* maxConcurrencyPerConnection= */ 1);
+
+    CountDownLatch ready = new CountDownLatch(n);
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch acquired = new CountDownLatch(n);
+    ExecutorService exec = Executors.newFixedThreadPool(n);
+    for (int i = 0; i < n; i++) {
+      exec.execute(
+          () -> {
+            ready.countDown();
+            try {
+              start.await();
+            } catch (InterruptedException e) {
+              return;
+            }
+            var unused = pool.create().subscribe(c -> acquired.countDown(), e -> {});
+          });
+    }
+    ready.await();
+    start.countDown();
+
+    boolean allAcquired = acquired.await(10, SECONDS);
+    exec.shutdownNow();
+    assertThat(allAcquired).isTrue();
   }
 
   @Test


### PR DESCRIPTION
numAvailableConnections() is called under lock but the connection creation happens outside of the lock so it's possible for the remote_max_concurrency_per_connection number of rpcs per connection to be exceeded.

This change makes the token acquisition happen under lock, while deferring the connection creation.

Closes #29693.

PiperOrigin-RevId: 926053103
Change-Id: I8cacb67ef7be1ffb338a7880d084b83074974914

Commit https://github.com/bazelbuild/bazel/commit/283438afca2f38f90b71d2146f126b788c30881e