### PR TITLE
Allow `File` values in `env` of `ctx.actions.run[_shell]`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
@@ -244,7 +244,7 @@ public abstract class AbstractAction extends ActionKeyComputer implements Action
     ActionEnvironment env = getEnvironment();
     Map<String, String> effectiveEnvironment =
         Maps.newLinkedHashMapWithExpectedSize(env.estimatedSize());
-    env.resolve(effectiveEnvironment, clientEnv);
+    env.resolve(effectiveEnvironment, clientEnv, pathMapper);
     return ImmutableMap.copyOf(effectiveEnvironment);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
@@ -18,6 +18,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Interner;
+import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.analysis.config.CoreOptions.OutputPathsMode;
 import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.util.Fingerprint;
 import java.util.Map;
@@ -32,7 +34,10 @@ import java.util.TreeSet;
  * <p>The action environment consists of two parts.
  *
  * <ol>
- *   <li>All the environment variables with a fixed value, stored in a map.
+ *   <li>All the environment variables with a fixed value, stored in a map. The value of such a
+ *       variable is either a {@link String}, which is used as is, or an {@link Artifact}, which is
+ *       resolved to its exec path in {@link #resolve(java.util.Map, java.util.Map,
+ *       com.google.devtools.build.lib.actions.PathMapper)} only so that it can be path mapped.
  *   <li>All the environment variables inherited from the client environment, stored in a set.
  * </ol>
  *
