### PR TITLE
[8.8.0] Fix `Attribute.valueToStarlark` to corretcly handle `TriState` values.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/Attribute.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Attribute.java
@@ -2422,7 +2422,7 @@ public final class Attribute implements Comparable<Attribute> {
       return StarlarkList.immutableCopyOf(set);
     } else if (x instanceof TriState triState) {
       // Convert TriState to integer (same as in query output and native.existing_rules())
-      return triState.toInt();
+      return Starlark.fromJava(triState.toInt(), /* mutability= */ null);
     }
 
     // For all other attribute values, shallow conversion is safe.


### PR DESCRIPTION
They need to be convetred to **starlark** ints, not **Java** ints.

PiperOrigin-RevId: 726183302
Change-Id: I885f5895fea04420224d2e7457d84bb879fa57db

Fix #29782.
