### PR TITLE
Ensure that transitive packages can be flattened efficiently

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/Package.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Package.java
@@ -1376,7 +1376,14 @@ public class Package extends Packageoid {
     }
   }
 
-  /** A collection of data that is known before BUILD file evaluation even begins. */
+  /**
+   * A collection of data that is known before BUILD file evaluation even begins.
+   *
+   * <p><b>Important:</b> Tracking of transitive packages relies on a {@link
+   * com.google.devtools.build.lib.collect.nestedset.NestedSet<Metadata>}, so this class must have a
+   * cheap {@link #hashCode()}. Some fields, such as {@link #repositoryMapping}, would be cheap to
+   * hash for Blaze but not Bazel.
+   */
   // TODO(bazel-team): move to Packageoid.java or to its own file to reduce size of Package.java?
   @AutoCodec
   public record Metadata(
@@ -1393,6 +1400,13 @@ public class Package extends Packageoid {
       @Nullable ConfigSettingVisibilityPolicy configSettingVisibilityPolicy,
       boolean succinctTargetNotFoundErrors,
       Root sourceRoot) {
+
+    // See class-level Javadoc for an explanation of why we need this.
+    @Override
+    public int hashCode() {
+      // Within a single build a package is uniquely identified by its PackageIdentifier.
+      return packageIdentifier.hashCode();
+    }
 
     public static Builder builder() {
       return new AutoBuilder_Package_Metadata_Builder();


### PR DESCRIPTION
### Description
Transitive package tracking relies on a `NestedSet<Package.Metadata>`, so `Package.Metadata`'s `hashCode` should be as efficient as possible. Since a package within a single build is uniquely identified by its `PackageIdentifier`, which already has a precomputed `hashCode`, hashing only this field is effectively optimal.

### Motivation
Fixes #29594 and avoids future regressions even if new fields are added.


### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Fixed a performance regression in Bazel 9 that causes `RepoMappingManifest` actions to consume a lot of CPU time.
