### PR TITLE
BES: preserve client-side transport cause in upload errors

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceUploader.java
@@ -344,7 +344,7 @@ public final class BuildEventServiceUploader implements Runnable {
       DetailedExitCode detailedExitCode =
           DetailedExitCode.of(
               FailureDetail.newBuilder()
-                  .setMessage(e.getMessage())
+                  .setMessage(e.getMessageWithCause())
                   .setBuildProgress(BuildProgress.newBuilder().setCode(e.getCode()).build())
                   .build());
       logger.atSevere().withCause(e).log();
@@ -750,7 +750,7 @@ public final class BuildEventServiceUploader implements Runnable {
 
     BuildEventUploadException(
         StreamStatus status, BuildProgress.Code code, @Nullable String additionalMessage) {
-      super(getMessage(status, additionalMessage));
+      super(getMessage(status, additionalMessage), status.getCause());
       this.status = status;
       this.code = code;
     }
@@ -763,6 +763,27 @@ public final class BuildEventServiceUploader implements Runnable {
       }
       sb.append(": ").append(status.getErrorMessage());
       return sb.toString();
+    }
+
+    /**
+     * Returns {@link #getMessage()} augmented with the underlying transport cause (e.g. {@link
+     * java.net.UnknownHostException}, {@link java.net.ConnectException}, {@code
+     * SSLHandshakeException}), so the failure is distinguishable from the bare gRPC status, which
+     * collapses every client-side transport error into {@code UNAVAILABLE}.
+     *
+     * <p>This is meant for the user-facing {@link FailureDetail}, which carries no stack trace. The
+     * cause is also attached to this exception (see the constructor), so {@code
+     * logger.atSevere().withCause(e)} records the full transport stack trace; rendering it here
+     * rather than in {@link #getMessage()} keeps it out of the logged message line, where the
+     * attached cause already appears as a {@code Caused by:} stack.
+     */
+    String getMessageWithCause() {
+      Throwable cause = status.getCause();
+      if (cause == null) {
+        return getMessage();
+      }
+      // Throwable.toString() renders "class: message", omitting ": null" when there is no message.
+      return getMessage() + " (cause: " + Throwables.getRootCause(cause) + ")";
     }
 
     BuildProgress.Code getCode() {

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BuildEventServiceClient.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BuildEventServiceClient.java
@@ -187,6 +187,17 @@ public interface BuildEventServiceClient {
 
     /** Returns an error message for this status. */
     String getErrorMessage();
+
+    /**
+     * Returns the underlying cause of this status, if it originated from a client-side failure
+     * (e.g. a transport-level {@link Throwable} such as a connection, DNS, or TLS error). Returns
+     * {@code null} when no cause is available, such as for errors reported by the remote server
+     * (which are not transmitted over the wire) or synthetic client-side protocol errors.
+     */
+    @Nullable
+    default Throwable getCause() {
+      return null;
+    }
   }
 
   /** An exception with an underlying {@link StreamStatus}. */

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BuildEventServiceGrpcClient.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BuildEventServiceGrpcClient.java
@@ -252,6 +252,12 @@ public class BuildEventServiceGrpcClient implements BuildEventServiceClient {
       }
       return sb.toString();
     }
+
+    @Override
+    @Nullable
+    public Throwable getCause() {
+      return status.getCause();
+    }
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BUILD
@@ -104,6 +104,28 @@ java_test(
 )
 
 java_test(
+    name = "BuildEventServiceUploaderCauseTest",
+    srcs = ["BuildEventServiceUploaderCauseTest.java"],
+    test_class = "com.google.devtools.build.lib.AllTests",
+    runtime_deps = ["//src/test/java/com/google/devtools/build/lib:test_runner"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/buildeventservice:build_event_service_options",
+        "//src/main/java/com/google/devtools/build/lib/buildeventservice:build_event_service_transport",
+        "//src/main/java/com/google/devtools/build/lib/buildeventservice/client:build_event_service_client",
+        "//src/main/java/com/google/devtools/build/lib/buildeventstream",
+        "//src/main/java/com/google/devtools/build/lib/clock",
+        "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
+        "//src/main/java/com/google/devtools/common/options",
+        "//src/test/java/com/google/devtools/build/lib/testutil",
+        "//third_party:guava",
+        "//third_party:jsr305",
+        "//third_party:junit4",
+        "//third_party:mockito",
+        "//third_party:truth",
+    ],
+)
+
+java_test(
     name = "BazelBuildEventServiceModuleTest",
     srcs = ["BazelBuildEventServiceModuleTest.java"],
     shard_count = 10,

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceUploaderCauseTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceUploaderCauseTest.java
@@ -1,0 +1,179 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.buildeventservice;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.buildeventservice.client.BuildEventServiceClient;
+import com.google.devtools.build.lib.buildeventservice.client.BuildEventServiceClient.AckCallback;
+import com.google.devtools.build.lib.buildeventservice.client.BuildEventServiceClient.CommandContext;
+import com.google.devtools.build.lib.buildeventservice.client.BuildEventServiceClient.LifecycleEvent;
+import com.google.devtools.build.lib.buildeventservice.client.BuildEventServiceClient.StreamContext;
+import com.google.devtools.build.lib.buildeventservice.client.BuildEventServiceClient.StreamStatus;
+import com.google.devtools.build.lib.buildeventstream.ArtifactGroupNamer;
+import com.google.devtools.build.lib.buildeventstream.BuildEventProtocolOptions;
+import com.google.devtools.build.lib.buildeventstream.LocalFilesArtifactUploader;
+import com.google.devtools.build.lib.clock.JavaClock;
+import com.google.devtools.build.lib.testutil.FoundationTestCase;
+import com.google.devtools.build.lib.util.AbruptExitException;
+import com.google.devtools.common.options.Options;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ExecutionException;
+import javax.annotation.Nullable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * End-to-end test that a client-side transport cause (e.g. an {@link UnknownHostException}) attached
+ * to a failing {@link StreamStatus} is surfaced both in the BES upload error message and in the
+ * resulting exception's cause chain, instead of being collapsed into the bare gRPC status.
+ */
+@RunWith(JUnit4.class)
+public class BuildEventServiceUploaderCauseTest extends FoundationTestCase {
+
+  private static final CommandContext COMMAND_CONTEXT =
+      CommandContext.builder()
+          .setBuildId("feedbeef-dead-4321-beef-deaddeaddead")
+          .setInvocationId("feedbeef-dead-4444-beef-deaddeaddead")
+          .setAttemptNumber(1)
+          .setKeywords(ImmutableSet.of("foo=bar"))
+          .setProjectId(null)
+          .setCheckPrecedingLifecycleEvents(false)
+          .build();
+
+  @Test
+  public void uploadFailure_surfacesTransportCauseInMessageAndCauseChain() {
+    // A transport failure as it appears client-side: an UNAVAILABLE status whose cause is the
+    // concrete network error. Wrap it so getRootCause() unwrapping is also exercised.
+    UnknownHostException rootCause = new UnknownHostException("sambanova-systems.buildbuddy.io");
+    StreamStatus failingStatus =
+        new FakeStreamStatus("UNAVAILABLE: ipv4:1.2.3.4:443", new RuntimeException(rootCause));
+
+    BuildEventServiceTransport transport = newTransport(new FailingBesClient(failingStatus));
+
+    ExecutionException exception =
+        assertThrows(ExecutionException.class, () -> transport.close().get());
+
+    // The user-facing message (which reaches the console / Jenkins log via the DetailedExitCode)
+    // names the root transport cause, not just the bare gRPC status.
+    assertThat(exception.getMessage()).contains("UNAVAILABLE");
+    assertThat(exception.getMessage())
+        .contains("(cause: java.net.UnknownHostException: sambanova-systems.buildbuddy.io)");
+
+    // The cause chain is preserved end-to-end so logger.atSevere().withCause(e) records the full
+    // transport stack trace.
+    assertThat(exception).hasCauseThat().isInstanceOf(AbruptExitException.class);
+    assertThat(Throwables.getCausalChain(exception)).contains(rootCause);
+  }
+
+  @Test
+  public void uploadFailure_withoutCause_omitsCauseSuffix() {
+    StreamStatus failingStatus = new FakeStreamStatus("UNAVAILABLE: server shutting down", null);
+
+    BuildEventServiceTransport transport = newTransport(new FailingBesClient(failingStatus));
+
+    ExecutionException exception =
+        assertThrows(ExecutionException.class, () -> transport.close().get());
+
+    assertThat(exception.getMessage()).contains("UNAVAILABLE: server shutting down");
+    assertThat(exception.getMessage()).doesNotContain("(cause:");
+  }
+
+  private BuildEventServiceTransport newTransport(BuildEventServiceClient client) {
+    BuildEventServiceOptions besOptions = Options.getDefaults(BuildEventServiceOptions.class);
+    besOptions.setBesTimeout(Duration.ZERO);
+    besOptions.setBesLifecycleEvents(true);
+
+    return new BuildEventServiceTransport.Builder()
+        .besOptions(besOptions)
+        // No real sleeping between retries, to keep the test fast.
+        .sleeper(sleepMillis -> {})
+        .eventBus(eventBus)
+        .besClient(client)
+        .artifactGroupNamer(mock(ArtifactGroupNamer.class))
+        .localFileUploader(new LocalFilesArtifactUploader())
+        .bepOptions(Options.getDefaults(BuildEventProtocolOptions.class))
+        .clock(new JavaClock())
+        .commandContext(COMMAND_CONTEXT)
+        .commandStartTime(Instant.ofEpochMilli(500L))
+        .build();
+  }
+
+  /** A {@link BuildEventServiceClient} whose every lifecycle publish fails with a fixed status. */
+  private static final class FailingBesClient implements BuildEventServiceClient {
+    private final StreamStatus failingStatus;
+
+    FailingBesClient(StreamStatus failingStatus) {
+      this.failingStatus = failingStatus;
+    }
+
+    @Override
+    public void publish(CommandContext commandContext, LifecycleEvent lifecycleEvent)
+        throws StreamException {
+      throw new StreamException(failingStatus, failingStatus.getCause());
+    }
+
+    @Override
+    public StreamContext openStream(CommandContext commandContext, AckCallback callback) {
+      throw new UnsupportedOperationException("stream should not be opened after lifecycle failure");
+    }
+
+    @Override
+    public void shutdown() {}
+  }
+
+  /** A {@link StreamStatus} that optionally carries a client-side transport cause. */
+  private static final class FakeStreamStatus implements StreamStatus {
+    private final String errorMessage;
+    @Nullable private final Throwable cause;
+
+    FakeStreamStatus(String errorMessage, @Nullable Throwable cause) {
+      this.errorMessage = errorMessage;
+      this.cause = cause;
+    }
+
+    @Override
+    public boolean isOk() {
+      return false;
+    }
+
+    @Override
+    public boolean isRetriable() {
+      return true;
+    }
+
+    @Override
+    public boolean isFailedPrecondition() {
+      return false;
+    }
+
+    @Override
+    public String getErrorMessage() {
+      return errorMessage;
+    }
+
+    @Override
+    @Nullable
+    public Throwable getCause() {
+      return cause;
+    }
+  }
+}


### PR DESCRIPTION
When a Build Event Protocol upload fails after exhausting retries, the gRPC status is reduced to its code + description, collapsing every client-side transport failure (DNS resolution, connection refused, TLS handshake, timeout) into a bare UNAVAILABLE with no way to tell them apart from Bazel's output.

io.grpc.Status.getCause() carries the underlying transport Throwable for client-side failures (it is never serialized over the wire, so the failures we care about are exactly the ones it covers), but it was discarded: BuildEventUploadException was built with a message only.

Expose the cause through the StreamStatus abstraction (defaulted to null, so non-gRPC and synthetic statuses are unaffected), render the root cause in the user-facing error message, and pass it as the exception cause so logger.atSevere().withCause(e) records the full transport stack trace.

Added an end-to-end test driving BuildEventServiceTransport with a fake client that fails with a cause-carrying status; it transitively covers the interface accessor, the uploader threading, and the message rendering.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
