### PR TITLE
Fix NPE in coverage action creation when some tests have coverage dis…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
@@ -216,6 +216,10 @@ public final class CoverageReportActionBuilder {
         continue;
       }
       TestParams testParams = target.getProvider(TestProvider.class).getTestParams();
+      FilesToRunProvider generator = testParams.getCoverageReportGenerator();
+      if (generator == null) {
+        continue;
+      }
       builder.addAll(testParams.getCoverageArtifacts());
       // targetsToTest has non-deterministic order, so we ensure that we pick the same action owner
       // and matching report generator each time by picking the owner that's lexicographically
@@ -223,7 +227,7 @@ public final class CoverageReportActionBuilder {
       if (reportGenerator == null
           || ACTION_OWNER_COMPARATOR.compare(testParams.getActionOwnerForCoverage(), actionOwner)
               > 0) {
-        reportGenerator = testParams.getCoverageReportGenerator();
+        reportGenerator = generator;
         actionOwner = testParams.getActionOwnerForCoverage();
       }
     }

--- a/src/test/java/com/google/devtools/build/lib/bazel/google/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/google/BUILD
@@ -17,8 +17,13 @@ java_test(
     name = "CoverageCommandUnitTest",
     srcs = ["CoverageCommandUnitTest.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
+        "//src/main/java/com/google/devtools/build/lib/bazel/coverage",
         "//src/main/java/com/google/devtools/build/lib/buildtool",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:coverage_report_value",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
+        "//third_party:guava",
         "//third_party:junit4",
         "//third_party:truth",
     ],

--- a/src/test/java/com/google/devtools/build/lib/bazel/google/CoverageCommandUnitTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/google/CoverageCommandUnitTest.java
@@ -16,7 +16,14 @@ package com.google.devtools.build.lib.bazel.google;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.buildtool.InstrumentationFilterSupport.getInstrumentedPrefix;
 
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.bazel.coverage.CoverageArgs;
+import com.google.devtools.build.lib.bazel.coverage.CoverageReportActionBuilder;
+import com.google.devtools.build.lib.skyframe.CoverageReportValue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -55,5 +62,110 @@ public final class CoverageCommandUnitTest extends BuildViewTestCase {
     assertThat(getInstrumentedPrefix("foo/internal")).isEqualTo("foo");
     assertThat(getInstrumentedPrefix("foo/public")).isEqualTo("foo");
     assertThat(getInstrumentedPrefix("foo/tests")).isEqualTo("foo");
+  }
+
+  @Test
+  public void testCoverageReportActionBuilder_disabledCoverageDoesNotNpe() throws Exception {
+    useConfiguration(
+        "--collect_code_coverage");
+
+    scratch.file(
+        "tools/allowlists/function_transition_allowlist/BUILD",
+        """
+        package_group(
+            name = "function_transition_allowlist",
+            packages = ["//..."],
+        )
+        """);
+
+    scratch.file(
+        "repro/repro.bzl",
+        """
+        def _disable_coverage_transition_impl(settings, attr):
+            return {"//command_line_option:collect_code_coverage": False}
+
+        disable_coverage_transition = transition(
+            implementation = _disable_coverage_transition_impl,
+            inputs = [],
+            outputs = ["//command_line_option:collect_code_coverage"],
+        )
+
+        def _my_test_impl(ctx):
+            executable = ctx.actions.declare_file(ctx.label.name + ".sh")
+            ctx.actions.write(
+                output = executable,
+                content = "#!/bin/bash\\nexit 0\\n",
+                is_executable = True,
+            )
+            return [
+                DefaultInfo(executable = executable),
+            ]
+
+        my_test = rule(
+            implementation = _my_test_impl,
+            test = True,
+            cfg = disable_coverage_transition,
+            attrs = {
+                "_allowlist_function_transition": attr.label(
+                    default = "//tools/allowlists/function_transition_allowlist"
+                ),
+            },
+        )
+
+        normal_test = rule(
+            implementation = _my_test_impl,
+            test = True,
+        )
+        """);
+
+    scratch.file(
+        "repro/BUILD",
+        """
+        load("//repro:repro.bzl", "my_test", "normal_test")
+
+        normal_test(
+            name = "normal_test_target",
+        )
+
+        my_test(
+            name = "transitioned_test_target",
+        )
+        """);
+
+    ConfiguredTarget normalTarget = getConfiguredTarget("//repro:normal_test_target");
+    ConfiguredTarget transitionedTarget = getConfiguredTarget("//repro:transitioned_test_target");
+
+    ImmutableList<ConfiguredTarget> targetsToTest = ImmutableList.of(normalTarget, transitionedTarget);
+
+    CoverageReportActionBuilder builder = new CoverageReportActionBuilder();
+    CoverageReportActionBuilder.CoverageHelper dummyHelper =
+        new CoverageReportActionBuilder.CoverageHelper() {
+          @Override
+          public ImmutableList<String> getArgs(
+              CoverageArgs args,
+              Artifact lcovOutput) {
+            return ImmutableList.of();
+          }
+
+          @Override
+          public String getLocationMessage(
+              CoverageArgs args,
+              Artifact lcovOutput) {
+            return "";
+          }
+        };
+
+    // This should not throw NullPointerException
+    builder.createCoverageActionsWrapper(
+        reporter,
+        directories,
+        /* configuredTargets= */ ImmutableList.of(),
+        targetsToTest,
+        view.getArtifactFactory(),
+        actionKeyContext,
+        CoverageReportValue.COVERAGE_REPORT_KEY,
+        /* workspaceName= */ "workspace",
+        dummyHelper,
+        /* htmlReport= */ null);
   }
 }


### PR DESCRIPTION
…abled

When coverage is enabled globally but disabled for specific test targets (e.g., via transition), those targets have null coverage params. This leads to null ActionOwners for coverage.
CoverageReportActionBuilder was comparing ActionOwners of all test targets without checking for null, causing a NullPointerException.

Fixes #29208

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
