### PR TITLE
Enable TCP keepalive by default for gRPC connections.

### DIFF
--- a/src/jdeps_modules.golden
+++ b/src/jdeps_modules.golden
@@ -6,4 +6,5 @@ java.naming
 java.sql
 java.xml
 jdk.management
+jdk.net
 jdk.unsupported

--- a/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
@@ -154,6 +154,61 @@ public abstract class AuthAndTLSOptions extends OptionsBase {
   public abstract Duration getGrpcKeepaliveTimeout();
 
   @Option(
+      name = "grpc_tcp_keepalive",
+      defaultValue = "true",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          """
+          Whether to enable TCP keep-alive (the SO_KEEPALIVE socket option) for outgoing gRPC
+          connections. This operates at the transport layer and is independent of the
+          application-level keep-alive pings configured with `--grpc_keepalive_time`. When enabled,
+          the keep-alive behavior is controlled by `--grpc_tcp_keepalive_time`,
+          `--grpc_tcp_keepalive_interval` and `--grpc_tcp_keepalive_count`. 
+          """)
+  public abstract boolean getGrpcTcpKeepalive();
+
+  @Option(
+      name = "grpc_tcp_keepalive_time",
+      defaultValue = "60s",
+      converter = DurationConverter.class,
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          """
+          When `--grpc_tcp_keepalive` is enabled, the amount of idle time on a gRPC connection
+          before the first TCP keep-alive probe is sent (TCP_KEEPIDLE). Has no effect if TCP
+          keep-alive is disabled.
+          """)
+  public abstract Duration getGrpcTcpKeepaliveTime();
+
+  @Option(
+      name = "grpc_tcp_keepalive_interval",
+      defaultValue = "10s",
+      converter = DurationConverter.class,
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          """
+          When `--grpc_tcp_keepalive` is enabled, the amount of time between successive TCP
+          keep-alive probes (TCP_KEEPINTVL). Has no effect if TCP keep-alive is disabled.
+          """)
+  public abstract Duration getGrpcTcpKeepaliveInterval();
+
+  @Option(
+      name = "grpc_tcp_keepalive_count",
+      defaultValue = "3",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          """
+          When `--grpc_tcp_keepalive` is enabled, the number of unacknowledged TCP keep-alive probes
+          to send before considering the connection dead (TCP_KEEPCNT). Has no effect if TCP
+          keep-alive is disabled.
+          """)
+  public abstract int getGrpcTcpKeepaliveCount();
+
+  @Option(
       name = "credential_helper",
       oldName = "experimental_credential_helper",
       defaultValue = "null",

--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -37,6 +37,7 @@ import io.grpc.auth.MoreCallCredentials;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollDomainSocketChannel;
@@ -44,6 +45,7 @@ import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.kqueue.KQueue;
 import io.netty.channel.kqueue.KQueueDomainSocketChannel;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.socket.nio.NioChannelOption;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -58,6 +60,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
+import jdk.net.ExtendedSocketOptions;
 
 /** Utility methods for using {@link AuthAndTLSOptions} with Google Cloud. */
 public final class GoogleAuthUtils {
@@ -99,6 +102,27 @@ public final class GoogleAuthUtils {
       if (options.getGrpcKeepaliveTime() != null && !options.getGrpcKeepaliveTime().isZero()) {
         builder.keepAliveTime(options.getGrpcKeepaliveTime().toNanos(), NANOSECONDS);
         builder.keepAliveTimeout(options.getGrpcKeepaliveTimeout().toNanos(), NANOSECONDS);
+      }
+      boolean isUnixSocketChannel =
+          targetUrl.startsWith("unix:") || !Strings.isNullOrEmpty(proxy);
+      if (options.getGrpcTcpKeepalive() && !isUnixSocketChannel) {
+        builder.withOption(ChannelOption.SO_KEEPALIVE, true);
+        long idleSeconds = options.getGrpcTcpKeepaliveTime().toSeconds();
+        if (idleSeconds > 0) {
+          builder.withOption(
+              NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPIDLE), Math.toIntExact(idleSeconds));
+        }
+        long intervalSeconds = options.getGrpcTcpKeepaliveInterval().toSeconds();
+        if (intervalSeconds > 0) {
+          builder.withOption(
+              NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPINTERVAL),
+              Math.toIntExact(intervalSeconds));
+        }
+        if (options.getGrpcTcpKeepaliveCount() > 0) {
+          builder.withOption(
+              NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPCOUNT),
+              options.getGrpcTcpKeepaliveCount());
+        }
       }
       if (interceptors != null) {
         builder.intercept(interceptors);


### PR DESCRIPTION
### Description

We (BuildBuddy) see a fair amount of support issues where connections are killed due to idle flow timeouts (e.g. NAT gateways) and the usual advice is for the customer to configure TCP keepalive on their client host.

Instead of playing whackamole, I'd like to make TCP keepalive on by default for Bazel with reasonable defaults rather than relying on client hosts having appropriate settings configured.

I've kept the settings as flags in case there are users that have more esoteric needs that require adjusting these settings since the explicit settings in this PR override the OS settings.

### Build API Changes

No

### Release Notes

RELNOTES: Enable TCP keepalive by default for gRPC connections with reasonable defaults
