### PR TITLE
[9.2.0] Implement `transition.and_then`

### DIFF
--- a/docs/extending/config.mdx
+++ b/docs/extending/config.mdx
@@ -646,6 +646,34 @@ hot_chocolate_transition = transition(
 )
 ```
 
+### Composing transitions {#composing-transitions}
+
+Two transitions can be combined into a single new transition using
+[`transition.and_then`](/rules/lib/builtins/transition#and_then):
+
+```python
+combined_transition = first_transition.and_then(second_transition)
+```
+
+The composition applies `first_transition` to the input configuration and then
+runs `second_transition` against each of its output configurations. The original
+transitions are not modified, and the result is itself a `transition` object
+that can be composed further with another `and_then` call.
+
+A composed transition can be attached to a rule or attribute wherever its
+component transitions could be used (subject to the usual restriction that an
+[incoming edge transition](#incoming-edge-transitions) must be 1:1). At most one
+of the composed transitions may be an exec transition (`"exec"` or
+[`config.exec`](/rules/lib/toplevel/config#exec)).
+
+When two of the composed transitions are 1:2+, the composition produces the
+cross product of their splits. The key for each combined split is the
+comma-separated concatenation of the component keys: if the first transition
+produces keys `{a, b}` and the second produces `{x, y}` for each of those, the
+composition produces the four keys `a,x`, `a,y`, `b,x`, and `b,y`. Note that
+each additional 1:2+ transition multiplies the resulting dependency count, so
+chain them with care.
+
 ### Accessing attributes with transitions {:#accessing-attributes-with-transitions}
 
 [End to end example](https://github.com/bazelbuild/examples/tree/HEAD/configurations/read_attr_in_transition){: .external}

--- a/site/en/extending/config.md
+++ b/site/en/extending/config.md
@@ -649,6 +649,34 @@ hot_chocolate_transition = transition(
 )
 ```
 
