### PR TITLE
Consider `flagAliasMapping` for `ParsedFlagsValue` identity

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/ParsedFlagsValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/ParsedFlagsValue.java
@@ -28,7 +28,6 @@ import com.google.devtools.build.lib.concurrent.ThreadSafety;
 import com.google.devtools.build.lib.skyframe.SkyFunctions;
 import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerialization;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
-import com.google.devtools.build.lib.util.HashCodes;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
@@ -40,13 +39,28 @@ import java.util.Map;
 
 /** Stores the {@link OptionsParsingResult} from {@link ParsedFlagsFunction}. */
 @AutoCodec
-public final class ParsedFlagsValue implements SkyValue {
+public class ParsedFlagsValue implements SkyValue {
 
   /** Key for {@link ParsedFlagsValue} based on the raw flags. */
   @ThreadSafety.Immutable
   @AutoCodec
-  public static final class Key implements SkyKey {
+  public record Key(
+      ImmutableList<String> rawFlags,
+      PackageContext packageContext,
+      boolean includeDefaultValues,
+      ImmutableMap<String, Label> flagAliasMappings)
+      implements SkyKey {
     private static final SkyKeyInterner<Key> interner = SkyKey.newInterner();
+
+    /**
+     * @deprecated Use {@link #create} instead to ensure interning.
+     */
+    @Deprecated
+    public Key {
+      checkNotNull(rawFlags);
+      checkNotNull(packageContext);
+      checkNotNull(flagAliasMappings);
+    }
 
     /**
      * Returns a new {@link Key} for the given command-line flags, such as {@code
@@ -73,70 +87,9 @@ public final class ParsedFlagsValue implements SkyValue {
           new Key(rawFlags, packageContext, includeDefaultValues, flagAliasMappings));
     }
 
-    private final ImmutableList<String> rawFlags;
-    private final PackageContext packageContext;
-    private final boolean includeDefaultValues;
-
-    private final ImmutableMap<String, Label> flagAliasMappings;
-
-    private Key(
-        ImmutableList<String> rawFlags,
-        PackageContext packageContext,
-        boolean includeDefaultValues,
-        ImmutableMap<String, Label> flagAliasMappings) {
-      this.rawFlags = checkNotNull(rawFlags);
-      this.packageContext = checkNotNull(packageContext);
-      this.includeDefaultValues = includeDefaultValues;
-      this.flagAliasMappings = flagAliasMappings;
-    }
-
-    ImmutableList<String> rawFlags() {
-      return rawFlags;
-    }
-
-    PackageContext packageContext() {
-      return packageContext;
-    }
-
-    boolean includeDefaultValues() {
-      return includeDefaultValues;
-    }
-
-    ImmutableMap<String, Label> flagAliasMappings() {
-      return flagAliasMappings;
-    }
-
     @Override
     public SkyFunctionName functionName() {
       return SkyFunctions.PARSED_FLAGS;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (!(o instanceof Key that)) {
-        return false;
-      }
-      return rawFlags.equals(that.rawFlags)
-          && packageContext.equals(that.packageContext)
-          && includeDefaultValues == that.includeDefaultValues;
-    }
-
-    @Override
-    public int hashCode() {
-      return HashCodes.hashObjects(rawFlags, packageContext) * 31
-          + Boolean.hashCode(includeDefaultValues);
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper("ParsedFlagsValue.Key")
-          .add("rawFlags", rawFlags)
-          .add("packageContext", packageContext)
-          .add("includeDefaultValues", includeDefaultValues)
-          .toString();
     }
 
     @Override


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
Also simplify is by making it a record.


### Motivation
`ParsedFlagValue#equals` and `#hashCode` did not consider `flagAliasMapping`, possibly resulting in incorrect change pruning.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
