### PR TITLE
Fix NullPointerException in CoverageReportActionBuilder comparator

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
@@ -100,11 +100,16 @@ public final class CoverageReportActionBuilder {
   private static final ResourceSet LOCAL_RESOURCES =
       ResourceSet.createWithRamCpu(/* memoryMb= */ 750, /* cpu= */ 1);
 
+  private static boolean hasExecProperties(ActionOwner actionOwner) {
+    return actionOwner != null && !actionOwner.getExecProperties().isEmpty();
+  }
+
   private static final Comparator<ActionOwner> ACTION_OWNER_COMPARATOR =
-      comparing(
-              (ActionOwner actionOwner) -> actionOwner.getExecProperties().isEmpty(), falseFirst())
-          .thenComparing(ActionOwner::getLabel)
-          .thenComparing(ActionOwner::getConfigurationChecksum);
+      Comparator.nullsFirst(
+          comparing(
+                  (ActionOwner actionOwner) -> !hasExecProperties(actionOwner), falseFirst())
+              .thenComparing(ActionOwner::getLabel)
+              .thenComparing(ActionOwner::getConfigurationChecksum));
 
   // SpawnActions can't be used because they need the AnalysisEnvironment and this action is
   // created specially at the very end of the analysis phase when we don't have it anymore.
@@ -220,11 +225,12 @@ public final class CoverageReportActionBuilder {
       // targetsToTest has non-deterministic order, so we ensure that we pick the same action owner
       // and matching report generator each time by picking the owner that's lexicographically
       // largest. We prefer an owner with exec properties set in case the action is run remotely.
+      ActionOwner currentActionOwner = testParams.getActionOwnerForCoverage();
       if (reportGenerator == null
-          || ACTION_OWNER_COMPARATOR.compare(testParams.getActionOwnerForCoverage(), actionOwner)
-              > 0) {
+          || (currentActionOwner != null
+              && ACTION_OWNER_COMPARATOR.compare(currentActionOwner, actionOwner) > 0)) {
         reportGenerator = testParams.getCoverageReportGenerator();
-        actionOwner = testParams.getActionOwnerForCoverage();
+        actionOwner = currentActionOwner;
       }
     }
     // If all tests are incompatible, there's nothing to do.

--- a/src/test/shell/bazel/bazel_coverage_sh_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_sh_test.sh
@@ -543,5 +543,63 @@ EOF
   [[ -e $coverage_file_path ]] || fail "Cannot find extra file"
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/29848
+# Running `bazel coverage` on a target set containing a test rule whose
+# configuration transition disables coverage (collect_code_coverage=False)
+# used to crash with a NullPointerException in CoverageReportActionBuilder
+# because the test's CoverageParams (and thus ActionOwner) is null.
+function test_coverage_with_null_coverage_action_owner() {
+  add_rules_shell "MODULE.bazel"
+
+  # A Starlark test rule that uses an incoming transition to disable coverage.
+  # This results in null CoverageParams and null ActionOwner for coverage.
+  cat <<'EOF' > defs.bzl
+def _disable_coverage_impl(settings, attr):
+    return {"//command_line_option:collect_code_coverage": False}
+
+_disable_coverage = transition(
+    implementation = _disable_coverage_impl,
+    inputs = [],
+    outputs = ["//command_line_option:collect_code_coverage"],
+)
+
+def _nocov_test_impl(ctx):
+    script = ctx.actions.declare_file(ctx.label.name + ".sh")
+    ctx.actions.write(script, "#!/bin/sh\nexit 0\n", is_executable = True)
+    return [DefaultInfo(executable = script)]
+
+nocov_test = rule(
+    implementation = _nocov_test_impl,
+    test = True,
+    cfg = _disable_coverage,
+    attrs = {
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)
+EOF
+
+  cat <<'EOF' > BUILD
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load(":defs.bzl", "nocov_test")
+
+sh_test(
+    name = "real_test",
+    srcs = ["real_test.sh"],
+)
+
+nocov_test(name = "nocov_test")
+EOF
+
+  cat <<'EOF' > real_test.sh
+#!/usr/bin/env bash
+echo "hello"
+EOF
+  chmod +x real_test.sh
+
+  bazel coverage //:all &>"$TEST_log" \
+      || fail "bazel coverage should not crash with null coverage action owner"
+}
 
 run_suite "test tests"


### PR DESCRIPTION
## Description

Fixes https://github.com/bazelbuild/bazel/issues/29848

`bazel coverage` crashes with a `NullPointerException` in `CoverageReportActionBuilder` when any test target in the coverage run returns `null` from `TestParams.getActionOwnerForCoverage()`. This happens when `CoverageParams` is null, e.g. for `analysis_test` targets that disable coverage via a configuration transition.

### Root cause

1. `ACTION_OWNER_COMPARATOR` calls `getExecProperties()` directly on `ActionOwner` values without null protection.
2. The loop in `createCoverageActionsWrapper` passes `getActionOwnerForCoverage()` directly to the comparator without checking for null.

### Fix

1. Add a `hasExecProperties()` helper that safely handles null.
2. Wrap `ACTION_OWNER_COMPARATOR` with `Comparator.nullsFirst()` so null `ActionOwner` values sort before non-null ones.
3. Extract `getActionOwnerForCoverage()` into a local variable and guard the comparison so that a null owner never replaces a non-null best candidate.

### Stack trace (before fix)

```
java.lang.NullPointerException
    at CoverageReportActionBuilder.lambda$static$0(CoverageReportActionBuilder.java:105)
    at java.util.Comparator.lambda$comparing$77a9974f$1(Comparator.java:469)
    at CoverageReportActionBuilder.createCoverageActionsWrapper(CoverageReportActionBuilder.java:224)
```

### Testing

Verified by running `bazel coverage` on a test suite containing `analysis_test` targets wrapped with a coverage-disabling configuration transition. Before the fix: NPE crash. After the fix: 34 tests pass, 0 skipped, 0 failures.

RELNOTES: Fixed a NullPointerException in `bazel coverage` when test targets have null coverage action owners.