### PR TITLE
[8.8.0] Remove the redundant `envResolved` parameter of `SpawnAction#getSpawn…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -303,8 +303,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     return new ActionSpawn(
         commandLines.allArguments(),
         this,
-        /* env= */ ImmutableMap.of(),
-        /* envResolved= */ false,
+        /* clientEnv= */ ImmutableMap.of(),
         inputs,
         // SpawnInfo doesn't report the runfiles trees of the Spawn, so it's fine to just pass in
         // an empty list here.
@@ -323,22 +322,16 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     return getSpawn(
         actionExecutionContext,
         actionExecutionContext.getClientEnv(),
-        /* envResolved= */ false,
         /* reportOutputs= */ true);
   }
 
   /**
    * Return a spawn that is representative of the command that this Action will execute in the given
-   * environment.
-   *
-   * @param envResolved If set to true, the passed environment variables will be used as the Spawn
-   *     effective environment. Otherwise they will be used as client environment to resolve the
-   *     action env.
+   * client environment.
    */
   protected Spawn getSpawn(
       ActionExecutionContext actionExecutionContext,
-      Map<String, String> env,
-      boolean envResolved,
+      Map<String, String> clientEnv,
       boolean reportOutputs)
       throws CommandLineExpansionException, InterruptedException {
     PathMapper pathMapper =
@@ -352,8 +345,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     return new ActionSpawn(
         expandedCommandLines.arguments(),
         this,
-        env,
-        envResolved,
+        clientEnv,
         getInputs(),
         expandedCommandLines.getParamFiles(),
         actionExecutionContext.getTopLevelFilesets(),
@@ -513,8 +505,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     private ActionSpawn(
         ImmutableList<String> arguments,
         SpawnAction parent,
-        Map<String, String> env,
-        boolean envResolved,
+        Map<String, String> clientEnv,
         NestedSet<Artifact> inputs,
         Iterable<? extends ActionInput> additionalInputs,
         Map<Artifact, FilesetOutputTree> filesetMappings,
@@ -534,15 +525,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
       this.inputs = inputsBuilder.build();
       this.filesetMappings = filesetMappings;
       this.pathMapper = pathMapper;
-
-      // If the action environment is already resolved using the client environment, the given
-      // environment variables are used as they are. Otherwise, they are used as clientEnv to
-      // resolve the action environment variables.
-      if (envResolved) {
-        effectiveEnvironment = ImmutableMap.copyOf(env);
-      } else {
-        effectiveEnvironment = parent.getEffectiveEnvironment(env);
-      }
+      this.effectiveEnvironment = parent.getEffectiveEnvironment(clientEnv);
       this.reportOutputs = reportOutputs;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -412,21 +412,6 @@ public class StarlarkAction extends SpawnAction {
           || (shadowedAction.isPresent() && shadowedAction.get().discoversInputs());
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * <p>Adds the environment of the shadowed action, if any, to the execution spawn.
-     */
-    @Override
-    public Spawn getSpawn(ActionExecutionContext actionExecutionContext)
-        throws CommandLineExpansionException, InterruptedException {
-      return getSpawn(
-          actionExecutionContext,
-          getEffectiveEnvironment(actionExecutionContext.getClientEnv()),
-          /* envResolved= */ true,
-          /* reportOutputs= */ true);
-    }
-
     @Override
     public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
         throws CommandLineExpansionException {

--- a/src/main/java/com/google/devtools/build/lib/analysis/extra/ExtraAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/extra/ExtraAction.java
@@ -171,7 +171,6 @@ public final class ExtraAction extends SpawnAction {
     return getSpawn(
         actionExecutionContext,
         actionExecutionContext.getClientEnv(),
-        /* envResolved= */ false,
         /* reportOutputs= */ false);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
@@ -260,10 +260,7 @@ public final class SpawnActionTest extends BuildViewTestCase {
 
     Spawn spawn =
         action.getSpawn(
-            actionExecutionContext,
-            ImmutableMap.of(),
-            /* envResolved= */ false,
-            /* reportOutputs= */ true);
+            actionExecutionContext, /* clientEnv= */ ImmutableMap.of(), /* reportOutputs= */ true);
     String paramFileName = output.getExecPathString() + "-0.params";
     // The spawn's primary arguments should reference the param file
     assertThat(spawn.getArguments())


### PR DESCRIPTION
…` (https://github.com/bazelbuild/bazel/pull/29826)

The `envResolved == true` path computed the same effective environment as the `envResolved == false` path: `ActionSpawn` resolves its environment via `Action#getEffectiveEnvironment`, which `EnhancedStarlarkAction` overrides to merge in the environment of its shadowed action.

Closes #29826.

PiperOrigin-RevId: 933229685
Change-Id: If6b74b34b805be0d7bfd2f5cbfaf2349cd3220bf

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/0e4ce9a18b2c0ebb1d5ad323dfc390f805057151