### PR TITLE
[9.2.0] create --incompatible_remove_ctx_android_fragment for flags migration…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -997,6 +997,18 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
             "Get Java resources from _proguard.jar instead of _deploy.jar in android_binary when "
                 + "bundling the final APK.")
     public boolean getJavaResourcesFromOptimizedJar;
+
+    @Option(
+        name = "incompatible_remove_ctx_android_fragment",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+        help =
+            "When true, Android build flags are defined with Android rules (in BUIILD files) and"
+                + " ctx.fragments.android is undefined. This is a migration flag to move all"
+                + " Android flags  from core Bazel to Python rules.")
+    public boolean disableAndroidFragment;
   }
 
   private final ConfigurationDistinguisher configurationDistinguisher;
@@ -1043,6 +1055,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   private final Label optimizingDexer;
   private final boolean disableInstrumentationManifestMerging;
   private final boolean getJavaResourcesFromOptimizedJar;
+  private final boolean disableAndroidFragment;
 
   public AndroidConfiguration(BuildOptions buildOptions) throws InvalidConfigurationException {
     Options options = buildOptions.get(Options.class);
@@ -1099,6 +1112,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
     this.optimizingDexer = options.optimizingDexer;
     this.disableInstrumentationManifestMerging = options.disableInstrumentationManifestMerging;
     this.getJavaResourcesFromOptimizedJar = options.getJavaResourcesFromOptimizedJar;
+    this.disableAndroidFragment = options.disableAndroidFragment;
 
     if (incrementalDexingShardsAfterProguard < 0) {
       throw new InvalidConfigurationException(
@@ -1113,6 +1127,11 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
       throw new InvalidConfigurationException(
           "Java 8 library support requires --desugar_java8 to be enabled.");
     }
+  }
+
+  @Override
+  public boolean shouldInclude() {
+    return !disableAndroidFragment;
   }
 
   /** Returns whether to use incremental dexing. */

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -154,6 +154,7 @@ bazel_fragments["AndroidConfiguration.Options"] = fragment(
         "//command_line_option:experimental_remove_r_classes_from_instrumentation_test_jar",
         "//command_line_option:experimental_use_rtxt_from_merged_resources",
         "//command_line_option:experimental_objc_provider_from_linked",
+        "//command_line_option:incompatible_remove_ctx_android_fragment",
     ],
     outputs = [
         "//command_line_option:Android configuration distinguisher",


### PR DESCRIPTION
… to Starlark.

[]

PiperOrigin-RevId: 886786353
Change-Id: I530616cd46424fbbb3ccead194c9bef115747647


### Description
create --incompatible_remove_ctx_android_fragment for Starlark Flags migration

### Motivation
Starlarkification of android flags

### Build API Changes
When the flag is flipped, `ctx.fragments.android` will be deleted. Since this is an incompatible flag, I'm planning on having it flipped only in bazel 10


### Release Notes

RELNOTES: create --incompatible_remove_ctx_android_fragment for Starlark Flags migration
