### PR TITLE
 Issue :#29660 fix: strip sensitive headers on cross-origin redirects to prevent credential leakage

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
@@ -61,6 +61,8 @@ class HttpConnector {
   private static final int READ_TIMEOUT_MS = 20000;
   private static final ImmutableSet<String> COMPRESSED_EXTENSIONS =
       ImmutableSet.of("bz2", "gz", "jar", "tgz", "war", "xz", "zip");
+  private static final ImmutableSet<String> SENSITIVE_HEADERS =
+      ImmutableSet.of("authorization", "cookie", "proxy-authorization");
   private static final String USER_AGENT_VALUE =
       "bazel/" + BlazeVersionInfo.instance().getVersion();
 
@@ -206,9 +208,26 @@ class HttpConnector {
             eventHandler.handle(Event.progress("Redirect loop detected in " + originalUrl));
             throw new UnrecoverableHttpException("Redirect loop detected");
           }
+          URI previousUrl = url;
           url = HttpUtils.getLocation(connection);
           if (code == 301) {
             originalUrl = url;
+          }
+          // Strip sensitive headers on cross-origin redirects or HTTPS->HTTP downgrades
+          // to prevent credential leakage. This follows the behavior of modern HTTP clients
+          // and browsers (RFC 7231, Fetch Standard).
+          if (isCrossOrigin(previousUrl, url) || isSchemeDowngrade(previousUrl, url)) {
+            final Function<URI, ImmutableMap<String, List<String>>> delegate = requestHeaders;
+            requestHeaders =
+                newUrl -> {
+                  ImmutableMap.Builder<String, List<String>> filtered = new ImmutableMap.Builder<>();
+                  for (Map.Entry<String, List<String>> entry : delegate.apply(newUrl).entrySet()) {
+                    if (!SENSITIVE_HEADERS.contains(Ascii.toLowerCase(entry.getKey()))) {
+                      filtered.put(entry.getKey(), entry.getValue());
+                    }
+                  }
+                  return filtered.build();
+                };
           }
         } else if (code == 403) {
           // jart@ has noticed BitBucket + Amazon AWS downloads frequently flake with this code.
@@ -326,5 +345,42 @@ class HttpConnector {
       ByteStreams.exhaust(stream);
       stream.close();
     }
+  }
+
+  /**
+   * Returns true if the two URIs have different origins (scheme + normalized host + normalized
+   * port). Origin comparison follows the Same-Origin Policy: scheme and host are compared
+   * case-insensitively, and default ports (80 for http, 443 for https) are normalized.
+   */
+  private static boolean isCrossOrigin(URI a, URI b) {
+    if (!Ascii.equalsIgnoreCase(
+        Strings.nullToEmpty(a.getScheme()), Strings.nullToEmpty(b.getScheme()))) {
+      return true;
+    }
+    if (!Ascii.equalsIgnoreCase(
+        Strings.nullToEmpty(a.getHost()), Strings.nullToEmpty(b.getHost()))) {
+      return true;
+    }
+    return getEffectivePort(a) != getEffectivePort(b);
+  }
+
+  /** Returns true if the redirect goes from HTTPS to HTTP (protocol downgrade). */
+  private static boolean isSchemeDowngrade(URI from, URI to) {
+    return HttpUtils.isProtocol(from, "https") && HttpUtils.isProtocol(to, "http");
+  }
+
+  /** Returns the port, or the default port for the scheme (80 for http, 443 for https). */
+  private static int getEffectivePort(URI uri) {
+    int port = uri.getPort();
+    if (port != -1) {
+      return port;
+    }
+    if (HttpUtils.isProtocol(uri, "https")) {
+      return 443;
+    }
+    if (HttpUtils.isProtocol(uri, "http")) {
+      return 80;
+    }
+    return port;
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
@@ -728,6 +728,73 @@ public class HttpConnectorTest {
     }
   }
 
