### PR TITLE
singlejar: bounds-check untrusted local header offset and entry size

### DIFF
--- a/src/tools/singlejar/input_jar.h
+++ b/src/tools/singlejar/input_jar.h
@@ -98,19 +98,20 @@ class InputJar {
   }
 
   const LH* LocalHeader(const CDH* cdh) const {
-    const unsigned char* addr =
-        mapped_file_.address(cdh->local_header_offset() + preamble_size_);
     // local_header_offset() comes from the untrusted central-directory record.
-    // The fixed part of the local header must be mapped before we can read the
-    // variable-length name/extra-field lengths it declares.
-    if (!mapped_file_.mapped(addr) ||
-        !mapped_file_.mapped(addr + sizeof(LH) - 1)) {
+    // Validate it in offset space so we never form an out-of-bounds pointer.
+    const uint64_t offset = cdh->local_header_offset() + preamble_size_;
+    const uint64_t mapped_size =
+        static_cast<uint64_t>(mapped_file_.end() - mapped_file_.start());
+    // The fixed part of the local header must fit, so the variable-length
+    // file-name and extra-field lengths it declares are readable.
+    if (offset > mapped_size || sizeof(LH) > mapped_size - offset) {
       return nullptr;
     }
-    const LH* lh = reinterpret_cast<const LH*>(addr);
-    // The whole local header (fixed part + file name + extra fields) must be
-    // mapped too.
-    if (!mapped_file_.mapped(addr + lh->size() - 1)) {
+    const LH* lh = reinterpret_cast<const LH*>(
+        mapped_file_.address(static_cast<off64_t>(offset)));
+    // The whole local header (fixed part + file name + extra fields) must fit.
+    if (lh->size() > mapped_size - offset) {
       return nullptr;
     }
     return lh;

--- a/src/tools/singlejar/input_jar.h
+++ b/src/tools/singlejar/input_jar.h
@@ -81,6 +81,12 @@ class InputJar {
     }
     cdh_ = reinterpret_cast<const CDH*>(new_cdr);
     *local_header_ptr = LocalHeader(current_cdh);
+    if (*local_header_ptr == nullptr) {
+      diag_errx(1,
+                "Invalid local header offset 0x%" PRIx64 " in %s",
+                static_cast<uint64_t>(current_cdh->local_header_offset()),
+                path_.c_str());
+    }
     return current_cdh;
   }
 
@@ -92,8 +98,22 @@ class InputJar {
   }
 
   const LH* LocalHeader(const CDH* cdh) const {
-    return reinterpret_cast<const LH*>(
-        mapped_file_.address(cdh->local_header_offset() + preamble_size_));
+    const unsigned char* addr =
+        mapped_file_.address(cdh->local_header_offset() + preamble_size_);
+    // local_header_offset() comes from the untrusted central-directory record.
+    // The fixed part of the local header must be mapped before we can read the
+    // variable-length name/extra-field lengths it declares.
+    if (!mapped_file_.mapped(addr) ||
+        !mapped_file_.mapped(addr + sizeof(LH) - 1)) {
+      return nullptr;
+    }
+    const LH* lh = reinterpret_cast<const LH*>(addr);
+    // The whole local header (fixed part + file name + extra fields) must be
+    // mapped too.
+    if (!mapped_file_.mapped(addr + lh->size() - 1)) {
+      return nullptr;
+    }
+    return lh;
   }
 
   uint64_t LocalHeaderOffset(const LH* lh) const {
@@ -101,6 +121,7 @@ class InputJar {
   }
 
   const uint8_t* mapped_start() const { return mapped_file_.address(0); }
+  const uint8_t* mapped_end() const { return mapped_file_.end(); }
 
  private:
   bool LocateCentralDirectory(const std::string& path);

--- a/src/tools/singlejar/output_jar.cc
+++ b/src/tools/singlejar/output_jar.cc
@@ -659,6 +659,18 @@ bool OutputJar::AddJar(int jar_path_index) {
       }
     }
 
+    // copy_from and num_bytes derive from untrusted local-header / central-
+    // directory size fields. Make sure the range we are about to read lies
+    // entirely within the mapped input archive before copying it.
+    const size_t input_mapped_size =
+        input_jar.mapped_end() - input_jar.mapped_start();
+    if (copy_from < 0 || static_cast<size_t>(copy_from) > input_mapped_size ||
+        num_bytes > input_mapped_size - static_cast<size_t>(copy_from)) {
+      diag_errx(1, "%s:%d: entry %.*s extends past the end of archive %s",
+                __FILE__, __LINE__, file_name_length, file_name,
+                input_jar_path.c_str());
+    }
+
     // Do the actual copy.
     if (!WriteBytes(input_jar.mapped_start() + copy_from, num_bytes)) {
       diag_err(1, "%s:%d: Cannot write %zu bytes of %.*s from %s", __FILE__,

--- a/src/tools/singlejar/output_jar.cc
+++ b/src/tools/singlejar/output_jar.cc
@@ -660,19 +660,25 @@ bool OutputJar::AddJar(int jar_path_index) {
     }
 
     // copy_from and num_bytes derive from untrusted local-header / central-
-    // directory size fields. Make sure the range we are about to read lies
-    // entirely within the mapped input archive before copying it.
+    // directory size fields. Convert the offset once and make sure the range
+    // we are about to read lies entirely within the mapped input archive.
+    if (copy_from < 0) {
+      diag_errx(1, "%s:%d: entry %.*s has a negative local header offset in %s",
+                __FILE__, __LINE__, file_name_length, file_name,
+                input_jar_path.c_str());
+    }
+    const size_t copy_from_offset = static_cast<size_t>(copy_from);
     const size_t input_mapped_size =
         input_jar.mapped_end() - input_jar.mapped_start();
-    if (copy_from < 0 || static_cast<size_t>(copy_from) > input_mapped_size ||
-        num_bytes > input_mapped_size - static_cast<size_t>(copy_from)) {
+    if (copy_from_offset > input_mapped_size ||
+        num_bytes > input_mapped_size - copy_from_offset) {
       diag_errx(1, "%s:%d: entry %.*s extends past the end of archive %s",
                 __FILE__, __LINE__, file_name_length, file_name,
                 input_jar_path.c_str());
     }
 
     // Do the actual copy.
-    if (!WriteBytes(input_jar.mapped_start() + copy_from, num_bytes)) {
+    if (!WriteBytes(input_jar.mapped_start() + copy_from_offset, num_bytes)) {
       diag_err(1, "%s:%d: Cannot write %zu bytes of %.*s from %s", __FILE__,
                __LINE__, num_bytes, file_name_length, file_name,
                input_jar_path.c_str());


### PR DESCRIPTION
### Problem

`singlejar` reads each input jar through `InputJar`. Two reads trust offset/size fields taken from the archive without checking they stay inside the mapped file:

- `InputJar::LocalHeader()` (`input_jar.h`) builds an `LH*` from the central-directory `local_header_offset()` field with no bounds check. The sibling `NextEntry()` validates the next central-directory record with `mapped_file_.mapped(...)`, but the local-header pointer it returns is not validated. `OutputJar::AddJar()` then reads `lh->size()` and the variable-length name / extra-field lengths it depends on from that pointer.
- `OutputJar::AddJar()` (`output_jar.cc`) copies `num_bytes` starting at `copy_from = local_header_offset()` into the output with `WriteBytes(input_jar.mapped_start() + copy_from, num_bytes)`, where `num_bytes` includes the entry's declared compressed size. Neither `copy_from` nor `num_bytes` is checked against the mapped size.

A crafted jar whose central directory points `local_header_offset` past the end of the file, or whose entry declares a compressed size larger than the file, drives an out-of-bounds read. Built with AddressSanitizer the first lands as a `heap-buffer-overflow` read inside `LH::file_name_length()` / `LH::size()`; the second inside the entry copy.

### Fix

- `LocalHeader()` now checks that the fixed part of the local header is mapped before reading the name / extra-field lengths it declares, then checks the full header is mapped, returning `nullptr` otherwise. `NextEntry()` reports a bad local-header offset the same way it already reports a bad central-directory record.
- `AddJar()` checks that `[copy_from, copy_from + num_bytes)` lies entirely within the mapped input before the copy.

### Testing

A standalone harness that drives the existing `InputJar` / `AddJar` read sequence over a malformed jar reproduced both out-of-bounds reads under ASAN before the change, and rejects the two entries as out of range (no ASAN error, clean diagnostic) after it.
