### PR TITLE
[9.2.0] Cache `hashCode` of `RepositoryMapping` entries (https://github.com/bazelbuild/bazel/pull/29786)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionRepoMappingEntriesFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionRepoMappingEntriesFunction.java
@@ -75,7 +75,9 @@ public class ModuleExtensionRepoMappingEntriesFunction implements SkyFunction {
     entries.putAll(bazelDepGraphValue.getFullRepoMapping(moduleKey).entries());
     entries.putAll(extensionEvalValue.canonicalRepoNameToInternalNames().inverse());
     entries.putAll(bazelDepGraphValue.getRepoOverrides().row(extensionId));
-    return ModuleExtensionRepoMappingEntriesValue.create(entries.buildKeepingLast(), moduleKey);
+    var builtEntries = entries.buildKeepingLast();
+    return ModuleExtensionRepoMappingEntriesValue.create(
+        builtEntries, builtEntries.hashCode(), moduleKey);
     // LINT.ThenChange(//src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionEvalStarlarkThreadContext.java)
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionRepoMappingEntriesValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionRepoMappingEntriesValue.java
@@ -30,7 +30,8 @@ import com.google.devtools.build.skyframe.SkyValue;
 /** The value for {@link ModuleExtensionRepoMappingEntriesFunction}. */
 @AutoCodec
 public record ModuleExtensionRepoMappingEntriesValue(
-    ImmutableMap<String, RepositoryName> entries, ModuleKey moduleKey) implements SkyValue {
+    ImmutableMap<String, RepositoryName> entries, int entriesHashCode, ModuleKey moduleKey)
+    implements SkyValue {
   public ModuleExtensionRepoMappingEntriesValue {
     requireNonNull(entries, "entries");
     requireNonNull(moduleKey, "moduleKey");
@@ -38,8 +39,8 @@ public record ModuleExtensionRepoMappingEntriesValue(
 
   @AutoCodec.Instantiator
   public static ModuleExtensionRepoMappingEntriesValue create(
-      ImmutableMap<String, RepositoryName> entries, ModuleKey moduleKey) {
-    return new ModuleExtensionRepoMappingEntriesValue(entries, moduleKey);
+      ImmutableMap<String, RepositoryName> entries, int entriesHashCode, ModuleKey moduleKey) {
+    return new ModuleExtensionRepoMappingEntriesValue(entries, entriesHashCode, moduleKey);
   }
 
   public static ModuleExtensionRepoMappingEntriesValue.Key key(ModuleExtensionId id) {

--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryMapping.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryMapping.java
@@ -38,10 +38,14 @@ public class RepositoryMapping {
 
   private final ImmutableMap<String, RepositoryName> entries;
   private final RepositoryName contextRepo;
+  // entries has an expensive hashCode() method that isn't cached.
+  private final int hashCode;
 
-  private RepositoryMapping(Map<String, RepositoryName> entries, RepositoryName contextRepo) {
+  private RepositoryMapping(
+      Map<String, RepositoryName> entries, int entriesHashCode, RepositoryName contextRepo) {
     this.entries = ImmutableMap.copyOf(entries);
     this.contextRepo = contextRepo;
+    this.hashCode = 31 * entriesHashCode + contextRepo.hashCode();
   }
 
   /** Returns all the entries in this repo mapping. */
@@ -67,7 +71,7 @@ public class RepositoryMapping {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(entries, contextRepo);
+    return hashCode;
   }
 
   @Override
@@ -77,8 +81,24 @@ public class RepositoryMapping {
 
   public static RepositoryMapping create(
       ImmutableMap<String, RepositoryName> entries, RepositoryName contextRepo) {
+    return createWithKnownEntriesHashCode(
+        entries, entries.hashCode(), Preconditions.checkNotNull(contextRepo));
+  }
+
+  /**
+   * Use this over {@link #create} if the {@link ImmutableMap#hashCode()} of the entries map is
+   * already known.
+   *
+   * <p>Avoids repeated recomputation for RepositoryMapping instances with identical entries maps.
+   */
+  public static RepositoryMapping createWithKnownEntriesHashCode(
+      ImmutableMap<String, RepositoryName> entries,
+      int entriesHashCode,
+      RepositoryName contextRepo) {
     return new RepositoryMapping(
-        Preconditions.checkNotNull(entries), Preconditions.checkNotNull(contextRepo));
+        Preconditions.checkNotNull(entries),
+        entriesHashCode,
+        Preconditions.checkNotNull(contextRepo));
   }
 
   /**
@@ -87,7 +107,7 @@ public class RepositoryMapping {
    */
   public RepositoryMapping withAdditionalMappings(
       ImmutableMap<String, RepositoryName> additionalMappings) {
-    return new RepositoryMapping(
+    return create(
         ImmutableMap.<String, RepositoryName>builderWithExpectedSize(
                 entries().size() + additionalMappings.size())
             .putAll(additionalMappings)
@@ -141,7 +161,7 @@ public class RepositoryMapping {
       inverse.putIfAbsent(entry.getValue(), entry.getKey());
     }
     var inverseCopy = ImmutableMap.copyOf(inverse);
-    return new RepositoryMapping(entries, contextRepo) {
+    return new RepositoryMapping(entries, entries.hashCode(), contextRepo) {
       @Override
       public Optional<String> getInverse(RepositoryName postMappingName) {
         return Optional.ofNullable(inverseCopy.get(postMappingName));

--- a/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunction.java
@@ -124,7 +124,11 @@ public class RepositoryMappingFunction implements SkyFunction {
         return null;
       }
       return RepositoryMappingValue.create(
-          RepositoryMapping.create(repoMappingEntriesValue.entries(), repositoryName),
+          // Avoids repeated computation of the hash code for the same entries object.
+          RepositoryMapping.createWithKnownEntriesHashCode(
+              repoMappingEntriesValue.entries(),
+              repoMappingEntriesValue.entriesHashCode(),
+              repositoryName),
           repoMappingEntriesValue.moduleKey().name(),
           repoMappingEntriesValue.moduleKey().version());
     }


### PR DESCRIPTION
The `hashCode` of the `entries` map in `RepositoryMapping` is computed once per map object and stored in `ModuleExtensionRepoMappingEntriesValue`.

This is meant to prevent future regressions similar to #29594. If a Bazel module has `N` dependencies managed by a particular module extension, creating the memory layout of the `N` resulting repo mappings takes `O(N)` time due to the shared `ImmutableMap` of entries, but even precomputing the `hashCode` in the `RepositoryMapping` constructor in the naive way would still take `O(N^2)` overall time since the inner `ImmutableMap` instance doesn't cache its `hashCode` and its size is `O(N)`.

Closes #29786.

PiperOrigin-RevId: 933451751
Change-Id: Iacb89b2b7dab260b482e04f65e19ce08a467d163

Commit https://github.com/bazelbuild/bazel/commit/a300dd5bb97283ce734b756cbafecb8312e8c3aa