### PR TITLE
Use script bootstrap for Python binaries

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 common --enable_platform_specific_config
+common --@rules_python//python/config_settings:bootstrap_impl=script
 
 # Either consumed as @remoteapis or as files.
 common --deleted_packages=third_party/remoteapis


### PR DESCRIPTION
## Summary

Enable `@rules_python//python/config_settings:bootstrap_impl=script` flag.

## Motivation

The default rules_python bootstrap launcher uses a non-hermetic bash dependency. When Bazel runs on a Windows host and dispatches Python tools to a Linux remote execution platform, that host-specific launcher cannot execute on Linux.

The script bootstrap is interpreted using the Python runtime selected on the execution platform, so the same Python tool can run when the host and execution operating systems differ.

## Validation

Ran:

```text
bazel build --nobuild --config=remote //src:md5
```

Bazel accepted and expanded the rules_python setting. Initialization then stopped because this development machine does not have the Google Application Default Credentials required by Bazel's upstream remote executor.
