### PR TITLE
Add support for detection of unused java dependencies

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/JavaLibraryBuildRequest.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/JavaLibraryBuildRequest.java
@@ -166,10 +166,17 @@ public final class JavaLibraryBuildRequest {
     if (optionsParser.getStrictJavaDeps() != null) {
       depsBuilder.setStrictJavaDeps(optionsParser.getStrictJavaDeps());
     }
-    if (!optionsParser.getDirectDepJars().isEmpty()) {
-      depsBuilder.addDirectDepJarsToVerify(
-          optionsParser.getDirectDepJars().stream().map(this::asPath).collect(toImmutableList()),
-          optionsParser.getDirectDepLabels());
+    if (!optionsParser.getDeclaredDeps().isEmpty()) {
+      ImmutableList.Builder<Path> jars = ImmutableList.builder();
+      ImmutableList.Builder<String> labels = ImmutableList.builder();
+      for (String declaredDep : optionsParser.getDeclaredDeps()) {
+        int separatorIdx = declaredDep.indexOf("::");
+        if (separatorIdx != -1) {
+          jars.add(asPath(declaredDep.substring(0, separatorIdx)));
+          labels.add(declaredDep.substring(separatorIdx + 2));
+        }
+      }
+      depsBuilder.addDirectDepJarsToVerify(jars.build(), labels.build());
     }
     if (optionsParser.getOutputDepsProtoFile() != null) {
       depsBuilder.setOutputDepsProtoFile(asPath(optionsParser.getOutputDepsProtoFile()));

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/JavaLibraryBuildRequest.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/JavaLibraryBuildRequest.java
@@ -166,6 +166,11 @@ public final class JavaLibraryBuildRequest {
     if (optionsParser.getStrictJavaDeps() != null) {
       depsBuilder.setStrictJavaDeps(optionsParser.getStrictJavaDeps());
     }
+    if (!optionsParser.getDirectDepJars().isEmpty()) {
+      depsBuilder.addDirectDepJarsToVerify(
+          optionsParser.getDirectDepJars().stream().map(this::asPath).collect(toImmutableList()),
+          optionsParser.getDirectDepLabels());
+    }
     if (optionsParser.getOutputDepsProtoFile() != null) {
       depsBuilder.setOutputDepsProtoFile(asPath(optionsParser.getOutputDepsProtoFile()));
     }

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/JavaLibraryBuildRequest.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/JavaLibraryBuildRequest.java
@@ -166,6 +166,18 @@ public final class JavaLibraryBuildRequest {
     if (optionsParser.getStrictJavaDeps() != null) {
       depsBuilder.setStrictJavaDeps(optionsParser.getStrictJavaDeps());
     }
+    if (!optionsParser.getDeclaredDeps().isEmpty()) {
+      ImmutableList.Builder<Path> jars = ImmutableList.builder();
+      ImmutableList.Builder<String> labels = ImmutableList.builder();
+      for (String declaredDep : optionsParser.getDeclaredDeps()) {
+        int separatorIdx = declaredDep.indexOf("::");
+        if (separatorIdx != -1) {
+          jars.add(asPath(declaredDep.substring(0, separatorIdx)));
+          labels.add(declaredDep.substring(separatorIdx + 2));
+        }
+      }
+      depsBuilder.addDirectDepJarsToVerify(jars.build(), labels.build());
+    }
     if (optionsParser.getOutputDepsProtoFile() != null) {
       depsBuilder.setOutputDepsProtoFile(asPath(optionsParser.getOutputDepsProtoFile()));
     }

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/OptionsParser.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/OptionsParser.java
@@ -50,6 +50,8 @@ public final class OptionsParser {
 
   private String outputDepsProtoFile;
   private final Set<String> depsArtifacts = new LinkedHashSet<>();
+  private final List<String> directDepJars = new ArrayList<>();
+  private final List<String> directDepLabels = new ArrayList<>();
 
   /** This modes controls how a probablistic Java classpath reduction is used. */
   public enum ReduceClasspathMode {
@@ -137,6 +139,12 @@ public final class OptionsParser {
           break;
         case "--strict_java_deps":
           strictJavaDeps = getArgument(argQueue, arg);
+          break;
+        case "--direct_dep_jar":
+          directDepJars.add(getArgument(argQueue, arg));
+          break;
+        case "--direct_dep_label":
+          directDepLabels.add(getArgument(argQueue, arg));
           break;
         case "--experimental_fix_deps_tool":
           fixDepsTool = getArgument(argQueue, arg);
@@ -363,6 +371,14 @@ public final class OptionsParser {
 
   public Set<String> getDepsArtifacts() {
     return depsArtifacts;
+  }
+
+  public List<String> getDirectDepJars() {
+    return directDepJars;
+  }
+
+  public List<String> getDirectDepLabels() {
+    return directDepLabels;
   }
 
   public ReduceClasspathMode reduceClasspathMode() {

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/OptionsParser.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/OptionsParser.java
@@ -50,8 +50,7 @@ public final class OptionsParser {
 
   private String outputDepsProtoFile;
   private final Set<String> depsArtifacts = new LinkedHashSet<>();
-  private final List<String> directDepJars = new ArrayList<>();
-  private final List<String> directDepLabels = new ArrayList<>();
+  private final List<String> declaredDeps = new ArrayList<>();
 
   /** This modes controls how a probablistic Java classpath reduction is used. */
   public enum ReduceClasspathMode {
@@ -140,11 +139,8 @@ public final class OptionsParser {
         case "--strict_java_deps":
           strictJavaDeps = getArgument(argQueue, arg);
           break;
-        case "--direct_dep_jar":
-          directDepJars.add(getArgument(argQueue, arg));
-          break;
-        case "--direct_dep_label":
-          directDepLabels.add(getArgument(argQueue, arg));
+        case "--declared_dep":
+          declaredDeps.add(getArgument(argQueue, arg));
           break;
         case "--experimental_fix_deps_tool":
           fixDepsTool = getArgument(argQueue, arg);
@@ -373,12 +369,8 @@ public final class OptionsParser {
     return depsArtifacts;
   }
 
-  public List<String> getDirectDepJars() {
-    return directDepJars;
-  }
-
-  public List<String> getDirectDepLabels() {
-    return directDepLabels;
+  public List<String> getDeclaredDeps() {
+    return declaredDeps;
   }
 
   public ReduceClasspathMode reduceClasspathMode() {

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/OptionsParser.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/OptionsParser.java
@@ -50,6 +50,7 @@ public final class OptionsParser {
 
   private String outputDepsProtoFile;
   private final Set<String> depsArtifacts = new LinkedHashSet<>();
+  private final List<String> declaredDeps = new ArrayList<>();
 
   /** This modes controls how a probablistic Java classpath reduction is used. */
   public enum ReduceClasspathMode {
@@ -137,6 +138,9 @@ public final class OptionsParser {
           break;
         case "--strict_java_deps":
           strictJavaDeps = getArgument(argQueue, arg);
+          break;
+        case "--declared_dep":
+          declaredDeps.add(getArgument(argQueue, arg));
           break;
         case "--experimental_fix_deps_tool":
           fixDepsTool = getArgument(argQueue, arg);
@@ -363,6 +367,10 @@ public final class OptionsParser {
 
   public Set<String> getDepsArtifacts() {
     return depsArtifacts;
+  }
+
+  public List<String> getDeclaredDeps() {
+    return declaredDeps;
   }
 
   public ReduceClasspathMode reduceClasspathMode() {

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/DependencyModule.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/DependencyModule.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/DependencyModule.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/DependencyModule.java
@@ -92,6 +92,8 @@ public final class DependencyModule {
   private final Set<String> exemptGenerators;
   private final Set<PackageSymbol> packages;
   @Nonnull private final Path workDir;
+  private final Map<Path, String> directDepJarsToVerify;
+  private final Set<String> allDeclaredLabels;
 
   DependencyModule(
       StrictJavaDeps strictJavaDeps,
@@ -104,7 +106,9 @@ public final class DependencyModule {
       Path outputDepsProtoFile,
       FixMessage fixMessage,
       Set<String> exemptGenerators,
-      @Nonnull Path workDir) {
+      @Nonnull Path workDir,
+      Map<Path, String> directDepJarsToVerify,
+      Set<String> allDeclaredLabels) {
     this.strictJavaDeps = strictJavaDeps;
     this.fixDepsTool = fixDepsTool;
     this.directJars = directJars;
@@ -117,8 +121,9 @@ public final class DependencyModule {
     this.platformJars = platformJars;
     this.fixMessage = fixMessage;
     this.exemptGenerators = exemptGenerators;
-    this.packages = new HashSet<>();
     this.workDir = requireNonNull(workDir);
+    this.directDepJarsToVerify = directDepJarsToVerify;
+    this.allDeclaredLabels = allDeclaredLabels;
   }
 
   /** Returns the sandbox working directory that output paths are relativized against. */
@@ -140,6 +145,14 @@ public final class DependencyModule {
     Path relative =
         !workDir.toString().isEmpty() && path.startsWith(workDir) ? workDir.relativize(path) : path;
     return relative.toString().replace(File.separatorChar, '/');
+  }
+
+  public Map<Path, String> getDirectDepJarsToVerify() {
+    return directDepJarsToVerify;
+  }
+
+  public Set<String> getAllDeclaredLabels() {
+    return allDeclaredLabels;
   }
 
   /** Returns a plugin to be enabled in the compiler. */
@@ -387,6 +400,9 @@ public final class DependencyModule {
       }
     }
 
+    private final Map<Path, String> directDepJarsToVerify = new HashMap<>();
+    private final Set<String> allDeclaredLabels = new HashSet<>();
+
     /**
      * Constructs the DependencyModule, guaranteeing that the maps are never null (they may be
      * empty), and the default strictJavaDeps setting is OFF.
@@ -401,16 +417,25 @@ public final class DependencyModule {
           strictClasspathMode,
           depsArtifacts,
           platformJars,
-          targetLabel,
-          outputDepsProtoFile,
-          fixMessage,
-          exemptGenerators,
-          workDir);
+          workDir,
+          directDepJarsToVerify,
+          allDeclaredLabels);
     }
 
     @CanIgnoreReturnValue
     public Builder setWorkDir(@Nonnull Path workDir) {
       this.workDir = workDir;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder addDirectDepJarsToVerify(List<Path> jars, List<String> labels) {
+      for (int i = 0; i < jars.size(); i++) {
+        Path jar = jars.get(i);
+        String label = labels.get(i);
+        this.directDepJarsToVerify.put(jar, label);
+        this.allDeclaredLabels.add(label);
+      }
       return this;
     }
 

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/DependencyModule.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/DependencyModule.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -92,6 +93,8 @@ public final class DependencyModule {
   private final Set<String> exemptGenerators;
   private final Set<PackageSymbol> packages;
   @Nonnull private final Path workDir;
+  private final Map<Path, String> directDepJarsToVerify;
+  private final Set<String> allDeclaredLabels;
 
   DependencyModule(
       StrictJavaDeps strictJavaDeps,
@@ -104,7 +107,9 @@ public final class DependencyModule {
       Path outputDepsProtoFile,
       FixMessage fixMessage,
       Set<String> exemptGenerators,
-      @Nonnull Path workDir) {
+      @Nonnull Path workDir,
+      Map<Path, String> directDepJarsToVerify,
+      Set<String> allDeclaredLabels) {
     this.strictJavaDeps = strictJavaDeps;
     this.fixDepsTool = fixDepsTool;
     this.directJars = directJars;
@@ -119,6 +124,8 @@ public final class DependencyModule {
     this.exemptGenerators = exemptGenerators;
     this.packages = new HashSet<>();
     this.workDir = requireNonNull(workDir);
+    this.directDepJarsToVerify = directDepJarsToVerify;
+    this.allDeclaredLabels = allDeclaredLabels;
   }
 
   /** Returns the sandbox working directory that output paths are relativized against. */
@@ -140,6 +147,14 @@ public final class DependencyModule {
     Path relative =
         !workDir.toString().isEmpty() && path.startsWith(workDir) ? workDir.relativize(path) : path;
     return relative.toString().replace(File.separatorChar, '/');
+  }
+
+  public Map<Path, String> getDirectDepJarsToVerify() {
+    return directDepJarsToVerify;
+  }
+
+  public Set<String> getAllDeclaredLabels() {
+    return allDeclaredLabels;
   }
 
   /** Returns a plugin to be enabled in the compiler. */
@@ -387,6 +402,9 @@ public final class DependencyModule {
       }
     }
 
+    private final Map<Path, String> directDepJarsToVerify = new HashMap<>();
+    private final Set<String> allDeclaredLabels = new HashSet<>();
+
     /**
      * Constructs the DependencyModule, guaranteeing that the maps are never null (they may be
      * empty), and the default strictJavaDeps setting is OFF.
@@ -405,12 +423,25 @@ public final class DependencyModule {
           outputDepsProtoFile,
           fixMessage,
           exemptGenerators,
-          workDir);
+          workDir,
+          directDepJarsToVerify,
+          allDeclaredLabels);
     }
 
     @CanIgnoreReturnValue
     public Builder setWorkDir(@Nonnull Path workDir) {
       this.workDir = workDir;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder addDirectDepJarsToVerify(List<Path> jars, List<String> labels) {
+      for (int i = 0; i < jars.size(); i++) {
+        Path jar = jars.get(i);
+        String label = labels.get(i);
+        this.directDepJarsToVerify.put(jar, label);
+        this.allDeclaredLabels.add(label);
+      }
       return this;
     }
 

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/DependencyModule.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/DependencyModule.java
@@ -122,6 +122,7 @@ public final class DependencyModule {
     this.platformJars = platformJars;
     this.fixMessage = fixMessage;
     this.exemptGenerators = exemptGenerators;
+    this.packages = new HashSet<>();
     this.workDir = requireNonNull(workDir);
     this.directDepJarsToVerify = directDepJarsToVerify;
     this.allDeclaredLabels = allDeclaredLabels;
@@ -418,6 +419,10 @@ public final class DependencyModule {
           strictClasspathMode,
           depsArtifacts,
           platformJars,
+          targetLabel,
+          outputDepsProtoFile,
+          fixMessage,
+          exemptGenerators,
           workDir,
           directDepJarsToVerify,
           allDeclaredLabels);

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
@@ -241,6 +241,31 @@ public final class StrictJavaDepsPlugin extends BlazeJavaCompilerPlugin {
         dependencyModule.setHasMissingTargets();
       }
     }
+
+    Map<Path, String> directDepJarsToVerify = dependencyModule.getDirectDepJarsToVerify();
+    if (!directDepJarsToVerify.isEmpty()) {
+      Set<String> usedLabels = new HashSet<>();
+      for (Path usedJar : dependencyModule.getExplicitDependenciesMap().keySet()) {
+        String label = directDepJarsToVerify.get(usedJar);
+        if (label != null) {
+          usedLabels.add(label);
+        }
+      }
+      Set<String> unusedLabels = new java.util.TreeSet<>(dependencyModule.getAllDeclaredLabels());
+      unusedLabels.removeAll(usedLabels);
+      if (!unusedLabels.isEmpty()) {
+        String targetLabel = dependencyModule.getTargetLabel();
+        if (targetLabel != null) {
+          for (String unusedLabel : unusedLabels) {
+            String msg = String.format(
+                "[unused-deps] Target '%s' is declared as a direct dependency of '%s' but is unused.",
+                unusedLabel,
+                targetLabel);
+            log.error(Position.NOPOS, Errors.ProcMessager(msg));
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
@@ -255,11 +255,14 @@ public final class StrictJavaDepsPlugin extends BlazeJavaCompilerPlugin {
       unusedLabels.removeAll(usedLabels);
       if (!unusedLabels.isEmpty()) {
         String targetLabel = dependencyModule.getTargetLabel();
-        for (String unusedLabel : unusedLabels) {
-          String msg = targetLabel != null
-              ? String.format("[unused-deps] Target '%s' is declared as a direct dependency of '%s' but is unused.", unusedLabel, targetLabel)
-              : String.format("[unused-deps] Target '%s' is declared as a direct dependency but is unused.", unusedLabel);
-          log.error(Position.NOPOS, Errors.ProcMessager(msg));
+        if (targetLabel != null) {
+          for (String unusedLabel : unusedLabels) {
+            String msg = String.format(
+                "[unused-deps] Target '%s' is declared as a direct dependency of '%s' but is unused.",
+                unusedLabel,
+                targetLabel);
+            log.error(Position.NOPOS, Errors.ProcMessager(msg));
+          }
         }
       }
     }

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
@@ -241,6 +241,28 @@ public final class StrictJavaDepsPlugin extends BlazeJavaCompilerPlugin {
         dependencyModule.setHasMissingTargets();
       }
     }
+
+    Map<Path, String> directDepJarsToVerify = dependencyModule.getDirectDepJarsToVerify();
+    if (!directDepJarsToVerify.isEmpty()) {
+      Set<String> usedLabels = new HashSet<>();
+      for (Path usedJar : dependencyModule.getExplicitDependenciesMap().keySet()) {
+        String label = directDepJarsToVerify.get(usedJar);
+        if (label != null) {
+          usedLabels.add(label);
+        }
+      }
+      Set<String> unusedLabels = new java.util.TreeSet<>(dependencyModule.getAllDeclaredLabels());
+      unusedLabels.removeAll(usedLabels);
+      if (!unusedLabels.isEmpty()) {
+        String targetLabel = dependencyModule.getTargetLabel();
+        for (String unusedLabel : unusedLabels) {
+          String msg = targetLabel != null
+              ? String.format("[unused-deps] Target '%s' is declared as a direct dependency of '%s' but is unused.", unusedLabel, targetLabel)
+              : String.format("[unused-deps] Target '%s' is declared as a direct dependency but is unused.", unusedLabel);
+          log.error(Position.NOPOS, Errors.ProcMessager(msg));
+        }
+      }
+    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
@@ -298,6 +298,8 @@ public final class JavaCompilationHelper {
         .getFixDepsTool(ruleContext.getRule(), getJavaConfiguration())
         .ifPresent(builder::setFixDepsTool);
     builder.setCompileTimeDependencyArtifacts(attributes.getCompileTimeDependencyArtifacts());
+    builder.setDirectDepJarsToVerify(attributes.getDirectDepJarsToVerify());
+    builder.setDirectDepLabelsToVerify(attributes.getDirectDepLabelsToVerify());
     builder.setTargetLabel(
         attributes.getTargetLabel() == null ? label : attributes.getTargetLabel());
     builder.setInjectingRuleKind(attributes.getInjectingRuleKind());

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
@@ -298,6 +298,7 @@ public final class JavaCompilationHelper {
         .getFixDepsTool(ruleContext.getRule(), getJavaConfiguration())
         .ifPresent(builder::setFixDepsTool);
     builder.setCompileTimeDependencyArtifacts(attributes.getCompileTimeDependencyArtifacts());
+    builder.setExtraCommandLineArgs(attributes.getExtraCommandLineArgs());
     builder.setTargetLabel(
         attributes.getTargetLabel() == null ? label : attributes.getTargetLabel());
     builder.setInjectingRuleKind(attributes.getInjectingRuleKind());

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -123,6 +123,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
   private final ImmutableMap<String, String> executionInfo;
   private final CommandLine executableLine;
   private final CommandLine flagLine;
+  private final ImmutableList<CommandLine> extraCommandLineArgs;
   private final BuildConfigurationValue configuration;
   private final OnDemandString progressMessage;
 
@@ -149,6 +150,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
       ExtraActionInfoSupplier extraActionInfoSupplier,
       CommandLine executableLine,
       CommandLine flagLine,
+      ImmutableList<CommandLine> extraCommandLineArgs,
       BuildConfigurationValue configuration,
       NestedSet<Artifact> dependencyArtifacts,
       Artifact outputDepsProto,
@@ -171,6 +173,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
         configuration.modifiedExecutionInfo(executionInfo, compilationType.mnemonic);
     this.executableLine = executableLine;
     this.flagLine = flagLine;
+    this.extraCommandLineArgs = extraCommandLineArgs;
     this.configuration = configuration;
     this.progressMessage = progressMessage;
     this.extraActionInfoSupplier = extraActionInfoSupplier;
@@ -230,6 +233,10 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
         actionKeyContext, inputMetadataProvider, effectiveOutputPathsMode, fp);
     flagLine.addToFingerprint(
         actionKeyContext, inputMetadataProvider, effectiveOutputPathsMode, fp);
+    for (CommandLine extraCommandLine : extraCommandLineArgs) {
+      extraCommandLine.addToFingerprint(
+          actionKeyContext, inputMetadataProvider, effectiveOutputPathsMode, fp);
+    }
     // As the classpath is no longer part of commandLines implicitly, we need to explicitly add
     // the transitive inputs to the key here.
     actionKeyContext.addNestedSetToFingerprint(fp, transitiveInputs);
@@ -309,12 +316,15 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
       classpathLine.add("--reduce_classpath_mode", fallback ? "BAZEL_FALLBACK" : "BAZEL_REDUCED");
     }
 
-    CommandLines reducedCommandLine =
+    CommandLines.Builder commandLinesBuilder =
         CommandLines.builder()
             .addCommandLine(executableLine)
-            .addCommandLine(flagLine, PARAM_FILE_INFO)
-            .addCommandLine(classpathLine.build(), PARAM_FILE_INFO)
-            .build();
+            .addCommandLine(flagLine, PARAM_FILE_INFO);
+    for (CommandLine extraCommandLine : extraCommandLineArgs) {
+      commandLinesBuilder.addCommandLine(extraCommandLine, PARAM_FILE_INFO);
+    }
+    commandLinesBuilder.addCommandLine(classpathLine.build(), PARAM_FILE_INFO);
+    CommandLines reducedCommandLine = commandLinesBuilder.build();
     CommandLines.ExpandedCommandLines expandedCommandLines =
         reducedCommandLine.expand(
             actionExecutionContext.getInputMetadataProvider(),
@@ -552,11 +562,14 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
   public ExtraActionInfo.Builder getExtraActionInfo(ActionKeyContext actionKeyContext)
       throws CommandLineExpansionException, InterruptedException {
     ExtraActionInfo.Builder builder = super.getExtraActionInfo(actionKeyContext);
-    CommandLines commandLinesWithoutExecutable =
+    CommandLines.Builder commandLinesBuilder =
         CommandLines.builder()
-            .addCommandLine(flagLine)
-            .addCommandLine(getFullClasspathLine())
-            .build();
+            .addCommandLine(flagLine);
+    for (CommandLine extraCommandLine : extraCommandLineArgs) {
+      commandLinesBuilder.addCommandLine(extraCommandLine);
+    }
+    commandLinesBuilder.addCommandLine(getFullClasspathLine());
+    CommandLines commandLinesWithoutExecutable = commandLinesBuilder.build();
     if (extraActionInfoSupplier != null) {
       extraActionInfoSupplier.extend(builder, commandLinesWithoutExecutable.allArguments());
     }
@@ -604,9 +617,14 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
 
   @VisibleForTesting
   public CommandLines getCommandLines() {
-    return CommandLines.builder()
-        .addCommandLine(executableLine)
-        .addCommandLine(flagLine, PARAM_FILE_INFO)
+    CommandLines.Builder builder =
+        CommandLines.builder()
+            .addCommandLine(executableLine)
+            .addCommandLine(flagLine, PARAM_FILE_INFO);
+    for (CommandLine extraCommandLine : extraCommandLineArgs) {
+      builder.addCommandLine(extraCommandLine, PARAM_FILE_INFO);
+    }
+    return builder
         .addCommandLine(getFullClasspathLine(), PARAM_FILE_INFO)
         .build();
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
@@ -157,6 +157,8 @@ public final class JavaCompileActionBuilder {
   private NestedSet<Artifact> extraData = NestedSetBuilder.emptySet(Order.NAIVE_LINK_ORDER);
   private Label targetLabel;
   @Nullable private String injectingRuleKind;
+  private ImmutableList<Artifact> directDepJarsToVerify = ImmutableList.of();
+  private ImmutableList<String> directDepLabelsToVerify = ImmutableList.of();
   private ImmutableList<Artifact> additionalInputs = ImmutableList.of();
   private Artifact genSourceOutput;
   private JavaCompileOutputs<Artifact> outputs;
@@ -320,6 +322,12 @@ public final class JavaCompileActionBuilder {
       result.add("--strict_java_deps", strictJavaDeps.toString());
       result.addExecPaths("--direct_dependencies", directJars);
     }
+    if (!directDepJarsToVerify.isEmpty()) {
+      for (int i = 0; i < directDepJarsToVerify.size(); i++) {
+        result.addExecPath("--direct_dep_jar", directDepJarsToVerify.get(i));
+        result.add("--direct_dep_label", directDepLabelsToVerify.get(i));
+      }
+    }
     result.add("--experimental_fix_deps_tool", fixDepsTool);
 
     // Chose what artifact to pass to JavaBuilder, as input to jacoco instrumentation processor.
@@ -375,6 +383,18 @@ public final class JavaCompileActionBuilder {
       NestedSet<Artifact> dependencyArtifacts) {
     checkNotNull(compileTimeDependencyArtifacts, "dependencyArtifacts must not be null");
     this.compileTimeDependencyArtifacts = dependencyArtifacts;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public JavaCompileActionBuilder setDirectDepJarsToVerify(ImmutableList<Artifact> directDepJarsToVerify) {
+    this.directDepJarsToVerify = directDepJarsToVerify;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public JavaCompileActionBuilder setDirectDepLabelsToVerify(ImmutableList<String> directDepLabelsToVerify) {
+    this.directDepLabelsToVerify = directDepLabelsToVerify;
     return this;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
@@ -324,8 +324,9 @@ public final class JavaCompileActionBuilder {
     }
     if (!directDepJarsToVerify.isEmpty()) {
       for (int i = 0; i < directDepJarsToVerify.size(); i++) {
-        result.addExecPath("--direct_dep_jar", directDepJarsToVerify.get(i));
-        result.add("--direct_dep_label", directDepLabelsToVerify.get(i));
+        result.add(
+            "--declared_dep",
+            directDepJarsToVerify.get(i).getExecPathString() + "::" + directDepLabelsToVerify.get(i));
       }
     }
     result.add("--experimental_fix_deps_tool", fixDepsTool);

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.ActionAnalysisMetadata;
 import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.CommandLine;
 import com.google.devtools.build.lib.actions.extra.ExtraActionInfo;
 import com.google.devtools.build.lib.actions.extra.JavaCompileInfo;
 import com.google.devtools.build.lib.analysis.RuleContext;
@@ -157,6 +158,7 @@ public final class JavaCompileActionBuilder {
   private NestedSet<Artifact> extraData = NestedSetBuilder.emptySet(Order.NAIVE_LINK_ORDER);
   private Label targetLabel;
   @Nullable private String injectingRuleKind;
+  private ImmutableList<CommandLine> extraCommandLineArgs = ImmutableList.of();
   private ImmutableList<Artifact> additionalInputs = ImmutableList.of();
   private Artifact genSourceOutput;
   private JavaCompileOutputs<Artifact> outputs;
@@ -260,6 +262,7 @@ public final class JavaCompileActionBuilder {
         /* extraActionInfoSupplier= */ extraActionInfoSupplier,
         /* executableLine= */ executableLine,
         /* flagLine= */ buildParamFileContents(javacOpts),
+        /* extraCommandLineArgs= */ extraCommandLineArgs,
         /* configuration= */ ruleContext.getConfiguration(),
         /* dependencyArtifacts= */ compileTimeDependencyArtifacts,
         /* outputDepsProto= */ outputs.depsProto(),
@@ -375,6 +378,13 @@ public final class JavaCompileActionBuilder {
       NestedSet<Artifact> dependencyArtifacts) {
     checkNotNull(compileTimeDependencyArtifacts, "dependencyArtifacts must not be null");
     this.compileTimeDependencyArtifacts = dependencyArtifacts;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public JavaCompileActionBuilder setExtraCommandLineArgs(
+      ImmutableList<CommandLine> extraCommandLineArgs) {
+    this.extraCommandLineArgs = extraCommandLineArgs;
     return this;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
@@ -655,6 +655,7 @@ public final class JavaHeaderCompileAction extends SpawnAction {
               /* extraActionInfoSupplier= */ null,
               /* executableLine= */ executableLine,
               /* flagLine= */ commandLine.build(),
+              /* extraCommandLineArgs= */ ImmutableList.of(),
               /* configuration= */ ruleContext.getConfiguration(),
               /* dependencyArtifacts= */ compileTimeDependencyArtifacts,
               /* outputDepsProto= */ outputDepsProto,

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -222,12 +222,34 @@ public class JavaStarlarkCommon
     ImmutableList.Builder<String> directDepLabelsToVerifyBuilder = ImmutableList.builder();
     for (Object obj : Sequence.cast(directDepJarsToVerify, Object.class, "direct_dep_jars_to_verify")) {
       if (obj instanceof StarlarkInfo struct) {
-        Artifact jar = (Artifact) struct.getValue("jar");
-        String label = (String) struct.getValue("label");
-        if (jar != null && label != null) {
-          directDepJarsToVerifyBuilder.add(jar);
-          directDepLabelsToVerifyBuilder.add(label);
+        Artifact jar = null;
+        Object jarObj = struct.getValue("jar");
+        if (jarObj != null && jarObj != Starlark.NONE) {
+          if (jarObj instanceof Artifact) {
+            jar = (Artifact) jarObj;
+          } else {
+            throw Starlark.errorf("Expected jar attribute to be an Artifact in struct, but got: %s", Starlark.type(jarObj));
+          }
         }
+        String label = null;
+        Object labelObj = struct.getValue("label");
+        if (labelObj != null && labelObj != Starlark.NONE) {
+          if (labelObj instanceof String) {
+            label = (String) labelObj;
+          } else {
+            throw Starlark.errorf("Expected label attribute to be a string in struct, but got: %s", Starlark.type(labelObj));
+          }
+        }
+        if (jar == null) {
+          throw Starlark.errorf("struct in direct_dep_jars_to_verify must contain a non-empty 'jar' field of type Artifact");
+        }
+        if (label == null) {
+          throw Starlark.errorf("struct in direct_dep_jars_to_verify must contain a non-empty 'label' field of type string");
+        }
+        directDepJarsToVerifyBuilder.add(jar);
+        directDepLabelsToVerifyBuilder.add(label);
+      } else {
+        throw Starlark.errorf("Expected direct_dep_jars_to_verify to contain structs, but got: %s", Starlark.type(obj));
       }
     }
     JavaTargetAttributes.Builder attributesBuilder =

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -201,7 +201,8 @@ public class JavaStarlarkCommon
       boolean enableJSpecify,
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
-      Sequence<?> additionalOutputs)
+      Sequence<?> additionalOutputs,
+      Sequence<?> directDepJarsToVerify)
       throws EvalException,
           TypeException,
           RuleErrorException,
@@ -217,11 +218,25 @@ public class JavaStarlarkCommon
             .nativeHeader(nativeHeader == Starlark.NONE ? null : (Artifact) nativeHeader)
             .manifestProto(manifestProto)
             .build();
+    ImmutableList.Builder<Artifact> directDepJarsToVerifyBuilder = ImmutableList.builder();
+    ImmutableList.Builder<String> directDepLabelsToVerifyBuilder = ImmutableList.builder();
+    for (Object obj : Sequence.cast(directDepJarsToVerify, Object.class, "direct_dep_jars_to_verify")) {
+      if (obj instanceof StarlarkInfo struct) {
+        Artifact jar = (Artifact) struct.getValue("jar");
+        String label = (String) struct.getValue("label");
+        if (jar != null && label != null) {
+          directDepJarsToVerifyBuilder.add(jar);
+          directDepLabelsToVerifyBuilder.add(label);
+        }
+      }
+    }
     JavaTargetAttributes.Builder attributesBuilder =
         new JavaTargetAttributes.Builder()
             .addSourceJars(Sequence.cast(sourceJars, Artifact.class, "source_jars"))
             .addSourceFiles(Depset.noneableCast(sourceFiles, Artifact.class, "sources").toList())
             .addDirectJars(directJars.getSet(Artifact.class))
+            .addDirectDepJarsToVerify(
+                directDepJarsToVerifyBuilder.build(), directDepLabelsToVerifyBuilder.build())
             .setCompileTimeClassPathEntriesWithPrependedDirectJars(
                 compileTimeClasspath.getSet(Artifact.class))
             .addClassPathResources(
@@ -413,6 +428,11 @@ public class JavaStarlarkCommon
   public Sequence<?> tokenizeJavacOpts(Sequence<?> opts) throws EvalException {
     return StarlarkList.immutableCopyOf(
         JavaHelper.tokenizeJavaOptions(Sequence.noneableCast(opts, String.class, "opts")));
+  }
+
+  @Override
+  public boolean isUnusedDepsSupported(StarlarkThread thread) throws EvalException {
+    return true;
   }
 
   static boolean isInstanceOfProvider(Object obj, Provider provider) {

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -51,6 +51,7 @@ import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.rules.cpp.CppFileTypes;
 import com.google.devtools.build.lib.starlarkbuildapi.core.ProviderApi;
 import com.google.devtools.build.lib.starlarkbuildapi.java.JavaCommonApi;
+import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Sequence;
 import net.starlark.java.eval.Starlark;
@@ -202,7 +203,7 @@ public class JavaStarlarkCommon
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
       Sequence<?> additionalOutputs,
-      Sequence<?> directDepJarsToVerify)
+      Dict<?, ?> directDepJarsToVerify)
       throws EvalException,
           TypeException,
           RuleErrorException,
@@ -218,49 +219,19 @@ public class JavaStarlarkCommon
             .nativeHeader(nativeHeader == Starlark.NONE ? null : (Artifact) nativeHeader)
             .manifestProto(manifestProto)
             .build();
-    ImmutableList.Builder<Artifact> directDepJarsToVerifyBuilder = ImmutableList.builder();
-    ImmutableList.Builder<String> directDepLabelsToVerifyBuilder = ImmutableList.builder();
-    for (Object obj : Sequence.cast(directDepJarsToVerify, Object.class, "direct_dep_jars_to_verify")) {
-      if (obj instanceof StarlarkInfo struct) {
-        Artifact jar = null;
-        Object jarObj = struct.getValue("jar");
-        if (jarObj != null && jarObj != Starlark.NONE) {
-          if (jarObj instanceof Artifact) {
-            jar = (Artifact) jarObj;
-          } else {
-            throw Starlark.errorf("Expected jar attribute to be an Artifact in struct, but got: %s", Starlark.type(jarObj));
-          }
-        }
-        String label = null;
-        Object labelObj = struct.getValue("label");
-        if (labelObj != null && labelObj != Starlark.NONE) {
-          if (labelObj instanceof String) {
-            label = (String) labelObj;
-          } else {
-            throw Starlark.errorf("Expected label attribute to be a string in struct, but got: %s", Starlark.type(labelObj));
-          }
-        }
-        if (jar == null) {
-          throw Starlark.errorf("struct in direct_dep_jars_to_verify is missing 'jar' field (type Artifact), got struct: %s", struct);
-        }
-        if (label == null) {
-          throw Starlark.errorf("struct in direct_dep_jars_to_verify is missing 'label' field (type string), got struct: %s", struct);
-        }
-        directDepJarsToVerifyBuilder.add(jar);
-        directDepLabelsToVerifyBuilder.add(label);
-      } else {
-        throw Starlark.errorf(
-            "Expected direct_dep_jars_to_verify to contain structs with 'jar' (Artifact) and 'label' (string) fields, but got: %s",
-            Starlark.type(obj));
-      }
-    }
+    Dict<Artifact, String> directDepJarsToVerifyDict = Dict.cast(
+        directDepJarsToVerify,
+        Artifact.class,
+        String.class,
+        "direct_dep_jars_to_verify");
     JavaTargetAttributes.Builder attributesBuilder =
         new JavaTargetAttributes.Builder()
             .addSourceJars(Sequence.cast(sourceJars, Artifact.class, "source_jars"))
             .addSourceFiles(Depset.noneableCast(sourceFiles, Artifact.class, "sources").toList())
             .addDirectJars(directJars.getSet(Artifact.class))
             .addDirectDepJarsToVerify(
-                directDepJarsToVerifyBuilder.build(), directDepLabelsToVerifyBuilder.build())
+                ImmutableList.copyOf(directDepJarsToVerifyDict.keySet()),
+                ImmutableList.copyOf(directDepJarsToVerifyDict.values()))
             .setCompileTimeClassPathEntriesWithPrependedDirectJars(
                 compileTimeClasspath.getSet(Artifact.class))
             .addClassPathResources(

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -249,7 +249,9 @@ public class JavaStarlarkCommon
         directDepJarsToVerifyBuilder.add(jar);
         directDepLabelsToVerifyBuilder.add(label);
       } else {
-        throw Starlark.errorf("Expected direct_dep_jars_to_verify to contain structs, but got: %s", Starlark.type(obj));
+        throw Starlark.errorf(
+            "Expected direct_dep_jars_to_verify to contain structs with 'jar' (Artifact) and 'label' (string) fields, but got: %s",
+            Starlark.type(obj));
       }
     }
     JavaTargetAttributes.Builder attributesBuilder =

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -241,10 +241,10 @@ public class JavaStarlarkCommon
           }
         }
         if (jar == null) {
-          throw Starlark.errorf("struct in direct_dep_jars_to_verify must contain a non-empty 'jar' field of type Artifact");
+          throw Starlark.errorf("struct in direct_dep_jars_to_verify is missing 'jar' field (type Artifact), got struct: %s", struct);
         }
         if (label == null) {
-          throw Starlark.errorf("struct in direct_dep_jars_to_verify must contain a non-empty 'label' field of type string");
+          throw Starlark.errorf("struct in direct_dep_jars_to_verify is missing 'label' field (type string), got struct: %s", struct);
         }
         directDepJarsToVerifyBuilder.add(jar);
         directDepLabelsToVerifyBuilder.add(label);

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -20,8 +20,12 @@ import com.google.common.base.Ascii;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.CommandLine;
+import com.google.devtools.build.lib.analysis.starlark.Args;
+import com.google.devtools.build.lib.starlarkbuildapi.CommandLineArgsApi;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.Expander;
 import com.google.devtools.build.lib.analysis.RuleContext;
@@ -51,6 +55,7 @@ import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.rules.cpp.CppFileTypes;
 import com.google.devtools.build.lib.starlarkbuildapi.core.ProviderApi;
 import com.google.devtools.build.lib.starlarkbuildapi.java.JavaCommonApi;
+import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Sequence;
 import net.starlark.java.eval.Starlark;
@@ -201,7 +206,8 @@ public class JavaStarlarkCommon
       boolean enableJSpecify,
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
-      Sequence<?> additionalOutputs)
+      Sequence<?> additionalOutputs,
+      Object extraArgs)
       throws EvalException,
           TypeException,
           RuleErrorException,
@@ -217,11 +223,26 @@ public class JavaStarlarkCommon
             .nativeHeader(nativeHeader == Starlark.NONE ? null : (Artifact) nativeHeader)
             .manifestProto(manifestProto)
             .build();
+    Iterable<CommandLineArgsApi> extraArgsList =
+        (extraArgs == null || extraArgs == Starlark.NONE)
+            ? ImmutableList.of()
+            : Sequence.cast(extraArgs, CommandLineArgsApi.class, "extra_args");
+    ImmutableList.Builder<CommandLine> extraCommandLineArgs = ImmutableList.builder();
+    ImmutableSet.Builder<Artifact> extraDirectoryInputs = ImmutableSet.builder();
+    for (CommandLineArgsApi argsApi : extraArgsList) {
+      if (argsApi instanceof Args args) {
+        extraCommandLineArgs.add(
+            args.build(ctx.getRuleContext().getAnalysisEnvironment()::getMainRepoMapping));
+        extraDirectoryInputs.addAll(args.getDirectoryArtifacts());
+      }
+    }
     JavaTargetAttributes.Builder attributesBuilder =
         new JavaTargetAttributes.Builder()
             .addSourceJars(Sequence.cast(sourceJars, Artifact.class, "source_jars"))
             .addSourceFiles(Depset.noneableCast(sourceFiles, Artifact.class, "sources").toList())
             .addDirectJars(directJars.getSet(Artifact.class))
+            .addExtraCommandLineArgs(extraCommandLineArgs.build())
+            .addAdditionalInputs(extraDirectoryInputs.build())
             .setCompileTimeClassPathEntriesWithPrependedDirectJars(
                 compileTimeClasspath.getSet(Artifact.class))
             .addClassPathResources(
@@ -413,6 +434,11 @@ public class JavaStarlarkCommon
   public Sequence<?> tokenizeJavacOpts(Sequence<?> opts) throws EvalException {
     return StarlarkList.immutableCopyOf(
         JavaHelper.tokenizeJavaOptions(Sequence.noneableCast(opts, String.class, "opts")));
+  }
+
+  @Override
+  public boolean isUnusedDepsSupported(StarlarkThread thread) throws EvalException {
+    return true;
   }
 
   static boolean isInstanceOfProvider(Object obj, Provider provider) {

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaTargetAttributes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaTargetAttributes.java
@@ -69,6 +69,8 @@ public class JavaTargetAttributes {
     private StrictDepsMode strictJavaDeps = StrictDepsMode.ERROR;
 
     private final NestedSetBuilder<Artifact> directJarsBuilder = NestedSetBuilder.naiveLinkOrder();
+    private final ImmutableList.Builder<Artifact> directDepJarsToVerify = ImmutableList.builder();
+    private final ImmutableList.Builder<String> directDepLabelsToVerify = ImmutableList.builder();
     private final NestedSetBuilder<Artifact> headerCompilationDirectJarsBuilder =
         NestedSetBuilder.naiveLinkOrder();
     private final NestedSetBuilder<Artifact> compileTimeDependencyArtifacts =
@@ -245,6 +247,14 @@ public class JavaTargetAttributes {
       return this;
     }
 
+    @CanIgnoreReturnValue
+    public Builder addDirectDepJarsToVerify(List<Artifact> jars, List<String> labels) {
+      Preconditions.checkArgument(!built);
+      this.directDepJarsToVerify.addAll(jars);
+      this.directDepLabelsToVerify.addAll(labels);
+      return this;
+    }
+
     public JavaTargetAttributes build() {
       built = true;
       NestedSet<Artifact> directJars = directJarsBuilder.build();
@@ -272,7 +282,9 @@ public class JavaTargetAttributes {
           compileTimeDependencyArtifacts.build(),
           targetLabel,
           injectingRuleKind,
-          strictJavaDeps);
+          strictJavaDeps,
+          directDepJarsToVerify.build(),
+          directDepLabelsToVerify.build());
     }
 
     // TODO(bazel-team): delete the following method - users should use the built
@@ -314,6 +326,8 @@ public class JavaTargetAttributes {
   @Nullable private final String injectingRuleKind;
 
   private final StrictDepsMode strictJavaDeps;
+  private final ImmutableList<Artifact> directDepJarsToVerify;
+  private final ImmutableList<String> directDepLabelsToVerify;
 
   /** Constructor of JavaTargetAttributes. */
   private JavaTargetAttributes(
@@ -332,7 +346,9 @@ public class JavaTargetAttributes {
       NestedSet<Artifact> compileTimeDependencyArtifacts,
       Label targetLabel,
       @Nullable String injectingRuleKind,
-      StrictDepsMode strictJavaDeps) {
+      StrictDepsMode strictJavaDeps,
+      ImmutableList<Artifact> directDepJarsToVerify,
+      ImmutableList<String> directDepLabelsToVerify) {
     this.sourceFiles = sourceFiles;
     this.directJars = directJars;
     this.headerCompilationDirectJars = headerCompilationDirectJars;
@@ -349,6 +365,8 @@ public class JavaTargetAttributes {
     this.targetLabel = targetLabel;
     this.injectingRuleKind = injectingRuleKind;
     this.strictJavaDeps = strictJavaDeps;
+    this.directDepJarsToVerify = directDepJarsToVerify;
+    this.directDepLabelsToVerify = directDepLabelsToVerify;
   }
 
   JavaTargetAttributes appendAdditionalTransitiveClassPathEntries(
@@ -373,7 +391,17 @@ public class JavaTargetAttributes {
         compileTimeDependencyArtifacts,
         targetLabel,
         injectingRuleKind,
-        strictJavaDeps);
+        strictJavaDeps,
+        directDepJarsToVerify,
+        directDepLabelsToVerify);
+  }
+
+  public ImmutableList<Artifact> getDirectDepJarsToVerify() {
+    return directDepJarsToVerify;
+  }
+
+  public ImmutableList<String> getDirectDepLabelsToVerify() {
+    return directDepLabelsToVerify;
   }
 
   public NestedSet<Artifact> getDirectJars() {

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaTargetAttributes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaTargetAttributes.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.CommandLine;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.StrictDepsMode;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
@@ -64,11 +65,14 @@ public class JavaTargetAttributes {
     private final ImmutableList.Builder<Artifact> classPathResources = ImmutableList.builder();
 
     private final ImmutableSet.Builder<Artifact> additionalOutputs = ImmutableSet.builder();
+    private final ImmutableSet.Builder<Artifact> additionalInputs = ImmutableSet.builder();
 
     /** @see {@link #setStrictJavaDeps}. */
     private StrictDepsMode strictJavaDeps = StrictDepsMode.ERROR;
 
     private final NestedSetBuilder<Artifact> directJarsBuilder = NestedSetBuilder.naiveLinkOrder();
+    private final ImmutableList.Builder<CommandLine> extraCommandLineArgs =
+        ImmutableList.builder();
     private final NestedSetBuilder<Artifact> headerCompilationDirectJarsBuilder =
         NestedSetBuilder.naiveLinkOrder();
     private final NestedSetBuilder<Artifact> compileTimeDependencyArtifacts =
@@ -245,6 +249,20 @@ public class JavaTargetAttributes {
       return this;
     }
 
+    @CanIgnoreReturnValue
+    public Builder addAdditionalInputs(Iterable<Artifact> additionalInputs) {
+      Preconditions.checkArgument(!built);
+      this.additionalInputs.addAll(additionalInputs);
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder addExtraCommandLineArgs(Iterable<CommandLine> commandLines) {
+      Preconditions.checkArgument(!built);
+      this.extraCommandLineArgs.addAll(commandLines);
+      return this;
+    }
+
     public JavaTargetAttributes build() {
       built = true;
       NestedSet<Artifact> directJars = directJarsBuilder.build();
@@ -267,12 +285,14 @@ public class JavaTargetAttributes {
           ImmutableList.copyOf(sourceJars),
           classPathResources.build(),
           additionalOutputs.build(),
+          additionalInputs.build(),
           directJars,
           /* headerCompilationDirectJars= */ headerCompilationDirectJars,
           compileTimeDependencyArtifacts.build(),
           targetLabel,
           injectingRuleKind,
-          strictJavaDeps);
+          strictJavaDeps,
+          extraCommandLineArgs.build());
     }
 
     // TODO(bazel-team): delete the following method - users should use the built
@@ -306,6 +326,7 @@ public class JavaTargetAttributes {
   private final ImmutableList<Artifact> classPathResources;
 
   private final ImmutableSet<Artifact> additionalOutputs;
+  private final ImmutableSet<Artifact> additionalInputs;
 
   private final NestedSet<Artifact> directJars;
   private final NestedSet<Artifact> headerCompilationDirectJars;
@@ -314,6 +335,7 @@ public class JavaTargetAttributes {
   @Nullable private final String injectingRuleKind;
 
   private final StrictDepsMode strictJavaDeps;
+  private final ImmutableList<CommandLine> extraCommandLineArgs;
 
   /** Constructor of JavaTargetAttributes. */
   private JavaTargetAttributes(
@@ -327,12 +349,14 @@ public class JavaTargetAttributes {
       ImmutableList<Artifact> sourceJars,
       ImmutableList<Artifact> classPathResources,
       ImmutableSet<Artifact> additionalOutputs,
+      ImmutableSet<Artifact> additionalInputs,
       NestedSet<Artifact> directJars,
       NestedSet<Artifact> headerCompilationDirectJars,
       NestedSet<Artifact> compileTimeDependencyArtifacts,
       Label targetLabel,
       @Nullable String injectingRuleKind,
-      StrictDepsMode strictJavaDeps) {
+      StrictDepsMode strictJavaDeps,
+      ImmutableList<CommandLine> extraCommandLineArgs) {
     this.sourceFiles = sourceFiles;
     this.directJars = directJars;
     this.headerCompilationDirectJars = headerCompilationDirectJars;
@@ -345,10 +369,12 @@ public class JavaTargetAttributes {
     this.sourceJars = sourceJars;
     this.classPathResources = classPathResources;
     this.additionalOutputs = additionalOutputs;
+    this.additionalInputs = additionalInputs;
     this.compileTimeDependencyArtifacts = compileTimeDependencyArtifacts;
     this.targetLabel = targetLabel;
     this.injectingRuleKind = injectingRuleKind;
     this.strictJavaDeps = strictJavaDeps;
+    this.extraCommandLineArgs = extraCommandLineArgs;
   }
 
   JavaTargetAttributes appendAdditionalTransitiveClassPathEntries(
@@ -368,12 +394,18 @@ public class JavaTargetAttributes {
         sourceJars,
         classPathResources,
         additionalOutputs,
+        additionalInputs,
         directJars,
         /* headerCompilationDirectJars= */ headerCompilationDirectJars,
         compileTimeDependencyArtifacts,
         targetLabel,
         injectingRuleKind,
-        strictJavaDeps);
+        strictJavaDeps,
+        extraCommandLineArgs);
+  }
+
+  public ImmutableList<CommandLine> getExtraCommandLineArgs() {
+    return extraCommandLineArgs;
   }
 
   public NestedSet<Artifact> getDirectJars() {

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
@@ -31,6 +31,7 @@ import net.starlark.java.annot.Param;
 import net.starlark.java.annot.ParamType;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.NoneType;
 import net.starlark.java.eval.Sequence;
@@ -526,7 +527,10 @@ public interface JavaCommonApi<
         @Param(name = "additional_outputs", defaultValue = "[]", named = true),
         @Param(
             name = "direct_dep_jars_to_verify",
-            defaultValue = "[]",
+            allowedTypes = {
+                @ParamType(type = Dict.class),
+            },
+            defaultValue = "{}",
             named = true,
             positional = false),
       })
@@ -559,7 +563,7 @@ public interface JavaCommonApi<
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
       Sequence<?> additionalOutputs,
-      Sequence<?> directDepJarsToVerify)
+      Dict<?, ?> directDepJarsToVerify)
       throws EvalException,
           TypeException,
           RuleErrorException,

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
@@ -524,6 +524,11 @@ public interface JavaCommonApi<
         @Param(name = "enable_direct_classpath", defaultValue = "True", named = true),
         @Param(name = "additional_inputs", defaultValue = "[]", named = true),
         @Param(name = "additional_outputs", defaultValue = "[]", named = true),
+        @Param(
+            name = "direct_dep_jars_to_verify",
+            defaultValue = "[]",
+            named = true,
+            positional = false),
       })
   void createCompilationAction(
       StarlarkRuleContextT ctx,
@@ -553,7 +558,8 @@ public interface JavaCommonApi<
       boolean enableJSpecify,
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
-      Sequence<?> additionalOutputs)
+      Sequence<?> additionalOutputs,
+      Sequence<?> directDepJarsToVerify)
       throws EvalException,
           TypeException,
           RuleErrorException,
@@ -697,4 +703,12 @@ public interface JavaCommonApi<
       documented = false,
       parameters = {@Param(name = "opts")})
   Sequence<?> tokenizeJavacOpts(Sequence<?> opts) throws EvalException, InterruptedException;
+
+  @StarlarkMethod(
+      name = "is_unused_deps_supported",
+      documented = false,
+      useStarlarkThread = true)
+  default boolean isUnusedDepsSupported(StarlarkThread thread) throws EvalException {
+    return false;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.collect.nestedset.Depset.TypeException;
 import com.google.devtools.build.lib.packages.Info;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
+import com.google.devtools.build.lib.starlarkbuildapi.CommandLineArgsApi;
 import com.google.devtools.build.lib.starlarkbuildapi.FileApi;
 import com.google.devtools.build.lib.starlarkbuildapi.StarlarkActionFactoryApi;
 import com.google.devtools.build.lib.starlarkbuildapi.StarlarkRuleContextApi;
@@ -31,6 +32,7 @@ import net.starlark.java.annot.Param;
 import net.starlark.java.annot.ParamType;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.NoneType;
 import net.starlark.java.eval.Sequence;
@@ -524,6 +526,15 @@ public interface JavaCommonApi<
         @Param(name = "enable_direct_classpath", defaultValue = "True", named = true),
         @Param(name = "additional_inputs", defaultValue = "[]", named = true),
         @Param(name = "additional_outputs", defaultValue = "[]", named = true),
+        @Param(
+            name = "extra_args",
+            allowedTypes = {
+                @ParamType(type = Sequence.class, generic1 = CommandLineArgsApi.class),
+                @ParamType(type = NoneType.class),
+            },
+            defaultValue = "None",
+            named = true,
+            positional = false),
       })
   void createCompilationAction(
       StarlarkRuleContextT ctx,
@@ -553,7 +564,8 @@ public interface JavaCommonApi<
       boolean enableJSpecify,
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
-      Sequence<?> additionalOutputs)
+      Sequence<?> additionalOutputs,
+      Object extraArgs)
       throws EvalException,
           TypeException,
           RuleErrorException,
@@ -697,4 +709,12 @@ public interface JavaCommonApi<
       documented = false,
       parameters = {@Param(name = "opts")})
   Sequence<?> tokenizeJavacOpts(Sequence<?> opts) throws EvalException, InterruptedException;
+
+  @StarlarkMethod(
+      name = "is_unused_deps_supported",
+      documented = false,
+      useStarlarkThread = true)
+  default boolean isUnusedDepsSupported(StarlarkThread thread) throws EvalException {
+    return false;
+  }
 }

--- a/src/main/starlark/builtins_bzl/common/java/java_common.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_common.bzl
@@ -36,6 +36,7 @@ def _internal_exports():
         incompatible_disable_non_executable_java_binary = _java_common_internal.incompatible_disable_non_executable_java_binary,
         incompatible_java_info_merge_runtime_module_flags = _java_common_internal._incompatible_java_info_merge_runtime_module_flags,
         target_kind = _java_common_internal.target_kind,
+        is_unused_deps_supported = _java_common_internal.is_unused_deps_supported,
     )
 
 java_common = struct(internal_DO_NOT_USE = _internal_exports)

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -698,6 +698,13 @@ launcher_flag_alias(
           ),
         )
         """);
+    config.create("bazel_features_workspace/private/BUILD");
+    config.create(
+        "bazel_features_workspace/private/util.bzl",
+        """
+        def ge(version):
+          return True
+        """);
 
     config.create(
         "embedded_tools/tools/allowlists/materializer_rule_allowlist/BUILD",

--- a/src/test/java/com/google/devtools/build/lib/rules/java/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/BUILD
@@ -60,6 +60,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:action_input_prefetcher",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/rules/java:java-compilation",
         "//src/main/protobuf:deps_java_proto",

--- a/src/test/java/com/google/devtools/build/lib/rules/java/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/BUILD
@@ -60,6 +60,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:action_input_prefetcher",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/remote:remote_action_file_system",

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
@@ -22,6 +22,7 @@ import static com.google.devtools.build.lib.rules.java.JavaCompileActionTestHelp
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.CommandAction;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.testutil.MoreAsserts;
@@ -280,5 +281,77 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
       throws Exception {
     return getInputs(compileAction, getDirectJars(compileAction)).stream()
         .filter(a -> a.getFilename().endsWith("-hjar.jar"));
+  }
+
+  @Test
+  public void testUnusedDepsVerifyFlags() throws Exception {
+    scratch.file("third_party/bazel_rules/rules_java/BUILD");
+    scratch.file(
+        "third_party/bazel_rules/rules_java/rule.bzl",
+        """
+        load("@rules_java//java:defs.bzl", "JavaInfo", "JavaPluginInfo", rules_java_common = "java_common")
+
+        def _my_rule_impl(ctx):
+            output = ctx.outputs.jar
+            manifest = ctx.actions.declare_file(ctx.label.name + ".manifest")
+            internal_common = java_common.internal_DO_NOT_USE()
+            dep = ctx.attr.deps[0]
+            compile_jar = dep[JavaInfo].compile_jars.to_list()[0]
+            internal_common.create_compilation_action(
+                ctx,
+                ctx.attr._java_toolchain[rules_java_common.JavaToolchainInfo],
+                output,
+                manifest,
+                JavaPluginInfo(runtime_deps = []),
+                depset([compile_jar]),
+                depset([compile_jar]),
+                depset(),
+                depset(),
+                depset(),
+                depset(),
+                "ERROR",
+                ctx.label,
+                direct_dep_jars_to_verify = [struct(jar = compile_jar, label = str(dep.label))],
+            )
+            return [DefaultInfo(files = depset([output]))]
+
+        my_rule = rule(
+            implementation = _my_rule_impl,
+            outputs = {
+                "jar": "%{name}.jar",
+            },
+            attrs = {
+                "deps": attr.label_list(),
+                "_java_toolchain": attr.label(default = "@bazel_tools//tools/jdk:current_java_toolchain"),
+            },
+            fragments = ["java"],
+            toolchains = ["@bazel_tools//tools/jdk:toolchain_type"],
+        )
+        """);
+    scratch.file(
+        "java/com/google/test/BUILD",
+        """
+        load("@rules_java//java:defs.bzl", "java_library")
+        load("//third_party/bazel_rules/rules_java:rule.bzl", "my_rule")
+
+        java_library(
+            name = "dep",
+            srcs = ["Dep.java"],
+        )
+
+        my_rule(
+            name = "a",
+            deps = [":dep"],
+        )
+        """);
+
+    JavaCompileAction compileAction =
+        (JavaCompileAction) getGeneratingActionForLabel("//java/com/google/test:a.jar");
+    List<String> command = getJavacArguments(compileAction);
+    assertThat(command).containsAtLeast("--direct_dep_jar", "--direct_dep_label");
+    int jarIdx = command.indexOf("--direct_dep_jar");
+    int labelIdx = command.indexOf("--direct_dep_label");
+    assertThat(command.get(jarIdx + 1)).contains("libdep");
+    assertThat(command.get(labelIdx + 1)).endsWith("//java/com/google/test:dep");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
@@ -486,6 +486,7 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
 
     reporter.removeHandler(failFastHandler);
     getConfiguredTarget("//java/com/google/test:a");
-    assertContainsEvent("Expected direct_dep_jars_to_verify to contain structs, but got: string");
+    assertContainsEvent(
+        "Expected direct_dep_jars_to_verify to contain structs with 'jar' (Artifact) and 'label' (string) fields, but got: string");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
@@ -419,7 +419,8 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
 
     reporter.removeHandler(failFastHandler);
     getConfiguredTarget("//java/com/google/test:a");
-    assertContainsEvent("struct in direct_dep_jars_to_verify must contain a non-empty 'jar' field");
+    assertContainsEvent(
+        "struct in direct_dep_jars_to_verify is missing 'jar' field (type Artifact), got struct: struct(label = \"@@//java/com/google/test:dep\")");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
@@ -354,4 +354,71 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
     assertThat(command.get(jarIdx + 1)).contains("libdep");
     assertThat(command.get(labelIdx + 1)).endsWith("//java/com/google/test:dep");
   }
+
+  @Test
+  public void testUnusedDepsVerifyFlags_missingJarThrows() throws Exception {
+    scratch.file("third_party/bazel_rules/rules_java/BUILD");
+    scratch.file(
+        "third_party/bazel_rules/rules_java/rule.bzl",
+        """
+        load("@rules_java//java:defs.bzl", "JavaInfo", "JavaPluginInfo", rules_java_common = "java_common")
+
+        def _my_rule_impl(ctx):
+            output = ctx.outputs.jar
+            manifest = ctx.actions.declare_file(ctx.label.name + ".manifest")
+            internal_common = java_common.internal_DO_NOT_USE()
+            dep = ctx.attr.deps[0]
+            compile_jar = dep[JavaInfo].compile_jars.to_list()[0]
+            internal_common.create_compilation_action(
+                ctx,
+                ctx.attr._java_toolchain[rules_java_common.JavaToolchainInfo],
+                output,
+                manifest,
+                JavaPluginInfo(runtime_deps = []),
+                depset([compile_jar]),
+                depset([compile_jar]),
+                depset(),
+                depset(),
+                depset(),
+                depset(),
+                "ERROR",
+                ctx.label,
+                direct_dep_jars_to_verify = [struct(label = str(dep.label))],
+            )
+            return [DefaultInfo(files = depset([output]))]
+
+        my_rule = rule(
+            implementation = _my_rule_impl,
+            outputs = {
+                "jar": "%{name}.jar",
+            },
+            attrs = {
+                "deps": attr.label_list(),
+                "_java_toolchain": attr.label(default = "@bazel_tools//tools/jdk:current_java_toolchain"),
+            },
+            fragments = ["java"],
+            toolchains = ["@bazel_tools//tools/jdk:toolchain_type"],
+        )
+        """);
+    scratch.file(
+        "java/com/google/test/BUILD",
+        """
+        load("@rules_java//java:defs.bzl", "java_library")
+        load("//third_party/bazel_rules/rules_java:rule.bzl", "my_rule")
+
+        java_library(
+            name = "dep",
+            srcs = ["Dep.java"],
+        )
+
+        my_rule(
+            name = "a",
+            deps = [":dep"],
+        )
+        """);
+
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//java/com/google/test:a");
+    assertContainsEvent("struct in direct_dep_jars_to_verify must contain a non-empty 'jar' field");
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
@@ -421,4 +421,71 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
     getConfiguredTarget("//java/com/google/test:a");
     assertContainsEvent("struct in direct_dep_jars_to_verify must contain a non-empty 'jar' field");
   }
+
+  @Test
+  public void testUnusedDepsVerifyFlags_notAStructThrows() throws Exception {
+    scratch.file("third_party/bazel_rules/rules_java/BUILD");
+    scratch.file(
+        "third_party/bazel_rules/rules_java/rule.bzl",
+        """
+        load("@rules_java//java:defs.bzl", "JavaInfo", "JavaPluginInfo", rules_java_common = "java_common")
+
+        def _my_rule_impl(ctx):
+            output = ctx.outputs.jar
+            manifest = ctx.actions.declare_file(ctx.label.name + ".manifest")
+            internal_common = java_common.internal_DO_NOT_USE()
+            dep = ctx.attr.deps[0]
+            compile_jar = dep[JavaInfo].compile_jars.to_list()[0]
+            internal_common.create_compilation_action(
+                ctx,
+                ctx.attr._java_toolchain[rules_java_common.JavaToolchainInfo],
+                output,
+                manifest,
+                JavaPluginInfo(runtime_deps = []),
+                depset([compile_jar]),
+                depset([compile_jar]),
+                depset(),
+                depset(),
+                depset(),
+                depset(),
+                "ERROR",
+                ctx.label,
+                direct_dep_jars_to_verify = ["not-a-struct"],
+            )
+            return [DefaultInfo(files = depset([output]))]
+
+        my_rule = rule(
+            implementation = _my_rule_impl,
+            outputs = {
+                "jar": "%{name}.jar",
+            },
+            attrs = {
+                "deps": attr.label_list(),
+                "_java_toolchain": attr.label(default = "@bazel_tools//tools/jdk:current_java_toolchain"),
+            },
+            fragments = ["java"],
+            toolchains = ["@bazel_tools//tools/jdk:toolchain_type"],
+        )
+        """);
+    scratch.file(
+        "java/com/google/test/BUILD",
+        """
+        load("@rules_java//java:defs.bzl", "java_library")
+        load("//third_party/bazel_rules/rules_java:rule.bzl", "my_rule")
+
+        java_library(
+            name = "dep",
+            srcs = ["Dep.java"],
+        )
+
+        my_rule(
+            name = "a",
+            deps = [":dep"],
+        )
+        """);
+
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//java/com/google/test:a");
+    assertContainsEvent("Expected direct_dep_jars_to_verify to contain structs, but got: string");
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
@@ -311,7 +311,7 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
                 depset(),
                 "ERROR",
                 ctx.label,
-                direct_dep_jars_to_verify = [struct(jar = compile_jar, label = str(dep.label))],
+                direct_dep_jars_to_verify = {compile_jar: str(dep.label)},
             )
             return [DefaultInfo(files = depset([output]))]
 
@@ -348,15 +348,14 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
     JavaCompileAction compileAction =
         (JavaCompileAction) getGeneratingActionForLabel("//java/com/google/test:a.jar");
     List<String> command = getJavacArguments(compileAction);
-    assertThat(command).containsAtLeast("--direct_dep_jar", "--direct_dep_label");
-    int jarIdx = command.indexOf("--direct_dep_jar");
-    int labelIdx = command.indexOf("--direct_dep_label");
-    assertThat(command.get(jarIdx + 1)).contains("libdep");
-    assertThat(command.get(labelIdx + 1)).endsWith("//java/com/google/test:dep");
+    assertThat(command).contains("--declared_dep");
+    int depIdx = command.indexOf("--declared_dep");
+    assertThat(command.get(depIdx + 1)).contains("libdep");
+    assertThat(command.get(depIdx + 1)).endsWith("::@@//java/com/google/test:dep");
   }
 
   @Test
-  public void testUnusedDepsVerifyFlags_missingJarThrows() throws Exception {
+  public void testUnusedDepsVerifyFlags_invalidKeyTypeThrows() throws Exception {
     scratch.file("third_party/bazel_rules/rules_java/BUILD");
     scratch.file(
         "third_party/bazel_rules/rules_java/rule.bzl",
@@ -383,7 +382,7 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
                 depset(),
                 "ERROR",
                 ctx.label,
-                direct_dep_jars_to_verify = [struct(label = str(dep.label))],
+                direct_dep_jars_to_verify = {"not-a-jar": str(dep.label)},
             )
             return [DefaultInfo(files = depset([output]))]
 
@@ -420,11 +419,11 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
     reporter.removeHandler(failFastHandler);
     getConfiguredTarget("//java/com/google/test:a");
     assertContainsEvent(
-        "struct in direct_dep_jars_to_verify is missing 'jar' field (type Artifact), got struct: struct(label = \"@@//java/com/google/test:dep\")");
+        "got dict<string, string> for 'direct_dep_jars_to_verify', want dict<File, string>");
   }
 
   @Test
-  public void testUnusedDepsVerifyFlags_notAStructThrows() throws Exception {
+  public void testUnusedDepsVerifyFlags_invalidValueTypeThrows() throws Exception {
     scratch.file("third_party/bazel_rules/rules_java/BUILD");
     scratch.file(
         "third_party/bazel_rules/rules_java/rule.bzl",
@@ -451,7 +450,7 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
                 depset(),
                 "ERROR",
                 ctx.label,
-                direct_dep_jars_to_verify = ["not-a-struct"],
+                direct_dep_jars_to_verify = {compile_jar: 123},
             )
             return [DefaultInfo(files = depset([output]))]
 
@@ -488,6 +487,6 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
     reporter.removeHandler(failFastHandler);
     getConfiguredTarget("//java/com/google/test:a");
     assertContainsEvent(
-        "Expected direct_dep_jars_to_verify to contain structs with 'jar' (Artifact) and 'label' (string) fields, but got: string");
+        "got dict<File, int> for 'direct_dep_jars_to_verify', want dict<File, string>");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
@@ -426,4 +426,145 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
     cacheMiss.setFilename(artifact.getExecPathString());
     return new BulkTransferException(cacheMiss);
   }
+
+  @Test
+  public void testUnusedDepsVerifyFlags() throws Exception {
+    scratch.file("third_party/bazel_rules/rules_java/BUILD");
+    scratch.file(
+        "third_party/bazel_rules/rules_java/rule.bzl",
+        """
+        load("@rules_java//java:defs.bzl", "JavaInfo", "JavaPluginInfo", rules_java_common = "java_common")
+
+        def _my_rule_impl(ctx):
+            output = ctx.outputs.jar
+            manifest = ctx.actions.declare_file(ctx.label.name + ".manifest")
+            internal_common = java_common.internal_DO_NOT_USE()
+            dep = ctx.attr.deps[0]
+            compile_jar = dep[JavaInfo].compile_jars.to_list()[0]
+            args = ctx.actions.args()
+            args.add("--declared_dep", compile_jar, format = "%s::" + str(dep.label))
+            internal_common.create_compilation_action(
+                ctx,
+                ctx.attr._java_toolchain[rules_java_common.JavaToolchainInfo],
+                output,
+                manifest,
+                JavaPluginInfo(runtime_deps = []),
+                depset([compile_jar]),
+                depset([compile_jar]),
+                depset(),
+                depset(),
+                depset(),
+                depset(),
+                "ERROR",
+                ctx.label,
+                extra_args = [args],
+            )
+            return [DefaultInfo(files = depset([output]))]
+
+        my_rule = rule(
+            implementation = _my_rule_impl,
+            outputs = {
+                "jar": "%{name}.jar",
+            },
+            attrs = {
+                "deps": attr.label_list(),
+                "_java_toolchain": attr.label(default = "@bazel_tools//tools/jdk:current_java_toolchain"),
+            },
+            fragments = ["java"],
+            toolchains = ["@bazel_tools//tools/jdk:toolchain_type"],
+        )
+        """);
+    scratch.file(
+        "java/com/google/test/BUILD",
+        """
+        load("@rules_java//java:defs.bzl", "java_library")
+        load("//third_party/bazel_rules/rules_java:rule.bzl", "my_rule")
+
+        java_library(
+            name = "dep",
+            srcs = ["Dep.java"],
+        )
+
+        my_rule(
+            name = "a",
+            deps = [":dep"],
+        )
+        """);
+
+    JavaCompileAction compileAction =
+        (JavaCompileAction) getGeneratingActionForLabel("//java/com/google/test:a.jar");
+    List<String> command = getJavacArguments(compileAction);
+    assertThat(command).contains("--declared_dep");
+    int depIdx = command.indexOf("--declared_dep");
+    assertThat(command.get(depIdx + 1)).contains("libdep");
+    assertThat(command.get(depIdx + 1)).endsWith("::@@//java/com/google/test:dep");
+  }
+
+  @Test
+  public void testExtraArgs_invalidElementTypeThrows() throws Exception {
+    scratch.file("third_party/bazel_rules/rules_java/BUILD");
+    scratch.file(
+        "third_party/bazel_rules/rules_java/rule.bzl",
+        """
+        load("@rules_java//java:defs.bzl", "JavaInfo", "JavaPluginInfo", rules_java_common = "java_common")
+
+        def _my_rule_impl(ctx):
+            output = ctx.outputs.jar
+            manifest = ctx.actions.declare_file(ctx.label.name + ".manifest")
+            internal_common = java_common.internal_DO_NOT_USE()
+            dep = ctx.attr.deps[0]
+            compile_jar = dep[JavaInfo].compile_jars.to_list()[0]
+            internal_common.create_compilation_action(
+                ctx,
+                ctx.attr._java_toolchain[rules_java_common.JavaToolchainInfo],
+                output,
+                manifest,
+                JavaPluginInfo(runtime_deps = []),
+                depset([compile_jar]),
+                depset([compile_jar]),
+                depset(),
+                depset(),
+                depset(),
+                depset(),
+                "ERROR",
+                ctx.label,
+                extra_args = ["not-an-args-object"],
+            )
+            return [DefaultInfo(files = depset([output]))]
+
+        my_rule = rule(
+            implementation = _my_rule_impl,
+            outputs = {
+                "jar": "%{name}.jar",
+            },
+            attrs = {
+                "deps": attr.label_list(),
+                "_java_toolchain": attr.label(default = "@bazel_tools//tools/jdk:current_java_toolchain"),
+            },
+            fragments = ["java"],
+            toolchains = ["@bazel_tools//tools/jdk:toolchain_type"],
+        )
+        """);
+    scratch.file(
+        "java/com/google/test/BUILD",
+        """
+        load("@rules_java//java:defs.bzl", "java_library")
+        load("//third_party/bazel_rules/rules_java:rule.bzl", "my_rule")
+
+        java_library(
+            name = "dep",
+            srcs = ["Dep.java"],
+        )
+
+        my_rule(
+            name = "a",
+            deps = [":dep"],
+        )
+        """);
+
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//java/com/google/test:a");
+    assertContainsEvent(
+        "at index 0 of extra_args, got element of type string, want Args");
+  }
 }

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -2531,4 +2531,193 @@ EOF
   expect_log "foo.txt"
 }
 
+function test_unused_deps() {
+  if [[ -n "${RULES_JAVA_OVERRIDE_PATH:-}" ]]; then
+    cat >> MODULE.bazel <<EOF
+local_path_override(
+    module_name = "rules_java",
+    path = "${RULES_JAVA_OVERRIDE_PATH}",
+)
+EOF
+  fi
+
+  # Check if rules_java has the toolchain-driven unused_deps support
+  # We check this by querying the attributes of java_package_configuration
+  # or attempting to build a package configuration target with 'unused_deps'.
+  # If rules_java does not have it, we skip the test.
+
+  mkdir -p pkg
+  cat > pkg/BUILD <<EOF
+load("@rules_java//java:defs.bzl", "java_package_configuration")
+java_package_configuration(
+    name = "test_config_query",
+    package_specs = [":spec_query"],
+    unused_deps = "error",
+)
+package_group(
+    name = "spec_query",
+    packages = ["//pkg/..."],
+)
+EOF
+
+  if ! bazel query //pkg:test_config_query >/dev/null 2>&1; then
+    echo "Skipping test_unused_deps: rules_java does not support unused_deps configuration yet"
+    return 0
+  fi
+
+  # Write the common toolchain definition for main repo targets
+  cat << 'EOF' > pkg/BUILD
+load("@rules_java//toolchains:default_java_toolchain.bzl", "default_java_toolchain")
+load("@rules_java//java:defs.bzl", "java_package_configuration")
+
+package_group(
+    name = "my_package_spec",
+    packages = ["//pkg/..."],
+)
+
+java_package_configuration(
+    name = "unused_deps_error_config",
+    package_specs = [":my_package_spec"],
+    unused_deps = "error",
+)
+
+default_java_toolchain(
+    name = "java_toolchain",
+    package_configuration = [":unused_deps_error_config"],
+)
+EOF
+
+  # -------------------------------------------------------------
+  # Scenario 1: Simple Unused (Error)
+  # -------------------------------------------------------------
+  cat << 'EOF' >> pkg/BUILD
+load("@rules_java//java:java_library.bzl", "java_library")
+java_library(name = "simple_unused", srcs = ["SimpleUnused.java"], deps = [":b"])
+java_library(name = "b", srcs = ["B.java"])
+EOF
+  echo "public class SimpleUnused {}" > pkg/SimpleUnused.java
+  echo "public class B {}" > pkg/B.java
+
+  bazel build //pkg:simple_unused \
+    --extra_toolchains=//pkg:java_toolchain_definition \
+    >& $TEST_log && fail "build succeeded, but expected it to fail due to unused dependency (Simple Unused)"
+
+  expect_log "Target '//pkg:b' is declared as a direct dependency of '//pkg:simple_unused' but is unused"
+
+  # -------------------------------------------------------------
+  # Scenario 2: Simple Used (Success)
+  # -------------------------------------------------------------
+  echo "public class SimpleUnused { B b; }" > pkg/SimpleUnused.java
+  bazel build //pkg:simple_unused \
+    --extra_toolchains=//pkg:java_toolchain_definition \
+    >& $TEST_log || fail "build failed, but expected Simple Used to succeed"
+
+  # -------------------------------------------------------------
+  # Scenario 3: Exported Only (Error)
+  # -------------------------------------------------------------
+  cat << 'EOF' >> pkg/BUILD
+java_library(name = "exported_only", srcs = ["ExportedOnly.java"], deps = [":exports_c"])
+java_library(name = "exports_c", exports = [":c"])
+java_library(name = "c", srcs = ["C.java"])
+EOF
+  echo "public class ExportedOnly { C c; }" > pkg/ExportedOnly.java
+  echo "public class C {}" > pkg/C.java
+
+  bazel build //pkg:exported_only \
+    --extra_toolchains=//pkg:java_toolchain_definition \
+    >& $TEST_log && fail "build succeeded, but expected it to fail due to unused dependency (Exported Only)"
+
+  expect_log "Target '//pkg:exports_c' is declared as a direct dependency of '//pkg:exported_only' but is unused"
+
+  # -------------------------------------------------------------
+  # Scenario 4: Exported & Direct Used (Success)
+  # -------------------------------------------------------------
+  # Define exports_c_with_srcs that exports C but also has its own class
+  cat << 'EOF' >> pkg/BUILD
+java_library(name = "exported_and_direct", srcs = ["ExportedAndDirect.java"], deps = [":exports_c_with_srcs"])
+java_library(name = "exports_c_with_srcs", srcs = ["B2.java"], exports = [":c"])
+EOF
+  echo "public class B2 {}" > pkg/B2.java
+  echo "public class ExportedAndDirect { B2 b; C c; }" > pkg/ExportedAndDirect.java
+
+  bazel build //pkg:exported_and_direct \
+    --extra_toolchains=//pkg:java_toolchain_definition \
+    >& $TEST_log || fail "build failed, but expected Exported & Direct Used to succeed"
+
+  # -------------------------------------------------------------
+  # Scenario 5: Indirect Used (Error - Strict Deps violation)
+  # -------------------------------------------------------------
+  cat << 'EOF' >> pkg/BUILD
+java_library(name = "indirect_used", srcs = ["IndirectUsed.java"], deps = [":dep_no_exports"])
+java_library(name = "dep_no_exports", deps = [":c"])
+EOF
+  echo "public class IndirectUsed { C c; }" > pkg/IndirectUsed.java
+
+  bazel build //pkg:indirect_used \
+    --extra_toolchains=//pkg:java_toolchain_definition \
+    >& $TEST_log && fail "build succeeded, but expected it to fail due to strict deps violation"
+
+  # Check that it's a strict deps error, not an unused deps error
+  expect_log "is not visible from target '//pkg:indirect_used'"
+
+  # -------------------------------------------------------------
+  # Scenario 6: Non-Main Repository Target (Success)
+  # -------------------------------------------------------------
+  mkdir -p ext
+  cat > ext/MODULE.bazel <<EOF
+module(name = "ext")
+bazel_dep(name = "rules_java")
+EOF
+  if [[ -n "${RULES_JAVA_OVERRIDE_PATH:-}" ]]; then
+    cat >> ext/MODULE.bazel <<EOF
+local_path_override(
+    module_name = "rules_java",
+    path = "${RULES_JAVA_OVERRIDE_PATH}",
+)
+EOF
+  fi
+
+  cat > ext/BUILD <<EOF
+load("@rules_java//java:java_library.bzl", "java_library")
+load("@rules_java//toolchains:default_java_toolchain.bzl", "default_java_toolchain")
+load("@rules_java//java:defs.bzl", "java_package_configuration")
+
+package_group(
+    name = "ext_package_spec",
+    packages = ["//..."],
+)
+
+java_package_configuration(
+    name = "unused_deps_error_config",
+    package_specs = [":ext_package_spec"],
+    unused_deps = "error",
+)
+
+default_java_toolchain(
+    name = "java_toolchain",
+    package_configuration = [":unused_deps_error_config"],
+)
+
+java_library(name = "ext_lib", srcs = ["Ext.java"], deps = [":ext_dep"])
+java_library(name = "ext_dep", srcs = ["ExtDep.java"])
+EOF
+
+  echo "public class Ext {}" > ext/Ext.java
+  echo "public class ExtDep {}" > ext/ExtDep.java
+
+  cat >> MODULE.bazel <<EOF
+bazel_dep(name = "ext")
+local_path_override(
+    module_name = "ext",
+    path = "ext",
+)
+EOF
+
+  # Build the target in the external repo. Even though ext_dep is unused,
+  # it should compile successfully because unused deps checking is disabled for non-main repos.
+  bazel build @ext//:ext_lib \
+    --extra_toolchains=@ext//:java_toolchain_definition \
+    >& $TEST_log || fail "build of external target failed, but expected to succeed (unused check disabled for external repos)"
+}
+
 run_suite "Java integration tests"

--- a/unused_deps_checking_design.md
+++ b/unused_deps_checking_design.md
@@ -1,0 +1,144 @@
+# Design Proposal: Toolchain-Driven Unused Java Dependencies Checking in Bazel
+
+This document outlines the design for introducing and configuring unused Java dependencies checking in Bazel. The configuration is driven by the Java toolchain, with supporting metadata tracking and configuration resolution implemented in `rules_java` Starlark rules, and native API execution handled by core Bazel.
+
+---
+
+## 1. Preface: Driver for the Change
+
+Bazel currently enforces strict Java dependencies (`strict_java_deps`), ensuring that a target cannot directly reference classes from a transitive dependency without declaring a direct dependency. While this guarantees dependency completeness, it does not prevent **unused dependencies**—libraries declared as direct dependencies but not referenced in code. Unused dependencies bloat deployment artifacts, increase build graph size, and lead to unnecessary cache invalidations.
+
+The goal is to implement a robust unused dependencies check (supporting `off` and `error` modes) that is configured via the Java toolchain but integrated into target analysis.
+
+### Why `warn` Mode is Unnecessary
+By leveraging `java_package_configuration`, teams can enforce the check as a hard compile-time error restricted to specific packages, gradually ratcheting up compliance package-by-package. This prevents warning noise in developer builds while enabling a safe, structured path to full enforcement.
+
+### Key Technical Challenges
+- **Conflation of Exported Transitive Dependencies**: Javac and JavaBuilder receive classpath inputs as flat lists of jar files. When a direct dependency exports a transitive dependency (via `exports`), those transitive dependency jars are merged into the target's direct classpath (`directJars`). This conflation occurs inside the Starlark rules of `@rules_java` (see [java_info.bzl#L612](https://github.com/bazelbuild/rules_java/blob/35e8391a1c37dd5941ba594a01dcb08d3985cbd8/java/private/java_info.bzl#L612) where exported compile jars are accumulated into the target's direct compile jars). To check for unused dependencies correctly without throwing false positives, the check must account for this conflation (where classes are consumed via the exported transitives of a declared direct dependency).
+
+---
+
+## 2. Toolchain-Driven Configuration API
+
+The unused dependencies check configuration is defined at the toolchain level using the existing `java_package_configuration` API. This allows operators to define check strictness globally or for specific packages.
+
+### Package Configuration Definition
+Using `java_package_configuration`, unused dependencies checking modes (`off`, `error`) can be mapped to specific package specs:
+
+```starlark
+java_package_configuration(
+    name = "unused_deps_error_config",
+    package_specs = [":my_package_spec"],
+    unused_deps = "error",  # "off" or "error"
+)
+```
+
+The matching `java_package_configuration` rules are registered on the `java_toolchain` rule:
+
+```starlark
+java_toolchain(
+    name = "toolchain",
+    package_configuration = [
+        ":unused_deps_error_config",
+    ],
+    ...
+)
+```
+
+---
+
+## 3. Expected Behaviors under Various Scenarios
+
+The table below outlines the compilation outcomes under different dependency configurations (assuming `unused_deps = "error"` is active):
+
+| Dependency Graph & Code Usage | Outcome | Reason / Action |
+| :--- | :--- | :--- |
+| **Simple Unused**: A depends on B. A's code does NOT reference B. | **Error** | B is unused. A must remove B from `deps`. |
+| **Simple Used**: A depends on B. A's code references B. | **Success** | B is directly used. |
+| **Exported Only**: B exports C. A depends on B, but A's code only references C (does NOT reference B). | **Error** | B is unused. A must add a direct dependency on C and remove B from `deps`. |
+| **Exported & Direct Used**: B exports C. A depends on B, and A's code references both B and C. | **Success** | B is directly used. C's usage is allowed because B exports it. |
+| **Indirect Used (Strict Deps)**: A depends on B. B depends on C (no export). A's code references C. | **Error** | Strict Java Deps violation. A must declare a direct dependency on C. |
+| **Non-Main Repository Target**: Target is in an external repository (e.g., `@some_repo//pkg:target`). | **Success** | Unused dependencies checking is disabled (`off`) for external repositories to avoid breaking builds on third-party code. |
+
+---
+
+## 4. Implied Changes to `rules_java`
+
+To support this toolchain-driven configuration, the Starlark rules in `rules_java` must be updated to define the attribute on `java_package_configuration`, track dependency declarations on compilation rules, and resolve the checking levels.
+
+### A. Java Package Configuration Rule Update
+The `java_package_configuration` rule definition (in `java/common/rules:java_package_configuration.bzl`) will define a new Starlark attribute to capture the checking strictness:
+```starlark
+unused_deps = attr.string(default = "off", values = ["off", "error"])
+```
+
+### B. Mapping Direct Dependencies to Compile Jars for Verification
+The rules (e.g., `java_library`, `java_binary`) must map each declared dependency to its direct compile jars (excluding transitively exported jars). This is achieved by extracting `java_outputs` from each dependency and pairing them with the dependency's declared label.
+
+```starlark
+# Inside rules_java compilation helper:
+direct_dep_jars_to_verify = []
+for dep in ctx.attr.deps:
+    # Collect only compile jars generated directly by this target (excluding exports)
+    for output in dep[JavaInfo].java_outputs:
+        if output.compile_jar:
+            direct_dep_jars_to_verify.append(struct(
+                jar = output.compile_jar,
+                label = str(dep.label),
+            ))
+```
+
+### C. Resolving Unused Dependencies Check Levels
+The Starlark rules will query the toolchain's package configurations to resolve the unused dependencies check level (`off` or `error`) for the package being compiled.
+- It parses the matching `java_package_configuration` from `ctx.attr._java_toolchain` for the current package.
+- It extracts the resolved checking mode directly from the new `unused_deps` attribute of the configuration object.
+- It verifies if the target belongs to the main repository (using `not ctx.label.workspace_name`). If the target belongs to an external repository (where `workspace_name` is non-empty), checking is overridden to `"off"` to prevent breaking third-party dependencies.
+
+### D. Calling Compilation Helper
+If the unused deps check is resolved to `error` for the package, the jar-to-label mappings are passed to the `java_common.compile` / `create_compilation_action` API:
+
+```starlark
+java_common.compile(
+    ctx,
+    ...
+    direct_dep_jars_to_verify = direct_dep_jars_to_verify,
+)
+```
+
+---
+
+## 5. Changes Required in Core Bazel
+
+Core Bazel's native APIs and action builders must be updated to receive the metadata from `rules_java` and forward them to JavaBuilder.
+
+### A. Native API Updates (`JavaStarlarkCommon.java`)
+Extend the `createCompilationAction` and `createHeaderCompilationAction` methods in `JavaStarlarkCommon` to accept the `direct_dep_jars_to_verify` mapping:
+
+```java
+public void createCompilationAction(
+    ...
+    List<Artifact> directDepJarsToVerify,
+    List<String> directDepLabelsToVerify,
+    ...)
+```
+
+### B. Compilation Action Builder Updates (`JavaCompileActionBuilder.java`)
+Update the builder to receive the jar-to-label mapping and translate it into parallel command-line flags for JavaBuilder. The presence of these flags instructs JavaBuilder to execute the check:
+
+```java
+// inside JavaCompileActionBuilder.java
+if (!directDepJarsToVerify.isEmpty()) {
+  for (int i = 0; i < directDepJarsToVerify.size(); i++) {
+    result.addPath("--direct_dep_jar", directDepJarsToVerify.get(i));
+    result.add("--direct_dep_label", directDepLabelsToVerify.get(i));
+  }
+}
+```
+
+### C. JavaBuilder Compiler Plugin (`StrictJavaDepsPlugin.java`)
+Update the strict Java dependencies plugin in JavaBuilder to:
+- Parse `--direct_dep_jar` and `--direct_dep_label` to build a map of `JarPath -> DeclaredLabel`.
+- Keep track of which direct dependency jar paths are actually loaded and used during compilation (leveraging the compiler plugin's existing AST traversal).
+- If a declared target label has all of its associated jars completely unused during compilation, emit a `[unused-deps]` error referencing the declared target label.
+
+

--- a/unused_deps_checking_design.md
+++ b/unused_deps_checking_design.md
@@ -73,19 +73,17 @@ unused_deps = attr.string(default = "off", values = ["off", "error"])
 ```
 
 ### B. Mapping Direct Dependencies to Compile Jars for Verification
-The rules (e.g., `java_library`, `java_binary`) must map each declared dependency to its direct compile jars (excluding transitively exported jars). This is achieved by extracting `java_outputs` from each dependency and pairing them with the dependency's declared label.
+The rules (e.g., `java_library`, `java_binary`) must map each declared dependency to its direct compile jars (excluding transitively exported jars). This is achieved by extracting `java_outputs` from each dependency and pairing them with the dependency's declared label in a dictionary.
 
 ```starlark
 # Inside rules_java compilation helper:
-direct_dep_jars_to_verify = []
+direct_dep_jars_to_verify = {}
 for dep in ctx.attr.deps:
     # Collect only compile jars generated directly by this target (excluding exports)
     for output in dep[JavaInfo].java_outputs:
-        if output.compile_jar:
-            direct_dep_jars_to_verify.append(struct(
-                jar = output.compile_jar,
-                label = str(dep.label),
-            ))
+        compile_jar = output.compile_jar if output.compile_jar else output.class_jar
+        if compile_jar:
+            direct_dep_jars_to_verify[compile_jar] = str(dep.label)
 ```
 
 ### C. Resolving Unused Dependencies Check Levels
@@ -117,27 +115,23 @@ Extend the `createCompilationAction` and `createHeaderCompilationAction` methods
 ```java
 public void createCompilationAction(
     ...
-    List<Artifact> directDepJarsToVerify,
-    List<String> directDepLabelsToVerify,
+    Dict<Artifact, String> directDepJarsToVerify,
     ...)
 ```
 
 ### B. Compilation Action Builder Updates (`JavaCompileActionBuilder.java`)
-Update the builder to receive the jar-to-label mapping and translate it into parallel command-line flags for JavaBuilder. The presence of these flags instructs JavaBuilder to execute the check:
+Update the builder to receive the jar-to-label mapping and translate it into a single `--declared_dep` flag with a `::` separator:
 
 ```java
 // inside JavaCompileActionBuilder.java
-if (!directDepJarsToVerify.isEmpty()) {
-  for (int i = 0; i < directDepJarsToVerify.size(); i++) {
-    result.addPath("--direct_dep_jar", directDepJarsToVerify.get(i));
-    result.add("--direct_dep_label", directDepLabelsToVerify.get(i));
-  }
+for (Map.Entry<Artifact, String> entry : directDepJarsToVerify.entrySet()) {
+  result.addFormatted("--declared_dep", "%s::%s", entry.getKey().getExecPathString(), entry.getValue());
 }
 ```
 
 ### C. JavaBuilder Compiler Plugin (`StrictJavaDepsPlugin.java`)
 Update the strict Java dependencies plugin in JavaBuilder to:
-- Parse `--direct_dep_jar` and `--direct_dep_label` to build a map of `JarPath -> DeclaredLabel`.
+- Parse `--declared_dep` in the format `path::label` to build a map of `JarPath -> DeclaredLabel`.
 - Keep track of which direct dependency jar paths are actually loaded and used during compilation (leveraging the compiler plugin's existing AST traversal).
 - If a declared target label has all of its associated jars completely unused during compilation, emit a `[unused-deps]` error referencing the declared target label.
 

--- a/unused_deps_checking_design.md
+++ b/unused_deps_checking_design.md
@@ -1,0 +1,137 @@
+# Design Proposal: Toolchain-Driven Unused Java Dependencies Checking in Bazel
+
+This document outlines the design for introducing and configuring unused Java dependencies checking in Bazel. The configuration is driven by the Java toolchain, with supporting metadata tracking and configuration resolution implemented in `rules_java` Starlark rules, and native API execution handled by core Bazel.
+
+---
+
+## 1. Preface: Driver for the Change
+
+Bazel currently enforces strict Java dependencies (`strict_java_deps`), ensuring that a target cannot directly reference classes from a transitive dependency without declaring a direct dependency. While this guarantees dependency completeness, it does not prevent **unused dependencies**—libraries declared as direct dependencies but not referenced in code. Unused dependencies bloat deployment artifacts, increase build graph size, and lead to unnecessary cache invalidations.
+
+The goal is to implement a robust unused dependencies check (supporting `off` and `error` modes) that is configured via the Java toolchain but integrated into target analysis.
+
+### Why `warn` Mode is Unnecessary
+By leveraging `java_package_configuration`, teams can enforce the check as a hard compile-time error restricted to specific packages, gradually ratcheting up compliance package-by-package. This prevents warning noise in developer builds while enabling a safe, structured path to full enforcement.
+
+### Key Technical Challenges
+- **Conflation of Exported Transitive Dependencies**: Javac and JavaBuilder receive classpath inputs as flat lists of jar files. When a direct dependency exports a transitive dependency (via `exports`), those transitive dependency jars are merged into the target's direct classpath (`directJars`). This conflation occurs inside the Starlark rules of `@rules_java` (see [java_info.bzl#L612](https://github.com/bazelbuild/rules_java/blob/35e8391a1c37dd5941ba594a01dcb08d3985cbd8/java/private/java_info.bzl#L612) where exported compile jars are accumulated into the target's direct compile jars). To check for unused dependencies correctly without throwing false positives, the check must account for this conflation (where classes are consumed via the exported transitives of a declared direct dependency).
+
+---
+
+## 2. Toolchain-Driven Configuration API
+
+The unused dependencies check configuration is defined at the toolchain level using the existing `java_package_configuration` API. This allows operators to define check strictness globally or for specific packages.
+
+### Package Configuration Definition
+Using `java_package_configuration`, unused dependencies checking modes (`off`, `error`) can be mapped to specific package specs:
+
+```starlark
+java_package_configuration(
+    name = "unused_deps_error_config",
+    package_specs = [":my_package_spec"],
+    unused_deps = "error",  # "off" or "error"
+)
+```
+
+The matching `java_package_configuration` rules are registered on the `java_toolchain` rule:
+
+```starlark
+java_toolchain(
+    name = "toolchain",
+    package_configuration = [
+        ":unused_deps_error_config",
+    ],
+    ...
+)
+```
+
+---
+
+## 3. Expected Behaviors under Various Scenarios
+
+The table below outlines the compilation outcomes under different dependency configurations (assuming `unused_deps = "error"` is active):
+
+| Dependency Graph & Code Usage | Outcome | Reason / Action |
+| :--- | :--- | :--- |
+| **Simple Unused**: A depends on B. A's code does NOT reference B. | **Error** | B is unused. A must remove B from `deps`. |
+| **Simple Used**: A depends on B. A's code references B. | **Success** | B is directly used. |
+| **Exported Only**: B exports C. A depends on B, but A's code only references C (does NOT reference B). | **Error** | B is unused. A must add a direct dependency on C and remove B from `deps`. |
+| **Exported & Direct Used**: B exports C. A depends on B, and A's code references both B and C. | **Success** | B is directly used. C's usage is allowed because B exports it. |
+| **Indirect Used (Strict Deps)**: A depends on B. B depends on C (no export). A's code references C. | **Error** | Strict Java Deps violation. A must declare a direct dependency on C. |
+| **Non-Main Repository Target**: Target is in an external repository (e.g., `@some_repo//pkg:target`). | **Success** | Unused dependencies checking is disabled (`off`) for external repositories to avoid breaking builds on third-party code. |
+
+---
+
+## 4. Implied Changes to `rules_java`
+
+To support this toolchain-driven configuration, the Starlark rules in `rules_java` must be updated to define the attribute on `java_package_configuration`, track dependency declarations on compilation rules, and resolve the checking levels.
+
+### A. Java Package Configuration Rule Update
+The `java_package_configuration` rule definition (in `java/common/rules:java_package_configuration.bzl`) will define a new Starlark attribute to capture the checking strictness:
+```starlark
+unused_deps = attr.string(default = "off", values = ["off", "error"])
+```
+
+### B. Formatting Declared Dependencies into an Args Object
+The rules (e.g., `java_library`, `java_binary`) map each declared dependency to its direct compile jars (excluding transitively exported jars) directly into a Starlark `Args` object (`ctx.actions.args()`). This avoids expanding artifact paths to strings during analysis time:
+
+```starlark
+# Inside rules_java compilation helper:
+unused_deps_args = ctx.actions.args()
+for dep in ctx.attr.deps:
+    # Collect only compile jars generated directly by this target (excluding exports)
+    for output in dep[JavaInfo].java_outputs:
+        compile_jar = output.compile_jar if output.compile_jar else output.class_jar
+        if compile_jar:
+            unused_deps_args.add("--declared_dep", compile_jar, format = "%s::" + str(dep.label))
+```
+
+### C. Resolving Unused Dependencies Check Levels
+The Starlark rules query the toolchain's package configurations to resolve the unused dependencies check level (`off` or `error`) for the package being compiled.
+- It parses the matching `java_package_configuration` from `ctx.attr._java_toolchain` for the current package.
+- It extracts the resolved checking mode directly from the new `unused_deps` attribute of the configuration object.
+- It verifies if the target belongs to the main repository (using `not ctx.label.workspace_name`). If the target belongs to an external repository (where `workspace_name` is non-empty), checking is overridden to `"off"` to prevent breaking third-party dependencies.
+
+### D. Calling Compilation Helper
+If the unused deps check is resolved to `error` for the package, the `Args` object is appended to `extra_args` and forwarded via `java_common.compile` / `create_compilation_action`:
+
+```starlark
+java_common.compile(
+    ctx,
+    ...
+    extra_args = extra_args,  # list of Args objects
+)
+```
+
+---
+
+## 5. Changes Required in Core Bazel
+
+Core Bazel's native APIs and action builders are updated to accept the generic `extra_args` parameter (a list of `CommandLineArgsApi` / `Args`) and attach their command lines and input manifests to the action. Core Bazel remains agnostic to the specific flags passed.
+
+### A. Native API Updates (`JavaStarlarkCommon.java` and `JavaCommonApi.java`)
+Extend `createCompilationAction` in `JavaStarlarkCommon` to accept `extra_args`:
+
+```java
+@Param(
+    name = "extra_args",
+    allowedTypes = {
+        @ParamType(type = Sequence.class, generic1 = CommandLineArgsApi.class),
+        @ParamType(type = NoneType.class),
+    },
+    defaultValue = "None",
+    named = true,
+    positional = false)
+Object extraArgs
+```
+
+### B. Action Compilation Pipeline (`JavaCompileActionBuilder.java` & `JavaCompileAction.java`)
+Forward each constructed `CommandLine` from `extra_args` to `JavaCompileAction`'s command lines (with `PARAM_FILE_INFO`) and add any directory inputs from each `Args` to mandatory action inputs.
+
+### C. JavaBuilder Compiler Plugin (`StrictJavaDepsPlugin.java`)
+Update the strict Java dependencies plugin in JavaBuilder to:
+- Parse `--declared_dep` in the format `path::label` to build a map of `JarPath -> DeclaredLabel`.
+- Keep track of which direct dependency jar paths are actually loaded and used during compilation (leveraging the compiler plugin's existing AST traversal).
+- If a declared target label has all of its associated jars completely unused during compilation, emit a `[unused-deps]` error referencing the declared target label.
+
+


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
This adds support to bazel for detection of unused direct dependencies in java_library/binary/test targets.  This means a dependency declared in the deps attr, but marked as something less than EXPLICIT by jdeps.
-->

### Motivation
Unused deps bloat the build graph, and while there is prior art in out-of-bazel detection, that requires extra repo-local build actions (via analysis-time-expensive aspects), extra CI tasks, or perhaps bot workflow to remediate the source code post-hoc.  None of these are as attractive as bazel-native support.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->
Yes this adds a new command line arg (marked experimental) to control default behaviour, plus a tag-based API to allow incremental adoption.

1 - No
2 - Yes, it's opt-in
3 - Not breaking (unless we eventually want to default to true)

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES[NEW]: Add detection of unused direct dependencies for java targets.
