### PR TITLE
ijar: bound constant-pool reads against the class data

### DIFF
--- a/third_party/ijar/classfile.cc
+++ b/third_party/ijar/classfile.cc
@@ -1450,7 +1450,7 @@ struct ClassFile : HasAttrs {
 
   void WriteClass(u1 *&p);
 
-  bool ReadConstantPool(const u1 *&p);
+  bool ReadConstantPool(const u1 *&p, const u1 *end);
 
   bool KeepForCompile();
 
@@ -1621,13 +1621,15 @@ void HasAttrs::WriteAttrs(u1 *&p) {
 }
 
 // See sec.4.4 of JVM spec.
-bool ClassFile::ReadConstantPool(const u1 *&p) {
+bool ClassFile::ReadConstantPool(const u1 *&p, const u1 *end) {
 
   const_pool_in.clear();
   const_pool_in.push_back(NULL); // dummy first item
 
   u2 cp_count = get_u2be(p);
   for (int ii = 1; ii < cp_count; ++ii) {
+    // Each constant needs at least its one-byte tag inside the class data.
+    if (p >= end) return false;
     u1 tag = get_u1(p);
 
     if (devtools_ijar::verbose) {
@@ -1662,6 +1664,11 @@ bool ClassFile::ReadConstantPool(const u1 *&p) {
       }
       case CONSTANT_Utf8: {
         u2 length = get_u2be(p);
+        // length comes from the class file; the string body must stay within
+        // the class data.
+        if (p > end || length > static_cast<size_t>(end - p)) {
+          return false;
+        }
         if (devtools_ijar::verbose) {
           fprintf(stderr, "Utf8: \"%s\" (%d)\n",
                   std::string((const char*) p, length).c_str(), length);
@@ -1769,7 +1776,7 @@ static ClassFile *ReadClass(const void *classdata, size_t length) {
   clazz->major = get_u2be(p);
   clazz->minor = get_u2be(p);
 
-  if (!clazz->ReadConstantPool(p)) {
+  if (!clazz->ReadConstantPool(p, static_cast<const u1 *>(classdata) + length)) {
     delete clazz;
     return NULL;
   }

--- a/third_party/ijar/classfile.cc
+++ b/third_party/ijar/classfile.cc
@@ -1621,16 +1621,55 @@ void HasAttrs::WriteAttrs(u1 *&p) {
 }
 
 // See sec.4.4 of JVM spec.
+// Number of fixed operand bytes that follow the one-byte tag of a constant
+// pool entry. The CONSTANT_Utf8 body is variable and is range-checked in its
+// own case. Returns 0 for unknown tags, which ReadConstantPool rejects.
+static size_t ConstantOperandSize(u1 tag) {
+  switch (tag) {
+    case CONSTANT_Utf8:  // 2-byte length; the body is checked separately
+    case CONSTANT_Class:
+    case CONSTANT_String:
+    case CONSTANT_MethodType:
+      return 2;
+    case CONSTANT_MethodHandle:
+      return 3;
+    case CONSTANT_FieldRef:
+    case CONSTANT_Methodref:
+    case CONSTANT_Interfacemethodref:
+    case CONSTANT_Integer:
+    case CONSTANT_Float:
+    case CONSTANT_NameAndType:
+    case CONSTANT_Dynamic:
+    case CONSTANT_InvokeDynamic:
+      return 4;
+    case CONSTANT_Long:
+    case CONSTANT_Double:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
 bool ClassFile::ReadConstantPool(const u1 *&p, const u1 *end) {
 
   const_pool_in.clear();
   const_pool_in.push_back(NULL); // dummy first item
 
+  // The constant pool count is the first two bytes of the pool.
+  if (end - p < 2) {
+    return false;
+  }
   u2 cp_count = get_u2be(p);
   for (int ii = 1; ii < cp_count; ++ii) {
     // Each constant needs at least its one-byte tag inside the class data.
     if (p >= end) return false;
     u1 tag = get_u1(p);
+
+    // The fixed operand bytes that follow the tag must also be inside the
+    // class data before any of the case bodies below read them.
+    if (static_cast<size_t>(end - p) < ConstantOperandSize(tag)) {
+      return false;
+    }
 
     if (devtools_ijar::verbose) {
       fprintf(stderr, "cp[%d/%d] = tag %d\n", ii, cp_count, tag);


### PR DESCRIPTION
### Problem

`ijar` strips class files via `StripClass()` -> `ReadClass()` -> `ClassFile::ReadConstantPool()`. The constant-pool reader walks the class with `get_u1` / `get_u2be` and friends (`common.h`), which advance a `const u1*` with no bounds check. The `length` argument to `ReadClass(classdata, length)` is stored but never used to bound the walk.

A truncated or crafted class drives out-of-bounds reads:

- the per-constant tag read `get_u1(p)` at the top of the loop runs past the end of the class data;
- a `CONSTANT_Utf8` entry declares a `length` (up to 65535) larger than the remaining bytes; the body pointer and length are stored and later copied into the output by `put_n`, leaking adjacent memory into the stripped jar.

Built with AddressSanitizer, the tag read lands as a `heap-buffer-overflow` in `get_u1` (`common.h:40`) called from `ReadConstantPool` (`classfile.cc:1631`).

### Fix

Pass the end of the class data into `ReadConstantPool`. Refuse a constant whose one-byte tag is already at or past the end, and refuse a `CONSTANT_Utf8` whose declared body would extend past the end (this also bounds the verbose-mode `std::string` that prints the body). On rejection `ReadClass` returns `NULL` and `StripClass` copies the class through unchanged, as it already does for other malformed classes.

### Testing

A harness that drives `StripClass()` over a truncated class reproduced the out-of-bounds read under ASAN before the change and returns cleanly (class passed through unstripped) after it.
