### PR TITLE
Add startup flag to use system certificates

### DIFF
--- a/src/main/cpp/BUILD
+++ b/src/main/cpp/BUILD
@@ -243,6 +243,7 @@ cc_library(
         ":blaze_util",
         ":startup_options",
         ":workspace_layout",
+        "//src/main/cpp/util",
         "//src/main/cpp/util:blaze_exit_code",
     ],
 )

--- a/src/main/cpp/bazel_startup_options.cc
+++ b/src/main/cpp/bazel_startup_options.cc
@@ -23,18 +23,30 @@
 #include "src/main/cpp/startup_options.h"
 #include "src/main/cpp/util/logging.h"
 #include "src/main/cpp/util/path_platform.h"
+#include "src/main/cpp/util/strings.h"
 
 namespace blaze {
+
+namespace {
+
+bool IsTruthyEnv(const std::string &name) {
+  std::string value = blaze_util::ToLower(blaze::GetEnv(name));
+  return !value.empty() && value != "0" && value != "false" && value != "no";
+}
+
+}  // namespace
 
 BazelStartupOptions::BazelStartupOptions()
     : StartupOptions("Bazel", /* lock_install_base= */ true),
       user_bazelrc_(""),
       use_system_rc(true),
       use_workspace_rc(true),
-      use_home_rc(true) {
+      use_home_rc(true),
+      use_system_certs(IsTruthyEnv("BAZEL_USE_SYSTEM_CERTS")) {
   RegisterNullaryStartupFlagNoRc("home_rc", &use_home_rc);
   RegisterNullaryStartupFlagNoRc("system_rc", &use_system_rc);
   RegisterNullaryStartupFlagNoRc("workspace_rc", &use_workspace_rc);
+  RegisterNullaryStartupFlag("use_system_certs", &use_system_certs);
   RegisterUnaryStartupFlag("bazelrc");
 }
 
@@ -106,6 +118,23 @@ void BazelStartupOptions::MaybeLogStartupOptionWarnings() const {
 void BazelStartupOptions::AddExtraOptions(
     std::vector<std::string> *result) const {
   StartupOptions::AddExtraOptions(result);
+  if (use_system_certs) {
+    result->push_back("--use_system_certs");
+  }
+}
+
+void BazelStartupOptions::AddJVMArgumentPrefix(
+    const blaze_util::Path &javabase, std::vector<std::string> *result) const {
+  StartupOptions::AddJVMArgumentPrefix(javabase, result);
+  if (!use_system_certs) {
+    return;
+  }
+
+#if defined(__APPLE__)
+  result->push_back("-Djavax.net.ssl.trustStoreType=KeychainStore");
+#elif defined(_WIN32) || defined(__CYGWIN__)
+  result->push_back("-Djavax.net.ssl.trustStoreType=Windows-ROOT");
+#endif
 }
 
 }  // namespace blaze

--- a/src/main/cpp/bazel_startup_options.h
+++ b/src/main/cpp/bazel_startup_options.h
@@ -29,6 +29,9 @@ class BazelStartupOptions : public StartupOptions {
 
   void AddExtraOptions(std::vector<std::string> *result) const override;
 
+  void AddJVMArgumentPrefix(const blaze_util::Path &javabase,
+                            std::vector<std::string> *result) const override;
+
   blaze_exit_code::ExitCode ProcessArgExtra(
       const char *arg, const char *next_arg, const std::string &rcfile,
       const char **value, bool *is_processed, std::string *error) override;
@@ -45,6 +48,7 @@ class BazelStartupOptions : public StartupOptions {
   bool use_system_rc;
   bool use_workspace_rc;
   bool use_home_rc;
+  bool use_system_certs;
 };
 
 }  // namespace blaze

--- a/src/main/java/com/google/devtools/build/lib/runtime/HostJvmStartupOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/HostJvmStartupOptions.java
@@ -50,6 +50,16 @@ public abstract class HostJvmStartupOptions extends OptionsBase {
   public abstract List<String> getHostJvmArgs();
 
   @Option(
+      name = "use_system_certs",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "Use the operating system trust store for the JVM executing Bazel, when supported by "
+              + "the current platform.")
+  public abstract boolean getUseSystemCerts();
+
+  @Option(
       name = "host_jvm_debug",
       defaultValue = "null", // NOTE: purely decorative!  See BlazeServerStartupOptions.
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,

--- a/src/test/cpp/bazel_startup_options_test.cc
+++ b/src/test/cpp/bazel_startup_options_test.cc
@@ -17,6 +17,8 @@
 #include <stdlib.h>
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "src/main/cpp/blaze_util_platform.h"
 #include "src/main/cpp/util/file_platform.h"
@@ -25,6 +27,22 @@
 
 namespace blaze {
 
+namespace {
+
+void ExpectSystemCertJvmArgs(const std::vector<std::string> &args) {
+#if defined(__APPLE__)
+  ASSERT_EQ(1, args.size());
+  EXPECT_EQ("-Djavax.net.ssl.trustStoreType=KeychainStore", args[0]);
+#elif defined(_WIN32) || defined(__CYGWIN__)
+  ASSERT_EQ(1, args.size());
+  EXPECT_EQ("-Djavax.net.ssl.trustStoreType=Windows-ROOT", args[0]);
+#else
+  EXPECT_TRUE(args.empty());
+#endif
+}
+
+}  // namespace
+
 class BazelStartupOptionsTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -32,11 +50,20 @@ class BazelStartupOptionsTest : public ::testing::Test {
     // being unset because we expect our test runner to set them in all cases.
     // Otherwise, we'll crash here, but this keeps our code simpler.
     old_test_tmpdir_ = GetPathEnv("TEST_TMPDIR");
+    old_use_system_certs_exists_ = ExistsEnv("BAZEL_USE_SYSTEM_CERTS");
+    old_use_system_certs_ = GetEnv("BAZEL_USE_SYSTEM_CERTS");
 
     ReinitStartupOptions();
   }
 
-  void TearDown() override { SetEnv("TEST_TMPDIR", old_test_tmpdir_); }
+  void TearDown() override {
+    SetEnv("TEST_TMPDIR", old_test_tmpdir_);
+    if (old_use_system_certs_exists_) {
+      SetEnv("BAZEL_USE_SYSTEM_CERTS", old_use_system_certs_);
+    } else {
+      UnsetEnv("BAZEL_USE_SYSTEM_CERTS");
+    }
+  }
 
   // Recreates startup_options_ after changes to the environment.
   void ReinitStartupOptions() {
@@ -53,6 +80,8 @@ class BazelStartupOptionsTest : public ::testing::Test {
 
  private:
   std::string old_test_tmpdir_;
+  bool old_use_system_certs_exists_;
+  std::string old_use_system_certs_;
 };
 
 TEST_F(BazelStartupOptionsTest, ProductName) {
@@ -62,6 +91,48 @@ TEST_F(BazelStartupOptionsTest, ProductName) {
 TEST_F(BazelStartupOptionsTest, JavaLoggingOptions) {
   ASSERT_EQ("com.google.devtools.build.lib.util.SingleLineFormatter",
             startup_options_->java_logging_formatter);
+}
+
+TEST_F(BazelStartupOptionsTest, UseSystemCertsAddsJvmTrustStoreType) {
+  std::string error;
+  const std::vector<RcStartupFlag> flags{
+      RcStartupFlag("somewhere", "--use_system_certs")};
+
+  const blaze_exit_code::ExitCode ec =
+      startup_options_->ProcessArgs(flags, &error);
+  ASSERT_EQ(blaze_exit_code::SUCCESS, ec)
+      << "ProcessArgs failed with error " << error;
+
+  std::vector<std::string> args;
+  startup_options_->AddJVMArgumentPrefix(blaze_util::Path("/javabase"), &args);
+  ExpectSystemCertJvmArgs(args);
+}
+
+TEST_F(BazelStartupOptionsTest, UseSystemCertsEnvAddsJvmTrustStoreType) {
+  SetEnv("BAZEL_USE_SYSTEM_CERTS", "1");
+  ReinitStartupOptions();
+
+  std::vector<std::string> args;
+  startup_options_->AddJVMArgumentPrefix(blaze_util::Path("/javabase"), &args);
+  ExpectSystemCertJvmArgs(args);
+}
+
+TEST_F(BazelStartupOptionsTest, NoUseSystemCertsOverridesEnv) {
+  SetEnv("BAZEL_USE_SYSTEM_CERTS", "1");
+  ReinitStartupOptions();
+
+  std::string error;
+  const std::vector<RcStartupFlag> flags{
+      RcStartupFlag("somewhere", "--nouse_system_certs")};
+
+  const blaze_exit_code::ExitCode ec =
+      startup_options_->ProcessArgs(flags, &error);
+  ASSERT_EQ(blaze_exit_code::SUCCESS, ec)
+      << "ProcessArgs failed with error " << error;
+
+  std::vector<std::string> args;
+  startup_options_->AddJVMArgumentPrefix(blaze_util::Path("/javabase"), &args);
+  EXPECT_TRUE(args.empty());
 }
 
 TEST_F(BazelStartupOptionsTest, EmptyFlagsAreInvalid) {
@@ -247,6 +318,7 @@ TEST_F(BazelStartupOptionsTest, ValidStartupFlags) {
   ExpectValidNullaryOption(options, "ignore_all_rc_files");
   ExpectValidNullaryOption(options, "shutdown_on_low_sys_mem");
   ExpectValidNullaryOption(options, "system_rc");
+  ExpectValidNullaryOption(options, "use_system_certs");
   ExpectValidNullaryOption(options, "workspace_rc");
   ExpectValidNullaryOption(options, "write_command_log");
   ExpectIsUnaryOption(options, "bazelrc");

--- a/src/test/java/com/google/devtools/build/lib/runtime/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BUILD
@@ -105,6 +105,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/runtime:counting_artifact_group_namer",
         "//src/main/java/com/google/devtools/build/lib/runtime:execution_graph_module",
         "//src/main/java/com/google/devtools/build/lib/runtime:gc_churning_detector",
+        "//src/main/java/com/google/devtools/build/lib/runtime:host_jvm_startup_options",
         "//src/main/java/com/google/devtools/build/lib/runtime:instrumentation_output",
         "//src/main/java/com/google/devtools/build/lib/runtime:keep_state_after_build_option",
         "//src/main/java/com/google/devtools/build/lib/runtime:line_buffered_output_stream",

--- a/src/test/java/com/google/devtools/build/lib/runtime/HostJvmStartupOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/HostJvmStartupOptionsTest.java
@@ -1,0 +1,44 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.runtime;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.common.options.OptionsParser;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Regression tests for {@link HostJvmStartupOptions}. */
+@RunWith(JUnit4.class)
+public class HostJvmStartupOptionsTest {
+
+  @Test
+  public void useSystemCertsIsFalseByDefault() throws Exception {
+    OptionsParser parser =
+        OptionsParser.builder().optionsClasses(HostJvmStartupOptions.class).build();
+    parser.parse();
+    HostJvmStartupOptions result = parser.getOptions(HostJvmStartupOptions.class);
+    assertThat(result.getUseSystemCerts()).isFalse();
+  }
+
+  @Test
+  public void useSystemCertsCanBeEnabled() throws Exception {
+    OptionsParser parser =
+        OptionsParser.builder().optionsClasses(HostJvmStartupOptions.class).build();
+    parser.parse("--use_system_certs");
+    HostJvmStartupOptions result = parser.getOptions(HostJvmStartupOptions.class);
+    assertThat(result.getUseSystemCerts()).isTrue();
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `startup --use_system_certs` startup flag that can be set from `.bazelrc`.
- When enabled, the Bazel launcher configures the host JVM to use the platform trust store on supported platforms: macOS KeychainStore and Windows-ROOT.
- Keeps `BAZEL_USE_SYSTEM_CERTS` as an environment-driven default and forwards the parsed startup option into the Java startup option set.

## Tests
- `bazel --host_jvm_args=-Djavax.net.ssl.trustStoreType=KeychainStore test --test_output=errors //src/test/cpp:bazel_startup_options_test`
- `bazel --host_jvm_args=-Djavax.net.ssl.trustStoreType=KeychainStore test --test_output=errors --test_filter=HostJvmStartupOptionsTest //src/test/java/com/google/devtools/build/lib/runtime:RuntimeTests`
- `git diff --check`

Fixes #29751
