### PR TITLE
startup: clarify macOS QoS values

### DIFF
--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -312,9 +312,11 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(const string& argstr,
              nullptr) {
     // We parse the value of this flag on all platforms even if it is
     // macOS-specific to ensure that rc files mentioning it are valid.
-    // There is also apparently "QOS_CLASS_MAINTENANCE", but this doesn't
-    // appear to have been exposed in the public headers as of macOS 11.1.
-    if (strcmp(value, "utility") == 0) {
+    if (strcmp(value, "default") == 0) {
+#if defined(__APPLE__)
+      macos_qos_class = QOS_CLASS_UNSPECIFIED;
+#endif
+    } else if (strcmp(value, "utility") == 0) {
 #if defined(__APPLE__)
       macos_qos_class = QOS_CLASS_UTILITY;
 #endif

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -312,6 +312,8 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(const string& argstr,
              nullptr) {
     // We parse the value of this flag on all platforms even if it is
     // macOS-specific to ensure that rc files mentioning it are valid.
+    // There is also apparently "QOS_CLASS_MAINTENANCE", but this doesn't
+    // appear to have been exposed in the public headers as of macOS 11.1.
     if (strcmp(value, "default") == 0) {
 #if defined(__APPLE__)
       macos_qos_class = QOS_CLASS_UNSPECIFIED;

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
@@ -463,8 +463,10 @@ public abstract class BlazeServerStartupOptions extends OptionsBase {
       help =
           "Sets the QoS service class of the %{product} server when running on macOS. This "
               + "flag has no effect on all other platforms but is supported to ensure rc files "
-              + "can be shared among them without changes. Possible values are: user-interactive, "
-              + "user-initiated, default, utility, and background.")
+              + "can be shared among them without changes. Possible values are: default (leave "
+              + "QoS unchanged), utility, and background. Only utility and background request "
+              + "a macOS process QoS class because Apple's posix_spawnattr_set_qos_class_np API "
+              + "does not accept user-interactive or user-initiated for spawned processes.")
   public abstract String getMacosQosClass();
 
   @Option(

--- a/src/test/cpp/bazel_startup_options_test.cc
+++ b/src/test/cpp/bazel_startup_options_test.cc
@@ -18,6 +18,8 @@
 
 #include <algorithm>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "src/main/cpp/blaze_util_platform.h"
 #include "src/main/cpp/util/file_platform.h"
@@ -265,6 +267,31 @@ TEST_F(BazelStartupOptionsTest, ValidStartupFlags) {
   ExpectIsUnaryOption(options, "output_base");
   ExpectIsUnaryOption(options, "output_user_root");
   ExpectIsUnaryOption(options, "server_javabase");
+}
+
+TEST_F(BazelStartupOptionsTest, MacosQosClassValues) {
+  for (const std::string qos_class : {"default", "utility", "background"}) {
+    ReinitStartupOptions();
+    std::string error;
+    const std::vector<RcStartupFlag> flags{
+        RcStartupFlag("somewhere", "--macos_qos_class=" + qos_class)};
+
+    EXPECT_EQ(blaze_exit_code::SUCCESS,
+              startup_options_->ProcessArgs(flags, &error))
+        << error;
+  }
+
+  for (const std::string qos_class : {"user-interactive", "user-initiated"}) {
+    ReinitStartupOptions();
+    std::string error;
+    const std::vector<RcStartupFlag> flags{
+        RcStartupFlag("somewhere", "--macos_qos_class=" + qos_class)};
+
+    EXPECT_EQ(blaze_exit_code::BAD_ARGV,
+              startup_options_->ProcessArgs(flags, &error));
+    EXPECT_EQ("Invalid argument to --macos_qos_class: '" + qos_class + "'.",
+              error);
+  }
 }
 
 TEST_F(BazelStartupOptionsTest, BlazercFlagsAreNotAccepted) {

--- a/src/test/shell/integration/client_test.sh
+++ b/src/test/shell/integration/client_test.sh
@@ -738,7 +738,7 @@ function test_proxy_settings() {
 }
 
 function test_macos_qos_class() {
-  for class in utility background; do
+  for class in default utility background; do
     bazel --macos_qos_class="${class}" info >"${TEST_log}" 2>&1 \
       || fail "Unknown QoS class ${class}"
     # On macOS it'd be nice to verify that the server is indeed running at the
@@ -748,7 +748,7 @@ function test_macos_qos_class() {
     # real thing would be quite expensive.
   done
 
-  for class in user-interactive user-initiated default ; do
+  for class in user-interactive user-initiated ; do
     bazel --macos_qos_class="${class}" >"${TEST_log}" 2>&1 \
       && fail "Expected failure with invalid QoS class name"
     expect_log "Invalid argument.*qos_class.*${class}"


### PR DESCRIPTION
Users report that documented --macos_qos_class values such as
user-initiated and user-interactive are rejected even though those
names are valid macOS QoS classes.  This is confusing for IDE and
Xcode-driven builds where foreground Bazel work can directly affect
user interaction latency through BSP or language-server requests.

The startup flag does not use a general-purpose thread QoS API.  It
uses Apple's posix_spawnattr_set_qos_class_np process-spawn API, which
documents only QOS_CLASS_UTILITY and QOS_CLASS_BACKGROUND as accepted
values for spawned processes.  Older Bazel code tried to pass every
public QoS class, but 688a2376d9 fixed #13291 after finding that the
spawn API rejected several values and Bazel was handling the errno
return incorrectly.

Keep user-initiated and user-interactive unavailable for this flag, and
document why they are not valid here.  Treat default as
QOS_CLASS_UNSPECIFIED so shared bazelrc files can explicitly select the
normal behavior without passing QOS_CLASS_DEFAULT to the spawn API.

This does not rule out a future IDE-focused mechanism for foreground
Bazel work.  The macOS/Xcode responsiveness and performance tradeoffs
discussed in #7446 and #7682 still apply, but supporting user-initiated
work needs a different implementation path, such as server-side or
per-thread QoS, rather than this process-level spawn clamp.

macOS-QoS-Docs: https://developer.apple.com/documentation/dispatch/dispatchqos/qosclass
macOS-Spawn-QoS-Header: https://github.com/apple-oss-distributions/libpthread/blob/main/include/pthread/spawn.h