### PR TITLE
[9.2.0] Fix fallout from #27119

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
@@ -553,7 +553,6 @@ public final class StarlarkRuleContext
                   ruleContext.attributes().get(attr.getName(), BuildType.LABEL_LIST_DICT),
                   prerequisites);
         } else {
-          Preconditions.checkState(attr.getType() == BuildType.LABEL_LIST, attr);
           value =
               StarlarkList.immutableCopyOf(
                   splitPrereq.getValue().stream()


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description

It added a precondition that asserted that this branch only ever is triggered for LABEL_LIST types, and it just ain't so.

The condition that triggered a crash was a split configuration transition on a label-to-string dictionary attribute.

PiperOrigin-RevId: 829037255
Change-Id: Iddf24302622c33c3ba98e8cb5a7bbbbfe3955fbd (cherry picked from commit 69b7f883b7e86bb1965faf15c2979caea541f260)

### Motivation

Fixes https://github.com/bazelbuild/bazel/issues/29830
Fixes https://github.com/bazelbuild/bazel/issues/29855

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Bazel no longer crashes when a `label_list_dict` attribute is used in a split transition (#29830).