### PR TITLE
Support HTTP proxies for remote cache / execution

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import io.grpc.CallCredentials;
 import io.grpc.ClientInterceptor;
+import io.grpc.HttpConnectProxiedSocketAddress;
 import io.grpc.ManagedChannel;
 import io.grpc.auth.MoreCallCredentials;
 import io.grpc.netty.GrpcSslContexts;
@@ -52,7 +53,9 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -200,6 +203,38 @@ public final class GoogleAuthUtils {
     throw new IOException("Unix domain sockets are unsupported on this platform");
   }
 
+  public static InetSocketAddress parseHttpProxyAddress(String proxyUrl) throws IOException {
+    URI proxyUri;
+    try {
+      proxyUri = new URI(proxyUrl);
+    } catch (URISyntaxException e) {
+      throw new IOException("Invalid proxy URL: " + proxyUrl, e);
+    }
+    String host = proxyUri.getHost();
+    if (host == null) {
+      throw new IOException("Invalid proxy URL (no host): " + proxyUrl);
+    }
+    int port = proxyUri.getPort();
+    if (port == -1) {
+      port = 80;
+    }
+    return new InetSocketAddress(host, port);
+  }
+
+  private static NettyChannelBuilder newHttpConnectProxyChannelBuilder(
+      String targetUrl, String proxyUrl) throws IOException {
+    InetSocketAddress proxyAddress = parseHttpProxyAddress(proxyUrl);
+
+    return NettyChannelBuilder.forTarget(targetUrl)
+        .defaultLoadBalancingPolicy("round_robin")
+        .proxyDetector(
+            targetServerAddress ->
+                HttpConnectProxiedSocketAddress.newBuilder()
+                    .setTargetAddress((InetSocketAddress) targetServerAddress)
+                    .setProxyAddress(proxyAddress)
+                    .build());
+  }
+
   private static NettyChannelBuilder newNettyChannelBuilder(String targetUrl, String proxy)
       throws IOException {
     if (targetUrl.startsWith("unix:")) {
@@ -210,11 +245,15 @@ public final class GoogleAuthUtils {
       return NettyChannelBuilder.forTarget(targetUrl).defaultLoadBalancingPolicy("round_robin");
     }
 
-    if (!proxy.startsWith("unix:")) {
-      throw new IOException("Remote proxy unsupported: " + proxy);
+    if (proxy.startsWith("unix:")) {
+      return newUnixNettyChannelBuilder(proxy).overrideAuthority(targetUrl);
     }
 
-    return newUnixNettyChannelBuilder(proxy).overrideAuthority(targetUrl);
+    if (proxy.startsWith("http://")) {
+      return newHttpConnectProxyChannelBuilder(targetUrl, proxy);
+    }
+
+    throw new IOException("Remote proxy unsupported: " + proxy);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -45,6 +45,7 @@ java_library(
     deps = [
         ":Retrier",
         "//src/main/java/com/google/devtools/build/lib/authandtls",
+        "//src/main/java/com/google/devtools/build/lib/authandtls:grpc",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
         "//src/main/java/com/google/devtools/build/lib/remote/disk",
         "//src/main/java/com/google/devtools/build/lib/remote/http",

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
@@ -19,6 +19,7 @@ import com.google.common.base.Ascii;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
+import com.google.devtools.build.lib.authandtls.GoogleAuthUtils;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.disk.DiskCacheClient;
 import com.google.devtools.build.lib.remote.http.HttpCacheClient;
@@ -28,6 +29,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import io.netty.channel.unix.DomainSocketAddress;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.Map.Entry;
 import javax.annotation.Nullable;
@@ -92,6 +94,20 @@ public final class CombinedCacheClientFactory {
         if (options.getRemoteProxy().startsWith("unix:")) {
           return HttpCacheClient.create(
               new DomainSocketAddress(options.getRemoteProxy().replaceFirst("^unix:", "")),
+              uri,
+              Math.toIntExact(options.getRemoteTimeout().toSeconds()),
+              options.getRemoteMaxConnections(),
+              options.getRemoteVerifyDownloads(),
+              effectiveHeaders(options),
+              digestUtil,
+              retrier,
+              creds,
+              authAndTlsOptions);
+        } else if (options.getRemoteProxy().startsWith("http://")) {
+          InetSocketAddress proxyAddress =
+              GoogleAuthUtils.parseHttpProxyAddress(options.getRemoteProxy());
+          return HttpCacheClient.create(
+              proxyAddress,
               uri,
               Math.toIntExact(options.getRemoteTimeout().toSeconds()),
               options.getRemoteMaxConnections(),

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
@@ -107,7 +107,6 @@ public final class CombinedCacheClientFactory {
           InetSocketAddress proxyAddress =
               GoogleAuthUtils.parseHttpProxyAddress(options.getRemoteProxy());
           return HttpCacheClient.create(
-              proxyAddress,
               uri,
               Math.toIntExact(options.getRemoteTimeout().toSeconds()),
               options.getRemoteMaxConnections(),
@@ -116,7 +115,8 @@ public final class CombinedCacheClientFactory {
               digestUtil,
               retrier,
               creds,
-              authAndTlsOptions);
+              authAndTlsOptions,
+              proxyAddress);
         } else {
           throw new Exception("Remote cache proxy unsupported: " + options.getRemoteProxy());
         }
@@ -130,7 +130,8 @@ public final class CombinedCacheClientFactory {
             digestUtil,
             retrier,
             creds,
-            authAndTlsOptions);
+            authAndTlsOptions,
+            /* httpConnectProxy= */ null);
       }
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -47,6 +47,7 @@ import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelpe
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialModule;
 import com.google.devtools.build.lib.authandtls.credentialhelper.GetCredentialsResponse;
 import com.google.devtools.build.lib.bazel.repository.downloader.Downloader;
+import com.google.devtools.build.lib.bazel.repository.downloader.ProxyHelper;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
 import com.google.devtools.build.lib.buildeventstream.LocalFilesArtifactUploader;
 import com.google.devtools.build.lib.buildtool.BuildRequest;
@@ -122,10 +123,13 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.channels.ClosedChannelException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -424,6 +428,15 @@ public final class RemoteModule extends BlazeModule {
     if (!Strings.isNullOrEmpty(remoteOptions.getRemoteExecutor())
         && Strings.isNullOrEmpty(remoteOptions.getRemoteCache())) {
       remoteOptions.setRemoteCache(remoteOptions.getRemoteExecutor());
+    }
+
+    String primaryTarget =
+        !Strings.isNullOrEmpty(remoteOptions.getRemoteExecutor())
+            ? remoteOptions.getRemoteExecutor()
+            : remoteOptions.getRemoteCache();
+    if (Strings.isNullOrEmpty(remoteOptions.getRemoteProxy())
+        && !Strings.isNullOrEmpty(primaryTarget)) {
+      remoteOptions.setRemoteProxy(resolveProxyFromEnvironment(primaryTarget, env.getClientEnv()));
     }
 
     if (shouldEnableRemoteOutputService(remoteOptions)) {
@@ -1252,6 +1265,39 @@ public final class RemoteModule extends BlazeModule {
       }
       return uploaderFactory0.create(env);
     }
+  }
+
+  /**
+   * Selects an HTTP CONNECT proxy, if applicable, for {@code target} from the environment.
+   * Uses the same sources as the repository downloader.
+   */
+  @VisibleForTesting
+  @Nullable
+  static String resolveProxyFromEnvironment(String target, Map<String, String> clientEnv)
+      throws AbruptExitException {
+    String httpUrl;
+    if (target.startsWith("grpcs://")) {
+      httpUrl = "https://" + target.substring("grpcs://".length());
+    } else if (target.startsWith("grpc://")) {
+      httpUrl = "http://" + target.substring("grpc://".length());
+    } else if (target.startsWith("http://") || target.startsWith("https://")) {
+      httpUrl = target;
+    } else {
+      return null;
+    }
+    Proxy proxy;
+    try {
+      proxy = new ProxyHelper(clientEnv).createProxyIfNeeded(URI.create(httpUrl)).proxy();
+    } catch (IOException e) {
+      throw createOptionsExitException(
+          "Failed to resolve proxy for " + target + ": " + e.getMessage(),
+          FailureDetails.RemoteOptions.Code.REMOTE_OPTIONS_UNKNOWN);
+    }
+    if (proxy.type() != Proxy.Type.HTTP) {
+      return null;
+    }
+    InetSocketAddress address = (InetSocketAddress) proxy.address();
+    return "http://" + address.getHostString() + ":" + address.getPort();
   }
 
   private static AbruptExitException createOptionsExitException(

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -64,6 +64,8 @@ import io.netty.handler.codec.http.HttpRequestEncoder;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.proxy.HttpProxyHandler;
+import io.netty.handler.proxy.ProxyHandler;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -72,6 +74,7 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.ReadTimeoutException;
 import io.netty.handler.timeout.WriteTimeoutException;
+import io.netty.resolver.NoopAddressResolverGroup;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import java.io.File;
@@ -175,6 +178,7 @@ public final class HttpCacheClient extends RemoteCacheClient {
         retrier,
         creds,
         authAndTlsOptions,
+        null,
         null);
   }
 
@@ -204,7 +208,8 @@ public final class HttpCacheClient extends RemoteCacheClient {
           retrier,
           creds,
           authAndTlsOptions,
-          domainSocketAddress);
+          domainSocketAddress,
+          null);
     } else if (Epoll.isAvailable()) {
       return new HttpCacheClient(
           EpollEventLoopGroup::new,
@@ -218,10 +223,39 @@ public final class HttpCacheClient extends RemoteCacheClient {
           retrier,
           creds,
           authAndTlsOptions,
-          domainSocketAddress);
+          domainSocketAddress,
+          null);
     } else {
       throw new Exception("Unix domain sockets are unsupported on this platform");
     }
+  }
+
+  public static HttpCacheClient create(
+      InetSocketAddress proxyAddress,
+      URI uri,
+      int timeoutSeconds,
+      int remoteMaxConnections,
+      boolean verifyDownloads,
+      ImmutableList<Entry<String, String>> extraHttpHeaders,
+      DigestUtil digestUtil,
+      RemoteRetrier retrier,
+      @Nullable final Credentials creds,
+      AuthAndTLSOptions authAndTlsOptions)
+      throws Exception {
+    return new HttpCacheClient(
+        NioEventLoopGroup::new,
+        NioSocketChannel.class,
+        uri,
+        timeoutSeconds,
+        remoteMaxConnections,
+        verifyDownloads,
+        extraHttpHeaders,
+        digestUtil,
+        retrier,
+        creds,
+        authAndTlsOptions,
+        null,
+        proxyAddress);
   }
 
   private HttpCacheClient(
@@ -236,7 +270,8 @@ public final class HttpCacheClient extends RemoteCacheClient {
       RemoteRetrier retrier,
       @Nullable final Credentials creds,
       AuthAndTLSOptions authAndTlsOptions,
-      @Nullable SocketAddress socketAddress)
+      @Nullable SocketAddress socketAddress,
+      @Nullable InetSocketAddress httpConnectProxy)
       throws Exception {
     useTls = uri.getScheme().equals("https");
     if (uri.getPort() == -1) {
@@ -253,7 +288,10 @@ public final class HttpCacheClient extends RemoteCacheClient {
     }
     this.uri = uri;
     if (socketAddress == null) {
-      socketAddress = new InetSocketAddress(uri.getHost(), uri.getPort());
+      socketAddress =
+          httpConnectProxy != null
+              ? InetSocketAddress.createUnresolved(uri.getHost(), uri.getPort())
+              : new InetSocketAddress(uri.getHost(), uri.getPort());
     }
 
     final SslContext sslCtx = useTls ? createSSLContext(authAndTlsOptions) : null;
@@ -266,6 +304,10 @@ public final class HttpCacheClient extends RemoteCacheClient {
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000 * timeoutSeconds)
             .group(eventLoop)
             .remoteAddress(socketAddress);
+    if (httpConnectProxy != null) {
+      // DNS is resolved on the proxy-side rather than client side
+      clientBootstrap.resolver(NoopAddressResolverGroup.INSTANCE);
+    }
 
     ChannelPoolHandler channelPoolHandler =
         new ChannelPoolHandler() {
@@ -278,6 +320,9 @@ public final class HttpCacheClient extends RemoteCacheClient {
           @Override
           public void channelCreated(Channel ch) {
             ChannelPipeline p = ch.pipeline();
+            if (httpConnectProxy != null) {
+              p.addLast("http-proxy-handler", new HttpProxyHandler(httpConnectProxy));
+            }
             if (sslCtx != null) {
               SSLEngine engine = sslCtx.newEngine(ch.alloc(), hostname, port);
               engine.setUseClientMode(true);
@@ -285,7 +330,7 @@ public final class HttpCacheClient extends RemoteCacheClient {
                   && authAndTlsOptions.getTlsClientKey() != null) {
                 engine.setNeedClientAuth(true);
               }
-              p.addFirst("ssl-handler", new SslHandler(engine));
+              p.addLast("ssl-handler", new SslHandler(engine));
             }
           }
         };
@@ -302,6 +347,54 @@ public final class HttpCacheClient extends RemoteCacheClient {
     this.retrier = retrier;
   }
 
+  /**
+   * Runs {@code onReady} once any HTTP CONNECT proxy handshake on the channel has completed. The
+   * proxy handler installs transient codec handlers while the tunnel is being established, so
+   * per-request handlers must not be added until then. Once the handshake succeeds the proxy
+   * handlers have done their job and are removed so the pipeline is clean before {@code onReady}
+   * adds the request handlers. If no proxy is configured (or it was already removed on a reused
+   * channel), {@code onReady} runs immediately.
+   */
+  @SuppressWarnings("FutureReturnValueIgnored")
+  private static void awaitProxyHandshake(
+      Channel channel, Promise<Channel> channelReady, Runnable onReady) {
+    ProxyHandler proxyHandler = channel.pipeline().get(ProxyHandler.class);
+    if (proxyHandler == null) {
+      onReady.run();
+      return;
+    }
+    proxyHandler
+        .connectFuture()
+        .addListener(
+            (Future<Channel> handshake) -> {
+              if (!handshake.isSuccess()) {
+                channelReady.setFailure(handshake.cause());
+                return;
+              }
+              // The listener fires from within the proxy handler's own channelRead, so defer the
+              // cleanup and handler setup to the event loop to avoid reentrant pipeline mutation.
+              channel
+                  .eventLoop()
+                  .execute(
+                      () -> {
+                        removeProxyHandlers(channel.pipeline());
+                        onReady.run();
+                      });
+            });
+  }
+
+  /**
+   * Strips the handlers an HTTP CONNECT proxy leaves behind once the tunnel is established: the
+   * proxy handler itself and the now-inert codec wrapper that Netty does not fully detach. These
+   * sit ahead of the persistent {@code ssl-handler}, so removing from the front until that handler
+   * (or an empty pipeline) is reached leaves the pipeline ready for per-request handlers.
+   */
+  private static void removeProxyHandlers(ChannelPipeline pipeline) {
+    while (pipeline.first() != null && !"ssl-handler".equals(pipeline.firstContext().name())) {
+      pipeline.removeFirst();
+    }
+  }
+
   @SuppressWarnings("FutureReturnValueIgnored")
   private Promise<Channel> acquireUploadChannel() {
     Promise<Channel> channelReady = eventLoop.next().newPromise();
@@ -313,48 +406,49 @@ public final class HttpCacheClient extends RemoteCacheClient {
                 channelReady.setFailure(channelAcquired.cause());
                 return;
               }
-
-              try {
-                Channel channel = channelAcquired.getNow();
-                ChannelPipeline pipeline = channel.pipeline();
-
-                if (!isChannelPipelineEmpty(pipeline)) {
-                  channelReady.setFailure(
-                      new IllegalStateException("Channel pipeline is not empty."));
-                  return;
-                }
-
-                pipeline.addFirst(
-                    "timeout-handler",
-                    new IdleTimeoutHandler(timeoutSeconds, WriteTimeoutException.INSTANCE));
-                pipeline.addLast(new HttpResponseDecoder());
-                // The 10KiB limit was chosen arbitrarily. We only expect HTTP servers to respond
-                // with an error message in the body, and that should always be less than 10KiB. If
-                // the response is larger than 10KiB, HttpUploadHandler will catch the
-                // TooLongFrameException that HttpObjectAggregator throws and convert it to an
-                // IOException.
-                pipeline.addLast(new HttpObjectAggregator(10 * 1024));
-                pipeline.addLast(new HttpRequestEncoder());
-                pipeline.addLast(new ChunkedWriteHandler());
-                synchronized (credentialsLock) {
-                  pipeline.addLast(new HttpUploadHandler(creds, extraHttpHeaders));
-                }
-
-                if (!channel.eventLoop().inEventLoop()) {
-                  // If addLast is called outside an event loop, then it doesn't complete until the
-                  // event loop is run again. In that case, a message sent to the last handler gets
-                  // delivered to the last non-pending handler, which will most likely end up
-                  // throwing UnsupportedMessageTypeException. Therefore, we only complete the
-                  // promise in the event loop.
-                  channel.eventLoop().execute(() -> channelReady.setSuccess(channel));
-                } else {
-                  channelReady.setSuccess(channel);
-                }
-              } catch (Throwable t) {
-                channelReady.setFailure(t);
-              }
+              Channel channel = channelAcquired.getNow();
+              awaitProxyHandshake(
+                  channel, channelReady, () -> setUpUploadChannel(channel, channelReady));
             });
     return channelReady;
+  }
+
+  private void setUpUploadChannel(Channel channel, Promise<Channel> channelReady) {
+    try {
+      ChannelPipeline pipeline = channel.pipeline();
+
+      if (!isChannelPipelineEmpty(pipeline)) {
+        channelReady.setFailure(new IllegalStateException("Channel pipeline is not empty."));
+        return;
+      }
+
+      pipeline.addFirst(
+          "timeout-handler",
+          new IdleTimeoutHandler(timeoutSeconds, WriteTimeoutException.INSTANCE));
+      pipeline.addLast(new HttpResponseDecoder());
+      // The 10KiB limit was chosen arbitrarily. We only expect HTTP servers to respond with an
+      // error message in the body, and that should always be less than 10KiB. If the response is
+      // larger than 10KiB, HttpUploadHandler will catch the TooLongFrameException that
+      // HttpObjectAggregator throws and convert it to an IOException.
+      pipeline.addLast(new HttpObjectAggregator(10 * 1024));
+      pipeline.addLast(new HttpRequestEncoder());
+      pipeline.addLast(new ChunkedWriteHandler());
+      synchronized (credentialsLock) {
+        pipeline.addLast(new HttpUploadHandler(creds, extraHttpHeaders));
+      }
+
+      if (!channel.eventLoop().inEventLoop()) {
+        // If addLast is called outside an event loop, then it doesn't complete until the event loop
+        // is run again. In that case, a message sent to the last handler gets delivered to the last
+        // non-pending handler, which will most likely end up throwing UnsupportedMessageTypeException.
+        // Therefore, we only complete the promise in the event loop.
+        channel.eventLoop().execute(() -> channelReady.setSuccess(channel));
+      } else {
+        channelReady.setSuccess(channel);
+      }
+    } catch (Throwable t) {
+      channelReady.setFailure(t);
+    }
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
@@ -388,41 +482,43 @@ public final class HttpCacheClient extends RemoteCacheClient {
                 channelReady.setFailure(channelAcquired.cause());
                 return;
               }
-
-              try {
-                Channel channel = channelAcquired.getNow();
-                ChannelPipeline pipeline = channel.pipeline();
-
-                if (!isChannelPipelineEmpty(pipeline)) {
-                  channelReady.setFailure(
-                      new IllegalStateException("Channel pipeline is not empty."));
-                  return;
-                }
-                pipeline.addFirst(
-                    "timeout-handler",
-                    new IdleTimeoutHandler(timeoutSeconds, ReadTimeoutException.INSTANCE));
-                pipeline.addLast(new HttpClientCodec());
-                pipeline.addLast("inflater", new HttpContentDecompressor());
-                synchronized (credentialsLock) {
-                  pipeline.addLast(new HttpDownloadHandler(creds, extraHttpHeaders));
-                }
-
-                if (!channel.eventLoop().inEventLoop()) {
-                  // If addLast is called outside an event loop, then it doesn't complete until the
-                  // event loop is run again. In that case, a message sent to the last handler gets
-                  // delivered to the last non-pending handler, which will most likely end up
-                  // throwing UnsupportedMessageTypeException. Therefore, we only complete the
-                  // promise in the event loop.
-                  channel.eventLoop().execute(() -> channelReady.setSuccess(channel));
-                } else {
-                  channelReady.setSuccess(channel);
-                }
-              } catch (Throwable t) {
-                channelReady.setFailure(t);
-              }
+              Channel channel = channelAcquired.getNow();
+              awaitProxyHandshake(
+                  channel, channelReady, () -> setUpDownloadChannel(channel, channelReady));
             });
 
     return channelReady;
+  }
+
+  private void setUpDownloadChannel(Channel channel, Promise<Channel> channelReady) {
+    try {
+      ChannelPipeline pipeline = channel.pipeline();
+
+      if (!isChannelPipelineEmpty(pipeline)) {
+        channelReady.setFailure(new IllegalStateException("Channel pipeline is not empty."));
+        return;
+      }
+      pipeline.addFirst(
+          "timeout-handler",
+          new IdleTimeoutHandler(timeoutSeconds, ReadTimeoutException.INSTANCE));
+      pipeline.addLast(new HttpClientCodec());
+      pipeline.addLast("inflater", new HttpContentDecompressor());
+      synchronized (credentialsLock) {
+        pipeline.addLast(new HttpDownloadHandler(creds, extraHttpHeaders));
+      }
+
+      if (!channel.eventLoop().inEventLoop()) {
+        // If addLast is called outside an event loop, then it doesn't complete until the event loop
+        // is run again. In that case, a message sent to the last handler gets delivered to the last
+        // non-pending handler, which will most likely end up throwing UnsupportedMessageTypeException.
+        // Therefore, we only complete the promise in the event loop.
+        channel.eventLoop().execute(() -> channelReady.setSuccess(channel));
+      } else {
+        channelReady.setSuccess(channel);
+      }
+    } catch (Throwable t) {
+      channelReady.setFailure(t);
+    }
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -64,8 +64,6 @@ import io.netty.handler.codec.http.HttpRequestEncoder;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.proxy.HttpProxyHandler;
-import io.netty.handler.proxy.ProxyHandler;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -74,7 +72,6 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.ReadTimeoutException;
 import io.netty.handler.timeout.WriteTimeoutException;
-import io.netty.resolver.NoopAddressResolverGroup;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import java.io.File;
@@ -260,10 +257,11 @@ public final class HttpCacheClient extends RemoteCacheClient {
               uri.getFragment());
     }
     this.uri = uri;
+    HttpConnectProxy proxy = HttpConnectProxy.create(httpConnectProxy);
     if (socketAddress == null) {
       socketAddress =
-          httpConnectProxy != null
-              ? InetSocketAddress.createUnresolved(uri.getHost(), uri.getPort())
+          proxy != null
+              ? proxy.remoteAddress(uri)
               : new InetSocketAddress(uri.getHost(), uri.getPort());
     }
 
@@ -277,9 +275,8 @@ public final class HttpCacheClient extends RemoteCacheClient {
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000 * timeoutSeconds)
             .group(eventLoop)
             .remoteAddress(socketAddress);
-    if (httpConnectProxy != null) {
-      // DNS is resolved on the proxy-side rather than client side
-      clientBootstrap.resolver(NoopAddressResolverGroup.INSTANCE);
+    if (proxy != null) {
+      proxy.configureBootstrap(clientBootstrap);
     }
 
     ChannelPoolHandler channelPoolHandler =
@@ -293,8 +290,8 @@ public final class HttpCacheClient extends RemoteCacheClient {
           @Override
           public void channelCreated(Channel ch) {
             ChannelPipeline p = ch.pipeline();
-            if (httpConnectProxy != null) {
-              p.addLast("http-proxy-handler", new HttpProxyHandler(httpConnectProxy));
+            if (proxy != null) {
+              proxy.addProxyHandler(p);
             }
             if (sslCtx != null) {
               SSLEngine engine = sslCtx.newEngine(ch.alloc(), hostname, port);
@@ -320,54 +317,6 @@ public final class HttpCacheClient extends RemoteCacheClient {
     this.retrier = retrier;
   }
 
-  /**
-   * Runs {@code onReady} once any HTTP CONNECT proxy handshake on the channel has completed. The
-   * proxy handler installs transient codec handlers while the tunnel is being established, so
-   * per-request handlers must not be added until then. Once the handshake succeeds the proxy
-   * handlers have done their job and are removed so the pipeline is clean before {@code onReady}
-   * adds the request handlers. If no proxy is configured (or it was already removed on a reused
-   * channel), {@code onReady} runs immediately.
-   */
-  @SuppressWarnings("FutureReturnValueIgnored")
-  private static void awaitProxyHandshake(
-      Channel channel, Promise<Channel> channelReady, Runnable onReady) {
-    ProxyHandler proxyHandler = channel.pipeline().get(ProxyHandler.class);
-    if (proxyHandler == null) {
-      onReady.run();
-      return;
-    }
-    proxyHandler
-        .connectFuture()
-        .addListener(
-            (Future<Channel> handshake) -> {
-              if (!handshake.isSuccess()) {
-                channelReady.setFailure(handshake.cause());
-                return;
-              }
-              // The listener fires from within the proxy handler's own channelRead, so defer the
-              // cleanup and handler setup to the event loop to avoid reentrant pipeline mutation.
-              channel
-                  .eventLoop()
-                  .execute(
-                      () -> {
-                        removeProxyHandlers(channel.pipeline());
-                        onReady.run();
-                      });
-            });
-  }
-
-  /**
-   * Strips the handlers an HTTP CONNECT proxy leaves behind once the tunnel is established: the
-   * proxy handler itself and the now-inert codec wrapper that Netty does not fully detach. These
-   * sit ahead of the persistent {@code ssl-handler}, so removing from the front until that handler
-   * (or an empty pipeline) is reached leaves the pipeline ready for per-request handlers.
-   */
-  private static void removeProxyHandlers(ChannelPipeline pipeline) {
-    while (pipeline.first() != null && !"ssl-handler".equals(pipeline.firstContext().name())) {
-      pipeline.removeFirst();
-    }
-  }
-
   @SuppressWarnings("FutureReturnValueIgnored")
   private Promise<Channel> acquireUploadChannel() {
     Promise<Channel> channelReady = eventLoop.next().newPromise();
@@ -380,7 +329,7 @@ public final class HttpCacheClient extends RemoteCacheClient {
                 return;
               }
               Channel channel = channelAcquired.getNow();
-              awaitProxyHandshake(
+              HttpConnectProxy.awaitHandshake(
                   channel, channelReady, () -> setUpUploadChannel(channel, channelReady));
             });
     return channelReady;
@@ -456,7 +405,7 @@ public final class HttpCacheClient extends RemoteCacheClient {
                 return;
               }
               Channel channel = channelAcquired.getNow();
-              awaitProxyHandshake(
+              HttpConnectProxy.awaitHandshake(
                   channel, channelReady, () -> setUpDownloadChannel(channel, channelReady));
             });
 

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -164,7 +164,8 @@ public final class HttpCacheClient extends RemoteCacheClient {
       DigestUtil digestUtil,
       RemoteRetrier retrier,
       @Nullable final Credentials creds,
-      AuthAndTLSOptions authAndTlsOptions)
+      AuthAndTLSOptions authAndTlsOptions,
+      @Nullable InetSocketAddress httpConnectProxy)
       throws Exception {
     return new HttpCacheClient(
         NioEventLoopGroup::new,
@@ -179,7 +180,7 @@ public final class HttpCacheClient extends RemoteCacheClient {
         creds,
         authAndTlsOptions,
         null,
-        null);
+        httpConnectProxy);
   }
 
   public static HttpCacheClient create(
@@ -228,34 +229,6 @@ public final class HttpCacheClient extends RemoteCacheClient {
     } else {
       throw new Exception("Unix domain sockets are unsupported on this platform");
     }
-  }
-
-  public static HttpCacheClient create(
-      InetSocketAddress proxyAddress,
-      URI uri,
-      int timeoutSeconds,
-      int remoteMaxConnections,
-      boolean verifyDownloads,
-      ImmutableList<Entry<String, String>> extraHttpHeaders,
-      DigestUtil digestUtil,
-      RemoteRetrier retrier,
-      @Nullable final Credentials creds,
-      AuthAndTLSOptions authAndTlsOptions)
-      throws Exception {
-    return new HttpCacheClient(
-        NioEventLoopGroup::new,
-        NioSocketChannel.class,
-        uri,
-        timeoutSeconds,
-        remoteMaxConnections,
-        verifyDownloads,
-        extraHttpHeaders,
-        digestUtil,
-        retrier,
-        creds,
-        authAndTlsOptions,
-        null,
-        proxyAddress);
   }
 
   private HttpCacheClient(

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpConnectProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpConnectProxy.java
@@ -1,0 +1,108 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.http;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.proxy.HttpProxyHandler;
+import io.netty.handler.proxy.ProxyHandler;
+import io.netty.resolver.NoopAddressResolverGroup;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import javax.annotation.Nullable;
+
+/**
+ * Tunnels {@link HttpCacheClient} connections through an HTTP CONNECT proxy, if configured.
+ */
+final class HttpConnectProxy {
+
+  private static final String SSL_HANDLER = "ssl-handler";
+
+  private final InetSocketAddress proxyAddress;
+
+  private HttpConnectProxy(InetSocketAddress proxyAddress) {
+    this.proxyAddress = proxyAddress;
+  }
+
+  /** Returns a proxy for {@code proxyAddress}, or {@code null} when no proxy is configured. */
+  @Nullable
+  static HttpConnectProxy create(@Nullable InetSocketAddress proxyAddress) {
+    return proxyAddress == null ? null : new HttpConnectProxy(proxyAddress);
+  }
+
+  /** The proxy connects to the server, so leave the host unresolved and let the proxy resolve it. */
+  SocketAddress remoteAddress(URI uri) {
+    return InetSocketAddress.createUnresolved(uri.getHost(), uri.getPort());
+  }
+
+  void configureBootstrap(Bootstrap bootstrap) {
+    // DNS is resolved on the proxy-side rather than client side.
+    bootstrap.resolver(NoopAddressResolverGroup.INSTANCE);
+  }
+
+  void addProxyHandler(ChannelPipeline pipeline) {
+    pipeline.addLast("http-proxy-handler", new HttpProxyHandler(proxyAddress));
+  }
+
+  /**
+   * Runs {@code onReady} once any HTTP CONNECT proxy handshake on the channel has completed. The
+   * proxy handler installs transient codec handlers while the tunnel is being established, so
+   * per-request handlers must not be added until then. Once the handshake succeeds the proxy
+   * handlers have done their job and are removed so the pipeline is clean before {@code onReady}
+   * adds the request handlers. If no proxy is configured (or it was already removed on a reused
+   * channel), {@code onReady} runs immediately.
+   */
+  @SuppressWarnings("FutureReturnValueIgnored")
+  static void awaitHandshake(Channel channel, Promise<Channel> channelReady, Runnable onReady) {
+    ProxyHandler proxyHandler = channel.pipeline().get(ProxyHandler.class);
+    if (proxyHandler == null) {
+      onReady.run();
+      return;
+    }
+    proxyHandler
+        .connectFuture()
+        .addListener(
+            (Future<Channel> handshake) -> {
+              if (!handshake.isSuccess()) {
+                channelReady.setFailure(handshake.cause());
+                return;
+              }
+              // The listener fires from within the proxy handler's own channelRead, so defer the
+              // cleanup and handler setup to the event loop to avoid reentrant pipeline mutation.
+              channel
+                  .eventLoop()
+                  .execute(
+                      () -> {
+                        removeProxyHandlers(channel.pipeline());
+                        onReady.run();
+                      });
+            });
+  }
+
+  /**
+   * Strips the handlers an HTTP CONNECT proxy leaves behind once the tunnel is established: the
+   * proxy handler itself and the now-inert codec wrapper that Netty does not fully detach. These
+   * sit ahead of the persistent {@code ssl-handler}, so removing from the front until that handler
+   * (or an empty pipeline) is reached leaves the pipeline ready for per-request handlers.
+   */
+  private static void removeProxyHandlers(ChannelPipeline pipeline) {
+    while (pipeline.first() != null && !SSL_HANDLER.equals(pipeline.firstContext().name())) {
+      pipeline.removeFirst();
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -53,8 +53,8 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
-          "Connect to the remote cache through a proxy. Currently this flag can only be used to "
-              + "configure a Unix domain socket (unix:/path/to/socket).")
+          "Connect to the remote cache through a proxy. Supported values are Unix domain sockets "
+              + "(unix:/path/to/socket) and HTTP CONNECT proxies (http://host:port).")
   public abstract String getRemoteProxy();
 
   public abstract void setRemoteProxy(String value);

--- a/src/test/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtilsTest.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.authandtls;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
@@ -34,6 +35,7 @@ import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.common.options.OptionsParsingException;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
@@ -45,6 +47,39 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class GoogleAuthUtilsTest {
+  @Test
+  public void parseHttpProxyAddress_withExplicitPort_usesThatPort() throws Exception {
+    InetSocketAddress address =
+        GoogleAuthUtils.parseHttpProxyAddress("http://proxy.example.com:3128");
+
+    assertThat(address.getHostString()).isEqualTo("proxy.example.com");
+    assertThat(address.getPort()).isEqualTo(3128);
+  }
+
+  @Test
+  public void parseHttpProxyAddress_withoutPort_defaultsTo80() throws Exception {
+    InetSocketAddress address = GoogleAuthUtils.parseHttpProxyAddress("http://proxy.example.com");
+
+    assertThat(address.getPort()).isEqualTo(80);
+  }
+
+  @Test
+  public void parseHttpProxyAddress_withoutHost_throws() {
+    IOException e =
+        assertThrows(
+            IOException.class, () -> GoogleAuthUtils.parseHttpProxyAddress("http://:8080"));
+
+    assertThat(e).hasMessageThat().contains("Invalid proxy URL");
+  }
+
+  @Test
+  public void parseHttpProxyAddress_malformedUrl_throwsIOException() {
+    IOException e =
+        assertThrows(IOException.class, () -> GoogleAuthUtils.parseHttpProxyAddress("http://"));
+
+    assertThat(e).hasMessageThat().contains("Invalid proxy URL");
+  }
+
   @Test
   public void testNetrc_emptyEnv_shouldIgnore() throws Exception {
     ImmutableMap<String, String> clientEnv = ImmutableMap.of();

--- a/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactoryTest.java
@@ -151,6 +151,25 @@ public class CombinedCacheClientFactoryTest {
   }
 
   @Test
+  public void createHttpCacheWithHttpConnectProxy() throws IOException {
+    remoteOptions.setRemoteCache("http://doesnotexist.com");
+    remoteOptions.setRemoteProxy("http://localhost:3128");
+
+    var blobStore =
+        CombinedCacheClientFactory.create(
+            remoteOptions,
+            remoteOptions.getDiskCachePath(workingDirectory),
+            /* creds= */ null,
+            authAndTlsOptions,
+            workingDirectory,
+            digestUtil,
+            retrier);
+
+    assertThat(blobStore.remoteCacheClient()).isInstanceOf(HttpCacheClient.class);
+    assertThat(blobStore.diskCacheClient()).isNull();
+  }
+
+  @Test
   public void createHttpCacheFailsWithUnsupportedProxyProtocol() {
     remoteOptions.setRemoteCache("http://doesnotexist.com");
     remoteOptions.setRemoteProxy("bad-proxy");

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -682,6 +682,54 @@ public final class RemoteModuleTest {
     assertThat(env.getIdleTasks()).isEmpty();
   }
 
+  @Test
+  public void resolveProxyFromEnvironment_unsupportedScheme_returnsNull() throws Exception {
+    assertThat(RemoteModule.resolveProxyFromEnvironment("unix:/some/socket", ImmutableMap.of()))
+        .isNull();
+  }
+
+  @Test
+  public void resolveProxyFromEnvironment_grpcTarget_usesHttpProxyEnv() throws Exception {
+    String proxy =
+        RemoteModule.resolveProxyFromEnvironment(
+            "grpc://cache.example.com",
+            ImmutableMap.of("http_proxy", "http://proxy.example.com:8080"));
+
+    assertThat(proxy).isEqualTo("http://proxy.example.com:8080");
+  }
+
+  @Test
+  public void resolveProxyFromEnvironment_grpcsTarget_usesHttpsProxyEnv() throws Exception {
+    String proxy =
+        RemoteModule.resolveProxyFromEnvironment(
+            "grpcs://cache.example.com",
+            ImmutableMap.of("https_proxy", "http://secure.example.com:8443"));
+
+    assertThat(proxy).isEqualTo("http://secure.example.com:8443");
+  }
+
+  @Test
+  public void resolveProxyFromEnvironment_noProxyMatch_returnsNull() throws Exception {
+    String proxy =
+        RemoteModule.resolveProxyFromEnvironment(
+            "grpc://internal.example.com",
+            ImmutableMap.of(
+                "http_proxy", "http://proxy.example.com:8080",
+                "no_proxy", "internal.example.com"));
+
+    assertThat(proxy).isNull();
+  }
+
+  @Test
+  public void resolveProxyFromEnvironment_socksProxy_returnsNull() throws Exception {
+    String proxy =
+        RemoteModule.resolveProxyFromEnvironment(
+            "grpc://cache.example.com",
+            ImmutableMap.of("http_proxy", "socks5://socks.example.com:1080"));
+
+    assertThat(proxy).isNull();
+  }
+
   private void assertCircuitBreakerInstance() {
     RemoteActionContextProvider actionContextProvider = remoteModule.getActionContextProvider();
     assertThat(actionContextProvider).isNotNull();

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -326,7 +326,8 @@ public class HttpCacheClientTest {
           DIGEST_UTIL,
           retrier,
           creds,
-          authAndTlsOptions);
+          authAndTlsOptions,
+          /* httpConnectProxy= */ null);
     } else {
       throw new IllegalStateException(
           "unsupported socket address class " + socketAddress.getClass());

--- a/src/test/shell/bazel/remote/BUILD
+++ b/src/test/shell/bazel/remote/BUILD
@@ -26,6 +26,7 @@ sh_test(
     timeout = "eternal",
     srcs = ["remote_execution_test.sh"],
     data = [
+        ":http_connect_proxy.py",
         ":remote_utils",
         ":uds_proxy.py",
         "//src/test/shell/bazel:test-deps",

--- a/src/test/shell/bazel/remote/http_connect_proxy.py
+++ b/src/test/shell/bazel/remote/http_connect_proxy.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Minimal HTTP CONNECT proxy for testing --remote_proxy=http://host:port."""
+
+import select
+import socket
+import sys
+import threading
+
+_log_lock = threading.Lock()
+_log_path = None
+# When set, every CONNECT is dialed to this host instead of the requested one. Lets a test target
+# the proxy with an unresolvable hostname (proving the client did not resolve it locally) while the
+# proxy still reaches the real backend.
+_force_host = None
+
+
+def record_connect(target):
+    """Append a CONNECT target to the log file so tests can assert proxy usage."""
+    if _log_path is None:
+        return
+    with _log_lock:
+        with open(_log_path, "a") as f:
+            f.write(target + "\n")
+
+
+def handle_connect(client_sock):
+    """Handle one HTTP CONNECT request."""
+    try:
+        data = b""
+        while b"\r\n\r\n" not in data:
+            chunk = client_sock.recv(4096)
+            if not chunk:
+                return
+            data += chunk
+
+        request_line = data.split(b"\r\n")[0].decode()
+        # e.g. "CONNECT buildfarm-server:8980 HTTP/1.1"
+        parts = request_line.split()
+        if len(parts) < 2 or parts[0] != "CONNECT":
+            client_sock.sendall(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+            return
+
+        target = parts[1]
+        record_connect(target)
+        host, port = target.rsplit(":", 1)
+        port = int(port)
+        if _force_host is not None:
+            host = _force_host
+
+        try:
+            remote_sock = socket.create_connection((host, port), timeout=10)
+        except Exception as e:
+            msg = f"HTTP/1.1 502 Bad Gateway\r\n\r\n{e}"
+            client_sock.sendall(msg.encode())
+            return
+
+        client_sock.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+
+        relay(client_sock, remote_sock)
+    except Exception:
+        pass
+    finally:
+        client_sock.close()
+
+
+def relay(sock_a, sock_b):
+    """Bidirectional relay between two sockets."""
+    sockets = [sock_a, sock_b]
+    try:
+        while True:
+            readable, _, _ = select.select(sockets, [], [], 30)
+            if not readable:
+                break
+            for s in readable:
+                other = sock_b if s is sock_a else sock_a
+                data = s.recv(65536)
+                if not data:
+                    return
+                other.sendall(data)
+    finally:
+        sock_a.close()
+        sock_b.close()
+
+
+def main():
+    global _log_path, _force_host
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 3128
+    if len(sys.argv) > 2:
+        _log_path = sys.argv[2]
+    if len(sys.argv) > 3 and sys.argv[3]:
+        _force_host = sys.argv[3]
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", port))
+    srv.listen(64)
+    print(f"HTTP CONNECT proxy listening on 127.0.0.1:{port}", flush=True)
+    while True:
+        client, addr = srv.accept()
+        t = threading.Thread(target=handle_connect, args=(client,), daemon=True)
+        t.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -53,6 +53,7 @@ function set_up() {
 function tear_down() {
   bazel clean >& $TEST_log
   stop_worker
+  stop_http_connect_proxy
 }
 
 function has_utf8_locale() {
@@ -287,6 +288,200 @@ EOF
   kill ${proxy_pid}
   rm "${socket_dir}/executor-socket"
   rmdir "${socket_dir}"
+}
+
+# Starts a HTTP CONNECT proxy on a random port.
+# Each CONNECT target it sees is appended to ${http_proxy_log} so callers can assert that traffic
+# was routed through it.
+# Optional $1: a host to which every CONNECT is redialed, regardless of the
+# requested target (used to point an unresolvable cache hostname at the worker).
+function start_http_connect_proxy() {
+  local force_host="${1:-}"
+  http_proxy_port=$(pick_random_unused_tcp_port) || fail "no port found"
+  http_proxy_log="${TEST_TMPDIR}/http_connect_proxy.connections"
+  local proxy_stdout="${TEST_TMPDIR}/http_connect_proxy.stdout"
+  rm -f "${http_proxy_log}" "${proxy_stdout}"
+  local proxy="$(rlocation io_bazel/src/test/shell/bazel/remote/http_connect_proxy.py)"
+  python3 "${proxy}" "${http_proxy_port}" "${http_proxy_log}" "${force_host}" \
+      >"${proxy_stdout}" 2>&1 &
+  http_proxy_pid=$!
+  local wait_seconds=0
+  until grep -q "listening" "${proxy_stdout}" 2>/dev/null || [[ "$wait_seconds" -eq 30 ]]; do
+    sleep 1
+    wait_seconds=$((wait_seconds + 1))
+  done
+  grep -q "listening" "${proxy_stdout}" || fail "HTTP CONNECT proxy did not start"
+}
+
+function stop_http_connect_proxy() {
+  if [[ -n "${http_proxy_pid:-}" ]]; then
+    kill "${http_proxy_pid}" 2>/dev/null || true
+    http_proxy_pid=""
+  fi
+}
+
+function test_remote_grpc_executor_via_http_connect_proxy() {
+  start_http_connect_proxy
+
+  mkdir -p a
+  cat > a/BUILD <<EOF
+genrule(
+  name = 'foo',
+  outs = ["foo.txt"],
+  cmd = "echo \"foo bar\" > \$@",
+)
+EOF
+
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_proxy=http://127.0.0.1:${http_proxy_port} \
+      //a:foo >& $TEST_log \
+      || fail "Failed to build //a:foo via HTTP CONNECT proxy"
+
+  expect_log "1 remote" "Build did not execute remotely through the proxy"
+  grep -q "localhost:${worker_port}" "${http_proxy_log}" \
+      || fail "Proxy did not receive a CONNECT for the remote executor"
+
+  stop_http_connect_proxy
+}
+
+function test_remote_grpc_executor_works_via_proxy_with_unresolvable_host_on_client_side() {
+  start_http_connect_proxy 127.0.0.1
+
+  mkdir -p a
+  cat > a/BUILD <<EOF
+genrule(
+  name = 'foo',
+  outs = ["foo.txt"],
+  cmd = "echo \"foo bar\" > \$@",
+)
+EOF
+
+  bazel build \
+      --remote_executor=grpc://executor.nonexistent.invalid:${worker_port} \
+      --remote_proxy=http://127.0.0.1:${http_proxy_port} \
+      //a:foo >& $TEST_log \
+      || fail "Failed to reach remote executor via proxy using unresolvable host"
+
+  expect_log "1 remote" "Build did not execute remotely through the proxy"
+  grep -q "executor.nonexistent.invalid:${worker_port}" "${http_proxy_log}" \
+      || fail "Proxy did not receive a CONNECT for the unresolved executor host"
+
+  stop_http_connect_proxy
+}
+
+function test_remote_http_cache_via_http_connect_proxy() {
+  local http_port=$(pick_random_unused_tcp_port) || fail "no port found"
+  stop_worker
+  start_worker --http_listen_port=${http_port}
+  start_http_connect_proxy
+
+  mkdir -p a
+  cat > a/BUILD <<EOF
+genrule(
+  name = 'foo',
+  outs = ["foo.txt"],
+  cmd = "echo \"foo bar\" > \$@",
+)
+EOF
+
+  bazel build \
+      --remote_cache=http://localhost:${http_port} \
+      --remote_proxy=http://127.0.0.1:${http_proxy_port} \
+      //a:foo >& $TEST_log \
+      || fail "Failed to populate HTTP cache via HTTP CONNECT proxy"
+
+  bazel clean
+  bazel build \
+      --remote_cache=http://localhost:${http_port} \
+      --remote_proxy=http://127.0.0.1:${http_proxy_port} \
+      //a:foo >& $TEST_log \
+      || fail "Failed to read HTTP cache via HTTP CONNECT proxy"
+
+  expect_log "remote cache hit" "HTTP cache was not served through the proxy"
+  grep -q "localhost:${http_port}" "${http_proxy_log}" \
+      || fail "Proxy did not receive a CONNECT for the HTTP cache"
+
+  stop_http_connect_proxy
+}
+
+function test_remote_http_cache_works_via_proxy_with_unresolvable_host_on_client_side() {
+  local http_port=$(pick_random_unused_tcp_port) || fail "no port found"
+  stop_worker
+  start_worker --http_listen_port=${http_port}
+  start_http_connect_proxy 127.0.0.1
+
+  mkdir -p a
+  cat > a/BUILD <<EOF
+genrule(
+  name = 'foo',
+  outs = ["foo.txt"],
+  cmd = "echo \"foo bar\" > \$@",
+)
+EOF
+
+  bazel build \
+      --remote_cache=http://cache.nonexistent.invalid:${http_port} \
+      --remote_proxy=http://127.0.0.1:${http_proxy_port} \
+      //a:foo >& $TEST_log \
+      || fail "Failed to reach HTTP cache via proxy using unresolvable host"
+
+  grep -q "cache.nonexistent.invalid:${http_port}" "${http_proxy_log}" \
+      || fail "Proxy did not receive a CONNECT for the unresolved cache host"
+
+  stop_http_connect_proxy
+}
+
+function test_http_proxy_env_var_fallback() {
+  start_http_connect_proxy
+
+  mkdir -p a
+  cat > a/BUILD <<EOF
+genrule(
+  name = 'foo',
+  outs = ["foo.txt"],
+  cmd = "echo \"foo bar\" > \$@",
+)
+EOF
+
+  HTTP_PROXY="http://127.0.0.1:${http_proxy_port}" \
+  no_proxy="" NO_PROXY="" \
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      //a:foo >& $TEST_log \
+      || fail "Failed to build //a:foo via HTTP_PROXY env var"
+
+  expect_log "1 remote" "Build did not execute remotely via HTTP_PROXY env var"
+  grep -q "localhost:${worker_port}" "${http_proxy_log}" \
+      || fail "Proxy did not receive a CONNECT from HTTP_PROXY fallback"
+
+  stop_http_connect_proxy
+}
+
+function test_no_proxy_bypasses_proxy() {
+  start_http_connect_proxy
+
+  mkdir -p a
+  cat > a/BUILD <<EOF
+genrule(
+  name = 'foo',
+  outs = ["foo.txt"],
+  cmd = "echo \"foo bar\" > \$@",
+)
+EOF
+
+  HTTP_PROXY="http://127.0.0.1:${http_proxy_port}" NO_PROXY="localhost" \
+  no_proxy="" \
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      //a:foo >& $TEST_log \
+      || fail "Failed to build //a:foo with NO_PROXY bypass"
+
+  expect_log "1 remote" "Build did not execute remotely when bypassing the proxy"
+  [[ ! -s "${http_proxy_log}" ]] \
+      || fail "Proxy was used despite NO_PROXY matching the target"
+
+  stop_http_connect_proxy
 }
 
 function test_cc_binary() {


### PR DESCRIPTION
### Description

This PR extends `--remote_proxy` to accept `http://host:port`, enabling native HTTP CONNECT proxy tunneling for gRPC remote executor, gRPC remote cache, and HTTP remote caches.

When `--remote_proxy` is not explicitly set, this PR now introduces a fallback so that remote caching and execution honour the same sources as repository downloader does: following HTTP proxy env vars, the Java system proxy system properties, as well as NO_PROXY configuration. This is done by reusing the same lookup as present in RemoteDownloader.

For gRPC based communication, this implementation is fairly simple and uses the existing proxy support present in the gRPC library. For HTTP cache communication, the change is slightly more involved. We insert a HttpProxyHandler to perform the CONNECT handshake, wait for the tunnel to be established, then add in the standard per-request handlers, after stripping the handlers that the proxy leaves behind. We also ensure that DNS is resolved on the proxy-side instead of on the client-side, in situations where the host does not resolve on the client.

This PR currently does not implement support for Proxy Authentication (like https://github.com/bazelbuild/bazel/pull/28088),  or for HTTPS proxies, but is left for a follow-up.

### Motivation

Right now, the `--remote_proxy` flag only supports Unix domain sockets, and users behind HTTP proxies had to set up TCP tunnels (e.g., via socat) to bridge remote cache / executor connections through a unix domain socket to the HTTP proxy. HTTP proxies are common in corporate environments, as well as in situations where we want to manage external network egress from a host.

Closes #27715

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Verification

Introduced some http proxy integration tests alongside the existing `remote_execution_test.sh`. Also tested in an internal environment using HTTP proxies.

### Release Notes

RELNOTES: --remote_proxy now supports HTTP proxy endpoints alongside unix domain sockets. The `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` environment variables as well as the equivalent Java system flags (`-Dhttp.proxyHost`) are now respected for remote cache / execution.