### PR TITLE
Remove legacy list of mnemonics that supports path mapping.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/PathMappers.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/PathMappers.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.lib.analysis.actions;
 
 
-import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.AbstractAction;
 import com.google.devtools.build.lib.actions.ActionAnalysisMetadata;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
@@ -39,27 +38,6 @@ import javax.annotation.Nullable;
  * PathMapper}).
  */
 public final class PathMappers {
-
-  // TODO: Remove actions from this list by adding ExecutionRequirements.SUPPORTS_PATH_MAPPING to
-  //  their execution info instead.
-  private static final ImmutableSet<String> SUPPORTED_MNEMONICS =
-      ImmutableSet.of(
-          "AndroidLint",
-          "CompileAndroidResources",
-          "DeJetify",
-          "DejetifySrcs",
-          "Desugar",
-          "DexBuilder",
-          "Jetify",
-          "JetifySrcs",
-          "LinkAndroidResources",
-          "MergeAndroidAssets",
-          "MergeManifests",
-          "ParseAndroidResources",
-          "StarlarkAARGenerator",
-          "StarlarkMergeCompiledAndroidResources",
-          "StarlarkRClassGenerator",
-          "Mock action");
 
   /**
    * Actions that support path mapping should call this method from {@link
@@ -157,8 +135,7 @@ public final class PathMappers {
       return OutputPathsMode.OFF;
     }
     if (outputPathsMode == OutputPathsMode.STRIP
-        && (SUPPORTED_MNEMONICS.contains(mnemonic)
-            || executionInfo.containsKey(ExecutionRequirements.SUPPORTS_PATH_MAPPING))) {
+        && executionInfo.containsKey(ExecutionRequirements.SUPPORTS_PATH_MAPPING)) {
       return OutputPathsMode.STRIP;
     }
     return OutputPathsMode.OFF;


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description

Remove legacy list of mnemonics that supports path mapping.


### Motivation
The new way to opt into output mapping should be through execution requirements: 
`modify_execution_info=<ACTION_NAME>=-supports-path-mapping`. By keeping this list alive, there is actually no way for these existing actions to opt-out as well.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Any existing action relying on the legacy hardcoded list in Bazel code being populated will now need to opt-into output mapping by modifying their execution requirements.
