### PR TITLE
Add --incompatible_track_executable_bit to preserve output executable bits

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -321,6 +321,14 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
         isFile ? fileValue.getSize() : 0,
         isFile ? fileValue.realFileStateValue().getContentsProxy() : null,
         isFile ? fileValue.getDigest() : null,
+        // Track the executable bit of source files so that it is reflected in remote execution
+        // inputs and the action cache instead of every source being treated as executable. This
+        // costs one extra stat when the (memoized) source metadata is computed. FOLLOW matches the
+        // digest, which is taken from the symlink target. Skipped on file systems that don't
+        // distinguish executable files (Windows), where the bit would otherwise always be set.
+        isFile
+            && artifact.getPath().getFileSystem().supportsExecutability()
+            && (artifact.getPath().stat(Symlinks.FOLLOW).getPermissions() & 0100) != 0,
         xattrProvider);
   }
 
@@ -351,6 +359,7 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
         stat.getSize(),
         FileContentsProxy.create(stat),
         stat instanceof FileStatusWithDigest statWithDigest ? statWithDigest.getDigest() : null,
+        /* isExecutable= */ false,
         xattrProvider);
   }
 
@@ -360,6 +369,7 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
       long size,
       FileContentsProxy proxy,
       @Nullable byte[] digest,
+      boolean isExecutable,
       XattrProvider xattrProvider)
       throws IOException {
     if (!isFile) {
@@ -372,7 +382,7 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
       digest = DigestUtils.getDigestWithManualFallback(path, xattrProvider);
     }
     checkState(digest != null, path);
-    return createForNormalFile(digest, proxy, size);
+    return createForNormalFile(digest, proxy, size, isExecutable);
   }
 
   public static FileArtifactValue createForVirtualActionInput(byte[] digest, long size) {
@@ -407,7 +417,13 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
   public static FileArtifactValue createForNormalFileUsingPath(
       Path path, long size, XattrProvider xattrProvider) throws IOException {
     return create(
-        path, /* isFile= */ true, size, /* proxy= */ null, /* digest= */ null, xattrProvider);
+        path,
+        /* isFile= */ true,
+        size,
+        /* proxy= */ null,
+        /* digest= */ null,
+        /* isExecutable= */ false,
+        xattrProvider);
   }
 
   public static FileArtifactValue createForDirectoryWithHash(byte[] digest) {

--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -130,6 +130,18 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
    */
   public void setContentsProxy(FileContentsProxy proxy) {}
 
+  /**
+   * Returns whether the underlying file system object has its owner executable bit set.
+   *
+   * <p>Only meaningful for regular files; always {@code false} for other file types. The bit is
+   * only tracked for action outputs when {@code --incompatible_track_executable_bit} is enabled.
+   * When the flag is disabled, this always returns {@code false} and consumers treat every file as
+   * executable (the historical behavior, see https://github.com/bazelbuild/bazel/issues/13262).
+   */
+  public boolean isExecutable() {
+    return false;
+  }
+
   @Nullable
   public byte[] getValueFingerprint() {
     // TODO(janakr): return fingerprint in other cases: symlink, directory.
@@ -234,6 +246,13 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
       // keeping the contents of a file the same should not cause rebuilds.
       fp.addLong(getModifiedTime());
     }
+    if (isExecutable()) {
+      // Distinguish an executable file from a non-executable one with otherwise identical metadata
+      // so that flipping the bit invalidates actions consuming the file. Only emitted when the bit
+      // is set, so non-executable files (always the case unless --incompatible_track_executable_bit
+      // produced an executable value) contribute exactly as before.
+      fp.addBoolean(true);
+    }
   }
 
   protected boolean couldBeModifiedByMetadata(FileArtifactValue lastKnown) {
@@ -307,7 +326,8 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
 
   public static FileArtifactValue createFromInjectedDigest(
       FileArtifactValue metadata, @Nullable byte[] digest) {
-    return createForNormalFile(digest, metadata.getContentsProxy(), metadata.getSize());
+    return createForNormalFile(
+        digest, metadata.getContentsProxy(), metadata.getSize(), metadata.isExecutable());
   }
 
   @VisibleForTesting
@@ -370,7 +390,14 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
 
   public static FileArtifactValue createForNormalFile(
       byte[] digest, @Nullable FileContentsProxy proxy, long size) {
-    return new RegularFileArtifactValue(digest, proxy, size);
+    return createForNormalFile(digest, proxy, size, /* isExecutable= */ false);
+  }
+
+  public static FileArtifactValue createForNormalFile(
+      byte[] digest, @Nullable FileContentsProxy proxy, long size, boolean isExecutable) {
+    return isExecutable
+        ? new ExecutableRegularFileArtifactValue(digest, proxy, size)
+        : new RegularFileArtifactValue(digest, proxy, size);
   }
 
   /**
@@ -406,8 +433,21 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
 
   public static FileArtifactValue createForRemoteFileWithMaterializationData(
       byte[] digest, long size, int locationIndex, @Nullable Instant expirationTime) {
-    return new RemoteFileArtifactValueWithMaterializationData(
-        digest, size, locationIndex, expirationTime);
+    return createForRemoteFileWithMaterializationData(
+        digest, size, locationIndex, expirationTime, /* isExecutable= */ false);
+  }
+
+  public static FileArtifactValue createForRemoteFileWithMaterializationData(
+      byte[] digest,
+      long size,
+      int locationIndex,
+      @Nullable Instant expirationTime,
+      boolean isExecutable) {
+    return isExecutable
+        ? new ExecutableRemoteFileArtifactValueWithMaterializationData(
+            digest, size, locationIndex, expirationTime)
+        : new RemoteFileArtifactValueWithMaterializationData(
+            digest, size, locationIndex, expirationTime);
   }
 
   public static FileArtifactValue createFromExistingWithResolvedPath(
@@ -546,7 +586,8 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     }
   }
 
-  private static final class RegularFileArtifactValue extends FileArtifactValue {
+  private static sealed class RegularFileArtifactValue extends FileArtifactValue
+      permits ExecutableRegularFileArtifactValue {
     private final byte[] digest;
     @Nullable private final FileContentsProxy proxy;
     private final long size;
@@ -568,12 +609,13 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
       }
       return Arrays.equals(digest, that.digest)
           && Objects.equals(proxy, that.proxy)
-          && size == that.size;
+          && size == that.size
+          && isExecutable() == that.isExecutable();
     }
 
     @Override
     public int hashCode() {
-      return HashCodes.hashObjects(Arrays.hashCode(digest), proxy, size);
+      return HashCodes.hashObjects(Arrays.hashCode(digest), proxy, size, isExecutable());
     }
 
     @Override
@@ -650,6 +692,32 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     @Override
     protected boolean couldBeModifiedByMetadata(FileArtifactValue lastKnown) {
       return size != lastKnown.getSize() || !Objects.equals(proxy, lastKnown.getContentsProxy());
+    }
+  }
+
+  /**
+   * A {@link RegularFileArtifactValue} for an executable file.
+   *
+   * <p>Modeled as a dedicated subclass rather than a field so that the common, non-executable case
+   * carries no extra memory. The executable bit participates in {@link #equals}, {@link #hashCode}
+   * (both inherited from the parent, which consults {@link #isExecutable}) and {@link
+   * #getValueFingerprint} so that flipping it invalidates dependent actions.
+   */
+  private static final class ExecutableRegularFileArtifactValue extends RegularFileArtifactValue {
+    private ExecutableRegularFileArtifactValue(
+        @Nullable byte[] digest, @Nullable FileContentsProxy proxy, long size) {
+      super(digest, proxy, size);
+    }
+
+    @Override
+    public boolean isExecutable() {
+      return true;
+    }
+
+    @Override
+    public byte[] getValueFingerprint() {
+      // Distinguish from a non-executable file with identical content.
+      return new Fingerprint().addBytes(getDigest()).addBoolean(true).digestAndReset();
     }
   }
 
@@ -794,8 +862,9 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
    * <p>This is used when the output mode allows for late materialization of remote outputs in the
    * local filesystem.
    */
