### PR TITLE
Allow `File` values in `env` of `ctx.actions.run[_shell]`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
@@ -239,12 +239,12 @@ public abstract class AbstractAction extends ActionKeyComputer implements Action
   }
 
   @Override
-  public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
-      throws CommandLineExpansionException {
+  public ImmutableMap<String, /* String | Artifact */ Object> getEffectiveEnvironment(
+      Map<String, String> clientEnv) throws CommandLineExpansionException {
     ActionEnvironment env = getEnvironment();
-    Map<String, String> effectiveEnvironment =
+    Map<String, Object> effectiveEnvironment =
         Maps.newLinkedHashMapWithExpectedSize(env.estimatedSize());
-    env.resolve(effectiveEnvironment, clientEnv);
+    env.resolveKeepingArtifacts(effectiveEnvironment, clientEnv);
     return ImmutableMap.copyOf(effectiveEnvironment);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/actions/Action.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Action.java
@@ -239,11 +239,17 @@ public interface Action extends ActionExecutionMetadata {
    * Called by {@link com.google.devtools.build.lib.analysis.actions.StarlarkAction} to use its
    * shadowed action, if any, complete list of environment variables in the Starlark action Spawn.
    *
+   * <p>The values of the returned map are either of type {@link String}, which are used as is, or
+   * {@link Artifact}, which are resolved to their exec paths when the spawn is created so that any
+   * applicable {@link PathMapper} can be applied to them. Callers that do not create a spawn
+   * should resolve the values via {@link ActionEnvironment#resolveValues} with {@link
+   * PathMapper#NOOP}.
+   *
    * <p>As this method is called from the StarlarkAction, make sure it is ok to call it from a
    * different thread than the one this action is executed on. By definition, the method should not
    * mutate any of the called action data but if necessary, its implementation must synchronize any
    * accesses to mutable data.
    */
-  ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
-      throws CommandLineExpansionException;
+  ImmutableMap<String, /* String | Artifact */ Object> getEffectiveEnvironment(
+      Map<String, String> clientEnv) throws CommandLineExpansionException;
 }

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Interner;
+import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.util.Fingerprint;
 import java.util.Map;
@@ -32,7 +33,10 @@ import java.util.TreeSet;
  * <p>The action environment consists of two parts.
  *
  * <ol>
- *   <li>All the environment variables with a fixed value, stored in a map.
+ *   <li>All the environment variables with a fixed value, stored in a map. The value of such a
+ *       variable is either a {@link String}, which is used as is, or an {@link Artifact}, which is
+ *       resolved to its exec path at execution time so that any applicable {@link PathMapper} can
+ *       be applied to it.
  *   <li>All the environment variables inherited from the client environment, stored in a set.
  * </ol>
  *
@@ -53,23 +57,27 @@ public abstract class ActionEnvironment {
       BlazeInterners.newWeakInterner();
 
   /** Convenience method for creating an {@link ActionEnvironment} with no inherited variables. */
-  public static ActionEnvironment create(ImmutableMap<String, String> fixedEnv) {
+  public static ActionEnvironment create(ImmutableMap<String, ?> fixedEnv) {
     return create(fixedEnv, /* inheritedEnv= */ ImmutableSet.of());
   }
 
   /**
    * Creates a new {@link ActionEnvironment}.
    *
+   * <p>The values of {@code fixedEnv} must be of type {@link String} or {@link Artifact}.
+   *
    * <p>If an environment variable is contained both as a key in {@code fixedEnv} and in {@code
    * inheritedEnv}, the result of {@link #resolve} will contain the value inherited from the client
    * environment.
    */
   public static ActionEnvironment create(
-      ImmutableMap<String, String> fixedEnv, ImmutableSet<String> inheritedEnv) {
+      ImmutableMap<String, ?> fixedEnv, ImmutableSet<String> inheritedEnv) {
     if (fixedEnv.isEmpty() && inheritedEnv.isEmpty()) {
       return EMPTY;
     }
-    return actionEnvironmentInterner.intern(new SimpleActionEnvironment(fixedEnv, inheritedEnv));
+    // copyOf returns the given map unchanged, with its value type widened to Object.
+    return actionEnvironmentInterner.intern(
+        new SimpleActionEnvironment(ImmutableMap.copyOf(fixedEnv), inheritedEnv));
   }
 
   /**
@@ -90,14 +98,42 @@ public abstract class ActionEnvironment {
     return create(ImmutableMap.copyOf(fixedEnv), ImmutableSet.copyOf(inheritedEnv));
   }
 
+  private static String maybeMapValue(Object value, PathMapper pathMapper) {
+    return value instanceof Artifact artifact
+        ? pathMapper.getMappedExecPathString(artifact)
+        : (String) value;
+  }
+
   private ActionEnvironment() {}
 
   /**
-   * Returns the 'fixed' part of the environment, i.e., those environment variables that are set to
-   * fixed values and their values. This should only be used for testing and to compute the cache
-   * keys of actions. Use {@link #resolve} instead to get the complete environment.
+   * Returns the 'fixed' part of the environment, with {@link String} values used as is and {@link
+   * Artifact} values resolved to their unmapped exec paths. This should only be used for testing
+   * and analysis-time introspection (e.g. aquery), as the value of an artifact-valued variable seen
+   * by the action may differ due to path mapping. Use {@link #resolve} instead to get the complete
+   * environment.
    */
-  public abstract ImmutableMap<String, String> getFixedEnv();
+  public final ImmutableMap<String, String> getFixedEnv() {
+    ImmutableMap<String, Object> fixedEnv = fixedEnv();
+    if (!hasArtifactValues(fixedEnv)) {
+      // Covariant cast of a map without Artifact values.
+      @SuppressWarnings("unchecked")
+      var stringEnv = (ImmutableMap<String, String>) (ImmutableMap<?, ?>) fixedEnv;
+      return stringEnv;
+    }
+    return ImmutableMap.copyOf(
+        Maps.transformValues(fixedEnv, value -> maybeMapValue(value, PathMapper.NOOP)));
+  }
+
+  private static boolean hasArtifactValues(ImmutableMap<String, Object> fixedEnv) {
+    return fixedEnv.values().stream().anyMatch(value -> value instanceof Artifact);
+  }
+
+  /**
+   * Returns the 'fixed' part of the environment, with values that are either of type {@link String}
+   * or {@link Artifact}.
+   */
+  abstract ImmutableMap<String, /* String | Artifact */ Object> fixedEnv();
 
   /**
    * Returns the 'inherited' part of the environment, i.e., those environment variables that are
@@ -116,13 +152,14 @@ public abstract class ActionEnvironment {
 
   /**
    * Resolves the action environment and adds the resulting entries to the given {@code result} map,
-   * by looking up any inherited env variables in the given {@code clientEnv}.
+   * by looking up any inherited env variables in the given {@code clientEnv} and resolving any
+   * artifact-valued env variables to their unmapped exec paths.
    *
    * <p>We pass in a map to mutate to avoid creating and merging intermediate maps.
    */
   public final void resolve(Map<String, String> result, Map<String, String> clientEnv) {
     checkNotNull(clientEnv);
-    result.putAll(getFixedEnv());
+    result.putAll(Maps.transformValues(fixedEnv(), value -> maybeMapValue(value, PathMapper.NOOP)));
     for (String var : getInheritedEnv()) {
       String value = clientEnv.get(var);
       if (value != null) {
@@ -131,16 +168,60 @@ public abstract class ActionEnvironment {
     }
   }
 
+  /**
+   * Like {@link #resolve}, but keeps {@link Artifact} values unresolved so that callers can later
+   * resolve them with a {@link PathMapper} applied via {@link #resolveValues}.
+   */
+  public final void resolveKeepingArtifacts(
+      Map<String, /* String | Artifact */ Object> result, Map<String, String> clientEnv) {
+    checkNotNull(clientEnv);
+    result.putAll(fixedEnv());
+    for (String var : getInheritedEnv()) {
+      String value = clientEnv.get(var);
+      if (value != null) {
+        result.put(var, value);
+      }
+    }
+  }
+
+  /**
+   * Resolves the values of an environment as returned by {@link Action#getEffectiveEnvironment}:
+   * {@link String} values are used as is and {@link Artifact} values are replaced by their exec
+   * paths with the given {@link PathMapper} applied.
+   *
+   * <p>Actions that support path mapping should pass in the path mapper of the spawn being created
+   * so that artifact-valued env variables reflect the paths seen by the action at execution time.
+   */
+  public static ImmutableMap<String, String> resolveValues(
+      Map<String, /* String | Artifact */ Object> env, PathMapper pathMapper) {
+    return ImmutableMap.copyOf(
+        Maps.transformValues(env, value -> maybeMapValue(value, pathMapper)));
+  }
+
   public final void addTo(Fingerprint f) {
-    f.addStringMap(getFixedEnv());
+    addTo(PathMapper.NOOP, f);
+  }
+
+  /**
+   * Adds this environment to the given fingerprint, resolving artifact-valued env variables with
+   * the given {@link PathMapper}.
+   *
+   * <p>Actions that support path mapping should pass in the path mapper returned by {@code
+   * PathMapper.forActionKey} to ensure that the action key remains stable across configurations if
+   * and only if the resolved environment does.
+   */
+  public final void addTo(PathMapper pathMapper, Fingerprint f) {
+    f.addStringMap(Maps.transformValues(fixedEnv(), value -> maybeMapValue(value, pathMapper)));
     f.addStrings(getInheritedEnv());
   }
 
   /**
    * Returns a copy of the environment with the given fixed variables added to it, <em>overwriting
    * any existing occurrences of those variables</em>.
+   *
+   * <p>The values of {@code fixedVars} must be of type {@link String} or {@link Artifact}.
    */
-  public final ActionEnvironment withAdditionalFixedVariables(Map<String, String> fixedVars) {
+  public final ActionEnvironment withAdditionalFixedVariables(Map<String, ?> fixedVars) {
     if (fixedVars.isEmpty()) {
       return this;
     }
@@ -155,7 +236,7 @@ public abstract class ActionEnvironment {
   private static final class EmptyActionEnvironment extends ActionEnvironment {
 
     @Override
-    public ImmutableMap<String, String> getFixedEnv() {
+    ImmutableMap<String, Object> fixedEnv() {
       return ImmutableMap.of();
     }
 
@@ -171,17 +252,17 @@ public abstract class ActionEnvironment {
   }
 
   private static final class SimpleActionEnvironment extends ActionEnvironment {
-    private final ImmutableMap<String, String> fixedEnv;
+    private final ImmutableMap<String, /* String | Artifact */ Object> fixedEnv;
     private final ImmutableSet<String> inheritedEnv;
 
     SimpleActionEnvironment(
-        ImmutableMap<String, String> fixedEnv, ImmutableSet<String> inheritedEnv) {
+        ImmutableMap<String, Object> fixedEnv, ImmutableSet<String> inheritedEnv) {
       this.fixedEnv = fixedEnv;
       this.inheritedEnv = inheritedEnv;
     }
 
     @Override
-    public ImmutableMap<String, String> getFixedEnv() {
+    ImmutableMap<String, Object> fixedEnv() {
       return fixedEnv;
     }
 
@@ -214,18 +295,18 @@ public abstract class ActionEnvironment {
 
   private static final class CompoundActionEnvironment extends ActionEnvironment {
     private final ActionEnvironment base;
-    private final ImmutableMap<String, String> fixedVars;
+    private final ImmutableMap<String, /* String | Artifact */ Object> fixedVars;
 
     private CompoundActionEnvironment(
-        ActionEnvironment base, ImmutableMap<String, String> fixedVars) {
+        ActionEnvironment base, ImmutableMap<String, Object> fixedVars) {
       this.base = base;
       this.fixedVars = fixedVars;
     }
 
     @Override
-    public ImmutableMap<String, String> getFixedEnv() {
-      return ImmutableMap.<String, String>builder()
-          .putAll(base.getFixedEnv())
+    ImmutableMap<String, Object> fixedEnv() {
+      return ImmutableMap.<String, Object>builder()
+          .putAll(base.fixedEnv())
           .putAll(fixedVars)
           .buildKeepingLast();
     }

--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -213,6 +213,7 @@ java_library(
     name = "action_environment",
     srcs = ["ActionEnvironment.java"],
     deps = [
+        ":artifacts",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -393,14 +393,13 @@ public class SpawnAction extends AbstractAction implements CommandAction {
       @Nullable InputMetadataProvider inputMetadataProvider,
       Fingerprint fp)
       throws CommandLineExpansionException, InterruptedException {
+    OutputPathsMode effectiveOutputPathsMode =
+        PathMappers.getEffectiveOutputPathsMode(outputPathsMode, getMnemonic(), getExecutionInfo());
     fp.addString(GUID);
     commandLines.addToFingerprint(
-        actionKeyContext,
-        inputMetadataProvider,
-        PathMappers.getEffectiveOutputPathsMode(outputPathsMode, getMnemonic(), getExecutionInfo()),
-        fp);
+        actionKeyContext, inputMetadataProvider, effectiveOutputPathsMode, fp);
     fp.addString(mnemonic);
-    env.addTo(fp);
+    env.addTo(PathMapper.forActionKey(effectiveOutputPathsMode), fp);
     fp.addStringMap(getExecutionInfo());
     PathMappers.addToFingerprint(
         getMnemonic(),
@@ -547,7 +546,8 @@ public class SpawnAction extends AbstractAction implements CommandAction {
           parent.resourceSetOrBuilder);
       this.inputs = SpawnInputs.of(inputs, additionalInputs);
       this.pathMapper = pathMapper;
-      this.effectiveEnvironment = parent.getEffectiveEnvironment(clientEnv);
+      this.effectiveEnvironment =
+          ActionEnvironment.resolveValues(parent.getEffectiveEnvironment(clientEnv), pathMapper);
       this.reportOutputs = reportOutputs;
     }
 
@@ -575,7 +575,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
   public static ActionEnvironment createActionEnvironment(
       BuildConfigurationValue configuration,
       boolean useDefaultShellEnvironment,
-      ImmutableMap<String, String> environment) {
+      ImmutableMap<String, /* String | Artifact */ ?> environment) {
     ActionEnvironment env;
     if (useDefaultShellEnvironment && !environment.isEmpty()) {
       // Inherited variables override fixed variables in ActionEnvironment. Since we want the
@@ -614,7 +614,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     private final NestedSetBuilder<Artifact> inputsBuilder = NestedSetBuilder.stableOrder();
     private final List<Artifact> outputs = new ArrayList<>();
     private ResourceSetOrBuilder resourceSetOrBuilder = AbstractAction.DEFAULT_RESOURCE_SET;
-    private ImmutableMap<String, String> environment = ImmutableMap.of();
+    private ImmutableMap<String, /* String | Artifact */ Object> environment = ImmutableMap.of();
     @Nullable private ActionEnvironment actionEnvironment = null;
     @Nullable private OutputPathsMode outputPathsMode = null;
     private ImmutableMap<String, String> executionInfo = ImmutableMap.of();
@@ -868,16 +868,20 @@ public class SpawnAction extends AbstractAction implements CommandAction {
       return this;
     }
 
-    private static final Interner<ImmutableMap<String, String>> envInterner =
+    private static final Interner<ImmutableMap<String, Object>> envInterner =
         BlazeInterners.newWeakInterner();
 
     /**
-     * Sets the map of environment variables. Do not use! This makes the builder ignore the 'default
-     * shell environment', which is computed from the --action_env command line option.
+     * Sets the map of environment variables. The values must be of type {@link String} or {@link
+     * Artifact}; the latter are resolved to their exec paths at execution time so that any
+     * applicable {@link PathMapper} can be applied to them.
+     *
+     * <p>Do not use! This makes the builder ignore the 'default shell environment', which is
+     * computed from the --action_env command line option.
      */
     @CanIgnoreReturnValue
-    public Builder setEnvironment(Map<String, String> environment) {
-      this.environment = envInterner.intern(ImmutableMap.copyOf(environment));
+    public Builder setEnvironment(Map<String, /* String | Artifact */ ?> environment) {
+      this.environment = envInterner.intern(ImmutableMap.<String, Object>copyOf(environment));
       this.useDefaultShellEnvironment = false;
       return this;
     }
@@ -946,8 +950,8 @@ public class SpawnAction extends AbstractAction implements CommandAction {
      * @see BuildConfigurationValue#getLocalShellEnvironment
      */
     @CanIgnoreReturnValue
-    public Builder useDefaultShellEnvironment(Map<String, String> environment) {
-      this.environment = ImmutableMap.copyOf(environment);
+    public Builder useDefaultShellEnvironment(Map<String, /* String | Artifact */ ?> environment) {
+      this.environment = ImmutableMap.<String, Object>copyOf(environment);
       this.useDefaultShellEnvironment = true;
       return this;
     }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -503,10 +503,10 @@ public class StarlarkAction extends SpawnAction {
     }
 
     @Override
-    public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
-        throws CommandLineExpansionException {
+    public ImmutableMap<String, /* String | Artifact */ Object> getEffectiveEnvironment(
+        Map<String, String> clientEnv) throws CommandLineExpansionException {
       ActionEnvironment env = getEnvironment();
-      Map<String, String> environment = Maps.newLinkedHashMapWithExpectedSize(env.estimatedSize());
+      Map<String, Object> environment = Maps.newLinkedHashMapWithExpectedSize(env.estimatedSize());
 
       if (shadowedAction.isPresent()) {
         // Put all the variables of the shadowed action's environment
@@ -515,7 +515,7 @@ public class StarlarkAction extends SpawnAction {
 
       // This order guarantees that the Starlark action can overwrite any variable in its shadowed
       // action environment with a new value.
-      env.resolve(environment, clientEnv);
+      env.resolveKeepingArtifacts(environment, clientEnv);
       return ImmutableMap.copyOf(environment);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -824,9 +824,16 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       builder.setProgressMessageFromStarlark((String) progressMessage);
     }
 
-    ImmutableMap<String, String> env = ImmutableMap.of();
+    ImmutableMap<String, /* String | Artifact */ Object> env = ImmutableMap.of();
     if (envUnchecked != Starlark.NONE) {
-      env = ImmutableMap.copyOf(Dict.cast(envUnchecked, String.class, String.class, "env"));
+      env = ImmutableMap.copyOf(Dict.cast(envUnchecked, String.class, Object.class, "env"));
+      for (Map.Entry<String, Object> entry : env.entrySet()) {
+        if (!(entry.getValue() instanceof String || entry.getValue() instanceof Artifact)) {
+          throw Starlark.errorf(
+              "expected value of type 'string' or 'File' for env variable '%s', but got %s instead",
+              entry.getKey(), Starlark.type(entry.getValue()));
+        }
+      }
     }
     if (Starlark.truth(useDefaultShellEnv)) {
       builder.useDefaultShellEnvironment(env);

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -967,7 +967,7 @@ public class CppCompileAction extends AbstractAction
   public ImmutableMap<String, String> getIncompleteEnvironmentForTesting()
       throws ActionExecutionException {
     try {
-      return getEffectiveEnvironment(ImmutableMap.of());
+      return getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP);
     } catch (CommandLineExpansionException e) {
       String message =
           String.format(
@@ -979,9 +979,9 @@ public class CppCompileAction extends AbstractAction
   }
 
   @Override
-  public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
-      throws CommandLineExpansionException {
-    return getEffectiveEnvironment(clientEnv, PathMapper.NOOP);
+  public ImmutableMap<String, /* String | Artifact */ Object> getEffectiveEnvironment(
+      Map<String, String> clientEnv) throws CommandLineExpansionException {
+    return ImmutableMap.copyOf(getEffectiveEnvironment(clientEnv, PathMapper.NOOP));
   }
 
   public ImmutableMap<String, String> getEffectiveEnvironment(
@@ -1056,7 +1056,7 @@ public class CppCompileAction extends AbstractAction
     }
     // TODO(ulfjack): Extra actions currently ignore the client environment.
     for (Map.Entry<String, String> envVariable :
-        getEffectiveEnvironment(/* clientEnv= */ ImmutableMap.of()).entrySet()) {
+        getEffectiveEnvironment(/* clientEnv= */ ImmutableMap.of(), PathMapper.NOOP).entrySet()) {
       info.addVariable(
           EnvironmentVariable.newBuilder()
               .setName(envVariable.getKey())

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.AbstractAction;
 import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
@@ -85,7 +84,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -325,7 +323,8 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
             .build();
     return new JavaSpawn(
         expandedCommandLines,
-        getEffectiveEnvironment(actionExecutionContext.getClientEnv()),
+        ActionEnvironment.resolveValues(
+            getEffectiveEnvironment(actionExecutionContext.getClientEnv()), pathMapper),
         getExecutionInfo(),
         inputs,
         /* onlyMandatoryOutput= */ fallback ? null : outputDepsProto,
@@ -346,20 +345,12 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
                 configuration.getCommandLineLimits());
     return new JavaSpawn(
         expandedCommandLines,
-        getEffectiveEnvironment(actionExecutionContext.getClientEnv()),
+        ActionEnvironment.resolveValues(
+            getEffectiveEnvironment(actionExecutionContext.getClientEnv()), pathMapper),
         getExecutionInfo(),
         getInputs(),
         /* onlyMandatoryOutput= */ null,
         pathMapper);
-  }
-
-  @Override
-  public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv) {
-    ActionEnvironment env = getEnvironment();
-    LinkedHashMap<String, String> effectiveEnvironment =
-        Maps.newLinkedHashMapWithExpectedSize(env.estimatedSize());
-    env.resolve(effectiveEnvironment, clientEnv);
-    return ImmutableMap.copyOf(effectiveEnvironment);
   }
 
   private ActionExecutionException wrapIOException(IOException e, String message) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
@@ -22,12 +22,14 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.AbstractAction;
 import com.google.devtools.build.lib.actions.ActionAnalysisMetadata;
+import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.CommandAction;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.analysis.AnalysisProtosV2;
 import com.google.devtools.build.lib.analysis.AspectValue;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
@@ -187,7 +189,8 @@ public class ActionGraphDump {
       // TODO(twerth): This handles the fixed environment. We probably want to output the inherited
       // environment as well.
       ImmutableMap<String, String> fixedEnvironment =
-          spawnAction.getEffectiveEnvironment(ImmutableMap.of());
+          ActionEnvironment.resolveValues(
+              spawnAction.getEffectiveEnvironment(ImmutableMap.of()), PathMapper.NOOP);
       for (Map.Entry<String, String> environmentVariable : fixedEnvironment.entrySet()) {
         actionBuilder.addEnvironmentVariables(
             AnalysisProtosV2.KeyValuePair.newBuilder()

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -519,7 +519,13 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
                 "Sets the dictionary of environment variables.<p>If both"
                     + " <code>use_default_shell_env</code> and <code>env</code> are set to"
                     + " <code>True</code>, values set in <code>env</code> will overwrite the"
-                    + " default shell environment."),
+                    + " default shell environment.<p>Values may also be <code>File</code>s, which"
+                    + " are expanded to their <a"
+                    + " href=\"../builtins/File.html#path\"><code>path</code></a> at execution"
+                    + " time. This form should be preferred over expanding the path during"
+                    + " analysis if the action supports path mapping via the"
+                    + " <code>supports-path-mapping</code> execution requirement, as it allows the"
+                    + " mapped path to be used."),
         @Param(
             name = "execution_requirements",
             allowedTypes = {
@@ -771,7 +777,13 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
                 "Sets the dictionary of environment variables.<p>If both"
                     + " <code>use_default_shell_env</code> and <code>env</code> are set to"
                     + " <code>True</code>, values set in <code>env</code> will overwrite the"
-                    + " default shell environment."),
+                    + " default shell environment.<p>Values may also be <code>File</code>s, which"
+                    + " are expanded to their <a"
+                    + " href=\"../builtins/File.html#path\"><code>path</code></a> at execution"
+                    + " time. This form should be preferred over expanding the path during"
+                    + " analysis if the action supports path mapping via the"
+                    + " <code>supports-path-mapping</code> execution requirement, as it allows the"
+                    + " mapped path to be used."),
         @Param(
             name = "execution_requirements",
             allowedTypes = {

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionEnvironmentTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionEnvironmentTest.java
@@ -18,6 +18,11 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
+import com.google.devtools.build.lib.testutil.Scratch;
+import com.google.devtools.build.lib.util.Fingerprint;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
@@ -27,6 +32,19 @@ import org.junit.runners.JUnit4;
 /** {@link ActionEnvironment}Test */
 @RunWith(JUnit4.class)
 public final class ActionEnvironmentTest {
+
+  /** Strips the config segment (e.g. "k8-fastbuild") from an output path. */
+  private static final PathMapper STRIP_CONFIG =
+      execPath -> execPath.subFragment(0, 1).getRelative(execPath.subFragment(2));
+
+  private final Scratch scratch = new Scratch();
+
+  private Artifact createOutputArtifact(String rootRelativePath) throws IOException {
+    ArtifactRoot root =
+        ArtifactRoot.asDerivedRoot(
+            scratch.dir("/exec"), RootType.OUTPUT, "bazel-out", "k8-fastbuild", "bin");
+    return ActionsTestUtil.createArtifact(root, rootRelativePath);
+  }
 
   @Test
   public void compoundEnvOrdering() {
@@ -66,6 +84,97 @@ public final class ActionEnvironmentTest {
   }
 
   @Test
+  public void artifactValueResolution() throws Exception {
+    Artifact artifact = createOutputArtifact("pkg/file");
+    ActionEnvironment env =
+        ActionEnvironment.create(ImmutableMap.of("FIXED", "fixed", "ARTIFACT", artifact));
+
+    assertThat(env.getFixedEnv())
+        .containsExactly("FIXED", "fixed", "ARTIFACT", "bazel-out/k8-fastbuild/bin/pkg/file");
+
+    Map<String, String> result = new HashMap<>();
+    env.resolve(result, ImmutableMap.of());
+    assertThat(result)
+        .containsExactly("FIXED", "fixed", "ARTIFACT", "bazel-out/k8-fastbuild/bin/pkg/file");
+  }
+
+  @Test
+  public void resolveKeepingArtifacts_resolveValuesAppliesPathMapper() throws Exception {
+    Artifact artifact = createOutputArtifact("pkg/file");
+    ActionEnvironment env =
+        ActionEnvironment.create(ImmutableMap.of("FIXED", "fixed", "ARTIFACT", artifact));
+
+    Map<String, Object> result = new HashMap<>();
+    env.resolveKeepingArtifacts(result, ImmutableMap.of());
+    assertThat(result).containsExactly("FIXED", "fixed", "ARTIFACT", artifact);
+
+    assertThat(ActionEnvironment.resolveValues(result, PathMapper.NOOP))
+        .containsExactly("FIXED", "fixed", "ARTIFACT", "bazel-out/k8-fastbuild/bin/pkg/file");
+    assertThat(ActionEnvironment.resolveValues(result, STRIP_CONFIG))
+        .containsExactly("FIXED", "fixed", "ARTIFACT", "bazel-out/bin/pkg/file");
+  }
+
+  @Test
+  public void resolveKeepingArtifacts_clientEnvOverridesArtifactValue() throws Exception {
+    Artifact artifact = createOutputArtifact("pkg/file");
+    ActionEnvironment env =
+        ActionEnvironment.create(
+            ImmutableMap.of("ARTIFACT", artifact), ImmutableSet.of("ARTIFACT"));
+
+    Map<String, Object> result = new HashMap<>();
+    env.resolveKeepingArtifacts(result, ImmutableMap.of("ARTIFACT", "from_client"));
+    assertThat(ActionEnvironment.resolveValues(result, STRIP_CONFIG))
+        .containsExactly("ARTIFACT", "from_client");
+
+    result.clear();
+    env.resolveKeepingArtifacts(result, ImmutableMap.of());
+    assertThat(ActionEnvironment.resolveValues(result, STRIP_CONFIG))
+        .containsExactly("ARTIFACT", "bazel-out/bin/pkg/file");
+  }
+
+  @Test
+  public void withAdditionalFixedVariables_artifactValues() throws Exception {
+    Artifact artifact1 = createOutputArtifact("pkg/file1");
+    Artifact artifact2 = createOutputArtifact("pkg/file2");
+    ActionEnvironment env =
+        ActionEnvironment.create(ImmutableMap.of("FOO", "foo", "ARTIFACT", artifact1))
+            .withAdditionalFixedVariables(ImmutableMap.of("BAR", "bar", "ARTIFACT", artifact2));
+
+    assertThat(env.getFixedEnv())
+        .containsExactly(
+            "FOO", "foo", "BAR", "bar", "ARTIFACT", "bazel-out/k8-fastbuild/bin/pkg/file2");
+  }
+
+  @Test
+  public void addTo_artifactValueAppliesPathMapper() throws Exception {
+    Artifact artifact = createOutputArtifact("pkg/file");
+    ActionEnvironment env = ActionEnvironment.create(ImmutableMap.of("ARTIFACT", artifact));
+
+    Fingerprint unmapped = new Fingerprint();
+    env.addTo(unmapped);
+    Fingerprint mapped = new Fingerprint();
+    env.addTo(STRIP_CONFIG, mapped);
+
+    assertThat(mapped.hexDigestAndReset()).isNotEqualTo(unmapped.hexDigestAndReset());
+  }
+
+  @Test
+  public void addTo_artifactValueSameFingerprintAsEqualStringValue() throws Exception {
+    Artifact artifact = createOutputArtifact("pkg/file");
+    ActionEnvironment artifactEnv = ActionEnvironment.create(ImmutableMap.of("ARTIFACT", artifact));
+    ActionEnvironment stringEnv =
+        ActionEnvironment.create(ImmutableMap.of("ARTIFACT", artifact.getExecPathString()));
+
+    Fingerprint artifactFingerprint = new Fingerprint();
+    artifactEnv.addTo(artifactFingerprint);
+    Fingerprint stringFingerprint = new Fingerprint();
+    stringEnv.addTo(stringFingerprint);
+
+    assertThat(artifactFingerprint.hexDigestAndReset())
+        .isEqualTo(stringFingerprint.hexDigestAndReset());
+  }
+
+  @Test
   public void emptyEnvironmentInterning() {
     ActionEnvironment emptyEnvironment =
         ActionEnvironment.create(ImmutableMap.of(), ImmutableSet.of());
@@ -74,5 +183,23 @@ public final class ActionEnvironmentTest {
     ActionEnvironment base =
         ActionEnvironment.create(ImmutableMap.of("FOO", "foo1"), ImmutableSet.of("baz"));
     assertThat(base.withAdditionalFixedVariables(ImmutableMap.of())).isSameInstanceAs(base);
+  }
+
+  @Test
+  public void artifactValueInterning() throws Exception {
+    Artifact artifact = createOutputArtifact("pkg/file");
+    ActionEnvironment env1 =
+        ActionEnvironment.create(
+            ImmutableMap.of("FOO", "foo", "ARTIFACT", artifact), ImmutableSet.of("baz"));
+    ActionEnvironment env2 =
+        ActionEnvironment.create(
+            ImmutableMap.of("FOO", "foo", "ARTIFACT", artifact), ImmutableSet.of("baz"));
+    ActionEnvironment env3 =
+        ActionEnvironment.create(
+            ImmutableMap.of("FOO", "foo", "ARTIFACT", artifact.getExecPathString()),
+            ImmutableSet.of("baz"));
+
+    assertThat(env2).isSameInstanceAs(env1);
+    assertThat(env3).isNotEqualTo(env1);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
@@ -18,6 +18,8 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static java.lang.String.format;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -299,6 +301,114 @@ public class PathMappersTest extends BuildViewTestCase {
         .containsExactly(
             "%s/cfg/bin/foo/script".formatted(outDir), "%s/cfg/bin/my_rule".formatted(outDir))
         .inOrder();
+  }
+
+  @Test
+  public void starlarkRule_artifactEnv() throws Exception {
+    scratch.file("defs/BUILD");
+    scratch.file(
+        "defs/defs.bzl",
+        """
+        def my_rule_impl(ctx):
+            out = ctx.actions.declare_file(ctx.label.name)
+            ctx.actions.run(
+                executable = ctx.executable._tool,
+                arguments = [ctx.actions.args().add(out)],
+                inputs = ctx.files.srcs,
+                outputs = [out],
+                env = {
+                    "GEN_SRC": ctx.files.srcs[0],
+                    "SOURCE_SRC": ctx.files.srcs[1],
+                    "OUT": out,
+                    "FIXED": "fixed_value",
+                },
+                mnemonic = "MyRuleAction",
+                execution_requirements = {"supports-path-mapping": "1"},
+            )
+            return [DefaultInfo(files = depset([out]))]
+        my_rule = rule(
+            implementation = my_rule_impl,
+            attrs = {
+                "srcs": attr.label_list(allow_files = True),
+                "_tool": attr.label(
+                    default = "//tool",
+                    executable = True,
+                    cfg = "exec",
+                ),
+            },
+        )
+        """);
+    scratch.file(
+        "pkg/BUILD",
+        """
+        load('//defs:defs.bzl', 'my_rule')
+        genrule(
+            name = 'gen_src',
+            outs = ['gen_src.txt'],
+            cmd = '<some command>',
+        )
+        my_rule(
+            name = 'my_rule',
+            srcs = [
+                ':gen_src',
+                'source.txt',
+            ],
+        )
+        """);
+    scratch.file(
+        "tool/BUILD",
+        """
+        load('//test_defs:foo_binary.bzl', 'foo_binary')
+        foo_binary(
+            name = 'tool',
+            srcs = ['tool.sh'],
+            visibility = ['//visibility:public'],
+        )
+        """);
+
+    ConfiguredTarget configuredTarget = getConfiguredTarget("//pkg:my_rule");
+    Artifact outputArtifact =
+        configuredTarget.getProvider(FileProvider.class).getFilesToBuild().toList().get(0);
+    SpawnAction action = (SpawnAction) getGeneratingAction(outputArtifact);
+    Spawn spawn =
+        action.getSpawn(
+            new ActionExecutionContextBuilder()
+                .setMetadataProvider(new FakeActionInputFileCache())
+                .build());
+
+    assertThat(spawn.getPathMapper().isNoop()).isFalse();
+    String outDir = analysisMock.getProductName() + "-out";
+    assertThat(spawn.getEnvironment())
+        .containsExactly(
+            "GEN_SRC",
+            format("%s/cfg/bin/pkg/gen_src.txt", outDir),
+            "SOURCE_SRC",
+            "pkg/source.txt",
+            "OUT",
+            format("%s/cfg/bin/pkg/my_rule", outDir),
+            "FIXED",
+            "fixed_value");
+
+    // Analysis-time consumers such as aquery see the unmapped paths.
+    Artifact genSrcArtifact =
+        action.getInputs().toList().stream()
+            .filter(input -> input.getFilename().equals("gen_src.txt"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(
+            ActionEnvironment.resolveValues(
+                action.getEffectiveEnvironment(ImmutableMap.of()), PathMapper.NOOP))
+        .containsExactly(
+            "GEN_SRC",
+            genSrcArtifact.getExecPathString(),
+            "SOURCE_SRC",
+            "pkg/source.txt",
+            "OUT",
+            outputArtifact.getExecPathString(),
+            "FIXED",
+            "fixed_value");
+    assertThat(genSrcArtifact.getExecPathString())
+        .isNotEqualTo(format("%s/cfg/bin/pkg/gen_src.txt", outDir));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkActionWithShadowedActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkActionWithShadowedActionTest.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.lib.actions.ActionInputPrefetcher;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.DiscoveredModulesPruner;
 import com.google.devtools.build.lib.actions.Executor;
+import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.ThreadStateReceiver;
 import com.google.devtools.build.lib.analysis.actions.StarlarkAction;
 import com.google.devtools.build.lib.analysis.util.AnalysisTestUtil;
@@ -343,12 +344,54 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
     expectedEnvironment.putAll(shadowedActionEnvironment);
     expectedEnvironment.putAll(starlarkActionEnvironment);
 
-    ImmutableMap<String, String> actualEnvironment =
+    ImmutableMap<String, Object> actualEnvironment =
         starlarkAction.getEffectiveEnvironment(ImmutableMap.of());
     assertThat(actualEnvironment).hasSize(5);
     // Starlark action's env overwrites any repeated variable from the shadowed action env
     assertThat(actualEnvironment).containsEntry("repeated_var", "starlark_val");
     assertThat(actualEnvironment).containsExactlyEntriesIn(expectedEnvironment);
+  }
+
+  @Test
+  public void testShadowedActionEnvironmentIsPathMapped() throws Exception {
+    useConfiguration("--experimental_output_paths=strip");
+    Artifact shadowedOutput = getBinArtifactWithNoOwner("shadowed_output");
+    Action shadowedAction =
+        createShadowedAction(
+            shadowedActionInputs, /* discoversInputs= */ false, /* discoveredInputs= */ null);
+    when(shadowedAction.getEffectiveEnvironment(ArgumentMatchers.anyMap()))
+        .thenReturn(ImmutableMap.of("shadowed_out", shadowedOutput));
+
+    StarlarkAction starlarkAction =
+        (StarlarkAction)
+            new StarlarkAction.Builder()
+                .setShadowedAction(Optional.of(shadowedAction))
+                .setExecutable(executable)
+                .addInput(starlarkActionInputs.toList().get(0))
+                .addOutput(output)
+                .setEnvironment(ImmutableMap.of("own_out", output))
+                .setExecutionInfo(ImmutableMap.of("supports-path-mapping", ""))
+                .build(NULL_ACTION_OWNER, targetConfig);
+    collectingAnalysisEnvironment.registerAction(starlarkAction);
+
+    Spawn spawn = starlarkAction.getSpawn(executionContext);
+
+    assertThat(spawn.getPathMapper().isNoop()).isFalse();
+    // Artifact-valued variables of both the Starlark action and its shadowed action are resolved
+    // with the spawn's path mapper.
+    assertThat(spawn.getEnvironment())
+        .containsExactly(
+            "shadowed_out", stripConfig(shadowedOutput), "own_out", stripConfig(output));
+    assertThat(stripConfig(output)).isNotEqualTo(output.getExecPathString());
+  }
+
+  private static String stripConfig(Artifact artifact) {
+    PathFragment execPath = artifact.getExecPath();
+    return execPath
+        .subFragment(0, 1)
+        .getRelative("cfg")
+        .getRelative(execPath.subFragment(2))
+        .getPathString();
   }
 
   private Action createShadowedAction(
@@ -365,7 +408,7 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
     when(shadowedAction.inputsKnown()).thenReturn(true);
     when(shadowedAction.getOwner()).thenReturn(NULL_ACTION_OWNER);
     when(shadowedAction.getEffectiveEnvironment(ArgumentMatchers.anyMap()))
-        .thenReturn(ImmutableMap.copyOf(shadowedActionEnvironment));
+        .thenReturn(ImmutableMap.<String, Object>copyOf(shadowedActionEnvironment));
 
     return shadowedAction;
   }

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.ActionAnalysisMetadata;
+import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.actions.ActionLookupData;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
@@ -492,6 +493,67 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
         "run() got unexpected keyword argument 'bad_param'",
         "f = ruleContext.actions.declare_file('foo.sh')",
         "ruleContext.actions.run(outputs=[], bad_param = 'some text', executable = f)");
+  }
+
+  @Test
+  public void testCreateSpawnActionEnvFileValue() throws Exception {
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+    ev.exec(
+        "ruleContext.actions.run_shell(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = ruleContext.files.srcs,",
+        "  env = {'SRC': ruleContext.files.srcs[0], 'FIXED': 'value'},",
+        "  mnemonic = 'DummyMnemonic',",
+        "  command = 'dummy_command')");
+    SpawnAction action =
+        (SpawnAction)
+            Iterables.getOnlyElement(
+                ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
+    assertThat(
+            ActionEnvironment.resolveValues(
+                action.getEffectiveEnvironment(ImmutableMap.of()), PathMapper.NOOP))
+        .containsExactly("SRC", "foo/a.txt", "FIXED", "value");
+  }
+
+  @Test
+  public void testCreateSpawnActionEnvFileValue_useDefaultShellEnv() throws Exception {
+    useConfiguration("--action_env=SRC", "--action_env=OTHER=other");
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+    ev.exec(
+        "ruleContext.actions.run_shell(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = ruleContext.files.srcs,",
+        "  env = {'SRC': ruleContext.files.srcs[0]},",
+        "  use_default_shell_env = True,",
+        "  mnemonic = 'DummyMnemonic',",
+        "  command = 'dummy_command')");
+    SpawnAction action =
+        (SpawnAction)
+            Iterables.getOnlyElement(
+                ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
+    // The action-provided value for SRC overrides the inherited variable of the same name, which
+    // the action thus no longer depends on.
+    assertThat(action.getClientEnvironmentVariables()).doesNotContain("SRC");
+    assertThat(
+            ActionEnvironment.resolveValues(
+                action.getEffectiveEnvironment(ImmutableMap.of("SRC", "from_client")),
+                PathMapper.NOOP))
+        .containsEntry("SRC", "foo/a.txt");
+    assertThat(action.getEffectiveEnvironment(ImmutableMap.of())).containsEntry("OTHER", "other");
+  }
+
+  @Test
+  public void testCreateSpawnActionEnvInvalidValueType() throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+    ev.checkEvalErrorContains(
+        "expected value of type 'string' or 'File' for env variable 'FOO', but got int instead",
+        "ruleContext.actions.run_shell(",
+        "  outputs = ruleContext.files.srcs,",
+        "  env = {'FOO': 1},",
+        "  mnemonic = 'DummyMnemonic',",
+        "  command = 'dummy_command')");
   }
 
   private Object createTestSpawnAction(StarlarkRuleContext ruleContext) throws Exception {
@@ -3764,7 +3826,7 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
     CommandLine commandLine1 =
         getCommandLine(
             mainRepoMapping,
-"""
+            """
 args = ruleContext.actions.args()
 args.add_all(depset([Label("@@canonical1+//foo:bar"), Label("@@canonical2+//foo:bar")]))
 """);
@@ -3975,7 +4037,7 @@ args.add_all(depset([Label("@@canonical1+//foo:bar"), Label("@@canonical2+//foo:
 
     CommandLine commandLine1 =
         getCommandLine(
-"""
+            """
 def _map_each(x):
   return x.field.root.path
 args = ruleContext.actions.args()
@@ -3984,7 +4046,7 @@ args.add_all(d, map_each = _map_each, uniquify = True)
 """);
     CommandLine commandLine2 =
         getCommandLine(
-"""
+            """
 def _map_each(x):
   return x.field
 args = ruleContext.actions.args()

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -406,6 +406,63 @@ EOF
   expect_log '2 remote[^ ]'
 }
 
+function test_path_stripping_env_files() {
+  mkdir pkg
+  cat > pkg/defs.bzl <<'EOF'
+def _copy_via_env_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".out")
+    ctx.actions.run_shell(
+        outputs = [out],
+        inputs = [ctx.file.src],
+        command = 'cat "$SRC_PATH" > "$OUT_PATH"',
+        env = {
+            "SRC_PATH": ctx.file.src,
+            "OUT_PATH": out,
+        },
+        execution_requirements = {"supports-path-mapping": ""},
+        mnemonic = "CopyViaEnv",
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+copy_via_env = rule(
+    implementation = _copy_via_env_impl,
+    attrs = {"src": attr.label(allow_single_file = True)},
+)
+EOF
+  cat > pkg/BUILD <<'EOF'
+load(":defs.bzl", "copy_via_env")
+
+genrule(
+    name = "gen_src",
+    outs = ["src.txt"],
+    cmd = "echo 'Hello, World!' > $@",
+)
+
+copy_via_env(
+    name = "copy",
+    src = ":gen_src",
+)
+EOF
+
+  bazel build -c fastbuild \
+    --experimental_output_paths=strip \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //pkg:copy &> $TEST_log || fail "build failed unexpectedly"
+  expect_not_log 'remote cache hit'
+  assert_contains 'Hello, World!' bazel-bin/pkg/copy.out
+
+  # The genrule does not support path mapping and runs again in the new
+  # configuration, but the CopyViaEnv action gets a remote cache hit since the
+  # mapped path in the SRC_PATH and OUT_PATH env variables is identical across
+  # configurations.
+  bazel build -c opt \
+    --experimental_output_paths=strip \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //pkg:copy &> $TEST_log || fail "build failed unexpectedly"
+  expect_log '1 remote cache hit'
+  assert_contains 'Hello, World!' bazel-bin/pkg/copy.out
+}
+
 function test_path_stripping_disabled_with_tags() {
   mkdir pkg
   cat > pkg/defs.bzl <<'EOF'


### PR DESCRIPTION
The values of the `env` dict of `ctx.actions.run` and `ctx.actions.run_shell` can now be `File`s in addition to strings. Such values are expanded to the file's exec path at execution time, after path mapping has been applied. Compared to expanding the path during analysis, this allows environment variables referencing input or output paths to benefit from cross-configuration cache hits with `--experimental_output_paths=strip`.

Implementation notes:
* `ActionEnvironment` stores fixed variables in a single `ImmutableMap<String, /* String | Artifact */ Object>`. All analysis-time views of the environment (`getFixedEnv()`, `resolve()`, aquery, extra actions, `Action.env` in Starlark) resolve `Artifact` values to their unmapped exec paths, so their types and behavior are unchanged.
* The spawn's environment re-resolves artifact values with the spawn's `PathMapper` (`ActionEnvironment#resolveArtifactValues`).
* The action key fingerprints artifact values with `PathMapper.forActionKey`, mirroring how command lines are fingerprinted. Environments without artifact values produce byte-identical fingerprints as before.
* `use_default_shell_env` and `--action_env` interact with `File`-valued variables exactly as with string-valued ones.

Tested via unit tests for `ActionEnvironment`, analysis tests for the mapped spawn environment and the Starlark API, and an end-to-end test in `path_mapping_test.sh` that verifies a remotely executed action reads its input through the mapped env var and gets a cross-configuration remote cache hit.
