### PR TITLE
Always expose `Action.execution_info` to Starlark

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/ActionApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/ActionApi.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.starlarkbuildapi;
 
 import com.google.devtools.build.docgen.annot.DocCategory;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
-import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import java.io.IOException;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.StarlarkBuiltin;
@@ -136,13 +135,14 @@ public interface ActionApi extends StarlarkValue {
       name = "execution_info",
       structField = true,
       doc =
-          "The execution requirements for this action, set for this action specifically. This is a"
-              + " dictionary that maps strings specifying execution info to arbitrary strings."
-              + " This is in order to match the structure of execution info in other parts of the"
-              + " code base; all relevant info is in the keyset. Returns None if this action does"
-              + " not expose execution requirements.",
-      allowReturnNones = true,
-      enableOnlyWithFlag = BuildLanguageOptions.EXPERIMENTAL_GOOGLE_LEGACY_API)
+          "For actions created by <a href=\"../builtins/actions.html#run\">ctx.actions.run()</a> or"
+              + " <a href=\"../builtins/actions.html#run_shell\">ctx.actions.run_shell()</a>, the"
+              + " execution requirements set for this action specifically (i.e. via the"
+              + " <code>execution_requirements</code> argument). This is a dictionary that maps"
+              + " strings specifying execution info to arbitrary strings; to match the structure of"
+              + " execution info elsewhere in the code base, all relevant info is in the keyset."
+              + " Returns <code>None</code> if this action does not expose execution requirements.",
+      allowReturnNones = true)
   @Nullable
   public Dict<String, String> getExecutionInfoDict();
 }

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkActionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkActionProviderTest.java
@@ -128,6 +128,7 @@ public class StarlarkActionProviderTest extends AnalysisTestCase {
                 command = "fakecmd",
                 mnemonic = "MyAction1",
                 env = {"pet": "bunny"},
+                execution_requirements = {"requires-network": "1"},
             )
             return None
 
@@ -143,7 +144,6 @@ public class StarlarkActionProviderTest extends AnalysisTestCase {
         )
         """);
 
-    useConfiguration("--experimental_google_legacy_api");
     AnalysisResult analysisResult =
         update(ImmutableList.of("test/aspect.bzl%MyAspect"), "//test:xxx");
 
@@ -171,7 +171,8 @@ public class StarlarkActionProviderTest extends AnalysisTestCase {
 
     Sequence<Dict<String, String>> executionInfo =
         (Sequence<Dict<String, String>>) fooProvider.getValue("execution_info");
-    assertThat(executionInfo).isNotNull();
+    assertThat(executionInfo).hasSize(2);
+    assertThat(executionInfo.get(1)).containsExactly("requires-network", "1");
 
     Sequence<Sequence<Artifact>> inputs =
         (Sequence<Sequence<Artifact>>) fooProvider.getValue("inputs");


### PR DESCRIPTION
## Summary

The `execution_info` field of the Starlark [`Action`](https://bazel.build/rules/lib/builtins/Action) object exposes the execution requirements set on an action (e.g. via the `execution_requirements` argument of `ctx.actions.run` / `ctx.actions.run_shell`). It was gated behind `--experimental_google_legacy_api`.

This PR removes that flag guard so the field is available unconditionally.

## Motivation

There is nothing Google-internal or legacy about an action's execution requirements. Keeping the field behind `--experimental_google_legacy_api` makes it unusable for the common, legitimate case of asserting on execution requirements in **analysis tests** — e.g. with [`rules_testing`](https://github.com/bazelbuild/rules_testing), whose `ActionSubject` can expose `mnemonic`, `env`, `inputs`, `argv`, `content`, etc., but cannot currently observe execution requirements because this is the only entry point and it is flag-gated.

Concretely, this came up while porting Bazel's `ctx.actions.run_shell` tests (e.g. `StarlarkRuleImplementationFunctionsTest#testCreateSpawnActionEnvAndExecInfo`) to Starlark analysis tests in `rules_shell`: the `env` half is observable via `Action.env`, but the `execution_requirements` half is not reachable without this flag.

## Changes

- `ActionApi.execution_info`: drop `enableOnlyWithFlag = EXPERIMENTAL_GOOGLE_LEGACY_API` (and the now-unused import); clarify the doc. Behavior is unchanged otherwise — the field still returns `None` for action types that do not expose execution requirements.
- `StarlarkActionProviderTest#aspectGetsActionProviderForStarlarkRule`: drop `--experimental_google_legacy_api` and assert that `execution_requirements` set on a `run_shell` action is visible via `a.execution_info`.

## Notes / open questions

- Naming: the field is `execution_info` (matching the keyset used elsewhere in the codebase). I kept that name rather than introducing an `execution_requirements` alias, but happy to reconsider.
- Marked **draft** pending CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)