### PR TITLE
Run rules_jvm_external jar tools with exec Java

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -65,7 +65,11 @@ bazel_dep(name = "onetbb", version = "2022.2.0", repo_name = None)
 single_version_override(
     module_name = "rules_jvm_external",
     patch_strip = 1,
-    patches = ["//third_party:rules_jvm_external_6.8_bazel_vendor.patch"],
+    patches = [
+        "//third_party:rules_jvm_external_6.8_bazel_vendor.patch",
+        # TODO: Remove this patch once a new version of rules_jvm_external is released and adopted by Bazel.
+        "//third_party:rules_jvm_external_6.8_exec_jar_tools.patch",
+    ],
     version = "6.8",
 )
 

--- a/third_party/rules_jvm_external_6.8_exec_jar_tools.patch
+++ b/third_party/rules_jvm_external_6.8_exec_jar_tools.patch
@@ -1,0 +1,76 @@
+diff --git a/private/rules/jvm_import.bzl b/private/rules/jvm_import.bzl
+index 0fbbd10..de36b90 100644
+--- a/private/rules/jvm_import.bzl
++++ b/private/rules/jvm_import.bzl
+@@ -7,7 +7,7 @@
+ # [0]: https://github.com/square/bazel_maven_repository/pull/48
+ # [1]: https://github.com/bazelbuild/bazel/issues/4549
+
+-load("@rules_java//java:defs.bzl", "JavaInfo")
++load("@rules_java//java:defs.bzl", "JavaInfo", "java_common")
+ load("@rules_license//rules:providers.bzl", "PackageInfo")
+ load("//private/lib:coordinates.bzl", "to_external_form", "to_purl", "unpack_coordinates")
+ load("//private/lib:urls.bzl", "scheme_and_host")
+@@ -26,6 +26,8 @@ def _jvm_import_impl(ctx):
+     if not ctx.attr.jar:
+         print(ctx.attr.name, "The `jars` attribute is deprecated and will be removed in `rules_jvm_external` 7.0. Please use the `jar` attribute instead.")
+
++    java_runtime = ctx.attr._java_runtime[java_common.JavaRuntimeInfo]
++    add_jar_manifest_entry = ctx.file._add_jar_manifest_entry
+     injar = ctx.file.jar if ctx.attr.jar else ctx.files.jars[0]
+
+     if ctx.attr._stamp_manifest[StampManifestProvider].stamp_enabled:
+@@ -33,11 +35,14 @@ def _jvm_import_impl(ctx):
+         args = ctx.actions.args()
+         args.add_all(["--source", injar, "--output", outjar])
+         args.add("--manifest-entry", ctx.label, format = "Target-Label:%s")
++        java_args = ctx.actions.args()
++        java_args.add_all(["-XX:-UsePerfData", "-jar", add_jar_manifest_entry])
+         ctx.actions.run(
+-            executable = ctx.executable._add_jar_manifest_entry,
+-            arguments = [args],
++            executable = java_runtime.java_executable_exec_path,
++            arguments = [java_args, args],
+             inputs = [injar],
+             outputs = [outjar],
++            tools = [add_jar_manifest_entry, java_runtime.files],
+             mnemonic = "StampJarManifest",
+             progress_message = "Stamping the manifest of %{label}",
+         )
+@@ -59,13 +64,16 @@ def _jvm_import_impl(ctx):
+     # Make sure the compile jar is safe to compile with
+     args.add("--make-safe")
+
++    java_args = ctx.actions.args()
++    java_args.add_all(["-XX:-UsePerfData", "-jar", add_jar_manifest_entry])
+     ctx.actions.run(
+-        executable = ctx.executable._add_jar_manifest_entry,
+-        arguments = [args],
++        executable = java_runtime.java_executable_exec_path,
++        arguments = [java_args, args],
+         inputs = [outjar],
+         outputs = [compilejar],
++        tools = [add_jar_manifest_entry, java_runtime.files],
+         mnemonic = "CreateCompileJar",
+-        progress_message = "Creating compile jar for %s" % ctx.label,
++        progress_message = "Creating compile jar for %{label}",
+     )
+
+     additional_providers = []
+@@ -129,9 +137,14 @@ jvm_import = rule(
+             doc = "URL from where `jar` will be downloaded from.",
+         ),
+         "_add_jar_manifest_entry": attr.label(
+-            executable = True,
++            allow_single_file = True,
++            cfg = "exec",
++            default = "//private/tools/java/com/github/bazelbuild/rules_jvm_external/jar:AddJarManifestEntry_deploy.jar",
++        ),
++        "_java_runtime": attr.label(
++            default = "@rules_java//toolchains:current_java_runtime",
++            providers = [java_common.JavaRuntimeInfo],
+             cfg = "exec",
+-            default = "//private/tools/java/com/github/bazelbuild/rules_jvm_external/jar:AddJarManifestEntry",
+         ),
+         "_stamp_manifest": attr.label(
+             default = "@rules_jvm_external//settings:stamp_manifest",


### PR DESCRIPTION
## Summary

- patch `rules_jvm_external` 6.8 so `jvm_import` runs `AddJarManifestEntry_deploy.jar` with the Java runtime selected for the execution platform
- avoid executing the generated `java_binary` Bash launcher directly
- use `%{label}` for the compile-JAR progress message

## Motivation

This is a follow-up to #29763 and currently includes that dependency commit because the dependency branch lives in the contributor fork. The exec-Java change is the second commit and can be rebased to `master` once #29763 lands.

The patch restores the intent of [rules_jvm_external#1059](https://github.com/bazel-contrib/rules_jvm_external/pull/1059), which was reverted by [rules_jvm_external#1061](https://github.com/bazel-contrib/rules_jvm_external/pull/1061) after downstream Bazel worked around the issue using tool-Java command-line flags.

Those flags are insufficient for a Windows host using Linux remote execution. The generated `java_binary` launcher is a Bash script, and Bazel may try to execute it as a Windows executable, failing with `%1 is not a valid Win32 application` before Java starts.

Invoking the deploy JAR through the Java runtime toolchain avoids the Bash wrapper entirely and makes manifest stamping and compile-JAR creation executable on the selected execution platform.

The corresponding upstream `rules_jvm_external` change is bazel-contrib/rules_jvm_external#1583.
