### PR TITLE
[8.8.0] Migrate RBE configuration to dynamic RBE toolchain generator

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -397,12 +397,6 @@ bazel_dep(name = "bazel_ci_rules", version = "2.0.0")
 bazel_dep(name = "rules_fuzzing", version = "0.5.2")
 bazel_dep(name = "wabt", version = "1.0.37")
 
-git_override(
-    module_name = "bazel_ci_rules",
-    remote = "https://github.com/bazelbuild/continuous-integration.git",
-    commit = "0fd2a39dee6b4faf8804762eaa589f5c2ae85d1c",
-    strip_prefix = "rules",
-)
 
 rbe = use_extension("@bazel_ci_rules//:rbe_config.bzl", "rbe_config_extension")
 rbe.config(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -393,16 +393,23 @@ use_repo(
 # Other Bazel testing dependencies
 # =========================================
 
-bazel_dep(name = "bazel_ci_rules", version = "1.0.0")
+bazel_dep(name = "bazel_ci_rules", version = "2.0.0")
 bazel_dep(name = "rules_fuzzing", version = "0.5.2")
 bazel_dep(name = "wabt", version = "1.0.37")
 
-rbe_preconfig = use_repo_rule("@bazel_ci_rules//:rbe_repo.bzl", "rbe_preconfig")
-
-rbe_preconfig(
-    name = "rbe_ubuntu2404",
-    toolchain = "ubuntu2404",
+git_override(
+    module_name = "bazel_ci_rules",
+    remote = "https://github.com/bazelbuild/continuous-integration.git",
+    commit = "0fd2a39dee6b4faf8804762eaa589f5c2ae85d1c",
+    strip_prefix = "rules",
 )
+
+rbe = use_extension("@bazel_ci_rules//:rbe_config.bzl", "rbe_config_extension")
+rbe.config(
+    name = "rbe_ubuntu2404",
+    preset = "ubuntu2404",
+)
+use_repo(rbe, "rbe_ubuntu2404")
 
 list_source_repository = use_repo_rule("//src/test/shell/bazel:list_source_repository.bzl", "list_source_repository")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -19,6 +19,8 @@
     "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
     "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
     "https://bcr.bazel.build/modules/apple_support/1.8.1/MODULE.bazel": "500f7aa32c008222e360dc9a158c248c2dbaeb3b6246c19e7269981dbd61e29b",
+    "https://bcr.bazel.build/modules/apple_support/2.3.0/MODULE.bazel": "d48f824ae8eeea5f837eb3038cef3615075d996d3e82eb9187192c2820605a81",
+    "https://bcr.bazel.build/modules/apple_support/2.3.0/source.json": "d99b0a50918c4484856d773026b2fd60a694668c70fc0e19d592786dc7e5e469",
     "https://bcr.bazel.build/modules/bazel_ci_rules/1.0.0/MODULE.bazel": "0f92c944b9c466066ed484cfc899cf43fca765df78caca18984c62479f7925eb",
     "https://bcr.bazel.build/modules/bazel_ci_rules/1.0.0/source.json": "3405a2a7f9f827a44934b01470faeac1b56fb1304955c98ee9fcd03ad2ca5dcc",
     "https://bcr.bazel.build/modules/bazel_features/1.0.0/MODULE.bazel": "d7f022dc887efb96e1ee51cec7b2e48d41e36ff59a6e4f216c40e4029e1585bf",
@@ -296,164 +298,45 @@
               ]
             }
           }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "",