+  @Test
+  public void crossOriginRedirect_stripsAuthorizationHeader() throws Exception {
+    final String secret = "Bearer my-secret-token";
+    final Map<String, List<String>> headers1 = new ConcurrentHashMap<>();
+    final Map<String, List<String>> headers2 = new ConcurrentHashMap<>();
+    try (ServerSocket server1 = new ServerSocket(0, 1, InetAddress.getByName(null));
+        ServerSocket server2 = new ServerSocket(0, 1, InetAddress.getByName(null))) {
+      @SuppressWarnings("unused")
+      Future<?> possiblyIgnoredError =
+          executor.submit(
+              new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                  try (Socket socket = server1.accept()) {
+                    readHttpRequest(socket.getInputStream(), headers1);
+                    sendLines(
+                        socket,
+                        "HTTP/1.1 302 Found",
+                        "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                        "Connection: close",
+                        String.format(
+                            "Location: http://localhost:%d/secret.tar.gz",
+                            server2.getLocalPort()),
+                        "Content-Length: 0",
+                        "",
+                        "");
+                  }
+                  return null;
+                }
+              });
+      @SuppressWarnings("unused")
+      Future<?> possiblyIgnoredError1 =
+          executor.submit(
+              new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                  try (Socket socket = server2.accept()) {
+                    readHttpRequest(socket.getInputStream(), headers2);
+                    sendLines(
+                        socket,
+                        "HTTP/1.1 200 OK",
+                        "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                        "Connection: close",
+                        "Content-Type: text/plain",
+                        "Content-Length: 5",
+                        "",
+                        "hello");
+                  }
+                  return null;
+                }
+              });
+      Function<URI, ImmutableMap<String, List<String>>> authHeaders =
+          url -> ImmutableMap.of("Authorization", ImmutableList.of(secret));
+      URLConnection connection =
+          connector.connect(
+              URI.create(String.format("http://localhost:%d", server1.getLocalPort())),
+              authHeaders);
+      try (InputStream input = connection.getInputStream()) {
+        assertThat(ByteStreams.toByteArray(input)).isEqualTo("hello".getBytes(US_ASCII));
+      }
+      // First request should have the Authorization header.
+      assertThat(headers1).containsEntry("authorization", ImmutableList.of(secret));
+      // Cross-origin redirect should strip the Authorization header.
+      assertThat(headers2).doesNotContainKey("authorization");
+    }
+  }
+
   private File createTempFile(byte[] fileContents) throws IOException {
     File temp = testFolder.newFile();
     try (FileOutputStream outputStream = new FileOutputStream(temp)) {


### PR DESCRIPTION
Dear Bazel maintainers,

Thank you for your continued dedication to the Bazel project. I discovered the security issue reported in #29660 during my usage and have attempted to submit a fix after analysis. I would appreciate any feedback or suggestions.

---

## Problem

Bazel's HTTP downloader (`HttpDownloader`) supports custom request headers via the `headers` parameter when processing `http_archive`, `http_file`, `ctx.download`, and similar rules. This is commonly used for accessing authenticated private artifact registries:

```starlark
http_archive(
    name = "private_dep",
    url = "https://registry.company.com/artifact.tar.gz",
    headers = {"Authorization": "Bearer <token>"},
)
```

However, when the target server returns a redirect response (301/302/303/307), `HttpDownloader` forwards these sensitive headers to the redirect destination as-is, which poses a credential leakage risk.

## Details

The issue lies in the redirect handling logic in `HttpConnector.connect()` (around line 203). After receiving a redirect response, the code obtains the new URL and proceeds to the next request loop without any header cleanup:

```java
url = HttpUtils.getLocation(connection);
// Proceeds to next loop iteration, requestHeaders not sanitized
```

This creates security risks in two scenarios:

**Scenario 1: Cross-origin redirect**

If `https://trusted.company.com/file` redirects to `https://attacker.com/payload`, the `Authorization` header is forwarded to `attacker.com`, allowing the attacker to obtain credentials originally intended for the private artifact registry.

**Scenario 2: HTTPS → HTTP protocol downgrade**

If `https://trusted.company.com/file` redirects to `http://attacker.com/payload`, credentials are transmitted in plaintext over the network, exposing them to man-in-the-middle attacks.

It should be noted that most modern HTTP clients and browsers already implement sensitive header stripping on cross-origin redirects (per the Fetch Standard and RFC 7231). Bazel currently lacks this protection.

## Fix

Added a security check in `HttpConnector.connect()` during redirect handling: compare whether the pre- and post-redirect URLs are same-origin (scheme + host + port), and whether a protocol downgrade occurred. If same-origin is not satisfied, filter the request headers and remove the three sensitive fields: `authorization`, `cookie`, and `proxy-authorization`.

The specific change:

```java
URI previousUrl = url;
url = HttpUtils.getLocation(connection);

// Strip sensitive headers on cross-origin or protocol downgrade
if (isCrossOrigin(previousUrl, url) || isSchemeDowngrade(previousUrl, url)) {
    final Function<URI, ImmutableMap<String, List<String>>> delegate = requestHeaders;
    requestHeaders = newUrl -> {
        // Filter out sensitive headers
        ...
    };
}
```

The same-origin check follows the Same-Origin Policy standard: scheme and host are compared case-insensitively, and ports are normalized to their default values (80 for HTTP, 443 for HTTPS). This ensures that a redirect from `https://example.com/a` to `https://example.com/b` won't inadvertently affect normal same-origin requests.

## Behavior after fix

- **Same-origin redirect** (e.g. `https://registry.com/v1` → `https://registry.com/v2`): Headers remain unchanged, credentials are carried as before, no impact on existing functionality
- **Cross-origin redirect** (e.g. `https://trusted.com` → `https://attacker.com`): `Authorization`, `Cookie`, and `Proxy-Authorization` are automatically stripped to prevent credential leakage
- **HTTPS → HTTP downgrade**: Sensitive headers are likewise stripped to avoid plaintext transmission

This is consistent with the behavior of browsers, curl, Python requests, and other mainstream HTTP clients.

## Scope

Only one file modified: `HttpConnector.java`, with approximately 40 lines added and three helper methods:

| Method | Description |
|---|---|
| `isCrossOrigin(URI, URI)` | Check if two URLs are cross-origin |
| `isSchemeDowngrade(URI, URI)` | Check if a protocol downgrade occurred |
| `getEffectivePort(URI)` | Get the normalized port number |

The change is at the header filtering layer and does not touch connection establishment, retry, or timeout logic, minimizing impact on existing behavior. Existing redirect tests (`redirectToDifferentPath_works`, `redirectToDifferentServer_works`) are unaffected.

## Test

Added `crossOriginRedirect_stripsAuthorizationHeader` in `HttpConnectorTest.java` to verify that the `Authorization` header is stripped on cross-origin redirects. The test sets up two local servers on different ports (different origins), where server1 returns a 302 redirect to server2, and asserts that the header is present on the first request but not forwarded to the redirect target.

Thank you for reviewing. Please let me know if there are any issues.
