### PR TITLE
remote: validate output symlink paths are within the exec root

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -940,6 +940,18 @@ public class RemoteExecutionService {
 
   private void createSymlinks(Iterable<SymlinkMetadata> symlinks) throws IOException {
     for (SymlinkMetadata symlink : symlinks) {
+      // Ensure the symlink is materialized inside the exec root. The local path is derived from an
+      // ActionResult output symlink path via execRoot.getRelative(...), which returns an absolute
+      // path verbatim, so without this check an absolute (or otherwise escaping) symlink path would
+      // be created outside the output tree. Output files already enforce containment via
+      // file.path.relativeTo(execRoot) in downloadOutputs(); apply the same guarantee to output
+      // symlinks (including tree-nested symlinks, which also flow through here).
+      if (!symlink.path().startsWith(execRoot)) {
+        throw new IOException(
+            String.format(
+                "Failed to create symlink %s: the output path escapes the output tree %s",
+                symlink.path(), execRoot));
+      }
       Preconditions.checkNotNull(
               symlink.path().getParentDirectory(),
               "Failed creating directory and parents for %s",

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -1344,6 +1344,32 @@ public class RemoteExecutionServiceTest {
   }
 
   @Test
+  public void downloadOutputs_outputSymlinkEscapingExecRoot_isRejected() throws Exception {
+    // An output symlink whose resolved local path is outside the exec root must be rejected, mirroring
+    // the containment enforced for output files (file.path.relativeTo(execRoot) throws in
+    // downloadOutputs). The escaping symlink is present only in the result passed to downloadOutputs;
+    // building the spawn from it would otherwise attempt to create a test artifact for the escaping
+    // path.
+    Spawn spawn =
+        newSpawnFromResult(
+            RemoteActionResult.createFromCache(
+                CachedActionResult.remote(ActionResult.getDefaultInstance())));
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    createOutputDirectories(spawn);
+    when(remoteOutputChecker.shouldDownloadOutput(ArgumentMatchers.<PathFragment>any(), any()))
+        .thenReturn(true);
+
+    ActionResult.Builder poisoned = ActionResult.newBuilder();
+    poisoned.addOutputSymlinksBuilder().setPath("outputs/../../../escape/link").setTarget("foo");
+    RemoteActionResult poisonedResult =
+        RemoteActionResult.createFromCache(CachedActionResult.remote(poisoned.build()));
+
+    assertThrows(IOException.class, () -> service.downloadOutputs(action, poisonedResult));
+  }
+
+  @Test
   public void downloadOutputs_outputSymlinksCompatibility_success() throws Exception {
     // Test that download outputs works when the action result contains both output_symlinks
     // and output_file_symlinks (or output_directory_symlinks).


### PR DESCRIPTION
When ingesting an `ActionResult` (remote execution or a remote/disk cache hit), `RemoteExecutionService.createSymlinks` materializes output symlinks without checking that the local path is inside the exec root.

The local path comes from the symlink output path via `execRoot.getRelative(outputPath)`, which returns an absolute path verbatim, so an absolute (or otherwise escaping) output symlink path is created outside the output tree.

Output **files** already enforce containment: `downloadOutputs()` calls `file.path.relativeTo(execRoot)`, which throws for paths outside the exec root. Output **symlinks** lacked the equivalent guard. This PR adds a `startsWith(execRoot)` check in `createSymlinks`, mirroring the file behavior and the existing symlink containment check in `AbstractActionInputPrefetcher`. Because both top-level and tree-nested output symlinks flow through `createSymlinks`, the single check covers both.

No behavior change for valid (in-tree) outputs; escaping symlink paths now fail closed instead of being materialized outside the exec root.