### PR TITLE
remote: verify inlined ActionResult output contents against their digest

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1166,13 +1166,28 @@ public class RemoteExecutionService {
     for (OutputFile outputFile : result.getOutputFilesList()) {
       Path localPath =
           remotePathResolver.outputPathToLocalPath(unicodeToInternal(outputFile.getPath()));
+      ByteString contents = outputFile.getContents();
+      if (!contents.isEmpty()) {
+        // Inlined output bytes are consumed directly (e.g. for in-memory outputs
+        // such as unused_inputs_list). They bypass the digest-keyed download path
+        // that verifies content via Utils.verifyBlobContents, so verify them here
+        // against the accompanying digest before they are trusted.
+        Digest contentDigest = digestUtil.compute(contents.toByteArray());
+        if (!contentDigest.equals(outputFile.getDigest())) {
+          OutputDigestMismatchException e =
+              new OutputDigestMismatchException(outputFile.getDigest(), contentDigest);
+          e.setOutputPath(outputFile.getPath());
+          e.setLocalPath(localPath);
+          throw e;
+        }
+      }
       files.put(
           localPath,
           new FileMetadata(
               localPath,
               outputFile.getDigest(),
               outputFile.getIsExecutable(),
-              outputFile.getContents()));
+              contents));
     }
 
     var symlinkMap = new HashMap<Path, SymlinkMetadata>();

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -649,13 +649,19 @@ public class RemoteExecutionService {
         CombinedCache combinedCache,
         DigestUtil digestUtil,
         RemoteActionExecutionContext context,
-        RemotePathResolver remotePathResolver)
+        RemotePathResolver remotePathResolver,
+        boolean verifyDownloads)
         throws IOException, InterruptedException {
       if (metadata == null) {
         try (SilentCloseable c = Profiler.instance().profile("Remote.parseActionResultMetadata")) {
           metadata =
               parseActionResultMetadata(
-                  combinedCache, digestUtil, context, actionResult, remotePathResolver);
+                  combinedCache,
+                  digestUtil,
+                  context,
+                  actionResult,
+                  remotePathResolver,
+                  verifyDownloads);
         }
       }
       return metadata;
@@ -796,7 +802,8 @@ public class RemoteExecutionService {
               combinedCache,
               digestUtil,
               action.getRemoteActionExecutionContext(),
-              action.getRemotePathResolver());
+              action.getRemotePathResolver(),
+              remoteOptions.getRemoteVerifyDownloads());
 
       // If we already know digests referenced by this AC is missing from remote cache, ignore it so
       // that we can fall back to execution. This could happen when the remote cache is an HTTP
