### PR TITLE
Materialize chains of symlinks in remote repos

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorManager.java
@@ -129,7 +129,11 @@ public class VendorManager {
         Path externalSymlink = vendorDirectory.getRelative(EXTERNAL_ROOT_SYMLINK_NAME);
         FileSystemUtils.ensureSymbolicLink(externalSymlink, externalRepoRoot);
         RepositoryUtils.replantSymlinks(
-            repoUnderVendor, workspace, externalRepoRoot, EXTERNAL_ROOT_SYMLINK_NAME);
+            repoUnderVendor,
+            workspace,
+            externalRepoRoot,
+            EXTERNAL_ROOT_SYMLINK_NAME,
+            /* replantSymlinksIntoMainRepo= */ true);
         // 5. Rename the temporary marker file after the move/copy is done.
         temporaryMarker.renameTo(markerUnderVendor);
         // 6. Leave a symlink in external dir to keep things working.

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryFetchFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryFetchFunction.java
@@ -314,18 +314,23 @@ public final class RepositoryFetchFunction implements SkyFunction {
       }
       digestWriter.writeMarkerFile(result.recordedInputValues());
       if (result.reproducible() == Reproducibility.YES && !repoDefinition.repoRule().local()) {
-        // This repo is eligible for the local and remote repo contents cache.
-        // Replant symlinks before caching to convert absolute symlinks pointing to the
-        // workspace or external root into relative paths, making the cached repo portable.
+        // This repo may be eligible for the local and remote repo contents cache.
+        // Replant symlinks before caching to convert absolute symlinks relative if possible, which
+        // can make more repos eligible.
         Path externalRepoRoot = RepositoryUtils.getExternalRepositoryDirectory(directories);
-        boolean safeForLocalCacheReuse;
+        RepositoryUtils.ReplantSymlinksResult replantSymlinksResult;
         try {
-          safeForLocalCacheReuse =
+          replantSymlinksResult =
               RepositoryUtils.replantSymlinks(
                   repoRoot,
                   directories.getWorkspace(),
                   externalRepoRoot,
-                  PathFragment.EMPTY_FRAGMENT);
+                  PathFragment.EMPTY_FRAGMENT,
+                  // The local repo contents cache can't handle any cross-repo symlinks and while
+                  // the remote repo contents cache could in theory handle main repo symlinks, this
+                  // would add a lot of complexity for little gain (local files are always
+                  // available).
+                  /* replantSymlinksIntoMainRepo= */ false);
         } catch (IOException e) {
           throw new RepositoryFunctionException(
               new IOException(
@@ -334,7 +339,7 @@ public final class RepositoryFetchFunction implements SkyFunction {
                   e),
               Transience.TRANSIENT);
         }
-        if (remoteRepoContentsCache != null) {
+        if (remoteRepoContentsCache != null && replantSymlinksResult.safeForRemoteCache()) {
           remoteRepoContentsCache.addToCache(
               repositoryName,
               repoRoot,
@@ -342,7 +347,7 @@ public final class RepositoryFetchFunction implements SkyFunction {
               digestWriter.predeclaredInputHash,
               env.getListener());
         }
-        if (safeForLocalCacheReuse && repoContentsCache.isEnabled()) {
+        if (repoContentsCache.isEnabled() && replantSymlinksResult.safeForLocalCache()) {
           CandidateRepo newCacheEntry;
           try {
             newCacheEntry =

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryUtils.java
@@ -76,12 +76,22 @@ public class RepositoryUtils {
   }
 
   /**
+   * The result of {@link #replantSymlinks}.
+   *
+   * @param safeForLocalCache whether the repo is safe to cache in the local repo contents cache
+   *     after replanting
+   * @param safeForRemoteCache whether the repo is safe to cache in the remote repo contents cache
+   *     after replanting
+   */
+  public record ReplantSymlinksResult(boolean safeForLocalCache, boolean safeForRemoteCache) {}
+
+  /**
    * Replants the symlinks under the specified repository directory.
    *
-   * <p>Re-writes symlinks that originally point to a path under the workspace or the external root
-   * to relative paths. Same-repo symlinks (those pointing back into {@code repoDir}) are replanted
-   * to repo-relative paths that work regardless of the repo's physical location. Cross-repo
-   * symlinks are replanted to relative paths going through {@code repoDirParentToExternalRoot}.
+   * <p>Re-writes symlinks that originally point to a path under the external root to relative
+   * paths. Same-repo symlinks (those pointing back into {@code repoDir}) are replanted to
+   * repo-relative paths that work regardless of the repo's physical location. Cross-repo symlinks
+   * are replanted to relative paths going through {@code repoDirParentToExternalRoot}.
    *
    * @param repoDir The path to the repository directory.
    * @param workspace The path to the workspace directory.
@@ -89,27 +99,39 @@ public class RepositoryUtils {
    * @param repoDirParentToExternalRoot The relative path from the parent directory of {@code
    *     repoDir} to the external root (or a symlink to it), which is used to rewrite cross-repo
    *     symlink targets to relative paths.
-   * @return {@code true} if it is safe to reuse the replanted repo from a different physical
-   *     location (e.g. a shared repo contents cache). This is the case when there are no cross-repo
-   *     symlinks or on Windows with symlinks enabled (where symlinks resolve using logical rather
-   *     than physical paths).
+   * @param replantSymlinksIntoMainRepo If true, symlinks pointing into the main repo are treated
+   *     like cross-repo symlinks by routing them through a symlink to the workspace planted under
+   *     the external root (used by vendoring, where the vendored repo has to keep working from a
+   *     different checkout of the workspace). If false, such symlinks are left untouched.
    * @throws IOException If an I/O error occurs while replanting the symlinks.
    */
   @CanIgnoreReturnValue
-  public static boolean replantSymlinks(
-      Path repoDir, Path workspace, Path externalRepoRoot, PathFragment repoDirParentToExternalRoot)
+  public static ReplantSymlinksResult replantSymlinks(
+      Path repoDir,
+      Path workspace,
+      Path externalRepoRoot,
+      PathFragment repoDirParentToExternalRoot,
+      boolean replantSymlinksIntoMainRepo)
       throws IOException {
     boolean portableSymlinksOnly = true;
+    boolean hasSymlinkIntoMainRepo = false;
     try {
       Collection<Path> symlinks = FileSystemUtils.traverseTree(repoDir, Path::isSymbolicLink);
       Path workspaceSymlinkUnderExternal = externalRepoRoot.getChild(WORKSPACE_SYMLINK_NAME);
-      FileSystemUtils.ensureSymbolicLink(workspaceSymlinkUnderExternal, workspace);
+      if (replantSymlinksIntoMainRepo) {
+        FileSystemUtils.ensureSymbolicLink(workspaceSymlinkUnderExternal, workspace);
+      }
       for (Path symlink : symlinks) {
         PathFragment target = symlink.readSymbolicLink();
         PathFragment originalTarget = target;
-        // Treat symlinks pointing into the workspace just like cross-repo symlinks by adding a
-        // symlink for the main repo to the external root and rewriting symlinks to it.
         if (target.startsWith(workspace.asFragment())) {
+          hasSymlinkIntoMainRepo = true;
+          if (!replantSymlinksIntoMainRepo) {
+            // Symlinks pointing into the main repo can't be replanted to a relative path that
+            // stays under the external root. They make the repo unsafe to cache.
+            portableSymlinksOnly = false;
+            continue;
+          }
           target =
               workspaceSymlinkUnderExternal
                   .asFragment()
@@ -172,6 +194,6 @@ public class RepositoryUtils {
       throw new IOException(
           String.format("Failed to rewrite symlinks under %s: %s", repoDir, e.getMessage()), e);
     }
-    return portableSymlinksOnly;
+    return new ReplantSymlinksResult(portableSymlinksOnly, !hasSymlinkIntoMainRepo);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -22,10 +22,13 @@ import static com.google.devtools.build.lib.remote.util.RxFutures.toCompletable;
 import static com.google.devtools.build.lib.remote.util.RxFutures.toListenableFuture;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 import static com.google.devtools.build.lib.remote.util.Utils.mergeBulkTransfer;
+import static io.reactivex.rxjava3.core.Completable.concat;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.SetMultimap;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.Futures;
@@ -51,12 +54,14 @@ import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.remote.util.AsyncTaskCache;
 import com.google.devtools.build.lib.util.TempPathGenerator;
+import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileSymlinkLoopException;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.OutputPermissions;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.Symlinks;
 import io.reactivex.rxjava3.core.Completable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -217,16 +222,20 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
   private final Striped<ReadWriteLock> treeArtifactLocks =
       Striped.lazyWeakReadWriteLock(Integer.MAX_VALUE);
 
-  /** A symlink in the output tree that points to another artifact's absolute path. */
-  record Symlink(Path linkPath, Path targetPath) {
+  /**
+   * A symlink in the output tree that either points to another artifact's absolute path or
+   * represents an unresolved symlink with its target path preserved verbatim.
+   */
+  record Symlink(Path linkPath, PathFragment targetPath) {
     Symlink {
       checkNotNull(linkPath, "linkPath");
       checkNotNull(targetPath, "targetPath");
-      checkArgument(!linkPath.equals(targetPath), "linkPath and targetPath must differ");
+      checkArgument(
+          !linkPath.asFragment().equals(targetPath), "linkPath and targetPath must differ");
     }
 
-    static Symlink of(Path linkPath, Path targetPath) {
-      return new Symlink(linkPath, targetPath);
+    Path resolveOne() throws IOException {
+      return resolveOneSymlink(linkPath, targetPath);
     }
   }
 
@@ -425,42 +434,42 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       if (metadata == null) {
         return immediateVoidFuture();
       }
-      if (metadata.getType() == FileStateType.SYMLINK && !inputPath.startsWith(execRoot)) {
-        return toListenableFuture(
-            plantUnresolvedSymlink(
-                inputPath.forHostFileSystem(),
-                PathFragment.create(metadata.getUnresolvedSymlinkTarget())));
-      }
+      var symlinks = getSymlinks(input, inputPath, metadata, metadataSupplier);
+      // On Windows, the type of symlink depends on the target file and the target may have to
+      // exist, so we plant symlinks in reverse order and only after any download has completed.
+      var plantSymlinks = concat(Lists.transform(symlinks.reverse(), this::plantSymlink));
+
       if (!canDownloadFile(inputPath, metadata)) {
-        return immediateVoidFuture();
+        // If the artifact is a declared ("unresolved") symlink, it can't be "downloaded", but the
+        // symlink logic above creates it.
+        return toListenableFuture(plantSymlinks);
       }
 
-      @Nullable Symlink symlink = maybeGetSymlink(input, inputPath, metadata, metadataSupplier);
-
-      if (symlink != null) {
-        // Symlink tracks the parent of a TreeFileArtifact, so the parent relative path has to be
+      if (!symlinks.isEmpty()) {
+        // Symlink may track the parent of a TreeFileArtifact, so the parent relative path has to be
         // translated relative to it.
-        var parentRelativePath = inputPath.relativeTo(symlink.linkPath());
-        inputPath = symlink.targetPath().getRelative(parentRelativePath);
+        var parentRelativePath = inputPath.relativeTo(symlinks.getFirst().linkPath());
+        inputPath =
+            inputPath
+                .getFileSystem()
+                .getPath(
+                    symlinks.getLast().resolveOne().asFragment().getRelative(parentRelativePath));
       }
 
       @Nullable Path treeRootPath = maybeGetTreeRoot(input, metadataSupplier);
 
       Completable result =
           downloadFileNoCheckRx(
-              action,
-              input,
-              inputPath,
-              treeRootPath,
-              directoriesByTreeRoot,
-              input,
-              metadata,
-              priority,
-              reason);
-
-      if (symlink != null) {
-        result = result.andThen(plantSymlink(symlink));
-      }
+                  action,
+                  input,
+                  inputPath,
+                  treeRootPath,
+                  directoriesByTreeRoot,
+                  input,
+                  metadata,
+                  priority,
+                  reason)
+              .andThen(plantSymlinks);
 
       return toListenableFuture(result);
     } catch (IOException | InterruptedException e) {
@@ -502,15 +511,17 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
   }
 
   /**
-   * Returns the symlink to be planted in the output tree for artifacts that are prefetched into a
-   * different location.
+   * Returns the symlinks to be planted on disk for inputs that are prefetched into a different
+   * location, ordered from the input path to the final target.
    *
    * <p>Some artifacts (notably, those created by {@code ctx.actions.symlink}) are materialized in
    * the output tree as a symlink to another artifact, as indicated by the {@link
    * FileArtifactValue#getResolvedPath()} field in their (or their parent tree artifact's) metadata.
+   *
+   * <p>Paths in external repos backed by the remote repo contents cache may be (part of) a chain of
+   * symlinks created by the repo rule, which has to be reproduced verbatim on disk.
    */
-  @Nullable
-  private Symlink maybeGetSymlink(
+  private ImmutableList<Symlink> getSymlinks(
       ActionInput input,
       Path inputPath,
       FileArtifactValue metadata,
@@ -527,22 +538,42 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
         //     created, but we're currently unable to prefetch the file(s) it points to.
         // TODO: b/401575099 - Treating fileset more like runfiles could make the tree metadata
         //  available for case (2).
-        return null;
+        return ImmutableList.of();
       }
-      return maybeGetSymlink(treeArtifact, treeArtifact.getPath(), treeMetadata, metadataSupplier);
+      return getSymlinks(treeArtifact, treeArtifact.getPath(), treeMetadata, metadataSupplier);
     }
-    if (metadata.getResolvedPath() == null) {
-      return null;
+    if ((metadata.isRemote() || metadata.getType() == FileStateType.SYMLINK)
+        && !inputPath.startsWith(execRoot)) {
+      // A path in an external repo, e.g. a source artifact consumed by an action or a file
+      // prefetched during the materialization of an external repo. It may be (part of) a chain of
+      // symlinks created by the repo rule, which has to be reproduced verbatim on disk.
+      var symlinkChain = ImmutableList.<Symlink>builder();
+      FileStatus stat;
+      Path currentPath = inputPath;
+      var maxAttempt = 32;
+      while ((stat = currentPath.statIfFound(Symlinks.NOFOLLOW)) != null && stat.isSymbolicLink()) {
+        if (maxAttempt-- == 0) {
+          throw new FileSymlinkLoopException(
+              inputPath.getPathString() + FileSystem.ERR_TOO_MANY_SYMLINKS);
+        }
+        var symlink = new Symlink(currentPath, currentPath.readSymbolicLink());
+        symlinkChain.add(symlink);
+        currentPath = symlink.resolveOne();
+      }
+      return symlinkChain.build();
     }
-    Path resolvedPath = inputPath.getFileSystem().getPath(metadata.getResolvedPath());
-    if (resolvedPath.equals(inputPath)) {
-      return null;
+    PathFragment resolvedPath = metadata.getResolvedPath();
+    if (resolvedPath == null || resolvedPath.equals(inputPath.asFragment())) {
+      return ImmutableList.of();
     }
-    return Symlink.of(inputPath, resolvedPath);
+    return ImmutableList.of(new Symlink(inputPath, resolvedPath));
   }
 
-  private static Path resolveOneSymlink(Path path) throws IOException {
-    var targetPathFragment = path.readSymbolicLink();
+  private static Path resolveOneSymlink(Path path, @Nullable PathFragment targetPathFragment)
+      throws IOException {
+    if (targetPathFragment == null) {
+      targetPathFragment = path.readSymbolicLink();
+    }
     if (targetPathFragment.isAbsolute()) {
       return path.getFileSystem().getPath(targetPathFragment);
     } else {
@@ -559,7 +590,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
     //      FileNotFoundException because we want to download output to that target path.
     var maxAttempt = 32;
     while (path.isSymbolicLink() && maxAttempt-- > 0) {
-      var resolvedPath = resolveOneSymlink(path);
+      var resolvedPath = resolveOneSymlink(path, /* targetPathFragment= */ null);
       if (resolvedPath.asFragment().equals(path.asFragment())) {
         throw new FileSymlinkLoopException(path.getPathString() + FileSystem.ERR_TOO_MANY_SYMLINKS);
       }
@@ -744,28 +775,23 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
   }
 
   private Completable plantSymlink(Symlink symlink) {
+    Path linkPath = symlink.linkPath().forHostFileSystem();
     return downloadCache.execute(
-        symlink.linkPath(),
-        Completable.defer(
-            () -> {
-              // Delete the link path if it already exists. This is the case for tree artifacts,
-              // whose root directory is created before the action runs.
-              symlink.linkPath().delete();
-              symlink.linkPath().createSymbolicLink(symlink.targetPath());
-              return Completable.complete();
-            }),
-        forceRefetch(symlink.linkPath));
-  }
-
-  private Completable plantUnresolvedSymlink(Path linkPath, PathFragment target) {
-    return downloadCache.executeIfNot(
         linkPath,
         Completable.defer(
             () -> {
+              if (!symlink.linkPath().asFragment().startsWith(execRoot.asFragment())) {
+                // If the symlink is a source file in an external repo, its parent directory may not
+                // exist yet.
+                checkNotNull(linkPath.getParentDirectory()).createDirectoryAndParents();
+              }
+              // Delete the link path if it already exists. This is the case for tree artifacts,
+              // whose root directory is created before the action runs.
               linkPath.delete();
-              linkPath.createSymbolicLink(target);
+              linkPath.createSymbolicLink(symlink.targetPath());
               return Completable.complete();
-            }));
+            }),
+        forceRefetch(linkPath));
   }
 
   public ImmutableSet<Path> downloadedFiles() {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionOutputDirectoryHelper;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.FileStateType;
 import com.google.devtools.build.lib.actions.VirtualActionInput;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
@@ -83,6 +84,11 @@ public class RemoteActionInputFetcher extends AbstractActionInputPrefetcher {
 
   @Override
   protected boolean canDownloadFile(Path path, FileArtifactValue metadata) {
+    // Only files and directories have remote-only content that can be downloaded.
+    if (metadata.getType() != FileStateType.REGULAR_FILE
+        && metadata.getType() != FileStateType.DIRECTORY) {
+      return false;
+    }
     // When action rewinding is enabled, an action that had remote metadata at some point during the
     // build may have been re-executed locally to regenerate lost inputs, but may then be rewound
     // again and thus have its (now local) outputs deleted. In this case, we need to download the

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -819,6 +819,425 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
         extra_flags=['--sandbox_base=' + tmpdir]
     )
 
+  def testUseRepoSymlinkInBuildRule_actionDoesNotUseCache(self):
+    # Regression test for https://github.com/bazelbuild/bazel/issues/29656.
+    if self.IsWindows():
+      self.ScratchFile(
+          '.bazelrc',
+          ['startup --windows_enable_symlinks'],
+          mode='a',
+      )
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            '  rctx.file("BUILD", "exports_files([\'link2.txt\'])")',
+            '  rctx.file("data.txt", "hello")',
+            # A chain of symlinks ending at a regular file. Only link2.txt is a
+            # declared input of the consuming action; link1.txt and data.txt are
+            # reached purely by resolving it.
+            '  rctx.symlink("data.txt", "link1.txt")',
+            '  rctx.symlink("link1.txt", "link2.txt")',
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(_repo_impl)',
+        ],
+    )
+    self.ScratchFile(
+        'main/BUILD.bazel',
+        [
+            'genrule(',
+            '  name = "use_link",',
+            '  srcs = ["@my_repo//:link2.txt"],',
+            '  outs = ["out.txt"],',
+            '  cmd = "cat $< > $@",',
+            '  tags = ["no-cache"],',
+            ')',
+        ],
+    )
+
+    repo_dir = self.RepoDir('my_repo')
+    link2 = os.path.join(repo_dir, 'link2.txt')
+    out = self.Path('bazel-bin/main/out.txt')
+
+    # First fetch: not cached
+    _, _, stderr = self.RunBazel(['build', '//main:use_link'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertTrue(os.path.islink(link2))
+    self.assertTrue(os.path.exists(link2))
+    with open(out) as f:
+      self.assertEqual(f.read(), 'hello')
+
+    # After expunging: the repo is a remote cache hit and is not fully
+    # materialized, but the no-cache action still runs locally and must be able
+    # to read the symlink it depends on.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '//main:use_link'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertFalse(os.path.exists(os.path.join(repo_dir, 'BUILD')))
+    self.assertTrue(os.path.islink(link2))
+    self.assertTrue(os.path.exists(link2))
+    self.assertTrue(os.path.exists(out))
+    with open(out) as f:
+      self.assertEqual(f.read(), 'hello')
+
+  def testRepoSymlinkChainMaterializationIsConsistent(self):
+    # Full repo materialization (triggered by another repo accessing my_repo) and lazy action-input
+    # materialization (triggered by a local action consuming a single symlink from my_repo) must
+    # produce the same on-disk representation for the symlink chain, rather than e.g. collapsing the
+    # chain to its resolved target in one case but not the other.
+    if self.IsWindows():
+      self.ScratchFile(
+          '.bazelrc',
+          ['startup --windows_enable_symlinks'],
+          mode='a',
+      )
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo")',
+            (
+                'other_repo_rule ='
+                ' use_repo_rule("//:other_repo.bzl", "other_repo_rule")'
+            ),
+            'other_repo_rule(name = "other", build_file = "@my_repo//:BUILD")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            (
+                '  rctx.file("BUILD", "filegroup(name=\'haha\')\\n'
+                'exports_files([\'link2.txt\'])")'
+            ),
+            '  rctx.file("data.txt", "hello")',
+            # A chain of symlinks ending at a regular file.
+            '  rctx.symlink("data.txt", "link1.txt")',
+            '  rctx.symlink("link1.txt", "link2.txt")',
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(_repo_impl)',
+        ],
+    )
+    self.ScratchFile(
+        'other_repo.bzl',
+        [
+            'def _other_repo_impl(rctx):',
+            # Reading my_repo's BUILD forces full materialization of my_repo.
+            '  rctx.file("BUILD", rctx.read(rctx.attr.build_file))',
+            # other is not reproducible, so it is always fetched and re-triggers
+            # materialization of my_repo from the cache.
+            '  return rctx.repo_metadata()',
+            (
+                'other_repo_rule = repository_rule(_other_repo_impl,'
+                ' attrs={"build_file": attr.label()})'
+            ),
+        ],
+    )
+    self.ScratchFile(
+        'main/BUILD.bazel',
+        [
+            'genrule(',
+            '  name = "use_link",',
+            '  srcs = ["@my_repo//:link2.txt"],',
+            '  outs = ["out.txt"],',
+            '  cmd = "cat $< > $@",',
+            '  tags = ["no-cache"],',
+            ')',
+        ],
+    )
+
+    repo_dir = self.RepoDir('my_repo')
+    chain = ['link2.txt', 'link1.txt', 'data.txt']
+
+    def snapshot():
+      # Record a platform-independent structural layout: whether each path is a
+      # symlink/file/absent and the contents it ultimately resolves to. The raw
+      # symlink target string is intentionally not compared, as its
+      # representation differs across platforms.
+      layout = {}
+      for name in chain:
+        p = os.path.join(repo_dir, name)
+        kind = (
+            'symlink'
+            if os.path.islink(p)
+            else 'file'
+            if os.path.isfile(p)
+            else 'absent'
+        )
+        content = None
+        if os.path.exists(p):
+          with open(p) as f:
+            content = f.read()
+        layout[name] = (kind, content)
+      return layout
+
+    # Cold build: my_repo is fetched and uploaded to the remote repo contents
+    # cache.
+    _, _, stderr = self.RunBazel(['build', '//main:use_link'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+    # Full materialization: my_repo is restored from the cache into the overlay
+    # and then fully materialized because other accesses it.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '@other//:haha'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    full_layout = snapshot()
+
+    # Lazy action-input materialization: my_repo is restored from the cache into
+    # the overlay and only the symlink consumed by the local action (and its
+    # resolved target) is materialized.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '//main:use_link'])
+    print('\n'.join(stderr))
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    action_layout = snapshot()
+
+    # The symlink chain must be reproduced identically, not collapsed to its
+    # resolved target: link2.txt and link1.txt must both remain symlinks (a
+    # collapsed chain would drop the intermediate link1.txt) that resolve to the
+    # file's contents.
+    self.assertEqual(action_layout, full_layout)
+    self.assertEqual(action_layout['link2.txt'], ('symlink', 'hello'))
+    self.assertEqual(action_layout['link1.txt'], ('symlink', 'hello'))
+    self.assertEqual(action_layout['data.txt'], ('file', 'hello'))
+    if not self.IsWindows():
+      # The exact relative symlink targets are reproduced (POSIX only, as the
+      # representation is platform-dependent).
+      self.assertEqual(os.readlink(os.path.join(repo_dir, 'link2.txt')), 'link1.txt')
+      self.assertEqual(os.readlink(os.path.join(repo_dir, 'link1.txt')), 'data.txt')
+
+  def testRepoWithSymlinkChainIntoMainRepoIsNotCached(self):
+    # A repo containing a symlink chain that ends with a symlink pointing at a
+    # file in the main repo must not be added to the remote repo contents
+    # cache: when restored from the cache, the chain would only exist in the
+    # in-memory overlay file system, which can't resolve symlinks that cross
+    # over into the native file system.
+    if self.IsWindows():
+      self.ScratchFile(
+          '.bazelrc',
+          ['startup --windows_enable_symlinks'],
+          mode='a',
+      )
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo", main_file = "//:main_data.txt")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile('main_data.txt', ['main_hello'])
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            '  rctx.file("BUILD", "exports_files([\'link2.txt\'])")',
+            # A chain of symlinks whose last link points (via an absolute path)
+            # at a source file in the main repo.
+            '  rctx.symlink(rctx.attr.main_file, "main_link.txt")',
+            '  rctx.symlink("main_link.txt", "link1.txt")',
+            '  rctx.symlink("link1.txt", "link2.txt")',
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            (
+                'repo = repository_rule(_repo_impl,'
+                ' attrs={"main_file": attr.label()})'
+            ),
+        ],
+    )
+    self.ScratchFile(
+        'main/BUILD.bazel',
+        [
+            'genrule(',
+            '  name = "use_link",',
+            '  srcs = ["@my_repo//:link2.txt"],',
+            '  outs = ["out.txt"],',
+            '  cmd = "cat $< > $@",',
+            '  tags = ["no-cache"],',
+            ')',
+        ],
+    )
+
+    repo_dir = self.RepoDir('my_repo')
+    out = self.Path('bazel-bin/main/out.txt')
+
+    def assert_chain_on_disk():
+      for name in ['link2.txt', 'link1.txt', 'main_link.txt']:
+        self.assertTrue(os.path.islink(os.path.join(repo_dir, name)))
+        with open(os.path.join(repo_dir, name)) as f:
+          self.assertEqual(f.read(), 'main_hello\n')
+      if not self.IsWindows():
+        # The exact symlink targets are preserved (POSIX only, as the
+        # representation is platform-dependent). The absolute symlink into the
+        # main repo is not replanted to a relative path.
+        self.assertEqual(
+            os.readlink(os.path.join(repo_dir, 'link2.txt')), 'link1.txt'
+        )
+        self.assertEqual(
+            os.readlink(os.path.join(repo_dir, 'link1.txt')), 'main_link.txt'
+        )
+        self.assertTrue(
+            os.path.isabs(os.readlink(os.path.join(repo_dir, 'main_link.txt')))
+        )
+
+    # Cold build: my_repo is fetched, but not uploaded to the remote repo
+    # contents cache due to the symlink pointing into the main repo.
+    _, _, stderr = self.RunBazel(['build', '//main:use_link'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+    assert_chain_on_disk()
+    with open(out) as f:
+      self.assertEqual(f.read(), 'main_hello\n')
+
+    # After expunging, the repo is fetched again rather than restored from the
+    # cache and the symlink chain keeps working.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '//main:use_link'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+    assert_chain_on_disk()
+    with open(out) as f:
+      self.assertEqual(f.read(), 'main_hello\n')
+
+  def testRepoExternalSymlinkMaterializationIsConsistent(self):
+    # A repo source symlink whose target lives in *another* repo (an absolute
+    # symlink into that repo) must be reproduced identically by full repo
+    # materialization and by lazy action-input materialization.
+    if self.IsWindows():
+      self.ScratchFile(
+          '.bazelrc',
+          ['startup --windows_enable_symlinks'],
+          mode='a',
+      )
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'dep_repo_rule = use_repo_rule("//:dep_repo.bzl", "dep_repo_rule")',
+            'dep_repo_rule(name = "dep_repo")',
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo", external_file = "@dep_repo//:dep_data.txt")',
+            (
+                'other_repo_rule ='
+                ' use_repo_rule("//:other_repo.bzl", "other_repo_rule")'
+            ),
+            (
+                'other_repo_rule(name = "other", build_file = "@my_repo//:BUILD",'
+                ' dep_file = "@dep_repo//:dep_data.txt")'
+            ),
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'dep_repo.bzl',
+        [
+            'def _dep_repo_impl(rctx):',
+            '  rctx.file("BUILD", "exports_files([\'dep_data.txt\'])")',
+            '  rctx.file("dep_data.txt", "dep_hello")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'dep_repo_rule = repository_rule(_dep_repo_impl)',
+        ],
+    )
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            (
+                '  rctx.file("BUILD", "filegroup(name=\'haha\')\\n'
+                'exports_files([\'external_link.txt\'])")'
+            ),
+            # An absolute symlink pointing at a file in another repo.
+            '  rctx.symlink(rctx.attr.external_file, "external_link.txt")',
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            (
+                'repo = repository_rule(_repo_impl,'
+                ' attrs={"external_file": attr.label()})'
+            ),
+        ],
+    )
+    self.ScratchFile(
+        'other_repo.bzl',
+        [
+            'def _other_repo_impl(rctx):',
+            # Materialize dep_repo before my_repo so that the external symlink
+            # target exists when my_repo is materialized.
+            '  rctx.watch(rctx.attr.dep_file)',
+            '  rctx.file("BUILD", rctx.read(rctx.attr.build_file))',
+            '  return rctx.repo_metadata()',
+            (
+                'other_repo_rule = repository_rule(_other_repo_impl,'
+                ' attrs={"build_file": attr.label(), "dep_file": attr.label()})'
+            ),
+        ],
+    )
+    self.ScratchFile(
+        'main/BUILD.bazel',
+        [
+            'genrule(',
+            '  name = "use_link",',
+            '  srcs = ["@my_repo//:external_link.txt"],',
+            '  outs = ["out.txt"],',
+            '  cmd = "cat $< > $@",',
+            '  tags = ["no-cache"],',
+            ')',
+        ],
+    )
+
+    repo_dir = self.RepoDir('my_repo')
+    external_link = os.path.join(repo_dir, 'external_link.txt')
+
+    def snapshot():
+      # The raw (absolute) symlink target string is intentionally not compared,
+      # as its representation differs across platforms; comparing whether it is a
+      # symlink and what it resolves to is sufficient and portable.
+      layout = {}
+      layout['type'] = (
+          'symlink'
+          if os.path.islink(external_link)
+          else 'file'
+          if os.path.isfile(external_link)
+          else 'absent'
+      )
+      # The resolved content (follows the cross-repo symlink on disk).
+      layout['resolves_to'] = (
+          open(external_link).read() if os.path.exists(external_link) else None
+      )
+      return layout
+
+    # Cold build: my_repo and dep_repo are fetched and uploaded to the cache.
+    _, _, stderr = self.RunBazel(['build', '//main:use_link'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+    # Full materialization: my_repo is restored from the cache into the overlay
+    # and fully materialized (along with dep_repo) because other accesses it.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '@other//:haha'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    full_layout = snapshot()
+
+    # Lazy action-input materialization: only external_link.txt and its resolved
+    # target in dep_repo are materialized.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '//main:use_link'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    action_layout = snapshot()
+
+    # The cross-repo symlink must be reproduced (as an absolute symlink into the
+    # other repo) and resolve to the other repo's file contents in both cases.
+    self.assertEqual(action_layout, full_layout)
+    self.assertEqual(action_layout['type'], 'symlink')
+    self.assertEqual(action_layout['resolves_to'], 'dep_hello')
+
   def testLostRemoteFile_build(self):
     # Create a repo with two BUILD files (one in a subpackage), build a target
     # from one to cause it to be cached, then build that target again after


### PR DESCRIPTION
### Description

When a remotely cached repo is partially materialized since it contains action inputs, Skyframe provides the metadata of these inputs after following all symlinks as it does for all source files. Since (chains of) symlinks need to be preserved and materialized in the same way as if the repo rule ran locally or was fully materialized as a dependency of another repo rule, `AbstractActionInputPrefetcher` is changed to walk the full chain of symlinks behind a prefetched external repo path replant every link verbatim on the host file system.

This proves very difficult to get right for repos with symlinks pointing into the main repo as such symlinks would cross over into the host filesystem. For this reason such symlinks now exclude a repo from being cached remotely. Note that the local repo contents cache already doesn't cache such repos. Since main repo files are readily available, this is considered a minor loss in usefulness only.


### Motivation

Fixes #29656
Fixes #29515

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: The remote repo contents cache now correctly materializes chains of symlinks as action inputs, but no longer supports symlinks into the main repository.
