### PR TITLE
ui: update terminal width on resize

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -241,6 +241,9 @@ class BlazeServer final {
   // connected state.
   void Cancel();
 
+  // Notifies the server that the client terminal size may have changed.
+  void TerminalSizeChanged();
+
   // Returns information about the actual server process and its configuration.
   const ServerProcessInfo &ProcessInfo() const { return process_info_; }
 
@@ -248,7 +251,13 @@ class BlazeServer final {
   std::optional<LockHandle> install_base_lock_;
   std::optional<LockHandle> output_base_lock_;
 
-  enum CancelThreadAction { NOTHING, JOIN, CANCEL, COMMAND_ID_RECEIVED };
+  enum CancelThreadAction {
+    NOTHING,
+    JOIN,
+    CANCEL,
+    COMMAND_ID_RECEIVED,
+    TERMINAL_SIZE_CHANGED
+  };
 
   std::unique_ptr<CommandServer::Stub> client_;
   std::string request_cookie_;
@@ -269,6 +278,7 @@ class BlazeServer final {
   void CancelThread();
   void SendAction(CancelThreadAction action);
   void SendCancelMessage();
+  void SendTerminalSizeMessage(int columns);
 
   ServerProcessInfo process_info_;
   const int connect_timeout_secs_;
@@ -1186,6 +1196,8 @@ static void EnsureCorrectRunningVersion(const StartupOptions &startup_options,
 
 static void CancelServer() { blaze_server->Cancel(); }
 
+static void TerminalSizeChanged() { blaze_server->TerminalSizeChanged(); }
+
 // Runs the launcher in client/server mode. Ensures that there's indeed a
 // running server, then forwards the user's command to the server and the
 // server's response back to the user. Does not return - exits via exit or
@@ -1246,7 +1258,8 @@ static ATTRIBUTE_NORETURN void RunClientServerMode(
 
   SignalHandler::Get().Install(startup_options.product_name,
                                startup_options.output_base,
-                               &server->ProcessInfo(), CancelServer);
+                               &server->ProcessInfo(), CancelServer,
+                               TerminalSizeChanged);
   SignalHandler::Get().PropagateSignalOrExit(server->Communicate(
       option_processor.GetCommand(), option_processor.GetCommandArguments(),
       startup_options.invocation_policy,
@@ -1816,6 +1829,8 @@ bool BlazeServer::Connect() {
 // - CANCEL. If the command ID is already available, a cancel request is sent.
 // - COMMAND_ID_RECEIVED. The client learned the command ID from the server.
 //   If there is a pending cancellation request, it is acted upon.
+// - TERMINAL_SIZE_CHANGED. The client terminal size may have changed. If the
+//   command ID is already available, a terminal size update is sent.
 //
 // The only data the cancellation thread shares with the main thread is the
 // file descriptor for receiving commands and command_id_, the latter of which
@@ -1834,6 +1849,15 @@ void BlazeServer::CancelThread() {
   bool running = true;
   bool cancel = false;
   bool command_id_received = false;
+  bool terminal_size_change_pending = false;
+  int last_sent_terminal_columns = GetTerminalColumns();
+  auto send_terminal_size_if_changed = [&]() {
+    int columns = GetTerminalColumns();
+    if (columns > 0 && columns != last_sent_terminal_columns) {
+      SendTerminalSizeMessage(columns);
+      last_sent_terminal_columns = columns;
+    }
+  };
   while (running) {
     char buf;
 
@@ -1860,6 +1884,10 @@ void BlazeServer::CancelThread() {
           SendCancelMessage();
           cancel = false;
         }
+        if (terminal_size_change_pending) {
+          send_terminal_size_if_changed();
+          terminal_size_change_pending = false;
+        }
         break;
 
       case CancelThreadAction::CANCEL:
@@ -1867,6 +1895,14 @@ void BlazeServer::CancelThread() {
           SendCancelMessage();
         } else {
           cancel = true;
+        }
+        break;
+
+      case CancelThreadAction::TERMINAL_SIZE_CHANGED:
+        if (command_id_received) {
+          send_terminal_size_if_changed();
+        } else {
+          terminal_size_change_pending = true;
         }
         break;
     }
@@ -1888,6 +1924,24 @@ void BlazeServer::SendCancelMessage() {
   if (!status.ok()) {
     BAZEL_LOG(USER) << "\nCould not interrupt server: (" << status.error_code()
                     << ") " << status.error_message().c_str() << "\n";
+  }
+}
+
+void BlazeServer::SendTerminalSizeMessage(int columns) {
+  std::unique_lock<std::mutex> lock(cancel_thread_mutex_);
+
+  command_server::TerminalSizeRequest request;
+  request.set_cookie(request_cookie_);
+  request.set_command_id(command_id_);
+  request.set_columns(columns);
+  grpc::ClientContext context;
+  context.set_deadline(std::chrono::system_clock::now() +
+                       std::chrono::seconds(10));
+  command_server::TerminalSizeResponse response;
+  grpc::Status status = client_->UpdateTerminalSize(&context, request, &response);
+  if (!status.ok()) {
+    BAZEL_LOG(INFO) << "Could not update terminal size: (" << status.error_code()
+                    << ") " << status.error_message().c_str();
   }
 }
 
@@ -2035,6 +2089,8 @@ unsigned int BlazeServer::Communicate(
 
     if (response.cookie() != response_cookie_) {
       BAZEL_LOG(USER) << "\nServer response cookie invalid, exiting";
+      SendAction(CancelThreadAction::JOIN);
+      cancel_thread.join();
       return blaze_exit_code::INTERNAL_ERROR;
     }
 
@@ -2162,6 +2218,11 @@ void BlazeServer::SendAction(CancelThreadAction action) {
 void BlazeServer::Cancel() {
   assert(Connected());
   SendAction(CancelThreadAction::CANCEL);
+}
+
+void BlazeServer::TerminalSizeChanged() {
+  assert(Connected());
+  SendAction(CancelThreadAction::TERMINAL_SIZE_CHANGED);
 }
 
 }  // namespace blaze

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -88,10 +88,16 @@ class SignalHandler {
   const std::string& GetProductName() const { return product_name_; }
   const blaze_util::Path& GetOutputBase() const { return output_base_; }
   void CancelServer() { cancel_server_(); }
+  void TerminalSizeChanged() {
+    if (terminal_size_changed_ != nullptr) {
+      terminal_size_changed_();
+    }
+  }
   void Install(const std::string& product_name,
                const blaze_util::Path& output_base,
                const ServerProcessInfo* server_process_info,
-               Callback cancel_server);
+               Callback cancel_server,
+               Callback terminal_size_changed);
   ATTRIBUTE_NORETURN void PropagateSignalOrExit(int exit_code);
 
  private:
@@ -101,8 +107,12 @@ class SignalHandler {
   blaze_util::Path output_base_;
   const ServerProcessInfo* server_process_info_;
   Callback cancel_server_;
+  Callback terminal_size_changed_;
 
-  SignalHandler() : server_process_info_(nullptr), cancel_server_(nullptr) {}
+  SignalHandler()
+      : server_process_info_(nullptr),
+        cancel_server_(nullptr),
+        terminal_size_changed_(nullptr) {}
 };
 
 // A signal-safe version of fprintf(stderr, ...).

--- a/src/main/cpp/blaze_util_posix.cc
+++ b/src/main/cpp/blaze_util_posix.cc
@@ -184,6 +184,9 @@ static void handler(int signum) {
                     .c_str());
       kill(SignalHandler::Get().GetServerProcessInfo()->server_pid_, SIGQUIT);
       break;
+    case SIGWINCH:
+      SignalHandler::Get().TerminalSizeChanged();
+      break;
   }
 
   errno = saved_errno;
@@ -192,11 +195,13 @@ static void handler(int signum) {
 void SignalHandler::Install(const string& product_name,
                             const blaze_util::Path& output_base,
                             const ServerProcessInfo* server_process_info,
-                            SignalHandler::Callback cancel_server) {
+                            SignalHandler::Callback cancel_server,
+                            SignalHandler::Callback terminal_size_changed) {
   product_name_ = product_name;
   output_base_ = output_base;
   server_process_info_ = server_process_info;
   cancel_server_ = cancel_server;
+  terminal_size_changed_ = terminal_size_changed;
 
   // Unblock all signals.
   sigset_t sigset;
@@ -204,12 +209,13 @@ void SignalHandler::Install(const string& product_name,
   sigprocmask(SIG_SETMASK, &sigset, nullptr);
 
   // SIGWINCH is reserved for Bazel server internal use and cannot be passed to
-  // it. The JVM is not attached to a terminal, making a signal insufficient to
-  // react to window size change event anyway.
+  // it. The JVM is not attached to a terminal, so the client forwards terminal
+  // size changes over the command RPC channel.
   signal(SIGINT, handler);
   signal(SIGTERM, handler);
   signal(SIGPIPE, handler);
   signal(SIGQUIT, handler);
+  signal(SIGWINCH, handler);
 }
 
 ATTRIBUTE_NORETURN void SignalHandler::PropagateSignalOrExit(int exit_code) {

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -325,11 +325,13 @@ BOOL WINAPI ConsoleCtrlHandler(_In_ DWORD ctrlType) {
 void SignalHandler::Install(const string& product_name,
                             const blaze_util::Path& output_base,
                             const ServerProcessInfo* server_process_info,
-                            SignalHandler::Callback cancel_server) {
+                            SignalHandler::Callback cancel_server,
+                            SignalHandler::Callback terminal_size_changed) {
   product_name_ = product_name;
   output_base_ = output_base;
   server_process_info_ = server_process_info;
   cancel_server_ = cancel_server;
+  terminal_size_changed_ = terminal_size_changed;
   ::SetConsoleCtrlHandler(&ConsoleCtrlHandler, TRUE);
 }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BUILD
@@ -87,6 +87,7 @@ java_library(
     deps = [
         ":blaze_command_result",
         "//src/main/java/com/google/devtools/build/lib/server:idle_task",
+        "//src/main/java/com/google/devtools/build/lib/server:terminal_size_monitor",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util/io:io-proto",
         "//src/main/java/com/google/devtools/build/lib/util/io:out-err",
@@ -368,6 +369,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/clock",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/pkgcache",
+        "//src/main/java/com/google/devtools/build/lib/server:terminal_size_monitor",
         "//src/main/java/com/google/devtools/build/lib/skyframe:configuration_phase_started_event",
         "//src/main/java/com/google/devtools/build/lib/skyframe:loading_phase_started_event",
         "//src/main/java/com/google/devtools/build/lib/skyframe:top_level_status_events",
@@ -1095,6 +1097,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/server:install_base_garbage_collector",
         "//src/main/java/com/google/devtools/build/lib/server:pid_file_watcher",
         "//src/main/java/com/google/devtools/build/lib/server:shutdown_hooks",
+        "//src/main/java/com/google/devtools/build/lib/server:terminal_size_monitor",
         "//src/main/java/com/google/devtools/build/lib/server/signal",
         "//src/main/java/com/google/devtools/build/lib/skyframe:build_result_listener",
         "//src/main/java/com/google/devtools/build/lib/skyframe:default_syscall_cache",

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -57,6 +57,7 @@ import com.google.devtools.build.lib.runtime.proto.InvocationPolicyOuterClass.In
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.IdleTask;
+import com.google.devtools.build.lib.server.TerminalSizeMonitor;
 import com.google.devtools.build.lib.skyframe.RepositoryMappingValue.RepositoryMappingResolutionException;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.AnsiStrippingOutputStream;
@@ -172,6 +173,37 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
       List<Any> commandExtensions,
       CommandExtensionReporter commandExtensionReporter)
       throws InterruptedException {
+    return exec(
+        invocationPolicy,
+        args,
+        outErr,
+        lockingMode,
+        uiVerbosity,
+        clientDescription,
+        firstContactTimeMillis,
+        startupOptionsTaggedWithBazelRc,
+        idleTaskResultsSupplier,
+        commandExtensions,
+        commandExtensionReporter,
+        TerminalSizeMonitor.NOOP);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public BlazeCommandResult exec(
+      InvocationPolicy invocationPolicy,
+      List<String> args,
+      OutErr outErr,
+      LockingMode lockingMode,
+      UiVerbosity uiVerbosity,
+      String clientDescription,
+      long firstContactTimeMillis,
+      Optional<List<Pair<String, String>>> startupOptionsTaggedWithBazelRc,
+      Supplier<ImmutableList<IdleTask.Result>> idleTaskResultsSupplier,
+      List<Any> commandExtensions,
+      CommandExtensionReporter commandExtensionReporter,
+      TerminalSizeMonitor terminalSizeMonitor)
+      throws InterruptedException {
     Preconditions.checkNotNull(clientDescription);
     if (args.isEmpty()) { // Default to help command if no arguments specified.
       args = HELP_COMMAND;
@@ -278,7 +310,8 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
                   attemptNumber,
                   attemptedCommandIds,
                   buildRequestIdOverride,
-                  commandExtensionReporter);
+                  commandExtensionReporter,
+                  terminalSizeMonitor);
           break;
         } catch (RemoteCacheTransientErrorException e) {
           attemptedCommandIds.add(e.getCommandId());
@@ -343,7 +376,8 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
       int attemptNumber,
       Set<UUID> attemptedCommandIds,
       @Nullable String buildRequestIdOverride,
-      CommandExtensionReporter commandExtensionReporter)
+      CommandExtensionReporter commandExtensionReporter,
+      TerminalSizeMonitor terminalSizeMonitor)
       throws RemoteCacheTransientErrorException {
     // Record the start time for the profiler. Do not put anything before this!
     long execStartTimeNanos = runtime.getClock().nanoTime();
@@ -519,7 +553,8 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
             options.getOptions(ExecutionOptions.class) != null
                 && options.getOptions(ExecutionOptions.class).getStatsSummary();
         UiEventHandler handler =
-            createEventHandler(outErr, eventHandlerOptions, quiet, env, newStatsSummary);
+            createEventHandler(
+                outErr, eventHandlerOptions, quiet, env, newStatsSummary, terminalSizeMonitor);
         env.setUiEventHandler(handler);
 
         // We register an ANSI-allowing handler associated with {@code handler} so that ANSI control
@@ -528,7 +563,13 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
         // modified.
         if (!eventHandlerOptions.useColor()) {
           UiEventHandler ansiAllowingHandler =
-              createEventHandler(colorfulOutErr, eventHandlerOptions, quiet, env, newStatsSummary);
+              createEventHandler(
+                  colorfulOutErr,
+                  eventHandlerOptions,
+                  quiet,
+                  env,
+                  newStatsSummary,
+                  terminalSizeMonitor);
           reporter.registerAnsiAllowingHandler(handler, ansiAllowingHandler);
           env.getEventBus().register(new PassiveExperimentalEventHandler(ansiAllowingHandler));
         }
@@ -959,7 +1000,8 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
       UiOptions eventOptions,
       boolean quiet,
       CommandEnvironment env,
-      boolean newStatsSummary) {
+      boolean newStatsSummary,
+      TerminalSizeMonitor terminalSizeMonitor) {
     Path workspacePath = runtime.getWorkspace().getDirectories().getWorkspace();
     PathFragment workspacePathFragment = workspacePath == null ? null : workspacePath.asFragment();
     return new UiEventHandler(
@@ -970,7 +1012,8 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
         env.getEventBus(),
         workspacePathFragment,
         env.withMergedAnalysisAndExecutionSourceOfTruth(),
-        newStatsSummary);
+        newStatsSummary,
+        terminalSizeMonitor);
   }
 
   /** Returns the runtime instance shared by the commands that this dispatcher dispatches to. */

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandDispatcher.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.runtime;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.runtime.proto.InvocationPolicyOuterClass.InvocationPolicy;
 import com.google.devtools.build.lib.server.IdleTask;
+import com.google.devtools.build.lib.server.TerminalSizeMonitor;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.util.io.CommandExtensionReporter;
 import com.google.devtools.build.lib.util.io.OutErr;
@@ -60,4 +61,38 @@ public interface CommandDispatcher {
       List<Any> commandExtensions,
       CommandExtensionReporter commandExtensionReporter)
       throws InterruptedException;
+
+  /**
+   * Executes a single command with a monitor carrying terminal size updates from the client.
+   *
+   * <p>The default implementation ignores terminal size updates so tests and embedders that do not
+   * render Bazel's terminal UI do not need to implement this overload.
+   */
+  default BlazeCommandResult exec(
+      InvocationPolicy invocationPolicy,
+      List<String> args,
+      OutErr outErr,
+      LockingMode lockingMode,
+      UiVerbosity uiVerbosity,
+      String clientDescription,
+      long firstContactTimeMillis,
+      Optional<List<Pair<String, String>>> startupOptionsTaggedWithBazelRc,
+      Supplier<ImmutableList<IdleTask.Result>> idleTaskResultsSupplier,
+      List<Any> commandExtensions,
+      CommandExtensionReporter commandExtensionReporter,
+      TerminalSizeMonitor terminalSizeMonitor)
+      throws InterruptedException {
+    return exec(
+        invocationPolicy,
+        args,
+        outErr,
+        lockingMode,
+        uiVerbosity,
+        clientDescription,
+        firstContactTimeMillis,
+        startupOptionsTaggedWithBazelRc,
+        idleTaskResultsSupplier,
+        commandExtensions,
+        commandExtensionReporter);
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
@@ -57,6 +57,7 @@ import com.google.devtools.build.lib.events.ExtendedEventHandler.FetchProgress;
 import com.google.devtools.build.lib.pkgcache.LoadingPhaseCompleteEvent;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
 import com.google.devtools.build.lib.runtime.CrashDebuggingProtos.InflightActionInfo;
+import com.google.devtools.build.lib.server.TerminalSizeMonitor;
 import com.google.devtools.build.lib.skyframe.ConfigurationPhaseStartedEvent;
 import com.google.devtools.build.lib.skyframe.LoadingPhaseStartedEvent;
 import com.google.devtools.build.lib.skyframe.TopLevelStatusEvents.SomeExecutionStartedEvent;
@@ -139,7 +140,7 @@ public final class UiEventHandler implements EventHandler {
   private ByteArrayOutputStream stderrLineBuffer;
 
   private final int maxStdoutErrBytes;
-  private final int terminalWidth;
+  private int terminalWidth;
 
   /**
    * An output stream that wraps another output stream and that fully buffers writes until flushed.
@@ -182,7 +183,29 @@ public final class UiEventHandler implements EventHandler {
       @Nullable PathFragment workspacePathFragment,
       boolean skymeldMode,
       boolean newStatsSummary) {
-    this.terminalWidth = (options.getTerminalColumns() > 0 ? options.getTerminalColumns() : 80);
+    this(
+        outErr,
+        options,
+        quiet,
+        clock,
+        eventBus,
+        workspacePathFragment,
+        skymeldMode,
+        newStatsSummary,
+        TerminalSizeMonitor.NOOP);
+  }
+
+  public UiEventHandler(
+      OutErr outErr,
+      UiOptions options,
+      boolean quiet,
+      Clock clock,
+      EventBus eventBus,
+      @Nullable PathFragment workspacePathFragment,
+      boolean skymeldMode,
+      boolean newStatsSummary,
+      TerminalSizeMonitor terminalSizeMonitor) {
+    this.terminalWidth = normalizeTerminalWidth(options.getTerminalColumns());
     this.maxStdoutErrBytes = options.getMaxStdoutErrBytes();
     this.outErr =
         OutErr.create(
@@ -209,12 +232,12 @@ public final class UiEventHandler implements EventHandler {
     if (skymeldMode) {
       this.stateTracker =
           this.cursorControl
-              ? new SkymeldUiStateTracker(clock, /* targetWidth= */ this.terminalWidth - 2)
+              ? new SkymeldUiStateTracker(clock, /* targetWidth= */ getProgressTargetWidth())
               : new SkymeldUiStateTracker(clock);
     } else {
       this.stateTracker =
           this.cursorControl
-              ? new UiStateTracker(clock, /* targetWidth= */ this.terminalWidth - 2)
+              ? new UiStateTracker(clock, /* targetWidth= */ getProgressTargetWidth())
               : new UiStateTracker(clock);
     }
     this.stateTracker.setProgressSampleSize(options.getUiActionsShown());
@@ -238,6 +261,48 @@ public final class UiEventHandler implements EventHandler {
     this.filteredEventKinds = options.getFilteredEventKinds();
     // The progress bar has not been updated yet.
     ignoreRefreshLimitOnce();
+    terminalSizeMonitor.addListener(this::terminalSizeChanged);
+  }
+
+  private static int normalizeTerminalWidth(int columns) {
+    return columns > 0 ? columns : 80;
+  }
+
+  private int getProgressTargetWidth() {
+    return Math.max(0, terminalWidth - 2);
+  }
+
+  private int getWrappingWidth() {
+    return Math.max(1, terminalWidth - 1);
+  }
+
+  private void terminalSizeChanged(int columns, int rows) {
+    int newTerminalWidth = normalizeTerminalWidth(columns);
+    updateLock.lock();
+    try {
+      synchronized (this) {
+        if (terminalWidth == newTerminalWidth) {
+          return;
+        }
+        if (showProgress && buildRunning && cursorControl) {
+          clearProgressBar();
+        }
+        terminalWidth = newTerminalWidth;
+        if (cursorControl) {
+          stateTracker.setTargetWidth(getProgressTargetWidth());
+        }
+        ignoreRefreshLimitOnce();
+        progressBarNeedsRefresh = true;
+        if (showProgress && buildRunning && cursorControl) {
+          addProgressBar();
+          terminal.flush();
+        }
+      }
+    } catch (IOException e) {
+      logger.atWarning().withCause(e).log("IO Error updating terminal size");
+    } finally {
+      updateLock.unlock();
+    }
   }
 
   /**
@@ -1081,7 +1146,7 @@ public final class UiEventHandler implements EventHandler {
     AnsiTerminalWriter terminalWriter = countingTerminalWriter;
     lastRefreshMillis = clock.currentTimeMillis();
     if (cursorControl) {
-      terminalWriter = new LineWrappingAnsiTerminalWriter(terminalWriter, terminalWidth - 1);
+      terminalWriter = new LineWrappingAnsiTerminalWriter(terminalWriter, getWrappingWidth());
     }
     String timestamp = null;
     if (showTimestamp) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -109,7 +109,7 @@ class UiStateTracker {
 
   // Desired maximal width of the progress bar, if positive.
   // Non-positive values indicate not to aim for a particular width.
-  protected final int targetWidth;
+  protected int targetWidth;
 
   /**
    * Tracker of strategy names to unique IDs and viceversa.
@@ -409,6 +409,11 @@ class UiStateTracker {
   /** Set the progress bar sample size. */
   void setProgressSampleSize(int sampleSize) {
     this.sampleSize = Math.max(1, sampleSize);
+  }
+
+  /** Set the desired maximal width of the progress bar. */
+  synchronized void setTargetWidth(int targetWidth) {
+    this.targetWidth = targetWidth;
   }
 
   void setNewStatsSummary(boolean newStatsSummary) {

--- a/src/main/java/com/google/devtools/build/lib/server/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/server/BUILD
@@ -22,11 +22,18 @@ java_library(
 )
 
 java_library(
+    name = "terminal_size_monitor",
+    srcs = ["TerminalSizeMonitor.java"],
+    deps = ["//third_party:guava"],
+)
+
+java_library(
     name = "command_manager",
     srcs = ["CommandManager.java"],
     deps = [
         ":idle_task",
         ":idle_task_manager",
+        ":terminal_size_monitor",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/protobuf:command_server_java_proto",
         "//third_party:flogger",
@@ -111,6 +118,7 @@ java_library(
         ":pid_file_watcher",
         ":server_watcher_runnable",
         ":shutdown_hooks",
+        ":terminal_size_monitor",
         "//src/main/java/com/google/devtools/build/lib/bugreport",
         "//src/main/java/com/google/devtools/build/lib/clock",
         "//src/main/java/com/google/devtools/build/lib/runtime:blaze_command_result",

--- a/src/main/java/com/google/devtools/build/lib/server/CommandManager.java
+++ b/src/main/java/com/google/devtools/build/lib/server/CommandManager.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.server.CommandProtos.CancelRequest;
+import com.google.devtools.build.lib.server.CommandProtos.TerminalSizeRequest;
 import com.google.devtools.build.lib.util.ThreadUtils;
 import java.util.Collections;
 import java.util.HashMap;
@@ -108,6 +109,19 @@ class CommandManager {
         } else {
           logger.atInfo().log("Cannot find command %s to interrupt", request.getCommandId());
         }
+      }
+    }
+  }
+
+  void doUpdateTerminalSize(TerminalSizeRequest request) {
+    synchronized (runningCommandsMap) {
+      RunningCommand pendingCommand = runningCommandsMap.get(request.getCommandId());
+      if (pendingCommand != null) {
+        pendingCommand.terminalSizeMonitor.updateTerminalSize(
+            request.getColumns(), request.getRows());
+      } else {
+        logger.atInfo().log(
+            "Cannot find command %s to update terminal size", request.getCommandId());
       }
     }
   }
@@ -229,6 +243,7 @@ class CommandManager {
     private final Thread thread;
     private final String id;
     private final boolean preemptible;
+    private final TerminalSizeMonitor terminalSizeMonitor = new TerminalSizeMonitor();
     private Optional<ImmutableList<IdleTask>> idleTasks = Optional.empty();
 
     private RunningCommand(boolean preemptible) {
@@ -256,6 +271,10 @@ class CommandManager {
 
     boolean isPreemptible() {
       return preemptible;
+    }
+
+    TerminalSizeMonitor getTerminalSizeMonitor() {
+      return terminalSizeMonitor;
     }
 
     /**

--- a/src/main/java/com/google/devtools/build/lib/server/CommandServer.java
+++ b/src/main/java/com/google/devtools/build/lib/server/CommandServer.java
@@ -37,6 +37,8 @@ import com.google.devtools.build.lib.server.CommandProtos.RunRequest;
 import com.google.devtools.build.lib.server.CommandProtos.RunResponse;
 import com.google.devtools.build.lib.server.CommandProtos.ServerInfo;
 import com.google.devtools.build.lib.server.CommandProtos.StartupOption;
+import com.google.devtools.build.lib.server.CommandProtos.TerminalSizeRequest;
+import com.google.devtools.build.lib.server.CommandProtos.TerminalSizeResponse;
 import com.google.devtools.build.lib.server.FailureDetails.Command;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.Filesystem;
@@ -514,7 +516,8 @@ public class CommandServer implements GrpcCommandServer.Callback {
                 Optional.of(startupOptions.build()),
                 commandManager::getIdleTaskResults,
                 request.getCommandExtensionsList(),
-                new RpcCommandExtensionReporter(command.getId(), responseCookie, responder));
+                new RpcCommandExtensionReporter(command.getId(), responseCookie, responder),
+                command.getTerminalSizeMonitor());
       } catch (OptionsParsingException e) {
         rpcOutErr.printErrLn(e.getMessage());
         result =
@@ -613,6 +616,30 @@ public class CommandServer implements GrpcCommandServer.Callback {
     } catch (IOException e) {
       // There is no one to report the failure to.
       logger.atInfo().withCause(e).log("Error while sending CancelResponse");
+    }
+  }
+
+  @Override
+  public void updateTerminalSize(byte[] serializedRequest, GrpcCommandServer.Responder responder) {
+    TerminalSizeRequest request;
+    try {
+      request =
+          TerminalSizeRequest.parseFrom(serializedRequest, ExtensionRegistry.getEmptyRegistry());
+    } catch (InvalidProtocolBufferException e) {
+      // Programming error: the SC proto must remain backwards-compatible with the LC proto.
+      throw new IllegalStateException(e);
+    }
+    logger.atInfo().log("Got TerminalSizeRequest for command id %s", request.getCommandId());
+    try {
+      if (isValidRequestCookie(request.getCookie())) {
+        commandManager.doUpdateTerminalSize(request);
+        responder.onNext(
+            TerminalSizeResponse.newBuilder().setCookie(responseCookie).build().toByteArray());
+      }
+      responder.onCompleted();
+    } catch (IOException e) {
+      // There is no one to report the failure to.
+      logger.atInfo().withCause(e).log("Error while sending TerminalSizeResponse");
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/server/GrpcCommandServer.java
+++ b/src/main/java/com/google/devtools/build/lib/server/GrpcCommandServer.java
@@ -63,6 +63,15 @@ public interface GrpcCommandServer {
     void cancel(byte[] request, Responder responder);
 
     /**
+     * Handles an UpdateTerminalSize RPC.
+     *
+     * @param request a serialized {@link com.google.devtools.build.lib.server.TerminalSizeRequest}
+     * @param responder a responder accepting serialized {@link
+     *     com.google.devtools.build.lib.server.TerminalSizeResponse}
+     */
+    void updateTerminalSize(byte[] request, Responder responder);
+
+    /**
      * Handles a Ping RPC.
      *
      * @param request a serialized {@link com.google.devtools.build.lib.server.PingRequest}

--- a/src/main/java/com/google/devtools/build/lib/server/GrpcCommandServerImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/server/GrpcCommandServerImpl.java
@@ -26,6 +26,8 @@ import com.google.devtools.build.lib.server.CommandProtos.PingRequest;
 import com.google.devtools.build.lib.server.CommandProtos.PingResponse;
 import com.google.devtools.build.lib.server.CommandProtos.RunRequest;
 import com.google.devtools.build.lib.server.CommandProtos.RunResponse;
+import com.google.devtools.build.lib.server.CommandProtos.TerminalSizeRequest;
+import com.google.devtools.build.lib.server.CommandProtos.TerminalSizeResponse;
 import com.google.devtools.build.lib.util.OS;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -253,5 +255,16 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
         new BlockingStreamObserver<>(streamObserver, CancelResponse.getDefaultInstance());
     byte[] serializedRequest = cancelRequest.toByteArray();
     callbackExecutorPool.execute(() -> callback.cancel(serializedRequest, blockingObserver));
+  }
+
+  @Override
+  public void updateTerminalSize(
+      TerminalSizeRequest request, StreamObserver<TerminalSizeResponse> streamObserver) {
+    checkNotNull(callback, "updateTerminalSize() called before serve()");
+    BlockingStreamObserver<TerminalSizeResponse> blockingObserver =
+        new BlockingStreamObserver<>(streamObserver, TerminalSizeResponse.getDefaultInstance());
+    byte[] serializedRequest = request.toByteArray();
+    callbackExecutorPool.execute(
+        () -> callback.updateTerminalSize(serializedRequest, blockingObserver));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/server/TerminalSizeMonitor.java
+++ b/src/main/java/com/google/devtools/build/lib/server/TerminalSizeMonitor.java
@@ -1,0 +1,76 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.server;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Tracks terminal size updates for a single running command. */
+public final class TerminalSizeMonitor {
+  public static final TerminalSizeMonitor NOOP = new TerminalSizeMonitor(/* enabled= */ false);
+
+  /** Listener for terminal size updates. */
+  public interface Listener {
+    void terminalSizeChanged(int columns, int rows);
+  }
+
+  private final Object lock = new Object();
+  private final boolean enabled;
+  private final List<Listener> listeners = new ArrayList<>();
+  private int columns;
+  private int rows;
+
+  public TerminalSizeMonitor() {
+    this(/* enabled= */ true);
+  }
+
+  private TerminalSizeMonitor(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public void addListener(Listener listener) {
+    if (!enabled) {
+      return;
+    }
+    int columnsSnapshot;
+    int rowsSnapshot;
+    synchronized (lock) {
+      listeners.add(listener);
+      columnsSnapshot = columns;
+      rowsSnapshot = rows;
+    }
+    if (columnsSnapshot > 0) {
+      listener.terminalSizeChanged(columnsSnapshot, rowsSnapshot);
+    }
+  }
+
+  public void updateTerminalSize(int columns, int rows) {
+    if (!enabled || columns <= 0) {
+      return;
+    }
+    ImmutableList<Listener> listenersSnapshot;
+    synchronized (lock) {
+      if (this.columns == columns && this.rows == rows) {
+        return;
+      }
+      this.columns = columns;
+      this.rows = rows;
+      listenersSnapshot = ImmutableList.copyOf(listeners);
+    }
+    for (Listener listener : listenersSnapshot) {
+      listener.terminalSizeChanged(columns, rows);
+    }
+  }
+}

--- a/src/main/protobuf/command_server.proto
+++ b/src/main/protobuf/command_server.proto
@@ -193,6 +193,28 @@ message CancelResponse {
   string cookie = 1;
 }
 
+// Passed to CommandServer.update_terminal_size to update terminal dimensions for
+// an in-flight command.
+message TerminalSizeRequest {
+  // The client request cookie (see RunRequest.cookie).
+  string cookie = 1;
+
+  // The id of the command whose UI should use the updated terminal size.
+  string command_id = 2;
+
+  // Terminal width in columns.
+  int32 columns = 3;
+
+  // Terminal height in rows. This is not currently used by Bazel's progress UI
+  // but is included so the RPC can carry the complete terminal size.
+  int32 rows = 4;
+}
+
+message TerminalSizeResponse {
+  // The server response cookie (see RunResponse.cookie).
+  string cookie = 1;
+}
+
 // Passed to CommandServer.ping to initiate a ping request.
 message PingRequest {
   // The client request cookie (see RunRequest.cookie).
@@ -249,6 +271,9 @@ service CommandServer {
   // Cancel a currently running Bazel command. May return before the run command
   // actually terminates.
   rpc Cancel(CancelRequest) returns (CancelResponse) {}
+
+  // Updates the terminal dimensions for a currently running Bazel command.
+  rpc UpdateTerminalSize(TerminalSizeRequest) returns (TerminalSizeResponse) {}
 
   // Does not do anything. Used for liveness check.
   rpc Ping(PingRequest) returns (PingResponse) {}

--- a/src/test/java/com/google/devtools/build/lib/runtime/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BUILD
@@ -133,6 +133,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/server:gc_and_interner_shrinking_idle_task",
         "//src/main/java/com/google/devtools/build/lib/server:idle_task",
         "//src/main/java/com/google/devtools/build/lib/server:install_base_garbage_collector",
+        "//src/main/java/com/google/devtools/build/lib/server:terminal_size_monitor",
         "//src/main/java/com/google/devtools/build/lib/skyframe:analysis_progress_receiver",
         "//src/main/java/com/google/devtools/build/lib/skyframe:configuration_phase_started_event",
         "//src/main/java/com/google/devtools/build/lib/skyframe:configured_target_key",

--- a/src/test/java/com/google/devtools/build/lib/runtime/UiEventHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/UiEventHandlerTest.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.pkgcache.LoadingPhaseCompleteEvent;
 import com.google.devtools.build.lib.runtime.UiOptions.UseCurses;
+import com.google.devtools.build.lib.server.TerminalSizeMonitor;
 import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.util.io.OutErr;
@@ -90,6 +91,10 @@ public class UiEventHandlerTest {
   }
 
   void createUiEventHandler(EventKind outputKind) {
+    createUiEventHandler(outputKind, TerminalSizeMonitor.NOOP);
+  }
+
+  void createUiEventHandler(EventKind outputKind, TerminalSizeMonitor terminalSizeMonitor) {
     uiOptions.setEventKindFilters(ImmutableList.of());
     output.flush();
     output.flushed.clear();
@@ -110,7 +115,8 @@ public class UiEventHandlerTest {
             new EventBus(),
             /* workspacePathFragment= */ null,
             skymeldMode,
-            /* newStatsSummary= */ false);
+            /* newStatsSummary= */ false,
+            terminalSizeMonitor);
     uiEventHandler.mainRepoMappingComputationStarted(new MainRepoMappingComputationStartingEvent());
     uiEventHandler.buildStarted(
         BuildStartingEvent.create(
@@ -339,6 +345,24 @@ public class UiEventHandlerTest {
     }
 
     @Test
+    public void terminalSizeChangeRefreshesProgressBarWithNewWidth() {
+      TerminalSizeMonitor terminalSizeMonitor = new TerminalSizeMonitor();
+      uiOptions.setShowProgress(true);
+      uiOptions.setUseCursesEnum(UseCurses.YES);
+      createUiEventHandler(EventKind.STDERR, terminalSizeMonitor);
+      uiEventHandler.mainRepoMappingComputationStarted(
+          new MainRepoMappingComputationStartingEvent());
+      output.flushed.clear();
+
+      terminalSizeMonitor.updateTerminalSize(/* columns= */ 12, /* rows= */ 24);
+      assertThat(output.flushed.getLast()).contains(CLEAR_PROGRESS_BAR);
+      output.flushed.clear();
+
+      terminalSizeMonitor.updateTerminalSize(/* columns= */ 80, /* rows= */ 24);
+      assertThat(countOccurrences(output.flushed.getLast(), CLEAR_PROGRESS_BAR)).isAtLeast(2);
+    }
+
+    @Test
     public void progressOff_disableProgressReturnsFalse() throws Exception {
       uiOptions.setShowProgress(false);
       createUiEventHandler();
@@ -362,6 +386,16 @@ public class UiEventHandlerTest {
         }
       };
     }
+  }
+
+  private static int countOccurrences(String haystack, String needle) {
+    int count = 0;
+    int index = 0;
+    while ((index = haystack.indexOf(needle, index)) != -1) {
+      count++;
+      index += needle.length();
+    }
+    return count;
   }
 
   private static final class FlushCollectingOutputStream extends OutputStream {

--- a/src/test/java/com/google/devtools/build/lib/runtime/UiStateTrackerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/UiStateTrackerTest.java
@@ -780,6 +780,30 @@ public class UiStateTrackerTest extends FoundationTestCase {
   }
 
   @Test
+  public void setTargetWidth_affectsSubsequentProgressBarRendering() throws Exception {
+    ManualClock clock = new ManualClock();
+    Action action = createDummyAction("Some random action");
+    UiStateTracker stateTracker = getUiStateTracker(clock, /* targetWidth= */ 70);
+    // Mimic being at the execution phase.
+    simulateExecutionPhase(stateTracker);
+    stateTracker.actionStarted(new ActionStartedEvent(action, clock.nanoTime()));
+    stateTracker.actionProgress(
+        ActionProgressEvent.create(action, "action-id", "action progress", false));
+
+    LoggingTerminalWriter wideTerminalWriter =
+        new LoggingTerminalWriter(/* discardHighlight= */ true);
+    stateTracker.writeProgressBar(wideTerminalWriter);
+    assertThat(wideTerminalWriter.getTranscript()).contains("action progress");
+
+    stateTracker.setTargetWidth(30);
+
+    LoggingTerminalWriter narrowTerminalWriter =
+        new LoggingTerminalWriter(/* discardHighlight= */ true);
+    stateTracker.writeProgressBar(narrowTerminalWriter);
+    assertThat(narrowTerminalWriter.getTranscript()).doesNotContain("action progress");
+  }
+
+  @Test
   public void actionProgress_withTooSmallWidth_progressSkipped() throws Exception {
     // arrange
     ManualClock clock = new ManualClock();

--- a/src/test/java/com/google/devtools/build/lib/server/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/server/BUILD
@@ -30,6 +30,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/server:pid_file_watcher",
         "//src/main/java/com/google/devtools/build/lib/server:server_watcher_runnable",
         "//src/main/java/com/google/devtools/build/lib/server:shutdown_hooks",
+        "//src/main/java/com/google/devtools/build/lib/server:terminal_size_monitor",
         "//src/main/java/com/google/devtools/build/lib/unix:procmeminfo_parser",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:os",

--- a/src/test/java/com/google/devtools/build/lib/server/CommandServerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/server/CommandServerTest.java
@@ -29,6 +29,8 @@ import com.google.devtools.build.lib.server.CommandProtos.CancelResponse;
 import com.google.devtools.build.lib.server.CommandProtos.EnvironmentVariable;
 import com.google.devtools.build.lib.server.CommandProtos.RunRequest;
 import com.google.devtools.build.lib.server.CommandProtos.RunResponse;
+import com.google.devtools.build.lib.server.CommandProtos.TerminalSizeRequest;
+import com.google.devtools.build.lib.server.CommandProtos.TerminalSizeResponse;
 import com.google.devtools.build.lib.server.CommandServerGrpc.CommandServerStub;
 import com.google.devtools.build.lib.server.FailureDetails.Command;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
@@ -60,6 +62,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -619,6 +622,131 @@ public final class CommandServerTest {
     assertThat(secondResponse.get().getFailureDetail().hasInterrupted()).isTrue();
     assertThat(secondResponse.get().getFailureDetail().getInterrupted().getCode())
         .isEqualTo(Code.INTERRUPTED);
+  }
+
+  @Test
+  public void updateTerminalSize_updatesRunningCommandMonitor() throws Exception {
+    CountDownLatch execStarted = new CountDownLatch(1);
+    CountDownLatch allowListenerRegistration = new CountDownLatch(1);
+    CountDownLatch resizeSeen = new CountDownLatch(1);
+    AtomicInteger columnsSeen = new AtomicInteger();
+    AtomicInteger rowsSeen = new AtomicInteger();
+
+    CommandDispatcher dispatcher =
+        new CommandDispatcher() {
+          @Override
+          public BlazeCommandResult exec(
+              InvocationPolicy invocationPolicy,
+              List<String> args,
+              OutErr outErr,
+              LockingMode lockingMode,
+              UiVerbosity uiVerbosity,
+              String clientDescription,
+              long firstContactTimeMillis,
+              Optional<List<Pair<String, String>>> startupOptionsTaggedWithBazelRc,
+              Supplier<ImmutableList<IdleTask.Result>> idleTaskResultsSupplier,
+              List<Any> commandExtensions,
+              CommandExtensionReporter commandExtensionReporter) {
+            throw new AssertionError("exec overload without terminal size monitor called");
+          }
+
+          @Override
+          public BlazeCommandResult exec(
+              InvocationPolicy invocationPolicy,
+              List<String> args,
+              OutErr outErr,
+              LockingMode lockingMode,
+              UiVerbosity uiVerbosity,
+              String clientDescription,
+              long firstContactTimeMillis,
+              Optional<List<Pair<String, String>>> startupOptionsTaggedWithBazelRc,
+              Supplier<ImmutableList<IdleTask.Result>> idleTaskResultsSupplier,
+              List<Any> commandExtensions,
+              CommandExtensionReporter commandExtensionReporter,
+              TerminalSizeMonitor terminalSizeMonitor)
+              throws InterruptedException {
+            execStarted.countDown();
+            assertThat(allowListenerRegistration.await(WAIT_TIMEOUT_SECONDS, SECONDS)).isTrue();
+            terminalSizeMonitor.addListener(
+                (columns, rows) -> {
+                  columnsSeen.set(columns);
+                  rowsSeen.set(rows);
+                  resizeSeen.countDown();
+                });
+            assertThat(resizeSeen.await(WAIT_TIMEOUT_SECONDS, SECONDS)).isTrue();
+            return BlazeCommandResult.success();
+          }
+        };
+
+    ServerAndStub serverAndStub = createServerAndStub(dispatcher);
+    CommandServer server = serverAndStub.server();
+    CommandServerStub stub = serverAndStub.stub();
+
+    AtomicReference<String> commandId = new AtomicReference<>();
+    CountDownLatch gotCommandId = new CountDownLatch(1);
+    CountDownLatch commandDone = new CountDownLatch(1);
+    stub.run(
+        createRequest("Foo"),
+        new StreamObserver<RunResponse>() {
+          @Override
+          public void onNext(RunResponse value) {
+            if (commandId.compareAndSet(null, value.getCommandId())) {
+              gotCommandId.countDown();
+            }
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            commandDone.countDown();
+          }
+
+          @Override
+          public void onCompleted() {
+            commandDone.countDown();
+          }
+        });
+
+    assertThat(gotCommandId.await(WAIT_TIMEOUT_SECONDS, SECONDS)).isTrue();
+    assertThat(execStarted.await(WAIT_TIMEOUT_SECONDS, SECONDS)).isTrue();
+
+    CountDownLatch terminalSizeRequestComplete = new CountDownLatch(1);
+    AtomicReference<TerminalSizeResponse> terminalSizeResponse = new AtomicReference<>();
+    TerminalSizeRequest terminalSizeRequest =
+        TerminalSizeRequest.newBuilder()
+            .setCookie(REQUEST_COOKIE)
+            .setCommandId(commandId.get())
+            .setColumns(47)
+            .setRows(12)
+            .build();
+    stub.updateTerminalSize(
+        terminalSizeRequest,
+        new StreamObserver<TerminalSizeResponse>() {
+          @Override
+          public void onNext(TerminalSizeResponse value) {
+            terminalSizeResponse.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            terminalSizeRequestComplete.countDown();
+          }
+
+          @Override
+          public void onCompleted() {
+            terminalSizeRequestComplete.countDown();
+          }
+        });
+
+    assertThat(terminalSizeRequestComplete.await(WAIT_TIMEOUT_SECONDS, SECONDS)).isTrue();
+    allowListenerRegistration.countDown();
+    assertThat(commandDone.await(WAIT_TIMEOUT_SECONDS, SECONDS)).isTrue();
+    server.shutdown();
+    server.awaitTermination();
+
+    assertThat(terminalSizeResponse.get()).isNotNull();
+    assertThat(terminalSizeResponse.get().getCookie()).isEqualTo(RESPONSE_COOKIE);
+    assertThat(columnsSeen.get()).isEqualTo(47);
+    assertThat(rowsSeen.get()).isEqualTo(12);
   }
 
   /**


### PR DESCRIPTION
Resizing a tmux pane during a long Bazel invocation could leave the
curses progress UI wrapping against stale dimensions because Bazel only
sampled the terminal width when the command started. Progress updates
then scrolled as repeated lines instead of replacing the same lines.

This follows up on https://github.com/bazelbuild/bazel/discussions/29746.

Forward SIGWINCH from the native client over a side-band command-server
RPC keyed by command id. Store the latest size per running command so
the UI receives updates even when the resize arrives before its listener
is registered, then refresh the progress bar with the new target width.
