### PR TITLE
remote: add gRPC service config support

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -76,21 +76,6 @@ public final class GoogleAuthUtils {
       String target,
       String proxy,
       AuthAndTLSOptions options,
-      @Nullable List<ClientInterceptor> interceptors)
-      throws IOException {
-    return newChannel(executor, target, proxy, options, interceptors, /* serviceConfig= */ null);
-  }
-
-  /**
-   * Create a new gRPC {@link ManagedChannel}.
-   *
-   * @throws IOException in case the channel can't be constructed.
-   */
-  public static ManagedChannel newChannel(
-      @Nullable Executor executor,
-      String target,
-      String proxy,
-      AuthAndTLSOptions options,
       @Nullable List<ClientInterceptor> interceptors,
       @Nullable Map<String, ?> serviceConfig)
       throws IOException {

--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -78,6 +78,22 @@ public final class GoogleAuthUtils {
       AuthAndTLSOptions options,
       @Nullable List<ClientInterceptor> interceptors)
       throws IOException {
+    return newChannel(executor, target, proxy, options, interceptors, /* serviceConfig= */ null);
+  }
+
+  /**
+   * Create a new gRPC {@link ManagedChannel}.
+   *
+   * @throws IOException in case the channel can't be constructed.
+   */
+  public static ManagedChannel newChannel(
+      @Nullable Executor executor,
+      String target,
+      String proxy,
+      AuthAndTLSOptions options,
+      @Nullable List<ClientInterceptor> interceptors,
+      @Nullable Map<String, ?> serviceConfig)
+      throws IOException {
     Preconditions.checkNotNull(target);
     Preconditions.checkNotNull(options);
 
@@ -134,6 +150,10 @@ public final class GoogleAuthUtils {
       }
       if (interceptors != null) {
         builder.intercept(interceptors);
+      }
+      if (serviceConfig != null) {
+        builder.disableServiceConfigLookUp();
+        builder.defaultServiceConfig(serviceConfig);
       }
       if (sslContext != null) {
         builder.sslContext(sslContext);

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModule.java
@@ -191,7 +191,8 @@ public class BazelBuildEventServiceModule
         config.besBackend(),
         config.besProxy(),
         config.authAndTLSOptions(),
-        /* interceptors= */ null);
+        /* interceptors= */ null,
+        /* serviceConfig= */ null);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -25,6 +25,18 @@ filegroup(
 )
 
 java_library(
+    name = "remote_grpc_service_config",
+    srcs = ["RemoteGrpcServiceConfig.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/remote/options",
+        "//third_party:guava",
+        "@googleapis//google/bytestream:bytestream_java_grpc",
+        "@remoteapis//:build_bazel_remote_asset_v1_remote_asset_java_grpc",
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
+    ],
+)
+
+java_library(
     name = "remote_action",
     srcs = ["RemoteAction.java"],
     deps = [
@@ -220,6 +232,7 @@ java_library(
     deps = [
         ":ReferenceCountedChannel",
         ":channel_factory",
+        ":remote_grpc_service_config",
         ":remote_server_capabilities",
         "//src/main/java/com/google/devtools/build/lib/authandtls",
         "//src/main/java/com/google/devtools/build/lib/events",

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -29,6 +29,9 @@ java_library(
     srcs = ["RemoteGrpcServiceConfig.java"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/remote/options",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        "//third_party:gson",
         "//third_party:guava",
         "@googleapis//google/bytestream:bytestream_java_grpc",
         "@remoteapis//:build_bazel_remote_asset_v1_remote_asset_java_grpc",
@@ -123,6 +126,7 @@ java_library(
         ":remote_action_input_fetcher",
         ":remote_execution_cache",
         ":remote_external_overlay_file_system",
+        ":remote_grpc_service_config",
         ":remote_important_output_handler",
         ":remote_lease_extension",
         ":remote_output_checker",

--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -13,11 +13,9 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static com.google.devtools.build.lib.remote.util.DigestUtil.isOldStyleDigestFunction;
 import static java.lang.String.format;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.DigestFunction;
@@ -65,7 +63,6 @@ final class ByteStreamUploader {
   private final String instanceName;
   private final ReferenceCountedChannel channel;
   private final CallCredentialsProvider callCredentialsProvider;
-  private final long callTimeoutSecs;
   private final RemoteRetrier retrier;
   private final DigestFunction.Value digestFunction;
   private final AtomicBoolean queryWriteStatusImplemented = new AtomicBoolean(true);
@@ -79,23 +76,18 @@ final class ByteStreamUploader {
    *     call. See the {@code ByteStream} service definition for details
    * @param channel the {@link io.grpc.Channel} to use for calls
    * @param callCredentialsProvider the credentials provider to use for authentication.
-   * @param callTimeoutSecs the timeout in seconds after which a {@code Write} gRPC call must be
-   *     complete. The timeout resets between retries
    * @param retrier the {@link RemoteRetrier} whose backoff strategy to use for retry timings.
    */
   ByteStreamUploader(
       @Nullable String instanceName,
       ReferenceCountedChannel channel,
       CallCredentialsProvider callCredentialsProvider,
-      long callTimeoutSecs,
       RemoteRetrier retrier,
       int maximumOpenFiles,
       DigestFunction.Value digestFunction) {
-    checkArgument(callTimeoutSecs > 0, "callTimeoutSecs must be gt 0.");
     this.instanceName = instanceName;
     this.channel = channel;
     this.callCredentialsProvider = callCredentialsProvider;
-    this.callTimeoutSecs = callTimeoutSecs;
     this.retrier = retrier;
     this.openedFilePermits = maximumOpenFiles != -1 ? new Semaphore(maximumOpenFiles) : null;
     this.digestFunction = digestFunction;
@@ -180,14 +172,7 @@ final class ByteStreamUploader {
       }
     }
     AsyncUpload newUpload =
-        new AsyncUpload(
-            context,
-            channel,
-            callCredentialsProvider,
-            callTimeoutSecs,
-            retrier,
-            resourceName,
-            chunker);
+        new AsyncUpload(context, channel, callCredentialsProvider, retrier, resourceName, chunker);
     ListenableFuture<Void> currUpload = newUpload.start();
     currUpload.addListener(
         () -> {
@@ -213,7 +198,6 @@ final class ByteStreamUploader {
     private final RemoteActionExecutionContext context;
     private final ReferenceCountedChannel channel;
     private final CallCredentialsProvider callCredentialsProvider;
-    private final long callTimeoutSecs;
     private final Retrier retrier;
     private final String resourceName;
     private final Chunker chunker;
@@ -225,14 +209,12 @@ final class ByteStreamUploader {
         RemoteActionExecutionContext context,
         ReferenceCountedChannel channel,
         CallCredentialsProvider callCredentialsProvider,
-        long callTimeoutSecs,
         Retrier retrier,
         String resourceName,
         Chunker chunker) {
       this.context = context;
       this.channel = channel;
       this.callCredentialsProvider = callCredentialsProvider;
-      this.callTimeoutSecs = callTimeoutSecs;
       this.retrier = retrier;
       this.progressiveBackoff = new ProgressiveBackoff(retrier::newBackoff);
       this.resourceName = resourceName;
@@ -322,16 +304,14 @@ final class ByteStreamUploader {
       return ByteStreamGrpc.newFutureStub(channel)
           .withInterceptors(
               TracingMetadataUtils.attachMetadataInterceptor(context.getRequestMetadata()))
-          .withCallCredentials(callCredentialsProvider.getCallCredentials())
-          .withDeadlineAfter(callTimeoutSecs, SECONDS);
+          .withCallCredentials(callCredentialsProvider.getCallCredentials());
     }
 
     private ByteStreamStub bsAsyncStub(Channel channel) {
       return ByteStreamGrpc.newStub(channel)
           .withInterceptors(
               TracingMetadataUtils.attachMetadataInterceptor(context.getRequestMetadata()))
-          .withCallCredentials(callCredentialsProvider.getCallCredentials())
-          .withDeadlineAfter(callTimeoutSecs, SECONDS);
+          .withCallCredentials(callCredentialsProvider.getCallCredentials());
     }
 
     private ListenableFuture<Long> query() {

--- a/src/main/java/com/google/devtools/build/lib/remote/ChannelFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ChannelFactory.java
@@ -18,10 +18,15 @@ import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 /** A factory interface for creating a {@link ManagedChannel}. */
 public interface ChannelFactory {
   ManagedChannel newChannel(
-      String target, String proxy, AuthAndTLSOptions options, List<ClientInterceptor> interceptors)
+      String target,
+      String proxy,
+      AuthAndTLSOptions options,
+      List<ClientInterceptor> interceptors,
+      Map<String, ?> serviceConfig)
       throws IOException;
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/GoogleChannelConnectionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GoogleChannelConnectionFactory.java
@@ -98,7 +98,13 @@ public class GoogleChannelConnectionFactory
   @Override
   public Single<ChannelConnectionWithServerCapabilities> create() {
     return Single.fromCallable(
-            () -> channelFactory.newChannel(target, proxy, options, interceptors))
+            () ->
+                channelFactory.newChannel(
+                    target,
+                    proxy,
+                    options,
+                    interceptors,
+                    RemoteGrpcServiceConfig.create(remoteOptions)))
         .flatMap(
             channel -> {
               var serverCapabilitiesSingle =

--- a/src/main/java/com/google/devtools/build/lib/remote/GoogleChannelConnectionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GoogleChannelConnectionFactory.java
@@ -39,6 +39,7 @@ import io.grpc.ManagedChannel;
 import io.reactivex.rxjava3.core.Single;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
@@ -61,6 +62,7 @@ public class GoogleChannelConnectionFactory
   private final Reporter reporter;
   @Nullable private final RemoteServerCapabilities remoteServerCapabilities;
   private final RemoteOptions remoteOptions;
+  private final Map<String, ?> serviceConfig;
   private final DigestFunction.Value digestFunction;
   private final ServerCapabilitiesRequirement requirement;
 
@@ -69,6 +71,7 @@ public class GoogleChannelConnectionFactory
       String target,
       String proxy,
       RemoteOptions remoteOptions,
+      Map<String, ?> serviceConfig,
       AuthAndTLSOptions options,
       List<ClientInterceptor> interceptors,
       int maxConcurrency,
@@ -91,6 +94,7 @@ public class GoogleChannelConnectionFactory
     this.reporter = reporter;
     this.remoteServerCapabilities = remoteServerCapabilities;
     this.remoteOptions = remoteOptions;
+    this.serviceConfig = serviceConfig;
     this.digestFunction = digestFunction;
     this.requirement = requirement;
   }
@@ -98,13 +102,7 @@ public class GoogleChannelConnectionFactory
   @Override
   public Single<ChannelConnectionWithServerCapabilities> create() {
     return Single.fromCallable(
-            () ->
-                channelFactory.newChannel(
-                    target,
-                    proxy,
-                    options,
-                    interceptors,
-                    RemoteGrpcServiceConfig.create(remoteOptions)))
+            () -> channelFactory.newChannel(target, proxy, options, interceptors, serviceConfig))
         .flatMap(
             channel -> {
               var serverCapabilitiesSingle =

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -76,7 +76,6 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -117,7 +116,6 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
             options.getRemoteInstanceName(),
             channel,
             callCredentialsProvider,
-            options.getRemoteTimeout().toSeconds(),
             retrier,
             options.getMaximumOpenFiles(),
             digestUtil.getDigestFunction());
@@ -150,8 +148,7 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
         .withInterceptors(
             TracingMetadataUtils.attachMetadataInterceptor(context.getRequestMetadata()),
             new NetworkTimeInterceptor(context::getNetworkTime))
-        .withCallCredentials(callCredentialsProvider.getCallCredentials())
-        .withDeadlineAfter(options.getRemoteTimeout().toSeconds(), TimeUnit.SECONDS);
+        .withCallCredentials(callCredentialsProvider.getCallCredentials());
   }
 
   private ByteStreamStub bsAsyncStub(RemoteActionExecutionContext context, Channel channel) {
@@ -159,8 +156,7 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
         .withInterceptors(
             TracingMetadataUtils.attachMetadataInterceptor(context.getRequestMetadata()),
             new NetworkTimeInterceptor(context::getNetworkTime))
-        .withCallCredentials(callCredentialsProvider.getCallCredentials())
-        .withDeadlineAfter(options.getRemoteTimeout().toSeconds(), TimeUnit.SECONDS);
+        .withCallCredentials(callCredentialsProvider.getCallCredentials());
   }
 
   private ActionCacheFutureStub acFutureStub(
@@ -169,8 +165,7 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
         .withInterceptors(
             TracingMetadataUtils.attachMetadataInterceptor(context.getRequestMetadata()),
             new NetworkTimeInterceptor(context::getNetworkTime))
-        .withCallCredentials(callCredentialsProvider.getCallCredentials())
-        .withDeadlineAfter(options.getRemoteTimeout().toSeconds(), TimeUnit.SECONDS);
+        .withCallCredentials(callCredentialsProvider.getCallCredentials());
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteGrpcServiceConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteGrpcServiceConfig.java
@@ -20,15 +20,49 @@ import build.bazel.remote.execution.v2.ContentAddressableStorageGrpc;
 import com.google.bytestream.ByteStreamGrpc;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Map;
 
 /** Builds Bazel's generated gRPC service config for remote services. */
 public final class RemoteGrpcServiceConfig {
+  private static final Gson GSON = new Gson();
+  private static final Type MAP_TYPE = new TypeToken<Map<String, ?>>() {}.getType();
+  private static final ImmutableSet<String> SUPPORTED_TOP_LEVEL_FIELDS =
+      ImmutableSet.of("methodConfig");
+  private static final ImmutableSet<String> SUPPORTED_METHOD_CONFIG_FIELDS =
+      ImmutableSet.of("name", "timeout");
+  private static final ImmutableSet<String> SUPPORTED_NAME_FIELDS =
+      ImmutableSet.of("service", "method");
+
   private RemoteGrpcServiceConfig() {}
 
   public static ImmutableMap<String, ?> create(RemoteOptions options) {
     return create(options.getRemoteTimeout());
+  }
+
+  public static ImmutableMap<String, ?> create(RemoteOptions options, Path workingDirectory)
+      throws IOException {
+    PathFragment serviceConfigPath = options.getRemoteGrpcServiceConfig();
+    if (serviceConfigPath == null) {
+      return create(options);
+    }
+    return parse(workingDirectory.getRelative(serviceConfigPath));
   }
 
   static ImmutableMap<String, ?> create(Duration remoteTimeout) {
@@ -45,5 +79,75 @@ public final class RemoteGrpcServiceConfig {
                     ImmutableMap.of("service", FetchGrpc.SERVICE_NAME)),
                 "timeout",
                 remoteTimeout.toSeconds() + "s")));
+  }
+
+  private static ImmutableMap<String, ?> parse(Path serviceConfigPath) throws IOException {
+    try (Reader reader =
+        new InputStreamReader(serviceConfigPath.getInputStream(), StandardCharsets.UTF_8)) {
+      JsonObject root = requireObject(JsonParser.parseReader(reader), "service config");
+      rejectUnsupportedFields(root, SUPPORTED_TOP_LEVEL_FIELDS, "service config");
+      rejectUnsupportedMethodConfigFields(root);
+      Map<String, ?> serviceConfig = GSON.fromJson(root, MAP_TYPE);
+      return ImmutableMap.copyOf(serviceConfig);
+    } catch (JsonParseException e) {
+      throw new IOException(
+          "failed to parse " + serviceConfigPath.getPathString() + ": " + e.getMessage(), e);
+    }
+  }
+
+  private static void rejectUnsupportedMethodConfigFields(JsonObject rootObject)
+      throws IOException {
+    JsonElement methodConfigsElement = rootObject.get("methodConfig");
+    if (methodConfigsElement == null || !methodConfigsElement.isJsonArray()) {
+      return;
+    }
+
+    JsonArray methodConfigs = methodConfigsElement.getAsJsonArray();
+    for (int i = 0; i < methodConfigs.size(); ++i) {
+      JsonElement methodConfigElement = methodConfigs.get(i);
+      if (!methodConfigElement.isJsonObject()) {
+        continue;
+      }
+
+      JsonObject methodConfig = methodConfigElement.getAsJsonObject();
+      String methodConfigPath = "methodConfig[" + i + "]";
+      rejectUnsupportedFields(methodConfig, SUPPORTED_METHOD_CONFIG_FIELDS, methodConfigPath);
+      rejectUnsupportedNameFields(methodConfig, methodConfigPath);
+    }
+  }
+
+  private static void rejectUnsupportedNameFields(JsonObject methodConfig, String methodConfigPath)
+      throws IOException {
+    JsonElement namesElement = methodConfig.get("name");
+    if (namesElement == null || !namesElement.isJsonArray()) {
+      return;
+    }
+
+    JsonArray names = namesElement.getAsJsonArray();
+    for (int i = 0; i < names.size(); ++i) {
+      JsonElement nameElement = names.get(i);
+      if (nameElement.isJsonObject()) {
+        rejectUnsupportedFields(
+            nameElement.getAsJsonObject(),
+            SUPPORTED_NAME_FIELDS,
+            methodConfigPath + ".name[" + i + "]");
+      }
+    }
+  }
+
+  private static void rejectUnsupportedFields(
+      JsonObject object, ImmutableSet<String> supportedFields, String path) throws IOException {
+    for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
+      if (!supportedFields.contains(entry.getKey())) {
+        throw new IOException(path + " contains unsupported field '" + entry.getKey() + "'");
+      }
+    }
+  }
+
+  private static JsonObject requireObject(JsonElement element, String path) throws IOException {
+    if (element == null || !element.isJsonObject()) {
+      throw new IOException(path + " must be an object");
+    }
+    return element.getAsJsonObject();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteGrpcServiceConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteGrpcServiceConfig.java
@@ -1,0 +1,49 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import build.bazel.remote.asset.v1.FetchGrpc;
+import build.bazel.remote.execution.v2.ActionCacheGrpc;
+import build.bazel.remote.execution.v2.CapabilitiesGrpc;
+import build.bazel.remote.execution.v2.ContentAddressableStorageGrpc;
+import com.google.bytestream.ByteStreamGrpc;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import java.time.Duration;
+
+/** Builds Bazel's generated gRPC service config for remote services. */
+public final class RemoteGrpcServiceConfig {
+  private RemoteGrpcServiceConfig() {}
+
+  public static ImmutableMap<String, ?> create(RemoteOptions options) {
+    return create(options.getRemoteTimeout());
+  }
+
+  static ImmutableMap<String, ?> create(Duration remoteTimeout) {
+    return ImmutableMap.of(
+        "methodConfig",
+        ImmutableList.of(
+            ImmutableMap.of(
+                "name",
+                ImmutableList.of(
+                    ImmutableMap.of("service", ActionCacheGrpc.SERVICE_NAME),
+                    ImmutableMap.of("service", CapabilitiesGrpc.SERVICE_NAME),
+                    ImmutableMap.of("service", ContentAddressableStorageGrpc.SERVICE_NAME),
+                    ImmutableMap.of("service", ByteStreamGrpc.SERVICE_NAME),
+                    ImmutableMap.of("service", FetchGrpc.SERVICE_NAME)),
+                "timeout",
+                remoteTimeout.toSeconds() + "s")));
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -126,6 +126,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.channels.ClosedChannelException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -165,14 +166,16 @@ public final class RemoteModule extends BlazeModule {
             String target,
             String proxy,
             AuthAndTLSOptions options,
-            List<ClientInterceptor> interceptors)
+            List<ClientInterceptor> interceptors,
+            Map<String, ?> serviceConfig)
             throws IOException {
           return GoogleAuthUtils.newChannel(
               executorService,
               target,
               proxy,
               options,
-              interceptors.isEmpty() ? null : interceptors);
+              interceptors.isEmpty() ? null : interceptors,
+              serviceConfig);
         }
       };
 
@@ -726,7 +729,6 @@ public final class RemoteModule extends BlazeModule {
             invocationId,
             remoteOptions.getRemoteInstanceName(),
             callCredentials,
-            remoteOptions.getRemoteTimeout().toSeconds(),
             retrier);
 
     ReferenceCountedChannel execChannel = null;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -657,6 +657,16 @@ public final class RemoteModule extends BlazeModule {
             // Resolved lazily: rpcLogFile is created further below, after this retrier.
             () -> rpcLogFile);
 
+    Map<String, ?> remoteGrpcServiceConfig;
+    try {
+      remoteGrpcServiceConfig =
+          RemoteGrpcServiceConfig.create(remoteOptions, env.getWorkingDirectory());
+    } catch (IOException e) {
+      throw createOptionsExitException(
+          "Invalid --remote_grpc_service_config: " + e.getMessage(),
+          FailureDetails.RemoteOptions.Code.REMOTE_GRPC_SERVICE_CONFIG_INVALID);
+    }
+
     if (!Strings.isNullOrEmpty(remoteOptions.getRemoteOutputService())) {
       var bazelOutputServiceChannel =
           createChannel(
@@ -666,6 +676,7 @@ public final class RemoteModule extends BlazeModule {
               Options.getDefaults(AuthAndTLSOptions.class),
               null,
               null,
+              remoteGrpcServiceConfig,
               channelFactory,
               remoteOptions.getRemoteOutputService(),
               null,
@@ -753,6 +764,7 @@ public final class RemoteModule extends BlazeModule {
                   TracingMetadataUtils.newExecHeadersInterceptor(
                       remoteOptions.getRemoteHeaders(), remoteOptions.getRemoteExecHeaders()),
                   loggingInterceptor,
+                  remoteGrpcServiceConfig,
                   channelFactory,
                   remoteOptions.getRemoteExecutor(),
                   remoteOptions.getRemoteProxy(),
@@ -773,6 +785,7 @@ public final class RemoteModule extends BlazeModule {
                   TracingMetadataUtils.newExecHeadersInterceptor(
                       remoteOptions.getRemoteHeaders(), remoteOptions.getRemoteExecHeaders()),
                   loggingInterceptor,
+                  remoteGrpcServiceConfig,
                   channelFactory,
                   remoteOptions.getRemoteExecutor(),
                   remoteOptions.getRemoteProxy(),
@@ -795,6 +808,7 @@ public final class RemoteModule extends BlazeModule {
                 TracingMetadataUtils.newCacheHeadersInterceptor(
                     remoteOptions.getRemoteHeaders(), remoteOptions.getRemoteCacheHeaders()),
                 loggingInterceptor,
+                remoteGrpcServiceConfig,
                 channelFactory,
                 remoteOptions.getRemoteCache(),
                 remoteOptions.getRemoteProxy(),
@@ -914,6 +928,7 @@ public final class RemoteModule extends BlazeModule {
                 authAndTlsOptions,
                 /* headersInterceptor= */ null,
                 loggingInterceptor,
+                remoteGrpcServiceConfig,
                 channelFactory,
                 remoteOptions.getRemoteDownloader(),
                 remoteOptions.getRemoteProxy(),
@@ -952,6 +967,7 @@ public final class RemoteModule extends BlazeModule {
       AuthAndTLSOptions authAndTlsOptions,
       @Nullable ClientInterceptor headersInterceptor,
       @Nullable ClientInterceptor loggingInterceptor,
+      Map<String, ?> serviceConfig,
       ChannelFactory channelFactory,
       String target,
       String proxy,
@@ -976,6 +992,7 @@ public final class RemoteModule extends BlazeModule {
                 target,
                 proxy,
                 remoteOptions,
+                serviceConfig,
                 authAndTlsOptions,
                 interceptors.build(),
                 maxConcurrencyPerConnection,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
@@ -34,7 +34,6 @@ import io.grpc.CallCredentials;
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /** Fetches the ServerCapabilities of the remote execution/cache server. */
@@ -43,7 +42,6 @@ class RemoteServerCapabilities {
   private final String commandId;
   @Nullable private final String instanceName;
   @Nullable private final CallCredentials callCredentials;
-  private final long callTimeoutSecs;
   private final RemoteRetrier retrier;
 
   public RemoteServerCapabilities(
@@ -51,13 +49,11 @@ class RemoteServerCapabilities {
       String commandId,
       @Nullable String instanceName,
       @Nullable CallCredentials callCredentials,
-      long callTimeoutSecs,
       RemoteRetrier retrier) {
     this.buildRequestId = buildRequestId;
     this.commandId = commandId;
     this.instanceName = instanceName;
     this.callCredentials = callCredentials;
-    this.callTimeoutSecs = callTimeoutSecs;
     this.retrier = retrier;
   }
 
@@ -66,8 +62,7 @@ class RemoteServerCapabilities {
     return CapabilitiesGrpc.newFutureStub(channel)
         .withInterceptors(
             TracingMetadataUtils.attachMetadataInterceptor(context.getRequestMetadata()))
-        .withCallCredentials(callCredentials)
-        .withDeadlineAfter(callTimeoutSecs, TimeUnit.SECONDS);
+        .withCallCredentials(callCredentials);
   }
 
   public ListenableFuture<ServerCapabilities> get(ManagedChannel channel) {

--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.remote.downloader;
 
-
 import build.bazel.remote.asset.v1.FetchBlobRequest;
 import build.bazel.remote.asset.v1.FetchBlobResponse;
 import build.bazel.remote.asset.v1.FetchGrpc;
@@ -57,7 +56,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -313,8 +311,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
         .withInterceptors(
             TracingMetadataUtils.newDownloaderHeadersInterceptor(
                 options.getRemoteHeaders(), options.getRemoteDownloaderHeaders()))
-        .withCallCredentials(credentials.orElse(null))
-        .withDeadlineAfter(options.getRemoteTimeout().toSeconds(), TimeUnit.SECONDS);
+        .withCallCredentials(credentials.orElse(null));
   }
 
   private OutputStream newOutputStream(Path destination, Optional<Checksum> checksum)

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -269,6 +269,21 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
   public abstract Duration getRemoteTimeout();
 
   @Option(
+      name = "remote_grpc_service_config",
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      converter = OptionsUtils.EmptyToNullPathFragmentConverter.class,
+      help =
+          "Path to a gRPC service config JSON file for remote gRPC channels. This replaces the"
+              + " service config Bazel generates from --remote_timeout. Only a subset of the gRPC"
+              + " service config JSON schema is supported: top-level methodConfig entries with"
+              + " name objects containing service and optional method, plus timeout. Other service"
+              + " config fields are rejected and may be supported in the future.")
+  @Nullable
+  public abstract PathFragment getRemoteGrpcServiceConfig();
+
+  @Option(
       name = "remote_bytestream_uri_prefix",
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.REMOTE,

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -309,6 +309,7 @@ message RemoteOptions {
     CREDENTIALS_WRITE_FAILURE = 3 [(metadata) = { exit_code: 36 }];
     DOWNLOADER_WITHOUT_GRPC_CACHE = 4 [(metadata) = { exit_code: 2 }];
     EXECUTION_WITH_INVALID_CACHE = 5 [(metadata) = { exit_code: 2 }];
+    REMOTE_GRPC_SERVICE_CONFIG_INVALID = 7 [(metadata) = { exit_code: 2 }];
 
     reserved 6;
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -136,6 +136,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote:remote_action_file_system",
         "//src/main/java/com/google/devtools/build/lib/remote:remote_action_input_fetcher",
         "//src/main/java/com/google/devtools/build/lib/remote:remote_execution_cache",
+        "//src/main/java/com/google/devtools/build/lib/remote:remote_grpc_service_config",
         "//src/main/java/com/google/devtools/build/lib/remote:remote_module",
         "//src/main/java/com/google/devtools/build/lib/remote:remote_output_checker",
         "//src/main/java/com/google/devtools/build/lib/remote:remote_repository_remote_executor",

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -1656,7 +1656,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -1713,7 +1712,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -171,7 +171,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -200,7 +199,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -265,7 +263,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            3,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -383,7 +380,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            300,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -506,7 +502,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            300,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -566,7 +561,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            1,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -626,7 +620,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            3,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -697,7 +690,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            3,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -737,7 +729,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            3,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -792,7 +783,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            300,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -826,7 +816,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -860,7 +849,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -895,7 +883,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             maximumOpenFiles,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -935,7 +922,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -973,7 +959,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -1105,7 +1090,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -1168,7 +1152,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -1206,7 +1189,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -1247,7 +1229,6 @@ public class ByteStreamUploaderTest {
             /* instanceName= */ null,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -1292,7 +1273,6 @@ public class ByteStreamUploaderTest {
             /* instanceName= */ null,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.BLAKE3);
@@ -1339,7 +1319,6 @@ public class ByteStreamUploaderTest {
             /* instanceName= */ null,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -1393,7 +1372,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             callCredentialsProvider,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -1450,7 +1428,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             callCredentialsProvider,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -1523,7 +1500,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);
@@ -1584,7 +1560,6 @@ public class ByteStreamUploaderTest {
             INSTANCE_NAME,
             referenceCountedChannel,
             CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
             retrier,
             /* maximumOpenFiles= */ -1,
             /* digestFunction= */ DigestFunction.Value.SHA256);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteGrpcServiceConfigTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteGrpcServiceConfigTest.java
@@ -1,0 +1,134 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.testutil.Scratch;
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import com.google.devtools.common.options.OptionsParser;
+import java.io.IOException;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link RemoteGrpcServiceConfig}. */
+@RunWith(JUnit4.class)
+public final class RemoteGrpcServiceConfigTest {
+
+  private static RemoteOptions parseRemoteOptions(String... args) throws Exception {
+    OptionsParser parser = OptionsParser.builder().optionsClasses(RemoteOptions.class).build();
+    parser.parse(args);
+    return parser.getOptions(RemoteOptions.class);
+  }
+
+  @Test
+  public void create_usesRemoteTimeoutForRemoteServices() {
+    assertThat(RemoteGrpcServiceConfig.create(Duration.ofSeconds(123)))
+        .containsExactly(
+            "methodConfig",
+            ImmutableList.of(
+                ImmutableMap.of(
+                    "name",
+                    ImmutableList.of(
+                        ImmutableMap.of("service", "build.bazel.remote.execution.v2.ActionCache"),
+                        ImmutableMap.of("service", "build.bazel.remote.execution.v2.Capabilities"),
+                        ImmutableMap.of(
+                            "service", "build.bazel.remote.execution.v2.ContentAddressableStorage"),
+                        ImmutableMap.of("service", "google.bytestream.ByteStream"),
+                        ImmutableMap.of("service", "build.bazel.remote.asset.v1.Fetch")),
+                    "timeout",
+                    "123s")));
+  }
+
+  @Test
+  public void create_usesUserSuppliedJsonFile() throws Exception {
+    Scratch scratch = new Scratch(new InMemoryFileSystem(DigestHashFunction.SHA256));
+    Path workspace = scratch.dir("/workspace");
+    scratch.file(
+        "/workspace/service_config.json",
+        """
+        {
+          "methodConfig": [
+            {
+              "name": [
+                {
+                  "service": "build.bazel.remote.execution.v2.ActionCache",
+                  "method": "GetActionResult"
+                },
+                {"service": "google.bytestream.ByteStream"}
+              ],
+              "timeout": "3.500s"
+            }
+          ]
+        }
+        """);
+
+    assertThat(
+            RemoteGrpcServiceConfig.create(
+                parseRemoteOptions("--remote_grpc_service_config=service_config.json"), workspace))
+        .containsExactly(
+            "methodConfig",
+            ImmutableList.of(
+                ImmutableMap.of(
+                    "name",
+                    ImmutableList.of(
+                        ImmutableMap.of(
+                            "service",
+                            "build.bazel.remote.execution.v2.ActionCache",
+                            "method",
+                            "GetActionResult"),
+                        ImmutableMap.of("service", "google.bytestream.ByteStream")),
+                    "timeout",
+                    "3.500s")));
+  }
+
+  @Test
+  public void create_rejectsUnsupportedJsonFields() throws Exception {
+    Scratch scratch = new Scratch(new InMemoryFileSystem(DigestHashFunction.SHA256));
+    Path workspace = scratch.dir("/workspace");
+    scratch.file(
+        "/workspace/service_config.json",
+        """
+        {
+          "methodConfig": [
+            {
+              "name": [{"service": "google.bytestream.ByteStream"}],
+              "timeout": "1s",
+              "retryPolicy": {}
+            }
+          ]
+        }
+        """);
+
+    IOException e =
+        Assert.assertThrows(
+            IOException.class,
+            () ->
+                RemoteGrpcServiceConfig.create(
+                    parseRemoteOptions("--remote_grpc_service_config=service_config.json"),
+                    workspace));
+
+    assertThat(e)
+        .hasMessageThat()
+        .contains("methodConfig[0] contains unsupported field 'retryPolicy'");
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -238,6 +238,12 @@ public final class RemoteModuleTest {
         .build();
   }
 
+  private static RemoteOptions parseRemoteOptions(String... args) throws Exception {
+    OptionsParser parser = OptionsParser.builder().optionsClasses(RemoteOptions.class).build();
+    parser.parse(args);
+    return parser.getOptions(RemoteOptions.class);
+  }
+
   @Test
   public void remoteGrpcServiceConfig_usesRemoteTimeoutForRemoteServices() {
     assertThat(RemoteGrpcServiceConfig.create(Duration.ofSeconds(123)))
@@ -255,6 +261,80 @@ public final class RemoteModuleTest {
                         ImmutableMap.of("service", "build.bazel.remote.asset.v1.Fetch")),
                     "timeout",
                     "123s")));
+  }
+
+  @Test
+  public void remoteGrpcServiceConfig_usesUserSuppliedJsonFile() throws Exception {
+    Scratch scratch = new Scratch(new InMemoryFileSystem(DigestHashFunction.SHA256));
+    Path workspace = scratch.dir("/workspace");
+    scratch.file(
+        "/workspace/service_config.json",
+        """
+        {
+          "methodConfig": [
+            {
+              "name": [
+                {
+                  "service": "build.bazel.remote.execution.v2.ActionCache",
+                  "method": "GetActionResult"
+                },
+                {"service": "google.bytestream.ByteStream"}
+              ],
+              "timeout": "3.500s"
+            }
+          ]
+        }
+        """);
+
+    assertThat(
+            RemoteGrpcServiceConfig.create(
+                parseRemoteOptions("--remote_grpc_service_config=service_config.json"),
+                workspace))
+        .containsExactly(
+            "methodConfig",
+            ImmutableList.of(
+                ImmutableMap.of(
+                    "name",
+                    ImmutableList.of(
+                        ImmutableMap.of(
+                            "service",
+                            "build.bazel.remote.execution.v2.ActionCache",
+                            "method",
+                            "GetActionResult"),
+                        ImmutableMap.of("service", "google.bytestream.ByteStream")),
+                    "timeout",
+                    "3.500s")));
+  }
+
+  @Test
+  public void remoteGrpcServiceConfig_rejectsUnsupportedJsonFields() throws Exception {
+    Scratch scratch = new Scratch(new InMemoryFileSystem(DigestHashFunction.SHA256));
+    Path workspace = scratch.dir("/workspace");
+    scratch.file(
+        "/workspace/service_config.json",
+        """
+        {
+          "methodConfig": [
+            {
+              "name": [{"service": "google.bytestream.ByteStream"}],
+              "timeout": "1s",
+              "retryPolicy": {}
+            }
+          ]
+        }
+        """);
+
+    IOException e =
+        Assert.assertThrows(
+            IOException.class,
+            () ->
+                RemoteGrpcServiceConfig.create(
+                    parseRemoteOptions("--remote_grpc_service_config=service_config.json"),
+                    workspace));
+
+    assertThat(e)
+        .hasMessageThat()
+        .contains("methodConfig[0] contains unsupported field 'retryPolicy'");
   }
 
   private RemoteModule remoteModule;

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -88,6 +88,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.Assert;
 import org.junit.Before;
@@ -138,8 +140,21 @@ public final class RemoteModuleTest {
                   .build())
           .build();
 
+  @FunctionalInterface
+  private interface WorkspaceInitializer {
+    void initialize(Scratch scratch) throws IOException;
+  }
+
   private static CommandEnvironment createTestCommandEnvironment(
       RemoteModule remoteModule, RemoteOptions remoteOptions)
+      throws IOException, AbruptExitException {
+    return createTestCommandEnvironment(remoteModule, remoteOptions, scratch -> {});
+  }
+
+  private static CommandEnvironment createTestCommandEnvironment(
+      RemoteModule remoteModule,
+      RemoteOptions remoteOptions,
+      WorkspaceInitializer workspaceInitializer)
       throws IOException, AbruptExitException {
     CoreOptions coreOptions = Options.getDefaults(CoreOptions.class);
     CommonCommandOptions commonCommandOptions = Options.getDefaults(CommonCommandOptions.class);
@@ -165,6 +180,8 @@ public final class RemoteModuleTest {
     ServerDirectories serverDirectories =
         new ServerDirectories(
             scratch.dir("install"), scratch.dir("output"), scratch.dir("user_root"));
+    Path workspacePath = scratch.dir("/workspace");
+    workspaceInitializer.initialize(scratch);
 
     BlazeRuntime runtime =
         new BlazeRuntime.Builder()
@@ -186,7 +203,7 @@ public final class RemoteModuleTest {
             .build();
 
     BlazeDirectories directories =
-        new BlazeDirectories(serverDirectories, scratch.dir("/workspace"), productName);
+        new BlazeDirectories(serverDirectories, workspacePath, productName);
     BlazeWorkspace workspace = runtime.initWorkspace(directories, BinTools.empty(directories));
     Command command = BuildCommand.class.getAnnotation(Command.class);
     return workspace.initCommand(
@@ -244,109 +261,97 @@ public final class RemoteModuleTest {
     return parser.getOptions(RemoteOptions.class);
   }
 
-  @Test
-  public void remoteGrpcServiceConfig_usesRemoteTimeoutForRemoteServices() {
-    assertThat(RemoteGrpcServiceConfig.create(Duration.ofSeconds(123)))
-        .containsExactly(
-            "methodConfig",
-            ImmutableList.of(
-                ImmutableMap.of(
-                    "name",
-                    ImmutableList.of(
-                        ImmutableMap.of("service", "build.bazel.remote.execution.v2.ActionCache"),
-                        ImmutableMap.of("service", "build.bazel.remote.execution.v2.Capabilities"),
-                        ImmutableMap.of(
-                            "service", "build.bazel.remote.execution.v2.ContentAddressableStorage"),
-                        ImmutableMap.of("service", "google.bytestream.ByteStream"),
-                        ImmutableMap.of("service", "build.bazel.remote.asset.v1.Fetch")),
-                    "timeout",
-                    "123s")));
-  }
-
-  @Test
-  public void remoteGrpcServiceConfig_usesUserSuppliedJsonFile() throws Exception {
-    Scratch scratch = new Scratch(new InMemoryFileSystem(DigestHashFunction.SHA256));
-    Path workspace = scratch.dir("/workspace");
-    scratch.file(
-        "/workspace/service_config.json",
-        """
-        {
-          "methodConfig": [
-            {
-              "name": [
-                {
-                  "service": "build.bazel.remote.execution.v2.ActionCache",
-                  "method": "GetActionResult"
-                },
-                {"service": "google.bytestream.ByteStream"}
-              ],
-              "timeout": "3.500s"
-            }
-          ]
-        }
-        """);
-
-    assertThat(
-            RemoteGrpcServiceConfig.create(
-                parseRemoteOptions("--remote_grpc_service_config=service_config.json"),
-                workspace))
-        .containsExactly(
-            "methodConfig",
-            ImmutableList.of(
-                ImmutableMap.of(
-                    "name",
-                    ImmutableList.of(
-                        ImmutableMap.of(
-                            "service",
-                            "build.bazel.remote.execution.v2.ActionCache",
-                            "method",
-                            "GetActionResult"),
-                        ImmutableMap.of("service", "google.bytestream.ByteStream")),
-                    "timeout",
-                    "3.500s")));
-  }
-
-  @Test
-  public void remoteGrpcServiceConfig_rejectsUnsupportedJsonFields() throws Exception {
-    Scratch scratch = new Scratch(new InMemoryFileSystem(DigestHashFunction.SHA256));
-    Path workspace = scratch.dir("/workspace");
-    scratch.file(
-        "/workspace/service_config.json",
-        """
-        {
-          "methodConfig": [
-            {
-              "name": [{"service": "google.bytestream.ByteStream"}],
-              "timeout": "1s",
-              "retryPolicy": {}
-            }
-          ]
-        }
-        """);
-
-    IOException e =
-        Assert.assertThrows(
-            IOException.class,
-            () ->
-                RemoteGrpcServiceConfig.create(
-                    parseRemoteOptions("--remote_grpc_service_config=service_config.json"),
-                    workspace));
-
-    assertThat(e)
-        .hasMessageThat()
-        .contains("methodConfig[0] contains unsupported field 'retryPolicy'");
-  }
-
   private RemoteModule remoteModule;
   private RemoteOptions remoteOptions;
+  private Map<String, Map<String, ?>> serviceConfigsByTarget;
 
   @Before
   public void initialize() {
+    serviceConfigsByTarget = new HashMap<>();
     remoteModule = new RemoteModule();
     remoteModule.setChannelFactory(
-        (target, proxy, options, interceptors, serviceConfig) ->
-            InProcessChannelBuilder.forName(target).directExecutor().build());
+        (target, proxy, options, interceptors, serviceConfig) -> {
+          serviceConfigsByTarget.put(target, serviceConfig);
+          return InProcessChannelBuilder.forName(target).directExecutor().build();
+        });
     remoteOptions = Options.getDefaults(RemoteOptions.class);
+  }
+
+  @Test
+  public void remoteGrpcServiceConfig_passesRemoteTimeoutConfigToChannelFactory() throws Exception {
+    CapabilitiesImpl cacheCapabilitiesImpl = new CapabilitiesImpl(CACHE_ONLY_CAPS);
+    Server cacheServer = createFakeServer(CACHE_SERVER_NAME, cacheCapabilitiesImpl);
+    cacheServer.start();
+
+    try {
+      remoteOptions =
+          parseRemoteOptions("--remote_cache=" + CACHE_SERVER_NAME, "--remote_timeout=123s");
+
+      beforeCommand();
+
+      assertThat(
+              remoteModule
+                  .getActionContextProvider()
+                  .getCombinedCache()
+                  .getRemoteCacheCapabilities())
+          .isEqualTo(CACHE_ONLY_CAPS.getCacheCapabilities());
+      assertThat(serviceConfigsByTarget.get(CACHE_SERVER_NAME))
+          .isEqualTo(RemoteGrpcServiceConfig.create(Duration.ofSeconds(123)));
+    } finally {
+      cacheServer.shutdownNow();
+      cacheServer.awaitTermination();
+    }
+  }
+
+  @Test
+  public void remoteGrpcServiceConfig_passesUserSuppliedJsonFileToChannelFactory()
+      throws Exception {
+    CapabilitiesImpl cacheCapabilitiesImpl = new CapabilitiesImpl(CACHE_ONLY_CAPS);
+    Server cacheServer = createFakeServer(CACHE_SERVER_NAME, cacheCapabilitiesImpl);
+    cacheServer.start();
+
+    try {
+      remoteOptions =
+          parseRemoteOptions(
+              "--remote_cache=" + CACHE_SERVER_NAME,
+              "--remote_grpc_service_config=service_config.json");
+
+      beforeCommand(
+          scratch ->
+              scratch.file(
+                  "/workspace/service_config.json",
+                  """
+                  {
+                    "methodConfig": [
+                      {
+                        "name": [{"service": "google.bytestream.ByteStream"}],
+                        "timeout": "3.500s"
+                      }
+                    ]
+                  }
+                  """));
+
+      assertThat(
+              remoteModule
+                  .getActionContextProvider()
+                  .getCombinedCache()
+                  .getRemoteCacheCapabilities())
+          .isEqualTo(CACHE_ONLY_CAPS.getCacheCapabilities());
+      assertThat(serviceConfigsByTarget.get(CACHE_SERVER_NAME))
+          .isEqualTo(
+              ImmutableMap.of(
+                  "methodConfig",
+                  ImmutableList.of(
+                      ImmutableMap.of(
+                          "name",
+                          ImmutableList.of(
+                              ImmutableMap.of("service", "google.bytestream.ByteStream")),
+                          "timeout",
+                          "3.500s"))));
+    } finally {
+      cacheServer.shutdownNow();
+      cacheServer.awaitTermination();
+    }
   }
 
   @Test
@@ -730,7 +735,14 @@ public final class RemoteModuleTest {
 
   @CanIgnoreReturnValue
   private CommandEnvironment beforeCommand() throws IOException, AbruptExitException {
-    CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);
+    return beforeCommand(scratch -> {});
+  }
+
+  @CanIgnoreReturnValue
+  private CommandEnvironment beforeCommand(WorkspaceInitializer workspaceInitializer)
+      throws IOException, AbruptExitException {
+    CommandEnvironment env =
+        createTestCommandEnvironment(remoteModule, remoteOptions, workspaceInitializer);
     remoteModule.beforeCommand(env);
     env.throwPendingException();
     return env;

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -186,10 +186,7 @@ public final class RemoteModuleTest {
             .build();
 
     BlazeDirectories directories =
-        new BlazeDirectories(
-            serverDirectories,
-            scratch.dir("/workspace"),
-            productName);
+        new BlazeDirectories(serverDirectories, scratch.dir("/workspace"), productName);
     BlazeWorkspace workspace = runtime.initWorkspace(directories, BinTools.empty(directories));
     Command command = BuildCommand.class.getAnnotation(Command.class);
     return workspace.initCommand(
@@ -241,6 +238,25 @@ public final class RemoteModuleTest {
         .build();
   }
 
+  @Test
+  public void remoteGrpcServiceConfig_usesRemoteTimeoutForRemoteServices() {
+    assertThat(RemoteGrpcServiceConfig.create(Duration.ofSeconds(123)))
+        .containsExactly(
+            "methodConfig",
+            ImmutableList.of(
+                ImmutableMap.of(
+                    "name",
+                    ImmutableList.of(
+                        ImmutableMap.of("service", "build.bazel.remote.execution.v2.ActionCache"),
+                        ImmutableMap.of("service", "build.bazel.remote.execution.v2.Capabilities"),
+                        ImmutableMap.of(
+                            "service", "build.bazel.remote.execution.v2.ContentAddressableStorage"),
+                        ImmutableMap.of("service", "google.bytestream.ByteStream"),
+                        ImmutableMap.of("service", "build.bazel.remote.asset.v1.Fetch")),
+                    "timeout",
+                    "123s")));
+  }
+
   private RemoteModule remoteModule;
   private RemoteOptions remoteOptions;
 
@@ -248,7 +264,7 @@ public final class RemoteModuleTest {
   public void initialize() {
     remoteModule = new RemoteModule();
     remoteModule.setChannelFactory(
-        (target, proxy, options, interceptors) ->
+        (target, proxy, options, interceptors, serviceConfig) ->
             InProcessChannelBuilder.forName(target).directExecutor().build());
     remoteOptions = Options.getDefaults(RemoteOptions.class);
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteServerCapabilitiesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteServerCapabilitiesTest.java
@@ -152,7 +152,7 @@ public class RemoteServerCapabilitiesTest {
             .directExecutor()
             .build();
     RemoteServerCapabilities client =
-        new RemoteServerCapabilities("build-req-id", "command-id", "instance", null, 3, retrier);
+        new RemoteServerCapabilities("build-req-id", "command-id", "instance", null, retrier);
 
     assertThat(client.get(channel).get()).isEqualTo(caps);
   }
@@ -196,7 +196,7 @@ public class RemoteServerCapabilitiesTest {
         InProcessChannelBuilder.forName(fakeServerName).directExecutor().build();
     RemoteServerCapabilities client =
         new RemoteServerCapabilities(
-            "build-req-id", "command-id", "instance", /* callCredentials= */ null, 3, retrier);
+            "build-req-id", "command-id", "instance", /* callCredentials= */ null, retrier);
 
     assertThat(client.get(channel).get()).isEqualTo(caps);
   }


### PR DESCRIPTION
Remote cache users currently have one `--remote_timeout` value that
applies across remote gRPC calls. That is a poor fit because fast
control-plane RPCs such as action cache lookups benefit from short
deadlines, while ByteStream reads and writes may need much longer
deadlines for large blobs. Setting the flag too low can make uploads or
downloads fail consistently; setting it too high makes stale requests
wait too long before Bazel retries.

This follows the direction discussed in
https://github.com/bazelbuild/bazel/discussions/26741.

This PR keeps the default user experience unchanged while moving remote
gRPC timeout handling onto service config, then adds an opt-in advanced
override.

It is structured as two commits:

- `remote: drive gRPC deadlines from service config` generates the same
  timeout policy Bazel previously applied from `--remote_timeout`,
  installs it on remote gRPC channels, and removes per-stub deadline
  plumbing.
- `remote: accept gRPC service config files` adds
  `--remote_grpc_service_config` for a user-owned JSON file. The initial
  supported schema is intentionally restricted to `methodConfig`,
  `name`, and `timeout`; unsupported fields such as retry, hedging,
  load balancing, and health checking are rejected so Bazel can expand
  support deliberately later.
