### PR TITLE
Fix flaky test attempts parsing for labels with @

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -39,6 +39,7 @@ import com.google.devtools.common.options.OptionsBase;
 import com.google.devtools.common.options.OptionsClass;
 import com.google.devtools.common.options.OptionsParsingException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -677,7 +678,7 @@ public abstract class ExecutionOptions extends OptionsBase {
     }
 
     private PerLabelOptions parseAsRegex(String input) throws OptionsParsingException {
-      PerLabelOptions testRegexps = super.convert(input);
+      PerLabelOptions testRegexps = parseAsTestAttempts(input);
       if (testRegexps.getOptions().size() != 1) {
         throw new OptionsParsingException("'" + input + "' has multiple runs for a single pattern");
       }
@@ -689,6 +690,23 @@ public abstract class ExecutionOptions extends OptionsBase {
         throw new OptionsParsingException("'" + input + "' has a non-numeric value", e);
       }
       return testRegexps;
+    }
+
+    private PerLabelOptions parseAsTestAttempts(String input) throws OptionsParsingException {
+      int atIndex = input.lastIndexOf('@');
+      if (atIndex < 0) {
+        return super.convert(input);
+      }
+      String filterPiece = input.substring(0, atIndex);
+      String optionsPiece = input.substring(atIndex + 1);
+      List<String> optionsList = new ArrayList<>();
+      for (String option : optionsPiece.split("(?<!\\\\),")) {
+        if (option != null && !option.trim().isEmpty()) {
+          optionsList.add(option.replace("\\,", ","));
+        }
+      }
+      return new PerLabelOptions(
+          new RegexFilter.RegexFilterConverter().convert(filterPiece), optionsList);
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/exec/BUILD
@@ -112,6 +112,18 @@ java_library(
 )
 
 java_test(
+    name = "ExecutionOptionsTest",
+    srcs = ["ExecutionOptionsTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/analysis/config:per_label_options",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/exec:execution_options",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
+java_test(
     name = "ExecTests",
     test_class = "com.google.devtools.build.lib.AllTests",
     runtime_deps = [

--- a/src/test/java/com/google/devtools/build/lib/exec/ExecutionOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/ExecutionOptionsTest.java
@@ -1,0 +1,44 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.exec;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.build.lib.analysis.config.PerLabelOptions;
+import com.google.devtools.build.lib.cmdline.Label;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class ExecutionOptionsTest {
+  private final ExecutionOptions.TestAttemptsConverter converter =
+      new ExecutionOptions.TestAttemptsConverter();
+
+  @Test
+  public void flakyTestAttempts_withAtInLabel() throws Exception {
+    PerLabelOptions options = converter.convert("//foo:v@lid-target@3");
+
+    assertThat(options.isIncluded(Label.parseCanonicalUnchecked("//foo:v@lid-target"))).isTrue();
+    assertThat(options.getOptions()).containsExactly("3");
+  }
+
+  @Test
+  public void flakyTestAttempts_withAtInLabelAndDefaultAttempts() throws Exception {
+    PerLabelOptions options = converter.convert("//foo:v@lid-target@default");
+
+    assertThat(options.isIncluded(Label.parseCanonicalUnchecked("//foo:v@lid-target"))).isTrue();
+    assertThat(options.getOptions()).containsExactly("default");
+  }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description

Update `--flaky_test_attempts` parsing so labels whose regex contains `@` are split from the attempt count at the final `@`. This keeps the generic per-label option parser unchanged while handling numeric and `default` attempt suffixes for test attempts.

Validation:

`bazelisk test //src/test/java/com/google/devtools/build/lib/exec:ExecutionOptionsTest` passed.

### Motivation

Fixes #19447.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
