### PR TITLE
Fix Windows Java launcher junction directory race condition

### DIFF
--- a/src/tools/launcher/BUILD
+++ b/src/tools/launcher/BUILD
@@ -44,6 +44,7 @@ win_cc_library(
     deps = [
         ":launcher_base",
         "//src/main/native/windows:lib-process",
+        "//src/tools/launcher/util",
     ],
 )
 

--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -168,7 +168,8 @@ static void WriteJarClasspath(const wstring& jar_path,
 wstring JavaBinaryLauncher::GetJunctionBaseDir() {
   wstring binary_base_path = GetBinaryPathWithExtension(GetLauncherPath());
   wstring result;
-  if (!NormalizePath(binary_base_path + L".j", &result)) {
+  if (!NormalizePath(binary_base_path + L".j-" + junction_base_dir_suffix_,
+                     &result)) {
     die(L"Failed to get normalized junction base directory.");
   }
   return result;

--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -168,7 +168,7 @@ static void WriteJarClasspath(const wstring& jar_path,
 wstring JavaBinaryLauncher::GetJunctionBaseDir() {
   wstring binary_base_path = GetBinaryPathWithExtension(GetLauncherPath());
   wstring result;
-  if (!NormalizePath(binary_base_path + L".j-" + junction_base_dir_suffix_,
+  if (!NormalizePath(binary_base_path + L".j-" + rand_id_,
                      &result)) {
     die(L"Failed to get normalized junction base directory.");
   }
@@ -249,7 +249,7 @@ wstring JavaBinaryLauncher::CreateClasspathJar(const wstring& classpath) {
     WriteJarClasspath(path, &manifest_classpath);
   }
 
-  wstring rand_id = L"-" + GetRandomStr(10);
+  const wstring rand_id = L"-" + rand_id_;
   // Enable long path support for jar_manifest_file_path.
   wstring jar_manifest_file_path =
       binary_base_path + rand_id + L".jar_manifest";

--- a/src/tools/launcher/java_launcher.h
+++ b/src/tools/launcher/java_launcher.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "src/tools/launcher/launcher.h"
+#include "src/tools/launcher/util/launcher_util.h"
 
 namespace bazel {
 namespace launcher {
@@ -35,7 +36,8 @@ class JavaBinaryLauncher : public BinaryLauncherBase {
       : BinaryLauncherBase(launch_info, launcher_path, argc, argv),
         singlejar(false),
         print_javabin(false),
-        classpath_limit(MAX_ARG_STRLEN) {}
+        classpath_limit(MAX_ARG_STRLEN),
+        junction_base_dir_suffix_(GetRandomStr(10)) {}
   ~JavaBinaryLauncher() override = default;
   ExitCode Launch() override;
 
@@ -86,6 +88,9 @@ class JavaBinaryLauncher : public BinaryLauncherBase {
   bool singlejar;
   bool print_javabin;
   int classpath_limit;
+  // Per-invocation random suffix used to make the junction base directory
+  // unique across concurrent launcher processes sharing the same binary path.
+  const std::wstring junction_base_dir_suffix_;
 
   // Create a classpath jar to pass CLASSPATH value when its length is over
   // limit.

--- a/src/tools/launcher/java_launcher.h
+++ b/src/tools/launcher/java_launcher.h
@@ -37,7 +37,7 @@ class JavaBinaryLauncher : public BinaryLauncherBase {
         singlejar(false),
         print_javabin(false),
         classpath_limit(MAX_ARG_STRLEN),
-        junction_base_dir_suffix_(GetRandomStr(10)) {}
+        rand_id_(GetRandomStr(10)) {}
   ~JavaBinaryLauncher() override = default;
   ExitCode Launch() override;
 
@@ -88,9 +88,9 @@ class JavaBinaryLauncher : public BinaryLauncherBase {
   bool singlejar;
   bool print_javabin;
   int classpath_limit;
-  // Per-invocation random suffix used to make the junction base directory
-  // unique across concurrent launcher processes sharing the same binary path.
-  const std::wstring junction_base_dir_suffix_;
+  // Per-invocation random suffix used to uniquify the junction base dir and
+  // classpath jar across concurrent launcher processes sharing the same binary.
+  const std::wstring rand_id_;
 
   // Create a classpath jar to pass CLASSPATH value when its length is over
   // limit.

--- a/src/tools/launcher/util/launcher_util_test.cc
+++ b/src/tools/launcher/util/launcher_util_test.cc
@@ -140,6 +140,29 @@ TEST_F(LaunchUtilTest, NormalizePathTest) {
   ASSERT_FALSE(NormalizePath(L"c:foo\\bar", &value));
 }
 
+TEST_F(LaunchUtilTest, GetRandomStrLengthTest) {
+  ASSERT_EQ(0u, GetRandomStr(0).length());
+  ASSERT_EQ(1u, GetRandomStr(1).length());
+  ASSERT_EQ(10u, GetRandomStr(10).length());
+  ASSERT_EQ(32u, GetRandomStr(32).length());
+}
+
+TEST_F(LaunchUtilTest, GetRandomStrCharsetTest) {
+  static constexpr std::wstring_view kAlphabet =
+      L"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  std::wstring s = GetRandomStr(256);
+  for (wchar_t c : s) {
+    ASSERT_NE(kAlphabet.find(c), std::wstring_view::npos)
+        << "Unexpected character in random string: " << c;
+  }
+}
+
+TEST_F(LaunchUtilTest, GetRandomStrUniquenessTest) {
+  // Two independent calls should produce different strings with overwhelming
+  // probability (collision chance < 62^-10 ≈ 8e-18 for length 10).
+  ASSERT_NE(GetRandomStr(10), GetRandomStr(10));
+}
+
 TEST_F(LaunchUtilTest, RelativeToTest) {
   wstring value;
   ASSERT_TRUE(RelativeTo(L"c:\\foo\\bar1", L"c:\\foo\\bar2", &value));


### PR DESCRIPTION
## Problem

When multiple Bazel actions invoke the same `java_binary` tool concurrently on Windows, the Java launcher crashes with:

```
LAUNCHER ERROR: Failed to delete junction directory: The process cannot access the file because it is being used by another process.
```

`GetJunctionBaseDir()` generates a fixed path based solely on the binary path (`<binary>.j`). All concurrent invocations resolve to the **same** directory. When any process calls `DeleteJunctionBaseDir()` at startup (to clear a previous run) or at teardown, it deletes junctions that sibling processes are actively reading from.

This surfaces reliably when many parallel test actions use the same Java tool (e.g. `ijar`). Tracked in issue #29639.

## Fix (Option B)

Initialize a per-invocation random suffix once in the `JavaBinaryLauncher` constructor and use it in `GetJunctionBaseDir()`. Each launcher process instance now gets its own unique directory:

```
<binary>.j-<10-char random>
```

This mirrors the existing pattern already used for classpath jar files (`rand_id = GetRandomStr(10)`), where uniqueness across concurrent invocations is already correctly handled.

The suffix is stored as `const std::wstring junction_base_dir_suffix_`, initialized in the constructor initializer list, and used consistently across both `GetJunctionBaseDir()` and `DeleteJunctionBaseDir()` (which calls `GetJunctionBaseDir()` internally).

## Changes

- `src/tools/launcher/java_launcher.h`: add `junction_base_dir_suffix_` member; initialize via `GetRandomStr(10)` in constructor; add explicit `#include` of `launcher_util.h`
- `src/tools/launcher/java_launcher.cc`: append suffix in `GetJunctionBaseDir()`
- `src/tools/launcher/BUILD`: add explicit `//src/tools/launcher/util` dep for `java_launcher` (the header now directly includes `launcher_util.h`)
- `src/tools/launcher/util/launcher_util_test.cc`: add three `GetRandomStr` tests (length, charset, uniqueness)

## Testing

Added unit tests in `//src/tools/launcher/util:util_test`:
- `GetRandomStrLengthTest` — verifies requested length is produced
- `GetRandomStrCharsetTest` — verifies all characters are from `[A-Za-z0-9]`
- `GetRandomStrUniquenessTest` — verifies two independent calls produce different strings (collision probability < 8×10⁻¹⁸ for length 10)

Closes #29639