### PR TITLE
Fix Java coverage on Windows by setting JACOCO_MAIN_CLASS env var

### DIFF
--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -49,6 +49,7 @@ static constexpr const char* JAR_BIN_PATH = "jar_bin_path";
 static constexpr const char* CLASSPATH = "classpath";
 static constexpr const char* JAVA_START_CLASS = "java_start_class";
 static constexpr const char* JVM_FLAGS = "jvm_flags";
+static constexpr const char* JACOCO_MAIN_CLASS = "jacoco_main_class";
 
 // Check if a string start with a certain prefix.
 // If it's true, store the substring without the prefix in value.
@@ -303,6 +304,16 @@ ExitCode JavaBinaryLauncher::Launch() {
     java_runfiles = this->GetRunfilesPath();
   }
   SetEnv(L"JAVA_RUNFILES", java_runfiles);
+
+  // Set JACOCO_MAIN_CLASS for JaCoCo coverage support.
+  // rules_java writes jacoco_main_class into the launch info when coverage is
+  // enabled; the Linux shell stub exports it as JACOCO_MAIN_CLASS but the
+  // Windows launcher was missing this step.
+  wstring jacoco_main_class =
+      this->GetLaunchInfoByKeyOrEmpty(JACOCO_MAIN_CLASS);
+  if (!jacoco_main_class.empty()) {
+    SetEnv(L"JACOCO_MAIN_CLASS", jacoco_main_class);
+  }
 
   // Print Java binary path if needed
   wstring java_bin = this->Rlocation(this->GetLaunchInfoByKey(JAVA_BIN_PATH),


### PR DESCRIPTION
## Summary

- The Windows Java launcher reads `jacoco_main_class` from the launch info params (written by `rules_java` when coverage is enabled) but never exports it as the `JACOCO_MAIN_CLASS` environment variable that `JacocoCoverageRunner.getMainClass()` expects.
- The Linux shell stub already does this via `export JACOCO_MAIN_CLASS=...` in the `java_stub_template.txt`.
- This one-line gap in the Windows C++ launcher causes `bazel coverage` on **any** `java_test` target on Windows to fail with:
  ```
  JACOCO_METADATA_JAR/JACOCO_MAIN_CLASS environment variables not set, and no
  META-INF/MANIFEST.MF on the classpath has a Coverage-Main-Class attribute.
  Cannot determine the name of the main class for the code under test.
  ```

## The Fix

Read the `jacoco_main_class` key from the launch info and call `SetEnv(L"JACOCO_MAIN_CLASS", ...)` before spawning the JVM — mirroring the Linux behavior. Uses `GetLaunchInfoByKeyOrEmpty` so non-coverage builds are unaffected (the key is absent when coverage is not enabled).

## How It Was Verified

1. Confirmed the launch info params file already contains `jacoco_main_class=<class>` (written by `_create_windows_exe_launcher` in `rules_java/java/bazel/rules/bazel_java_binary.bzl` line 288).
2. Applied the equivalent workaround (`env = {"JACOCO_MAIN_CLASS": "com.google.testing.junit.runner.BazelTestRunner"}`) to a `java_test` BUILD rule — both `bazel test` and `bazel coverage` pass on Windows.
3. This confirms the only missing piece is the env var propagation in the Windows launcher.

## Related

- Fixes #18839
- Supersedes #26710 and #26821 (both closed without merge; those PRs attempted the same fix)
- No `rules_java` change needed — the Starlark side already writes `jacoco_main_class` into the params correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)