### PR TITLE
Embed `asInvoker` UAC manifest in the Windows launcher stub

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -104,6 +104,7 @@ JAVA_TOOLS = [
                "//src/main/cpp/util:embedded_tools",
                "//src/main/native:embedded_tools",
                "//src/main/protobuf:srcs",
+               "//src/main/res:srcs",
                "//src/tools/launcher:srcs",
                "//third_party:gpl-srcs",
                "//third_party/def_parser:srcs",

--- a/src/main/res/winsdk_configure.bzl
+++ b/src/main/res/winsdk_configure.bzl
@@ -38,7 +38,7 @@ Usage:
 load("@bazel_tools//tools/cpp:cc_configure.bzl", "MSVC_ENVVARS")
 load("@bazel_tools//tools/cpp:windows_cc_configure.bzl", "find_vc_path", "setup_vc_env_vars")
 
-# Keys: target architecture, as in <Windows-SDK-path>/<target-architecture>/bin/rc.exe
+# Keys: host architecture, as in <Windows-SDK-path>/<host-architecture>/bin/rc.exe
 # Values: corresponding Bazel CPU value under @platforms//cpu:*
 _TARGET_ARCH = {
     "arm": "arm",
@@ -117,11 +117,11 @@ toolchain(
     name = "local_{arch}",
     exec_compatible_with = [
         "@platforms//os:windows",
-        "@platforms//cpu:x86_64",
+        "@platforms//cpu:{cpu}",
     ],
     target_compatible_with = [
         "@platforms//os:windows",
-        "@platforms//cpu:{cpu}",
+        # cpu omitted: .res files are architecture-neutral
     ],
     toolchain = ":local_{arch}_tc",
     toolchain_type = WINDOWS_RESOURCE_COMPILER_TOOLCHAIN_TYPE,

--- a/src/main/res/winsdk_toolchain.bzl
+++ b/src/main/res/winsdk_toolchain.bzl
@@ -40,7 +40,8 @@ Usage:
     )
 """
 
-WINDOWS_RESOURCE_COMPILER_TOOLCHAIN_TYPE = "@io_bazel//src/main/res:toolchain_type"
+# Label resolves to this file's repo: @io_bazel in source builds, @bazel_tools once embedded
+WINDOWS_RESOURCE_COMPILER_TOOLCHAIN_TYPE = Label("//src/main/res:toolchain_type")
 
 WindowsResourceCompilerInfo = provider(
     fields = ["rc_exe"],

--- a/src/test/py/bazel/launcher_test.py
+++ b/src/test/py/bazel/launcher_test.py
@@ -16,6 +16,7 @@
 import os
 import stat
 import string
+import xml.etree.ElementTree
 from absl.testing import absltest
 from src.test.py.bazel import test_base
 
@@ -47,6 +48,45 @@ if os.name == 'nt':
         return output_buf.value
       else:
         output_buf_size = needed
+
+  _LoadLibraryExW = kernel32.LoadLibraryExW
+  _LoadLibraryExW.argtypes = [wintypes.LPCWSTR, ctypes.c_void_p, wintypes.DWORD]
+  _LoadLibraryExW.restype = ctypes.c_void_p
+
+  _FindResourceW = kernel32.FindResourceW
+  _FindResourceW.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
+  _FindResourceW.restype = ctypes.c_void_p
+
+  _LoadResource = kernel32.LoadResource
+  _LoadResource.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+  _LoadResource.restype = ctypes.c_void_p
+
+  _SizeofResource = kernel32.SizeofResource
+  _SizeofResource.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+  _SizeofResource.restype = wintypes.DWORD
+
+  _LockResource = kernel32.LockResource
+  _LockResource.argtypes = [ctypes.c_void_p]
+  _LockResource.restype = ctypes.c_void_p
+
+  _FreeLibrary = kernel32.FreeLibrary
+  _FreeLibrary.argtypes = [ctypes.c_void_p]
+  _FreeLibrary.restype = wintypes.BOOL
+
+  def _get_exe_manifest(exe_path):
+    """Returns the RT_MANIFEST XML embedded in a Windows PE binary."""
+    if not (module := _LoadLibraryExW(exe_path, None, 0x2)):  # LOAD_LIBRARY_AS_DATAFILE
+      raise ctypes.WinError()
+    try:
+      if not (info := _FindResourceW(module, 1, 24)):  # id=1, RT_MANIFEST=24
+        raise ctypes.WinError()
+      if not (data := _LoadResource(module, info)):  # "there is no need to free the resource"
+        raise ctypes.WinError()
+      resource = _LockResource(data)  # "there is no way to unlock a resource"
+      size = _SizeofResource(module, info)
+      return ctypes.string_at(resource, size).decode()
+    finally:
+      _FreeLibrary(module)
 
 
 class LauncherTest(test_base.TestBase):
@@ -849,6 +889,41 @@ class LauncherTest(test_base.TestBase):
     )
     self.assertEqual('helloworld', ''.join(stdout))
 
+  # Regression test for https://github.com/bazelbuild/bazel/issues/29819
+  def testWindowsNativeLauncherUserAccessControlManifest(self):
+    if not self.IsWindows():
+      return
+    self.AddBazelDep('rules_python')
+    self.ScratchFile(
+        'BUILD',
+        [
+            'load("@rules_python//python:py_binary.bzl", "py_binary")',
+            'py_binary(',
+            '    name = "not_an_installer",',
+            '    srcs = ["not_an_installer.py"],',
+            ')',
+        ],
+    )
+    self.ScratchFile('not_an_installer.py', ['print("hello")'])
+
+    _, stdout, _ = self.RunBazel(['info', 'bazel-bin'])
+    bazel_bin = stdout[0]
+
+    self.RunBazel(['build', '//:not_an_installer'])
+    exe = os.path.join(bazel_bin, 'not_an_installer.exe')
+    self.assertTrue(os.path.isfile(exe))
+
+    # first, verify the manifest's content
+    manifest = xml.etree.ElementTree.fromstring(_get_exe_manifest(exe))
+    el = manifest.find('.//{urn:schemas-microsoft-com:asm.v3}requestedExecutionLevel')
+    self.assertIsNotNone(el, 'no requestedExecutionLevel in manifest')
+    self.assertEqual(el.get('level'), 'asInvoker')
+    self.assertEqual(el.get('uiAccess'), 'false')
+
+    # then, verify the manifest's effectiveness (would pass as admin even without the fix)
+    exit_code, _, stderr = self.RunProgram([exe], allow_failure=True)
+    self.AssertExitCode(exit_code, 0, stderr)
+
   # Regression test for
   # https://github.com/bazelbuild/bazel/pull/24703#issuecomment-2665963637
   def testBuildLaunchersWithClangClOnWindows(self):
@@ -864,6 +939,8 @@ class LauncherTest(test_base.TestBase):
             'use_repo(cc_configure, "local_config_cc")',
             # Register all cc toolchains for Windows
             'register_toolchains("@local_config_cc//:all")',
+            # Register the no-op RC toolchain since resource compilation is not under test here
+            'register_toolchains("@bazel_tools//src/main/res:empty_rc_toolchain")',
         ],
         mode='a',
     )

--- a/src/tools/launcher/BUILD
+++ b/src/tools/launcher/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("//src/main/res:win_res.bzl", "windows_resources")
 load(":launcher_maker_test.bzl", "launcher_maker_test")
 load(":win_rules.bzl", "win_cc_binary", "win_cc_library")
 
@@ -6,6 +7,12 @@ filegroup(
     name = "srcs",
     srcs = glob(["**"]) + ["//src/tools/launcher/util:srcs"],
     visibility = ["//src:__pkg__"],
+)
+
+windows_resources(
+    name = "win_resources",
+    rc_files = ["win_resources.rc"],
+    resources = ["win_manifest.xml"],
 )
 
 win_cc_binary(
@@ -20,6 +27,7 @@ win_cc_binary(
         ":java_launcher",
         ":launcher_base",
         ":python_launcher",
+        ":win_resources",
         "//src/tools/launcher/util",
         "//src/tools/launcher/util:data_parser",
     ],

--- a/src/tools/launcher/win_manifest.xml
+++ b/src/tools/launcher/win_manifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <!-- executables named "*install*", "*update*", etc. may otherwise cause UAC to demand elevation (error 740) -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/src/tools/launcher/win_resources.rc
+++ b/src/tools/launcher/win_resources.rc
@@ -1,0 +1,2 @@
+// id 1 (CREATEPROCESS_MANIFEST_RESOURCE_ID), type 24 (RT_MANIFEST)
+1 24 "win_manifest.xml"


### PR DESCRIPTION
### Description
Add `win_manifest.xml` (`requestedExecutionLevel`: `asInvoker`) and `win_resources.rc` to `src/tools/launcher`, link them via the existing `windows_resources` rule, and add a regression test.

### Motivation
On Windows, manifest-less PE executables whose name contains keywords like "install", "setup", "update", or "patch" trigger the "[UAC installer-detection heuristic](https://www.advancedinstaller.com/user-guide/vista-uac.html)" and demand elevation, even when the target does nothing privileged.

When running such executables without admin privileges, one indeed face errors resembling:
```
FATAL: ExecuteProgram(C:\[...]\install.exe) failed: ERROR: src/main/native/windows/process.cc(189): CreateProcessW("C:\[...]\install.exe"): The requested operation requires elevation.
 (error: 740)
 ```

Declaring `asInvoker` in the launcher stub bypasses the heuristic, similar to rust-lang/cargo#393 (`cargo update` triggered the same heuristic): cargo now ships a `windows.manifest.xml` embedded via its build script.

Because the manifest lives in the PE resource section, `launcher_maker`'s byte-copy propagates it to every generated binary automatically.

Fixes bazelbuild/bazel#29819.

### Build API Changes
No

### Checklist
- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes
RELNOTES[NEW]: Windows launcher stubs now embed an `asInvoker` UAC manifest, preventing "The requested operation requires elevation. (error: 740)" for targets whose name matches the installer-detection heuristic.