### PR TITLE
[9.2.0] Add support for config_settings in target_compatible_with

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/target_compatible_with.html
+++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/target_compatible_with.html
@@ -5,12 +5,15 @@ List of <a href="${link build-ref#labels}">labels</a>; default is <code>[]</code
 <p>
 A list of
 <code><a href="platforms-and-toolchains.html#constraint_value">constraint_value</a></code>s
-that must be present in the target platform for this target to be considered
+that must be present in the target platform and
+<code><a href="general.html#config_setting">config_setting</a></code>s that
+must match the target configuration for this target to be considered
 <em>compatible</em>. This is in addition to any constraints already set by the
-rule type. If the target platform does not satisfy all listed constraints then
-the target is considered <em>incompatible</em>. Incompatible targets are
-skipped for building and testing when the target pattern is expanded
-(e.g. <code>//...</code>, <code>:all</code>). When explicitly specified on the
+rule type. If the target platform does not satisfy all listed constraints, or
+the target configuration does not match all listed config_settings, then the
+target is considered <em>incompatible</em>. Incompatible targets are skipped
+for building and testing when the target pattern is expanded (e.g.
+<code>//...</code>, <code>:all</code>). When explicitly specified on the
 command line, incompatible targets cause Bazel to print an error and cause a
 build or test failure.
 </p>

--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1677,6 +1677,7 @@ java_library(
         ":visibility_provider",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:build_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:config_conditions",
+        "//src/main/java/com/google/devtools/build/lib/analysis/config:config_matching_provider",
         "//src/main/java/com/google/devtools/build/lib/analysis/platform",
         "//src/main/java/com/google/devtools/build/lib/analysis/platform:utils",
         "//src/main/java/com/google/devtools/build/lib/cmdline",

--- a/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
@@ -28,6 +28,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
 import com.google.devtools.build.lib.analysis.config.ExecutionTransitionFactory;
 import com.google.devtools.build.lib.analysis.config.RunUnder.LabelRunUnder;
 import com.google.devtools.build.lib.analysis.config.transitions.NoConfigTransition;
@@ -328,6 +329,7 @@ public class BaseRuleClasses {
           // has to be excluded in `IncompatibleTargetChecker`.
           .add(
               attr(RuleClass.TARGET_COMPATIBLE_WITH_ATTR, LABEL_LIST)
+                  .mandatoryBuiltinProviders(ImmutableList.of(ConfigMatchingProvider.class))
                   .mandatoryProviders(ConstraintValueInfo.PROVIDER.id())
                   // This should be configurable to allow for complex types of restrictions.
                   .tool(

--- a/src/main/java/com/google/devtools/build/lib/analysis/IncompatiblePlatformProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/IncompatiblePlatformProvider.java
@@ -38,28 +38,35 @@ import javax.annotation.Nullable;
  * <p>This provider is able to keep track of _why_ the corresponding target is considered
  * incompatible. If the target is incompatible because the target platform didn't satisfy one of the
  * constraints in target_compatible_with, then all the relevant constraints are accessible via
- * {@code getConstraintsResponsibleForIncompatibility()}. On the other hand, if the corresponding
- * target is incompatible because one of its dependencies is incompatible, then all the incompatible
+ * {@code getConstraintsResponsibleForIncompatibility()}. If the target is incompatible because one
+ * of the <code>config_setting</code> targets in target_compatible_with didn't match, then all the
+ * relevant config_setting labels are accessible via {@code
+ * getConfigSettingsResponsibleForIncompatibility()}. On the other hand, if the corresponding target
+ * is incompatible because one of its dependencies is incompatible, then all the incompatible
  * dependencies are available via {@code getTargetResponsibleForIncompatibility()}.
  *
  * @param targetPlatform Returns the target platform of the target that was incompatible.
  * @param targetsResponsibleForIncompatibility Returns the incompatible dependencies that caused
  *     this provider to be present.
- *     <p>This may be null. If it is null, then {@code
- *     getConstraintsResponsibleForIncompatibility()} is guaranteed to be non-null. It will have at
- *     least one element in it if it is not null.
+ *     <p>This may be null. If it is null, then at least one of {@code
+ *     getConstraintsResponsibleForIncompatibility()} and {@code
+ *     getConfigSettingsResponsibleForIncompatibility()} is guaranteed to be non-null. It will have
+ *     at least one element in it if it is not null.
  * @param constraintsResponsibleForIncompatibility Returns the constraints that the target platform
  *     didn't satisfy.
- *     <p>This may be null. If it is null, then {@code getTargetsResponsibleForIncompatibility()} is
- *     guaranteed to be non-null. It will have at least one element in it if it is not null.
+ *     <p>This may be null. It will have at least one element in it if it is not null.
  *     <p>The list is sorted based on the stringified label of each constraint.
+ * @param configSettingsResponsibleForIncompatibility Returns the config_settings that didn't match.
+ *     <p>This may be null. It will have at least one element in it if it is not null.
+ *     <p>The list is sorted based on the stringified label of each config_setting.
  */
 @Immutable
 @AutoCodec
 public record IncompatiblePlatformProvider(
     @Nullable Label targetPlatform,
     @Nullable ImmutableList<ConfiguredTarget> targetsResponsibleForIncompatibility,
-    @Nullable ImmutableList<ConstraintValueInfo> constraintsResponsibleForIncompatibility)
+    @Nullable ImmutableList<ConstraintValueInfo> constraintsResponsibleForIncompatibility,
+    @Nullable ImmutableList<Label> configSettingsResponsibleForIncompatibility)
     implements Info, IncompatiblePlatformProviderApi {
   /** Name used in Starlark for accessing this provider. */
   public static final String STARLARK_NAME = "IncompatiblePlatformProvider";
@@ -80,13 +87,28 @@ public record IncompatiblePlatformProvider(
     Preconditions.checkNotNull(targetsResponsibleForIncompatibility);
     Preconditions.checkArgument(!targetsResponsibleForIncompatibility.isEmpty());
     return new IncompatiblePlatformProvider(
-        targetPlatform, targetsResponsibleForIncompatibility, null);
+        targetPlatform, targetsResponsibleForIncompatibility, null, null);
   }
 
   public static IncompatiblePlatformProvider incompatibleDueToConstraints(
       @Nullable Label targetPlatform, ImmutableList<ConstraintValueInfo> constraints) {
+    return incompatibleDueToConstraintsAndConfigSettings(
+        targetPlatform, constraints, ImmutableList.of());
+  }
+
+  public static IncompatiblePlatformProvider incompatibleDueToConfigSettings(
+      @Nullable Label targetPlatform, ImmutableList<Label> configSettings) {
+    return incompatibleDueToConstraintsAndConfigSettings(
+        targetPlatform, ImmutableList.of(), configSettings);
+  }
+
+  public static IncompatiblePlatformProvider incompatibleDueToConstraintsAndConfigSettings(
+      @Nullable Label targetPlatform,
+      ImmutableList<ConstraintValueInfo> constraints,
+      ImmutableList<Label> configSettings) {
     Preconditions.checkNotNull(constraints);
-    Preconditions.checkArgument(!constraints.isEmpty());
+    Preconditions.checkNotNull(configSettings);
+    Preconditions.checkArgument(!constraints.isEmpty() || !configSettings.isEmpty());
 
     // Deduplicate and sort the list of incompatible constraints. Doing it here means that everyone
     // inspecting this provider doesn't have to deal with it.
@@ -96,7 +118,17 @@ public record IncompatiblePlatformProvider(
             .distinct()
             .collect(toImmutableList());
 
-    return new IncompatiblePlatformProvider(targetPlatform, null, constraints);
+    configSettings =
+        configSettings.stream()
+            .sorted(Comparator.naturalOrder())
+            .distinct()
+            .collect(toImmutableList());
+
+    return new IncompatiblePlatformProvider(
+        targetPlatform,
+        null,
+        constraints.isEmpty() ? null : constraints,
+        configSettings.isEmpty() ? null : configSettings);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/IncompatibleTargetChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/IncompatibleTargetChecker.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.analysis.constraints;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.stream.Collectors.joining;
 
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
@@ -30,6 +31,8 @@ import com.google.devtools.build.lib.analysis.TransitiveInfoProviderMapBuilder;
 import com.google.devtools.build.lib.analysis.VisibilityProvider;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.ConfigConditions;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider.AccumulateResults;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
 import com.google.devtools.build.lib.analysis.platform.ConstraintCollection;
 import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
@@ -65,7 +68,8 @@ import javax.annotation.Nullable;
  *
  * <ol>
  *   <li>The target's <code>target_compatible_with</code> attribute specifies a constraint that is
- *       not present in the target platform. The target is said to be "directly incompatible".
+ *       not present in the target platform or a config_setting that does not match the target
+ *       configuration. The target is said to be "directly incompatible".
  *   <li>One or more of the target's dependencies is incompatible. The target is said to be
  *       "indirectly incompatible."
  * </ol>
@@ -84,8 +88,8 @@ public class IncompatibleTargetChecker {
   /**
    * Creates an incompatible configured target if it is "directly incompatible".
    *
-   * <p>In other words, this state machine checks if a target is incompatible because of its
-   * "target_compatible_with" attribute.
+   * <p>In other words, this state machine checks if a target is incompatible because of constraints
+   * or <code>config_settings</code> in its "target_compatible_with" attribute.
    *
    * <p>Outputs an {@code Optional} {@link RuleConfiguredTargetValue} as follows.
    *
@@ -110,6 +114,8 @@ public class IncompatibleTargetChecker {
     private final ImmutableList.Builder<ConstraintValueInfo> allConstraintValuesBuilder =
         new ImmutableList.Builder<>();
     private final ImmutableList.Builder<ConstraintValueInfo> invalidConstraintValuesBuilder =
+        new ImmutableList.Builder<>();
+    private final ImmutableList.Builder<ConfigMatchingProvider> configSettingsBuilder =
         new ImmutableList.Builder<>();
 
     /** Sink for the output of this state machine. */
@@ -173,17 +179,29 @@ public class IncompatibleTargetChecker {
     public void accept(SkyValue value) {
       var configuredTarget = ((ConfiguredTargetValue) value).getConfiguredTarget();
       @Nullable ConstraintValueInfo info = PlatformProviderUtils.constraintValue(configuredTarget);
-      if (info == null) {
-        return;
+      if (info != null) {
+        allConstraintValuesBuilder.add(info);
+        if (!platformInfo.constraints().hasConstraintValue(info)) {
+          invalidConstraintValuesBuilder.add(info);
+        }
       }
-      allConstraintValuesBuilder.add(info);
-      if (!platformInfo.constraints().hasConstraintValue(info)) {
-        invalidConstraintValuesBuilder.add(info);
+      @Nullable
+      ConfigMatchingProvider configSetting =
+          configuredTarget.getProvider(ConfigMatchingProvider.class);
+      if (configSetting != null) {
+        configSettingsBuilder.add(
+            ConfigMatchingProvider.create(
+                configuredTarget.getOriginalLabel(),
+                configSetting.settingsMap(),
+                configSetting.flagSettingsMap(),
+                configSetting.constraintValuesSetting(),
+                configSetting.result()));
       }
     }
 
     private StateMachine processResult(Tasks tasks) {
       var allConstraintValues = allConstraintValuesBuilder.build();
+      var configSettings = configSettingsBuilder.build();
 
       // Validate that there are no duplicate constraint values from the same constraint setting
       try {
@@ -193,16 +211,26 @@ public class IncompatibleTargetChecker {
         return runAfter;
       }
 
+      AccumulateResults configSettingResults =
+          ConfigMatchingProvider.accumulateMatchResults(configSettings);
+      if (!configSettingResults.errors().isEmpty()) {
+        sink.acceptValidationException(
+            new ValidationException(formatConfigSettingErrors(configSettingResults)));
+        return runAfter;
+      }
+
       var invalidConstraintValues = invalidConstraintValuesBuilder.build();
-      if (!invalidConstraintValues.isEmpty()) {
+      if (!invalidConstraintValues.isEmpty() || !configSettingResults.nonMatching().isEmpty()) {
         sink.acceptIncompatibleTarget(
             Optional.of(
                 createIncompatibleRuleConfiguredTarget(
                     configuredTargetKey,
                     targetAndConfiguration.getConfiguration(),
                     configConditions,
-                    IncompatiblePlatformProvider.incompatibleDueToConstraints(
-                        platformInfo.label(), invalidConstraintValues),
+                    IncompatiblePlatformProvider.incompatibleDueToConstraintsAndConfigSettings(
+                        platformInfo.label(),
+                        invalidConstraintValues,
+                        configSettingResults.nonMatching()),
                     targetAndConfiguration
                         .getTarget()
                         .getAssociatedRule()
@@ -213,6 +241,16 @@ public class IncompatibleTargetChecker {
       }
       sink.acceptIncompatibleTarget(Optional.empty());
       return runAfter;
+    }
+
+    private static String formatConfigSettingErrors(AccumulateResults configSettingResults) {
+      return configSettingResults.errors().asMap().entrySet().stream()
+          .map(
+              entry ->
+                  String.format(
+                      "For config_setting %s: %s",
+                      entry.getKey(), String.join(", ", entry.getValue())))
+          .collect(joining("; "));
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
@@ -275,7 +275,8 @@ public class TopLevelConstraintSemantics {
    *
    * <p>This is useful when trying to explain to the user why an explicitly requested target on the
    * command line is considered incompatible. The goal is to print out the dependency chain and the
-   * constraint that wasn't satisfied so that the user can immediately figure out what happened.
+   * constraint or <code>config_setting</code> that wasn't satisfied so that the user can
+   * immediately figure out what happened.
    *
    * @param target the incompatible target that was explicitly requested on the command line.
    * @return the verbose error message to show to the user.
@@ -304,28 +305,50 @@ public class TopLevelConstraintSemantics {
 
     message +=
         String.format(
-            "   <-- target platform (%s) didn't satisfy constraint", provider.targetPlatform());
-    if (provider.constraintsResponsibleForIncompatibility().size() == 1) {
-      message += " " + provider.constraintsResponsibleForIncompatibility().get(0).label();
-      return message;
-    }
-
-    message += "s [";
-
-    boolean first = true;
-    for (ConstraintValueInfo constraintValueInfo :
-        provider.constraintsResponsibleForIncompatibility()) {
-      if (first) {
-        first = false;
-      } else {
-        message += ", ";
-      }
-      message += constraintValueInfo.label();
-    }
-
-    message += "]";
-
+            "   <--%s",
+            formatIncompatibilityReasons(
+                provider.targetPlatform(),
+                provider.constraintsResponsibleForIncompatibility(),
+                provider.configSettingsResponsibleForIncompatibility()));
     return message;
+  }
+
+  private static String formatIncompatibilityReasons(
+      @Nullable Label targetPlatform,
+      @Nullable ImmutableList<ConstraintValueInfo> constraints,
+      @Nullable ImmutableList<Label> configSettings) {
+    StringJoiner reasons = new StringJoiner(" and");
+    if (constraints != null) {
+      reasons.add(formatConstraintIncompatibility(targetPlatform, constraints));
+    }
+    if (configSettings != null) {
+      reasons.add(formatConfigSettingIncompatibility(configSettings));
+    }
+    return reasons.toString();
+  }
+
+  private static String formatConstraintIncompatibility(
+      @Nullable Label targetPlatform, ImmutableList<ConstraintValueInfo> constraints) {
+    String message =
+        String.format(" target platform (%s) didn't satisfy constraint", targetPlatform);
+    if (constraints.size() == 1) {
+      return message + " " + constraints.get(0).label();
+    }
+    return message
+        + "s ["
+        + constraints.stream()
+            .map(constraintValueInfo -> constraintValueInfo.label().toString())
+            .collect(joining(", "))
+        + "]";
+  }
+
+  private static String formatConfigSettingIncompatibility(ImmutableList<Label> configSettings) {
+    if (configSettings.size() == 1) {
+      return " target configuration didn't match config_setting " + configSettings.get(0);
+    }
+    return " target configuration didn't match config_settings ["
+        + configSettings.stream().map(Label::toString).collect(joining(", "))
+        + "]";
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -45,6 +45,7 @@ import com.google.devtools.build.lib.analysis.DormantDependency;
 import com.google.devtools.build.lib.analysis.PackageSpecificationProvider;
 import com.google.devtools.build.lib.analysis.RuleDefinitionEnvironment;
 import com.google.devtools.build.lib.analysis.TemplateVariableInfo;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
 import com.google.devtools.build.lib.analysis.config.ExecutionTransitionFactory;
 import com.google.devtools.build.lib.analysis.config.StarlarkDefinedConfigTransition;
 import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
@@ -182,6 +183,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
                   .value(ImmutableMap.of()))
           .add(
               attr(RuleClass.TARGET_COMPATIBLE_WITH_ATTR, LABEL_LIST)
+                  .mandatoryBuiltinProviders(ImmutableList.of(ConfigMatchingProvider.class))
                   .mandatoryProviders(ConstraintValueInfo.PROVIDER.id())
                   // This should be configurable to allow for complex types of restrictions.
                   .tool(

--- a/src/main/java/com/google/devtools/build/lib/packages/ConfiguredAttributeMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/ConfiguredAttributeMapper.java
@@ -126,7 +126,7 @@ public class ConfiguredAttributeMapper extends AbstractAttributeMapper {
 
   /** ValidationException indicates an error during attribute validation. */
   public static final class ValidationException extends Exception {
-    private ValidationException(String message) {
+    public ValidationException(String message) {
       super(message);
     }
   }

--- a/src/test/shell/integration/target_compatible_with_test.sh
+++ b/src/test/shell/integration/target_compatible_with_test.sh
@@ -257,11 +257,14 @@ compiler_flag = rule(
 EOF
 }
 
-# Validates that we get a good error message when passing a config_setting into
-# the target_compatible_with attribute. This is a regression test for
-# https://github.com/bazelbuild/bazel/issues/13250.
+# Validates that config_settings can be used directly in the
+# target_compatible_with attribute. This is a regression test for
+# https://github.com/bazelbuild/bazel/issues/21857.
 function test_config_setting_in_target_compatible_with() {
-  cat >> target_skipping/BUILD <<'EOF'
+  add_bazel_skylib "MODULE.bazel"
+
+  cat >> target_skipping/BUILD <<EOF
+load("${skylib_package}lib:selects.bzl", "selects")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 config_setting(
@@ -269,11 +272,40 @@ config_setting(
     constraint_values = [":foo3"],
 )
 
+config_setting(
+    name = "feature_enabled",
+    define_values = {"feature": "enabled"},
+)
+
+selects.config_setting_group(
+    name = "foo3_or_feature_enabled",
+    match_any = [
+        ":foo3_config_setting",
+        ":feature_enabled",
+    ],
+)
+
 sh_binary(
-    name = "problematic_foo3_target",
+    name = "pass_on_foo3_config_setting",
     srcs = ["pass.sh"],
     target_compatible_with = [
         ":foo3_config_setting",
+    ],
+)
+
+sh_binary(
+    name = "pass_when_feature_enabled",
+    srcs = ["pass.sh"],
+    target_compatible_with = [
+        ":feature_enabled",
+    ],
+)
+
+sh_binary(
+    name = "pass_when_group_matches",
+    srcs = ["pass.sh"],
+    target_compatible_with = [
+        ":foo3_or_feature_enabled",
     ],
 )
 EOF
@@ -284,9 +316,58 @@ EOF
     --show_result=10 \
     --host_platform=@//target_skipping:foo3_platform \
     --platforms=@//target_skipping:foo3_platform \
-    ... &> "${TEST_log}" && fail "Bazel succeeded unexpectedly."
+    //target_skipping:pass_on_foo3_config_setting &> "${TEST_log}" \
+    || fail "Bazel failed unexpectedly."
 
-  expect_log "'//target_skipping:foo3_config_setting' does not have mandatory providers: 'ConstraintValueInfo'"
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:foo1_bar1_platform \
+    --platforms=@//target_skipping:foo1_bar1_platform \
+    //target_skipping:pass_on_foo3_config_setting &> "${TEST_log}" \
+    && fail "Bazel succeeded unexpectedly."
+
+  expect_log "target configuration didn't match config_setting //target_skipping:foo3_config_setting"
+
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:foo1_bar1_platform \
+    --platforms=@//target_skipping:foo1_bar1_platform \
+    --define feature=enabled \
+    //target_skipping:pass_when_feature_enabled &> "${TEST_log}" \
+    || fail "Bazel failed unexpectedly."
+
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:foo1_bar1_platform \
+    --platforms=@//target_skipping:foo1_bar1_platform \
+    //target_skipping:pass_when_feature_enabled &> "${TEST_log}" \
+    && fail "Bazel succeeded unexpectedly."
+
+  expect_log "target configuration didn't match config_setting //target_skipping:feature_enabled"
+
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:foo3_platform \
+    --platforms=@//target_skipping:foo3_platform \
+    //target_skipping:pass_when_group_matches &> "${TEST_log}" \
+    || fail "Bazel failed unexpectedly."
+
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:foo1_bar1_platform \
+    --platforms=@//target_skipping:foo1_bar1_platform \
+    --define feature=enabled \
+    //target_skipping:pass_when_group_matches &> "${TEST_log}" \
+    || fail "Bazel failed unexpectedly."
+
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:foo1_bar1_platform \
+    --platforms=@//target_skipping:foo1_bar1_platform \
+    //target_skipping:pass_when_group_matches &> "${TEST_log}" \
+    && fail "Bazel succeeded unexpectedly."
+
+  expect_log "target configuration didn't match config_setting //target_skipping:foo3_or_feature_enabled"
 }
 
 # Validates that we get an error when target_compatible_with contains duplicate


### PR DESCRIPTION
Previously you could only put constraint_values directly in
target_compatible_with. Therefore for other configs you had to do
something like:

```bzl
target_compatible_with = select({
  ":my_config_setting": [],
  "//conditions:default": ["@platforms//:incompatible"],
})
```

Now you can inline that just like config settings:

```bzl
target_compatible_with = [":my_config_setting"],
```

Fixes https://github.com/bazelbuild/bazel/issues/21857

Closes https://github.com/bazelbuild/bazel/pull/29475.

PiperOrigin-RevId: 927432687
Change-Id: Ia76951fe673304a1b6c7e22757586362643c1366

Commit https://github.com/bazelbuild/bazel/commit/57ccfd709a5c8b510660a56f07612b1b436ff223 and https://github.com/bazelbuild/bazel/commit/3d44100793e3e165e46014fea7864c0bbf479636