### PR TITLE
[9.2.0] Fix concurrent TreeArtifact prefetches (https://github.com/bazelbuild…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -24,11 +24,13 @@ import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 import static com.google.devtools.build.lib.remote.util.Utils.mergeBulkTransfer;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
+import com.google.common.collect.SetMultimap;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.Striped;
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
@@ -58,10 +60,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
 import javax.annotation.Nullable;
 
 /**
@@ -203,6 +206,14 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
 
   private final DirectoryTracker directoryTracker = new DirectoryTracker();
 
+  // Tree artifact downloads use temporary paths. Coordinate by resolved tree root: a read lock
+  // protects reopening ancestors and moving one child into place, while a write lock protects
+  // restoring every directory touched by a prefetchFiles call to its output permissions. Weak
+  // locks over the full hash space allow unrelated trees to finalize concurrently without
+  // retaining every lock for the lifetime of the prefetcher.
+  private final Striped<ReadWriteLock> treeArtifactLocks =
+      Striped.lazyWeakReadWriteLock(Integer.MAX_VALUE);
+
   /** A symlink in the output tree that points to another artifact's absolute path. */
   record Symlink(Path linkPath, Path targetPath) {
     Symlink {
@@ -342,21 +353,19 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       return immediateVoidFuture();
     }
 
-    // Collect the set of directories whose output permissions must be set at the end of this call.
-    // This responsibility cannot lie with the downloading of an individual file, because multiple
-    // files may be concurrently downloaded into the same directory within a single call to
-    // prefetchFiles, and two concurrent calls to prefetchFiles may prefetch the same file. In the
-    // latter case, the second call will have its downloads deduplicated against the first call, but
-    // it must still synchronize on the output permissions having been set.
-    Set<Path> dirsWithOutputPermissions = Sets.newConcurrentHashSet();
+    // Collect directories whose output permissions must be restored at the end of this call,
+    // grouped by tree root for synchronization. Keeping permission restoration scoped to this
+    // prefetchFiles call avoids toggling shared ancestors between child finalizations. A concurrent
+    // call to prefetchFiles for the same child may await the same download, but must still
+    // participate in permission restoration before returning.
+    SetMultimap<Path, Path> directoriesByTreeRoot = HashMultimap.create();
 
     // Using plain futures to avoid RxJava overheads.
     List<ListenableFuture<Void>> transfers = new ArrayList<>(files.size());
     try (var s = Profiler.instance().profile("compose prefetches")) {
       for (var file : files) {
         transfers.add(
-            prefetchFile(
-                action, dirsWithOutputPermissions, metadataSupplier, file, priority, reason));
+            prefetchFile(action, directoriesByTreeRoot, metadataSupplier, file, priority, reason));
       }
     }
 
@@ -369,10 +378,17 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
         mergedTransfer,
         unused -> {
           try {
-            // Set output permissions on tree artifact subdirectories, matching the behavior of
-            // SkyframeActionExecutor#checkOutputs for artifacts produced by local actions.
-            for (Path dir : dirsWithOutputPermissions) {
-              directoryTracker.setOutputPermissions(dir);
+            // Match the directory output permissions set by SkyframeActionExecutor#checkOutputs.
+            for (var entry : directoriesByTreeRoot.asMap().entrySet()) {
+              Lock lock = treeArtifactLocks.get(entry.getKey().asFragment()).writeLock();
+              lock.lock();
+              try {
+                for (Path dir : entry.getValue()) {
+                  directoryTracker.setOutputPermissions(dir);
+                }
+              } finally {
+                lock.unlock();
+              }
             }
           } catch (IOException e) {
             return immediateFailedFuture(e);
@@ -384,7 +400,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
 
   private ListenableFuture<Void> prefetchFile(
       @Nullable ActionExecutionMetadata action,
-      Set<Path> dirsWithOutputPermissions,
+      SetMultimap<Path, Path> directoriesByTreeRoot,
       MetadataSupplier metadataSupplier,
       ActionInput input,
       Priority priority,
@@ -432,7 +448,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
               input,
               inputPath,
               treeRootPath,
-              dirsWithOutputPermissions,
+              directoriesByTreeRoot,
               input,
               metadata,
               priority,
@@ -556,7 +572,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       ActionInput input,
       Path path,
       @Nullable Path treeRoot,
-      Set<Path> dirsWithOutputPermissions,
+      SetMultimap<Path, Path> directoriesByTreeRoot,
       ActionInput actionInput,
       FileArtifactValue metadata,
       Priority priority,
@@ -577,24 +593,27 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       return Completable.error(e);
     }
 
-    if (treeRoot != null
-        && actionInput instanceof Artifact artifact
-        && artifact.isChildOfDeclaredDirectory()) {
-      // Arrange for the output permissions to be set on every directory inside the tree artifact.
-      // This must be done at assembly time to ensure that the permissions are set before the
-      // prefetchFiles call returns, even when the actual downloads are deduplicated against a
-      // concurrent call. See finalizeDownload for why we don't do so in other cases.
-      for (Path dir = path.getParentDirectory();
-          dir.startsWith(treeRoot);
+    // Downloads are written to the actual host file system, not any overlays.
+    Path finalPath = path.forHostFileSystem();
+
+    @Nullable
+    Path finalTreeRoot =
+        treeRoot != null
+                && actionInput instanceof Artifact artifact
+                && artifact.isChildOfDeclaredDirectory()
+            ? treeRoot.forHostFileSystem()
+            : null;
+    if (finalTreeRoot != null) {
+      // Record directories child-to-root. If a directory is already present for this tree root, an
+      // earlier traversal also recorded every ancestor through the root.
+      for (Path dir = finalPath.getParentDirectory();
+          dir.startsWith(finalTreeRoot);
           dir = dir.getParentDirectory()) {
-        if (!dirsWithOutputPermissions.add(dir)) {
+        if (!directoriesByTreeRoot.put(finalTreeRoot, dir)) {
           break;
         }
       }
     }
-
-    // Downloads should always be written to the "actual" host file system, not any overlays.
-    Path finalPath = path.forHostFileSystem();
 
     Completable download =
         usingTempPath(
@@ -613,10 +632,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
                     .doOnComplete(
                         () -> {
                           finalizeDownload(
-                              metadata,
-                              tempPath.forHostFileSystem(),
-                              finalPath,
-                              dirsWithOutputPermissions);
+                              metadata, tempPath.forHostFileSystem(), finalPath, finalTreeRoot);
                           alreadyDeleted.set(true);
                         }));
 
@@ -633,40 +649,58 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
   }
 
   private void finalizeDownload(
-      FileArtifactValue metadata, Path tmpPath, Path finalPath, Set<Path> dirsWithOutputPermissions)
+      FileArtifactValue metadata, Path tmpPath, Path finalPath, @Nullable Path treeRoot)
       throws IOException {
-    Path parentDir = checkNotNull(finalPath.getParentDirectory());
+    // Set file output permissions, matching SkyframeActionExecutor#checkOutputs for artifacts
+    // produced by local actions. The temporary path is outside the output tree, so this can happen
+    // before entering the tree artifact root's critical section.
+    tmpPath.chmod(outputPermissions.getPermissionsMode());
 
-    // Compare as fragments since execRoot may be located on a file system overlaying the host
-    // file system where the download is written to.
-    if (finalPath.asFragment().startsWith(execRoot.asFragment())) {
-      // Ensure the parent directory exists and is writable. We cannot rely on this precondition to
-      // have been established by the execution of the owning action in a previous invocation, since
-      // the output tree may have been externally modified in between invocations.
-      if (dirsWithOutputPermissions.contains(parentDir)) {
-        // The file belongs to a tree artifact created by an action that declared an output
-        // directory (as opposed to an action template expansion). The output permissions should be
-        // set on the parent directory after prefetching.
-        directoryTracker.setTemporarilyWritable(parentDir);
-      } else {
-        // One of the following must apply:
-        //   (1) The file does not belong to a tree artifact.
-        //   (2) The file belongs to a tree artifact created by an action template expansion.
-        // In case (1), the parent directory is a package or a subdirectory of a package, and should
-        // remain writable. In case (2), even though we arguably ought to set the output permissions
-        // on the parent directory to match local execution, we choose not to do it and avoid the
-        // additional implementation complexity required to detect a race condition between
-        // concurrent calls touching the same directory.
-        directoryTracker.setPermanentlyWritable(parentDir);
-      }
-    } else {
-      parentDir.createDirectoryAndParents();
+    Path parentDir = checkNotNull(finalPath.getParentDirectory());
+    @Nullable
+    Lock treeArtifactLock =
+        treeRoot == null ? null : treeArtifactLocks.get(treeRoot.asFragment()).readLock();
+    if (treeArtifactLock != null) {
+      treeArtifactLock.lock();
     }
 
-    // Set output permissions on files, matching the behavior of SkyframeActionExecutor#checkOutputs
-    // for artifacts produced by local actions.
-    tmpPath.chmod(outputPermissions.getPermissionsMode());
-    FileSystemUtils.moveFile(tmpPath, finalPath);
+    try {
+      // Compare as fragments since execRoot may be located on a file system overlaying the host
+      // file system where the download is written to.
+      if (finalPath.asFragment().startsWith(execRoot.asFragment())) {
+        // Ensure the parent directory exists and is writable. We cannot rely on this precondition
+        // to have been established by the execution of the owning action in a previous invocation,
+        // since the output tree may have been externally modified in between invocations.
+        if (treeRoot != null) {
+          // Reopen every ancestor because ActionOutputDirectoryHelper caches existing directories
+          // and may otherwise leave a previously restored ancestor read-only.
+          Path dir = treeRoot;
+          directoryTracker.setTemporarilyWritable(dir);
+          for (String segment : parentDir.relativeTo(treeRoot).segments()) {
+            dir = dir.getChild(segment);
+            directoryTracker.setTemporarilyWritable(dir);
+          }
+        } else {
+          // One of the following must apply:
+          //   (1) The file does not belong to a tree artifact.
+          //   (2) The file belongs to a tree artifact created by an action template expansion.
+          // In case (1), the parent directory is a package or a subdirectory of a package, and
+          // should remain writable. In case (2), even though we arguably ought to set the output
+          // permissions on the parent directory to match local execution, we choose not to do it
+          // and avoid the additional implementation complexity required to detect a race condition
+          // between concurrent calls touching the same directory.
+          directoryTracker.setPermanentlyWritable(parentDir);
+        }
+      } else {
+        parentDir.createDirectoryAndParents();
+      }
+
+      FileSystemUtils.moveFile(tmpPath, finalPath);
+    } finally {
+      if (treeArtifactLock != null) {
+        treeArtifactLock.unlock();
+      }
+    }
 
     // Set the contents proxy when supported, to make future modification checks cheaper.
     metadata.setContentsProxy(FileContentsProxy.create(finalPath.stat()));

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -76,6 +76,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -621,6 +622,45 @@ public abstract class ActionInputPrefetcherTestBase {
   }
 
   @Test
+  public void prefetchFiles_treeFiles_sequentialCalls_reopenAncestors() throws Exception {
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+    Map<HashCode, byte[]> cas = new HashMap<>();
+    Pair<SpecialArtifact, ImmutableList<TreeFileArtifact>> treeAndChildren =
+        createRemoteTreeArtifact(
+            "dir",
+            /* localContentMap= */ ImmutableMap.of(),
+            /* remoteContentMap= */ ImmutableMap.of(
+                "subdir1/file1", "content1", "subdir2/file2", "content2"),
+            metadata,
+            cas);
+    SpecialArtifact tree = treeAndChildren.getFirst();
+    ImmutableList<TreeFileArtifact> children = treeAndChildren.getSecond();
+    AbstractActionInputPrefetcher prefetcher = createPrefetcher(cas);
+
+    // The first call leaves the directory helper's cache populated but the tree read-only. The
+    // second call must explicitly reopen the cached root before creating a sibling directory, then
+    // restore its output permissions.
+    wait(
+        prefetcher.prefetchFilesInterruptibly(
+            action,
+            ImmutableList.of(children.get(0)),
+            metadata::get,
+            Priority.MEDIUM,
+            Reason.INPUTS));
+    assertTreeReadableNonWritableAndExecutable(tree.getPath());
+
+    wait(
+        prefetcher.prefetchFilesInterruptibly(
+            action,
+            ImmutableList.of(children.get(1)),
+            metadata::get,
+            Priority.MEDIUM,
+            Reason.INPUTS));
+    assertThat(FileSystemUtils.readContent(children.get(1).getPath(), UTF_8)).isEqualTo("content2");
+    assertTreeReadableNonWritableAndExecutable(tree.getPath());
+  }
+
+  @Test
   public void prefetchFiles_treeFiles_multipleThreads_waitForPermissionsToBeSet() throws Exception {
     Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
     Map<HashCode, byte[]> cas = new HashMap<>();
@@ -664,6 +704,166 @@ public abstract class ActionInputPrefetcherTestBase {
 
     f1.get();
     f2.get();
+  }
+
+  @Test
+  public void prefetchFiles_treeFiles_concurrentFinalizations_doNotRacePermissions()
+      throws Exception {
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+    Map<HashCode, byte[]> cas = new HashMap<>();
+    Pair<SpecialArtifact, ImmutableList<TreeFileArtifact>> treeAndChildren =
+        createRemoteTreeArtifact(
+            "dir",
+            /* localContentMap= */ ImmutableMap.of(),
+            /* remoteContentMap= */ ImmutableMap.of(
+                "subdir1/file1", "content1", "subdir2/file2", "content2"),
+            metadata,
+            cas);
+    SpecialArtifact tree = treeAndChildren.getFirst();
+    ImmutableList<TreeFileArtifact> children = treeAndChildren.getSecond();
+
+    SettableFuture<Void> firstDownload = SettableFuture.create();
+    SettableFuture<Void> secondDownload = SettableFuture.create();
+    LinkedBlockingQueue<ListenableFuture<Void>> downloads = new LinkedBlockingQueue<>();
+    downloads.add(firstDownload);
+    downloads.add(secondDownload);
+    AbstractActionInputPrefetcher prefetcher = spy(createPrefetcher(cas));
+    mockDownload(prefetcher, cas, downloads::remove);
+
+    ListenableFuture<Void> firstPrefetch =
+        prefetcher.prefetchFilesInterruptibly(
+            action,
+            ImmutableList.of(children.get(0)),
+            metadata::get,
+            Priority.MEDIUM,
+            Reason.INPUTS);
+    ListenableFuture<Void> secondPrefetch =
+        prefetcher.prefetchFilesInterruptibly(
+            action,
+            ImmutableList.of(children.get(1)),
+            metadata::get,
+            Priority.MEDIUM,
+            Reason.INPUTS);
+
+    Semaphore secondFinalizationStarted = new Semaphore(0);
+    Semaphore secondFinalizationMayContinue = new Semaphore(0);
+    AtomicBoolean blockNextTempFileMove = new AtomicBoolean(true);
+    // Pause the second finalization after it has made the tree writable, but before it moves its
+    // temporary file into the tree.
+    doAnswer(
+            invocation -> {
+              PathFragment source = invocation.getArgument(0);
+              PathFragment target = invocation.getArgument(1);
+              if (source.startsWith(tempPathGenerator.getTempDir().asFragment())
+                  && target.startsWith(tree.getPath().asFragment())
+                  && blockNextTempFileMove.getAndSet(false)) {
+                secondFinalizationStarted.release();
+                secondFinalizationMayContinue.acquireUninterruptibly();
+              }
+              return invocation.callRealMethod();
+            })
+        .when(fs)
+        .renameTo(any(), any());
+    Thread secondCompletion = new Thread(() -> secondDownload.set(null));
+    // Completing the first download runs its direct-executor finalization on this thread. Its move
+    // may proceed concurrently with the paused move, but its permission restoration must wait for
+    // the paused finalization to release its read lock.
+    Thread firstCompletion = new Thread(() -> firstDownload.set(null));
+    secondCompletion.start();
+    try {
+      assertThat(secondFinalizationStarted.tryAcquire(10, SECONDS)).isTrue();
+      firstCompletion.start();
+
+      long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+      while (!children.get(0).getPath().exists() && System.nanoTime() < deadline) {
+        Thread.yield();
+      }
+      assertThat(children.get(0).getPath().exists()).isTrue();
+      assertThat(firstPrefetch.isDone()).isFalse();
+      assertThat(tree.getPath().isWritable()).isTrue();
+    } finally {
+      secondFinalizationMayContinue.release();
+      firstCompletion.join(10_000);
+      secondCompletion.join(10_000);
+    }
+
+    wait(firstPrefetch);
+    wait(secondPrefetch);
+    assertTreeReadableNonWritableAndExecutable(tree.getPath());
+  }
+
+  @Test
+  public void prefetchFiles_treeFiles_manyConcurrentOverlappingCalls() throws Exception {
+    int treeCount = 4;
+    int childrenPerTree = 16;
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+    Map<HashCode, byte[]> cas = new HashMap<>();
+    ImmutableList.Builder<SpecialArtifact> trees = ImmutableList.builder();
+    ImmutableList.Builder<ImmutableList<TreeFileArtifact>> childrenByTree = ImmutableList.builder();
+    for (int treeIndex = 0; treeIndex < treeCount; treeIndex++) {
+      ImmutableMap.Builder<String, String> remoteContent = ImmutableMap.builder();
+      for (int childIndex = 0; childIndex < childrenPerTree; childIndex++) {
+        remoteContent.put("subdir-" + childIndex + "/file", "content");
+      }
+      Pair<SpecialArtifact, ImmutableList<TreeFileArtifact>> treeAndChildren =
+          createRemoteTreeArtifact(
+              "dir-" + treeIndex,
+              /* localContentMap= */ ImmutableMap.of(),
+              remoteContent.buildOrThrow(),
+              metadata,
+              cas);
+      trees.add(treeAndChildren.getFirst());
+      childrenByTree.add(treeAndChildren.getSecond());
+    }
+    ImmutableList<SpecialArtifact> treeList = trees.build();
+    ImmutableList<ImmutableList<TreeFileArtifact>> childLists = childrenByTree.build();
+    AbstractActionInputPrefetcher prefetcher = createPrefetcher(cas);
+
+    int concurrency = 32;
+    int requestCount = 128;
+    CountDownLatch requestsReady = new CountDownLatch(concurrency);
+    CountDownLatch startRequests = new CountDownLatch(1);
+    ThreadPoolExecutor pool =
+        new ThreadPoolExecutor(concurrency, concurrency, 0, SECONDS, new LinkedBlockingQueue<>());
+    ImmutableList.Builder<Future<Void>> requests = ImmutableList.builder();
+    try {
+      for (int requestIndex = 0; requestIndex < requestCount; requestIndex++) {
+        int treeIndex = requestIndex % treeCount;
+        int childIndex = (requestIndex / treeCount) % childrenPerTree;
+        ImmutableList<TreeFileArtifact> children = childLists.get(treeIndex);
+        ImmutableList<ActionInput> inputs =
+            ImmutableList.of(
+                children.get(childIndex), children.get((childIndex + 1) % childrenPerTree));
+        requests.add(
+            pool.submit(
+                () -> {
+                  requestsReady.countDown();
+                  startRequests.await();
+                  wait(
+                      prefetcher.prefetchFilesInterruptibly(
+                          action, inputs, metadata::get, Priority.MEDIUM, Reason.INPUTS));
+                  return null;
+                }));
+      }
+
+      boolean allRequestsReady = requestsReady.await(10, SECONDS);
+      startRequests.countDown();
+      assertThat(allRequestsReady).isTrue();
+      for (Future<Void> request : requests.build()) {
+        request.get(30, SECONDS);
+      }
+    } finally {
+      startRequests.countDown();
+      pool.shutdownNow();
+      pool.awaitTermination(10, SECONDS);
+    }
+
+    for (int treeIndex = 0; treeIndex < treeCount; treeIndex++) {
+      for (TreeFileArtifact child : childLists.get(treeIndex)) {
+        assertThat(FileSystemUtils.readContent(child.getPath(), UTF_8)).isEqualTo("content");
+      }
+      assertTreeReadableNonWritableAndExecutable(treeList.get(treeIndex).getPath());
+    }
   }
 
   @Test


### PR DESCRIPTION
…/bazel/pull/29803)

Remote prefetches download into temporary files, but finalization and output-permission restoration can race across calls targeting the same TreeArtifact. One call can make the tree read-only while another is moving a child into it.

Coordinate these operations by resolved TreeArtifact root. Allow child finalizations to proceed concurrently, but restore permissions only after all in-progress finalizations have completed. Weakly retain the per-root locks so a long-lived prefetcher does not retain every tree it touches.

Reopen every ancestor before moving a child because ActionOutputDirectoryHelper caches directory creation after output permissions are restored.

Fixes #29801.

Closes #29803.

PiperOrigin-RevId: 934616991
Change-Id: I2aa1ba7c52f19db2e3f874d99846107d9591423b

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/27b62a2a65182434b180aca702d24831c8fd4e2e