### PR TITLE
[8.8.0] Support `patches` in `git_repository` registry sources (https://githu…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
@@ -19,6 +19,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.List;
+import net.starlark.java.eval.Dict;
+import net.starlark.java.eval.StarlarkInt;
 
 /**
  * Builder for a {@link RepoSpec} object that indicates how to materialize a repo corresponding to a
@@ -75,11 +77,21 @@ public class GitRepoSpecBuilder {
   }
 
   @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setRemotePatches(ImmutableMap<String, String> remotePatches) {
+    return setAttr("remote_patches", remotePatches);
+  }
+
+  @CanIgnoreReturnValue
   public GitRepoSpecBuilder setRemoteModuleFile(
       ArchiveRepoSpecBuilder.RemoteFile remoteModuleFile) {
     attrBuilder.put("remote_module_file_urls", remoteModuleFile.urls());
     attrBuilder.put("remote_module_file_integrity", remoteModuleFile.integrity());
     return this;
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setRemotePatchStrip(int remotePatchStrip) {
+    return setAttr("remote_patch_strip", remotePatchStrip);
   }
 
   public RepoSpec build() {
@@ -105,6 +117,20 @@ public class GitRepoSpecBuilder {
     if (value != null && !value.isEmpty()) {
       attrBuilder.put(name, value);
     }
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  private GitRepoSpecBuilder setAttr(String name, ImmutableMap<?, ?> value) {
+    if (value != null && !value.isEmpty()) {
+      attrBuilder.put(name, Dict.immutableCopyOf(value));
+    }
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  private GitRepoSpecBuilder setAttr(String name, int value) {
+    attrBuilder.put(name, StarlarkInt.of(value));
     return this;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -291,6 +291,8 @@ public class IndexRegistry implements Registry {
     String tag;
     boolean initSubmodules;
     boolean verbose;
+    Map<String, String> patches;
+    int patchStrip;
     String stripPrefix;
   }
 
@@ -380,7 +382,7 @@ public class IndexRegistry implements Registry {
             parseJson(jsonString.get(), jsonUrl, GitRepoSourceJson.class);
         var moduleFileUrl = constructModuleFileUrl(key);
         var moduleFileChecksum = moduleFileHashes.get(moduleFileUrl).get();
-        return createGitRepoSpec(typedSourceJson, moduleFileUrl, moduleFileChecksum);
+        return createGitRepoSpec(typedSourceJson, moduleFileUrl, moduleFileChecksum, key);
       }
       default ->
           throw new IOException(
@@ -525,7 +527,7 @@ public class IndexRegistry implements Registry {
         .setUrls(urls.build())
         .setIntegrity(sourceJson.integrity)
         .setStripPrefix(Strings.nullToEmpty(sourceJson.stripPrefix))
-        .setRemotePatches(remotePatches.buildOrThrow())
+        .setRemotePatches(remotePatches.buildKeepingLast())
         .setOverlay(overlay)
         .setRemoteModuleFile(
             new RemoteFile(
@@ -536,7 +538,26 @@ public class IndexRegistry implements Registry {
   }
 
   private RepoSpec createGitRepoSpec(
-      GitRepoSourceJson sourceJson, String moduleFileUrl, Checksum moduleFileChecksum) {
+      GitRepoSourceJson sourceJson,
+      String moduleFileUrl,
+      Checksum moduleFileChecksum,
+      ModuleKey key) {
+    // Build remote patches as key-value pairs of "url" => "integrity".
+    ImmutableMap.Builder<String, String> remotePatches = new ImmutableMap.Builder<>();
+    if (sourceJson.patches != null) {
+      for (Map.Entry<String, String> entry : sourceJson.patches.entrySet()) {
+        remotePatches.put(
+            constructUrl(
+                getUrl(),
+                "modules",
+                key.name(),
+                key.version().toString(),
+                "patches",
+                entry.getKey()),
+            entry.getValue());
+      }
+    }
+
     return new GitRepoSpecBuilder()
         .setRemote(sourceJson.remote)
         .setCommit(sourceJson.commit)
@@ -548,6 +569,8 @@ public class IndexRegistry implements Registry {
         .setRemoteModuleFile(
             new RemoteFile(
                 moduleFileChecksum.toSubresourceIntegrity(), ImmutableList.of(moduleFileUrl)))
+        .setRemotePatches(remotePatches.buildKeepingLast())
+        .setRemotePatchStrip(sourceJson.patchStrip)
         .build();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -333,7 +333,11 @@ public class IndexRegistryTest extends FoundationTestCase {
         {
             "type": "git_repository",
             "remote": "https://github.com/raspberrypi/pico-sdk.git",
-            "commit": "4b6e647590213f253f2789ad9026df1d00f38c5d"
+            "commit": "4b6e647590213f253f2789ad9026df1d00f38c5d",
+            "patches": {
+                "foo.patch": "sha256-totallyarealhash"
+            },
+            "patch_strip": 1
         }
         """);
     server.serve("/modules/foo/1.0/MODULE.bazel", "module(name = \"foo\", version = \"1.0\")");
@@ -365,6 +369,11 @@ public class IndexRegistryTest extends FoundationTestCase {
                         sha256("module(name = \"foo\", version = \"1.0\")")
                             .toSubresourceIntegrity(),
                         ImmutableList.of(server.getUrl() + "/modules/foo/1.0/MODULE.bazel")))
+                .setRemotePatches(
+                    ImmutableMap.of(
+                        server.getUrl() + "/modules/foo/1.0/patches/foo.patch",
+                        "sha256-totallyarealhash"))
+                .setRemotePatchStrip(1)
                 .build());
   }
 


### PR DESCRIPTION
…b.com/bazelbuild/bazel/pull/28597)

Closes #22857.

Closes #28597.

PiperOrigin-RevId: 874069887
Change-Id: I518fae15e9d099425ae24f90a10fa1ee5c2bc909

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/f12c6cec35c3864738dc7c49e03083b059ee6c06