-            "abseil-cpp",
-            "abseil-cpp+"
-          ],
-          [
-            "",
-            "apple_support",
-            "apple_support+"
-          ],
-          [
-            "",
-            "async_profiler",
-            "+async_profiler_repos+async_profiler"
-          ],
-          [
-            "",
-            "async_profiler_linux_arm64",
-            "+async_profiler_repos+async_profiler_linux_arm64"
-          ],
-          [
-            "",
-            "async_profiler_linux_x64",
-            "+async_profiler_repos+async_profiler_linux_x64"
-          ],
-          [
-            "",
-            "async_profiler_macos",
-            "+async_profiler_repos+async_profiler_macos"
-          ],
-          [
-            "",
-            "bazel_skylib",
-            "bazel_skylib+"
-          ],
-          [
-            "",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "",
-            "blake3",
-            "blake3+"
-          ],
-          [
-            "",
-            "c-ares",
-            "c-ares+"
-          ],
-          [
-            "",
-            "chicory",
-            "chicory+"
-          ],
-          [
-            "",
-            "com_github_grpc_grpc",
-            "grpc+"
-          ],
-          [
-            "",
-            "com_google_protobuf",
-            "protobuf+"
-          ],
-          [
-            "",
-            "googleapis",
-            "googleapis+"
-          ],
-          [
-            "",
-            "grpc-java",
-            "grpc-java+"
-          ],
-          [
-            "",
-            "io_bazel_skydoc",
-            "stardoc+"
-          ],
-          [
-            "",
-            "platforms",
-            "platforms"
-          ],
-          [
-            "",
-            "re2",
-            "re2+"
-          ],
-          [
-            "",
-            "rules_cc",
-            "rules_cc+"
-          ],
-          [
-            "",
-            "rules_go",
-            "rules_go+"
-          ],
-          [
-            "",
-            "rules_graalvm",
-            "rules_graalvm+"
-          ],
-          [
-            "",
-            "rules_java",
-            "rules_java+"
-          ],
-          [
-            "",
-            "rules_jvm_external",
-            "rules_jvm_external+"
-          ],
-          [
-            "",
-            "rules_kotlin",
-            "rules_kotlin+"
-          ],
-          [
-            "",
-            "rules_license",
-            "rules_license+"
-          ],
-          [
-            "",
-            "rules_pkg",
-            "rules_pkg+"
-          ],
-          [
-            "",
-            "rules_proto",
-            "rules_proto+"
-          ],
-          [
-            "",
-            "rules_python",
-            "rules_python+"
-          ],
-          [
-            "",
-            "rules_shell",
-            "rules_shell+"
-          ],
-          [
-            "",
-            "zlib",
-            "zlib+"
-          ],
-          [
-            "",
-            "zstd-jni",
-            "zstd-jni+"
-          ]
-        ]
+        }
+      }
+    },
+    "@@bazel_ci_rules+//:rbe_config.bzl%rbe_config_extension": {
+      "general": {
+        "bzlTransitiveDigest": "9+l/EBrynYwo8/gokt6U/+ZoE2tIACzH5rOoPfI01wE=",
+        "usagesDigest": "HujAq5EGA+Tlz7DHoDf3wQuuXcobfsrLb9WdkQry/+A=",
+        "recordedInputs": [],
+        "generatedRepoSpecs": {
+          "rbe_ubuntu2404": {
+            "repoRuleId": "@@bazel_ci_rules+//:rbe_config.bzl%_rbe_config",
+            "attributes": {
+              "preset_name": "ubuntu2404"
+            }
+          }
+        }
+      }
+    },
+    "@@envoy_api+//bazel:repositories.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "9WmOn7ZEOTymbChrodgB7kkXkW9M2y+/emhjtH43DMc=",
+        "usagesDigest": "lOhJkV09ITWn6LOK9fLMuf1t3969wdr45lToQ2MVQoU=",
+        "recordedInputs": [
+          "REPO_MAPPING:envoy_api+,bazel_tools bazel_tools",
+          "REPO_MAPPING:envoy_api+,envoy_api envoy_api+"
+        ],
+        "generatedRepoSpecs": {
+          "prometheus_metrics_model": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/prometheus/client_model/archive/v0.6.2.tar.gz"
+              ],
+              "sha256": "47c5ea7949f68e7f7b344350c59b6bd31eeb921f0eec6c3a566e27cf1951470c",
+              "strip_prefix": "client_model-0.6.2",
+              "build_file_content": "\nload(\"@envoy_api//bazel:api_build_system.bzl\", \"api_cc_py_proto_library\")\nload(\"@io_bazel_rules_go//proto:def.bzl\", \"go_proto_library\")\n\napi_cc_py_proto_library(\n    name = \"client_model\",\n    srcs = [\n        \"io/prometheus/client/metrics.proto\",\n    ],\n    visibility = [\"//visibility:public\"],\n)\n\ngo_proto_library(\n    name = \"client_model_go_proto\",\n    importpath = \"github.com/prometheus/client_model/go\",\n    proto = \":client_model\",\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          }
+        }
       }
     },
     "@@googleapis+//:extensions.bzl%switched_rules": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -19,6 +19,8 @@
     "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
     "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
     "https://bcr.bazel.build/modules/apple_support/1.8.1/MODULE.bazel": "500f7aa32c008222e360dc9a158c248c2dbaeb3b6246c19e7269981dbd61e29b",
