### PR TITLE
Validate SplitBlob chunk sizes before download

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloader.java
@@ -21,6 +21,7 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.SplitBlobResponse;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.remote.chunking.ChunkingConfig;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.util.DigestOutputStream;
@@ -45,12 +46,17 @@ public class ChunkedBlobDownloader {
   private final GrpcCacheClient grpcCacheClient;
   private final CombinedCache combinedCache;
   private final DigestUtil digestUtil;
+  private final long maxChunkSize;
 
   public ChunkedBlobDownloader(
-      GrpcCacheClient grpcCacheClient, CombinedCache combinedCache, DigestUtil digestUtil) {
+      GrpcCacheClient grpcCacheClient,
+      CombinedCache combinedCache,
+      ChunkingConfig chunkingConfig,
+      DigestUtil digestUtil) {
     this.grpcCacheClient = grpcCacheClient;
     this.combinedCache = combinedCache;
     this.digestUtil = digestUtil;
+    this.maxChunkSize = chunkingConfig.maxChunkSize();
   }
 
   /**
@@ -88,7 +94,45 @@ public class ChunkedBlobDownloader {
     if (chunkDigests.isEmpty()) {
       throw new CacheNotFoundException(blobDigest);
     }
+    validateChunkDigests(blobDigest, chunkDigests);
     return chunkDigests;
+  }
+
+  private void validateChunkDigests(Digest blobDigest, List<Digest> chunkDigests)
+      throws IOException {
+    long remainingSize = blobDigest.getSizeBytes();
+    if (remainingSize < 0) {
+      throw new IOException(
+          "Invalid SplitBlob response for %s: blob size is negative"
+              .formatted(DigestUtil.toString(blobDigest)));
+    }
+    for (Digest chunkDigest : chunkDigests) {
+      long chunkSize = chunkDigest.getSizeBytes();
+      if (chunkSize <= 0) {
+        throw new IOException(
+            "Invalid SplitBlob response for %s: chunk %s has non-positive size"
+                .formatted(DigestUtil.toString(blobDigest), DigestUtil.toString(chunkDigest)));
+      }
+      if (chunkSize > maxChunkSize) {
+        throw new IOException(
+            "Invalid SplitBlob response for %s: chunk %s exceeds max chunk size %d"
+                .formatted(
+                    DigestUtil.toString(blobDigest),
+                    DigestUtil.toString(chunkDigest),
+                    maxChunkSize));
+      }
+      if (chunkSize > remainingSize) {
+        throw new IOException(
+            "Invalid SplitBlob response for %s: chunk sizes exceed blob size"
+                .formatted(DigestUtil.toString(blobDigest)));
+      }
+      remainingSize -= chunkSize;
+    }
+    if (remainingSize != 0) {
+      throw new IOException(
+          "Invalid SplitBlob response for %s: chunk sizes do not match blob size"
+              .formatted(DigestUtil.toString(blobDigest)));
+    }
   }
 
   private static final class PendingDownload {

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -126,7 +126,7 @@ public class CombinedCache extends AbstractReferenceCounted {
         synchronized (this) {
           config = ChunkingConfig.fromServerCapabilities(getRemoteServerCapabilities());
           if (config != null) {
-            downloader = new ChunkedBlobDownloader(grpcClient, CombinedCache.this, digestUtil);
+            downloader = new ChunkedBlobDownloader(grpcClient, CombinedCache.this, config, digestUtil);
             uploader = new ChunkedBlobUploader(grpcClient, CombinedCache.this, config, digestUtil);
           }
           initialized = true;

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloaderTest.java
@@ -17,6 +17,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,6 +26,7 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.SplitBlobResponse;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.devtools.build.lib.remote.chunking.ChunkingConfig;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
@@ -51,6 +53,8 @@ import org.mockito.junit.MockitoRule;
 public class ChunkedBlobDownloaderTest {
   private static final DigestUtil DIGEST_UTIL =
       new DigestUtil(SyscallCache.NO_CACHE, DigestHashFunction.SHA256);
+  private static final ChunkingConfig CHUNKING_CONFIG =
+      new ChunkingConfig(/* avgChunkSize= */ 1024, /* normalizationLevel= */ 2, /* seed= */ 0);
   private static final int MAX_IN_FLIGHT_CHUNK_DOWNLOADS = 16;
 
   @Rule public final MockitoRule mockito = MockitoJUnit.rule();
