### PR TITLE
Fix enabling TCP keepalive on Linux.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -40,6 +40,7 @@ import io.grpc.netty.NettyChannelBuilder;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.epoll.EpollDomainSocketChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.kqueue.KQueue;
@@ -106,21 +107,28 @@ public final class GoogleAuthUtils {
       boolean isUnixSocketChannel = targetUrl.startsWith("unix:") || !Strings.isNullOrEmpty(proxy);
       if (options.getGrpcTcpKeepalive() && !isUnixSocketChannel) {
         builder.withOption(ChannelOption.SO_KEEPALIVE, true);
+        boolean epoll = Epoll.isAvailable();
         long idleSeconds = options.getGrpcTcpKeepaliveTime().toSeconds();
         if (idleSeconds > 0) {
           builder.withOption(
-              NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPIDLE),
+              epoll
+                  ? EpollChannelOption.TCP_KEEPIDLE
+                  : NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPIDLE),
               Math.toIntExact(idleSeconds));
         }
         long intervalSeconds = options.getGrpcTcpKeepaliveInterval().toSeconds();
         if (intervalSeconds > 0) {
           builder.withOption(
-              NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPINTERVAL),
+              epoll
+                  ? EpollChannelOption.TCP_KEEPINTVL
+                  : NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPINTERVAL),
               Math.toIntExact(intervalSeconds));
         }
         if (options.getGrpcTcpKeepaliveCount() > 0) {
           builder.withOption(
-              NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPCOUNT),
+              epoll
+                  ? EpollChannelOption.TCP_KEEPCNT
+                  : NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPCOUNT),
               options.getGrpcTcpKeepaliveCount());
         }
       }


### PR DESCRIPTION
On Linux, gRPC defaults to epoll which uses a different set of options.

https://github.com/bazelbuild/bazel/pull/29879 worked on Mac but was a no-op on Linux.