### PR TITLE
[8.8.0] Preserve empty `factsVersions` map in the lockfile merge driver (http…

### DIFF
--- a/scripts/bazel-lockfile-merge.jq
+++ b/scripts/bazel-lockfile-merge.jq
@@ -72,7 +72,7 @@ def shallow_merge(f):
                   if length > 0 then group_by(.key) | shallow_merge({(.[0].key): shallow_merge(.value)}) else {} end
                 else null end),
         # Keep only non-zero versions, mirroring how Bazel writes the lockfile.
-        factsVersions: (if ($maxFactsVersions | with_entries(select(.value != 0)) | length) > 0 then
+        factsVersions: (if any(has("factsVersions")) then
                           $maxFactsVersions | with_entries(select(.value != 0))
                         else null end),
     }

--- a/scripts/bazel_lockfile_merge_test.sh
+++ b/scripts/bazel_lockfile_merge_test.sh
@@ -446,4 +446,24 @@ EOF
   diff -u expected left || fail "output differs"
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/29742.
+function test_merge_preserves_empty_facts_versions() {
+  cat > base <<'EOF'
+{
+  "lockFileVersion": 28,
+  "registryFileHashes": {},
+  "selectedYankedVersions": {},
+  "moduleExtensions": {},
+  "facts": {},
+  "factsVersions": {}
+}
+EOF
+  cp base left
+  cp base right
+  cp base expected
+
+  do_merge base left right
+  diff -u expected left || fail "output differs"
+}
+
 run_suite "Tests of bash completion of 'blaze' command."

--- a/scripts/bazel_lockfile_merge_test.sh
+++ b/scripts/bazel_lockfile_merge_test.sh
@@ -465,5 +465,3 @@ EOF
   do_merge base left right
   diff -u expected left || fail "output differs"
 }
-
-run_suite "Tests of bash completion of 'blaze' command."


### PR DESCRIPTION
…s://github.com/bazelbuild/bazel/pull/29748)

Fixes https://github.com/bazelbuild/bazel/issues/29742

No

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES: None

Closes #29748.

PiperOrigin-RevId: 928760659
Change-Id: I51456dfe4f53098bba2adc38b843e109436ca2c7

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/fc489f293a495cdf7f5a46ec9c38c2eb2d881a22