@@ -53,19 +58,21 @@ public abstract class ActionEnvironment {
       BlazeInterners.newWeakInterner();
 
   /** Convenience method for creating an {@link ActionEnvironment} with no inherited variables. */
-  public static ActionEnvironment create(ImmutableMap<String, String> fixedEnv) {
+  public static ActionEnvironment create(ImmutableMap<String, /* String | Artifact */ ?> fixedEnv) {
     return create(fixedEnv, /* inheritedEnv= */ ImmutableSet.of());
   }
 
   /**
    * Creates a new {@link ActionEnvironment}.
    *
+   * <p>The values of {@code fixedEnv} must be of type {@link String} or {@link Artifact}.
+   *
    * <p>If an environment variable is contained both as a key in {@code fixedEnv} and in {@code
    * inheritedEnv}, the result of {@link #resolve} will contain the value inherited from the client
    * environment.
    */
   public static ActionEnvironment create(
-      ImmutableMap<String, String> fixedEnv, ImmutableSet<String> inheritedEnv) {
+      ImmutableMap<String, /* String | Artifact */ ?> fixedEnv, ImmutableSet<String> inheritedEnv) {
     if (fixedEnv.isEmpty() && inheritedEnv.isEmpty()) {
       return EMPTY;
     }
@@ -90,14 +97,46 @@ public abstract class ActionEnvironment {
     return create(ImmutableMap.copyOf(fixedEnv), ImmutableSet.copyOf(inheritedEnv));
   }
 
+  private static String maybeMapValue(Object value, PathMapper pathMapper) {
+    return switch (value) {
+      case String s -> s;
+      case Artifact artifact -> pathMapper.getMappedExecPathString(artifact);
+      default ->
+          throw new IllegalStateException(
+              "Expected env value of type String or Artifact, but got: " + value);
+    };
+  }
+
   private ActionEnvironment() {}
 
   /**
-   * Returns the 'fixed' part of the environment, i.e., those environment variables that are set to
-   * fixed values and their values. This should only be used for testing and to compute the cache
-   * keys of actions. Use {@link #resolve} instead to get the complete environment.
+   * Returns the 'fixed' part of the environment, with {@link String} values used as is and {@link
+   * Artifact} values resolved to their unmapped exec paths. This should only be used for testing
+   * and analysis-time introspection (e.g. aquery), as the value of an artifact-valued variable seen
+   * by the action may differ due to path mapping. Use {@link #resolve} instead to get the complete
+   * environment.
    */
-  public abstract ImmutableMap<String, String> getFixedEnv();
+  public final ImmutableMap<String, String> getFixedEnv() {
+    ImmutableMap<String, Object> fixedEnv = fixedEnv();
+    if (!hasArtifactValues(fixedEnv)) {
+      // Covariant cast of a map without Artifact values.
+      @SuppressWarnings("unchecked")
+      var stringEnv = (ImmutableMap<String, String>) (ImmutableMap<?, ?>) fixedEnv;
+      return stringEnv;
+    }
+    return ImmutableMap.copyOf(
+        Maps.transformValues(fixedEnv, value -> maybeMapValue(value, PathMapper.NOOP)));
+  }
+
+  private static boolean hasArtifactValues(ImmutableMap<String, Object> fixedEnv) {
+    return fixedEnv.values().stream().anyMatch(value -> value instanceof Artifact);
+  }
+
+  /**
+   * Returns the 'fixed' part of the environment, with values that are either of type {@link String}
+   * or {@link Artifact}.
+   */
+  abstract ImmutableMap<String, /* String | Artifact */ Object> fixedEnv();
 
   /**
    * Returns the 'inherited' part of the environment, i.e., those environment variables that are
@@ -116,13 +155,32 @@ public abstract class ActionEnvironment {
 
   /**
    * Resolves the action environment and adds the resulting entries to the given {@code result} map,
-   * by looking up any inherited env variables in the given {@code clientEnv}.
+   * by looking up any inherited env variables in the given {@code clientEnv} and resolving any
+   * artifact-valued env variables to their unmapped exec paths.
+   *
+   * <p>We pass in a map to mutate to avoid creating and merging intermediate maps.
+   *
+   * <p>Note: Prefer {@link #resolve(Map, Map, PathMapper)} if a {@link PathMapper} is available,
+   * i.e., during action execution.
+   */
+  public final void resolve(Map<String, String> result, Map<String, String> clientEnv) {
+    resolve(result, clientEnv, PathMapper.NOOP);
+  }
+
+  /**
+   * Resolves the action environment and adds the resulting entries to the given {@code result} map,
+   * by looking up any inherited env variables in the given {@code clientEnv} and resolving any
+   * artifact-valued env variables to their exec paths with the given {@link PathMapper} applied.
+   *
+   * <p>Actions that support path mapping should pass in the path mapper of the spawn being created
+   * so that artifact-valued env variables reflect the paths seen by the action at execution time.
    *
    * <p>We pass in a map to mutate to avoid creating and merging intermediate maps.
    */
-  public final void resolve(Map<String, String> result, Map<String, String> clientEnv) {
+  public final void resolve(
+      Map<String, String> result, Map<String, String> clientEnv, PathMapper pathMapper) {
     checkNotNull(clientEnv);
-    result.putAll(getFixedEnv());
+    result.putAll(Maps.transformValues(fixedEnv(), value -> maybeMapValue(value, pathMapper)));
     for (String var : getInheritedEnv()) {
       String value = clientEnv.get(var);
       if (value != null) {
@@ -131,16 +189,26 @@ public abstract class ActionEnvironment {
     }
   }
 
-  public final void addTo(Fingerprint f) {
-    f.addStringMap(getFixedEnv());
+  /**
+   * Adds this environment to the given fingerprint, resolving artifact-valued env variables with
+   * the given {@link PathMapper}.
+   */
+  public final void addTo(OutputPathsMode effectiveOutputPathsMode, Fingerprint f) {
+    f.addStringMap(
+        Maps.transformValues(
+            fixedEnv(),
+            value -> maybeMapValue(value, PathMapper.forActionKey(effectiveOutputPathsMode))));
     f.addStrings(getInheritedEnv());
   }
 
   /**
    * Returns a copy of the environment with the given fixed variables added to it, <em>overwriting
    * any existing occurrences of those variables</em>.
+   *
+   * <p>The values of {@code fixedVars} must be of type {@link String} or {@link Artifact}.
    */
-  public final ActionEnvironment withAdditionalFixedVariables(Map<String, String> fixedVars) {
+  public final ActionEnvironment withAdditionalFixedVariables(
+      Map<String, /* String | Artifact */ ?> fixedVars) {
     if (fixedVars.isEmpty()) {
       return this;
     }
@@ -155,7 +223,7 @@ public abstract class ActionEnvironment {
   private static final class EmptyActionEnvironment extends ActionEnvironment {
 
     @Override
-    public ImmutableMap<String, String> getFixedEnv() {
+    ImmutableMap<String, Object> fixedEnv() {
       return ImmutableMap.of();
     }
 
@@ -171,17 +239,16 @@ public abstract class ActionEnvironment {
   }
 
   private static final class SimpleActionEnvironment extends ActionEnvironment {
-    private final ImmutableMap<String, String> fixedEnv;
+    private final ImmutableMap<String, /* String | Artifact */ Object> fixedEnv;
     private final ImmutableSet<String> inheritedEnv;
 
-    SimpleActionEnvironment(
-        ImmutableMap<String, String> fixedEnv, ImmutableSet<String> inheritedEnv) {
-      this.fixedEnv = fixedEnv;
+    SimpleActionEnvironment(ImmutableMap<String, ?> fixedEnv, ImmutableSet<String> inheritedEnv) {
+      this.fixedEnv = ImmutableMap.copyOf(fixedEnv);
       this.inheritedEnv = inheritedEnv;
     }
 
     @Override
-    public ImmutableMap<String, String> getFixedEnv() {
+    ImmutableMap<String, Object> fixedEnv() {
       return fixedEnv;
     }
 
@@ -214,18 +281,18 @@ public abstract class ActionEnvironment {
 
   private static final class CompoundActionEnvironment extends ActionEnvironment {
     private final ActionEnvironment base;
-    private final ImmutableMap<String, String> fixedVars;
+    private final ImmutableMap<String, /* String | Artifact */ Object> fixedVars;
 
     private CompoundActionEnvironment(
-        ActionEnvironment base, ImmutableMap<String, String> fixedVars) {
+        ActionEnvironment base, ImmutableMap<String, Object> fixedVars) {
       this.base = base;
       this.fixedVars = fixedVars;
     }
 
     @Override
-    public ImmutableMap<String, String> getFixedEnv() {
-      return ImmutableMap.<String, String>builder()
-          .putAll(base.getFixedEnv())
+    ImmutableMap<String, Object> fixedEnv() {
+      return ImmutableMap.<String, Object>builder()
+          .putAll(base.fixedEnv())
           .putAll(fixedVars)
           .buildKeepingLast();
     }

--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -213,6 +213,8 @@ java_library(
     name = "action_environment",
     srcs = ["ActionEnvironment.java"],
     deps = [
+        ":artifacts",
+        "//src/main/java/com/google/devtools/build/lib/analysis/config:core_options",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/PathMappers.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/PathMappers.java
@@ -47,22 +47,18 @@ public final class PathMappers {
    * <p>Compared to {@link #create}, this method does not flatten nested sets and thus can't result
    * in memory regressions.
    *
-   * @param outputPathsMode the value of {@link CoreOptions#outputPathsMode}
+   * @param effectiveOutputPathsMode the value returned by {@link #getEffectiveOutputPathsMode}
    * @param fingerprint the fingerprint to add to
    */
   public static void addToFingerprint(
-      String mnemonic,
-      Map<String, String> executionInfo,
       NestedSet<Artifact> additionalArtifactsForPathMapping,
       ActionKeyContext actionKeyContext,
-      OutputPathsMode outputPathsMode,
+      OutputPathsMode effectiveOutputPathsMode,
       Fingerprint fingerprint)
       throws CommandLineExpansionException, InterruptedException {
     // Creating a new PathMapper instance can be expensive, but isn't needed here: Whether and
     // how path mapping applies to the action only depends on the output paths mode and the action
     // inputs, which are already part of the action key.
-    OutputPathsMode effectiveOutputPathsMode =
-        getEffectiveOutputPathsMode(outputPathsMode, mnemonic, executionInfo);
     if (effectiveOutputPathsMode == OutputPathsMode.STRIP) {
       fingerprint.addString(StrippingPathMapper.GUID);
       // These artifacts are not part of the actual command line or inputs, but influence the

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -391,21 +391,18 @@ public class SpawnAction extends AbstractAction implements CommandAction {
       @Nullable InputMetadataProvider inputMetadataProvider,
       Fingerprint fp)
       throws CommandLineExpansionException, InterruptedException {
+    var effectiveOutputPathsMode =
+        PathMappers.getEffectiveOutputPathsMode(outputPathsMode, getMnemonic(), getExecutionInfo());
     fp.addString(GUID);
     commandLines.addToFingerprint(
-        actionKeyContext,
-        inputMetadataProvider,
-        PathMappers.getEffectiveOutputPathsMode(outputPathsMode, getMnemonic(), getExecutionInfo()),
-        fp);
+        actionKeyContext, inputMetadataProvider, effectiveOutputPathsMode, fp);
     fp.addString(mnemonic);
-    env.addTo(fp);
+    env.addTo(effectiveOutputPathsMode, fp);
     fp.addStringMap(getExecutionInfo());
     PathMappers.addToFingerprint(
-        getMnemonic(),
-        getExecutionInfo(),
         NestedSetBuilder.emptySet(Order.STABLE_ORDER),
         actionKeyContext,
-        outputPathsMode,
+        effectiveOutputPathsMode,
         fp);
   }
 
@@ -573,7 +570,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
   public static ActionEnvironment createActionEnvironment(
       BuildConfigurationValue configuration,
       boolean useDefaultShellEnvironment,
-      ImmutableMap<String, String> environment) {
+      ImmutableMap<String, /* String | Artifact */ ?> environment) {
     ActionEnvironment env;
     if (useDefaultShellEnvironment && !environment.isEmpty()) {
       // Inherited variables override fixed variables in ActionEnvironment. Since we want the
@@ -610,7 +607,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     private final NestedSetBuilder<Artifact> inputsBuilder = NestedSetBuilder.stableOrder();
     private final List<Artifact> outputs = new ArrayList<>();
     private ResourceSetOrBuilder resourceSetOrBuilder = AbstractAction.DEFAULT_RESOURCE_SET;
-    private ImmutableMap<String, String> environment = ImmutableMap.of();
+    private ImmutableMap<String, /* String | Artifact */ Object> environment = ImmutableMap.of();
     @Nullable private ActionEnvironment actionEnvironment = null;
     @Nullable private OutputPathsMode outputPathsMode = null;
     private ImmutableMap<String, String> executionInfo = ImmutableMap.of();
@@ -862,16 +859,20 @@ public class SpawnAction extends AbstractAction implements CommandAction {
       return this;
     }
 
-    private static final Interner<ImmutableMap<String, String>> envInterner =
+    private static final Interner<ImmutableMap<String, Object>> envInterner =
         BlazeInterners.newWeakInterner();
 
     /**
-     * Sets the map of environment variables. Do not use! This makes the builder ignore the 'default
-     * shell environment', which is computed from the --action_env command line option.
+     * Sets the map of environment variables. The values must be of type {@link String} or {@link
+     * Artifact}; the latter are resolved to their exec paths at execution time so that any
+     * applicable {@link PathMapper} can be applied to them.
+     *
+     * <p>Do not use! This makes the builder ignore the 'default shell environment', which is
+     * computed from the --action_env command line option.
      */
     @CanIgnoreReturnValue
-    public Builder setEnvironment(Map<String, String> environment) {
-      this.environment = envInterner.intern(ImmutableMap.copyOf(environment));
+    public Builder setEnvironment(Map<String, /* String | Artifact */ ?> environment) {
+      this.environment = envInterner.intern(ImmutableMap.<String, Object>copyOf(environment));
       this.useDefaultShellEnvironment = false;
       return this;
     }
@@ -940,8 +941,8 @@ public class SpawnAction extends AbstractAction implements CommandAction {
      * @see BuildConfigurationValue#getLocalShellEnvironment
      */
     @CanIgnoreReturnValue
-    public Builder useDefaultShellEnvironment(Map<String, String> environment) {
-      this.environment = ImmutableMap.copyOf(environment);
+    public Builder useDefaultShellEnvironment(Map<String, /* String | Artifact */ ?> environment) {
+      this.environment = ImmutableMap.<String, Object>copyOf(environment);
       this.useDefaultShellEnvironment = true;
       return this;
     }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -515,7 +515,7 @@ public class StarlarkAction extends SpawnAction {
 
       // This order guarantees that the Starlark action can overwrite any variable in its shadowed
       // action environment with a new value.
-      env.resolve(environment, clientEnv);
+      env.resolve(environment, clientEnv, pathMapper);
       return ImmutableMap.copyOf(environment);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkMapActionTemplate.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkMapActionTemplate.java
@@ -326,14 +326,14 @@ public final class StarlarkMapActionTemplate extends ActionKeyComputer
     fp.addStringMap(executionRequirements);
     fp.addString(getMnemonic());
     fp.addString(expandedActionsMnemonic);
+    var effectiveOutputPathsMode =
+        PathMappers.getEffectiveOutputPathsMode(outputPathsMode, getMnemonic(), getExecutionInfo());
     PathMappers.addToFingerprint(
-        getMnemonic(),
-        getExecutionInfo(),
         NestedSetBuilder.emptySet(Order.STABLE_ORDER),
         actionKeyContext,
-        outputPathsMode,
+        effectiveOutputPathsMode,
         fp);
-    env.addTo(fp);
+    env.addTo(effectiveOutputPathsMode, fp);
     fp.addString(implementation.getName());
     fp.addBytes(BazelModuleContext.of(implementation.getModule()).bzlTransitiveDigest());
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkTreeAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkTreeAction.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.actions.RichDataProducingAction;
 import com.google.devtools.build.lib.analysis.Runfiles;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue.RunfileSymlinksMode;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
@@ -205,7 +206,7 @@ public final class SymlinkTreeAction extends AbstractAction implements RichDataP
     fp.addString(GUID);
     fp.addNullableString(workspaceNameForFileset);
     fp.addInt(runfileSymlinksMode.ordinal());
-    env.addTo(fp);
+    env.addTo(CoreOptions.OutputPathsMode.OFF, fp);
     // We need to ensure that the fingerprints for two different instances of this action are
     // different. Consider the hypothetical scenario where we add a second runfiles object to this
     // class, which could also be null: the sequence

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -824,9 +824,16 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       builder.setProgressMessageFromStarlark((String) progressMessage);
     }
 
-    ImmutableMap<String, String> env = ImmutableMap.of();
+    ImmutableMap<String, /* String | Artifact */ Object> env = ImmutableMap.of();
     if (envUnchecked != Starlark.NONE) {
-      env = ImmutableMap.copyOf(Dict.cast(envUnchecked, String.class, String.class, "env"));
+      env = ImmutableMap.copyOf(Dict.cast(envUnchecked, String.class, Object.class, "env"));
+      for (Map.Entry<String, Object> entry : env.entrySet()) {
+        if (!(entry.getValue() instanceof String || entry.getValue() instanceof Artifact)) {
+          throw Starlark.errorf(
+              "expected value of type 'string' or 'File' for env variable '%s', but got %s instead",
+              entry.getKey(), Starlark.type(entry.getValue()));
+        }
+      }
     }
     if (Starlark.truth(useDefaultShellEnv)) {
       builder.useDefaultShellEnvironment(env);

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
@@ -48,6 +48,7 @@ import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.TestExecException;
 import com.google.devtools.build.lib.analysis.FilesToRunProvider;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.analysis.config.RunUnder;
 import com.google.devtools.build.lib.analysis.test.TestActionContext.AttemptGroup;
 import com.google.devtools.build.lib.analysis.test.TestActionContext.ProcessedAttemptResult;
@@ -509,11 +510,11 @@ public class TestRunnerAction extends AbstractAction
     RunUnder runUnder = executionSettings.getRunUnder();
     fp.addString(runUnder == null ? "" : runUnder.value());
     fp.addStringMap(coverageEnv);
-    extraTestEnv.addTo(fp);
+    extraTestEnv.addTo(CoreOptions.OutputPathsMode.OFF, fp);
     // TODO(ulfjack): It might be better for performance to hash the action and test envs in config,
     // and only add a hash here.
-    configuration.getActionEnvironment().addTo(fp);
-    configuration.getTestActionEnvironment().addTo(fp);
+    configuration.getActionEnvironment().addTo(CoreOptions.OutputPathsMode.OFF, fp);
+    configuration.getTestActionEnvironment().addTo(CoreOptions.OutputPathsMode.OFF, fp);
     // The 'requiredClientEnvVariables' are handled by Skyframe and don't need to be added here.
     fp.addString(testProperties.getSize().toString());
     fp.addString(testProperties.getTimeout().toString());

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -1393,8 +1393,10 @@ public class CppCompileAction extends AbstractAction
       String mnemonic,
       OutputPathsMode outputPathsMode)
       throws CommandLineExpansionException, InterruptedException {
+    var effectiveOutputPathsMode =
+        PathMappers.getEffectiveOutputPathsMode(outputPathsMode, mnemonic, executionInfo);
     fp.addUUID(GUID);
-    env.addTo(fp);
+    env.addTo(effectiveOutputPathsMode, fp);
     fp.addStringMap(environmentVariables);
     fp.addStringMap(executionInfo);
     fp.addBytes(commandLineKey);
@@ -1419,11 +1421,9 @@ public class CppCompileAction extends AbstractAction
     actionKeyContext.addNestedSetToFingerprint(fp, inputsForInvalidation);
 
     PathMappers.addToFingerprint(
-        mnemonic,
-        executionInfo,
         NestedSetBuilder.emptySet(Order.STABLE_ORDER),
         actionKeyContext,
-        outputPathsMode,
+        effectiveOutputPathsMode,
         fp);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LtoBackendAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LtoBackendAction.java
@@ -306,7 +306,7 @@ public final class LtoBackendAction extends SpawnAction {
       bitcodeFiles.addToFingerprint(fp);
       fp.addPath(imports.getExecPath());
     }
-    getEnvironment().addTo(fp);
+    getEnvironment().addTo(OutputPathsMode.OFF, fp);
     fp.addStringMap(getExecutionInfo());
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -234,15 +234,10 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
     // As the classpath is no longer part of commandLines implicitly, we need to explicitly add
     // the transitive inputs to the key here.
     actionKeyContext.addNestedSetToFingerprint(fp, transitiveInputs);
-    getEnvironment().addTo(fp);
+    getEnvironment().addTo(effectiveOutputPathsMode, fp);
     fp.addStringMap(executionInfo);
     PathMappers.addToFingerprint(
-        getMnemonic(),
-        getExecutionInfo(),
-        getAdditionalArtifactsForPathMapping(),
-        actionKeyContext,
-        outputPathsMode,
-        fp);
+        getAdditionalArtifactsForPathMapping(), actionKeyContext, effectiveOutputPathsMode, fp);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -372,7 +372,7 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             defaultValue = "None",
             named = true,
             positional = false,
-        doc = "A one-word description of the action, for example, CppCompile or GoLink."),
+            doc = "A one-word description of the action, for example, CppCompile or GoLink."),
         @Param(
             name = "execution_requirements",
             allowedTypes = {
@@ -477,7 +477,7 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             defaultValue = "None",
             named = true,
             positional = false,
-        doc = "A one-word description of the action, for example, CppCompile or GoLink."),
+            doc = "A one-word description of the action, for example, CppCompile or GoLink."),
         @Param(
             name = "progress_message",
             allowedTypes = {
@@ -519,7 +519,12 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
                 "Sets the dictionary of environment variables.<p>If both"
                     + " <code>use_default_shell_env</code> and <code>env</code> are set to"
                     + " <code>True</code>, values set in <code>env</code> will overwrite the"
-                    + " default shell environment."),
+                    + " default shell environment.<p>Values may also be <code>File</code>s, which"
+                    + " are expanded to their <a"
+                    + " href=\"../builtins/File.html#path\"><code>path</code></a> at execution"
+                    + " time. This form should be preferred over passing the path string so that"
+                    + " the action can support path mapping via the <code>supports-path-mapping</code>"
+                    + " execution requirement."),
         @Param(
             name = "execution_requirements",
             allowedTypes = {
@@ -695,7 +700,7 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             defaultValue = "None",
             named = true,
             positional = false,
-        doc = "A one-word description of the action, for example, CppCompile or GoLink."),
+            doc = "A one-word description of the action, for example, CppCompile or GoLink."),
         @Param(
             name = "command",
             allowedTypes = {
@@ -771,7 +776,12 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
                 "Sets the dictionary of environment variables.<p>If both"
                     + " <code>use_default_shell_env</code> and <code>env</code> are set to"
                     + " <code>True</code>, values set in <code>env</code> will overwrite the"
-                    + " default shell environment."),
+                    + " default shell environment.<p>Values may also be <code>File</code>s, which"
+                    + " are expanded to their <a"
+                    + " href=\"../builtins/File.html#path\"><code>path</code></a> at execution"
+                    + " time. This form should be preferred over passing the path string so that"
+                    + " the action can support path mapping via the <code>supports-path-mapping</code>"
+                    + " execution requirement."),
         @Param(
             name = "execution_requirements",
             allowedTypes = {

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionEnvironmentTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionEnvironmentTest.java
@@ -18,6 +18,12 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
+import com.google.devtools.build.lib.testutil.Scratch;
+import com.google.devtools.build.lib.util.Fingerprint;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
@@ -27,6 +33,19 @@ import org.junit.runners.JUnit4;
 /** {@link ActionEnvironment}Test */
 @RunWith(JUnit4.class)
 public final class ActionEnvironmentTest {
+
+  /** Strips the config segment (e.g. "k8-fastbuild") from an output path. */
+  private static final PathMapper STRIP_CONFIG =
+      execPath -> execPath.subFragment(0, 1).getRelative(execPath.subFragment(2));
+
+  private final Scratch scratch = new Scratch();
+
+  private Artifact createOutputArtifact(String rootRelativePath) throws IOException {
+    ArtifactRoot root =
+        ArtifactRoot.asDerivedRoot(
+            scratch.dir("/exec"), RootType.OUTPUT, "bazel-out", "k8-fastbuild", "bin");
+    return ActionsTestUtil.createArtifact(root, rootRelativePath);
+  }
 
   @Test
   public void compoundEnvOrdering() {
@@ -63,6 +82,108 @@ public final class ActionEnvironmentTest {
             "inherited",
             "INHERITED_ONLY",
             "inherited");
+  }
+
+  @Test
+  public void artifactValueResolution() throws Exception {
+    Artifact artifact = createOutputArtifact("pkg/file");
+    ActionEnvironment env =
+        ActionEnvironment.create(ImmutableMap.of("FIXED", "fixed", "ARTIFACT", artifact));
+
+    assertThat(env.getFixedEnv())
+        .containsExactly("FIXED", "fixed", "ARTIFACT", "bazel-out/k8-fastbuild/bin/pkg/file");
+
+    Map<String, String> result = new HashMap<>();
+    env.resolve(result, ImmutableMap.of());
+    assertThat(result)
+        .containsExactly("FIXED", "fixed", "ARTIFACT", "bazel-out/k8-fastbuild/bin/pkg/file");
+  }
+
+  @Test
+  public void resolve_artifactValueAppliesPathMapper() throws Exception {
+    Artifact artifact = createOutputArtifact("pkg/file");
+    ActionEnvironment env =
+        ActionEnvironment.create(ImmutableMap.of("FIXED", "fixed", "ARTIFACT", artifact));
+
+    Map<String, String> result = new HashMap<>();
+    env.resolve(result, ImmutableMap.of(), STRIP_CONFIG);
+    assertThat(result).containsExactly("FIXED", "fixed", "ARTIFACT", "bazel-out/bin/pkg/file");
+  }
+
+  @Test
+  public void resolve_mappedArtifactValueOverridesClientEnv() throws Exception {
+    Artifact artifact = createOutputArtifact("pkg/file");
+    ActionEnvironment env =
+        ActionEnvironment.create(
+            ImmutableMap.of("ARTIFACT", artifact), ImmutableSet.of("ARTIFACT"));
+
+    Map<String, String> result = new HashMap<>();
+    env.resolve(result, ImmutableMap.of("ARTIFACT", "from_client"), STRIP_CONFIG);
+    assertThat(result).containsExactly("ARTIFACT", "from_client");
+
+    result.clear();
+    env.resolve(result, ImmutableMap.of(), STRIP_CONFIG);
+    assertThat(result).containsExactly("ARTIFACT", "bazel-out/bin/pkg/file");
+  }
+
+  @Test
+  public void withAdditionalFixedVariables_artifactValues() throws Exception {
+    Artifact artifact1 = createOutputArtifact("pkg/file1");
+    Artifact artifact2 = createOutputArtifact("pkg/file2");
+    ActionEnvironment env =
+        ActionEnvironment.create(ImmutableMap.of("FOO", "foo", "ARTIFACT", artifact1))
+            .withAdditionalFixedVariables(ImmutableMap.of("BAR", "bar", "ARTIFACT", artifact2));
+
+    assertThat(env.getFixedEnv())
+        .containsExactly(
+            "FOO", "foo", "BAR", "bar", "ARTIFACT", "bazel-out/k8-fastbuild/bin/pkg/file2");
+  }
+
+  @Test
+  public void addTo_artifactValueAppliesPathMapper() throws Exception {
+    Artifact artifact = createOutputArtifact("pkg/file");
+    ActionEnvironment env = ActionEnvironment.create(ImmutableMap.of("ARTIFACT", artifact));
+
+    Fingerprint unmapped = new Fingerprint();
+    env.addTo(CoreOptions.OutputPathsMode.OFF, unmapped);
+    Fingerprint mapped = new Fingerprint();
+    env.addTo(CoreOptions.OutputPathsMode.STRIP, mapped);
+
+    assertThat(mapped.hexDigestAndReset()).isNotEqualTo(unmapped.hexDigestAndReset());
+  }
+
+  @Test
+  public void addTo_artifactValueFingerprintNotSameAsStringValue() throws Exception {
+    Artifact artifact = createOutputArtifact("pkg/file");
+    ActionEnvironment artifactEnv = ActionEnvironment.create(ImmutableMap.of("ARTIFACT", artifact));
+    ActionEnvironment stringEnv =
+        ActionEnvironment.create(ImmutableMap.of("ARTIFACT", artifact.getExecPathString()));
+
+    Fingerprint artifactFingerprint = new Fingerprint();
+    artifactEnv.addTo(CoreOptions.OutputPathsMode.STRIP, artifactFingerprint);
+    Fingerprint stringFingerprint = new Fingerprint();
+    stringEnv.addTo(CoreOptions.OutputPathsMode.OFF, stringFingerprint);
+
+    assertThat(artifactFingerprint.hexDigestAndReset())
+        .isNotEqualTo(stringFingerprint.hexDigestAndReset());
+  }
+
+  @Test
+  public void artifactValueInterning() throws Exception {
+    Artifact artifact = createOutputArtifact("pkg/file");
+    ActionEnvironment env1 =
+        ActionEnvironment.create(
+            ImmutableMap.of("FOO", "foo", "ARTIFACT", artifact), ImmutableSet.of("baz"));
+    ActionEnvironment env2 =
+        ActionEnvironment.create(
+            ImmutableMap.of("FOO", "foo", "ARTIFACT", artifact), ImmutableSet.of("baz"));
+    ActionEnvironment env3 =
+        ActionEnvironment.create(
+            ImmutableMap.of("FOO", "foo", "ARTIFACT", artifact.getExecPathString()),
+            ImmutableSet.of("baz"));
+
+    assertThat(env2).isSameInstanceAs(env1);
+    assertThat(env3).isNotEqualTo(env1);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
@@ -302,6 +302,97 @@ public class PathMappersTest extends BuildViewTestCase {
   }
 
   @Test
+  public void starlarkRule_artifactEnv() throws Exception {
+    scratch.file("defs/BUILD");
+    scratch.file(
+        "defs/defs.bzl",
+        """
+        def my_rule_impl(ctx):
+            out = ctx.actions.declare_file(ctx.label.name)
+            ctx.actions.run(
+                executable = ctx.executable._tool,
+                arguments = [ctx.actions.args().add(out)],
+                inputs = ctx.files.srcs,
+                outputs = [out],
+                env = {
+                    "GEN_SRC": ctx.files.srcs[0],
+                    "SOURCE_SRC": ctx.files.srcs[1],
+                    "OUT": out,
+                    "STRING_PATH": ctx.files.srcs[0].path,
+                    "FIXED": "fixed_value",
+                },
+                mnemonic = "MyRuleAction",
+                execution_requirements = {"supports-path-mapping": "1"},
+            )
+            return [DefaultInfo(files = depset([out]))]
+        my_rule = rule(
+            implementation = my_rule_impl,
+            attrs = {
+                "srcs": attr.label_list(allow_files = True),
+                "_tool": attr.label(
+                    default = "//tool",
+                    executable = True,
+                    cfg = "exec",
+                ),
+            },
+        )
+        """);
+    scratch.file(
+        "pkg/BUILD",
+        """
+        load('//defs:defs.bzl', 'my_rule')
+        genrule(
+            name = 'gen_src',
+            outs = ['gen_src.txt'],
+            cmd = '<some command>',
+        )
+        my_rule(
+            name = 'my_rule',
+            srcs = [
+                ':gen_src',
+                'source.txt',
+            ],
+        )
+        """);
+    scratch.file(
+        "tool/BUILD",
+        """
+        load('//test_defs:foo_binary.bzl', 'foo_binary')
+        foo_binary(
+            name = 'tool',
+            srcs = ['tool.sh'],
+            visibility = ['//visibility:public'],
+        )
+        """);
+
+    ConfiguredTarget configuredTarget = getConfiguredTarget("//pkg:my_rule");
+    Artifact outputArtifact =
+        configuredTarget.getProvider(FileProvider.class).getFilesToBuild().toList().get(0);
+    SpawnAction action = (SpawnAction) getGeneratingAction(outputArtifact);
+    Spawn spawn =
+        action.getSpawn(
+            new ActionExecutionContextBuilder()
+                .setMetadataProvider(new FakeActionInputFileCache())
+                .build());
+
+    assertThat(spawn.getPathMapper().isNoop()).isFalse();
+    String outDir = analysisMock.getProductName() + "-out";
+    assertThat(spawn.getEnvironment())
+        .containsExactly(
+            "GEN_SRC",
+            format("%s/cfg/bin/pkg/gen_src.txt", outDir),
+            "SOURCE_SRC",
+            "pkg/source.txt",
+            "OUT",
+            format("%s/cfg/bin/pkg/my_rule", outDir),
+            // String paths are not mapped.
+            "STRING_PATH",
+            format("%s/pkg/gen_src.txt", outputArtifact.getExecPath().subFragment(0, 3)),
+            "FIXED",
+            "fixed_value");
+  }
+
+  @Test
   public void forActionKey() {
     var pathMapper = PathMapper.forActionKey(CoreOptions.OutputPathsMode.STRIP);
     assertThat(pathMapper.isNoop()).isFalse();

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkActionWithShadowedActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkActionWithShadowedActionTest.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.lib.actions.DiscoveredModulesPruner;
 import com.google.devtools.build.lib.actions.Executor;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.ThreadStateReceiver;
+import com.google.devtools.build.lib.analysis.actions.SpawnAction;
 import com.google.devtools.build.lib.analysis.actions.StarlarkAction;
 import com.google.devtools.build.lib.analysis.util.AnalysisTestUtil;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
@@ -352,6 +353,42 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
     // Starlark action's env overwrites any repeated variable from the shadowed action env
     assertThat(actualEnvironment).containsEntry("repeated_var", "starlark_val");
     assertThat(actualEnvironment).containsExactlyEntriesIn(expectedEnvironment);
+  }
+
+  @Test
+  public void testPathMappingShadowedActionEnvironment() throws Exception {
+    Artifact starlarkEnvFile = getSourceArtifact("pkg/starlark_env_file");
+    Artifact shadowedEnvFile = getSourceArtifact("pkg/shadowed_env_file");
+
+    SpawnAction shadowedAction =
+        new SpawnAction.Builder()
+            .setExecutable(executable)
+            .addInput(shadowedEnvFile)
+            .addOutput(getBinArtifactWithNoOwner("shadowed_out"))
+            .setEnvironment(ImmutableMap.of("SHADOWED_FILE", shadowedEnvFile))
+            .build(NULL_ACTION_OWNER, targetConfig);
+
+    StarlarkAction starlarkAction =
+        (StarlarkAction)
+            new StarlarkAction.Builder()
+                .setShadowedAction(Optional.of(shadowedAction))
+                .setExecutable(executable)
+                .addInput(starlarkEnvFile)
+                .addOutput(output)
+                .setEnvironment(ImmutableMap.of("STARLARK_FILE", starlarkEnvFile))
+                .build(NULL_ACTION_OWNER, targetConfig);
+    collectingAnalysisEnvironment.registerAction(starlarkAction);
+
+    assertThat(starlarkAction.getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP))
+        .containsExactly(
+            "SHADOWED_FILE", shadowedEnvFile.getExecPathString(),
+            "STARLARK_FILE", starlarkEnvFile.getExecPathString());
+
+    PathMapper pathMapper = execPath -> PathFragment.create(execPath.getPathString() + "_mapped");
+    assertThat(starlarkAction.getEffectiveEnvironment(ImmutableMap.of(), pathMapper))
+        .containsExactly(
+            "SHADOWED_FILE", shadowedEnvFile.getExecPathString() + "_mapped",
+            "STARLARK_FILE", starlarkEnvFile.getExecPathString() + "_mapped");
   }
 
   private Action createShadowedAction(

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
@@ -494,6 +494,66 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
         "ruleContext.actions.run(outputs=[], bad_param = 'some text', executable = f)");
   }
 
+  @Test
+  public void testCreateSpawnActionEnvFileValue() throws Exception {
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+    ev.exec(
+        "ruleContext.actions.run_shell(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = ruleContext.files.srcs,",
+        "  env = {'SRC': ruleContext.files.srcs[0], 'FIXED': 'value'},",
+        "  mnemonic = 'DummyMnemonic',",
+        "  command = 'dummy_command')");
+    SpawnAction action =
+        (SpawnAction)
+            Iterables.getOnlyElement(
+                ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
+    assertThat(
+            action.getEffectiveEnvironment(
+                ImmutableMap.of(), execPath -> PathFragment.create(execPath + "_mapped")))
+        .containsExactly("SRC", "foo/a.txt_mapped", "FIXED", "value");
+  }
+
+  @Test
+  public void testCreateSpawnActionEnvFileValue_useDefaultShellEnv() throws Exception {
+    useConfiguration("--action_env=SRC", "--action_env=OTHER=other");
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+    ev.exec(
+        "ruleContext.actions.run_shell(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = ruleContext.files.srcs,",
+        "  env = {'SRC': ruleContext.files.srcs[0]},",
+        "  use_default_shell_env = True,",
+        "  mnemonic = 'DummyMnemonic',",
+        "  command = 'dummy_command')");
+    SpawnAction action =
+        (SpawnAction)
+            Iterables.getOnlyElement(
+                ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
+    // The action-provided value for SRC overrides the inherited variable of the same name, which
+    // the action thus no longer depends on.
+    assertThat(action.getClientEnvironmentVariables()).doesNotContain("SRC");
+    assertThat(
+            action.getEffectiveEnvironment(ImmutableMap.of("SRC", "from_client"), PathMapper.NOOP))
+        .containsEntry("SRC", "foo/a.txt");
+    assertThat(action.getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP))
+        .containsEntry("OTHER", "other");
+  }
+
+  @Test
+  public void testCreateSpawnActionEnvInvalidValueType() throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+    ev.checkEvalErrorContains(
+        "expected value of type 'string' or 'File' for env variable 'FOO', but got int instead",
+        "ruleContext.actions.run_shell(",
+        "  outputs = ruleContext.files.srcs,",
+        "  env = {'FOO': 1},",
+        "  mnemonic = 'DummyMnemonic',",
+        "  command = 'dummy_command')");
+  }
+
   private Object createTestSpawnAction(StarlarkRuleContext ruleContext) throws Exception {
     setRuleContext(ruleContext);
     return ev.eval(

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -406,6 +406,63 @@ EOF
   expect_log '2 remote[^ ]'
 }
 
+function test_path_stripping_env_files() {
+  mkdir pkg
+  cat > pkg/defs.bzl <<'EOF'
+def _copy_via_env_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".out")
+    ctx.actions.run_shell(
+        outputs = [out],
+        inputs = [ctx.file.src],
+        command = 'cat "$SRC_PATH" > "$OUT_PATH"',
+        env = {
+            "SRC_PATH": ctx.file.src,
+            "OUT_PATH": out,
+        },
+        execution_requirements = {"supports-path-mapping": ""},
+        mnemonic = "CopyViaEnv",
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+copy_via_env = rule(
+    implementation = _copy_via_env_impl,
+    attrs = {"src": attr.label(allow_single_file = True)},
+)
+EOF
+  cat > pkg/BUILD <<'EOF'
+load(":defs.bzl", "copy_via_env")
+
+genrule(
+    name = "gen_src",
+    outs = ["src.txt"],
+    cmd = "echo 'Hello, World!' > $@",
+)
+
+copy_via_env(
+    name = "copy",
+    src = ":gen_src",
+)
+EOF
+
+  bazel build -c fastbuild \
+    --experimental_output_paths=strip \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //pkg:copy &> $TEST_log || fail "build failed unexpectedly"
+  expect_not_log 'remote cache hit'
+  assert_contains 'Hello, World!' bazel-bin/pkg/copy.out
+
+  # The genrule does not support path mapping and runs again in the new
+  # configuration, but the CopyViaEnv action gets a remote cache hit since the
+  # mapped path in the SRC_PATH and OUT_PATH env variables is identical across
+  # configurations.
+  bazel build -c opt \
+    --experimental_output_paths=strip \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //pkg:copy &> $TEST_log || fail "build failed unexpectedly"
+  expect_log '1 remote cache hit'
+  assert_contains 'Hello, World!' bazel-bin/pkg/copy.out
+}
+
 function test_path_stripping_disabled_with_tags() {
   mkdir pkg
   cat > pkg/defs.bzl <<'EOF'


### PR DESCRIPTION
Adds support for path mappable environment variables by generalizing the existing custom support for C++ actions. `ActionEnvironment` is extended to allow `Artifact` values in addition to `String` and the change is largely contained to that class, with `getEffectiveEnvironment` retaining its `Map<String, String>` return value.

RELNOTES: The values of the `env` dict of `ctx.actions.run` and `ctx.actions.run_shell` can now be `File`s in addition to strings to support path mapping environment variables (see #22658).