### PR TITLE
Restore permissions after failed finalization

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -24,11 +24,14 @@ import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 import static com.google.devtools.build.lib.remote.util.Utils.mergeBulkTransfer;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
+import com.google.common.collect.SetMultimap;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.Striped;
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
@@ -60,10 +63,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
@@ -206,6 +209,10 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
 
   private final DirectoryTracker directoryTracker = new DirectoryTracker();
 
+  // TreeArtifact downloads use temporary paths. Serialize only permission changes and final file
+  // moves, keyed by resolved tree root, so unrelated trees can still finalize concurrently.
+  private final Striped<Lock> treeArtifactLocks = Striped.lock(64);
+
   /** A symlink in the output tree that points to another artifact's absolute path. */
   record Symlink(Path linkPath, Path targetPath) {
     Symlink {
@@ -346,21 +353,18 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       return immediateVoidFuture();
     }
 
-    // Collect the set of directories whose output permissions must be set at the end of this call.
-    // This responsibility cannot lie with the downloading of an individual file, because multiple
-    // files may be concurrently downloaded into the same directory within a single call to
-    // prefetchFiles, and two concurrent calls to prefetchFiles may prefetch the same file. In the
-    // latter case, the second call will have its downloads deduplicated against the first call, but
-    // it must still synchronize on the output permissions having been set.
-    Set<Path> dirsWithOutputPermissions = Sets.newConcurrentHashSet();
+    // Collect directories whose output permissions must be restored at the end of this call,
+    // grouped by tree root for synchronization. Keeping restoration call-scoped avoids toggling
+    // shared ancestors between child finalizations. A concurrent call for the same child may join
+    // the cached download but must still participate in permission restoration before returning.
+    SetMultimap<Path, Path> directoriesByTreeRoot = HashMultimap.create();
 
     // Using plain futures to avoid RxJava overheads.
     List<ListenableFuture<Void>> transfers = new ArrayList<>(files.size());
     try (var s = Profiler.instance().profile("compose prefetches")) {
       for (var file : files) {
         transfers.add(
-            prefetchFile(
-                action, dirsWithOutputPermissions, metadataSupplier, file, priority, reason));
+            prefetchFile(action, directoriesByTreeRoot, metadataSupplier, file, priority, reason));
       }
     }
 
