### PR TITLE
[9.2.0] Propagate project-scoped flags through exec transitions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/Scope.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/Scope.java
@@ -33,7 +33,14 @@ public class Scope {
     UNIVERSAL,
     /** The flag's value resets on exec transitions. * */
     TARGET,
-    /** The flag resets on targets outside the flag's project. See PROJECT.scl. * */
+    /**
+     * The flag resets on targets outside the flag's project. See PROJECT.scl.
+     *
+     * <p>Unlike {@code target} scope, this flag's value is preserved across exec transitions: the
+     * value propagates from the target configuration into exec configurations. The project-boundary
+     * enforcement (resetting out-of-scope targets to the baseline) is still applied independently
+     * for each target configuration via {@code BuildConfigurationKeyProducer}.
+     */
     PROJECT,
     /** Placeholder for flags that don't explicitly specify scope. Shouldn't be set directly. * */
     DEFAULT;

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyProducer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyProducer.java
@@ -320,9 +320,9 @@ public final class BuildConfigurationKeyProducer<C>
   private static BuildOptions resetFlags(
       BuildOptionsScopeValue buildOptionsScopeValue,
       BuildOptions baselineConfiguration,
-      Label label) {
+      @Nullable Label label) {
     Preconditions.checkNotNull(buildOptionsScopeValue);
-    Preconditions.checkNotNull(label);
+
 
     BuildOptions transitionedOptionsWithScopeType =
         buildOptionsScopeValue.getResolvedBuildOptionsWithScopeTypes();
@@ -371,8 +371,16 @@ public final class BuildConfigurationKeyProducer<C>
     return scopedBuildOptions;
   }
 
-  private static boolean isInScope(Label label, Scope.ScopeDefinition scopeDefinition) {
-    Preconditions.checkNotNull(scopeDefinition);
+  private static boolean isInScope(
+      @Nullable Label label, @Nullable Scope.ScopeDefinition scopeDefinition) {
+    // A null scopeDefinition means the flag's package has no PROJECT.scl file. Treat the target
+    // as not in scope so the flag resets to its baseline value.
+    // Also, if the label is null, we are evaluating a configuration without a target, so we also
+    // treat it
+    // as out of scope.
+    if (scopeDefinition == null || label == null) {
+      return false;
+    }
     for (String path : scopeDefinition.getOwnedCodePaths()) {
       if (label.getCanonicalForm().startsWith(path)) {
         return true;

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
@@ -238,11 +238,14 @@ public final class FunctionTransitionUtil {
     }
     if (!options.get(CoreOptions.class).excludeStarlarkFlagsFromExecConfig) {
       // Starlark flags propagate to exec by default. This can only be changed by a flag explicitly
-      // setting "scope = 'target'".
+      // setting "scope = 'target'". Project-scoped flags also propagate through exec transitions:
+      // their value is maintained across exec boundaries, with project-boundary enforcement still
+      // applied at target-configuration time by BuildConfigurationKeyProducer.
       return starlarkOptions.entrySet().stream()
           .filter(
               entry ->
                   options.getScopeTypeMap().get(entry.getKey()) == Scope.ScopeType.UNIVERSAL
+                      || options.getScopeTypeMap().get(entry.getKey()) == Scope.ScopeType.PROJECT
                       || options.getScopeTypeMap().get(entry.getKey()) == Scope.ScopeType.DEFAULT)
           .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
@@ -261,7 +264,11 @@ public final class FunctionTransitionUtil {
 
     ImmutableMap.Builder<Label, Object> ans = ImmutableMap.builder();
     for (Map.Entry<Label, Object> entry : starlarkOptions.entrySet()) {
-      if (options.getScopeTypeMap().get(entry.getKey()) == Scope.ScopeType.UNIVERSAL) {
+      if (options.getScopeTypeMap().get(entry.getKey()) == Scope.ScopeType.UNIVERSAL
+        || options.getScopeTypeMap().get(entry.getKey()) == Scope.ScopeType.PROJECT) {
+        // Universal flags always propagate. Project-scoped flags also propagate through exec
+        // transitions; their value is maintained across exec boundaries, with project-boundary
+        // enforcement applied later at target-configuration time.
         ans.put(entry);
       } else if (options.getScopeTypeMap().get(entry.getKey()) == Scope.ScopeType.TARGET) {
         // Don't propagate this flag.

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValueTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.analysis.config.BuildOptions.MapBackedChecksumCache;
 import com.google.devtools.build.lib.analysis.config.BuildOptions.OptionsChecksumCache;
+import com.google.devtools.build.lib.analysis.util.AnalysisTestUtil;
 import com.google.devtools.build.lib.analysis.util.ConfigurationTestCase;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -492,30 +493,69 @@ public final class BuildConfigurationValueTest extends ConfigurationTestCase {
             build_setting_default = "default",
             scope = "universal",
         )
+        string_flag(
+            name = "flag_in_exec_config_set_to_another_value",
+            build_setting_default = "default",
+            scope = "target",
+            on_leave_scope = "another_value"
+        )
+        string_flag(
+            name = "project_scope",
+            build_setting_default = "default",
+            scope = "project",
+        )
+        string_flag(
+            name = "another_flag",
+            build_setting_default = "default",
+        )
+        string_flag(
+            name = "flag_in_exec_config_reference_another_flag_value",
+            build_setting_default = "default",
+            scope = "exec:--//test:another_flag",
+        )
         """);
 
-    BuildConfigurationValue execConfig =
-        createExec(
+    BuildOptions targetOptions =
+        parseBuildOptions(
             ImmutableMap.of(
                 "//test:default_scope",
                 "custom",
                 "//test:target_scope",
                 "custom",
                 "//test:universal_scope",
+                "custom",
+                "//test:project_scope",
                 "custom"),
             "--experimental_exclude_starlark_flags_from_exec_config="
                 + (propagateByDefault ? "false" : "true"));
 
+    BuildOptions execOptions =
+        AnalysisTestUtil.execOptions(targetOptions, skyframeExecutor, reporter);
+
     if (propagateByDefault) {
-      assertThat(execConfig.getOptions().getStarlarkOptions())
+      assertThat(execOptions.getStarlarkOptions())
           .containsExactly(
-              Label.parseCanonicalUnchecked("//test:universal_scope"),
+              Label.parseCanonicalUnchecked(
+                  "//test:universal_scope"), // Universal survives all transitions, of course.
+              "custom",
+              Label.parseCanonicalUnchecked(
+                  "//test:project_scope"), // This is just asserting that project scope survives the
+              // exec transition.  If we had changed project scope,
+              // this flag wouldn't be present.
               "custom",
               Label.parseCanonicalUnchecked("//test:default_scope"),
               "custom");
     } else {
-      assertThat(execConfig.getOptions().getStarlarkOptions())
-          .containsExactly(Label.parseCanonicalUnchecked("//test:universal_scope"), "custom");
+      assertThat(execOptions.getStarlarkOptions())
+          .containsExactly(
+              Label.parseCanonicalUnchecked(
+                  "//test:universal_scope"), // Universal survives all transitions, of course.
+              "custom",
+              Label.parseCanonicalUnchecked(
+                  "//test:project_scope"), // This is just asserting that project scope survives the
+              // exec transition.  If we had changed project scope,
+              // this flag wouldn't be present.
+              "custom");
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValueTest.java
@@ -494,24 +494,9 @@ public final class BuildConfigurationValueTest extends ConfigurationTestCase {
             scope = "universal",
         )
         string_flag(
-            name = "flag_in_exec_config_set_to_another_value",
-            build_setting_default = "default",
-            scope = "target",
-            on_leave_scope = "another_value"
-        )
-        string_flag(
             name = "project_scope",
             build_setting_default = "default",
             scope = "project",
-        )
-        string_flag(
-            name = "another_flag",
-            build_setting_default = "default",
-        )
-        string_flag(
-            name = "flag_in_exec_config_reference_another_flag_value",
-            build_setting_default = "default",
-            scope = "exec:--//test:another_flag",
         )
         """);
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValueTest.java
@@ -472,7 +472,7 @@ public final class BuildConfigurationValueTest extends ConfigurationTestCase {
         string_flag = rule(
             implementation = lambda ctx: [],
             build_setting = config.string(flag = True),
-            attrs = {"scope": attr.string(values = ["target", "universal"])},
+            attrs = {"scope": attr.string(values = ["target", "universal", "project"])},
         )
         """);
     scratch.file(
@@ -553,7 +553,7 @@ public final class BuildConfigurationValueTest extends ConfigurationTestCase {
         string_flag = rule(
             implementation = lambda ctx: [],
             build_setting = config.string(flag = True),
-            attrs = {"scope": attr.string(values = ["target", "universal"])},
+            attrs = {"scope": attr.string(values = ["target", "universal", "project"])},
         )
         """);
     scratch.file(

--- a/src/test/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyProducerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyProducerTest.java
@@ -670,6 +670,133 @@ public class BuildConfigurationKeyProducerTest extends ProducerTestCase {
   }
 
   @Test
+  public void createKey_withScopedBuildOptions_projectFlag_isPreservedForInScopeTarget()
+      throws Exception {
+    // Tests that when a target is evaluated within a flag's project boundary, the project-scoped
+    // flag's value is correctly preserved.
+    createStarlarkFlagRule();
+    scratch.file(
+        "flag/BUILD",
+        """
+        load(":def.bzl", "basic_flag")
+        basic_flag(
+            name = "foo",
+            scope = "project",
+            build_setting_default = "default",
+        )
+        """);
+    scratch.file(
+        "flag/PROJECT.scl",
+        """
+        load("//test:project_proto.scl", "project_pb2")
+        project = project_pb2.Project.create(
+            project_directories = ["//my_project"],
+        )
+        """);
+
+    invalidatePackages(false);
+
+    // The target being built is inside the flag's project boundary.
+    BuildOptions baseOptions = createBuildOptions("--//flag:foo=foo");
+    BuildConfigurationKey result =
+        fetch(baseOptions, Label.parseCanonicalUnchecked("//my_project:my_target"));
+    assertThat(result).isNotNull();
+
+    // The flag is in scope for //my_project:my_target, so its value should be preserved.
+    assertThat(
+            result
+                .getOptions()
+                .getStarlarkOptions()
+                .get(Label.parseCanonicalUnchecked("//flag:foo")))
+        .isEqualTo("foo");
+  }
+
+  @Test
+  public void createKey_withScopedBuildOptions_projectFlag_resetsOutsideProject() throws Exception {
+    // Tests that when a project-scoped flag arrives at a target evaluation,
+    // if the target is outside the flag's project boundary, the project-boundary
+    // enforcement resets the flag to its baseline value.
+    createStarlarkFlagRule();
+    scratch.file(
+        "flag/BUILD",
+        """
+        load(":def.bzl", "basic_flag")
+        basic_flag(
+            name = "foo",
+            scope = "project",
+            build_setting_default = "default",
+        )
+        """);
+    scratch.file(
+        "flag/PROJECT.scl",
+        """
+        load("//test:project_proto.scl", "project_pb2")
+        project = project_pb2.Project.create(
+            project_directories = ["//my_project"],
+        )
+        """);
+
+    invalidatePackages(false);
+
+    // The target being built is outside the flag's project boundary.
+    BuildOptions baseOptions = createBuildOptions("--//flag:foo=foo");
+    BuildConfigurationKey result =
+        fetch(baseOptions, Label.parseCanonicalUnchecked("//other_project:my_target"));
+    assertThat(result).isNotNull();
+
+    // The flag is out of scope and resets to baseline.
+    // Since the baseline doesn't have //flag:foo set, it should be absent from the options.
+    assertThat(
+            result
+                .getOptions()
+                .getStarlarkOptions()
+                .get(Label.parseCanonicalUnchecked("//flag:foo")))
+        .isNull();
+  }
+
+  @Test
+  public void createKey_withNullLabel_resetsProjectScopedFlags() throws Exception {
+    createStarlarkFlagRule();
+    scratch.file(
+        "flag/BUILD",
+        """
+        load(":def.bzl", "basic_flag")
+        basic_flag(
+            name = "foo",
+            scope = "project",
+            build_setting_default = "default",
+        )
+        """);
+    scratch.file(
+        "flag/PROJECT.scl",
+        """
+        load("//test:project_proto.scl", "project_pb2")
+        project = project_pb2.Project.create(
+            project_directories = ["//my_project"],
+        )
+        """);
+
+    invalidatePackages(false);
+
+    // Provide a non-default flag value
+    BuildOptions baseOptions = createBuildOptions("--//flag:foo=foo");
+
+    // Fetching with a null label acts as if evaluating a top-level config or
+    // an exec transitions headless config. The flag should be aggressively reset to baseline
+    // because no project boundary could possibly be validated.
+    BuildConfigurationKey result = fetch(baseOptions, null);
+
+    assertThat(result).isNotNull();
+    // It should have reset to baseline, meaning //flag:foo is absent.
+    assertThat(
+            result
+                .getOptions()
+                .getStarlarkOptions()
+                .get(Label.parseCanonicalUnchecked("//flag:foo")))
+        .isNull();
+  }
+
+  @Test
   public void checkFinalizeBuildOptions_haveCorrectScopeTypeMap_noScopingApplied()
       throws Exception {
     createStarlarkFlagRule();

--- a/src/test/shell/integration/flags_scoping_integration_tests.sh
+++ b/src/test/shell/integration/flags_scoping_integration_tests.sh
@@ -284,4 +284,190 @@ EOF
   bazel build //${pkg}:main --experimental_enable_scl_dialect || fail "bazel failed"
 }
 
+function test_foobar_exec_transition_foo_baz_keeps_flag() {
+  echo "testing test_foobar_exec_transition_foo_baz_keeps_flag"
+  local -r pkg="foo"
+
+  mkdir -p "${pkg}"
+
+  # define a project-scoped flag
+  cat > "${pkg}/flag.bzl" <<EOF
+BuildSettingInfo = provider(fields = ["value"])
+
+def _sample_flag_impl(ctx):
+    return BuildSettingInfo(value = ctx.build_setting_value)
+
+sample_flag = rule(
+    implementation = _sample_flag_impl,
+    build_setting = config.string(flag = True),
+    attrs = {
+      "scope": attr.string(default = "universal"),
+    }
+)
+EOF
+
+  cat > "${pkg}/BUILD" <<EOF
+load("//${pkg}:flag.bzl", "sample_flag")
+
+sample_flag(
+    name = "project_flag",
+    scope = "project",
+    build_setting_default = "default",
+)
+EOF
+
+  # create PROJECT.scl
+  cat > "${pkg}/PROJECT.scl" <<EOF
+load("//third_party/bazel/src/main/protobuf/project:project_proto.scl", "project_pb2")
+project = project_pb2.Project.create(project_directories = [ "//${pkg}"])
+EOF
+
+  # create rules that use the flag
+  cat > "${pkg}/rules.bzl" <<EOF
+load("//${pkg}:flag.bzl", "BuildSettingInfo")
+
+def _exec_dep_impl(ctx):
+    print("Exec dep flag value: " + ctx.attr._flag[BuildSettingInfo].value)
+
+exec_dep_rule = rule(
+    implementation = _exec_dep_impl,
+    attrs = {
+        "_flag": attr.label(default = "//${pkg}:project_flag"),
+    }
+)
+
+def _main_rule_impl(ctx):
+    pass
+
+def _set_flag_transition_impl(settings, attr):
+    return {"//${pkg}:project_flag": "custom_value"}
+
+set_flag_transition = transition(
+    implementation = _set_flag_transition_impl,
+    inputs = [],
+    outputs = ["//${pkg}:project_flag"]
+)
+
+main_rule = rule(
+    implementation = _main_rule_impl,
+    cfg = set_flag_transition,
+    attrs = {
+        "exec_dep": attr.label(cfg = "exec"),
+    }
+)
+EOF
+
+  cat >> "${pkg}/BUILD" <<EOF
+load("//${pkg}:rules.bzl", "main_rule", "exec_dep_rule")
+
+exec_dep_rule(
+    name = "exec_target",
+)
+
+main_rule(
+    name = "main_target",
+    exec_dep = ":exec_target",
+)
+EOF
+
+  bazel build //${pkg}:main_target --experimental_enable_scl_dialect >& $TEST_log || fail "bazel failed"
+
+  expect_log "Exec dep flag value: custom_value"
+}
+
+function test_foobar_exec_transition_otherpackage_baz_drops_flag() {
+  echo "testing test_foobar_exec_transition_otherpackage_baz_drops_flag"
+  local -r pkg="foo"
+  local -r other_pkg="otherpackage"
+
+  mkdir -p "${pkg}"
+  mkdir -p "${other_pkg}"
+
+  # define a project-scoped flag
+  cat > "${pkg}/flag.bzl" <<EOF
+BuildSettingInfo = provider(fields = ["value"])
+
+def _sample_flag_impl(ctx):
+    return BuildSettingInfo(value = ctx.build_setting_value)
+
+sample_flag = rule(
+    implementation = _sample_flag_impl,
+    build_setting = config.string(flag = True),
+    attrs = {
+      "scope": attr.string(default = "universal"),
+    }
+)
+EOF
+
+  cat > "${pkg}/BUILD" <<EOF
+load("//${pkg}:flag.bzl", "sample_flag")
+
+package(default_visibility = ["//visibility:public"])
+
+sample_flag(
+    name = "project_flag",
+    scope = "project",
+    build_setting_default = "default",
+)
+EOF
+
+  # create PROJECT.scl
+  cat > "${pkg}/PROJECT.scl" <<EOF
+load("//third_party/bazel/src/main/protobuf/project:project_proto.scl", "project_pb2")
+project = project_pb2.Project.create(project_directories = [ "//${pkg}"])
+EOF
+
+  # create rules that use the flag
+  cat > "${other_pkg}/rules.bzl" <<EOF
+load("//${pkg}:flag.bzl", "BuildSettingInfo")
+
+def _exec_dep_impl(ctx):
+    print("Exec dep flag value: " + ctx.attr._flag[BuildSettingInfo].value)
+
+exec_dep_rule = rule(
+    implementation = _exec_dep_impl,
+    attrs = {
+        "_flag": attr.label(default = "//${pkg}:project_flag"),
+    }
+)
+
+def _main_rule_impl(ctx):
+    pass
+
+def _set_flag_transition_impl(settings, attr):
+    return {"//${pkg}:project_flag": "custom_value"}
+
+set_flag_transition = transition(
+    implementation = _set_flag_transition_impl,
+    inputs = [],
+    outputs = ["//${pkg}:project_flag"]
+)
+
+main_rule = rule(
+    implementation = _main_rule_impl,
+    cfg = set_flag_transition,
+    attrs = {
+        "exec_dep": attr.label(cfg = "exec"),
+    }
+)
+EOF
+
+  cat > "${other_pkg}/BUILD" <<EOF
+load("//${other_pkg}:rules.bzl", "main_rule", "exec_dep_rule")
+
+exec_dep_rule(
+    name = "exec_target",
+)
+
+main_rule(
+    name = "main_target",
+    exec_dep = ":exec_target",
+)
+EOF
+
+  bazel build //${other_pkg}:main_target --experimental_enable_scl_dialect >& $TEST_log || fail "bazel failed"
+
+  expect_log "Exec dep flag value: default"
+}
+
 run_suite "Integration tests for flags scoping"


### PR DESCRIPTION
*forked from https://github.com/bazelbuild/bazel/pull/29232*

Fixes https://github.com/bazelbuild/bazel/issues/29851.

### Description

This change alters the behavior of the project scope so that flags explicitly defined with this scope correctly propagate through exec transitions instead of being systematically stripped.

At target-configuration time, BuildConfigurationKeyProducer enforces the project boundary restrictions. If a target is evaluated outside of the directories defined by its associated PROJECT.scl, the flag value is gracefully reset to its baseline execution defaults.

This PR addresses two NullPointerExceptions surfaced when flags propagate natively through these headless environments:

1. Exec configuration and top-level testing pathways frequently parse configurations without assigned target labels (label == null). BuildConfigurationKeyProducer.resetFlags() has been null-guarded to gracefully wipe project-scoped flags from the evaluated configuration when there is no target label context.
2. An edge-case NPE has been fixed where un-scoped Starlark variables dynamically injected back into the options map without corresponding scopeTypeMap metadata incorrectly triggered a verification failure during loop validation.

Updated BuildConfigurationValueTest behavior to test execution options against AnalysisTestUtil.execOptions directly instead of artificially piping through getConfiguration() tests (which obscured the transitions raw output since createExec() silently dropped unsupported scopes). Added detailed tests to BuildConfigurationKeyProducerTest explicitly validating boundary enforcement inside and outside of project trees as well as providing guaranteed protection against these headless/null evaluation situations.

### Motivation
See https://github.com/bazelbuild/bazel/issues/28320

### Build API Changes
Yes - it changes the behaviour of the 'project' scope flag.


### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes
RELNOTES: None