+### Composing transitions {:#composing-transitions}
+
+Two transitions can be combined into a single new transition using
+[`transition.and_then`](/rules/lib/builtins/transition#and_then):
+
+```python
+combined_transition = first_transition.and_then(second_transition)
+```
+
+The composition applies `first_transition` to the input configuration and then
+runs `second_transition` against each of its output configurations. The original
+transitions are not modified, and the result is itself a `transition` object
+that can be composed further with another `and_then` call.
+
+A composed transition can be attached to a rule or attribute wherever its
+component transitions could be used (subject to the usual restriction that an
+[incoming edge transition](#incoming-edge-transitions) must be 1:1). At most one
+of the composed transitions may be an exec transition (`"exec"` or
+[`config.exec`](/rules/lib/toplevel/config#exec)).
+
+When two of the composed transitions are 1:2+, the composition produces the
+cross product of their splits. The key for each combined split is the
+comma-separated concatenation of the component keys: if the first transition
+produces keys `{a, b}` and the second produces `{x, y}` for each of those, the
+composition produces the four keys `a,x`, `a,y`, `b,x`, and `b,y`. Note that
+each additional 1:2+ transition multiplies the resulting dependency count, so
+chain them with care.
+
 ### Accessing attributes with transitions {:#accessing-attributes-with-transitions}
 
 [End to end example](https://github.com/bazelbuild/examples/tree/HEAD/configurations/read_attr_in_transition){: .external}

--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -101,6 +101,7 @@ java_library(
         "extra/ExtraAction.java",
         "extra/ExtraActionMapProvider.java",
         "extra/ExtraActionSpec.java",
+        "starlark/ComposedTransitionMaterializer.java",
         "starlark/StarlarkActionFactory.java",
         "starlark/StarlarkAspectPropagationContext.java",
         "starlark/StarlarkAttrModule.java",

--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
@@ -391,7 +391,7 @@ public /*final*/ class ConfiguredRuleClassProvider
         trimmingTransitionFactory = factory;
       } else {
         trimmingTransitionFactory =
-            ComposingTransitionFactory.of(trimmingTransitionFactory, factory);
+            ComposingTransitionFactory.ofUnchecked(trimmingTransitionFactory, factory);
       }
       return this;
     }

--- a/src/main/java/com/google/devtools/build/lib/analysis/DependencyResolutionHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/DependencyResolutionHelpers.java
@@ -228,9 +228,11 @@ public final class DependencyResolutionHelpers {
       return ExecutionPlatformResult.ofNullLabel();
     }
 
-    TransitionFactory<AttributeTransitionData> transitionFactory =
-        kind.getAttribute().getTransitionFactory();
-    if (!(transitionFactory instanceof ExecutionTransitionFactory)) {
+    // The exec transition may be composed with other transitions (via transition.and_then), so
+    // look for it anywhere in the (possibly composed) transition factory.
+    ExecutionTransitionFactory execTransitionFactory =
+        findExecutionTransitionFactory(kind.getAttribute().getTransitionFactory());
+    if (execTransitionFactory == null) {
       return ExecutionPlatformResult.ofLabel(
           toolchainContexts
               .getToolchainContext(DeclaredExecGroup.DEFAULT_EXEC_GROUP_NAME)
@@ -238,7 +240,7 @@ public final class DependencyResolutionHelpers {
               .label());
     }
 
-    String execGroup = ((ExecutionTransitionFactory) transitionFactory).getExecGroup();
+    String execGroup = execTransitionFactory.getExecGroup();
     if (toolchainContexts.hasToolchainContext(execGroup)) {
       PlatformInfo platform = toolchainContexts.getToolchainContext(execGroup).executionPlatform();
       return platform == null
@@ -250,6 +252,24 @@ public final class DependencyResolutionHelpers {
         String.format(
             "Attr '%s' declares a transition for non-existent exec group '%s'",
             kind.getAttribute().getName(), execGroup));
+  }
+
+  /**
+   * Returns the {@link ExecutionTransitionFactory} within the given transition factory, or {@code
+   * null} if there is none. A composition contains at most one native transition, so there is at
+   * most one match.
+   */
+  @Nullable
+  private static ExecutionTransitionFactory findExecutionTransitionFactory(
+      TransitionFactory<AttributeTransitionData> transitionFactory) {
+    var found = new ExecutionTransitionFactory[1];
+    transitionFactory.visit(
+        factory -> {
+          if (factory instanceof ExecutionTransitionFactory execFactory) {
+            found[0] = execFactory;
+          }
+        });
+    return found[0];
   }
 
   /** True if {@code owningAspect} is the main aspect, the last one in {@code aspectsList}. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/transitions/ComposingTransitionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/transitions/ComposingTransitionFactory.java
@@ -48,16 +48,20 @@ public abstract class ComposingTransitionFactory<T extends TransitionFactory.Dat
    * one of the transitions is {@link NoTransition}, and returns an efficiently composed transition.
    */
   public static <T extends TransitionFactory.Data> TransitionFactory<T> of(
-      TransitionFactory<T> transitionFactory1, TransitionFactory<T> transitionFactory2) {
-
+      TransitionFactory<T> transitionFactory1, TransitionFactory<T> transitionFactory2)
+      throws IncompatibleTransitionsException {
     Preconditions.checkNotNull(transitionFactory1);
     Preconditions.checkNotNull(transitionFactory2);
-    Preconditions.checkArgument(
-        transitionFactory1.transitionType().isCompatibleWith(transitionFactory2.transitionType()),
-        "transition factory types must be compatible");
-    Preconditions.checkArgument(
-        !transitionFactory1.isSplit() || !transitionFactory2.isSplit(),
-        "can't compose two split transition factories");
+    if (!transitionFactory1
+        .transitionType()
+        .isCompatibleWith(transitionFactory2.transitionType())) {
+      throw new IncompatibleTransitionsException(
+          "transition types must be compatible, got %s and %s"
+              .formatted(transitionFactory1.transitionType(), transitionFactory2.transitionType()));
+    }
+    if (transitionFactory1.isTool() && transitionFactory2.isTool()) {
+      throw new IncompatibleTransitionsException("can't compose two exec transitions");
+    }
 
     if (NoTransition.isInstance(transitionFactory1)) {
       // Since transitionFactory1 causes no changes, use transitionFactory2 directly.
@@ -68,6 +72,26 @@ public abstract class ComposingTransitionFactory<T extends TransitionFactory.Dat
     }
 
     return create(transitionFactory1, transitionFactory2);
+  }
+
+  /**
+   * Use {@link #of} instead unless the two transition factories are statically guaranteed to be
+   * compatible.
+   */
+  public static <T extends TransitionFactory.Data> TransitionFactory<T> ofUnchecked(
+      TransitionFactory<T> transitionFactory1, TransitionFactory<T> transitionFactory2) {
+    try {
+      return of(transitionFactory1, transitionFactory2);
+    } catch (IncompatibleTransitionsException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  /** Thrown when two {@link TransitionFactory} instances cannot be composed. */
+  public static final class IncompatibleTransitionsException extends Exception {
+    IncompatibleTransitionsException(String message) {
+      super(message);
+    }
   }
 
   private static <T extends TransitionFactory.Data> TransitionFactory<T> create(
@@ -84,8 +108,11 @@ public abstract class ComposingTransitionFactory<T extends TransitionFactory.Dat
 
   @Override
   public TransitionType transitionType() {
-    // Both types must match so this is correct.
-    return transitionFactory1().transitionType();
+    // The two types are compatible, so at most one of them is non-ANY; return the more specific
+    // one.
+    return transitionFactory1().transitionType() == TransitionType.ANY
+        ? transitionFactory2().transitionType()
+        : transitionFactory1().transitionType();
   }
 
   abstract TransitionFactory<T> transitionFactory1();
@@ -186,22 +213,19 @@ public abstract class ComposingTransitionFactory<T extends TransitionFactory.Dat
     }
 
     /**
-     * Composes a new key out of two given keys. Composing two split transitions is not allowed at
-     * the moment, so what this essentially does are (1) make sure not both transitions are split
-     * and (2) choose one from a split transition, if there's any, or return {@code
-     * PATCH_TRANSITION_KEY}, if there isn't.
+     * Composes a new key out of two given keys. If either transition is a patch (1:1) its
+     * placeholder {@code PATCH_TRANSITION_KEY} is absorbed; if both transitions split, the keys are
+     * joined by a comma so the composition produces the cross product of their splits (e.g. keys
+     * {@code "a"} and {@code "x"} compose to {@code "a,x"}).
      */
-    private String composeKeys(String key1, String key2) {
-      if (!key1.equals(PATCH_TRANSITION_KEY)) {
-        if (!key2.equals(PATCH_TRANSITION_KEY)) {
-          throw new IllegalStateException(
-              String.format(
-                  "can't compose two split transitions %s and %s",
-                  transition1.getName(), transition2.getName()));
-        }
+    private static String composeKeys(String key1, String key2) {
+      if (key1.equals(PATCH_TRANSITION_KEY)) {
+        return key2;
+      }
+      if (key2.equals(PATCH_TRANSITION_KEY)) {
         return key1;
       }
-      return key2;
+      return key1 + "," + key2;
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/RuleTransitionApplier.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/RuleTransitionApplier.java
@@ -254,7 +254,7 @@ public class RuleTransitionApplier
         targetAndConfigurationData.getTrimmingTransitionFactory();
     if (trimmingTransitionFactory != null) {
       transitionFactory =
-          ComposingTransitionFactory.of(transitionFactory, trimmingTransitionFactory);
+          ComposingTransitionFactory.ofUnchecked(transitionFactory, trimmingTransitionFactory);
     }
     ConfiguredTargetKey preRuleTransitionKey = targetAndConfigurationData.getPreRuleTransitionKey();
     var transitionData =

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/ComposedTransitionMaterializer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/ComposedTransitionMaterializer.java
@@ -1,0 +1,76 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.analysis.starlark;
+
+import com.google.devtools.build.lib.analysis.config.transitions.ComposingTransitionFactory;
+import com.google.devtools.build.lib.analysis.config.transitions.ComposingTransitionFactory.IncompatibleTransitionsException;
+import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
+import com.google.devtools.build.lib.starlarkbuildapi.config.ComposedConfigurationTransition;
+import com.google.devtools.build.lib.starlarkbuildapi.config.ConfigurationTransitionApi;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Starlark;
+
+/**
+ * Helpers for turning a {@link ComposedConfigurationTransition} (the deferred result of {@code
+ * transition.and_then}) into a single {@link TransitionFactory} for a specific use context (rule
+ * vs. attribute).
+ */
+final class ComposedTransitionMaterializer {
+
+  private ComposedTransitionMaterializer() {}
+
+  /** Converts one element of a composed transition into a {@link TransitionFactory}. */
+  @FunctionalInterface
+  interface ElementConverter<T extends TransitionFactory.Data> {
+    TransitionFactory<T> convert(ConfigurationTransitionApi element) throws EvalException;
+  }
+
+  /**
+   * Folds {@code composition}'s elements into a single {@link TransitionFactory} by converting each
+   * with {@code converter} and combining them with {@link ComposingTransitionFactory#of}.
+   *
+   * @param incompatibleElementMessage error suffix used when an element can't be converted in this
+   *     context (e.g. a native attribute-only transition used as a rule {@code cfg})
+   */
+  static <T extends TransitionFactory.Data> TransitionFactory<T> fold(
+      ComposedConfigurationTransition composition,
+      ElementConverter<T> converter,
+      String incompatibleElementMessage)
+      throws EvalException {
+    TransitionFactory<T> result = null;
+    for (ConfigurationTransitionApi element : composition.getElements()) {
+      TransitionFactory<T> factory;
+      try {
+        factory = converter.convert(element);
+      } catch (EvalException unused) {
+        throw Starlark.errorf(
+            "invalid composed transition for `cfg`: %s (composed at %s)",
+            incompatibleElementMessage, composition.getLocation());
+      }
+      if (result == null) {
+        result = factory;
+      } else {
+        try {
+          result = ComposingTransitionFactory.of(result, factory);
+        } catch (IncompatibleTransitionsException e) {
+          throw Starlark.errorf(
+              "invalid composed transition for `cfg`: %s (composed at %s)",
+              e.getMessage(), composition.getLocation());
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrModule.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrModule.java
@@ -56,6 +56,7 @@ import com.google.devtools.build.lib.packages.Types;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.starlarkbuildapi.NativeComputedDefaultApi;
 import com.google.devtools.build.lib.starlarkbuildapi.StarlarkAttrModuleApi;
+import com.google.devtools.build.lib.starlarkbuildapi.config.ComposedConfigurationTransition;
 import com.google.devtools.build.lib.starlarkbuildapi.config.ConfigurationTransitionApi;
 import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
 import com.google.devtools.build.lib.util.FileType;
@@ -534,6 +535,12 @@ public final class StarlarkAttrModule implements StarlarkAttrModuleApi {
     }
     if (trans instanceof StarlarkDefinedConfigTransition starlarkDefinedTransition) {
       return new StarlarkAttributeTransitionProvider(starlarkDefinedTransition);
+    }
+    if (trans instanceof ComposedConfigurationTransition composition) {
+      return ComposedTransitionMaterializer.fold(
+          composition,
+          element -> convertCfg(thread, element),
+          "it contains a native transition that can only be used as a rule transition");
     }
     if (trans instanceof ConfigurationTransitionApi cta) {
       // Every ConfigurationTransitionApi must be a TransitionFactory instance to be usable.

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -114,6 +114,7 @@ import com.google.devtools.build.lib.skyframe.serialization.autocodec.Serializat
 import com.google.devtools.build.lib.starlarkbuildapi.MacroFunctionApi;
 import com.google.devtools.build.lib.starlarkbuildapi.StarlarkRuleFunctionsApi;
 import com.google.devtools.build.lib.starlarkbuildapi.StarlarkSubruleApi;
+import com.google.devtools.build.lib.starlarkbuildapi.config.ComposedConfigurationTransition;
 import com.google.devtools.build.lib.starlarkbuildapi.config.ConfigurationTransitionApi;
 import com.google.devtools.build.lib.util.FileTypeSet;
 import com.google.devtools.build.lib.util.Pair;
@@ -1097,7 +1098,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
         });
     if (parent != null) {
       transitionFactory =
-          ComposingTransitionFactory.of(transitionFactory, parent.getTransitionFactory());
+          ComposingTransitionFactory.ofUnchecked(transitionFactory, parent.getTransitionFactory());
     }
     // Check if the transition has any Starlark code.
     StarlarkTransitionCheckingVisitor visitor = new StarlarkTransitionCheckingVisitor();
@@ -1248,6 +1249,13 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
     if (cfg instanceof StarlarkDefinedConfigTransition starlarkDefinedConfigTransition) {
       // defined in Starlark via, cfg = transition
       return new StarlarkRuleTransitionProvider(starlarkDefinedConfigTransition);
+    }
+    if (cfg instanceof ComposedConfigurationTransition composition) {
+      return ComposedTransitionMaterializer.fold(
+          composition,
+          StarlarkRuleClassFunctions::convertConfig,
+          "it contains a native transition that can only be used as an attribute transition, such"
+              + " as the exec transition");
     }
     if (cfg instanceof ConfigurationTransitionApi cta) {
       // Every ConfigurationTransitionApi must be a TransitionFactory instance to be usable.

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryTransitionResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryTransitionResolver.java
@@ -263,7 +263,7 @@ public class CqueryTransitionResolver {
     boolean isAlias = rule.getAssociatedRule().getName().equals("alias");
     if (trimmingTransitionFactory != null && !isAlias) {
       transitionFactory =
-          ComposingTransitionFactory.of(transitionFactory, trimmingTransitionFactory);
+          ComposingTransitionFactory.ofUnchecked(transitionFactory, trimmingTransitionFactory);
     }
 
     var transitionData = RuleTransitionData.create(rule, /* configConditions= */ null, "");

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/config/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/config/BUILD
@@ -21,11 +21,16 @@ filegroup(
 
 java_library(
     name = "configuration_transition_api",
-    srcs = ["ConfigurationTransitionApi.java"],
+    srcs = [
+        "ComposedConfigurationTransition.java",
+        "ConfigurationTransitionApi.java",
+    ],
     deps = [
         "//src/main/java/com/google/devtools/build/docgen/annot",
         "//src/main/java/net/starlark/java/annot",
         "//src/main/java/net/starlark/java/eval",
+        "//src/main/java/net/starlark/java/syntax",
+        "//third_party:guava",
     ],
 )
 
@@ -45,6 +50,7 @@ java_library(
     srcs = glob(
         ["*.java"],
         exclude = [
+            "ComposedConfigurationTransition.java",
             "ConfigurationTransitionApi.java",
             "StarlarkToolchainTypeRequirement.java",
         ],

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/config/ComposedConfigurationTransition.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/config/ComposedConfigurationTransition.java
@@ -1,0 +1,73 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.starlarkbuildapi.config;
+
+import com.google.common.collect.ImmutableList;
+import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.StarlarkSemantics;
+import net.starlark.java.syntax.Location;
+
+/**
+ * A {@link ConfigurationTransitionApi} formed by composing transitions with {@code
+ * transition.and_then}.
+ *
+ * <p>The elements are applied in order: the first reads the original configuration and each
+ * subsequent transition reads the build settings produced by the previous one. Nested compositions
+ * are flattened, so {@link #getElements} is always a flat chain of non-composed transitions.
+ */
+public final class ComposedConfigurationTransition implements ConfigurationTransitionApi {
+
+  private final ImmutableList<ConfigurationTransitionApi> elements;
+  private final Location location;
+
+  private ComposedConfigurationTransition(
+      ImmutableList<ConfigurationTransitionApi> elements, Location location) {
+    this.elements = elements;
+    this.location = location;
+  }
+
+  static ConfigurationTransitionApi compose(
+      ConfigurationTransitionApi first, ConfigurationTransitionApi second, Location location) {
+    ImmutableList.Builder<ConfigurationTransitionApi> elements = ImmutableList.builder();
+    flatten(first, elements);
+    flatten(second, elements);
+    return new ComposedConfigurationTransition(elements.build(), location);
+  }
+
+  private static void flatten(
+      ConfigurationTransitionApi transition,
+      ImmutableList.Builder<ConfigurationTransitionApi> elements) {
+    if (transition instanceof ComposedConfigurationTransition composed) {
+      elements.addAll(composed.elements);
+    } else {
+      elements.add(transition);
+    }
+  }
+
+  /** Returns the flattened chain of transitions, in application order. */
+  public ImmutableList<ConfigurationTransitionApi> getElements() {
+    return elements;
+  }
+
+  /** Returns the Starlark location of the {@code and_then} call that produced this composition. */
+  public Location getLocation() {
+    return location;
+  }
+
+  @Override
+  public void repr(Printer printer, StarlarkSemantics semantics) {
+    printer.append("<transition object>");
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/config/ConfigurationTransitionApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/config/ConfigurationTransitionApi.java
@@ -15,7 +15,11 @@
 package com.google.devtools.build.lib.starlarkbuildapi.config;
 
 import com.google.devtools.build.docgen.annot.DocCategory;
+import net.starlark.java.annot.Param;
 import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.StarlarkValue;
 
 /** Represents a configuration transition across a dependency edge. */
@@ -28,4 +32,24 @@ import net.starlark.java.eval.StarlarkValue;
             + " configuration transition, then the configuration of <code>//package:bar</code> (and"
             + " its dependencies) will be <code>//package:foo</code>'s configuration plus the"
             + " changes specified by the transition function.")
-public interface ConfigurationTransitionApi extends StarlarkValue {}
+public interface ConfigurationTransitionApi extends StarlarkValue {
+
+  @StarlarkMethod(
+      name = "and_then",
+      doc =
+          "Returns a new transition that applies this transition followed by the given one. The"
+              + " second transition reads the build settings produced by this one; the original"
+              + " transitions are left unchanged. The result is itself a transition and may be"
+              + " composed further.<p>A composition may be used as a rule or attribute transition"
+              + " wherever its component transitions could be used. At most one of the composed"
+              + " transitions may target the exec configuration (e.g. <code>config.exec</code>)."
+              + " When two transitions in the chain split the configuration, the result has the"
+              + " cross product of their splits; the key for each combined split is the"
+              + " comma-separated concatenation of the component keys.",
+      parameters = {@Param(name = "transition", doc = "The transition to apply after this one.")},
+      useStarlarkThread = true)
+  default ConfigurationTransitionApi andThen(
+      ConfigurationTransitionApi transition, StarlarkThread thread) throws EvalException {
+    return ComposedConfigurationTransition.compose(this, transition, thread.getCallerLocation());
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/transitions/ComposingTransitionFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/transitions/ComposingTransitionFactoryTest.java
@@ -15,7 +15,6 @@ package com.google.devtools.build.lib.analysis.config.transitions;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -129,18 +128,37 @@ public class ComposingTransitionFactoryTest {
   }
 
   @Test
-  public void compose_split_split() {
-    // Combining two split transition factories is not allowed.
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            ComposingTransitionFactory.of(
-                new StubSplitFactory(FLAG_1, "value1a", "value1b"),
-                new StubSplitFactory(FLAG_2, "value2a", "value2b")));
+  public void compose_split_split() throws Exception {
+    // Two split transitions compose into the cross product of their splits, with composed keys.
+    TransitionFactory<StubData> composed =
+        ComposingTransitionFactory.of(
+            new StubSplitFactory(FLAG_1, "value1a", "value1b"),
+            new StubSplitFactory(FLAG_2, "value2a", "value2b"));
+
+    assertThat(composed).isNotNull();
+    assertThat(composed.isSplit()).isTrue();
+    ConfigurationTransition transition = composed.create(new StubData());
+    Map<String, BuildOptions> results =
+        transition.apply(
+            TransitionUtil.restrict(transition, BuildOptions.builder().build()), eventHandler);
+    assertThat(results.keySet())
+        .containsExactly(
+            "stub_split0,stub_split0",
+            "stub_split0,stub_split1",
+            "stub_split1,stub_split0",
+            "stub_split1,stub_split1");
+    assertThat(results.get("stub_split0,stub_split0").getStarlarkOptions())
+        .containsAtLeast(FLAG_1, "value1a", FLAG_2, "value2a");
+    assertThat(results.get("stub_split0,stub_split1").getStarlarkOptions())
+        .containsAtLeast(FLAG_1, "value1a", FLAG_2, "value2b");
+    assertThat(results.get("stub_split1,stub_split0").getStarlarkOptions())
+        .containsAtLeast(FLAG_1, "value1b", FLAG_2, "value2a");
+    assertThat(results.get("stub_split1,stub_split1").getStarlarkOptions())
+        .containsAtLeast(FLAG_1, "value1b", FLAG_2, "value2b");
   }
 
   @Test
-  public void compose_noTrans_first() {
+  public void compose_noTrans_first() throws Exception {
     TransitionFactory<StubData> patch = new StubPatchFactory(FLAG_1, "value");
     TransitionFactory<StubData> composed =
         ComposingTransitionFactory.of(NoTransition.getFactory(), patch);
@@ -150,7 +168,7 @@ public class ComposingTransitionFactoryTest {
   }
 
   @Test
-  public void compose_noTrans_second() {
+  public void compose_noTrans_second() throws Exception {
     TransitionFactory<StubData> patch = new StubPatchFactory(FLAG_1, "value");
     TransitionFactory<StubData> composed =
         ComposingTransitionFactory.of(patch, NoTransition.getFactory());

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/BUILD
@@ -173,6 +173,20 @@ java_test(
 )
 
 java_test(
+    name = "StarlarkTransitionCompositionTest",
+    srcs = ["StarlarkTransitionCompositionTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
+        "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
+        "//src/test/java/com/google/devtools/build/lib/analysis/util",
+        "//src/test/java/com/google/devtools/build/lib/testutil",
+        "//third_party:guava",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
+java_test(
     name = "StarlarkTransitionTest",
     srcs = ["StarlarkTransitionTest.java"],
     deps = [

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTransitionCompositionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTransitionCompositionTest.java
@@ -1,0 +1,343 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.analysis.starlark;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.analysis.util.DummyTestFragment;
+import com.google.devtools.build.lib.analysis.util.DummyTestFragment.DummyTestOptions;
+import com.google.devtools.build.lib.testutil.TestRuleClassProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@code transition.and_then}, which composes configuration transitions in Starlark. */
+@RunWith(JUnit4.class)
+public final class StarlarkTransitionCompositionTest extends BuildViewTestCase {
+
+  @Override
+  protected ConfiguredRuleClassProvider createRuleClassProvider() {
+    ConfiguredRuleClassProvider.Builder builder = new ConfiguredRuleClassProvider.Builder();
+    TestRuleClassProvider.addStandardRules(builder);
+    builder.addConfigurationFragment(DummyTestFragment.class);
+    return builder.build();
+  }
+
+  /**
+   * Writes Starlark transitions on the {@code --foo} and {@code --bar} native options: {@code
+   * set_foo} and {@code set_bar} set them to fixed values, while {@code foo_to_bar} reads {@code
+   * --foo} and writes {@code --bar} based on it (so applying it after {@code set_foo} proves the
+   * second transition sees the first one's output).
+   */
+  private void writeTransitions() throws Exception {
+    scratch.file(
+        "test/transitions.bzl",
+        """
+        def _set_foo_impl(settings, attr):
+            return {"//command_line_option:foo": "foo_set"}
+
+        set_foo = transition(
+            implementation = _set_foo_impl,
+            inputs = [],
+            outputs = ["//command_line_option:foo"],
+        )
+
+        def _set_bar_impl(settings, attr):
+            return {"//command_line_option:bar": "bar_set"}
+
+        set_bar = transition(
+            implementation = _set_bar_impl,
+            inputs = [],
+            outputs = ["//command_line_option:bar"],
+        )
+
+        def _foo_to_bar_impl(settings, attr):
+            return {
+                "//command_line_option:bar": settings["//command_line_option:foo"] + "_to_bar",
+            }
+
+        foo_to_bar = transition(
+            implementation = _foo_to_bar_impl,
+            inputs = ["//command_line_option:foo"],
+            outputs = ["//command_line_option:bar"],
+        )
+
+        def _split_foo_impl(settings, attr):
+            return {
+                "a": {"//command_line_option:foo": "a"},
+                "b": {"//command_line_option:foo": "b"},
+            }
+
+        split_foo = transition(
+            implementation = _split_foo_impl,
+            inputs = [],
+            outputs = ["//command_line_option:foo"],
+        )
+
+        def _split_bar_impl(settings, attr):
+            return {
+                "x": {"//command_line_option:bar": "x"},
+                "y": {"//command_line_option:bar": "y"},
+            }
+
+        split_bar = transition(
+            implementation = _split_bar_impl,
+            inputs = [],
+            outputs = ["//command_line_option:bar"],
+        )
+        """);
+  }
+
+  private DummyTestOptions optionsOf(ConfiguredTarget target) {
+    return getConfiguration(target).getOptions().get(DummyTestOptions.class);
+  }
+
+  @Test
+  public void ruleTransition_starlarkThenStarlark() throws Exception {
+    writeTransitions();
+    scratch.file(
+        "test/rules.bzl",
+        """
+        load("//test:transitions.bzl", "foo_to_bar", "set_foo")
+
+        my_rule = rule(
+            implementation = lambda ctx: [],
+            cfg = set_foo.and_then(foo_to_bar),
+        )
+        """);
+    scratch.file(
+        "test/BUILD",
+        """
+        load("//test:rules.bzl", "my_rule")
+
+        my_rule(name = "test")
+        """);
+
+    ConfiguredTarget test = getConfiguredTarget("//test:test");
+
+    assertThat(optionsOf(test).foo).isEqualTo("foo_set");
+    assertThat(optionsOf(test).bar).isEqualTo("foo_set_to_bar");
+  }
+
+  @Test
+  public void attributeTransition_starlarkThenStarlark() throws Exception {
+    writeRuleWithAttributeTransition("set_foo.and_then(foo_to_bar)");
+
+    ConfiguredTarget dep = getDirectPrerequisite(getConfiguredTarget("//test:test"), "//test:dep");
+
+    assertThat(optionsOf(dep).foo).isEqualTo("foo_set");
+    assertThat(optionsOf(dep).bar).isEqualTo("foo_set_to_bar");
+    assertThat(getConfiguration(dep).isExecConfiguration()).isFalse();
+  }
+
+  @Test
+  public void attributeTransition_starlarkThenExec() throws Exception {
+    writeRuleWithAttributeTransition("set_foo.and_then(config.exec())");
+
+    ConfiguredTarget dep = getDirectPrerequisite(getConfiguredTarget("//test:test"), "//test:dep");
+
+    assertThat(getConfiguration(dep).isExecConfiguration()).isTrue();
+    // set_foo runs before the exec transition, which resets --foo back to its default.
+    assertThat(optionsOf(dep).foo).isEmpty();
+  }
+
+  @Test
+  public void attributeTransition_execThenStarlark() throws Exception {
+    writeRuleWithAttributeTransition("config.exec().and_then(set_foo)");
+
+    ConfiguredTarget dep = getDirectPrerequisite(getConfiguredTarget("//test:test"), "//test:dep");
+
+    // set_foo runs after the exec transition, so its effect is visible.
+    assertThat(optionsOf(dep).foo).isEqualTo("foo_set");
+    assertThat(getConfiguration(dep).isExecConfiguration()).isTrue();
+  }
+
+  @Test
+  public void attributeTransition_starlarkThenExecThenStarlark() throws Exception {
+    writeRuleWithAttributeTransition("set_foo.and_then(config.exec()).and_then(set_bar)");
+
+    ConfiguredTarget dep = getDirectPrerequisite(getConfiguredTarget("//test:test"), "//test:dep");
+
+    assertThat(optionsOf(dep).bar).isEqualTo("bar_set");
+    assertThat(getConfiguration(dep).isExecConfiguration()).isTrue();
+    // set_foo runs before the exec transition, which resets --foo back to its default.
+    assertThat(optionsOf(dep).foo).isEmpty();
+  }
+
+  @Test
+  public void attributeTransition_starlarkThenStarlarkThenExec() throws Exception {
+    writeRuleWithAttributeTransition("set_foo.and_then(set_bar).and_then(config.exec())");
+
+    ConfiguredTarget dep = getDirectPrerequisite(getConfiguredTarget("//test:test"), "//test:dep");
+
+    assertThat(getConfiguration(dep).isExecConfiguration()).isTrue();
+    // Both Starlark transitions run before the exec transition, which resets --foo and --bar.
+    assertThat(optionsOf(dep).foo).isEmpty();
+    assertThat(optionsOf(dep).bar).isEmpty();
+  }
+
+  @Test
+  public void attributeTransition_execThenStarlarkThenStarlark() throws Exception {
+    writeRuleWithAttributeTransition("config.exec().and_then(set_foo).and_then(foo_to_bar)");
+
+    ConfiguredTarget dep = getDirectPrerequisite(getConfiguredTarget("//test:test"), "//test:dep");
+
+    // Both Starlark transitions run after the exec transition, and foo_to_bar reads set_foo's
+    // output.
+    assertThat(optionsOf(dep).foo).isEqualTo("foo_set");
+    assertThat(optionsOf(dep).bar).isEqualTo("foo_set_to_bar");
+    assertThat(getConfiguration(dep).isExecConfiguration()).isTrue();
+  }
+
+  @Test
+  public void attributeTransition_splitComposedWithSplit() throws Exception {
+    writeTransitions();
+    scratch.file(
+        "test/rules.bzl",
+        """
+        load("//test:transitions.bzl", "split_bar", "split_foo")
+
+        my_rule = rule(
+            implementation = lambda ctx: [],
+            attrs = {"deps": attr.label_list(cfg = split_foo.and_then(split_bar))},
+        )
+
+        simple = rule(implementation = lambda ctx: [])
+        """);
+    scratch.file(
+        "test/BUILD",
+        """
+        load("//test:rules.bzl", "my_rule", "simple")
+
+        my_rule(name = "test", deps = [":dep"])
+
+        simple(name = "dep")
+        """);
+
+    ConfiguredTarget test = getConfiguredTarget("//test:test");
+
+    ImmutableSet<String> combos =
+        getDirectPrerequisites(test).stream()
+            .filter(ct -> ct.getLabel().toString().equals("//test:dep"))
+            .map(ct -> optionsOf(ct).foo + "," + optionsOf(ct).bar)
+            .collect(toImmutableSet());
+
+    assertThat(combos).containsExactly("a,x", "a,y", "b,x", "b,y");
+  }
+
+  @Test
+  public void noOpTransitionComposition() throws Exception {
+    // config.target() is a no-op and may be freely composed even alongside the exec transition.
+    writeRuleWithAttributeTransition("config.target().and_then(set_foo).and_then(config.exec())");
+
+    ConfiguredTarget dep = getDirectPrerequisite(getConfiguredTarget("//test:test"), "//test:dep");
+
+    assertThat(getConfiguration(dep).isExecConfiguration()).isTrue();
+    // set_foo runs before the exec transition, which resets --foo back to its default.
+    assertThat(optionsOf(dep).foo).isEmpty();
+  }
+
+  @Test
+  public void execComposedWithExec_fails() throws Exception {
+    writeTransitions();
+    scratch.file(
+        "test/rules.bzl",
+        """
+        bad_transition = config.exec().and_then(config.exec())
+
+        my_rule = rule(
+            implementation = lambda ctx: [],
+            attrs = {"dep": attr.label(cfg = bad_transition)},
+        )
+        """);
+    scratch.file(
+        "test/BUILD",
+        """
+        load("//test:rules.bzl", "my_rule")
+
+        my_rule(name = "test", dep = ":dep")
+
+        filegroup(name = "dep")
+        """);
+
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//test:test");
+
+    assertContainsEvent("can't compose two exec transitions");
+    // The error reports both the use site (the `cfg=` attribute) and the original `.and_then`
+    // call site, so users can find the offending composition even when it is defined in a
+    // different .bzl file.
+    assertContainsEvent("attrs = {\"dep\": attr.label(cfg = bad_transition)},");
+    assertContainsEvent("composed at /workspace/test/rules.bzl:1:");
+  }
+
+  @Test
+  public void execInRuleTransition_fails() throws Exception {
+    writeTransitions();
+    scratch.file(
+        "test/rules.bzl",
+        """
+        load("//test:transitions.bzl", "set_foo")
+
+        my_rule = rule(
+            implementation = lambda ctx: [],
+            cfg = set_foo.and_then(config.exec()),
+        )
+        """);
+    scratch.file(
+        "test/BUILD",
+        """
+        load("//test:rules.bzl", "my_rule")
+
+        my_rule(name = "test")
+        """);
+
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//test:test");
+
+    assertContainsEvent("can only be used as an attribute transition");
+  }
+
+  private void writeRuleWithAttributeTransition(String composedTransition) throws Exception {
+    writeTransitions();
+    scratch.file(
+        "test/rules.bzl",
+        String.format(
+            """
+            load("//test:transitions.bzl", "foo_to_bar", "set_bar", "set_foo")
+
+            my_rule = rule(
+                implementation = lambda ctx: [],
+                attrs = {"dep": attr.label(cfg = %s)},
+            )
+
+            simple = rule(implementation = lambda ctx: [])
+            """,
+            composedTransition));
+    scratch.file(
+        "test/BUILD",
+        """
+        load("//test:rules.bzl", "my_rule", "simple")
+
+        my_rule(name = "test", dep = ":dep")
+
+        simple(name = "dep")
+        """);
+  }
+}


### PR DESCRIPTION
Implements the proposal https://github.com/bazelbuild/proposals/blob/main/designs/2024-04-16-transition-composition.md.

This change in particular allows non-toolchain dependencies of rules to inherit both the execution platform (via `config.exec()`) as well as the current target platform (via a custom transition that records `//command_line_option:platforms`), which is important for certain cross-compilation scenarios.

Yes, as discussed and approved in https://github.com/bazelbuild/proposals/blob/main/designs/2024-04-16-transition-composition.md.

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

RELNOTES[NEW]: The `and_then` method on `transition`s can be used to compose transitions. Both Starlark transitions and native transitions (e.g. `config.exec()`) are supported.

Closes #29542.

PiperOrigin-RevId: 934095515
Change-Id: I3f36ec0907c4af5bdf43e38323d166422b47051c 
(cherry picked from commit d089ae2e46b3483e2a30238f913f2053481cf974)

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