@@ -373,10 +377,19 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
         mergedTransfer,
         unused -> {
           try {
-            // Set output permissions on tree artifact subdirectories, matching the behavior of
-            // SkyframeActionExecutor#checkOutputs for artifacts produced by local actions.
-            for (Path dir : dirsWithOutputPermissions) {
-              directoryTracker.setOutputPermissions(dir);
+            // Match the directory output permissions set by SkyframeActionExecutor#checkOutputs.
+            // Take the same root lock as finalization so restoration cannot make an ancestor
+            // read-only while another call moves a child into the tree.
+            for (var entry : directoriesByTreeRoot.asMap().entrySet()) {
+              Lock lock = treeArtifactLocks.get(entry.getKey().asFragment());
+              lock.lock();
+              try {
+                for (Path dir : entry.getValue()) {
+                  directoryTracker.setOutputPermissions(dir);
+                }
+              } finally {
+                lock.unlock();
+              }
             }
           } catch (IOException e) {
             return immediateFailedFuture(e);
@@ -388,7 +401,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
 
   private ListenableFuture<Void> prefetchFile(
       @Nullable ActionExecutionMetadata action,
-      Set<Path> dirsWithOutputPermissions,
+      SetMultimap<Path, Path> directoriesByTreeRoot,
       MetadataSupplier metadataSupplier,
       ActionInput input,
       Priority priority,
@@ -436,7 +449,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
               input,
               inputPath,
               treeRootPath,
-              dirsWithOutputPermissions,
+              directoriesByTreeRoot,
               input,
               metadata,
               priority,
@@ -560,7 +573,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       ActionInput input,
       Path path,
       @Nullable Path treeRoot,
-      Set<Path> dirsWithOutputPermissions,
+      SetMultimap<Path, Path> directoriesByTreeRoot,
       ActionInput actionInput,
       FileArtifactValue metadata,
       Priority priority,
@@ -581,24 +594,27 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       return Completable.error(e);
     }
 
+    // Downloads are written to the actual host file system, not any overlays.
+    Path finalPath = path.forHostFileSystem();
+
+    ImmutableList.Builder<Path> dirsWithOutputPermissions = ImmutableList.builder();
     if (treeRoot != null
         && actionInput instanceof Artifact artifact
         && artifact.isChildOfDeclaredDirectory()) {
-      // Arrange for the output permissions to be set on every directory inside the tree artifact.
-      // This must be done at assembly time to ensure that the permissions are set before the
-      // prefetchFiles call returns, even when the actual downloads are deduplicated against a
-      // concurrent call. See finalizeDownload for why we don't do so in other cases.
-      for (Path dir = path.getParentDirectory();
-          dir.startsWith(treeRoot);
+      Path finalTreeRoot = treeRoot.forHostFileSystem();
+      // Record directories child-to-root. Every ancestor must be explicitly reopened because
+      // ActionOutputDirectoryHelper caches existing directories and may otherwise leave a
+      // previously restored ancestor read-only.
+      for (Path dir = finalPath.getParentDirectory();
+          dir.startsWith(finalTreeRoot);
           dir = dir.getParentDirectory()) {
-        if (!dirsWithOutputPermissions.add(dir)) {
-          break;
-        }
+        dirsWithOutputPermissions.add(dir);
       }
     }
-
-    // Downloads should always be written to the "actual" host file system, not any overlays.
-    Path finalPath = path.forHostFileSystem();
+    ImmutableList<Path> directories = dirsWithOutputPermissions.build();
+    if (!directories.isEmpty()) {
+      directoriesByTreeRoot.putAll(directories.getLast(), directories);
+    }
 
     Completable download =
         usingTempPath(
@@ -617,10 +633,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
                     .doOnComplete(
                         () -> {
                           finalizeDownload(
-                              metadata,
-                              tempPath.forHostFileSystem(),
-                              finalPath,
-                              dirsWithOutputPermissions);
+                              metadata, tempPath.forHostFileSystem(), finalPath, directories);
                           alreadyDeleted.set(true);
                         }));
 
@@ -637,40 +650,57 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
   }
 
   private void finalizeDownload(
-      FileArtifactValue metadata, Path tmpPath, Path finalPath, Set<Path> dirsWithOutputPermissions)
+      FileArtifactValue metadata,
+      Path tmpPath,
+      Path finalPath,
+      ImmutableList<Path> dirsWithOutputPermissions)
       throws IOException {
-    Path parentDir = checkNotNull(finalPath.getParentDirectory());
+    // Set file output permissions, matching SkyframeActionExecutor#checkOutputs for artifacts
+    // produced by local actions. The temporary path is outside the output tree, so this can happen
+    // before entering the TreeArtifact root's critical section.
+    tmpPath.chmod(outputPermissions.getPermissionsMode());
 
-    // Compare as fragments since execRoot may be located on a file system overlaying the host
-    // file system where the download is written to.
-    if (finalPath.asFragment().startsWith(execRoot.asFragment())) {
-      // Ensure the parent directory exists and is writable. We cannot rely on this precondition to
-      // have been established by the execution of the owning action in a previous invocation, since
-      // the output tree may have been externally modified in between invocations.
-      if (dirsWithOutputPermissions.contains(parentDir)) {
-        // The file belongs to a tree artifact created by an action that declared an output
-        // directory (as opposed to an action template expansion). The output permissions should be
-        // set on the parent directory after prefetching.
-        directoryTracker.setTemporarilyWritable(parentDir);
-      } else {
-        // One of the following must apply:
-        //   (1) The file does not belong to a tree artifact.
-        //   (2) The file belongs to a tree artifact created by an action template expansion.
-        // In case (1), the parent directory is a package or a subdirectory of a package, and should
-        // remain writable. In case (2), even though we arguably ought to set the output permissions
-        // on the parent directory to match local execution, we choose not to do it and avoid the
-        // additional implementation complexity required to detect a race condition between
-        // concurrent calls touching the same directory.
-        directoryTracker.setPermanentlyWritable(parentDir);
-      }
-    } else {
-      parentDir.createDirectoryAndParents();
+    Path parentDir = checkNotNull(finalPath.getParentDirectory());
+    @Nullable Lock treeArtifactLock =
+        dirsWithOutputPermissions.isEmpty()
+            ? null
+            : treeArtifactLocks.get(dirsWithOutputPermissions.getLast().asFragment());
+    if (treeArtifactLock != null) {
+      treeArtifactLock.lock();
     }
 
-    // Set output permissions on files, matching the behavior of SkyframeActionExecutor#checkOutputs
-    // for artifacts produced by local actions.
-    tmpPath.chmod(outputPermissions.getPermissionsMode());
-    FileSystemUtils.moveFile(tmpPath, finalPath);
+    try {
+      // Compare as fragments since execRoot may be located on a file system overlaying the host
+      // file system where the download is written to.
+      if (finalPath.asFragment().startsWith(execRoot.asFragment())) {
+        // Ensure the parent directory exists and is writable. We cannot rely on this precondition
+        // to have been established by the execution of the owning action in a previous invocation,
+        // since the output tree may have been externally modified in between invocations.
+        if (!dirsWithOutputPermissions.isEmpty()) {
+          for (Path dir : dirsWithOutputPermissions.reverse()) {
+            directoryTracker.setTemporarilyWritable(dir);
+          }
+        } else {
+          // One of the following must apply:
+          //   (1) The file does not belong to a tree artifact.
+          //   (2) The file belongs to a tree artifact created by an action template expansion.
+          // In case (1), the parent directory is a package or a subdirectory of a package, and
+          // should remain writable. In case (2), even though we arguably ought to set the output
+          // permissions on the parent directory to match local execution, we choose not to do it
+          // and avoid the additional implementation complexity required to detect a race condition
+          // between concurrent calls touching the same directory.
+          directoryTracker.setPermanentlyWritable(parentDir);
+        }
+      } else {
+        parentDir.createDirectoryAndParents();
+      }
+
+      FileSystemUtils.moveFile(tmpPath, finalPath);
+    } finally {
+      if (treeArtifactLock != null) {
+        treeArtifactLock.unlock();
+      }
+    }
 
     // Set the contents proxy when supported, to make future modification checks cheaper.
     metadata.setContentsProxy(FileContentsProxy.create(finalPath.stat()));

--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -663,12 +663,14 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
     tmpPath.chmod(outputPermissions.getPermissionsMode());
 
     Path parentDir = checkNotNull(finalPath.getParentDirectory());
+    @Nullable Path deepestTemporarilyWritableDirectory = null;
     @Nullable Lock treeArtifactLock =
         treeRoot == null ? null : treeArtifactLocks.get(treeRoot.asFragment()).readLock();
     if (treeArtifactLock != null) {
       treeArtifactLock.lock();
     }
 
+    @Nullable IOException finalizationError = null;
     try {
       // Compare as fragments since execRoot may be located on a file system overlaying the host
       // file system where the download is written to.
@@ -681,9 +683,11 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
           // and may otherwise leave a previously restored ancestor read-only.
           Path dir = treeRoot;
           directoryTracker.setTemporarilyWritable(dir);
+          deepestTemporarilyWritableDirectory = dir;
           for (String segment : parentDir.relativeTo(treeRoot).segments()) {
             dir = dir.getChild(segment);
             directoryTracker.setTemporarilyWritable(dir);
+            deepestTemporarilyWritableDirectory = dir;
           }
         } else {
           // One of the following must apply:
@@ -701,14 +705,45 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       }
 
       FileSystemUtils.moveFile(tmpPath, finalPath);
+    } catch (IOException e) {
+      finalizationError = e;
     } finally {
       if (treeArtifactLock != null) {
         treeArtifactLock.unlock();
       }
     }
 
-    // Set the contents proxy when supported, to make future modification checks cheaper.
-    metadata.setContentsProxy(FileContentsProxy.create(finalPath.stat()));
+    if (finalizationError == null) {
+      try {
+        // Set the contents proxy when supported, to make future modification checks cheaper.
+        metadata.setContentsProxy(FileContentsProxy.create(finalPath.stat()));
+        return;
+      } catch (IOException e) {
+        finalizationError = e;
+      }
+    }
+
+    // Successful calls restore permissions after every finalization has completed. A failed
+    // finalization never reaches that call-scoped restoration, so roll back the directories this
+    // finalization reopened before propagating the original error.
+    if (treeRoot != null && deepestTemporarilyWritableDirectory != null) {
+      Lock permissionRestorationLock = treeArtifactLocks.get(treeRoot.asFragment()).writeLock();
+      permissionRestorationLock.lock();
+      try {
+        for (Path dir = deepestTemporarilyWritableDirectory;
+            dir.startsWith(treeRoot);
+            dir = dir.getParentDirectory()) {
+          try {
+            directoryTracker.setOutputPermissions(dir);
+          } catch (IOException restorationError) {
+            finalizationError.addSuppressed(restorationError);
+          }
+        }
+      } finally {
+        permissionRestorationLock.unlock();
+      }
+    }
+    throw finalizationError;
   }
 
   private interface TaskWithTempPath {

--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -210,9 +210,11 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
 
   private final DirectoryTracker directoryTracker = new DirectoryTracker();
 
-  // TreeArtifact downloads use temporary paths. Coordinate finalization and permission restoration
-  // by resolved tree root. Weak locks over the full hash space allow unrelated trees to finalize
-  // concurrently without retaining every lock for the lifetime of the prefetcher.
+  // Tree artifact downloads use temporary paths. Coordinate by resolved tree root: a read lock
+  // protects reopening ancestors and moving one child into place, while a write lock protects
+  // restoring every directory touched by a prefetchFiles call to its output permissions. Weak
+  // locks over the full hash space allow unrelated trees to finalize concurrently without
+  // retaining every lock for the lifetime of the prefetcher.
   private final Striped<ReadWriteLock> treeArtifactLocks =
       Striped.lazyWeakReadWriteLock(Integer.MAX_VALUE);
 
@@ -357,9 +359,10 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
     }
 
     // Collect directories whose output permissions must be restored at the end of this call,
-    // grouped by tree root for synchronization. Keeping restoration call-scoped avoids toggling
-    // shared ancestors between child finalizations. A concurrent call for the same child may join
-    // the cached download but must still participate in permission restoration before returning.
+    // grouped by tree root for synchronization. Keeping permission restoration scoped to this
+    // prefetchFiles call avoids toggling shared ancestors between child finalizations. A concurrent
+    // call to prefetchFiles for the same child may await the same download, but must still
+    // participate in permission restoration before returning.
     SetMultimap<Path, Path> directoriesByTreeRoot = HashMultimap.create();
 
     // Using plain futures to avoid RxJava overheads.
@@ -381,8 +384,6 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
         unused -> {
           try {
             // Match the directory output permissions set by SkyframeActionExecutor#checkOutputs.
-            // Take the root write lock so restoration cannot make an ancestor read-only while any
-            // call holds a read lock to move a child into the tree.
             for (var entry : directoriesByTreeRoot.asMap().entrySet()) {
               Lock lock = treeArtifactLocks.get(entry.getKey().asFragment()).writeLock();
               lock.lock();
@@ -600,23 +601,22 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
     // Downloads are written to the actual host file system, not any overlays.
     Path finalPath = path.forHostFileSystem();
 
-    ImmutableList.Builder<Path> dirsWithOutputPermissions = ImmutableList.builder();
-    if (treeRoot != null
-        && actionInput instanceof Artifact artifact
-        && artifact.isChildOfDeclaredDirectory()) {
-      Path finalTreeRoot = treeRoot.forHostFileSystem();
-      // Record directories child-to-root. Every ancestor must be explicitly reopened because
-      // ActionOutputDirectoryHelper caches existing directories and may otherwise leave a
-      // previously restored ancestor read-only.
+    @Nullable Path finalTreeRoot =
+        treeRoot != null
+                && actionInput instanceof Artifact artifact
+                && artifact.isChildOfDeclaredDirectory()
+            ? treeRoot.forHostFileSystem()
+            : null;
+    if (finalTreeRoot != null) {
+      // Record directories child-to-root. If a directory is already present for this tree root, an
+      // earlier traversal also recorded every ancestor through the root.
       for (Path dir = finalPath.getParentDirectory();
           dir.startsWith(finalTreeRoot);
           dir = dir.getParentDirectory()) {
-        dirsWithOutputPermissions.add(dir);
+        if (!directoriesByTreeRoot.put(finalTreeRoot, dir)) {
+          break;
+        }
       }
-    }
-    ImmutableList<Path> directories = dirsWithOutputPermissions.build();
-    if (!directories.isEmpty()) {
-      directoriesByTreeRoot.putAll(directories.getLast(), directories);
     }
 
     Completable download =
@@ -636,7 +636,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
                     .doOnComplete(
                         () -> {
                           finalizeDownload(
-                              metadata, tempPath.forHostFileSystem(), finalPath, directories);
+                              metadata, tempPath.forHostFileSystem(), finalPath, finalTreeRoot);
                           alreadyDeleted.set(true);
                         }));
 
@@ -656,22 +656,16 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       FileArtifactValue metadata,
       Path tmpPath,
       Path finalPath,
-      ImmutableList<Path> dirsWithOutputPermissions)
+      @Nullable Path treeRoot)
       throws IOException {
     // Set file output permissions, matching SkyframeActionExecutor#checkOutputs for artifacts
     // produced by local actions. The temporary path is outside the output tree, so this can happen
-    // before entering the TreeArtifact root's critical section.
+    // before entering the tree artifact root's critical section.
     tmpPath.chmod(outputPermissions.getPermissionsMode());
 
     Path parentDir = checkNotNull(finalPath.getParentDirectory());
-    // A read lock allows concurrent child moves, while preventing a prefetch call from restoring
-    // the tree's output permissions until every move in progress has completed.
     @Nullable Lock treeArtifactLock =
-        dirsWithOutputPermissions.isEmpty()
-            ? null
-            : treeArtifactLocks
-                .get(dirsWithOutputPermissions.getLast().asFragment())
-                .readLock();
+        treeRoot == null ? null : treeArtifactLocks.get(treeRoot.asFragment()).readLock();
     if (treeArtifactLock != null) {
       treeArtifactLock.lock();
     }
@@ -683,8 +677,13 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
         // Ensure the parent directory exists and is writable. We cannot rely on this precondition
         // to have been established by the execution of the owning action in a previous invocation,
         // since the output tree may have been externally modified in between invocations.
-        if (!dirsWithOutputPermissions.isEmpty()) {
-          for (Path dir : dirsWithOutputPermissions.reverse()) {
+        if (treeRoot != null) {
+          // Reopen every ancestor because ActionOutputDirectoryHelper caches existing directories
+          // and may otherwise leave a previously restored ancestor read-only.
+          Path dir = treeRoot;
+          directoryTracker.setTemporarilyWritable(dir);
+          for (String segment : parentDir.relativeTo(treeRoot).segments()) {
+            dir = dir.getChild(segment);
             directoryTracker.setTemporarilyWritable(dir);
           }
         } else {

--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -67,6 +67,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
@@ -209,9 +210,11 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
 
   private final DirectoryTracker directoryTracker = new DirectoryTracker();
 
-  // TreeArtifact downloads use temporary paths. Serialize only permission changes and final file
-  // moves, keyed by resolved tree root, so unrelated trees can still finalize concurrently.
-  private final Striped<Lock> treeArtifactLocks = Striped.lock(64);
+  // TreeArtifact downloads use temporary paths. Coordinate finalization and permission restoration
+  // by resolved tree root. Weak locks over the full hash space allow unrelated trees to finalize
+  // concurrently without retaining every lock for the lifetime of the prefetcher.
+  private final Striped<ReadWriteLock> treeArtifactLocks =
+      Striped.lazyWeakReadWriteLock(Integer.MAX_VALUE);
 
   /** A symlink in the output tree that points to another artifact's absolute path. */
   record Symlink(Path linkPath, Path targetPath) {
@@ -378,10 +381,10 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
         unused -> {
           try {
             // Match the directory output permissions set by SkyframeActionExecutor#checkOutputs.
-            // Take the same root lock as finalization so restoration cannot make an ancestor
-            // read-only while another call moves a child into the tree.
+            // Take the root write lock so restoration cannot make an ancestor read-only while any
+            // call holds a read lock to move a child into the tree.
             for (var entry : directoriesByTreeRoot.asMap().entrySet()) {
-              Lock lock = treeArtifactLocks.get(entry.getKey().asFragment());
+              Lock lock = treeArtifactLocks.get(entry.getKey().asFragment()).writeLock();
               lock.lock();
               try {
                 for (Path dir : entry.getValue()) {
@@ -661,10 +664,14 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
     tmpPath.chmod(outputPermissions.getPermissionsMode());
 
     Path parentDir = checkNotNull(finalPath.getParentDirectory());
+    // A read lock allows concurrent child moves, while preventing a prefetch call from restoring
+    // the tree's output permissions until every move in progress has completed.
     @Nullable Lock treeArtifactLock =
         dirsWithOutputPermissions.isEmpty()
             ? null
-            : treeArtifactLocks.get(dirsWithOutputPermissions.getLast().asFragment());
+            : treeArtifactLocks
+                .get(dirsWithOutputPermissions.getLast().asFragment())
+                .readLock();
     if (treeArtifactLock != null) {
       treeArtifactLock.lock();
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -25,7 +25,6 @@ import static com.google.devtools.build.lib.remote.util.Utils.mergeBulkTransfer;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 import com.google.common.flogger.GoogleLogger;

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -24,6 +24,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -658,6 +659,60 @@ public abstract class ActionInputPrefetcherTestBase {
             Reason.INPUTS));
     assertThat(FileSystemUtils.readContent(children.get(1).getPath(), UTF_8))
         .isEqualTo("content2");
+    assertTreeReadableNonWritableAndExecutable(tree.getPath());
+  }
+
+  @Test
+  public void prefetchFiles_treeFile_failedFinalization_restoresPermissions() throws Exception {
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+    Map<HashCode, byte[]> cas = new HashMap<>();
+    Pair<SpecialArtifact, ImmutableList<TreeFileArtifact>> treeAndChildren =
+        createRemoteTreeArtifact(
+            "dir",
+            /* localContentMap= */ ImmutableMap.of(),
+            /* remoteContentMap= */ ImmutableMap.of("subdir/file", "content"),
+            metadata,
+            cas);
+    SpecialArtifact tree = treeAndChildren.getFirst();
+    TreeFileArtifact child = Iterables.getOnlyElement(treeAndChildren.getSecond());
+    AbstractActionInputPrefetcher prefetcher = createPrefetcher(cas);
+    PathFragment tempDir = tempPathGenerator.getTempDir().asFragment();
+
+    doAnswer(
+            invocation -> {
+              PathFragment source = invocation.getArgument(0);
+              if (source.startsWith(tempDir)) {
+                throw new IOException("move failed");
+              }
+              return invocation.callRealMethod();
+            })
+        .when(fs)
+        .renameTo(any(), any());
+    doAnswer(
+            invocation -> {
+              PathFragment path = invocation.getArgument(0);
+              if (path.startsWith(tempDir)) {
+                throw new IOException("copy fallback failed");
+              }
+              return invocation.callRealMethod();
+            })
+        .when(fs)
+        .stat(any(), anyBoolean());
+
+    IOException error =
+        assertThrows(
+            IOException.class,
+            () ->
+                wait(
+                    prefetcher.prefetchFilesInterruptibly(
+                        action,
+                        ImmutableList.of(child),
+                        metadata::get,
+                        Priority.MEDIUM,
+                        Reason.INPUTS)));
+
+    assertThat(error).hasMessageThat().isEqualTo("copy fallback failed");
+    assertThat(child.getPath().exists()).isFalse();
     assertTreeReadableNonWritableAndExecutable(tree.getPath());
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -76,6 +76,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -765,9 +766,9 @@ public abstract class ActionInputPrefetcherTestBase {
         .when(fs)
         .renameTo(any(), any());
     Thread secondCompletion = new Thread(() -> secondDownload.set(null));
-    // Completing the first download runs its direct-executor finalization on this thread. Without
-    // root-level synchronization it completes and restores the shared root while the second move
-    // is paused; with synchronization it waits for the second finalization to release the lock.
+    // Completing the first download runs its direct-executor finalization on this thread. Its move
+    // may proceed concurrently with the paused move, but its permission restoration must wait for
+    // the paused finalization to release its read lock.
     Thread firstCompletion = new Thread(() -> firstDownload.set(null));
     secondCompletion.start();
     try {
@@ -775,16 +776,11 @@ public abstract class ActionInputPrefetcherTestBase {
       firstCompletion.start();
 
       long deadline = System.nanoTime() + SECONDS.toNanos(10);
-      while (!firstPrefetch.isDone()
-          && firstCompletion.getState() != Thread.State.BLOCKED
-          && firstCompletion.getState() != Thread.State.WAITING
-          && System.nanoTime() < deadline) {
+      while (!children.get(0).getPath().exists() && System.nanoTime() < deadline) {
         Thread.yield();
       }
-      assertThat(firstPrefetch.isDone()
-              || firstCompletion.getState() == Thread.State.BLOCKED
-              || firstCompletion.getState() == Thread.State.WAITING)
-          .isTrue();
+      assertThat(children.get(0).getPath().exists()).isTrue();
+      assertThat(firstPrefetch.isDone()).isFalse();
       assertThat(tree.getPath().isWritable()).isTrue();
     } finally {
       secondFinalizationMayContinue.release();
@@ -795,6 +791,82 @@ public abstract class ActionInputPrefetcherTestBase {
     wait(firstPrefetch);
     wait(secondPrefetch);
     assertTreeReadableNonWritableAndExecutable(tree.getPath());
+  }
+
+  @Test
+  public void prefetchFiles_treeFiles_manyConcurrentOverlappingCalls() throws Exception {
+    int treeCount = 4;
+    int childrenPerTree = 16;
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+    Map<HashCode, byte[]> cas = new HashMap<>();
+    ImmutableList.Builder<SpecialArtifact> trees = ImmutableList.builder();
+    ImmutableList.Builder<ImmutableList<TreeFileArtifact>> childrenByTree =
+        ImmutableList.builder();
+    for (int treeIndex = 0; treeIndex < treeCount; treeIndex++) {
+      ImmutableMap.Builder<String, String> remoteContent = ImmutableMap.builder();
+      for (int childIndex = 0; childIndex < childrenPerTree; childIndex++) {
+        remoteContent.put("subdir-" + childIndex + "/file", "content");
+      }
+      Pair<SpecialArtifact, ImmutableList<TreeFileArtifact>> treeAndChildren =
+          createRemoteTreeArtifact(
+              "dir-" + treeIndex,
+              /* localContentMap= */ ImmutableMap.of(),
+              remoteContent.buildOrThrow(),
+              metadata,
+              cas);
+      trees.add(treeAndChildren.getFirst());
+      childrenByTree.add(treeAndChildren.getSecond());
+    }
+    ImmutableList<SpecialArtifact> treeList = trees.build();
+    ImmutableList<ImmutableList<TreeFileArtifact>> childLists = childrenByTree.build();
+    AbstractActionInputPrefetcher prefetcher = createPrefetcher(cas);
+
+    int concurrency = 32;
+    int requestCount = 128;
+    CountDownLatch requestsReady = new CountDownLatch(concurrency);
+    CountDownLatch startRequests = new CountDownLatch(1);
+    ThreadPoolExecutor pool =
+        new ThreadPoolExecutor(
+            concurrency, concurrency, 0, SECONDS, new LinkedBlockingQueue<>());
+    ImmutableList.Builder<Future<Void>> requests = ImmutableList.builder();
+    try {
+      for (int requestIndex = 0; requestIndex < requestCount; requestIndex++) {
+        int treeIndex = requestIndex % treeCount;
+        int childIndex = (requestIndex / treeCount) % childrenPerTree;
+        ImmutableList<TreeFileArtifact> children = childLists.get(treeIndex);
+        ImmutableList<ActionInput> inputs =
+            ImmutableList.of(
+                children.get(childIndex), children.get((childIndex + 1) % childrenPerTree));
+        requests.add(
+            pool.submit(
+                () -> {
+                  requestsReady.countDown();
+                  startRequests.await();
+                  wait(
+                      prefetcher.prefetchFilesInterruptibly(
+                          action, inputs, metadata::get, Priority.MEDIUM, Reason.INPUTS));
+                  return null;
+                }));
+      }
+
+      boolean allRequestsReady = requestsReady.await(10, SECONDS);
+      startRequests.countDown();
+      assertThat(allRequestsReady).isTrue();
+      for (Future<Void> request : requests.build()) {
+        request.get(30, SECONDS);
+      }
+    } finally {
+      startRequests.countDown();
+      pool.shutdownNow();
+      pool.awaitTermination(10, SECONDS);
+    }
+
+    for (int treeIndex = 0; treeIndex < treeCount; treeIndex++) {
+      for (TreeFileArtifact child : childLists.get(treeIndex)) {
+        assertThat(FileSystemUtils.readContent(child.getPath(), UTF_8)).isEqualTo("content");
+      }
+      assertTreeReadableNonWritableAndExecutable(treeList.get(treeIndex).getPath());
+    }
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -621,6 +621,46 @@ public abstract class ActionInputPrefetcherTestBase {
   }
 
   @Test
+  public void prefetchFiles_treeFiles_sequentialCalls_reopenAncestors() throws Exception {
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+    Map<HashCode, byte[]> cas = new HashMap<>();
+    Pair<SpecialArtifact, ImmutableList<TreeFileArtifact>> treeAndChildren =
+        createRemoteTreeArtifact(
+            "dir",
+            /* localContentMap= */ ImmutableMap.of(),
+            /* remoteContentMap= */ ImmutableMap.of(
+                "subdir1/file1", "content1", "subdir2/file2", "content2"),
+            metadata,
+            cas);
+    SpecialArtifact tree = treeAndChildren.getFirst();
+    ImmutableList<TreeFileArtifact> children = treeAndChildren.getSecond();
+    AbstractActionInputPrefetcher prefetcher = createPrefetcher(cas);
+
+    // The first call leaves the directory helper's cache populated but the tree read-only. The
+    // second call must explicitly reopen the cached root before creating a sibling directory, then
+    // restore its output permissions.
+    wait(
+        prefetcher.prefetchFilesInterruptibly(
+            action,
+            ImmutableList.of(children.get(0)),
+            metadata::get,
+            Priority.MEDIUM,
+            Reason.INPUTS));
+    assertTreeReadableNonWritableAndExecutable(tree.getPath());
+
+    wait(
+        prefetcher.prefetchFilesInterruptibly(
+            action,
+            ImmutableList.of(children.get(1)),
+            metadata::get,
+            Priority.MEDIUM,
+            Reason.INPUTS));
+    assertThat(FileSystemUtils.readContent(children.get(1).getPath(), UTF_8))
+        .isEqualTo("content2");
+    assertTreeReadableNonWritableAndExecutable(tree.getPath());
+  }
+
+  @Test
   public void prefetchFiles_treeFiles_multipleThreads_waitForPermissionsToBeSet() throws Exception {
     Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
     Map<HashCode, byte[]> cas = new HashMap<>();
@@ -664,6 +704,97 @@ public abstract class ActionInputPrefetcherTestBase {
 
     f1.get();
     f2.get();
+  }
+
+  @Test
+  public void prefetchFiles_treeFiles_concurrentFinalizations_doNotRacePermissions()
+      throws Exception {
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+    Map<HashCode, byte[]> cas = new HashMap<>();
+    Pair<SpecialArtifact, ImmutableList<TreeFileArtifact>> treeAndChildren =
+        createRemoteTreeArtifact(
+            "dir",
+            /* localContentMap= */ ImmutableMap.of(),
+            /* remoteContentMap= */ ImmutableMap.of(
+                "subdir1/file1", "content1", "subdir2/file2", "content2"),
+            metadata,
+            cas);
+    SpecialArtifact tree = treeAndChildren.getFirst();
+    ImmutableList<TreeFileArtifact> children = treeAndChildren.getSecond();
+
+    SettableFuture<Void> firstDownload = SettableFuture.create();
+    SettableFuture<Void> secondDownload = SettableFuture.create();
+    LinkedBlockingQueue<ListenableFuture<Void>> downloads = new LinkedBlockingQueue<>();
+    downloads.add(firstDownload);
+    downloads.add(secondDownload);
+    AbstractActionInputPrefetcher prefetcher = spy(createPrefetcher(cas));
+    mockDownload(prefetcher, cas, downloads::remove);
+
+    ListenableFuture<Void> firstPrefetch =
+        prefetcher.prefetchFilesInterruptibly(
+            action,
+            ImmutableList.of(children.get(0)),
+            metadata::get,
+            Priority.MEDIUM,
+            Reason.INPUTS);
+    ListenableFuture<Void> secondPrefetch =
+        prefetcher.prefetchFilesInterruptibly(
+            action,
+            ImmutableList.of(children.get(1)),
+            metadata::get,
+            Priority.MEDIUM,
+            Reason.INPUTS);
+
+    Semaphore secondFinalizationStarted = new Semaphore(0);
+    Semaphore secondFinalizationMayContinue = new Semaphore(0);
+    AtomicBoolean blockNextTempFileMove = new AtomicBoolean(true);
+    // Pause the second finalization after it has made the tree writable, but before it moves its
+    // temporary file into the tree.
+    doAnswer(
+            invocation -> {
+              PathFragment source = invocation.getArgument(0);
+              PathFragment target = invocation.getArgument(1);
+              if (source.startsWith(tempPathGenerator.getTempDir().asFragment())
+                  && target.startsWith(tree.getPath().asFragment())
+                  && blockNextTempFileMove.getAndSet(false)) {
+                secondFinalizationStarted.release();
+                secondFinalizationMayContinue.acquireUninterruptibly();
+              }
+              return invocation.callRealMethod();
+            })
+        .when(fs)
+        .renameTo(any(), any());
+    Thread secondCompletion = new Thread(() -> secondDownload.set(null));
+    // Completing the first download runs its direct-executor finalization on this thread. Without
+    // root-level synchronization it completes and restores the shared root while the second move
+    // is paused; with synchronization it waits for the second finalization to release the lock.
+    Thread firstCompletion = new Thread(() -> firstDownload.set(null));
+    secondCompletion.start();
+    try {
+      assertThat(secondFinalizationStarted.tryAcquire(10, SECONDS)).isTrue();
+      firstCompletion.start();
+
+      long deadline = System.nanoTime() + SECONDS.toNanos(10);
+      while (!firstPrefetch.isDone()
+          && firstCompletion.getState() != Thread.State.BLOCKED
+          && firstCompletion.getState() != Thread.State.WAITING
+          && System.nanoTime() < deadline) {
+        Thread.yield();
+      }
+      assertThat(firstPrefetch.isDone()
+              || firstCompletion.getState() == Thread.State.BLOCKED
+              || firstCompletion.getState() == Thread.State.WAITING)
+          .isTrue();
+      assertThat(tree.getPath().isWritable()).isTrue();
+    } finally {
+      secondFinalizationMayContinue.release();
+      firstCompletion.join(10_000);
+      secondCompletion.join(10_000);
+    }
+
+    wait(firstPrefetch);
+    wait(secondPrefetch);
+    assertTreeReadableNonWritableAndExecutable(tree.getPath());
   }
 
   @Test


### PR DESCRIPTION
Tree artifact finalization reopens ancestors before moving a downloaded
child. If reopening, moving, or statting the final file fails, the merged
prefetch fails and call-scoped permission restoration does not run, leaving
those ancestors writable.

Record the deepest directory successfully reopened. After releasing the
read lock, restore that ancestor chain leaf-to-root under the root write
lock, so rollback cannot race active child moves. Preserve the original
finalization error and attach restoration failures as suppressed exceptions.

This draft is stacked on
https://github.com/tamird/bazel/commit/6a0eebd1e19ee46ce74f16dd115fef0e139eecc3
and will be rebased onto master after that commit series lands.