### PR TITLE
Fix exclusive-if-local limiting concurrency on remote exec

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/SpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SpawnStrategy.java
@@ -49,4 +49,15 @@ public interface SpawnStrategy {
   // TODO(katre): Remove once strategies are only instantiated if used, the callback can then be
   //  done upon construction.
   default void usedContext(ActionContext.ActionContextRegistry actionContextRegistry) {}
+
+  /**
+   * Returns {@code true} to indicate that "exclusive-if-local" tests should be treated as regular
+   * parallel tests.
+   *
+   * <p>Returning {@code true} may make sense for certain remote spawn strategies where running tests
+   * in sequence would be wasteful.
+   */
+  default boolean forceExclusiveIfLocalTestsInParallel() {
+    return false;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/BuildView.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BuildView.java
@@ -915,11 +915,15 @@ public class BuildView {
         if (target instanceof Rule rule) {
           if (isExclusive || TargetUtils.isExclusiveTestRule(rule)) {
             exclusiveTests.add(configuredTarget);
-          } else if (TargetUtils.isExclusiveIfLocalTestRule((Rule) target)
-              && TargetUtils.isLocalTestRule((Rule) target)) {
-            exclusiveTests.add(configuredTarget);
-          } else if (TargetUtils.isExclusiveIfLocalTestRule((Rule) target)) {
-            exclusiveIfLocalTests.add(configuredTarget);
+          } else if (TargetUtils.isExclusiveIfLocalTestRule(rule)) {
+            // An "exclusive-if-local" test that can never run remotely (because it is pinned to
+            // local execution by its tags) must stay serialized. Only tests that are actually
+            // eligible for remote execution may later be promoted to parallel tests.
+            if (TargetUtils.isLocalTestRule(rule) || TargetUtils.isNoRemoteExecTestRule(rule)) {
+              exclusiveTests.add(configuredTarget);
+            } else {
+              exclusiveIfLocalTests.add(configuredTarget);
+            }
           } else {
             parallelTests.add(configuredTarget);
           }

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java
@@ -548,7 +548,7 @@ public class BuildTool {
           analysisResult = analysisResult.withExclusiveTestsAsParallelTests();
         }
         if (!analysisResult.getExclusiveIfLocalTests().isEmpty()
-            && executionTool.getTestActionContext().forceExclusiveIfLocalTestsInParallel()) {
+            && executionTool.getSpawnStrategyRegistry().forceExclusiveIfLocalTestsInParallel()) {
           analysisResult = analysisResult.withExclusiveIfLocalTestsAsParallelTests();
         }
 
@@ -655,7 +655,7 @@ public class BuildTool {
                 @Override
                 public boolean forceExclusiveIfLocalTestsInParallel() {
                   return executionTool
-                      .getTestActionContext()
+                      .getSpawnStrategyRegistry()
                       .forceExclusiveIfLocalTestsInParallel();
                 }
               },

--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -253,6 +253,10 @@ public class ExecutionTool {
     return actionContextRegistry.getContext(TestActionContext.class);
   }
 
+  SpawnStrategyRegistry getSpawnStrategyRegistry() {
+    return spawnStrategyRegistry;
+  }
+
   /**
    * Sets up for execution.
    *

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistry.java
@@ -159,7 +159,7 @@ public final class SpawnStrategyRegistry
    * parallel test.
    */
   public boolean forceExclusiveIfLocalTestsInParallel() {
-    // Mirrors the mnemonic used by TestRunnerAction to avoid a analysis layer dependency.
+    // Mirrors the mnemonic used by TestRunnerAction to avoid an analysis layer dependency.
     String mnemonic = "TestRunner";
     List<SpawnStrategy> candidates = new ArrayList<>();
     if (mnemonicToStrategies.containsKey(mnemonic)) {
@@ -172,6 +172,7 @@ public final class SpawnStrategyRegistry
     } else if (mnemonicToRemoteDynamicStrategies.containsKey("")) {
       candidates.addAll(mnemonicToRemoteDynamicStrategies.get(""));
     }
+    // Not selecting a strategy; just checking if any candidate allows parallel execution.
     return candidates.stream().anyMatch(SpawnStrategy::forceExclusiveIfLocalTestsInParallel);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistry.java
@@ -145,6 +145,36 @@ public final class SpawnStrategyRegistry
     return defaultStrategies;
   }
 
+  /**
+   * Returns if "exclusive-if-local" tests should run in parallel or serialized.
+   *
+   * <p>Whether a test runs locally or remotely is only decided by the underlying {@link
+   * SpawnStrategy} during execution, so this consults the strategies that may execute a {@code
+   * TestRunner} spawn and returns {@code true} if any of them opts in. Both the regularly selected
+   * strategies and the remote branch of dynamic execution are considered, so that
+   * "exclusive-if-local" is honored under {@code --strategy=TestRunner=dynamic} as well.
+   *
+   * <p>This is a global signal: callers must still ensure that an individual test is actually
+   * eligible for remote execution (e.g. not tagged {@code no-remote-exec}) before treating it as a
+   * parallel test.
+   */
+  public boolean forceExclusiveIfLocalTestsInParallel() {
+    // Mirrors the mnemonic used by TestRunnerAction to avoid a analysis layer dependency.
+    String mnemonic = "TestRunner";
+    List<SpawnStrategy> candidates = new ArrayList<>();
+    if (mnemonicToStrategies.containsKey(mnemonic)) {
+      candidates.addAll(mnemonicToStrategies.get(mnemonic));
+    } else {
+      candidates.addAll(defaultStrategies);
+    }
+    if (mnemonicToRemoteDynamicStrategies.containsKey(mnemonic)) {
+      candidates.addAll(mnemonicToRemoteDynamicStrategies.get(mnemonic));
+    } else if (mnemonicToRemoteDynamicStrategies.containsKey("")) {
+      candidates.addAll(mnemonicToRemoteDynamicStrategies.get(""));
+    }
+    return candidates.stream().anyMatch(SpawnStrategy::forceExclusiveIfLocalTestsInParallel);
+  }
+
   @Override
   public void notifyUsedDynamic(ActionContext.ActionContextRegistry actionContextRegistry) {
     for (SandboxedSpawnStrategy strategy : mnemonicToLocalDynamicStrategies.values()) {

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -120,6 +120,23 @@ public final class TargetUtils {
   }
 
   /**
+   * Returns true if the test is pinned to local execution by its tags, i.e. it can never run
+   * remotely.
+   *
+   * <p>This mirrors the {@code no-remote} / {@code no-remote-exec} portion of {@link
+   * com.google.devtools.build.lib.actions.Spawns#mayBeExecutedRemotely}. It is used to keep an
+   * "exclusive-if-local" test serialized even when remote execution is configured, because such a
+   * test will still run locally. The {@code local} tag is handled separately by {@link
+   * #isLocalTestRule}.
+   *
+   * <p>Method assumes that passed target is a test rule, so usually it should be used only after
+   * isTestRule() or isTestOrTestSuiteRule(). Behavior is undefined otherwise.
+   */
+  public static boolean isNoRemoteExecTestRule(Rule rule) {
+    return hasConstraint(rule, "no-remote-exec") || hasConstraint(rule, "no-remote");
+  }
+
+  /**
    * Returns true if test marked as "local" by the appropriate keyword in the tags attribute.
    *
    * <p>Method assumes that passed target is a test rule, so usually it should be used only after

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -570,6 +570,7 @@ java_library(
     name = "remote_spawn_strategy",
     srcs = ["RemoteSpawnStrategy.java"],
     deps = [
+        ":bazel_output_service_cluster",
         "//src/main/java/com/google/devtools/build/lib/exec:abstract_spawn_strategy",
         "//src/main/java/com/google/devtools/build/lib/exec:execution_options",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_runner",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -201,6 +201,7 @@ final class RemoteActionContextProvider {
   public void registerRemoteSpawnStrategy(SpawnStrategyRegistry.Builder registryBuilder) {
     ExecutionOptions executionOptions =
         checkNotNull(env.getOptions().getOptions(ExecutionOptions.class));
+    RemoteExecutionService remoteExecutionService = getRemoteExecutionService();
     RemoteSpawnRunner spawnRunner =
         new RemoteSpawnRunner(
             checkNotNull(env.getOptions().getOptions(RemoteOptions.class)),
@@ -208,10 +209,10 @@ final class RemoteActionContextProvider {
             env.getReporter(),
             retryScheduler,
             logDir,
-            getRemoteExecutionService(),
+            remoteExecutionService,
             digestUtil);
     registryBuilder.registerStrategy(
-        new RemoteSpawnStrategy(spawnRunner, executionOptions), "remote");
+        new RemoteSpawnStrategy(remoteExecutionService, spawnRunner, executionOptions), "remote");
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -365,6 +365,14 @@ public class RemoteExecutionService {
         && !isScrubbedSpawn(spawn, scrubber);
   }
 
+  /**
+   * Returns {@code true} if this service is configured for remote execution, in which case
+   * "exclusive-if-local" tests should be allowed to run in parallel rather than serialized.
+   */
+  public boolean forceExclusiveIfLocalTestsInParallel() {
+    return combinedCache instanceof RemoteExecutionCache && remoteExecutor != null;
+  }
+
   @Nullable
   private static ByteString buildSalt(Spawn spawn, @Nullable SpawnScrubber spawnScrubber) {
     CacheSalt.Builder saltBuilder =

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnStrategy.java
@@ -22,12 +22,24 @@ import com.google.devtools.build.lib.exec.SpawnRunner;
  * strategy also support offloading the work to a remote worker.
  */
 final class RemoteSpawnStrategy extends AbstractSpawnStrategy {
-  RemoteSpawnStrategy(SpawnRunner spawnRunner, ExecutionOptions executionOptions) {
+
+  private final RemoteExecutionService remoteExecutionService;
+
+  RemoteSpawnStrategy(
+      RemoteExecutionService remoteExecutionService,
+      SpawnRunner spawnRunner,
+      ExecutionOptions executionOptions) {
     super(spawnRunner, executionOptions);
+    this.remoteExecutionService = remoteExecutionService;
   }
 
   @Override
   public String toString() {
     return "remote";
+  }
+
+  @Override
+  public boolean forceExclusiveIfLocalTestsInParallel() {
+    return remoteExecutionService.forceExclusiveIfLocalTestsInParallel();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeBuildView.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeBuildView.java
@@ -1135,7 +1135,10 @@ public final class SkyframeBuildView {
     TestType fromExplicitFlagOrTag;
     if (buildDriverKeyTestContext.getTestStrategy().equals("exclusive")
         || TargetUtils.isExclusiveTestRule(rule)
-        || (TargetUtils.isExclusiveIfLocalTestRule(rule) && TargetUtils.isLocalTestRule(rule))) {
+        || (TargetUtils.isExclusiveIfLocalTestRule(rule)
+            && (TargetUtils.isLocalTestRule(rule) || TargetUtils.isNoRemoteExecTestRule(rule)))) {
+      // An "exclusive-if-local" test that can never run remotely (because it is pinned to local
+      // execution by its tags) is treated like an ordinary "exclusive" test.
       fromExplicitFlagOrTag = TestType.EXCLUSIVE;
     } else if (TargetUtils.isExclusiveIfLocalTestRule(rule)) {
       fromExplicitFlagOrTag = TestType.EXCLUSIVE_IF_LOCAL;
@@ -1143,10 +1146,8 @@ public final class SkyframeBuildView {
       fromExplicitFlagOrTag = TestType.PARALLEL;
     }
 
-    if ((fromExplicitFlagOrTag == TestType.EXCLUSIVE
-            && buildDriverKeyTestContext.forceExclusiveTestsInParallel())
-        || (fromExplicitFlagOrTag == TestType.EXCLUSIVE_IF_LOCAL
-            && buildDriverKeyTestContext.forceExclusiveIfLocalTestsInParallel())) {
+    if (fromExplicitFlagOrTag == TestType.EXCLUSIVE
+        && buildDriverKeyTestContext.forceExclusiveTestsInParallel()) {
       eventHandler.handle(
           Event.warn(
               label
@@ -1155,6 +1156,13 @@ public final class SkyframeBuildView {
                   + ", but --test_strategy="
                   + buildDriverKeyTestContext.getTestStrategy()
                   + " forces parallel test execution."));
+      return TestType.PARALLEL;
+    }
+    // A remote-eligible "exclusive-if-local" test is allowed to run in parallel when remote
+    // execution is enabled. This is the expected behavior of the tag rather than a forced override,
+    // so (unlike the "exclusive" case above) no warning is emitted.
+    if (fromExplicitFlagOrTag == TestType.EXCLUSIVE_IF_LOCAL
+        && buildDriverKeyTestContext.forceExclusiveIfLocalTestsInParallel()) {
       return TestType.PARALLEL;
     }
     return fromExplicitFlagOrTag;

--- a/src/test/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistryTest.java
@@ -695,6 +695,59 @@ public class SpawnStrategyRegistryTest {
     assertThat(strategy7.usedCalled).isEqualTo(0);
   }
 
+  @Test
+  public void forceExclusiveIfLocalTestsInParallel_localOnlyTestRunnerStrategy_returnsFalse()
+      throws Exception {
+    SpawnStrategyRegistry strategyRegistry =
+        SpawnStrategyRegistry.builder()
+            .registerStrategy(new NoopStrategy("local"), "local")
+            .addMnemonicFilter("TestRunner", ImmutableList.of("local"))
+            .build();
+
+    assertThat(strategyRegistry.forceExclusiveIfLocalTestsInParallel()).isFalse();
+  }
+
+  @Test
+  public void forceExclusiveIfLocalTestsInParallel_remoteCapableTestRunnerStrategy_returnsTrue()
+      throws Exception {
+    SpawnStrategyRegistry strategyRegistry =
+        SpawnStrategyRegistry.builder()
+            .registerStrategy(new ForceExclusiveIfLocalInParallelStrategy("remote"), "remote")
+            .addMnemonicFilter("TestRunner", ImmutableList.of("remote"))
+            .build();
+
+    assertThat(strategyRegistry.forceExclusiveIfLocalTestsInParallel()).isTrue();
+  }
+
+  @Test
+  public void forceExclusiveIfLocalTestsInParallel_consultsDefaultStrategies() throws Exception {
+    // No mnemonic filter for "TestRunner", so the implicit default strategies are consulted.
+    SpawnStrategyRegistry strategyRegistry =
+        SpawnStrategyRegistry.builder()
+            .registerStrategy(new ForceExclusiveIfLocalInParallelStrategy("remote"), "remote")
+            .build();
+
+    assertThat(strategyRegistry.forceExclusiveIfLocalTestsInParallel()).isTrue();
+  }
+
+  @Test
+  public void forceExclusiveIfLocalTestsInParallel_consultsDynamicRemoteBranch_returnsTrue()
+      throws Exception {
+    // Under --strategy=TestRunner=dynamic the regular strategy does not opt in, but the remote
+    // branch of dynamic execution does. The registry must consult it.
+    SpawnStrategyRegistry strategyRegistry =
+        SpawnStrategyRegistry.builder()
+            .registerStrategy(new NoopSandboxedStrategy("local"), "local")
+            .registerStrategy(
+                new ForceExclusiveIfLocalInParallelSandboxedStrategy("remote"), "remote")
+            .addMnemonicFilter("TestRunner", ImmutableList.of("local"))
+            .addDynamicLocalStrategies(ImmutableMap.of("TestRunner", ImmutableList.of("local")))
+            .addDynamicRemoteStrategies(ImmutableMap.of("TestRunner", ImmutableList.of("remote")))
+            .build();
+
+    assertThat(strategyRegistry.forceExclusiveIfLocalTestsInParallel()).isTrue();
+  }
+
   private static Spawn createSpawnWithMnemonicAndDescription(String mnemonic, String description) {
     return new SimpleSpawn(
         new FakeOwner(mnemonic, description, "//dummy:label"),
@@ -750,6 +803,33 @@ public class SpawnStrategyRegistryTest {
         ActionExecutionContext actionExecutionContext,
         @Nullable SandboxedSpawnStrategy.StopConcurrentSpawns stopConcurrentSpawns) {
       throw new UnsupportedOperationException();
+    }
+  }
+
+  /** A strategy that opts "exclusive-if-local" tests into parallel execution, like remote. */
+  private static class ForceExclusiveIfLocalInParallelStrategy extends NoopStrategy {
+
+    private ForceExclusiveIfLocalInParallelStrategy(String name) {
+      super(name);
+    }
+
+    @Override
+    public boolean forceExclusiveIfLocalTestsInParallel() {
+      return true;
+    }
+  }
+
+  /** Sandboxed variant usable in the remote branch of dynamic execution. */
+  private static class ForceExclusiveIfLocalInParallelSandboxedStrategy
+      extends NoopSandboxedStrategy {
+
+    private ForceExclusiveIfLocalInParallelSandboxedStrategy(String name) {
+      super(name);
+    }
+
+    @Override
+    public boolean forceExclusiveIfLocalTestsInParallel() {
+      return true;
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/packages/TargetUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/TargetUtilsTest.java
@@ -407,6 +407,16 @@ public class TargetUtilsTest extends PackageLoadingTestCase {
             tags = ["exclusive"],
         )
 
+        foo_test(
+            name = "exclusive_if_local_no_remote_exec",
+            size = "small",
+            srcs = ["a"],
+            tags = [
+                "exclusive-if-local",
+                "no-remote-exec",
+            ],
+        )
+
         test_suite(
             name = "ts",
             tests = ["z"],
@@ -474,9 +484,15 @@ public class TargetUtilsTest extends PackageLoadingTestCase {
     assertThat(TargetUtils.isExclusiveIfLocalTestRule(exclusiveIfRunLocally)).isTrue();
     assertThat(TargetUtils.isLocalTestRule(exclusiveIfRunLocally)).isFalse();
     assertThat(TargetUtils.isExclusiveTestRule(exclusiveIfRunLocally)).isFalse();
+    assertThat(TargetUtils.isNoRemoteExecTestRule(exclusiveIfRunLocally)).isFalse();
     Rule exclusive = (Rule) getTarget("//x:exclusive_only");
     assertThat(TargetUtils.isExclusiveTestRule(exclusive)).isTrue();
     assertThat(TargetUtils.isLocalTestRule(exclusive)).isFalse(); // LOCAL tag gets added later.
     assertThat(TargetUtils.isExclusiveIfLocalTestRule(exclusive)).isFalse();
+    Rule exclusiveIfLocalNoRemoteExec =
+        (Rule) getTarget("//x:exclusive_if_local_no_remote_exec");
+    assertThat(TargetUtils.isExclusiveIfLocalTestRule(exclusiveIfLocalNoRemoteExec)).isTrue();
+    assertThat(TargetUtils.isLocalTestRule(exclusiveIfLocalNoRemoteExec)).isFalse();
+    assertThat(TargetUtils.isNoRemoteExecTestRule(exclusiveIfLocalNoRemoteExec)).isTrue();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -259,6 +259,21 @@ public class RemoteExecutionServiceTest {
   }
 
   @Test
+  public void forceExclusiveIfLocalTestsInParallel_withRemoteExecutor_returnsTrue() {
+    RemoteExecutionService service = newRemoteExecutionService();
+
+    assertThat(service.forceExclusiveIfLocalTestsInParallel()).isTrue();
+  }
+
+  @Test
+  public void forceExclusiveIfLocalTestsInParallel_withoutRemoteExecutor_returnsFalse() {
+    executor = null;
+    RemoteExecutionService service = newRemoteExecutionService();
+
+    assertThat(service.forceExclusiveIfLocalTestsInParallel()).isFalse();
+  }
+
+  @Test
   public void buildRemoteAction_withRegularFileAsOutput() throws Exception {
     PathFragment execPath = execRoot.getRelative("path/to/tree").asFragment();
     Spawn spawn =

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -2060,6 +2060,29 @@ sh_test(
 EOF
 }
 
+function setup_exclusive_if_local_test_case() {
+  local extra_tag="${1:-}"
+  local tags='"exclusive-if-local"'
+  if [[ -n "${extra_tag}" ]]; then
+    tags="${tags}, \"${extra_tag}\""
+  fi
+  add_rules_shell "MODULE.bazel"
+  mkdir -p a
+  cat > a/success.sh <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+  chmod 755 a/success.sh
+  cat > a/BUILD <<EOF
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+sh_test(
+  name = "success_test",
+  srcs = ["success.sh"],
+  tags = [${tags}],
+)
+EOF
+}
+
 function test_exclusive_test_hit_remote_cache() {
   # Test that the exclusive test works with the remote cache.
   setup_exclusive_test_case
@@ -2112,6 +2135,33 @@ function test_exclusive_test_wont_remote_exec() {
 
   # test action + test xml generation
   expect_log "2.*-sandbox"
+}
+
+function test_exclusive_if_local_test_remote_exec() {
+  # Test that an exclusive-if-local test is allowed to run remotely in parallel
+  setup_exclusive_if_local_test_case
+
+  bazel test \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //a:success_test >& $TEST_log || fail "Failed to test //a:success_test"
+
+  # test action + test xml generation should run remotely, not on local
+  expect_log "2 remote\\."
+  expect_not_log "-sandbox"
+}
+
+function test_exclusive_if_local_test_no_remote_exec_runs_locally() {
+  # Test that an exclusive-if-local test that is also tagged no-remote-exec stays
+  # serialized (runs locally) even when remote execution is enabled.
+  setup_exclusive_if_local_test_case "no-remote-exec"
+
+  bazel test \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //a:success_test >& $TEST_log || fail "Failed to test //a:success_test"
+
+  # Because the test can't run remotely, it executes locally like an "exclusive" test
+  expect_log "2.*-sandbox"
+  expect_not_log "2 remote\\."
 }
 
 # TODO(alpha): Add a test that fails remote execution when remote worker


### PR DESCRIPTION
### Description
The tag `exclusive-if-local` doesn't differentiate on remote spawn strategy. 
Specifically, the `exclusive-if-local` tag was being treated the same as `exclusive`.

### Motivation
Fixes #17834 

### Build API Changes
No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Fixed exclusive-if-local tag limiting concurrency on remote exec
