### PR TITLE
Support `_` separators in Starlark number literals

### DIFF
--- a/src/main/java/net/starlark/java/eval/MethodLibrary.java
+++ b/src/main/java/net/starlark/java/eval/MethodLibrary.java
@@ -522,6 +522,7 @@ class MethodLibrary {
         default:
           // finite
           try {
+            // TODO: Add support for PEP 515 underscores - they are already supported in literals.
             d = Double.parseDouble(s);
             if (!Double.isFinite(d)) {
               // parseDouble accepts signed "NaN" and "Infinity" (case sensitive)
@@ -621,6 +622,7 @@ class MethodLibrary {
     if (x instanceof String) {
       int base = baseO == Starlark.UNBOUND ? 10 : Starlark.toInt(baseO, "base");
       try {
+        // TODO: Add support for PEP 515 underscores - they are already supported in literals.
         return StarlarkInt.parse((String) x, base);
       } catch (NumberFormatException ex) {
         throw Starlark.errorf("%s", ex.getMessage());

--- a/src/main/java/net/starlark/java/syntax/IntLiteral.java
+++ b/src/main/java/net/starlark/java/syntax/IntLiteral.java
@@ -92,6 +92,11 @@ public final class IntLiteral extends Expression {
           radix = 8;
           str = str.substring(2);
           break;
+        case 'b':
+        case 'B':
+          radix = 2;
+          str = str.substring(2);
+          break;
         default:
           throw new NumberFormatException(
               "invalid octal literal: " + str + " (use '0o" + str.substring(1) + "')");

--- a/src/main/java/net/starlark/java/syntax/IntLiteral.java
+++ b/src/main/java/net/starlark/java/syntax/IntLiteral.java
@@ -73,12 +73,13 @@ public final class IntLiteral extends Expression {
   /**
    * Returns the value denoted by a non-negative integer literal with an optional base prefix (but
    * no +/- sign), using the narrowest type of Integer, Long, or BigInteger capable of exactly
-   * representing the value.
+   * representing the value. PEP 515 '_' separators are ignored.
    *
    * @throws NumberFormatException if the string is not a valid literal.
    */
   public static Number scan(String str) {
     String orig = str;
+    str = str.replace("_", ""); // strip PEP 515 digit group separators
     int radix = 10;
     if (str.length() > 1 && str.charAt(0) == '0') {
       switch (str.charAt(1)) {

--- a/src/main/java/net/starlark/java/syntax/IntLiteral.java
+++ b/src/main/java/net/starlark/java/syntax/IntLiteral.java
@@ -73,7 +73,8 @@ public final class IntLiteral extends Expression {
   /**
    * Returns the value denoted by a non-negative integer literal with an optional base prefix (but
    * no +/- sign), using the narrowest type of Integer, Long, or BigInteger capable of exactly
-   * representing the value. PEP 515 '_' separators are ignored.
+   * representing the value. PEP 515 '_' separators are ignored and callers must ensure that they
+   * are valid if present (i.e., no leading/trailing/consecutive separators).
    *
    * @throws NumberFormatException if the string is not a valid literal.
    */

--- a/src/main/java/net/starlark/java/syntax/Lexer.java
+++ b/src/main/java/net/starlark/java/syntax/Lexer.java
@@ -934,18 +934,22 @@ final class Lexer {
 
       } else if (c == 'o' || c == 'O') {
         // octal
+        // Scan decimal, not just octal, digits so that a digit invalid in base 8 makes the whole
+        // literal invalid ("0o777999" is an error, not the two tokens "0o777" and "999"); it is
+        // reported by IntLiteral.scan below.
         c = next();
         int digitsStart = pos;
-        c = scanDigits(c, Lexer::isodigit, /* leadingSeparatorOk= */ true);
+        c = scanDigits(c, Lexer::isdigit, /* leadingSeparatorOk= */ true);
         if (pos == digitsStart) {
           error("invalid octal literal", start);
         }
 
       } else if (c == 'b' || c == 'B') {
         // binary
+        // As for octal, scan decimal digits and let IntLiteral.scan report invalid ones.
         c = next();
         int digitsStart = pos;
-        c = scanDigits(c, Lexer::isbdigit, /* leadingSeparatorOk= */ true);
+        c = scanDigits(c, Lexer::isdigit, /* leadingSeparatorOk= */ true);
         if (pos == digitsStart) {
           error("invalid binary literal", start);
         }
@@ -1005,7 +1009,7 @@ final class Lexer {
 
     // int
     setToken(TokenKind.INT, start, pos);
-    String literal = bufferSlice(start, pos).replace("_", "");
+    String literal = bufferSlice(start, pos);
     Number value = 0;
     try {
       value = IntLiteral.scan(literal);
@@ -1038,14 +1042,6 @@ final class Lexer {
 
   private static boolean isxdigit(int c) {
     return isdigit(c) || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f');
-  }
-
-  private static boolean isodigit(int c) {
-    return '0' <= c && c <= '7';
-  }
-
-  private static boolean isbdigit(int c) {
-    return c == '0' || c == '1';
   }
 
   /**

--- a/src/main/java/net/starlark/java/syntax/Lexer.java
+++ b/src/main/java/net/starlark/java/syntax/Lexer.java
@@ -459,7 +459,7 @@ final class Lexer {
               // There was a CRLF after the newline. No shortcut possible, since it needs to be
               // transformed into a single LF.
               pos = contentStartPos;
-              escapedStringLiteral(quot, /* leadingSeparatorOk= */ true);
+              escapedStringLiteral(quot, true);
               return;
             } else {
               pos++;
@@ -468,7 +468,7 @@ final class Lexer {
           }
           // oops, hit an escape, need to start over & build a new string buffer
           pos = contentStartPos;
-          escapedStringLiteral(quot, /* leadingSeparatorOk= */ false);
+          escapedStringLiteral(quot, false);
           return;
         case '\'':
         case '"':
@@ -848,7 +848,7 @@ final class Lexer {
           break;
         case '\'':
         case '\"':
-          stringLiteral(c, /* leadingSeparatorOk= */ false);
+          stringLiteral(c, false);
           break;
         default:
           // detect raw strings, e.g. r"str"
@@ -856,7 +856,7 @@ final class Lexer {
             int c0 = peek(0);
             if (c0 == '\'' || c0 == '\"') {
               pos++;
-              stringLiteral((char) c0, /* leadingSeparatorOk= */ true);
+              stringLiteral((char) c0, true);
               break;
             }
           }

--- a/src/main/java/net/starlark/java/syntax/Lexer.java
+++ b/src/main/java/net/starlark/java/syntax/Lexer.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
+import java.util.function.IntPredicate;
 
 /** A scanner for Starlark. */
 final class Lexer {
@@ -458,7 +459,7 @@ final class Lexer {
               // There was a CRLF after the newline. No shortcut possible, since it needs to be
               // transformed into a single LF.
               pos = contentStartPos;
-              escapedStringLiteral(quot, true);
+              escapedStringLiteral(quot, /* leadingSeparatorOk= */ true);
               return;
             } else {
               pos++;
@@ -467,7 +468,7 @@ final class Lexer {
           }
           // oops, hit an escape, need to start over & build a new string buffer
           pos = contentStartPos;
-          escapedStringLiteral(quot, false);
+          escapedStringLiteral(quot, /* leadingSeparatorOk= */ false);
           return;
         case '\'':
         case '"':
@@ -847,7 +848,7 @@ final class Lexer {
           break;
         case '\'':
         case '\"':
-          stringLiteral(c, false);
+          stringLiteral(c, /* leadingSeparatorOk= */ false);
           break;
         default:
           // detect raw strings, e.g. r"str"
@@ -855,7 +856,7 @@ final class Lexer {
             int c0 = peek(0);
             if (c0 == '\'' || c0 == '\"') {
               pos++;
-              stringLiteral((char) c0, true);
+              stringLiteral((char) c0, /* leadingSeparatorOk= */ true);
               break;
             }
           }
@@ -925,35 +926,33 @@ final class Lexer {
       } else if (c == 'x' || c == 'X') {
         // hex
         c = next();
-        if (!isxdigit(c)) {
+        int digitsStart = pos;
+        c = scanDigits(c, Lexer::isxdigit, /* leadingSeparatorOk= */ true);
+        if (pos == digitsStart) {
           error("invalid hex literal", start);
-        }
-        while (isxdigit(c)) {
-          c = next();
         }
 
       } else if (c == 'o' || c == 'O') {
         // octal
         c = next();
-        while (isdigit(c)) {
-          c = next();
+        int digitsStart = pos;
+        c = scanDigits(c, Lexer::isodigit, /* leadingSeparatorOk= */ true);
+        if (pos == digitsStart) {
+          error("invalid octal literal", start);
         }
 
       } else if (c == 'b' || c == 'B') {
         // binary
         c = next();
-        if (!isbdigit(c)) {
+        int digitsStart = pos;
+        c = scanDigits(c, Lexer::isbdigit, /* leadingSeparatorOk= */ true);
+        if (pos == digitsStart) {
           error("invalid binary literal", start);
-        }
-        while (isbdigit(c)) {
-          c = next();
         }
 
       } else {
         // "0" or float or obsolete octal "0755"
-        while (isdigit(c)) {
-          c = next();
-        }
+        c = scanDigits(c, Lexer::isdigit, /* leadingSeparatorOk= */ true);
         if (c == '.') {
           fraction = true;
         } else if (c == 'e' || c == 'E') {
@@ -963,9 +962,7 @@ final class Lexer {
 
     } else {
       // decimal
-      while (isdigit(c)) {
-        c = next();
-      }
+      c = scanDigits(c, Lexer::isdigit, /* leadingSeparatorOk= */ false);
       if (c == '.') {
         fraction = true;
       } else if (c == 'e' || c == 'E') {
@@ -975,9 +972,7 @@ final class Lexer {
 
     if (fraction) {
       c = next(); // consume '.'
-      while (isdigit(c)) {
-        c = next();
-      }
+      c = scanDigits(c, Lexer::isdigit, /* leadingSeparatorOk= */ false);
 
       if (c == 'e' || c == 'E') {
         exponent = true;
@@ -989,9 +984,7 @@ final class Lexer {
       if (c == '+' || c == '-') {
         c = next();
       }
-      while (isdigit(c)) {
-        c = next();
-      }
+      c = scanDigits(c, Lexer::isdigit, /* leadingSeparatorOk= */ false);
     }
 
     // float?
@@ -999,7 +992,7 @@ final class Lexer {
       setToken(TokenKind.FLOAT, start, pos);
       double value = 0.0;
       try {
-        value = Double.parseDouble(bufferSlice(start, pos));
+        value = Double.parseDouble(bufferSlice(start, pos).replace("_", ""));
         if (!Double.isFinite(value)) {
           error("floating-point literal too large", start);
         }
@@ -1012,7 +1005,7 @@ final class Lexer {
 
     // int
     setToken(TokenKind.INT, start, pos);
-    String literal = bufferSlice(start, pos);
+    String literal = bufferSlice(start, pos).replace("_", "");
     Number value = 0;
     try {
       value = IntLiteral.scan(literal);
@@ -1022,12 +1015,33 @@ final class Lexer {
     setValue(value);
   }
 
+  // Consumes a maximal run of digits (accepted by isDigit) interspersed with PEP 515 '_' separators
+  // between digits, e.g. "1_000". When leadingSeparatorOk, a '_' may also appear before the first
+  // digit, as it may right after a base prefix ("0x_ff"). Returns the first character past the run.
+  private int scanDigits(int c, IntPredicate isDigit, boolean leadingSeparatorOk) {
+    boolean afterDigit = leadingSeparatorOk;
+    while (true) {
+      if (isDigit.test(c)) {
+        afterDigit = true;
+      } else if (c == '_' && afterDigit && isDigit.test(peek(1))) {
+        afterDigit = false;
+      } else {
+        return c;
+      }
+      c = next();
+    }
+  }
+
   private static boolean isdigit(int c) {
     return '0' <= c && c <= '9';
   }
 
   private static boolean isxdigit(int c) {
     return isdigit(c) || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f');
+  }
+
+  private static boolean isodigit(int c) {
+    return '0' <= c && c <= '7';
   }
 
   private static boolean isbdigit(int c) {

--- a/src/test/java/net/starlark/java/eval/testdata/float.star
+++ b/src/test/java/net/starlark/java/eval/testdata/float.star
@@ -338,3 +338,9 @@ assert_fails(lambda: (1<<500<<500<<500) // 1.0, "int too large to convert to flo
 assert_fails(lambda: 1.0 // (1<<500<<500<<500), "int too large to convert to float")
 assert_fails(lambda: (1<<500<<500<<500) % 1.0, "int too large to convert to float")
 assert_fails(lambda: 1.0 % (1<<500<<500<<500), "int too large to convert to float")
+
+# PEP 515: underscores as digit-group separators in float literals
+assert_eq(1_000.5, 1000.5)
+assert_eq(1_0.0_1, 10.01)
+assert_eq(1_0e1_0, 1e11)
+assert_eq(3.14_15, 3.1415)

--- a/src/test/java/net/starlark/java/eval/testdata/int.star
+++ b/src/test/java/net/starlark/java/eval/testdata/int.star
@@ -351,3 +351,15 @@ assert_eq(((0x1010 << 100) | (0x1100 << 100)) >> 100, 0x1110)
 assert_eq(((0x1010 << 100) ^ (0x1100 << 100)) >> 100, 0x0110)
 assert_eq(((0x1010 << 100) & (0x1100 << 100)) >> 100, 0x1000)
 assert_eq(~((~(0x1010 << 100)) >> 100), 0x1010)
+
+# binary literals
+assert_eq(0b1010, 10)
+assert_eq(0B1101, 13)
+
+# PEP 515: underscores as digit-group separators in int literals
+assert_eq(1_000_000, 1000000)
+assert_eq(0xFF_FF, 65535)
+assert_eq(0x_FF, 255)
+assert_eq(0o7_7_7, 511)
+assert_eq(0b1010_1010, 170)
+assert_eq(1_000_000_000_000_000_000_000, 1000000000000000000000)

--- a/src/test/java/net/starlark/java/syntax/LexerTest.java
+++ b/src/test/java/net/starlark/java/syntax/LexerTest.java
@@ -346,6 +346,8 @@ public class LexerTest {
     check("1_0.0_1", "FLOAT(10.01) NEWLINE EOF");
     check("1_0e1_0", "FLOAT(1.0E11) NEWLINE EOF");
     check("1.5e1_0", "FLOAT(1.5E10) NEWLINE EOF");
+    check("1.5e+1_0", "FLOAT(1.5E10) NEWLINE EOF");
+    check("1.5e-1_0", "FLOAT(1.5E-10) NEWLINE EOF");
 
     // A leading underscore is an identifier, not a number.
     check("_100", "IDENTIFIER(_100) NEWLINE EOF");
@@ -361,6 +363,8 @@ public class LexerTest {
     check("1_.5", "INT(1) IDENTIFIER(_) FLOAT(0.5) NEWLINE EOF");
     check("1._5", "FLOAT(1.0) IDENTIFIER(_5) NEWLINE EOF");
     checkErrors("1e_5", "FLOAT(0.0) IDENTIFIER(_5) NEWLINE EOF", "^ invalid float literal");
+    checkErrors("1e+_5", "FLOAT(0.0) IDENTIFIER(_5) NEWLINE EOF", "^ invalid float literal");
+    checkErrors("1e-_5", "FLOAT(0.0) IDENTIFIER(_5) NEWLINE EOF", "^ invalid float literal");
     check("1_e5", "INT(1) IDENTIFIER(_e5) NEWLINE EOF");
   }
 

--- a/src/test/java/net/starlark/java/syntax/LexerTest.java
+++ b/src/test/java/net/starlark/java/syntax/LexerTest.java
@@ -274,7 +274,10 @@ public class LexerTest {
     // binary
     check("0b101-", "INT(5) MINUS NEWLINE EOF");
     check("0B1101", "INT(13) NEWLINE EOF");
-    check("0b1012", "INT(5) INT(2) NEWLINE EOF"); // '2' terminates the binary literal
+    checkErrors(
+        "0b1012", // '2' is not a valid binary digit
+        "INT(0) NEWLINE EOF",
+        "^ invalid base-2 integer literal: 0b1012");
     checkErrors(
         "0b", //
         "INT(0) NEWLINE EOF",
@@ -285,7 +288,10 @@ public class LexerTest {
     check("0o12345-", "INT(5349) MINUS NEWLINE EOF");
     check("0O77", "INT(63) NEWLINE EOF");
     check("0o1o2349-", "INT(1) IDENTIFIER(o2349) MINUS NEWLINE EOF");
-    check("0o12349-", "INT(668) INT(9) MINUS NEWLINE EOF"); // '9' terminates the octal literal
+    checkErrors(
+        "0o12349-", // '9' is not a valid octal digit
+        "INT(0) MINUS NEWLINE EOF",
+        "^ invalid base-8 integer literal: 0o12349");
     checkErrors(
         "0o", //
         "INT(0) NEWLINE EOF",
@@ -343,6 +349,11 @@ public class LexerTest {
 
     // A leading underscore is an identifier, not a number.
     check("_100", "IDENTIFIER(_100) NEWLINE EOF");
+
+    // A digit invalid in the literal's base is an error, not the start of a new token,
+    // even when separated from the valid digits by an underscore.
+    checkErrors("0b1_2", "INT(0) NEWLINE EOF", "^ invalid base-2 integer literal: 0b1_2");
+    checkErrors("0o7_8", "INT(0) NEWLINE EOF", "^ invalid base-8 integer literal: 0o7_8");
 
     // A misplaced underscore terminates the number, like any other non-digit.
     check("1__0", "INT(1) IDENTIFIER(__0) NEWLINE EOF");

--- a/src/test/java/net/starlark/java/syntax/LexerTest.java
+++ b/src/test/java/net/starlark/java/syntax/LexerTest.java
@@ -240,6 +240,7 @@ public class LexerTest {
     checkErrors(
         "0or()",
         "INT(0) IDENTIFIER(r) LPAREN RPAREN NEWLINE EOF",
+        "^ invalid octal literal",
         "^ invalid base-8 integer literal: 0o");
   }
 
@@ -270,19 +271,25 @@ public class LexerTest {
     // decimal
     check("12345-", "INT(12345) MINUS NEWLINE EOF");
 
-    // TODO(adonovan): add tests for 0b binary literals
+    // binary
+    check("0b101-", "INT(5) MINUS NEWLINE EOF");
+    check("0B1101", "INT(13) NEWLINE EOF");
+    check("0b1012", "INT(5) INT(2) NEWLINE EOF"); // '2' terminates the binary literal
+    checkErrors(
+        "0b", //
+        "INT(0) NEWLINE EOF",
+        "^ invalid binary literal",
+        "^ invalid base-2 integer literal: 0b");
 
     // octal
     check("0o12345-", "INT(5349) MINUS NEWLINE EOF");
     check("0O77", "INT(63) NEWLINE EOF");
     check("0o1o2349-", "INT(1) IDENTIFIER(o2349) MINUS NEWLINE EOF");
-    checkErrors(
-        "0o12349-", //
-        "INT(0) MINUS NEWLINE EOF",
-        "^ invalid base-8 integer literal: 0o12349");
+    check("0o12349-", "INT(668) INT(9) MINUS NEWLINE EOF"); // '9' terminates the octal literal
     checkErrors(
         "0o", //
         "INT(0) NEWLINE EOF",
+        "^ invalid octal literal",
         "^ invalid base-8 integer literal: 0o");
     checkErrors(
         "012345", //
@@ -304,6 +311,46 @@ public class LexerTest {
     check(
         "123456789123456789123456789 0xABCDEFABCDEFABCDEFABCDEFABCDEF",
         "INT(123456789123456789123456789) INT(892059645479943313385225296292859375) NEWLINE EOF");
+  }
+
+  @Test
+  public void testUnderscoresInNumbers() throws Exception {
+    // PEP 515: single underscores may separate digits.
+
+    // decimal (MINUS proves we don't over-consume)
+    check("1_000_000", "INT(1000000) NEWLINE EOF");
+    check("1_2-", "INT(12) MINUS NEWLINE EOF");
+    check("123_456_789_123_456_789_123", "INT(123456789123456789123) NEWLINE EOF");
+
+    // hex (last case: separator right after the base prefix)
+    check("0xFF_FF", "INT(65535) NEWLINE EOF");
+    check("0xA_B_C", "INT(2748) NEWLINE EOF");
+    check("0x_FF", "INT(255) NEWLINE EOF");
+
+    // octal
+    check("0o1_2345", "INT(5349) NEWLINE EOF");
+    check("0o_77", "INT(63) NEWLINE EOF");
+
+    // binary
+    check("0b1010_1010", "INT(170) NEWLINE EOF");
+    check("0b_1111", "INT(15) NEWLINE EOF");
+
+    // float
+    check("1_000.5", "FLOAT(1000.5) NEWLINE EOF");
+    check("1_0.0_1", "FLOAT(10.01) NEWLINE EOF");
+    check("1_0e1_0", "FLOAT(1.0E11) NEWLINE EOF");
+    check("1.5e1_0", "FLOAT(1.5E10) NEWLINE EOF");
+
+    // A leading underscore is an identifier, not a number.
+    check("_100", "IDENTIFIER(_100) NEWLINE EOF");
+
+    // A misplaced underscore terminates the number, like any other non-digit.
+    check("1__0", "INT(1) IDENTIFIER(__0) NEWLINE EOF");
+    check("1_0_", "INT(10) IDENTIFIER(_) NEWLINE EOF");
+    check("1_.5", "INT(1) IDENTIFIER(_) FLOAT(0.5) NEWLINE EOF");
+    check("1._5", "FLOAT(1.0) IDENTIFIER(_5) NEWLINE EOF");
+    checkErrors("1e_5", "FLOAT(0.0) IDENTIFIER(_5) NEWLINE EOF", "^ invalid float literal");
+    check("1_e5", "INT(1) IDENTIFIER(_e5) NEWLINE EOF");
   }
 
   @Test


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
Adds support for `1_000_000` style separator in Starlark ints and floats.

Along the way, completes the support for binary literals, which were supported by the lexer but not by `IntLiteral`.

### Motivation
This matches PEP 515 and makes larger decimal literals (e.g. for resource constraints) easier to read.

### Build API Changes
Yes, it faithfully implements a Python language features (PEP 515) that has very small API surface.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes


RELNOTES[NEW]: Starlark supports `0b/0B` binary int literals.
RELNOTES[NEW]: Starlark supports PEP 515 style int separators (e.g. `1_000_000`).