-  private static final class RemoteFileArtifactValueWithMaterializationData
-      extends RemoteFileArtifactValue {
+  private static sealed class RemoteFileArtifactValueWithMaterializationData
+      extends RemoteFileArtifactValue
+      permits ExecutableRemoteFileArtifactValueWithMaterializationData {
     private long expirationTime;
     @Nullable private FileContentsProxy proxy;
 
@@ -857,12 +926,14 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
 
       return Arrays.equals(getDigest(), that.getDigest())
           && getSize() == that.getSize()
-          && getLocationIndex() == that.getLocationIndex();
+          && getLocationIndex() == that.getLocationIndex()
+          && isExecutable() == that.isExecutable();
     }
 
     @Override
     public int hashCode() {
-      return HashCodes.hashObjects(Arrays.hashCode(getDigest()), getSize(), getLocationIndex());
+      return HashCodes.hashObjects(
+          Arrays.hashCode(getDigest()), getSize(), getLocationIndex(), isExecutable());
     }
 
     @Override
@@ -874,6 +945,29 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
           .add("expirationTime", fromEpochMilli(expirationTime))
           .add("proxy", proxy)
           .toString();
+    }
+  }
+
+  /**
+   * A {@link RemoteFileArtifactValueWithMaterializationData} for an executable file. See {@link
+   * ExecutableRegularFileArtifactValue} for the rationale of modeling this as a subclass.
+   */
+  private static final class ExecutableRemoteFileArtifactValueWithMaterializationData
+      extends RemoteFileArtifactValueWithMaterializationData {
+    private ExecutableRemoteFileArtifactValueWithMaterializationData(
+        byte[] digest, long size, int locationIndex, @Nullable Instant expirationTime) {
+      super(digest, size, locationIndex, expirationTime);
+    }
+
+    @Override
+    public boolean isExecutable() {
+      return true;
+    }
+
+    @Override
+    public byte[] getValueFingerprint() {
+      // Distinguish from a non-executable file with identical content.
+      return new Fingerprint().addBytes(getDigest()).addBoolean(true).digestAndReset();
     }
   }
 
@@ -931,6 +1025,11 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     @Override
     public void setContentsProxy(FileContentsProxy proxy) {
       delegate.setContentsProxy(proxy);
+    }
+
+    @Override
+    public boolean isExecutable() {
+      return delegate.isExecutable();
     }
 
     @Override