@@ -1114,7 +1121,8 @@ public class RemoteExecutionService {
       DigestUtil digestUtil,
       RemoteActionExecutionContext context,
       ActionResult result,
-      RemotePathResolver remotePathResolver)
+      RemotePathResolver remotePathResolver,
+      boolean verifyDownloads)
       throws IOException, InterruptedException {
     checkNotNull(combinedCache, "combinedCache can't be null");
 
@@ -1167,11 +1175,12 @@ public class RemoteExecutionService {
       Path localPath =
           remotePathResolver.outputPathToLocalPath(unicodeToInternal(outputFile.getPath()));
       ByteString contents = outputFile.getContents();
-      if (!contents.isEmpty()) {
+      if (verifyDownloads && !contents.isEmpty()) {
         // Inlined output bytes are consumed directly (e.g. for in-memory outputs
         // such as unused_inputs_list). They bypass the digest-keyed download path
         // that verifies content via Utils.verifyBlobContents, so verify them here
-        // against the accompanying digest before they are trusted.
+        // against the accompanying digest before they are trusted. Gated on
+        // --remote_verify_downloads to stay consistent with the other blob paths.
         Digest contentDigest = digestUtil.compute(contents::writeTo);
         if (!contentDigest.equals(outputFile.getDigest())) {
           OutputDigestMismatchException e =
@@ -1257,7 +1266,11 @@ public class RemoteExecutionService {
 
     ActionResultMetadata metadata =
         result.getOrParseActionResultMetadata(
-            combinedCache, digestUtil, context, action.getRemotePathResolver());
+            combinedCache,
+            digestUtil,
+            context,
+            action.getRemotePathResolver(),
+            remoteOptions.getRemoteVerifyDownloads());
 
     // The expiration time for remote cache entries.
     var expirationTime = Instant.now().plus(remoteOptions.getRemoteCacheTtl());

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1172,7 +1172,7 @@ public class RemoteExecutionService {
         // such as unused_inputs_list). They bypass the digest-keyed download path
         // that verifies content via Utils.verifyBlobContents, so verify them here
         // against the accompanying digest before they are trusted.
-        Digest contentDigest = digestUtil.compute(contents.toByteArray());
+        Digest contentDigest = digestUtil.compute(contents::writeTo);
         if (!contentDigest.equals(outputFile.getDigest())) {
           OutputDigestMismatchException e =
               new OutputDigestMismatchException(outputFile.getDigest(), contentDigest);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -658,13 +658,19 @@ public class RemoteExecutionService {
         CombinedCache combinedCache,
         DigestUtil digestUtil,
         RemoteActionExecutionContext context,
-        RemotePathResolver remotePathResolver)
+        RemotePathResolver remotePathResolver,
+        boolean verifyDownloads)
         throws IOException, InterruptedException {
       if (metadata == null) {
         try (SilentCloseable c = Profiler.instance().profile("Remote.parseActionResultMetadata")) {
           metadata =
               parseActionResultMetadata(
-                  combinedCache, digestUtil, context, actionResult, remotePathResolver);
+                  combinedCache,
+                  digestUtil,
+                  context,
+                  actionResult,
+                  remotePathResolver,
+                  verifyDownloads);
         }
       }
       return metadata;
@@ -805,7 +811,8 @@ public class RemoteExecutionService {
               combinedCache,
               digestUtil,
               action.getRemoteActionExecutionContext(),
-              action.getRemotePathResolver());
+              action.getRemotePathResolver(),
+              remoteOptions.getRemoteVerifyDownloads());
 
       // If we already know digests referenced by this AC is missing from remote cache, ignore it so
       // that we can fall back to execution. This could happen when the remote cache is an HTTP
@@ -1147,7 +1154,8 @@ public class RemoteExecutionService {
       DigestUtil digestUtil,
       RemoteActionExecutionContext context,
       ActionResult result,
-      RemotePathResolver remotePathResolver)
+      RemotePathResolver remotePathResolver,
+      boolean verifyDownloads)
       throws IOException, InterruptedException {
     checkNotNull(combinedCache, "combinedCache can't be null");
 
@@ -1200,11 +1208,12 @@ public class RemoteExecutionService {
       Path localPath =
           remotePathResolver.outputPathToLocalPath(unicodeToInternal(outputFile.getPath()));
       ByteString contents = outputFile.getContents();
-      if (!contents.isEmpty()) {
+      if (verifyDownloads && !contents.isEmpty()) {
         // Inlined output bytes are consumed directly (e.g. for in-memory outputs
         // such as unused_inputs_list). They bypass the digest-keyed download path
         // that verifies content via Utils.verifyBlobContents, so verify them here
-        // against the accompanying digest before they are trusted.
+        // against the accompanying digest before they are trusted. Gated on
+        // --remote_verify_downloads to stay consistent with the other blob paths.
         Digest contentDigest = digestUtil.compute(contents::writeTo);
         if (!contentDigest.equals(outputFile.getDigest())) {
           OutputDigestMismatchException e =
@@ -1290,7 +1299,11 @@ public class RemoteExecutionService {
 
     ActionResultMetadata metadata =
         result.getOrParseActionResultMetadata(
-            combinedCache, digestUtil, context, action.getRemotePathResolver());
+            combinedCache,
+            digestUtil,
+            context,
+            action.getRemotePathResolver(),
+            remoteOptions.getRemoteVerifyDownloads());
 
     // The expiration time for remote cache entries.
     var expirationTime = Instant.now().plus(remoteOptions.getRemoteCacheTtl());

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1205,7 +1205,7 @@ public class RemoteExecutionService {
         // such as unused_inputs_list). They bypass the digest-keyed download path
         // that verifies content via Utils.verifyBlobContents, so verify them here
         // against the accompanying digest before they are trusted.
-        Digest contentDigest = digestUtil.compute(contents.toByteArray());
+        Digest contentDigest = digestUtil.compute(contents::writeTo);
         if (!contentDigest.equals(outputFile.getDigest())) {
           OutputDigestMismatchException e =
               new OutputDigestMismatchException(outputFile.getDigest(), contentDigest);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1199,13 +1199,28 @@ public class RemoteExecutionService {
     for (OutputFile outputFile : result.getOutputFilesList()) {
       Path localPath =
           remotePathResolver.outputPathToLocalPath(unicodeToInternal(outputFile.getPath()));
+      ByteString contents = outputFile.getContents();
+      if (!contents.isEmpty()) {
+        // Inlined output bytes are consumed directly (e.g. for in-memory outputs
+        // such as unused_inputs_list). They bypass the digest-keyed download path
+        // that verifies content via Utils.verifyBlobContents, so verify them here
+        // against the accompanying digest before they are trusted.
+        Digest contentDigest = digestUtil.compute(contents.toByteArray());
+        if (!contentDigest.equals(outputFile.getDigest())) {
+          OutputDigestMismatchException e =
+              new OutputDigestMismatchException(outputFile.getDigest(), contentDigest);
+          e.setOutputPath(outputFile.getPath());
+          e.setLocalPath(localPath);
+          throw e;
+        }
+      }
       files.put(
           localPath,
           new FileMetadata(
               localPath,
               outputFile.getDigest(),
               outputFile.getIsExecutable(),
-              outputFile.getContents()));
+              contents));
     }
 
     var symlinkMap = new HashMap<Path, SymlinkMetadata>();

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -2241,6 +2241,35 @@ public class RemoteExecutionServiceTest {
   }
 
   @Test
+  public void downloadOutputs_inlinedContents_mismatchingDigest_notVerifiedWhenDisabled()
+      throws Exception {
+    // With --noremote_verify_downloads the inline path skips verification, matching the other
+    // blob download paths, and the unverified contents are served as-is.
+    remoteOptions.setRemoteVerifyDownloads(false);
+    Digest digestOfContent1 = digestUtil.computeAsUtf8("content1");
+    ActionResult r =
+        ActionResult.newBuilder()
+            .setExitCode(0)
+            .addOutputFiles(
+                OutputFile.newBuilder()
+                    .setPath("outputs/file1")
+                    .setDigest(digestOfContent1)
+                    .setContents(ByteString.copyFromUtf8("tampered")))
+            .build();
+    RemoteActionResult result = RemoteActionResult.createFromCache(CachedActionResult.remote(r));
+    Spawn spawn = newSpawnFromResultWithInMemoryOutput(result, PathFragment.create("outputs/file1"));
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    createOutputDirectories(spawn);
+
+    InMemoryOutput inMemoryOutput = service.downloadOutputs(action, result);
+
+    assertThat(inMemoryOutput).isNotNull();
+    assertThat(inMemoryOutput.getContents()).isEqualTo(ByteString.copyFromUtf8("tampered"));
+  }
+
+  @Test
   public void downloadOutputs_missingInMemoryOutput_returnsNull() throws Exception {
     // Test that downloadOutputs returns null if a declared in-memory output is missing from action
     // result.

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -104,6 +104,7 @@ import com.google.devtools.build.lib.remote.CombinedCache.CachedActionResult;
 import com.google.devtools.build.lib.remote.RemoteExecutionService.RemoteActionResult;
 import com.google.devtools.build.lib.remote.RemoteScrubbing.Config;
 import com.google.devtools.build.lib.remote.common.BulkTransferException;
+import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
@@ -2138,6 +2139,105 @@ public class RemoteExecutionServiceTest {
     assertThat(execRoot.getRelative("outputs/file1").exists()).isFalse();
     assertThat(execRoot.getRelative("outputs/file2").exists()).isFalse();
     assertThat(context.isLockOutputFilesCalled()).isTrue();
+  }
+
+  @Test
+  public void downloadOutputs_inlinedContents_matchingDigest_servedFromMemory() throws Exception {
+    // Inlined contents that match their digest pass verification and are served directly as the
+    // in-memory output, without a digest-keyed download.
+    Digest d1 = digestUtil.computeAsUtf8("content1");
+    ActionResult r =
+        ActionResult.newBuilder()
+            .setExitCode(0)
+            .addOutputFiles(
+                OutputFile.newBuilder()
+                    .setPath("outputs/file1")
+                    .setDigest(d1)
+                    .setContents(ByteString.copyFromUtf8("content1")))
+            .build();
+    RemoteActionResult result = RemoteActionResult.createFromCache(CachedActionResult.remote(r));
+    Spawn spawn = newSpawnFromResultWithInMemoryOutput(result, PathFragment.create("outputs/file1"));
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    createOutputDirectories(spawn);
+
+    InMemoryOutput inMemoryOutput = service.downloadOutputs(action, result);
+
+    assertThat(inMemoryOutput).isNotNull();
+    assertThat(inMemoryOutput.getContents()).isEqualTo(ByteString.copyFromUtf8("content1"));
+  }
+
+  @Test
+  public void downloadOutputs_inlinedContents_mismatchingDigest_throws() throws Exception {
+    // Inlined contents that do not match the accompanying digest are rejected at parse time.
+    Digest digestOfContent1 = digestUtil.computeAsUtf8("content1");
+    ActionResult r =
+        ActionResult.newBuilder()
+            .setExitCode(0)
+            .addOutputFiles(
+                OutputFile.newBuilder()
+                    .setPath("outputs/file1")
+                    .setDigest(digestOfContent1)
+                    .setContents(ByteString.copyFromUtf8("tampered")))
+            .build();
+    RemoteActionResult result = RemoteActionResult.createFromCache(CachedActionResult.remote(r));
+    Spawn spawn = newSpawnFromResultWithInMemoryOutput(result, PathFragment.create("outputs/file1"));
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    createOutputDirectories(spawn);
+
+    assertThrows(OutputDigestMismatchException.class, () -> service.downloadOutputs(action, result));
+  }
+
+  @Test
+  public void downloadOutputs_inlinedContents_nonEmptyContentsWithEmptyDigest_throws()
+      throws Exception {
+    // The contents field has no presence information, so emptiness is judged by the digest size
+    // (see the inline serving path). Non-empty inline contents paired with the empty-blob digest
+    // must be rejected rather than served as if the file were empty.
+    Digest emptyDigest = digestUtil.compute(new byte[0]);
+    ActionResult r =
+        ActionResult.newBuilder()
+            .setExitCode(0)
+            .addOutputFiles(
+                OutputFile.newBuilder()
+                    .setPath("outputs/file1")
+                    .setDigest(emptyDigest)
+                    .setContents(ByteString.copyFromUtf8("not empty")))
+            .build();
+    RemoteActionResult result = RemoteActionResult.createFromCache(CachedActionResult.remote(r));
+    Spawn spawn = newSpawnFromResultWithInMemoryOutput(result, PathFragment.create("outputs/file1"));
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    createOutputDirectories(spawn);
+
+    assertThrows(OutputDigestMismatchException.class, () -> service.downloadOutputs(action, result));
+  }
+
+  @Test
+  public void downloadOutputs_emptyContents_notTreatedAsInlined() throws Exception {
+    // Empty contents are not an inlined output and skip the new verification. A genuinely empty
+    // file (empty-blob digest) is still served correctly, so the check does not misfire on it.
+    Digest emptyDigest = digestUtil.compute(new byte[0]);
+    ActionResult r =
+        ActionResult.newBuilder()
+            .setExitCode(0)
+            .addOutputFiles(OutputFile.newBuilder().setPath("outputs/file1").setDigest(emptyDigest))
+            .build();
+    RemoteActionResult result = RemoteActionResult.createFromCache(CachedActionResult.remote(r));
+    Spawn spawn = newSpawnFromResultWithInMemoryOutput(result, PathFragment.create("outputs/file1"));
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    createOutputDirectories(spawn);
+
+    InMemoryOutput inMemoryOutput = service.downloadOutputs(action, result);
+
+    assertThat(inMemoryOutput).isNotNull();
+    assertThat(inMemoryOutput.getContents()).isEqualTo(ByteString.EMPTY);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -107,6 +107,7 @@ import com.google.devtools.build.lib.remote.CombinedCache.CachedActionResult;
 import com.google.devtools.build.lib.remote.RemoteExecutionService.RemoteActionResult;
 import com.google.devtools.build.lib.remote.RemoteScrubbing.Config;
 import com.google.devtools.build.lib.remote.common.BulkTransferException;
+import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
@@ -2178,6 +2179,105 @@ public class RemoteExecutionServiceTest {
     assertThat(execRoot.getRelative("outputs/file1").exists()).isFalse();
     assertThat(execRoot.getRelative("outputs/file2").exists()).isFalse();
     assertThat(context.isLockOutputFilesCalled()).isTrue();
+  }
+
+  @Test
+  public void downloadOutputs_inlinedContents_matchingDigest_servedFromMemory() throws Exception {
+    // Inlined contents that match their digest pass verification and are served directly as the
+    // in-memory output, without a digest-keyed download.
+    Digest d1 = digestUtil.computeAsUtf8("content1");
+    ActionResult r =
+        ActionResult.newBuilder()
+            .setExitCode(0)
+            .addOutputFiles(
+                OutputFile.newBuilder()
+                    .setPath("outputs/file1")
+                    .setDigest(d1)
+                    .setContents(ByteString.copyFromUtf8("content1")))
+            .build();
+    RemoteActionResult result = RemoteActionResult.createFromCache(CachedActionResult.remote(r));
+    Spawn spawn = newSpawnFromResultWithInMemoryOutput(result, PathFragment.create("outputs/file1"));
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    createOutputDirectories(spawn);
+
+    InMemoryOutput inMemoryOutput = service.downloadOutputs(action, result);
+
+    assertThat(inMemoryOutput).isNotNull();
+    assertThat(inMemoryOutput.getContents()).isEqualTo(ByteString.copyFromUtf8("content1"));
+  }
+
+  @Test
+  public void downloadOutputs_inlinedContents_mismatchingDigest_throws() throws Exception {
+    // Inlined contents that do not match the accompanying digest are rejected at parse time.
+    Digest digestOfContent1 = digestUtil.computeAsUtf8("content1");
+    ActionResult r =
+        ActionResult.newBuilder()
+            .setExitCode(0)
+            .addOutputFiles(
+                OutputFile.newBuilder()
+                    .setPath("outputs/file1")
+                    .setDigest(digestOfContent1)
+                    .setContents(ByteString.copyFromUtf8("tampered")))
+            .build();
+    RemoteActionResult result = RemoteActionResult.createFromCache(CachedActionResult.remote(r));
+    Spawn spawn = newSpawnFromResultWithInMemoryOutput(result, PathFragment.create("outputs/file1"));
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    createOutputDirectories(spawn);
+
+    assertThrows(OutputDigestMismatchException.class, () -> service.downloadOutputs(action, result));
+  }
+
+  @Test
+  public void downloadOutputs_inlinedContents_nonEmptyContentsWithEmptyDigest_throws()
+      throws Exception {
+    // The contents field has no presence information, so emptiness is judged by the digest size
+    // (see the inline serving path). Non-empty inline contents paired with the empty-blob digest
+    // must be rejected rather than served as if the file were empty.
+    Digest emptyDigest = digestUtil.compute(new byte[0]);
+    ActionResult r =
+        ActionResult.newBuilder()
+            .setExitCode(0)
+            .addOutputFiles(
+                OutputFile.newBuilder()
+                    .setPath("outputs/file1")
+                    .setDigest(emptyDigest)
+                    .setContents(ByteString.copyFromUtf8("not empty")))
+            .build();
+    RemoteActionResult result = RemoteActionResult.createFromCache(CachedActionResult.remote(r));
+    Spawn spawn = newSpawnFromResultWithInMemoryOutput(result, PathFragment.create("outputs/file1"));
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    createOutputDirectories(spawn);
+
+    assertThrows(OutputDigestMismatchException.class, () -> service.downloadOutputs(action, result));
+  }
+
+  @Test
+  public void downloadOutputs_emptyContents_notTreatedAsInlined() throws Exception {
+    // Empty contents are not an inlined output and skip the new verification. A genuinely empty
+    // file (empty-blob digest) is still served correctly, so the check does not misfire on it.
+    Digest emptyDigest = digestUtil.compute(new byte[0]);
+    ActionResult r =
+        ActionResult.newBuilder()
+            .setExitCode(0)
+            .addOutputFiles(OutputFile.newBuilder().setPath("outputs/file1").setDigest(emptyDigest))
+            .build();
+    RemoteActionResult result = RemoteActionResult.createFromCache(CachedActionResult.remote(r));
+    Spawn spawn = newSpawnFromResultWithInMemoryOutput(result, PathFragment.create("outputs/file1"));
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    createOutputDirectories(spawn);
+
+    InMemoryOutput inMemoryOutput = service.downloadOutputs(action, result);
+
+    assertThat(inMemoryOutput).isNotNull();
+    assertThat(inMemoryOutput.getContents()).isEqualTo(ByteString.EMPTY);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -2281,6 +2281,35 @@ public class RemoteExecutionServiceTest {
   }
 
   @Test
+  public void downloadOutputs_inlinedContents_mismatchingDigest_notVerifiedWhenDisabled()
+      throws Exception {
+    // With --noremote_verify_downloads the inline path skips verification, matching the other
+    // blob download paths, and the unverified contents are served as-is.
+    remoteOptions.setRemoteVerifyDownloads(false);
+    Digest digestOfContent1 = digestUtil.computeAsUtf8("content1");
+    ActionResult r =
+        ActionResult.newBuilder()
+            .setExitCode(0)
+            .addOutputFiles(
+                OutputFile.newBuilder()
+                    .setPath("outputs/file1")
+                    .setDigest(digestOfContent1)
+                    .setContents(ByteString.copyFromUtf8("tampered")))
+            .build();
+    RemoteActionResult result = RemoteActionResult.createFromCache(CachedActionResult.remote(r));
+    Spawn spawn = newSpawnFromResultWithInMemoryOutput(result, PathFragment.create("outputs/file1"));
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    createOutputDirectories(spawn);
+
+    InMemoryOutput inMemoryOutput = service.downloadOutputs(action, result);
+
+    assertThat(inMemoryOutput).isNotNull();
+    assertThat(inMemoryOutput.getContents()).isEqualTo(ByteString.copyFromUtf8("tampered"));
+  }
+
+  @Test
   public void downloadOutputs_missingInMemoryOutput_returnsNull() throws Exception {
     // Test that downloadOutputs returns null if a declared in-memory output is missing from action
     // result.


### PR DESCRIPTION
### Problem

When a remote/HTTP cache returns an `ActionResult` with an output file's bytes inlined in `OutputFile.contents`, `parseActionResultMetadata` copies those bytes into `FileMetadata.contents` and `downloadOutputs` consumes them directly (for example `inMemoryOutputData.set(file.contents)` for in-memory outputs such as `unused_inputs_list`) without comparing them against `OutputFile.digest`.

Every other output channel is checked against its digest: the digest-keyed download path verifies content via `Utils.verifyBlobContents`, the only producer of `OutputDigestMismatchException`. The inline channel is the one path that isn't, so `--remote_verify_downloads` (default on) does not cover it. `StarlarkAction` sets `REMOTE_EXECUTION_INLINE_OUTPUTS` automatically for any action using `unused_inputs_list`, so this is on a common code path, and the same channel also feeds C++ include scanning and `jdeps`.

To be clear about scope: this is not a defense against a malicious action cache. The cache supplies the digest and the inline bytes together and has to be trusted regardless, since it can set `digest = compute(contents)` for any bytes it inlines. What this closes is a verification-consistency gap: a buggy or inconsistent cache or proxy that inlines stale or wrong bytes is trusted silently today instead of failing fast like every other output.

### Fix

In `parseActionResultMetadata`, for any output file with non-empty inline `contents`, compute the digest of those bytes and compare it to `OutputFile.digest`, throwing `OutputDigestMismatchException` on mismatch, the same guarantee `Utils.verifyBlobContents` gives the digest-keyed path. Verifying once at parse covers every inline consumer (in-memory outputs, `unused_inputs_list`, include scanning, `jdeps`). Output files without inline contents are unaffected.

### Tests

`RemoteExecutionServiceTest` covers matching inline contents (served from memory), mismatching contents (rejected), and the empty/non-empty boundary: non-empty contents paired with the empty-blob digest are rejected, while truly empty contents are not treated as inlined and still resolve via the digest.