+    "https://bcr.bazel.build/modules/bazel_ci_rules/2.0.0/MODULE.bazel": "96dc6d2eac255b530a645cbf9102064ea997cae7b22acbe34fcc976f3dd53cbf",
+    "https://bcr.bazel.build/modules/bazel_ci_rules/2.0.0/source.json": "b6948e739190180af80dd91ceb9e3fb2b0c0160ecbf81177de2130475b54b516",
     "https://bcr.bazel.build/modules/bazel_features/1.0.0/MODULE.bazel": "d7f022dc887efb96e1ee51cec7b2e48d41e36ff59a6e4f216c40e4029e1585bf",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -19,10 +19,6 @@
     "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
     "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
     "https://bcr.bazel.build/modules/apple_support/1.8.1/MODULE.bazel": "500f7aa32c008222e360dc9a158c248c2dbaeb3b6246c19e7269981dbd61e29b",
-    "https://bcr.bazel.build/modules/apple_support/2.3.0/MODULE.bazel": "d48f824ae8eeea5f837eb3038cef3615075d996d3e82eb9187192c2820605a81",
-    "https://bcr.bazel.build/modules/apple_support/2.3.0/source.json": "d99b0a50918c4484856d773026b2fd60a694668c70fc0e19d592786dc7e5e469",
-    "https://bcr.bazel.build/modules/bazel_ci_rules/1.0.0/MODULE.bazel": "0f92c944b9c466066ed484cfc899cf43fca765df78caca18984c62479f7925eb",
-    "https://bcr.bazel.build/modules/bazel_ci_rules/1.0.0/source.json": "3405a2a7f9f827a44934b01470faeac1b56fb1304955c98ee9fcd03ad2ca5dcc",
     "https://bcr.bazel.build/modules/bazel_features/1.0.0/MODULE.bazel": "d7f022dc887efb96e1ee51cec7b2e48d41e36ff59a6e4f216c40e4029e1585bf",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