@@ -1276,6 +1375,11 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     @Override
     public void setContentsProxy(FileContentsProxy proxy) {
       delegate.setContentsProxy(proxy);
+    }
+
+    @Override
+    public boolean isExecutable() {
+      return delegate.isExecutable();
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -790,12 +790,19 @@ public class CompactPersistentActionCache implements ActionCache {
     VarInt.putVarLong(
         value.getExpirationTime() != null ? value.getExpirationTime().toEpochMilli() : -1, sink);
 
+    // The trailing varint is a bitmask: bit 0 marks the presence of a resolved path, bit 1 the
+    // executable bit. Older caches only ever wrote 0 or 1, so they decode as non-executable.
     PathFragment resolvedPath = value.getResolvedPath();
+    int flags = 0;
     if (resolvedPath != null) {
-      VarInt.putVarInt(1, sink);
+      flags |= 1;
+    }
+    if (value.isExecutable()) {
+      flags |= 2;
+    }
+    VarInt.putVarInt(flags, sink);
+    if (resolvedPath != null) {
       VarInt.putVarInt(indexer.getOrCreateIndex(resolvedPath.toString()), sink);
-    } else {
-      VarInt.putVarInt(0, sink);
     }
   }
 
@@ -804,7 +811,7 @@ public class CompactPersistentActionCache implements ActionCache {
           + VarInt.MAX_VARLONG_SIZE // size
           + VarInt.MAX_VARINT_SIZE // locationIndex
           + VarInt.MAX_VARLONG_SIZE // expirationTime
-          + (1 + VarInt.MAX_VARINT_SIZE); // resolvedPath
+          + (1 + VarInt.MAX_VARINT_SIZE); // flags byte + resolvedPath index
 
   private FileArtifactValue decodeRemoteMetadata(ByteBuffer source) throws IOException {
     byte[] digest = MetadataDigestUtils.read(source);
@@ -815,12 +822,11 @@ public class CompactPersistentActionCache implements ActionCache {
 
     long expirationTimeEpochMilli = VarInt.getVarLong(source);
 
+    int flags = VarInt.getVarInt(source);
+    boolean hasResolvedPath = (flags & 1) != 0;
+    boolean isExecutable = (flags & 2) != 0;
     PathFragment resolvedPath = null;
-    int numResolvedPath = VarInt.getVarInt(source);
-    if (numResolvedPath > 0) {
-      if (numResolvedPath != 1) {
-        throw new IOException("Invalid presence marker for resolved path");
-      }
+    if (hasResolvedPath) {
       resolvedPath = PathFragment.create(getStringForIndex(indexer, VarInt.getVarInt(source)));
     }
 
@@ -829,7 +835,8 @@ public class CompactPersistentActionCache implements ActionCache {
             digest,
             size,
             locationIndex,
-            expirationTimeEpochMilli >= 0 ? Instant.ofEpochMilli(expirationTimeEpochMilli) : null);
+            expirationTimeEpochMilli >= 0 ? Instant.ofEpochMilli(expirationTimeEpochMilli) : null,
+            isExecutable);
 
     if (resolvedPath != null) {
       metadata = FileArtifactValue.createFromExistingWithResolvedPath(metadata, resolvedPath);

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -341,6 +341,22 @@ public abstract class CoreOptions extends FragmentOptions implements Cloneable {
       help = "If true, the file permissions of action outputs are set to `0755` instead of `0555`")
   public abstract boolean getExperimentalWritableOutputs();
 
+  // This execution-time behavior is an input to analysis (AFFECTS_OUTPUTS) so that flipping the
+  // flag invalidates already-executed actions. It is preserved by the exec transition, like other
+  // incompatible flags, so tools track the executable bit consistently with the target config.
+  @Option(
+      name = "incompatible_track_executable_bit",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          "If true, Bazel preserves the executable bit of action output files instead of forcing"
+              + " every output to be executable, and propagates the real bit to remote execution"
+              + " inputs and the remote cache. See"
+              + " https://github.com/bazelbuild/bazel/issues/13262.")
+  public abstract boolean getTrackExecutableBit();
+
   @Option(
       name = "stamp",
       defaultValue = "false",

--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -81,6 +81,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
   private final AsyncTaskCache.NoResult<Path> downloadCache = AsyncTaskCache.NoResult.create();
   private final TempPathGenerator tempPathGenerator;
   private final OutputPermissions outputPermissions;
+  private final boolean trackExecutableBit;
 
   protected final Path execRoot;
   protected final RemoteOutputChecker remoteOutputChecker;
@@ -236,13 +237,15 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       TempPathGenerator tempPathGenerator,
       RemoteOutputChecker remoteOutputChecker,
       @Nullable ActionOutputDirectoryHelper outputDirectoryHelper,
-      OutputPermissions outputPermissions) {
+      OutputPermissions outputPermissions,
+      boolean trackExecutableBit) {
     this.reporter = reporter;
     this.execRoot = execRoot;
     this.tempPathGenerator = tempPathGenerator;
     this.remoteOutputChecker = remoteOutputChecker;
     this.outputDirectoryHelper = outputDirectoryHelper;
     this.outputPermissions = outputPermissions;
+    this.trackExecutableBit = trackExecutableBit;
   }
 
   private static boolean shouldDownloadFile(Path path, FileArtifactValue metadata)
@@ -658,7 +661,12 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
     // Set file output permissions, matching SkyframeActionExecutor#checkOutputs for artifacts
     // produced by local actions. The temporary path is outside the output tree, so this can happen
     // before entering the tree artifact root's critical section.
-    tmpPath.chmod(outputPermissions.getPermissionsMode());
+    int mode = outputPermissions.getPermissionsMode();
+    if (trackExecutableBit && !metadata.isExecutable()) {
+      // Preserve the real executable bit instead of forcing every output to be executable.
+      mode &= ~0111;
+    }
+    tmpPath.chmod(mode);
 
     Path parentDir = checkNotNull(finalPath.getParentDirectory());
     @Nullable

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -460,6 +460,7 @@ java_library(
         ":remote_spawn_cache",
         ":remote_spawn_runner",
         ":remote_spawn_strategy",
+        "//src/main/java/com/google/devtools/build/lib/analysis/config:core_options",
         "//src/main/java/com/google/devtools/build/lib/exec:execution_options",
         "//src/main/java/com/google/devtools/build/lib/exec:module_action_context_registry",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_cache",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import build.bazel.remote.execution.v2.Digest;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.ModuleActionContextRegistry;
 import com.google.devtools.build.lib.exec.SpawnCache;
@@ -167,6 +168,8 @@ final class RemoteActionContextProvider {
 
       boolean verboseFailures =
           checkNotNull(env.getOptions().getOptions(ExecutionOptions.class)).getVerboseFailures();
+      CoreOptions coreOptions = env.getOptions().getOptions(CoreOptions.class);
+      boolean trackExecutableBit = coreOptions != null && coreOptions.getTrackExecutableBit();
       remoteExecutionService =
           new RemoteExecutionService(
               env.getReporter(),
@@ -179,6 +182,7 @@ final class RemoteActionContextProvider {
               digestUtil,
               checkNotNull(env.getOptions().getOptions(RemoteOptions.class)),
               checkNotNull(env.getOptions().getOptions(ExecutionOptions.class)),
+              trackExecutableBit,
               combinedCache,
               remoteExecutor,
               tempPathGenerator,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -305,14 +305,15 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
     this.action = action;
   }
 
-  void injectRemoteFile(PathFragment path, byte[] digest, long size, Instant expirationTime)
+  void injectRemoteFile(
+      PathFragment path, byte[] digest, long size, boolean isExecutable, Instant expirationTime)
       throws IOException {
     if (!isOutput(path)) {
       return;
     }
     var metadata =
         FileArtifactValue.createForRemoteFileWithMaterializationData(
-            digest, size, /* locationIndex= */ 1, expirationTime);
+            digest, size, /* locationIndex= */ 1, expirationTime, isExecutable);
     remoteOutputTree.injectFile(path, metadata);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -63,14 +63,16 @@ public class RemoteActionInputFetcher extends AbstractActionInputPrefetcher {
       TempPathGenerator tempPathGenerator,
       RemoteOutputChecker remoteOutputChecker,
       @Nullable ActionOutputDirectoryHelper outputDirectoryHelper,
-      OutputPermissions outputPermissions) {
+      OutputPermissions outputPermissions,
+      boolean trackExecutableBit) {
     super(
         reporter,
         execRoot,
         tempPathGenerator,
         remoteOutputChecker,
         outputDirectoryHelper,
-        outputPermissions);
+        outputPermissions,
+        trackExecutableBit);
     this.buildRequestId = Preconditions.checkNotNull(buildRequestId);
     this.commandId = Preconditions.checkNotNull(commandId);
     this.combinedCache = Preconditions.checkNotNull(combinedCache);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -184,6 +184,7 @@ public class RemoteExecutionService {
   private final MerkleTreeComputer merkleTreeComputer;
   private final RemoteOptions remoteOptions;
   private final ExecutionOptions executionOptions;
+  private final boolean trackExecutableBit;
   @Nullable private final CombinedCache combinedCache;
   @Nullable private final RemoteExecutionClient remoteExecutor;
   private final TempPathGenerator tempPathGenerator;
@@ -217,6 +218,7 @@ public class RemoteExecutionService {
       DigestUtil digestUtil,
       RemoteOptions remoteOptions,
       ExecutionOptions executionOptions,
+      boolean trackExecutableBit,
       @Nullable CombinedCache combinedCache,
       @Nullable RemoteExecutionClient remoteExecutor,
       TempPathGenerator tempPathGenerator,
@@ -233,6 +235,7 @@ public class RemoteExecutionService {
     this.digestUtil = digestUtil;
     this.remoteOptions = remoteOptions;
     this.executionOptions = executionOptions;
+    this.trackExecutableBit = trackExecutableBit;
     this.combinedCache = combinedCache;
     this.remoteExecutor = remoteExecutor;
     this.merkleTreeComputer =
@@ -244,7 +247,8 @@ public class RemoteExecutionService {
                 : null,
             buildRequestId,
             commandId,
-            workspaceName);
+            workspaceName,
+            trackExecutableBit);
 
     this.scrubber = remoteOptions.getScrubber();
 
@@ -1290,6 +1294,7 @@ public class RemoteExecutionService {
                   file.path().asFragment(),
                   DigestUtil.toBinaryDigest(file.digest()),
                   file.digest().getSizeBytes(),
+                  trackExecutableBit && file.isExecutable(),
                   expirationTime);
         }
 
@@ -1344,6 +1349,7 @@ public class RemoteExecutionService {
                   file.path().asFragment(),
                   DigestUtil.toBinaryDigest(file.digest()),
                   file.digest().getSizeBytes(),
+                  trackExecutableBit && file.isExecutable(),
                   expirationTime);
         }
       }
@@ -1395,6 +1401,14 @@ public class RemoteExecutionService {
     } else {
       moveOutputsToFinalLocation(
           Iterables.transform(finishedDownloads, FileMetadata::path), realToTmpPath);
+      if (trackExecutableBit) {
+        // moveOutputsToFinalLocation deliberately doesn't carry over the executable bit. Set it
+        // from the action result so the post-execution chmod in ActionOutputMetadataStore preserves
+        // it instead of forcing every downloaded output to be executable.
+        for (FileMetadata file : finishedDownloads) {
+          file.path().setExecutable(file.isExecutable());
+        }
+      }
     }
 
     List<SymlinkMetadata> symlinksInDirectories = new ArrayList<>();
@@ -1740,7 +1754,7 @@ public class RemoteExecutionService {
           spawnResult.exitCode(),
           spawnResult.getStartTime(),
           spawnResult.getWallTimeInMs(),
-          /* preserveExecutableBit= */ false);
+          /* preserveExecutableBit= */ trackExecutableBit);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -320,6 +320,7 @@ public final class RemoteModule extends BlazeModule {
         coreOptions != null && coreOptions.getExperimentalWritableOutputs()
             ? OutputPermissions.WRITABLE
             : OutputPermissions.READONLY;
+    var trackExecutableBit = coreOptions != null && coreOptions.getTrackExecutableBit();
     return new RemoteActionInputFetcher(
         env.getReporter(),
         env.getBuildRequestId(),
@@ -331,7 +332,8 @@ public final class RemoteModule extends BlazeModule {
         env.getOptions().getOptions(BuildRequestOptions.class) != null
             ? env.getOutputDirectoryHelper()
             : null,
-        outputPermissions);
+        outputPermissions,
+        trackExecutableBit);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
@@ -146,7 +146,8 @@ public class RemoteRepositoryRemoteExecutor implements RepositoryRemoteExecutor 
                 /* remoteExecutionCache= */ null,
                 buildRequestId,
                 commandId,
-                workspaceName)
+                workspaceName,
+                /* trackExecutableBit= */ false)
             .buildForFiles(inputFiles);
     Action action =
         buildAction(

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
@@ -176,6 +176,7 @@ public final class MerkleTreeComputer {
   private final String buildRequestId;
   private final String commandId;
   private final String workspaceName;
+  private final boolean trackExecutableBit;
   private final Digest emptyDigest;
   private final MerkleTree.Uploadable emptyTree;
   private final TaskDeduplicator<InFlightCacheKey, MerkleTree.RootOnly> inFlightComputations =
@@ -186,12 +187,14 @@ public final class MerkleTreeComputer {
       @Nullable MerkleTreeUploader remoteExecutionCache,
       String buildRequestId,
       String commandId,
-      String workspaceName) {
+      String workspaceName,
+      boolean trackExecutableBit) {
     this.digestUtil = digestUtil;
     this.merkleTreeUploader = remoteExecutionCache;
     this.buildRequestId = buildRequestId;
     this.commandId = commandId;
     this.workspaceName = workspaceName;
+    this.trackExecutableBit = trackExecutableBit;
     var emptyBlob = new byte[0];
     this.emptyDigest = digestUtil.compute(emptyBlob);
     this.emptyTree =
@@ -662,7 +665,13 @@ public final class MerkleTreeComputer {
             lastSourceDirPath = path;
           } else {
             var digest = DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());
-            addFile(currentDirectory, name, digest, nodeProperties);
+            // The executable bit is only tracked for generated artifacts, whose metadata carries
+            // it. Source artifacts (and the input kinds handled below) retain the historical
+            // always-executable behavior.
+            boolean isExecutable =
+                !trackExecutableBit || fileOrSourceDirectory.isSourceArtifact()
+                    || metadata.isExecutable();
+            addFile(currentDirectory, name, digest, nodeProperties, isExecutable);
             if (blobPolicy != BlobPolicy.DISCARD && digest.getSizeBytes() != 0) {
               // If there is both a Digest and a FileArtifactValue key for the same content, prefer
               // the FileArtifactValue as it is retained anyway.
@@ -674,7 +683,7 @@ public final class MerkleTreeComputer {
         }
         case VirtualActionInput virtualActionInput -> {
           var digest = digestUtil.compute(virtualActionInput);
-          addFile(currentDirectory, name, digest, nodeProperties);
+          addFile(currentDirectory, name, digest, nodeProperties, /* isExecutable= */ true);
           if (blobPolicy != BlobPolicy.DISCARD && digest.getSizeBytes() != 0) {
             blobs.putIfAbsent(digest, virtualActionInput);
           }
@@ -686,14 +695,14 @@ public final class MerkleTreeComputer {
         case null -> {
           // This is a sentinel value for an empty file. This case only occurs when this method is
           // called from computeForRunfilesTreeIfAbsent.
-          addFile(currentDirectory, name, emptyDigest, nodeProperties);
+          addFile(currentDirectory, name, emptyDigest, nodeProperties, /* isExecutable= */ true);
           inputFiles++;
         }
         default -> {
           // The input is not represented by a known subtype of ActionInput. Bare ActionInputs
           // arise from exploded source directories, repository rules or tests.
           var digest = digestUtil.compute(artifactPathResolver.toPath(input));
-          addFile(currentDirectory, name, digest, nodeProperties);
+          addFile(currentDirectory, name, digest, nodeProperties, /* isExecutable= */ true);
           if (blobPolicy != BlobPolicy.DISCARD && digest.getSizeBytes() != 0) {
             blobs.putIfAbsent(digest, input);
           }
@@ -1004,18 +1013,19 @@ public final class MerkleTreeComputer {
       Directory.Builder directory,
       String name,
       Digest digest,
-      @Nullable NodeProperties nodeProperties) {
+      @Nullable NodeProperties nodeProperties,
+      boolean isExecutable) {
+    // Unless --incompatible_track_executable_bit is set, files are always treated as executable
+    // since Bazel will `chmod 555` on the output files of an action within
+    // ActionOutputMetadataStore#getMetadata after action execution if no metadata was injected.
+    // We can't use the real executable bit of the file until this behavior is changed. See
+    // https://github.com/bazelbuild/bazel/issues/13262 for more details.
     var builder =
         directory
             .addFilesBuilder()
             .setName(name)
             .setDigest(digest)
-            // We always treat files as executable since Bazel will `chmod 555` on the output
-            // files of an action within ActionOutputMetadataStore#getMetadata after action
-            // execution if no metadata was injected. We can't use real executable bit of the
-            // file until this behavior is changed. See
-            // https://github.com/bazelbuild/bazel/issues/13262 for more details.
-            .setIsExecutable(true);
+            .setIsExecutable(isExecutable);
     if (nodeProperties != null) {
       builder.setNodeProperties(nodeProperties);
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
@@ -665,12 +665,21 @@ public final class MerkleTreeComputer {
             lastSourceDirPath = path;
           } else {
             var digest = DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());
-            // The executable bit is only tracked for generated artifacts, whose metadata carries
-            // it. Source artifacts (and the input kinds handled below) retain the historical
-            // always-executable behavior.
+            // Generated and source artifacts both carry the real executable bit in their metadata.
+            // The remaining input kinds handled below (virtual inputs, exploded source directories,
+            // repository and test inputs) retain the historical always-executable behavior. On file
+            // systems that don't distinguish executable files (Windows), a source file's bit can't
+            // be determined, so fall back to forcing it executable rather than marking it
+            // non-executable; generated artifacts carry a trustworthy bit (e.g. from a remote action
+            // result) even there.
             boolean isExecutable =
-                !trackExecutableBit || fileOrSourceDirectory.isSourceArtifact()
-                    || metadata.isExecutable();
+                !trackExecutableBit
+                    || metadata.isExecutable()
+                    || (fileOrSourceDirectory.isSourceArtifact()
+                        && !artifactPathResolver
+                            .toPath(fileOrSourceDirectory)
+                            .getFileSystem()
+                            .supportsExecutability());
             addFile(currentDirectory, name, digest, nodeProperties, isExecutable);
             if (blobPolicy != BlobPolicy.DISCARD && digest.getSizeBytes() != 0) {
               // If there is both a Digest and a FileArtifactValue key for the same content, prefer

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
@@ -756,6 +756,7 @@ public final class ActionExecutionFunction implements SkyFunction {
         ActionOutputMetadataStore.create(
             skyframeActionExecutor.useArchivedTreeArtifacts(action),
             skyframeActionExecutor.getOutputPermissions(),
+            skyframeActionExecutor.shouldTrackExecutableBit(),
             ImmutableSet.copyOf(action.getOutputs()),
             skyframeActionExecutor.getXattrProvider(),
             tsgm.get(),

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
@@ -81,6 +81,7 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
   static ActionOutputMetadataStore create(
       boolean archivedTreeArtifactsEnabled,
       OutputPermissions outputPermissions,
+      boolean trackExecutableBit,
       ImmutableSet<Artifact> outputs,
       XattrProvider xattrProvider,
       TimestampGranularityMonitor tsgm,
@@ -88,6 +89,7 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
     return new ActionOutputMetadataStore(
         archivedTreeArtifactsEnabled,
         outputPermissions,
+        trackExecutableBit,
         outputs,
         xattrProvider,
         tsgm,
@@ -96,6 +98,7 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
 
   private final boolean archivedTreeArtifactsEnabled;
   private final OutputPermissions outputPermissions;
+  private final boolean trackExecutableBit;
 
   private final XattrProvider xattrProvider;
   private final TimestampGranularityMonitor tsgm;
@@ -112,12 +115,14 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
   private ActionOutputMetadataStore(
       boolean archivedTreeArtifactsEnabled,
       OutputPermissions outputPermissions,
+      boolean trackExecutableBit,
       ImmutableSet<Artifact> outputs,
       XattrProvider xattrProvider,
       TimestampGranularityMonitor tsgm,
       ArtifactPathResolver artifactPathResolver) {
     this.archivedTreeArtifactsEnabled = archivedTreeArtifactsEnabled;
     this.outputPermissions = outputPermissions;
+    this.trackExecutableBit = trackExecutableBit;
     this.outputs = checkNotNull(outputs);
     this.xattrProvider = xattrProvider;
     this.tsgm = checkNotNull(tsgm);
@@ -391,6 +396,7 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
             artifact,
             artifactPathResolver,
             statNoFollow,
+            trackExecutableBit,
             xattrProvider,
             // Prevent constant metadata artifacts from notifying the timestamp granularity monitor
             // and potentially delaying the build for no reason.
@@ -463,8 +469,15 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
       XattrProvider xattrProvider,
       @Nullable TimestampGranularityMonitor tsgm)
       throws IOException {
+    // External callers re-derive metadata only for couldBeModifiedSince comparisons, which ignore
+    // the executable bit, so it doesn't need to be tracked here.
     return fileArtifactValueFromArtifact(
-            artifact, ArtifactPathResolver.IDENTITY, statNoFollow, xattrProvider, tsgm)
+            artifact,
+            ArtifactPathResolver.IDENTITY,
+            statNoFollow,
+            /* trackExecutableBit= */ false,
+            xattrProvider,
+            tsgm)
         .fileArtifactValue();
   }
 
@@ -472,6 +485,7 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
       Artifact artifact,
       ArtifactPathResolver artifactPathResolver,
       @Nullable FileStatusWithDigest statNoFollow,
+      boolean trackExecutableBit,
       XattrProvider xattrProvider,
       @Nullable TimestampGranularityMonitor tsgm)
       throws IOException {
@@ -501,7 +515,8 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
 
     if (statNoFollow == null || !statNoFollow.isSymbolicLink()) {
       var fileArtifactValue =
-          fileArtifactValueFromStat(rootedPathNoFollow, statNoFollow, xattrProvider, tsgm);
+          fileArtifactValueFromStat(
+              rootedPathNoFollow, statNoFollow, trackExecutableBit, xattrProvider, tsgm);
       return FileArtifactStatAndValue.create(
           pathNoFollow, /* realPath= */ null, statNoFollow, fileArtifactValue);
     }
@@ -524,7 +539,8 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
     FileStatus realStat = realRootedPath.asPath().statIfFound(Symlinks.NOFOLLOW);
     FileStatusWithDigest realStatWithDigest = FileStatusWithDigestAdapter.maybeAdapt(realStat);
     var fileArtifactValue =
-        fileArtifactValueFromStat(realRootedPath, realStatWithDigest, xattrProvider, tsgm);
+        fileArtifactValueFromStat(
+            realRootedPath, realStatWithDigest, trackExecutableBit, xattrProvider, tsgm);
 
     // If the artifact was materialized in the filesystem as as symlink to another artifact, record
     // the real path in the metadata so that it can be recreated as such later.
@@ -562,6 +578,7 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
   private static FileArtifactValue fileArtifactValueFromStat(
       RootedPath rootedPath,
       FileStatusWithDigest stat,
+      boolean trackExecutableBit,
       XattrProvider xattrProvider,
       @Nullable TimestampGranularityMonitor tsgm)
       throws IOException {
@@ -581,19 +598,53 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
         FileStateValue.createWithStatNoFollow(rootedPath, stat, xattrProvider, tsgm);
 
     return FileArtifactValue.createForNormalFile(
-        fileStateValue.getDigest(), fileStateValue.getContentsProxy(), stat.getSize());
+        fileStateValue.getDigest(),
+        fileStateValue.getContentsProxy(),
+        stat.getSize(),
+        // When the flag is disabled, the bit is left unset; the file has already been chmodded to
+        // be executable by setPathPermissions, matching the historical always-executable behavior.
+        /* isExecutable= */ trackExecutableBit && (stat.getPermissions() & 0100) != 0);
   }
 
   private void setPathPermissionsIfFile(Path path) throws IOException {
     FileStatus stat = path.statIfFound(Symlinks.NOFOLLOW);
-    if (stat != null
-        && stat.isFile()
-        && stat.getPermissions() != outputPermissions.getPermissionsMode()) {
-      setPathPermissions(path);
+    if (stat != null && stat.isFile()) {
+      chmodToTarget(path, stat);
     }
   }
 
   private void setPathPermissions(Path path) throws IOException {
-    path.chmod(outputPermissions.getPermissionsMode());
+    if (!trackExecutableBit) {
+      // Fast path: force the configured output permissions (always executable) without a stat.
+      path.chmod(outputPermissions.getPermissionsMode());
+      return;
+    }
+    FileStatus stat = path.statIfFound(Symlinks.NOFOLLOW);
+    if (stat != null) {
+      chmodToTarget(path, stat);
+    }
+  }
+
+  private void chmodToTarget(Path path, FileStatus stat) throws IOException {
+    int currentMode = stat.getPermissions();
+    int targetMode = targetPermissions(currentMode, stat.isDirectory());
+    if (currentMode != targetMode) {
+      path.chmod(targetMode);
+    }
+  }
+
+  /**
+   * Computes the permissions an output should be chmodded to. Without {@link #trackExecutableBit},
+   * this is always {@link #outputPermissions} (every output is made executable). With the flag, the
+   * file's own executable bit is preserved while the read/write bits are normalized; directories
+   * always keep their execute (i.e. searchable) bit.
+   */
+  private int targetPermissions(int currentMode, boolean isDirectory) {
+    int outputMode = outputPermissions.getPermissionsMode();
+    if (!trackExecutableBit || isDirectory) {
+      return outputMode;
+    }
+    int nonExecutableMode = outputMode & ~0111;
+    return (currentMode & 0100) != 0 ? nonExecutableMode | 0111 : nonExecutableMode;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -450,6 +450,10 @@ public final class SkyframeActionExecutor {
         : OutputPermissions.READONLY;
   }
 
+  boolean shouldTrackExecutableBit() {
+    return options.getOptions(CoreOptions.class).getTrackExecutableBit();
+  }
+
   XattrProvider getXattrProvider() {
     return checkNotNull(outputService.getXattrProvider(syscallCache));
   }

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -178,6 +178,18 @@ public abstract class FileSystem {
   public abstract boolean mayBeCaseOrNormalizationInsensitive();
 
   /**
+   * Returns true if this file system distinguishes executable files, i.e. {@link #getPermissions}
+   * reflects a real executable bit and {@link #setExecutable} has an effect.
+   *
+   * <p>Returns false on file systems where every file is implicitly executable (notably Windows).
+   * On such file systems the executable bit reported by {@link #getPermissions} carries no
+   * information and must not be tracked, as it would otherwise mark every file as executable.
+   */
+  public boolean supportsExecutability() {
+    return true;
+  }
+
+  /**
    * Returns the type of the file system path belongs to.
    *
    * <p>The string returned is obtained directly from the operating system, so it's a best guess in

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -244,6 +244,13 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
+  public boolean supportsExecutability() {
+    // getPermissions always reports files as executable and setExecutable is a no-op, so the
+    // executable bit carries no information on Windows.
+    return false;
+  }
+
+  @Override
   public void setWritable(PathFragment path, boolean writable) throws IOException {
     // Windows does not have a notion of read-only directories.
     // See https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants.

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -206,6 +206,7 @@ bazel_fragments["CoreOptions"] = fragment(
         "//command_line_option:incompatible_auto_exec_groups",
         "//command_line_option:incompatible_bazel_test_exec_run_under",
         "//command_line_option:experimental_writable_outputs",
+        "//command_line_option:incompatible_track_executable_bit",
         "//command_line_option:build_runfile_manifests",
         "//command_line_option:build_runfile_links",
         "//command_line_option:experimental_remotable_source_manifests",

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -449,6 +449,43 @@ public final class ActionCacheCheckerTest {
   }
 
   @Test
+  public void executableBitChangeOfInputCausesReexecution() throws Exception {
+    Artifact input = createArtifact(artifactRoot, "input");
+    input.getPath().getParentDirectory().createDirectoryAndParents();
+    writeContentAsLatin1(input.getPath(), "content");
+    Artifact output = createArtifact(artifactRoot, "output");
+    Action action = new WriteEmptyOutputAction(ImmutableList.of(input), output);
+
+    byte[] digest = input.getPath().getDigest();
+    long size = input.getPath().getFileSize();
+    FileArtifactValue nonExecutable =
+        FileArtifactValue.createForNormalFile(
+            digest, /* proxy= */ null, size, /* isExecutable= */ false);
+    FileArtifactValue executable =
+        FileArtifactValue.createForNormalFile(
+            digest, /* proxy= */ null, size, /* isExecutable= */ true);
+
+    // The producing action first emits a non-executable input; populates the cache.
+    runAction(
+        action,
+        new StaticInputMetadataProvider(ImmutableMap.of(input, nonExecutable)),
+        new FakeInputMetadataHandler());
+    // The producing action now emits the same content but with the executable bit set: the
+    // consuming action must re-execute and notice the change rather than hitting the cache.
+    runAction(
+        action,
+        new StaticInputMetadataProvider(ImmutableMap.of(input, executable)),
+        new FakeInputMetadataHandler());
+
+    assertStatistics(
+        0,
+        new MissDetailsBuilder()
+            .set(MissReason.NOT_CACHED, 1)
+            .set(MissReason.DIGEST_MISMATCH, 1)
+            .build());
+  }
+
+  @Test
   public void testUnconditionalExecution() throws Exception {
     Action action =
         new WriteEmptyOutputAction() {
@@ -1909,6 +1946,10 @@ public final class ActionCacheCheckerTest {
 
     WriteEmptyOutputAction(Artifact... outputs) {
       super(outputs);
+    }
+
+    WriteEmptyOutputAction(ImmutableList<Artifact> inputs, Artifact... outputs) {
+      super(inputs, outputs);
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.vfs.FileSystemUtils.readContent;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assume.assumeFalse;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
@@ -155,6 +156,77 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
 
   @Override
   protected void injectFile(byte[] content) {}
+
+  @Test
+  public void executableBit_preservedForDownloadedRemoteOutputs() throws Exception {
+    // The executable bit is a Unix concept; Path#isExecutable has different semantics on Windows.
+    assumeFalse(OS.getCurrent() == OS.WINDOWS);
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'nonexec',",
+        "  outs = ['nonexec.txt'],",
+        "  cmd = 'echo hi > $@',",
+        ")",
+        "genrule(",
+        "  name = 'exec',",
+        "  outs = ['exec.sh'],",
+        "  cmd = 'echo hi > $@ && chmod +x $@',",
+        ")");
+    addOptions("--incompatible_track_executable_bit");
+    setDownloadAll();
+
+    buildTarget("//:nonexec", "//:exec");
+    waitDownloads();
+
+    assertThat(getOutputPath("nonexec.txt").isExecutable()).isFalse();
+    assertThat(getOutputPath("exec.sh").isExecutable()).isTrue();
+  }
+
+  @Test
+  public void executableBit_forcedForDownloadedRemoteOutputsWithoutFlag() throws Exception {
+    assumeFalse(OS.getCurrent() == OS.WINDOWS);
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'nonexec',",
+        "  outs = ['nonexec.txt'],",
+        "  cmd = 'echo hi > $@',",
+        ")");
+    setDownloadAll();
+
+    buildTarget("//:nonexec");
+    waitDownloads();
+
+    // Historical behavior: every output is forced executable regardless of the action's intent.
+    assertThat(getOutputPath("nonexec.txt").isExecutable()).isTrue();
+  }
+
+  @Test
+  public void executableBit_trackedInMetadataWhenNotDownloaded() throws Exception {
+    assumeFalse(OS.getCurrent() == OS.WINDOWS);
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'nonexec',",
+        "  outs = ['nonexec.txt'],",
+        "  cmd = 'echo hi > $@',",
+        ")",
+        "genrule(",
+        "  name = 'exec',",
+        "  outs = ['exec.sh'],",
+        "  cmd = 'echo hi > $@ && chmod +x $@',",
+        ")");
+    addOptions("--incompatible_track_executable_bit", "--remote_download_outputs=minimal");
+
+    buildTarget("//:nonexec", "//:exec");
+    waitDownloads();
+
+    // The outputs aren't downloaded; the executable bit survives in the injected remote metadata.
+    assertThat(getOnlyElement(getMetadata("//:nonexec").values()).isRemote()).isTrue();
+    assertThat(getOnlyElement(getMetadata("//:nonexec").values()).isExecutable()).isFalse();
+    assertThat(getOnlyElement(getMetadata("//:exec").values()).isExecutable()).isTrue();
+  }
 
   @Test
   public void executeRemotely_actionFails_outputsAreAvailableLocallyForDebuggingPurpose()

--- a/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
@@ -125,7 +125,8 @@ public class CombinedCacheTest {
           /* remoteExecutionCache= */ null,
           "buildRequestId",
           "commandId",
-          TestConstants.WORKSPACE_NAME);
+          TestConstants.WORKSPACE_NAME,
+          /* trackExecutableBit= */ false);
   private FakeActionInputFileCache fakeFileCache;
 
   private ListeningScheduledExecutorService retryService;

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -323,7 +323,12 @@ public class GrpcCacheClientTest {
         };
     var merkleTreeComputer =
         new MerkleTreeComputer(
-            DIGEST_UTIL, client, "buildRequestId", "commandId", TestConstants.WORKSPACE_NAME);
+            DIGEST_UTIL,
+            client,
+            "buildRequestId",
+            "commandId",
+            TestConstants.WORKSPACE_NAME,
+            /* trackExecutableBit= */ false);
     var spawn = new SpawnBuilder().withInput(virtualActionInput).build();
     var merkleTree =
         (MerkleTree.Uploadable)

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -1163,7 +1163,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     byte[] digest = getDigest(content);
     int size = Utf8.encodedLength(content);
     ((RemoteActionFileSystem) actionFs)
-        .injectRemoteFile(path, digest, size, /* expirationTime= */ null);
+        .injectRemoteFile(path, digest, size, /* isExecutable= */ false, /* expirationTime= */ null);
     return FileArtifactValue.createForRemoteFileWithMaterializationData(
         digest, size, /* locationIndex= */ 1, /* expirationTime= */ null);
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -75,7 +75,8 @@ public class RemoteActionInputFetcherTest extends ActionInputPrefetcherTestBase 
         tempPathGenerator,
         DUMMY_REMOTE_OUTPUT_CHECKER,
         ActionOutputDirectoryHelper.createForTesting(),
-        OutputPermissions.READONLY);
+        OutputPermissions.READONLY,
+        /* trackExecutableBit= */ false);
   }
 
   @Test
@@ -92,7 +93,8 @@ public class RemoteActionInputFetcherTest extends ActionInputPrefetcherTestBase 
             tempPathGenerator,
             DUMMY_REMOTE_OUTPUT_CHECKER,
             ActionOutputDirectoryHelper.createForTesting(),
-            OutputPermissions.READONLY);
+            OutputPermissions.READONLY,
+            /* trackExecutableBit= */ false);
     VirtualActionInput a = ActionsTestUtil.createVirtualActionInput("file1", "hello world");
 
     // act
@@ -126,7 +128,8 @@ public class RemoteActionInputFetcherTest extends ActionInputPrefetcherTestBase 
             tempPathGenerator,
             DUMMY_REMOTE_OUTPUT_CHECKER,
             ActionOutputDirectoryHelper.createForTesting(),
-            OutputPermissions.READONLY);
+            OutputPermissions.READONLY,
+            /* trackExecutableBit= */ false);
 
     // act
     wait(

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -3121,7 +3121,8 @@ public class RemoteExecutionServiceTest {
             tempPathGenerator,
             remoteOutputChecker,
             ActionOutputDirectoryHelper.createForTesting(),
-            OutputPermissions.READONLY);
+            OutputPermissions.READONLY,
+            /* trackExecutableBit= */ false);
 
     var actionFileSystem =
         new RemoteActionFileSystem(
@@ -3151,6 +3152,7 @@ public class RemoteExecutionServiceTest {
         digestUtil,
         remoteOptions,
         Options.getDefaults(ExecutionOptions.class),
+        /* trackExecutableBit= */ false,
         cache,
         executor,
         tempPathGenerator,

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -316,6 +316,7 @@ public class RemoteSpawnCacheTest {
                 digestUtil,
                 options,
                 executionOptions,
+                /* trackExecutableBit= */ false,
                 combinedCache,
                 null,
                 tempPathGenerator,

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -280,7 +280,8 @@ public class RemoteSpawnRunnerTest {
             tempPathGenerator,
             remoteOutputChecker,
             ActionOutputDirectoryHelper.createForTesting(),
-            OutputPermissions.READONLY);
+            OutputPermissions.READONLY,
+            /* trackExecutableBit= */ false);
 
     var actionFileSystem =
         new RemoteActionFileSystem(
@@ -1322,6 +1323,7 @@ public class RemoteSpawnRunnerTest {
             digestUtil,
             remoteOptions,
             executionOptions,
+            /* trackExecutableBit= */ false,
             cache,
             executor,
             tempPathGenerator,
@@ -1858,6 +1860,7 @@ public class RemoteSpawnRunnerTest {
                 digestUtil,
                 remoteOptions,
                 Options.getDefaults(ExecutionOptions.class),
+                /* trackExecutableBit= */ false,
                 cache,
                 executor,
                 tempPathGenerator,

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
@@ -356,6 +356,7 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
             DIGEST_UTIL,
             remoteOptions,
             Options.getDefaults(ExecutionOptions.class),
+            /* trackExecutableBit= */ false,
             remoteCache,
             executor,
             tempPathGenerator,
@@ -1588,7 +1589,8 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
             tempPathGenerator,
             remoteOutputChecker,
             ActionOutputDirectoryHelper.createForTesting(),
-            OutputPermissions.READONLY);
+            OutputPermissions.READONLY,
+            /* trackExecutableBit= */ false);
 
     var actionFileSystem =
         new RemoteActionFileSystem(

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputerTest.java
@@ -375,13 +375,65 @@ public class MerkleTreeComputerTest {
     assertThat(ensureInputsPresentCount.get()).isEqualTo(1);
   }
 
+  @Test
+  public void executableBitAffectsRootDigestWhenTracked() throws Exception {
+    assertThat(rootDigestForFile(/* isExecutable= */ true, /* trackExecutableBit= */ true))
+        .isNotEqualTo(rootDigestForFile(/* isExecutable= */ false, /* trackExecutableBit= */ true));
+  }
+
+  @Test
+  public void executableBitIgnoredWhenNotTracked() throws Exception {
+    // Without tracking, every input is forced executable, so the input's own bit is irrelevant.
+    assertThat(rootDigestForFile(/* isExecutable= */ true, /* trackExecutableBit= */ false))
+        .isEqualTo(rootDigestForFile(/* isExecutable= */ false, /* trackExecutableBit= */ false));
+  }
+
+  @Test
+  public void trackedExecutableInputMatchesForcedExecutableEncoding() throws Exception {
+    // A genuinely executable tracked input encodes identically to the legacy forced-executable
+    // input; tracking only changes the encoding of non-executable inputs.
+    assertThat(rootDigestForFile(/* isExecutable= */ true, /* trackExecutableBit= */ true))
+        .isEqualTo(rootDigestForFile(/* isExecutable= */ false, /* trackExecutableBit= */ false));
+  }
+
   private MerkleTreeComputer createMerkleTreeComputer(MerkleTreeUploader uploader) {
+    return createMerkleTreeComputer(uploader, /* trackExecutableBit= */ false);
+  }
+
+  private MerkleTreeComputer createMerkleTreeComputer(
+      MerkleTreeUploader uploader, boolean trackExecutableBit) {
     return new MerkleTreeComputer(
         new DigestUtil(SyscallCache.NO_CACHE, DigestHashFunction.SHA256),
         uploader,
         "buildRequestId",
         "commandId",
-        "_main");
+        "_main",
+        trackExecutableBit);
+  }
+
+  private Digest rootDigestForFile(boolean isExecutable, boolean trackExecutableBit)
+      throws Exception {
+    var fileArtifact = ActionsTestUtil.createArtifact(artifactRoot, "dir/file");
+    fileArtifact.getPath().getParentDirectory().createDirectoryAndParents();
+    FileSystemUtils.writeContentAsLatin1(fileArtifact.getPath(), "file content");
+    var fakeFileCache = new FakeActionInputFileCache();
+    fakeFileCache.put(
+        fileArtifact,
+        FileArtifactValue.createForNormalFile(
+            fileArtifact.getPath().getDigest(),
+            /* proxy= */ null,
+            fileArtifact.getPath().getFileSize(),
+            isExecutable));
+    var spawn = new SpawnBuilder().withInputs(fileArtifact).build();
+    return createMerkleTreeComputer(/* uploader= */ null, trackExecutableBit)
+        .buildForSpawn(
+            spawn,
+            ImmutableSet.of(),
+            /* scrubber= */ null,
+            createSpawnExecutionContext(spawn, fakeFileCache),
+            RemotePathResolver.createDefault(execRoot),
+            MerkleTreeComputer.BlobPolicy.KEEP)
+        .digest();
   }
 
   private FakeSpawnExecutionContext createSpawnExecutionContext(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStoreTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStoreTest.java
@@ -106,14 +106,25 @@ public final class ActionOutputMetadataStoreTest {
   }
 
   private ActionOutputMetadataStore createStore(ImmutableSet<Artifact> outputs) {
-    return createStore(outputs, /* actionFs= */ null);
+    return createStore(outputs, /* actionFs= */ null, /* trackExecutableBit= */ false);
   }
 
   private ActionOutputMetadataStore createStore(
       ImmutableSet<Artifact> outputs, @Nullable FileSystem actionFs) {
+    return createStore(outputs, actionFs, /* trackExecutableBit= */ false);
+  }
+
+  private ActionOutputMetadataStore createStore(
+      ImmutableSet<Artifact> outputs, boolean trackExecutableBit) {
+    return createStore(outputs, /* actionFs= */ null, trackExecutableBit);
+  }
+
+  private ActionOutputMetadataStore createStore(
+      ImmutableSet<Artifact> outputs, @Nullable FileSystem actionFs, boolean trackExecutableBit) {
     return ActionOutputMetadataStore.create(
         /* archivedTreeArtifactsEnabled= */ false,
         OutputPermissions.READONLY,
+        trackExecutableBit,
         outputs,
         SyscallCache.NO_CACHE,
         tsgm,
@@ -284,6 +295,62 @@ public final class ActionOutputMetadataStoreTest {
   }
 
   @Test
+  public void trackExecutableBit_preservesNonExecutableOutput() throws Exception {
+    Artifact artifact =
+        ActionsTestUtil.createArtifactWithRootRelativePath(
+            outputRoot, PathFragment.create("foo/bar"));
+    Path outputPath = scratch.file(artifact.getPath().getPathString(), "content");
+    outputPath.chmod(0644);
+    chmodCalls.clear();
+    ActionOutputMetadataStore store =
+        createStore(/* outputs= */ ImmutableSet.of(artifact), /* trackExecutableBit= */ true);
+    store.prepareForActionExecution();
+
+    FileArtifactValue metadata = store.getOutputMetadata(artifact);
+
+    assertThat(metadata.isExecutable()).isFalse();
+    // The read/write bits are normalized but the (absent) executable bit is preserved: 0444.
+    assertThat(chmodCalls).containsExactly(outputPath, 0444);
+  }
+
+  @Test
+  public void trackExecutableBit_preservesExecutableOutput() throws Exception {
+    Artifact artifact =
+        ActionsTestUtil.createArtifactWithRootRelativePath(
+            outputRoot, PathFragment.create("foo/bar"));
+    Path outputPath = scratch.file(artifact.getPath().getPathString(), "content");
+    outputPath.chmod(0755);
+    chmodCalls.clear();
+    ActionOutputMetadataStore store =
+        createStore(/* outputs= */ ImmutableSet.of(artifact), /* trackExecutableBit= */ true);
+    store.prepareForActionExecution();
+
+    FileArtifactValue metadata = store.getOutputMetadata(artifact);
+
+    assertThat(metadata.isExecutable()).isTrue();
+    assertThat(chmodCalls).containsExactly(outputPath, 0555);
+  }
+
+  @Test
+  public void withoutTrackExecutableBit_forcesExecutableAndLeavesBitUnset() throws Exception {
+    Artifact artifact =
+        ActionsTestUtil.createArtifactWithRootRelativePath(
+            outputRoot, PathFragment.create("foo/bar"));
+    Path outputPath = scratch.file(artifact.getPath().getPathString(), "content");
+    outputPath.chmod(0644);
+    chmodCalls.clear();
+    ActionOutputMetadataStore store =
+        createStore(/* outputs= */ ImmutableSet.of(artifact), /* trackExecutableBit= */ false);
+    store.prepareForActionExecution();
+
+    FileArtifactValue metadata = store.getOutputMetadata(artifact);
+
+    // Historical behavior: every output is forced executable and the bit is not recorded.
+    assertThat(metadata.isExecutable()).isFalse();
+    assertThat(chmodCalls).containsExactly(outputPath, 0555);
+  }
+
+  @Test
   public void injectRemoteArtifactMetadata() throws Exception {
     PathFragment path = PathFragment.create("foo/bar");
     Artifact artifact = ActionsTestUtil.createArtifactWithRootRelativePath(outputRoot, path);
@@ -299,6 +366,28 @@ public final class ActionOutputMetadataStoreTest {
     assertThat(v).isNotNull();
     assertThat(v.getDigest()).isEqualTo(digest);
     assertThat(v.getSize()).isEqualTo(size);
+    assertThat(chmodCalls).isEmpty();
+  }
+
+  @Test
+  public void injectRemoteArtifactMetadata_executable_preservesExecutableBit() throws Exception {
+    PathFragment path = PathFragment.create("foo/bar");
+    Artifact artifact = ActionsTestUtil.createArtifactWithRootRelativePath(outputRoot, path);
+    ActionOutputMetadataStore store = createStore(/* outputs= */ ImmutableSet.of(artifact));
+    store.prepareForActionExecution();
+
+    // Mirrors a remote (build-without-the-bytes) output whose action result marked it executable.
+    store.injectFile(
+        artifact,
+        FileArtifactValue.createForRemoteFileWithMaterializationData(
+            new byte[] {1, 2, 3},
+            /* size= */ 10,
+            /* locationIndex= */ 1,
+            /* expirationTime= */ null,
+            /* isExecutable= */ true));
+
+    assertThat(store.getOutputMetadata(artifact).isExecutable()).isTrue();
+    // Injected metadata is never chmodded on disk.
     assertThat(chmodCalls).isEmpty();
   }
 
@@ -623,6 +712,7 @@ public final class ActionOutputMetadataStoreTest {
         ActionOutputMetadataStore.create(
             /* archivedTreeArtifactsEnabled= */ false,
             OutputPermissions.WRITABLE,
+            /* trackExecutableBit= */ false,
             /* outputs= */ ImmutableSet.of(output),
             SyscallCache.NO_CACHE,
             tsgm,

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTest.java
@@ -113,6 +113,43 @@ public class ArtifactFunctionTest extends ArtifactFunctionTestCase {
   }
 
   @Test
+  public void sourceArtifact_executable_tracksExecutableBit() throws Exception {
+    Artifact artifact = createSourceArtifact("executable");
+    file(artifact.getPath(), "contents");
+    artifact.getPath().setExecutable(true);
+
+    assertThat(evaluateFileArtifactValue(artifact).isExecutable()).isTrue();
+  }
+
+  @Test
+  public void sourceArtifact_nonExecutable_isNotExecutable() throws Exception {
+    Artifact artifact = createSourceArtifact("nonexecutable");
+    file(artifact.getPath(), "contents");
+    artifact.getPath().setExecutable(false);
+
+    assertThat(evaluateFileArtifactValue(artifact).isExecutable()).isFalse();
+  }
+
+  @Test
+  public void sourceArtifact_notTrackedOnFilesystemWithoutExecutability() throws Exception {
+    // Mirrors Windows, where getPermissions always reports files as executable. The bit carries no
+    // information there and must not be tracked, otherwise every source would re-fingerprint as
+    // executable.
+    setupRoot(
+        new CustomInMemoryFs() {
+          @Override
+          public boolean supportsExecutability() {
+            return false;
+          }
+        });
+    Artifact artifact = createSourceArtifact("executable");
+    file(artifact.getPath(), "contents");
+    artifact.getPath().setExecutable(true);
+
+    assertThat(evaluateFileArtifactValue(artifact).isExecutable()).isFalse();
+  }
+
+  @Test
   public void testUnreadableInputWithFsWithAvailableDigest() throws Throwable {
     final byte[] expectedDigest = {1, 2, 3, 4};
     setupRoot(

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
@@ -421,7 +421,9 @@ final class ExecutionServer extends ExecutionImplBase {
                 exitCode,
                 startTime,
                 (int) wallTime.toMillis(),
-                /* preserveExecutableBit= */ false);
+                // Report the real executable bit of action outputs, like a production remote
+                // execution backend, so it is available to clients that track it.
+                /* preserveExecutableBit= */ true);
         result = manifest.upload(context, cache, NullEventHandler.INSTANCE);
       } catch (ExecException e) {
         if (errStatus == null) {


### PR DESCRIPTION
## Summary

By default, Bazel `chmod 0555`s every action output after execution and reports `is_executable=true` for every file in remote-execution input roots and cache uploads, so an output's real executable bit is lost (#13262).

This PR adds `--incompatible_track_executable_bit` (default off). When enabled, Bazel preserves and propagates the real executable bit of action outputs across local execution, remote execution, build-without-the-bytes, and the action cache.

## Behavior under the flag

- Outputs keep their real executable bit (the read/write bits are still normalized to read-only / writable).
- The bit is carried on `FileArtifactValue` (via dedicated subclasses, so the common non-executable case costs no extra memory), read from local outputs, injected from remote action results, set on downloaded remote outputs, persisted in the action cache, emitted into remote-execution input roots, and uploaded to the remote cache.
- It participates in `FileArtifactValue` equality/fingerprint and `addTo()`, so flipping only the executable bit of an output invalidates consuming actions.

## Commit 2: source artifacts

The second commit extends tracking to **source files**: their real executable bit is read in `createForSourceArtifact` and carried on the source `FileArtifactValue`, so source inputs are no longer force-marked executable when the flag is on.

Unlike outputs, this is **not gated on the flag** — source-artifact metadata is configuration-independent, so it can't depend on a per-build flag without going stale across flag flips or adding a Skyframe edge from every source node to a single precomputed value. The bit is therefore always carried (one extra stat per memoized source-metadata computation). Consequence: **executable source files re-fingerprint once on upgrade** (bounded to files that are `+x`), re-running the actions that consume them a single time — see the caveat below.

## Flag off = no change (with one caveat)

For **outputs**, flag-off is byte-for-byte unchanged: no executable `FileArtifactValue` is ever constructed, so fingerprints, the action-cache on-disk format (the trailing resolved-path marker is reused as a bitmask, no version bump), chmod behavior, Merkle trees and cache uploads are identical to today.

The only deviation is the source-artifact commit above: repos with **executable source files** get a one-time re-fingerprint of those files (and a one-time re-run of the actions consuming them) on upgrade, independent of the flag. Non-executable sources and all outputs are unaffected.

## Other changes

- The in-tree remote worker (`ExecutionServer`) now reports the real executable bit, like a production backend. Required for the bit to round-trip through remote execution.
- `--incompatible_track_executable_bit` is added to the exec-transition propagate allowlist so tools track the bit consistently with the target config.

## Tests

- `ActionOutputMetadataStoreTest` — local outputs preserve `0444`/`0555` vs. forced `0555`; remote-injected (BwoB) metadata carries the bit.
- `MerkleTreeComputerTest` — the bit changes the input-root digest when tracked, is ignored when not, and tracked-executable matches the legacy forced-executable encoding.
- `ActionCacheCheckerTest` — an input whose executable bit flips (same content) causes a `DIGEST_MISMATCH` and re-execution.
- `ArtifactFunctionTest` — executable / non-executable source files are reflected in source metadata.
- `BuildWithoutTheBytesIntegrationTest` — end-to-end over remote execution: downloaded outputs keep their real bit, are forced executable without the flag, and the bit survives in injected metadata when outputs aren't downloaded.

Progress towards #13262 (behind the flag).
