### PR TITLE
[9.2.0] Ensure that transitive packages can be flattened efficiently (https://github.com/bazelbuild/bazel/pull/29800)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/Package.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Package.java
@@ -1376,7 +1376,14 @@ public class Package extends Packageoid {
     }
   }
 
-  /** A collection of data that is known before BUILD file evaluation even begins. */
+  /**
+   * A collection of data that is known before BUILD file evaluation even begins.
+   *
+   * <p><b>Important:</b> Tracking of transitive packages relies on a {@link
+   * com.google.devtools.build.lib.collect.nestedset.NestedSet<Metadata>}, so this class must have a
+   * cheap {@link #hashCode()}. Some fields, such as {@link #repositoryMapping}, would be cheap to
+   * hash for Blaze but not Bazel.
+   */
   // TODO(bazel-team): move to Packageoid.java or to its own file to reduce size of Package.java?
   @AutoCodec
   public record Metadata(
@@ -1393,6 +1400,13 @@ public class Package extends Packageoid {
       @Nullable ConfigSettingVisibilityPolicy configSettingVisibilityPolicy,
       boolean succinctTargetNotFoundErrors,
       Root sourceRoot) {
+
+    // See class-level Javadoc for an explanation of why we need this.
+    @Override
+    public int hashCode() {
+      // Within a single build a package is uniquely identified by its PackageIdentifier.
+      return packageIdentifier.hashCode();
+    }
 
     public static Builder builder() {
       return new AutoBuilder_Package_Metadata_Builder();


### PR DESCRIPTION
Transitive package tracking relies on a `NestedSet<Package.Metadata>`, so `Package.Metadata`'s `hashCode` should be as efficient as possible. Since a package within a single build is uniquely identified by its `PackageIdentifier`, which already has a precomputed `hashCode`, hashing only this field is effectively optimal.

Fixes #29594 and avoids future regressions even if new fields are added.

RELNOTES: Fixed a performance regression in Bazel 9 that causes `RepoMappingManifest` actions to consume a lot of CPU time.

Closes #29800.

PiperOrigin-RevId: 930047392
Change-Id: I23ae2d87621baabdcd2632d38bfaca3ec667d00f

Commit https://github.com/bazelbuild/bazel/commit/cc52973b642f03ca6c4d6e6cb0542e7efb5dcb26