### PR TITLE
[8.8.0] Fix ArtifactFactory.getPathFromSourceExecPath for external repos (htt…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
@@ -513,10 +513,27 @@ public class ArtifactFactory implements ArtifactResolver {
   public Path getPathFromSourceExecPath(Path execRoot, PathFragment execPath) {
     Preconditions.checkState(
         !execPath.startsWith(derivedPathPrefix), "%s is derived: %s", execPath, derivedPathPrefix);
+
+    Pair<RepositoryName, PathFragment> repo =
+        RepositoryName.fromPathFragment(execPath, siblingRepositoryLayout);
+    RepositoryName repositoryName = RepositoryName.MAIN;
+    PathFragment repositoryRelativePath = execPath;
+    if (repo != null) {
+      repositoryName = repo.getFirst();
+      repositoryRelativePath = repo.getSecond();
+    }
+
     Root sourceRoot =
-        packageRoots.getRootForPackage(PackageIdentifier.create(RepositoryName.MAIN, execPath));
+        packageRoots.getRootForPackage(
+            PackageIdentifier.create(repositoryName, repositoryRelativePath));
+    if (sourceRoot == null) {
+      sourceRoot =
+          findSourceRoot(
+              execPath, /* baseExecPath= */ null, /* baseRoot= */ null, RepositoryName.MAIN);
+    }
+
     if (sourceRoot != null) {
-      return sourceRoot.getRelative(execPath);
+      return sourceRoot.getRelative(repositoryRelativePath);
     }
     return execRoot.getRelative(execPath);
   }

--- a/src/test/java/com/google/devtools/build/lib/actions/ArtifactFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ArtifactFactoryTest.java
@@ -131,6 +131,40 @@ public class ArtifactFactoryTest {
   }
 
   @Test
+  public void testGetPathFromSourceExecPath_inExternalRepo() throws Exception {
+    Root externalRoot = Root.fromPath(scratch.dir("/external/alien"));
+    Path sourceFile = scratch.file("/external/alien/pkg/header.h", "");
+    ImmutableMap<PackageIdentifier, Root> packageRoots =
+        ImmutableMap.of(
+            PackageIdentifier.create("alien", PathFragment.create("pkg")), externalRoot);
+    artifactFactory.setPackageRoots(packageRoots::get);
+
+    Path path =
+        artifactFactory.getPathFromSourceExecPath(
+            execRoot, PathFragment.create("external/alien/pkg/header.h"));
+
+    assertThat(path).isEqualTo(sourceFile);
+    assertThat(path.isFile()).isTrue();
+  }
+
+  @Test
+  public void testGetPathFromSourceExecPath_externalRepoPackageDirectory() throws Exception {
+    Root externalRoot = Root.fromPath(scratch.dir("/external/alien"));
+    Path packageDirectory = scratch.dir("/external/alien/pkg");
+    ImmutableMap<PackageIdentifier, Root> packageRoots =
+        ImmutableMap.of(
+            PackageIdentifier.create("alien", PathFragment.create("pkg")), externalRoot);
+    artifactFactory.setPackageRoots(packageRoots::get);
+
+    Path path =
+        artifactFactory.getPathFromSourceExecPath(
+            execRoot, PathFragment.create("external/alien/pkg"));
+
+    assertThat(path).isEqualTo(packageDirectory);
+    assertThat(path.isDirectory()).isTrue();
+  }
+
+  @Test
   public void testResolveArtifact_noDerived_derivedRoot() throws Exception {
     assertThat(
             artifactFactory.resolveSourceArtifact(


### PR DESCRIPTION
…ps://github.com/bazelbuild/bazel/pull/29657)

This function is only called for include scanning, which isn't used widely externally today. Previously if a source file was from an external repo it would not be correctly found by this function, which assumed all source files are relative to the workspace.

Closes #29657.

PiperOrigin-RevId: 924751755
Change-Id: Ifadb17823a3247b98cbeea13c98e31b05de8e19e

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/a11ca574c706141a2d6baa345f5085b7a5bbe394