### PR TITLE
Track server Instance ID in `BuildMetrics` BES event

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -1111,6 +1111,14 @@ message BuildMetrics {
     // one. Will be incremented for every build/test/run/etc. command that
     // reaches the execution phase.
     int32 num_builds = 12;
+    // UUID of the Bazel server instance that ran this command. Every command
+    // handled by the same server process reports the same value; it changes
+    // only when the server restarts. Useful for correlating invocations that
+    // shared a server (and therefore its incremental state), e.g. to fetch and
+    // diff stats/metrics/inputs/outputs against earlier invocations on the same
+    // server. Always non-empty; only streams produced by Bazel versions that
+    // predate this field lack it.
+    string instance_id = 13;
   }
 
   CumulativeMetrics cumulative_metrics = 6;

--- a/src/main/java/com/google/devtools/build/lib/metrics/MetricsCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/metrics/MetricsCollector.java
@@ -115,6 +115,7 @@ class MetricsCollector {
   // For CumulativeMetrics.
   private final AtomicInteger numAnalyses;
   private final AtomicInteger numBuilds;
+  private final String instanceId;
 
   private final ActionSummary.Builder actionSummary = ActionSummary.newBuilder();
   private final TargetMetrics.Builder targetMetrics = TargetMetrics.newBuilder();
@@ -144,6 +145,7 @@ class MetricsCollector {
     this.recordSkyframeMetrics = options != null && options.getRecordSkyframeMetrics();
     this.numAnalyses = numAnalyses;
     this.numBuilds = numBuilds;
+    this.instanceId = env.getRuntime().getInstanceId().toString();
     env.getEventBus().register(this);
     WorkerProcessMetricsCollector.instance().setClock(env.getClock());
     this.buildAccountedFor = new AtomicBoolean();
@@ -646,6 +648,7 @@ class MetricsCollector {
     return CumulativeMetrics.newBuilder()
         .setNumAnalyses(numAnalyses.get())
         .setNumBuilds(numBuilds.get())
+        .setInstanceId(instanceId)
         .build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -167,6 +167,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   private final FileSystem fileSystem;
+  private final UUID instanceId;
   private final ImmutableList<BlazeModule> blazeModules;
   private final ImmutableList<BlazeService> blazeServices;
   private final Map<String, BlazeCommand> commandMap = new LinkedHashMap<>();
@@ -215,6 +216,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
 
   private BlazeRuntime(
       FileSystem fileSystem,
+      UUID instanceId,
       QueryEnvironmentFactory queryEnvironmentFactory,
       ImmutableList<QueryFunction> queryFunctions,
       ImmutableList<OutputFormatter> queryOutputFormatters,
@@ -240,6 +242,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
       FileSystemLock installBaseLock) {
     // Server state
     this.fileSystem = fileSystem;
+    this.instanceId = instanceId;
     this.blazeModules = blazeModules;
     this.blazeServices = blazeServices;
     overrideCommands(commands);
@@ -546,6 +549,14 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
 
   public FileSystem getFileSystem() {
     return fileSystem;
+  }
+
+  /**
+   * Returns the ID of this Bazel server instance. It is stable for the lifetime of the server and
+   * changes when the server restarts.
+   */
+  public UUID getInstanceId() {
+    return instanceId;
   }
 
   public BlazeWorkspace getWorkspace() {
@@ -1808,6 +1819,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
       BlazeRuntime runtime =
           new BlazeRuntime(
               fileSystem,
+              instanceId,
               serverBuilder.getQueryEnvironmentFactory(),
               serverBuilder.getQueryFunctions(),
               serverBuilder.getQueryOutputFormatters(),

--- a/src/test/java/com/google/devtools/build/lib/metrics/MetricsCollectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/metrics/MetricsCollectorTest.java
@@ -734,19 +734,37 @@ public class MetricsCollectorTest extends BuildIntegrationTestCase {
 
   @Test
   public void cumulativeMetrics() throws Exception {
+    // The instance ID is the server's UUID, stable for the server's lifetime, so every event
+    // below reports the same value.
+    String instanceId = getRuntime().getInstanceId().toString();
     buildTarget("//foo:foo");
     assertThat(buildMetricsEventListener.event.getBuildMetrics().getCumulativeMetrics())
-        .isEqualTo(CumulativeMetrics.newBuilder().setNumAnalyses(1).setNumBuilds(1).build());
+        .isEqualTo(
+            CumulativeMetrics.newBuilder()
+                .setNumAnalyses(1)
+                .setNumBuilds(1)
+                .setInstanceId(instanceId)
+                .build());
 
     addOptions("--nobuild");
     buildTarget("//foo:foo");
     assertThat(buildMetricsEventListener.event.getBuildMetrics().getCumulativeMetrics())
-        .isEqualTo(CumulativeMetrics.newBuilder().setNumAnalyses(2).setNumBuilds(1).build());
+        .isEqualTo(
+            CumulativeMetrics.newBuilder()
+                .setNumAnalyses(2)
+                .setNumBuilds(1)
+                .setInstanceId(instanceId)
+                .build());
 
     addOptions("--build", "--noanalyze");
     buildTarget("//foo:foo");
     assertThat(buildMetricsEventListener.event.getBuildMetrics().getCumulativeMetrics())
-        .isEqualTo(CumulativeMetrics.newBuilder().setNumAnalyses(2).setNumBuilds(1).build());
+        .isEqualTo(
+            CumulativeMetrics.newBuilder()
+                .setNumAnalyses(2)
+                .setNumBuilds(1)
+                .setInstanceId(instanceId)
+                .build());
 
     write(
         "foo/BUILD",
@@ -762,7 +780,12 @@ public class MetricsCollectorTest extends BuildIntegrationTestCase {
     addOptions("--analyze");
     assertThrows(ViewCreationFailedException.class, () -> buildTarget("//foo:foo"));
     assertThat(buildMetricsEventListener.event.getBuildMetrics().getCumulativeMetrics())
-        .isEqualTo(CumulativeMetrics.newBuilder().setNumAnalyses(3).setNumBuilds(1).build());
+        .isEqualTo(
+            CumulativeMetrics.newBuilder()
+                .setNumAnalyses(3)
+                .setNumBuilds(1)
+                .setInstanceId(instanceId)
+                .build());
 
     write(
         "foo/BUILD",
@@ -776,7 +799,35 @@ public class MetricsCollectorTest extends BuildIntegrationTestCase {
 
     assertThrows(BuildFailedException.class, () -> buildTarget("//foo:foo"));
     assertThat(buildMetricsEventListener.event.getBuildMetrics().getCumulativeMetrics())
-        .isEqualTo(CumulativeMetrics.newBuilder().setNumAnalyses(4).setNumBuilds(2).build());
+        .isEqualTo(
+            CumulativeMetrics.newBuilder()
+                .setNumAnalyses(4)
+                .setNumBuilds(2)
+                .setInstanceId(instanceId)
+                .build());
+  }
+
+  @Test
+  public void instanceId_matchesServerInstanceIdAndChangesOnRestart() throws Exception {
+    String firstInstanceId = getRuntime().getInstanceId().toString();
+    buildTarget("//foo:foo");
+    assertThat(reportedInstanceId()).isEqualTo(firstInstanceId);
+
+    // Simulate a server restart: the new runtime mints a new instance ID.
+    reinitializeAndPreserveOptions();
+    writeTrivialFooTarget();
+    buildTarget("//foo:foo");
+    String secondInstanceId = getRuntime().getInstanceId().toString();
+    assertThat(secondInstanceId).isNotEqualTo(firstInstanceId);
+    assertThat(reportedInstanceId()).isEqualTo(secondInstanceId);
+  }
+
+  private String reportedInstanceId() {
+    return buildMetricsEventListener
+        .event
+        .getBuildMetrics()
+        .getCumulativeMetrics()
+        .getInstanceId();
   }
 
   @Test


### PR DESCRIPTION
### Description

This PR adds a new field to the `CumulativeMetrics` message that belongs to the `BuildMetrics` BES event. The field is named `instance_id`, and is simply the instance ID of the current running server. It will persist across builds on the server, but if the server is killed and restarted, it will be a cold start and therefore have a brand new instance ID.

### Motivation

To help debug incrementality or performance issues, it's often handy to work out what ran on the Bazel server directly before my build. Tracking this allows us to fetch metrics/logs for invocations that ran on the server with this instance ID and diff stats/metrics/inputs/outputs to understand why the current build behaved the way it did.

The instance ID and also the previous invocation ID is already available in the server log, but putting it here as well alongside the other cumulative metrics makes it even more accessible.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Added a new `instance_id` field to the `BuildMetrics` BES event, in order to help diff between the current and previous builds on the running server.