### PR TITLE
[9.2.0] Fix NPE in UrlRewriter.isMatchingHostName when URI.getHost() is null (https://github.com/bazelbuild/bazel/pull/29756)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
@@ -255,7 +255,8 @@ public class UrlRewriter {
   }
 
   private static boolean isMatchingHostName(URI url, String host) {
-    return host.equals(url.getHost()) || url.getHost().endsWith("." + host);
+    String urlHost = url.getHost();
+    return urlHost != null && (host.equals(urlHost) || urlHost.endsWith("." + host));
   }
 
   private ImmutableList<RewrittenURL> applyRewriteRules(URI url) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
@@ -467,6 +467,43 @@ public class UrlRewriterTest {
     }
   }
 
+  @Test
+  public void rewriteRuleProducingNullHostUriDoesNotCrash() throws Exception {
+    // A rewrite rule whose replacement contains an unsubstituted placeholder of the form
+    // @VAR@ causes prefixWithProtocol to produce "https://@VAR@/path". Java's URI parser
+    // splits the authority at the last '@', leaving an empty (or null) host.
+    // isMatchingHostName must not NPE — the URL should be treated as unmatched by the
+    // allow-list and fall through to the block-list.
+    String config = "block *\nrewrite (example.com)/(.*) @UNSUBSTITUTED@/$1/$2";
+    UrlRewriter rewriter = testUrlRewriter("/dev/null", new StringReader(config));
+
+    // Should not throw; the malformed rewritten URL matches nothing in the allow-list
+    // and is then blocked by "block *", so the result is an empty list.
+    ImmutableList<URI> amended =
+        rewriter.amend(ImmutableList.of(URI.create("https://example.com/foo/bar"))).stream()
+            .map(UrlRewriter.RewrittenURL::url)
+            .collect(toImmutableList());
+
+    assertThat(amended).isEmpty();
+  }
+
+  @Test
+  public void allowListDoesNotCrashOnNullHostUri() throws Exception {
+    // Guard the allow-list path: even if a rewritten URI has a null host, iterating
+    // the allow-list must not NPE.
+    String config = "allow example.com\nblock *\nrewrite (example.com)/(.*) @PLACEHOLDER@/$1/$2";
+    UrlRewriter rewriter = testUrlRewriter("/dev/null", new StringReader(config));
+
+    ImmutableList<URI> amended =
+        rewriter.amend(ImmutableList.of(URI.create("https://example.com/foo"))).stream()
+            .map(UrlRewriter.RewrittenURL::url)
+            .collect(toImmutableList());
+
+    // The rewritten URL has a null/malformed host and should NOT match the allow-list
+    // entry for "example.com", so it falls through to "block *" and is dropped.
+    assertThat(amended).isEmpty();
+  }
+
   private static Credentials parseNetrc(String content)
       throws IOException, UrlRewriterParseException {
     String home = "/home/foo";


### PR DESCRIPTION
## Problem

The URL→URI migration in #28802 (Bazel 9.1.0) introduced a `NullPointerException` in `UrlRewriter.isMatchingHostName`. Unlike `java.net.URL.getHost()`, which always returns a non-null string (empty for hostless URLs), `java.net.URI.getHost()` returns `null` for opaque or malformed-authority URIs.

The method calls `url.getHost()` twice:

```java
private static boolean isMatchingHostName(URI url, String host) {
  return host.equals(url.getHost()) || url.getHost().endsWith("." + host);
  //                                     ^^^^^^^^^ NPE when getHost() returns null
}
```

`String.equals(null)` is safe (returns false), so the first call survives. But the second call invokes `.endsWith()` on the return value of `getHost()` directly — if that is null, the JVM crashes.

This appears in the wild when a rewrite rule's replacement string produces a URI with a malformed authority (e.g. `https://@PLACEHOLDER@/path`, where Java splits at the last `@` and finds an empty host string that it represents as `null`).

Stack trace from a real crash:

```
java.lang.NullPointerException: Cannot invoke "String.endsWith(String)"
    because the return value of "java.net.URI.getHost()" is null
    at UrlRewriter.isMatchingHostName(UrlRewriter.java:258)
    at UrlRewriter.isAllowMatched(UrlRewriter.java:236)
    at UrlRewriter.rewrite(UrlRewriter.java:220)
    at UrlRewriter.amend(UrlRewriter.java:151)
    at DownloadManager.downloadInExecutor(DownloadManager.java:216)
```

Tracked in #29754. The same class of bug was fixed in `ProgressInputStream` by #29501 and in `DownloadManager.getUrlBaseName` by #29549, but this instance in `UrlRewriter` was missed.

## Fix

Apply the same null-guard pattern used in #29501: extract `getHost()` once into a local variable, guard on non-null, then use it:

```java
private static boolean isMatchingHostName(URI url, String host) {
  String urlHost = url.getHost();
  return urlHost != null && (host.equals(urlHost) || urlHost.endsWith("." + host));
}
```

A URI with no resolvable host should match nothing in the allow-list and fall through to `isBlockMatched` — which is the correct behaviour.

Closes #29756.

PiperOrigin-RevId: 928762807
Change-Id: Id3965cfcd0fa325ce86ab6692e8f01164c21bb80

Commit https://github.com/bazelbuild/bazel/commit/fddbd53bf197702506055bf3e98162ffbaa124f6