@@ -64,7 +68,8 @@ public class ChunkedBlobDownloaderTest {
   @Before
   public void setUp() {
     when(grpcCacheClient.shouldVerifyDownloads()).thenReturn(true);
-    downloader = new ChunkedBlobDownloader(grpcCacheClient, combinedCache, DIGEST_UTIL);
+    downloader =
+        new ChunkedBlobDownloader(grpcCacheClient, combinedCache, CHUNKING_CONFIG, DIGEST_UTIL);
   }
 
   @Test
@@ -325,6 +330,79 @@ public class ChunkedBlobDownloaderTest {
     downloader.downloadChunked(context, blobDigest, out);
 
     assertThat(out.toByteArray()).isEmpty();
+  }
+
+  @Test
+  public void downloadChunked_oversizedChunk_throwsIOExceptionBeforeDownload() {
+    Digest blobDigest = DIGEST_UTIL.compute(new byte[1024]);
+    Digest chunkDigest =
+        DigestUtil.buildDigest(blobDigest.getHash(), CHUNKING_CONFIG.maxChunkSize() + 1L);
+    SplitBlobResponse splitResponse =
+        SplitBlobResponse.newBuilder().addChunkDigests(chunkDigest).build();
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+        .thenReturn(Futures.immediateFuture(splitResponse));
+
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () -> downloader.downloadChunked(context, blobDigest, new ByteArrayOutputStream()));
+
+    assertThat(e).hasMessageThat().contains("exceeds max chunk size");
+    verify(combinedCache, never()).downloadBlob(any(), any(Digest.class));
+  }
+
+  @Test
+  public void downloadChunked_negativeChunkSize_throwsIOExceptionBeforeDownload() {
+    Digest blobDigest = DIGEST_UTIL.compute(new byte[1024]);
+    Digest chunkDigest = DigestUtil.buildDigest(blobDigest.getHash(), -1);
+    SplitBlobResponse splitResponse =
+        SplitBlobResponse.newBuilder().addChunkDigests(chunkDigest).build();
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+        .thenReturn(Futures.immediateFuture(splitResponse));
+
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () -> downloader.downloadChunked(context, blobDigest, new ByteArrayOutputStream()));
+
+    assertThat(e).hasMessageThat().contains("non-positive size");
+    verify(combinedCache, never()).downloadBlob(any(), any(Digest.class));
+  }
+
+  @Test
+  public void downloadChunked_chunkSizesExceedBlobSize_throwsIOExceptionBeforeDownload() {
+    Digest blobDigest = DIGEST_UTIL.compute(new byte[1024]);
+    Digest chunkDigest = DigestUtil.buildDigest(blobDigest.getHash(), 1025);
+    SplitBlobResponse splitResponse =
+        SplitBlobResponse.newBuilder().addChunkDigests(chunkDigest).build();
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+        .thenReturn(Futures.immediateFuture(splitResponse));
+
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () -> downloader.downloadChunked(context, blobDigest, new ByteArrayOutputStream()));
+
+    assertThat(e).hasMessageThat().contains("chunk sizes exceed blob size");
+    verify(combinedCache, never()).downloadBlob(any(), any(Digest.class));
+  }
+
+  @Test
+  public void downloadChunked_chunkSizesLessThanBlobSize_throwsIOExceptionBeforeDownload() {
+    Digest blobDigest = DIGEST_UTIL.compute(new byte[1024]);
+    Digest chunkDigest = DigestUtil.buildDigest(blobDigest.getHash(), 1023);
+    SplitBlobResponse splitResponse =
+        SplitBlobResponse.newBuilder().addChunkDigests(chunkDigest).build();
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+        .thenReturn(Futures.immediateFuture(splitResponse));
+
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () -> downloader.downloadChunked(context, blobDigest, new ByteArrayOutputStream()));
+
+    assertThat(e).hasMessageThat().contains("chunk sizes do not match blob size");
+    verify(combinedCache, never()).downloadBlob(any(), any(Digest.class));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedTransferBenchmark.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedTransferBenchmark.java
@@ -144,7 +144,9 @@ public class ChunkedTransferBenchmark {
       when(grpcCacheClient.splitBlob(any(), any(Digest.class)))
           .thenReturn(Futures.immediateFuture(splitBlobResponse));
 
-      downloader = new ChunkedBlobDownloader(grpcCacheClient, combinedCache, DIGEST_UTIL);
+      ChunkingConfig chunkingConfig = new ChunkingConfig(chunkSizeBytes, 2, 0);
+      downloader =
+          new ChunkedBlobDownloader(grpcCacheClient, combinedCache, chunkingConfig, DIGEST_UTIL);
     }
 
     @TearDown(Level.Trial)


### PR DESCRIPTION
## What changed

- Validate `SplitBlobResponse` chunk digest sizes before starting any chunk downloads.
- Reject non-positive chunk sizes, chunks larger than the negotiated FastCDC maximum, and chunk size totals that do not exactly match the requested blob size.
- Thread the negotiated `ChunkingConfig` into `ChunkedBlobDownloader` so download-side validation matches the advertised server chunking parameters.
- Add regression coverage that malformed chunk metadata is rejected before `CombinedCache.downloadBlob(...)` is called.

## Why

Chunked remote cache downloads trust metadata returned by `SplitBlob`. Validating that metadata before starting per-chunk downloads keeps malformed responses from driving inconsistent chunk reassembly or oversized in-memory chunk downloads.

## Validation

- `/tmp/bazelisk --output_base=/tmp/ob-bazel-chunk-vrp test //src/test/java/com/google/devtools/build/lib/remote:RemoteTests --test_filter=ChunkedBlobDownloaderTest --test_output=errors`
- `/tmp/bazelisk --output_base=/tmp/ob-bazel-chunk-vrp build //src/test/java/com/google/devtools/build/lib/remote:ChunkedTransferBenchmark`
