### PR TITLE
Report user-friendly error for invalid cc_shared_library shared_lib_name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
@@ -261,7 +261,8 @@ public class CcStarlarkInternal implements StarlarkValue {
       StarlarkRuleContext ruleContext,
       Artifact artifact,
       String solibDirectory,
-      String runtimeSolibDirBase) {
+      String runtimeSolibDirBase)
+      throws EvalException {
     return SolibSymlinkAction.getCppRuntimeSymlink(
         ruleContext.getRuleContext(), artifact, solibDirectory, runtimeSolibDirBase);
   }
@@ -281,7 +282,8 @@ public class CcStarlarkInternal implements StarlarkValue {
       Artifact library,
       String solibDirectory,
       boolean preserveName,
-      boolean prefixConsumer) {
+      boolean prefixConsumer)
+      throws EvalException {
     return SolibSymlinkAction.getDynamicLibrarySymlink(
         actions.getRuleContext(), solibDirectory, library, preserveName, prefixConsumer);
   }
@@ -296,7 +298,8 @@ public class CcStarlarkInternal implements StarlarkValue {
         @Param(name = "path"),
       })
   public Artifact dynamicLibrarySymlinkAction2(
-      StarlarkActionFactory actions, Artifact library, String solibDirectory, String path) {
+      StarlarkActionFactory actions, Artifact library, String solibDirectory, String path)
+      throws EvalException {
     return SolibSymlinkAction.getDynamicLibrarySymlink(
         actions.getRuleContext(), solibDirectory, library, PathFragment.create(path));
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/SolibSymlinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/SolibSymlinkAction.java
@@ -50,6 +50,8 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Starlark;
 
 /**
  * Creates mangled symlinks in the solib directory for all shared libraries. For shared libraries
@@ -160,7 +162,8 @@ public final class SolibSymlinkAction extends AbstractAction {
       String solibDir,
       final Artifact library,
       boolean preserveName,
-      boolean prefixConsumer) {
+      boolean prefixConsumer)
+      throws EvalException {
     PathFragment mangledName =
         getMangledName(
             actionConstructionContext.getOwner().getLabel(),
@@ -190,9 +193,10 @@ public final class SolibSymlinkAction extends AbstractAction {
       ActionConstructionContext actionConstructionContext,
       String solibDir,
       final Artifact library,
-      PathFragment path) {
-    Preconditions.checkArgument(Link.SHARED_LIBRARY_FILETYPES.matches(library.getFilename()));
-    Preconditions.checkArgument(Link.SHARED_LIBRARY_FILETYPES.matches(path.getBaseName()));
+      PathFragment path)
+      throws EvalException {
+    checkSharedLibraryFiletype(library.getFilename());
+    checkSharedLibraryFiletype(path.getBaseName());
     Preconditions.checkArgument(
         !library.getRootRelativePath().getPathString().startsWith("_solib_"));
 
@@ -210,7 +214,8 @@ public final class SolibSymlinkAction extends AbstractAction {
       RuleContext ruleContext,
       Artifact library,
       String toolchainProvidedSolibDir,
-      String solibDirOverride) {
+      String solibDirOverride)
+      throws EvalException {
     PathFragment solibDir =
         PathFragment.create(
             solibDirOverride != null ? solibDirOverride : toolchainProvidedSolibDir);
@@ -228,11 +233,9 @@ public final class SolibSymlinkAction extends AbstractAction {
   private static Artifact getDynamicLibrarySymlinkInternal(
       ActionConstructionContext actionConstructionContext,
       Artifact library,
-      PathFragment symlinkName) {
-    Preconditions.checkArgument(
-        Link.SHARED_LIBRARY_FILETYPES.matches(library.getFilename()),
-        "Library '%s' does not match expected filetype",
-        library.getFilename());
+      PathFragment symlinkName)
+      throws EvalException {
+    checkSharedLibraryFiletype(library.getFilename());
     Preconditions.checkArgument(
         !library.getRootRelativePath().getPathString().startsWith("_solib_"));
 
@@ -242,6 +245,20 @@ public final class SolibSymlinkAction extends AbstractAction {
     actionConstructionContext.registerAction(
         new SolibSymlinkAction(actionConstructionContext.getActionOwner(), library, symlink));
     return symlink;
+  }
+
+  /**
+   * Verifies that {@code filename} has a recognized shared library extension, raising a
+   * user-friendly {@link EvalException} otherwise. This guards against invalid user-provided names
+   * (e.g. a {@code cc_shared_library}'s {@code shared_lib_name}) reaching here and crashing Bazel.
+   */
+  private static void checkSharedLibraryFiletype(String filename) throws EvalException {
+    if (!Link.SHARED_LIBRARY_FILETYPES.matches(filename)) {
+      throw Starlark.errorf(
+          "shared library name '%s' must end with a recognized shared library extension (one of:"
+              + " %s) or have no extension",
+          filename, String.join(", ", Link.SHARED_LIBRARY_FILETYPES.getExtensions()));
+    }
   }
 
   @VisibleForTesting public static final int MAX_FILENAME_LENGTH = 255;


### PR DESCRIPTION
## Summary

Fixes #26029.

A `cc_shared_library` with an arbitrary `shared_lib_name` whose extension is not a recognized shared library filetype (e.g. `shared_lib_name = "bar.ext"`) caused Bazel to crash with a `FATAL: bazel crashed due to an internal error`:

```
Caused by: java.lang.IllegalArgumentException
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:127)
	at com.google.devtools.build.lib.rules.cpp.SolibSymlinkAction.getDynamicLibrarySymlinkInternal(SolibSymlinkAction.java:228)
```

The filetype was enforced with a `Preconditions.checkArgument`, so a disallowed (but otherwise plausible) user-provided name surfaced as an unchecked `IllegalArgumentException` during Starlark evaluation and crashed the server.

## Change

- Replace the user-reachable filetype assertions in `SolibSymlinkAction` with a checked `EvalException` carrying a clear message.
- Propagate it through the `cc_internal` Starlark entry points (`CcStarlarkInternal`) so the bad input is reported as an ordinary analysis error with a Starlark traceback.

The internal `_solib_` invariant check is left as a `Preconditions` assertion since it is not user-triggerable. Note that `cc_shared_library` now lives in `@rules_cc`, but its `shared_lib_name` is still passed unvalidated through `cc_common.link` into this Java code path, so the fix belongs here.

## Verification

Built a dev Bazel and ran the issue's exact reproduction.

Before: `FATAL ... internal error` with a Java stack trace.

After, `shared_lib_name = "bar.ext"` produces a clean analysis error pointing at the user's target:

```
ERROR: .../BUILD.bazel:8:18: in cc_shared_library rule //:bar:
...
Error in dynamic_library_symlink: shared library name 'bar.ext' must end with a recognized shared library extension (e.g. .so, .dylib, .dll, .ifso, .tbd, .lib, .dll.a) or have no extension
```

A valid name (`shared_lib_name = "libbar.so"`) still builds successfully, confirming the happy path is unaffected.