### PR TITLE
[9.2.0] Move `CppCompileAction#getEffectiveEnvironment(Map, PathMapper)` up to `Action`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
@@ -233,8 +233,8 @@ public abstract class AbstractAction extends ActionKeyComputer implements Action
   }
 
   @Override
-  public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
-      throws CommandLineExpansionException {
+  public ImmutableMap<String, String> getEffectiveEnvironment(
+      Map<String, String> clientEnv, PathMapper pathMapper) throws CommandLineExpansionException {
     ActionEnvironment env = getEnvironment();
     Map<String, String> effectiveEnvironment =
         Maps.newLinkedHashMapWithExpectedSize(env.estimatedSize());
@@ -465,7 +465,7 @@ public abstract class AbstractAction extends ActionKeyComputer implements Action
     }
 
     for (PathFragment path : additionalPathOutputsToDelete) {
-      deleteOutput(execRoot.getRelative(path), /*root=*/ null);
+      deleteOutput(execRoot.getRelative(path), /* root= */ null);
     }
 
     for (PathFragment path : directoryOutputsToDelete) {

--- a/src/main/java/com/google/devtools/build/lib/actions/Action.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Action.java
@@ -132,26 +132,23 @@ public interface Action extends ActionExecutionMetadata {
       throws ActionExecutionException, InterruptedException;
 
   /**
-   * Returns true iff action must be executed regardless of its current state.
-   * Default implementation can be overridden by some actions that might be
-   * executed unconditionally under certain circumstances - e.g., if caching of
-   * test results is not requested, this method could be used to force test
-   * execution even if all dependencies are up-to-date.
+   * Returns true iff action must be executed regardless of its current state. Default
+   * implementation can be overridden by some actions that might be executed unconditionally under
+   * certain circumstances - e.g., if caching of test results is not requested, this method could be
+   * used to force test execution even if all dependencies are up-to-date.
    *
-   * <p>Note, it is <b>very</b> important not to abuse this method, since it
-   * completely overrides dependency checking. Any use of this method must
-   * be carefully reviewed and proved to be necessary.
+   * <p>Note, it is <b>very</b> important not to abuse this method, since it completely overrides
+   * dependency checking. Any use of this method must be carefully reviewed and proved to be
+   * necessary.
    *
-   * <p>Note that the definition of {@link #isVolatile} depends on the
-   * definition of this method, so be sure to consider both methods together
-   * when making changes.
+   * <p>Note that the definition of {@link #isVolatile} depends on the definition of this method, so
+   * be sure to consider both methods together when making changes.
    */
   boolean executeUnconditionally();
 
   /**
-   * Returns true if it's ever possible that {@link #executeUnconditionally}
-   * could evaluate to true during the lifetime of this instance, false
-   * otherwise.
+   * Returns true if it's ever possible that {@link #executeUnconditionally} could evaluate to true
+   * during the lifetime of this instance, false otherwise.
    */
   boolean isVolatile();
 
@@ -211,9 +208,7 @@ public interface Action extends ActionExecutionMetadata {
    */
   void updateInputs(NestedSet<Artifact> inputs);
 
-  /**
-   * Returns true if the output should bypass output filtering. This is used for test actions.
-   */
+  /** Returns true if the output should bypass output filtering. This is used for test actions. */
   boolean showsOutputUnconditionally();
 
   /**
@@ -234,7 +229,11 @@ public interface Action extends ActionExecutionMetadata {
    * different thread than the one this action is executed on. By definition, the method should not
    * mutate any of the called action data but if necessary, its implementation must synchronize any
    * accesses to mutable data.
+   *
+   * <p>Pass {@link PathMapper#NOOP} to obtain the analysis time form of the environment. During
+   * action execution, pass the actual {@link PathMapper} to ensure that artifact paths in
+   * environment variables are mapped correctly.
    */
-  ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
-      throws CommandLineExpansionException;
+  ImmutableMap<String, String> getEffectiveEnvironment(
+      Map<String, String> clientEnv, PathMapper pathMapper) throws CommandLineExpansionException;
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -300,7 +300,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
                 .setSpawn(
                     FailureDetails.Spawn.newBuilder().setCode(Code.COMMAND_LINE_EXPANSION_FAILURE))
                 .build());
-    return new ActionExecutionException(e, this, /*catastrophe=*/ false, detailedExitCode);
+    return new ActionExecutionException(e, this, /* catastrophe= */ false, detailedExitCode);
   }
 
   @VisibleForTesting
@@ -348,9 +348,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
   public Spawn getSpawn(ActionExecutionContext actionExecutionContext)
       throws CommandLineExpansionException, InterruptedException {
     return getSpawn(
-        actionExecutionContext,
-        actionExecutionContext.getClientEnv(),
-        /* reportOutputs= */ true);
+        actionExecutionContext, actionExecutionContext.getClientEnv(), /* reportOutputs= */ true);
   }
 
   /**
@@ -550,7 +548,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
               .addAll(additionalInputs)
               .build();
       this.pathMapper = pathMapper;
-      this.effectiveEnvironment = parent.getEffectiveEnvironment(clientEnv);
+      this.effectiveEnvironment = parent.getEffectiveEnvironment(clientEnv, pathMapper);
       this.reportOutputs = reportOutputs;
     }
 
@@ -608,9 +606,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     return env;
   }
 
-  /**
-   * Builder class to construct {@link SpawnAction} instances.
-   */
+  /** Builder class to construct {@link SpawnAction} instances. */
   public static class Builder {
 
     private final NestedSetBuilder<Artifact> toolsBuilder = NestedSetBuilder.stableOrder();

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -480,14 +480,14 @@ public class StarlarkAction extends SpawnAction {
     }
 
     @Override
-    public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
-        throws CommandLineExpansionException {
+    public ImmutableMap<String, String> getEffectiveEnvironment(
+        Map<String, String> clientEnv, PathMapper pathMapper) throws CommandLineExpansionException {
       ActionEnvironment env = getEnvironment();
       Map<String, String> environment = Maps.newLinkedHashMapWithExpectedSize(env.estimatedSize());
 
       if (shadowedAction.isPresent()) {
         // Put all the variables of the shadowed action's environment
-        environment.putAll(shadowedAction.get().getEffectiveEnvironment(clientEnv));
+        environment.putAll(shadowedAction.get().getEffectiveEnvironment(clientEnv, pathMapper));
       }
 
       // This order guarantees that the Starlark action can overwrite any variable in its shadowed

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -964,7 +964,7 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
   public ImmutableMap<String, String> getIncompleteEnvironmentForTesting()
       throws ActionExecutionException {
     try {
-      return getEffectiveEnvironment(ImmutableMap.of());
+      return getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP);
     } catch (CommandLineExpansionException e) {
       String message =
           String.format(
@@ -976,11 +976,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
   }
 
   @Override
-  public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
-      throws CommandLineExpansionException {
-    return getEffectiveEnvironment(clientEnv, PathMapper.NOOP);
-  }
-
   public ImmutableMap<String, String> getEffectiveEnvironment(
       Map<String, String> clientEnv, PathMapper pathMapper) throws CommandLineExpansionException {
     ActionEnvironment env = getEnvironment();
@@ -1060,7 +1055,7 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     }
     // TODO(ulfjack): Extra actions currently ignore the client environment.
     for (Map.Entry<String, String> envVariable :
-        getEffectiveEnvironment(/*clientEnv=*/ ImmutableMap.of()).entrySet()) {
+        getEffectiveEnvironment(/*clientEnv=*/ ImmutableMap.of(), PathMapper.NOOP).entrySet()) {
       info.addVariable(
           EnvironmentVariable.newBuilder()
               .setName(envVariable.getKey())

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.AbstractAction;
 import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
@@ -84,7 +83,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -341,7 +339,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
             .build();
     return new JavaSpawn(
         expandedCommandLines,
-        getEffectiveEnvironment(actionExecutionContext.getClientEnv()),
+        getEffectiveEnvironment(actionExecutionContext.getClientEnv(), pathMapper),
         getExecutionInfo(),
         inputs,
         /* onlyMandatoryOutput= */ fallback ? null : outputDepsProto,
@@ -362,7 +360,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
                 configuration.getCommandLineLimits());
     return new JavaSpawn(
         expandedCommandLines,
-        getEffectiveEnvironment(actionExecutionContext.getClientEnv()),
+        getEffectiveEnvironment(actionExecutionContext.getClientEnv(), pathMapper),
         getExecutionInfo(),
         NestedSetBuilder.<Artifact>stableOrder()
             .addTransitive(mandatoryInputs)
@@ -379,15 +377,6 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
             .build(),
         /* onlyMandatoryOutput= */ null,
         pathMapper);
-  }
-
-  @Override
-  public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv) {
-    ActionEnvironment env = getEnvironment();
-    LinkedHashMap<String, String> effectiveEnvironment =
-        Maps.newLinkedHashMapWithExpectedSize(env.estimatedSize());
-    env.resolve(effectiveEnvironment, clientEnv);
-    return ImmutableMap.copyOf(effectiveEnvironment);
   }
 
   private ActionExecutionException wrapIOException(IOException e, String message) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.CommandAction;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.analysis.AnalysisProtosV2;
 import com.google.devtools.build.lib.analysis.AspectValue;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
@@ -140,7 +141,9 @@ public class ActionGraphDump {
   }
 
   private void dumpSingleAction(ConfiguredTarget configuredTarget, ActionAnalysisMetadata action)
-      throws CommandLineExpansionException, InterruptedException, IOException,
+      throws CommandLineExpansionException,
+          InterruptedException,
+          IOException,
           TemplateExpansionException {
 
     // Store the content of param files.
@@ -187,7 +190,7 @@ public class ActionGraphDump {
       // TODO(twerth): This handles the fixed environment. We probably want to output the inherited
       // environment as well.
       ImmutableMap<String, String> fixedEnvironment =
-          spawnAction.getEffectiveEnvironment(ImmutableMap.of());
+          spawnAction.getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP);
       for (Map.Entry<String, String> environmentVariable : fixedEnvironment.entrySet()) {
         actionBuilder.addEnvironmentVariables(
             AnalysisProtosV2.KeyValuePair.newBuilder()
@@ -210,7 +213,6 @@ public class ActionGraphDump {
         actionBuilder.setFileContents(contents);
       }
     }
-
 
     if (action instanceof UnresolvedSymlinkAction) {
       actionBuilder.setUnresolvedSymlinkTarget(((UnresolvedSymlinkAction) action).getTarget());
@@ -315,7 +317,9 @@ public class ActionGraphDump {
   }
 
   public void dumpConfiguredTarget(RuleConfiguredTargetValue configuredTargetValue)
-      throws CommandLineExpansionException, InterruptedException, IOException,
+      throws CommandLineExpansionException,
+          InterruptedException,
+          IOException,
           TemplateExpansionException {
     ConfiguredTarget configuredTarget = configuredTargetValue.getConfiguredTarget();
     if (!includeInActionGraph(configuredTarget.getLabel().toString())) {

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
@@ -375,7 +375,8 @@ toolchain(name = "toolchain", toolchain = ":cc_toolchain", toolchain_type = '\
         "cc_binary(name = 'foo')");
 
     SpawnAction linkAction = (SpawnAction) Iterables.getOnlyElement(getActions("//foo", "CppLink"));
-    assertThat(linkAction.getEffectiveEnvironment(ImmutableMap.of())).containsEntry("foo", "bar");
+    assertThat(linkAction.getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP))
+        .containsEntry("foo", "bar");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkActionWithShadowedActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkActionWithShadowedActionTest.java
@@ -16,6 +16,8 @@ package com.google.devtools.build.lib.starlark;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.actions.util.ActionsTestUtil.NULL_ACTION_OWNER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +30,7 @@ import com.google.devtools.build.lib.actions.ActionInputPrefetcher;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.DiscoveredModulesPruner;
 import com.google.devtools.build.lib.actions.Executor;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.ThreadStateReceiver;
 import com.google.devtools.build.lib.analysis.actions.StarlarkAction;
 import com.google.devtools.build.lib.analysis.util.AnalysisTestUtil;
@@ -124,7 +127,7 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
     // them should return empty set
     Action shadowedAction =
         createShadowedAction(
-            NestedSetBuilder.emptySet(Order.STABLE_ORDER), /*discoversInputs=*/ false, null);
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER), /* discoversInputs= */ false, null);
     StarlarkAction starlarkAction =
         (StarlarkAction)
             new StarlarkAction.Builder()
@@ -164,7 +167,7 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
     Action shadowedAction =
         createShadowedAction(
             NestedSetBuilder.emptySet(Order.STABLE_ORDER),
-            /*discoversInputs=*/ true,
+            /* discoversInputs= */ true,
             discoveredInputs);
     StarlarkAction starlarkAction =
         (StarlarkAction)
@@ -236,7 +239,7 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
     // Test using Starlark actions's inputs with shadowed action's inputs
     Action shadowedAction =
         createShadowedAction(
-            shadowedActionInputs, /*discoversInputs=*/ false, /*discoveredInputs=*/ null);
+            shadowedActionInputs, /* discoversInputs= */ false, /* discoveredInputs= */ null);
     starlarkAction =
         (StarlarkAction)
             new StarlarkAction.Builder()
@@ -307,13 +310,13 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
                 .build(NULL_ACTION_OWNER, targetConfig);
     collectingAnalysisEnvironment.registerAction(starlarkAction);
 
-    assertThat(starlarkAction.getEffectiveEnvironment(ImmutableMap.of()))
+    assertThat(starlarkAction.getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP))
         .containsExactlyEntriesIn(starlarkActionEnvironment);
 
     // Test using shadowed action's environment without Starlark actions's environment
     Action shadowedAction =
         createShadowedAction(
-            shadowedActionInputs, /*discoversInputs=*/ false, /*discoveredInputs=*/ null);
+            shadowedActionInputs, /* discoversInputs= */ false, /* discoveredInputs= */ null);
     starlarkAction =
         (StarlarkAction)
             new StarlarkAction.Builder()
@@ -324,7 +327,7 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
                 .build(NULL_ACTION_OWNER, targetConfig);
     collectingAnalysisEnvironment.registerAction(starlarkAction);
 
-    assertThat(starlarkAction.getEffectiveEnvironment(ImmutableMap.of()))
+    assertThat(starlarkAction.getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP))
         .containsExactlyEntriesIn(shadowedActionEnvironment);
 
     // Test using Starlark actions's environment with shadowed action's environment
@@ -344,7 +347,7 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
     expectedEnvironment.putAll(starlarkActionEnvironment);
 
     ImmutableMap<String, String> actualEnvironment =
-        starlarkAction.getEffectiveEnvironment(ImmutableMap.of());
+        starlarkAction.getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP);
     assertThat(actualEnvironment).hasSize(5);
     // Starlark action's env overwrites any repeated variable from the shadowed action env
     assertThat(actualEnvironment).containsEntry("repeated_var", "starlark_val");
@@ -363,7 +366,7 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
         .thenReturn(discoveredInputs);
     when(shadowedAction.inputsKnown()).thenReturn(true);
     when(shadowedAction.getOwner()).thenReturn(NULL_ACTION_OWNER);
-    when(shadowedAction.getEffectiveEnvironment(ArgumentMatchers.anyMap()))
+    when(shadowedAction.getEffectiveEnvironment(anyMap(), any()))
         .thenReturn(ImmutableMap.copyOf(shadowedActionEnvironment));
 
     return shadowedAction;


### PR DESCRIPTION
This is a pure refactoring that allows dropping a few overrides and simplifies future efforts to make env variables path mappable in Starlark actions.

RELNOTES: None

Closes #29874.

PiperOrigin-RevId: 934717486
Change-Id: I856d4ffdf0dcea1d24b52ffc59a743412da12cc1 
(cherry picked from commit eca84e30a8e16073f389f73653fb76aa47eb40e8)

Fixes #29906
