### PR TITLE
[9.2.0] Reupload in-memory blobs when inputs are force uploaded (https://github.com/bazelbuild/bazel/pull/29831)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
@@ -234,9 +234,12 @@ public class RemoteExecutionCache extends CombinedCache implements MerkleTreeUpl
 
   @Override
   public ListenableFuture<Void> uploadVirtualActionInput(
-      RemoteActionExecutionContext context, Digest digest, VirtualActionInput virtualActionInput) {
+      RemoteActionExecutionContext context,
+      Digest digest,
+      VirtualActionInput virtualActionInput,
+      boolean force) {
     return remoteCacheClient.uploadBlob(
-        context, digest, new VirtualActionInputBlob(virtualActionInput), /* force= */ false);
+        context, digest, new VirtualActionInputBlob(virtualActionInput), force);
   }
 
   private record VirtualActionInputBlob(VirtualActionInput virtualActionInput) implements Blob {
@@ -278,9 +281,9 @@ public class RemoteExecutionCache extends CombinedCache implements MerkleTreeUpl
 
   @Override
   public ListenableFuture<Void> uploadBlob(
-      RemoteActionExecutionContext context, Digest digest, byte[] data) {
+      RemoteActionExecutionContext context, Digest digest, byte[] data, boolean force) {
     return remoteCacheClient.uploadBlob(
-        context, digest, () -> new ByteArrayInputStream(data), /* force= */ false);
+        context, digest, () -> new ByteArrayInputStream(data), force);
   }
 
   private ListenableFuture<Void> uploadBlob(

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -175,9 +175,10 @@ public sealed interface MerkleTree {
         Digest digest,
         boolean force) {
       return switch (blobs.get(digest)) {
-        case byte[] data -> Optional.of(uploader.uploadBlob(context, digest, data));
+        case byte[] data -> Optional.of(uploader.uploadBlob(context, digest, data, force));
         case VirtualActionInput virtualActionInput ->
-            Optional.of(uploader.uploadVirtualActionInput(context, digest, virtualActionInput));
+            Optional.of(
+                uploader.uploadVirtualActionInput(context, digest, virtualActionInput, force));
         case ActionInput actionInput -> {
           var spawnExecutionContext = context.getSpawnExecutionContext();
           var pathResolver =

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeUploader.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 public interface MerkleTreeUploader {
   /** Uploads an in-memory blob to the remote cache. */
   ListenableFuture<Void> uploadBlob(
-      RemoteActionExecutionContext context, Digest digest, byte[] data);
+      RemoteActionExecutionContext context, Digest digest, byte[] data, boolean force);
 
   /** Uploads a local file to the remote cache. */
   ListenableFuture<Void> uploadFile(
@@ -37,7 +37,10 @@ public interface MerkleTreeUploader {
 
   /** Uploads a virtual action input to the remote cache. */
   ListenableFuture<Void> uploadVirtualActionInput(
-      RemoteActionExecutionContext context, Digest digest, VirtualActionInput virtualActionInput);
+      RemoteActionExecutionContext context,
+      Digest digest,
+      VirtualActionInput virtualActionInput,
+      boolean force);
 
   /**
    * Ensures that all inputs as well as metadata protos in the given Merkle tree are present in the

--- a/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
@@ -83,6 +83,7 @@ import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.common.options.Options;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Deque;
@@ -379,6 +380,54 @@ public class CombinedCacheTest {
         .containsExactly(
             DigestUtil.toString(digestUtil.computeAsUtf8("bar")),
             ActionInputHelper.fromPath("foo"));
+  }
+
+  @Test
+  public void ensureInputsPresent_blobsLostAfterUpload_forceReuploadsDirectoryProtos()
+      throws Exception {
+    InMemoryCacheClient cacheProtocol = new InMemoryCacheClient();
+    RemoteExecutionCache remoteCache = newRemoteExecutionCache(cacheProtocol);
+    remoteActionExecutionContext = RemoteActionExecutionContext.create(metadata);
+
+    // A file in a subdirectory ensures that the Merkle tree contains directory protos, which are
+    // retained as in-memory byte arrays rather than as action inputs.
+    Path path = execRoot.getRelative("dir/foo");
+    path.getParentDirectory().createDirectoryAndParents();
+    FileSystemUtils.writeContentAsLatin1(path, "bar");
+    SortedMap<PathFragment, Path> inputs = new TreeMap<>();
+    inputs.put(PathFragment.create("dir/foo"), path);
+    var merkleTree = merkleTreeComputer.buildForFiles(inputs);
+    Message message = Digest.newBuilder().setHash("message standing in for an Action").build();
+    var messageDigest = digestUtil.compute(message);
+    var additionalInputs = ImmutableMap.of(messageDigest, message);
+    var allDigests =
+        ImmutableSet.<Digest>builder().addAll(merkleTree.allDigests()).add(messageDigest).build();
+    var remotePathResolver = new RemotePathResolver.DefaultRemotePathResolver(execRoot);
+
+    remoteCache.ensureInputsPresent(
+        remoteActionExecutionContext,
+        merkleTree,
+        additionalInputs,
+        /* force= */ false,
+        remotePathResolver);
+    assertThat(
+            getFromFuture(remoteCache.findMissingDigests(remoteActionExecutionContext, allDigests)))
+        .isEmpty();
+
+    // Simulate a remote cache that loses all blobs right after they have been uploaded.
+    for (Digest digest : allDigests) {
+      cacheProtocol.removeCasEntry(digest);
+    }
+
+    remoteCache.ensureInputsPresent(
+        remoteActionExecutionContext,
+        merkleTree,
+        additionalInputs,
+        /* force= */ true,
+        remotePathResolver);
+    assertThat(
+            getFromFuture(remoteCache.findMissingDigests(remoteActionExecutionContext, allDigests)))
+        .isEmpty();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputerTest.java
@@ -208,7 +208,7 @@ public class MerkleTreeComputerTest {
             new MerkleTreeUploader() {
               @Override
               public ListenableFuture<Void> uploadBlob(
-                  RemoteActionExecutionContext context, Digest digest, byte[] data) {
+                  RemoteActionExecutionContext context, Digest digest, byte[] data, boolean force) {
                 return immediateVoidFuture();
               }
 
@@ -226,7 +226,8 @@ public class MerkleTreeComputerTest {
               public ListenableFuture<Void> uploadVirtualActionInput(
                   RemoteActionExecutionContext context,
                   Digest digest,
-                  VirtualActionInput virtualActionInput) {
+                  VirtualActionInput virtualActionInput,
+                  boolean force) {
                 return immediateVoidFuture();
               }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
@@ -67,6 +67,11 @@ public class InMemoryCacheClient extends RemoteCacheClient {
     downloadFailures.put(digest, e);
   }
 
+  /** Removes a CAS entry, e.g. to simulate the remote cache losing a previously uploaded blob. */
+  public void removeCasEntry(Digest digest) {
+    cas.remove(digest);
+  }
+
   public int getNumSuccessfulDownloads() {
     return numSuccess.get();
   }


### PR DESCRIPTION
`force` mode wasn't wired up correctly for in-memory blobs, which can still be lost server-side.

Closes #29831.

PiperOrigin-RevId: 933589518
Change-Id: I67ceaaef56e8e938ef0fa978672f6aff5a93d255

Commit https://github.com/bazelbuild/bazel/commit/bcee363749cf74414a129197366d82b0439ae89b