### PR TITLE
Fix remote repo content caching for non-gRPC backends

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -334,6 +334,44 @@ public final class RemoteModule extends BlazeModule {
         outputPermissions);
   }
 
+  /**
+   * Initializes the repository remote helpers factory and primes the {@link
+   * RemoteExternalOverlayFileSystem} (when one is in use) with the per-build state it needs.
+   */
+  private void initRepoHelpersAndOverlayFs(
+      CommandEnvironment env, String buildRequestId, String invocationId, boolean verboseFailures) {
+    if (actionContextProvider == null) {
+      return;
+    }
+    CombinedCache combinedCache = actionContextProvider.getCombinedCache();
+    if (combinedCache == null) {
+      return;
+    }
+    repositoryRemoteHelpersFactoryDelegate.init(
+        new RepositoryRemoteHelpersFactoryImpl(
+            env.getDirectories(),
+            combinedCache,
+            actionContextProvider.getRemoteExecutionClient(),
+            buildRequestId,
+            invocationId,
+            env.getWorkspaceName(),
+            remoteOptions.getRemoteInstanceName(),
+            remoteOptions.getRemoteAcceptCached(),
+            remoteOptions.getRemoteUploadLocalResults(),
+            verboseFailures));
+    if (env.getDirectories().getOutputBase().getFileSystem()
+        instanceof RemoteExternalOverlayFileSystem remoteFs) {
+      remoteFs.beforeCommand(
+          combinedCache,
+          actionInputFetcher,
+          env.getReporter(),
+          buildRequestId,
+          invocationId,
+          env.getSkyframeExecutor().getEvaluator(),
+          remoteOptions.getRemoteCacheTtl());
+    }
+  }
+
   @Override
   public void workspaceInit(
       BlazeRuntime runtime, BlazeDirectories directories, WorkspaceBuilder builder) {
@@ -624,6 +662,7 @@ public final class RemoteModule extends BlazeModule {
     if ((enableHttpCache || enableDiskCache) && !enableGrpcCache) {
       initHttpAndDiskCache(
           env, credentials, authAndTlsOptions, remoteOptions, diskCachePath, digestUtil);
+      initRepoHelpersAndOverlayFs(env, buildRequestId, invocationId, verboseFailures);
       return;
     }
 
@@ -801,29 +840,7 @@ public final class RemoteModule extends BlazeModule {
 
     actionInputFetcher = createActionInputFetcher(actionContextProvider.getCombinedCache());
 
-    repositoryRemoteHelpersFactoryDelegate.init(
-        new RepositoryRemoteHelpersFactoryImpl(
-            env.getDirectories(),
-            actionContextProvider.getCombinedCache(),
-            actionContextProvider.getRemoteExecutionClient(),
-            buildRequestId,
-            invocationId,
-            env.getWorkspaceName(),
-            remoteOptions.getRemoteInstanceName(),
-            remoteOptions.getRemoteAcceptCached(),
-            remoteOptions.getRemoteUploadLocalResults(),
-            verboseFailures));
-    if (env.getDirectories().getOutputBase().getFileSystem()
-        instanceof RemoteExternalOverlayFileSystem remoteFs) {
-      remoteFs.beforeCommand(
-          actionContextProvider.getCombinedCache(),
-          actionInputFetcher,
-          env.getReporter(),
-          buildRequestId,
-          invocationId,
-          env.getSkyframeExecutor().getEvaluator(),
-          remoteOptions.getRemoteCacheTtl());
-    }
+    initRepoHelpersAndOverlayFs(env, buildRequestId, invocationId, verboseFailures);
 
     buildEventArtifactUploaderFactoryDelegate.init(
         new ByteStreamBuildEventArtifactUploaderFactory(
@@ -1302,6 +1319,11 @@ public final class RemoteModule extends BlazeModule {
   @VisibleForTesting
   RemoteActionContextProvider getActionContextProvider() {
     return actionContextProvider;
+  }
+
+  @VisibleForTesting
+  RepositoryRemoteHelpersFactory getRepositoryRemoteHelpersFactoryDelegate() {
+    return repositoryRemoteHelpersFactoryDelegate;
   }
 
   @VisibleForTesting

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -618,6 +618,20 @@ public final class RemoteModuleTest {
         .isEqualTo(new CollectionPolicy(Optional.of(1234567890L), Optional.of(Duration.ofDays(7))));
   }
 
+  @Test
+  public void repositoryRemoteHelpersFactory_initializedForDiskCacheOnlyPath() throws Exception {
+    // Regression test: non-gRPC caches must still register the
+    // RepositoryRemoteHelpersFactory delegate so repo rules can use the remote
+    // contents cache. 
+    var diskCacheDir = TestUtils.createUniqueTmpDir(null);
+    remoteOptions.setDiskCache(diskCacheDir.asFragment());
+
+    beforeCommand();
+
+    assertThat(remoteModule.getRepositoryRemoteHelpersFactoryDelegate().createRepoContentsCache())
+        .isNotNull();
+  }
+
   @CanIgnoreReturnValue
   private CommandEnvironment beforeCommand() throws IOException, AbruptExitException {
     CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);


### PR DESCRIPTION
### Description

This change extracts setup logic for remote repo content caching from the gRPC path so it can be shared with the HTTP/disk path.

### Motivation

Remote repo content caching is currently only initialized for gRPC cache backends. The `--experimental_remote_repo_contents_cache` flag is a no-op when using a cache backend like GCS.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Fixed repo content caching for non-gRPC cache backends.
