### PR TITLE
Remove the redundant `envResolved` parameter of `SpawnAction#getSpawn`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -333,8 +333,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     return new ActionSpawn(
         commandLines.allArguments(),
         this,
-        /* env= */ ImmutableMap.of(),
-        /* envResolved= */ false,
+        /* clientEnv= */ ImmutableMap.of(),
         inputs,
         // SpawnInfo doesn't report the runfiles trees of the Spawn, so it's fine to just pass in
         // an empty list here.
@@ -352,22 +351,16 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     return getSpawn(
         actionExecutionContext,
         actionExecutionContext.getClientEnv(),
-        /* envResolved= */ false,
         /* reportOutputs= */ true);
   }
 
   /**
    * Return a spawn that is representative of the command that this Action will execute in the given
-   * environment.
-   *
-   * @param envResolved If set to true, the passed environment variables will be used as the Spawn
-   *     effective environment. Otherwise they will be used as client environment to resolve the
-   *     action env.
+   * client environment.
    */
   protected Spawn getSpawn(
       ActionExecutionContext actionExecutionContext,
-      Map<String, String> env,
-      boolean envResolved,
+      Map<String, String> clientEnv,
       boolean reportOutputs)
       throws CommandLineExpansionException, InterruptedException {
     PathMapper pathMapper =
@@ -382,8 +375,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     return new ActionSpawn(
         expandedCommandLines.arguments(),
         this,
-        env,
-        envResolved,
+        clientEnv,
         getInputs(),
         expandedCommandLines.getParamFiles(),
         reportOutputs,
@@ -541,8 +533,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     private ActionSpawn(
         ImmutableList<String> arguments,
         SpawnAction parent,
-        Map<String, String> env,
-        boolean envResolved,
+        Map<String, String> clientEnv,
         NestedSet<Artifact> inputs,
         List<? extends ActionInput> additionalInputs,
         boolean reportOutputs,
@@ -556,15 +547,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
           parent.resourceSetOrBuilder);
       this.inputs = SpawnInputs.of(inputs, additionalInputs);
       this.pathMapper = pathMapper;
-
-      // If the action environment is already resolved using the client environment, the given
-      // environment variables are used as they are. Otherwise, they are used as clientEnv to
-      // resolve the action environment variables.
-      if (envResolved) {
-        effectiveEnvironment = ImmutableMap.copyOf(env);
-      } else {
-        effectiveEnvironment = parent.getEffectiveEnvironment(env);
-      }
+      this.effectiveEnvironment = parent.getEffectiveEnvironment(clientEnv);
       this.reportOutputs = reportOutputs;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -502,21 +502,6 @@ public class StarlarkAction extends SpawnAction {
       return createInputs(inputFilesForExtraAction, allStarlarkActionInputs);
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * <p>Adds the environment of the shadowed action, if any, to the execution spawn.
-     */
-    @Override
-    public Spawn getSpawn(ActionExecutionContext actionExecutionContext)
-        throws CommandLineExpansionException, InterruptedException {
-      return getSpawn(
-          actionExecutionContext,
-          getEffectiveEnvironment(actionExecutionContext.getClientEnv()),
-          /* envResolved= */ true,
-          /* reportOutputs= */ true);
-    }
-
     @Override
     public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
         throws CommandLineExpansionException {

--- a/src/main/java/com/google/devtools/build/lib/analysis/extra/ExtraAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/extra/ExtraAction.java
@@ -208,7 +208,6 @@ public final class ExtraAction extends SpawnAction {
     return getSpawn(
         actionExecutionContext,
         actionExecutionContext.getClientEnv(),
-        /* envResolved= */ false,
         /* reportOutputs= */ false);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
@@ -261,8 +261,7 @@ public final class SpawnActionTest extends BuildViewTestCase {
     Spawn spawn =
         action.getSpawn(
             actionExecutionContext,
-            ImmutableMap.of(),
-            /* envResolved= */ false,
+            /* clientEnv= */ ImmutableMap.of(),
             /* reportOutputs= */ true);
     String paramFileName = output.getExecPathString() + "-0.params";
     // The spawn's primary arguments should reference the param file


### PR DESCRIPTION
The `envResolved == true` path computed the same effective environment as the `envResolved == false` path: `ActionSpawn` resolves its environment via `Action#getEffectiveEnvironment`, which `EnhancedStarlarkAction` overrides to merge in the environment of its shadowed action.