@@ -298,14 +294,173 @@
               ]
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "abseil-cpp",
+            "abseil-cpp+"
+          ],
+          [
+            "",
+            "apple_support",
+            "apple_support+"
+          ],
+          [
+            "",
+            "async_profiler",
+            "+async_profiler_repos+async_profiler"
+          ],
+          [
+            "",
+            "async_profiler_linux_arm64",
+            "+async_profiler_repos+async_profiler_linux_arm64"
+          ],
+          [
+            "",
+            "async_profiler_linux_x64",
+            "+async_profiler_repos+async_profiler_linux_x64"
+          ],
+          [
+            "",
+            "async_profiler_macos",
+            "+async_profiler_repos+async_profiler_macos"
+          ],
+          [
+            "",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "",
+            "blake3",
+            "blake3+"
+          ],
+          [
+            "",
+            "c-ares",
+            "c-ares+"
+          ],
+          [
+            "",
+            "chicory",
+            "chicory+"
+          ],
+          [
+            "",
+            "com_github_grpc_grpc",
+            "grpc+"
+          ],
+          [
+            "",
+            "com_google_protobuf",
+            "protobuf+"
+          ],
+          [
+            "",
+            "googleapis",
+            "googleapis+"
+          ],
+          [
+            "",
+            "grpc-java",
+            "grpc-java+"
+          ],
+          [
+            "",
+            "io_bazel_skydoc",
+            "stardoc+"
+          ],
+          [
+            "",
+            "platforms",
+            "platforms"
+          ],
+          [
+            "",
+            "re2",
+            "re2+"
+          ],
+          [
+            "",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "",
+            "rules_go",
+            "rules_go+"
+          ],
+          [
+            "",
+            "rules_graalvm",
+            "rules_graalvm+"
+          ],
+          [
+            "",
+            "rules_java",
+            "rules_java+"
+          ],
+          [
+            "",
+            "rules_jvm_external",
+            "rules_jvm_external+"
+          ],
+          [
+            "",
+            "rules_kotlin",
+            "rules_kotlin+"
+          ],
+          [
+            "",
+            "rules_license",
+            "rules_license+"
+          ],
+          [
+            "",
+            "rules_pkg",
+            "rules_pkg+"
+          ],
+          [
+            "",
+            "rules_proto",
+            "rules_proto+"
+          ],
+          [
+            "",
+            "rules_python",
+            "rules_python+"
+          ],
+          [
+            "",
+            "rules_shell",
+            "rules_shell+"
+          ],
+          [
+            "",
+            "zlib",
+            "zlib+"
+          ],
+          [
+            "",
+            "zstd-jni",
+            "zstd-jni+"
+          ]
+        ]
       }
     },
     "@@bazel_ci_rules+//:rbe_config.bzl%rbe_config_extension": {
       "general": {
         "bzlTransitiveDigest": "9+l/EBrynYwo8/gokt6U/+ZoE2tIACzH5rOoPfI01wE=",
-        "usagesDigest": "HujAq5EGA+Tlz7DHoDf3wQuuXcobfsrLb9WdkQry/+A=",
-        "recordedInputs": [],
+        "usagesDigest": "5vIBdfgMAV2hRsMtbGC8pQMlUpv+E89m6+LG5pVdIGk=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
         "generatedRepoSpecs": {
           "rbe_ubuntu2404": {
             "repoRuleId": "@@bazel_ci_rules+//:rbe_config.bzl%_rbe_config",
@@ -313,30 +468,8 @@
               "preset_name": "ubuntu2404"
             }
           }
-        }
-      }
-    },
-    "@@envoy_api+//bazel:repositories.bzl%non_module_deps": {
-      "general": {
-        "bzlTransitiveDigest": "9WmOn7ZEOTymbChrodgB7kkXkW9M2y+/emhjtH43DMc=",
-        "usagesDigest": "lOhJkV09ITWn6LOK9fLMuf1t3969wdr45lToQ2MVQoU=",
-        "recordedInputs": [
-          "REPO_MAPPING:envoy_api+,bazel_tools bazel_tools",
-          "REPO_MAPPING:envoy_api+,envoy_api envoy_api+"
-        ],
-        "generatedRepoSpecs": {
-          "prometheus_metrics_model": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "urls": [
-                "https://github.com/prometheus/client_model/archive/v0.6.2.tar.gz"
-              ],
-              "sha256": "47c5ea7949f68e7f7b344350c59b6bd31eeb921f0eec6c3a566e27cf1951470c",
-              "strip_prefix": "client_model-0.6.2",
-              "build_file_content": "\nload(\"@envoy_api//bazel:api_build_system.bzl\", \"api_cc_py_proto_library\")\nload(\"@io_bazel_rules_go//proto:def.bzl\", \"go_proto_library\")\n\napi_cc_py_proto_library(\n    name = \"client_model\",\n    srcs = [\n        \"io/prometheus/client/metrics.proto\",\n    ],\n    visibility = [\"//visibility:public\"],\n)\n\ngo_proto_library(\n    name = \"client_model_go_proto\",\n    importpath = \"github.com/prometheus/client_model/go\",\n    proto = \":client_model\",\n    visibility = [\"//visibility:public\"],\n)\n"
-            }
-          }
-        }
+        },
+        "recordedRepoMappingEntries": []
       }
     },
     "@@googleapis+//:extensions.bzl%switched_rules": {


### PR DESCRIPTION
This migration replaces the legacy 'rbe_preconfig' rule with the new dynamic RBE toolchain generator ('rbe_config') provided by the unreleased 'bazel_ci_rules' v2.0.0 module extension.

We are dogfooding the unreleased 'bazel_ci_rules' from bazelbuild/continuous-integration master branch (integrated via git_override) to test and validate the dynamic toolchain generation rule under live conditions for both the Bazel repository builds and our downstream CI pipelines. This ensures the dynamic generator is fully robust across major Bazel versions (including Bazel 9.x/master and 8.x) before its official release.

Disabling more tests around sandbox since they are currently broken on RBE.

PiperOrigin-RevId: 921469827
Change-Id: Ib96019763e448491b30e261df363c11dd6e5adc6

Commit https://github.com/bazelbuild/bazel/commit/c7268b24d2b33abb1de8baa12bc86b4513e58cb8 and https://github.com/bazelbuild/bazel/commit/1a04a7b58cb55b80f4968fe5485fab55dca8f608 