### PR TITLE
remote: add gRPC download idle timeout

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -132,6 +132,7 @@ java_library(
         ":remote_output_checker",
         ":remote_output_service",
         ":remote_server_capabilities",
+        ":remote_download_idle_timeout_interceptor",
         ":repository_remote_helpers_factory_impl",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:important_output_handler",
@@ -193,6 +194,17 @@ java_library(
         "//third_party:rxjava3",
         "//third_party/grpc-java:grpc-jar",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+    ],
+)
+
+java_library(
+    name = "remote_download_idle_timeout_interceptor",
+    srcs = ["RemoteDownloadIdleTimeoutInterceptor.java"],
+    deps = [
+        "//third_party:guava",
+        "@googleapis//google/bytestream:bytestream_java_grpc",
+        "//third_party:jsr305",
+        "//third_party/grpc-java:grpc-jar",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteDownloadIdleTimeoutInterceptor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteDownloadIdleTimeoutInterceptor.java
@@ -1,0 +1,212 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import com.google.bytestream.ByteStreamGrpc;
+import com.google.common.annotations.VisibleForTesting;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.function.LongSupplier;
+import javax.annotation.Nullable;
+
+/** Cancels remote downloads after a configured period without response data. */
+final class RemoteDownloadIdleTimeoutInterceptor implements ClientInterceptor {
+
+  private final long timeoutNanos;
+  private final ScheduledExecutorService scheduler;
+  private final LongSupplier nanoTime;
+
+  RemoteDownloadIdleTimeoutInterceptor(Duration timeout, ScheduledExecutorService scheduler) {
+    this(timeout, scheduler, System::nanoTime);
+  }
+
+  @VisibleForTesting
+  RemoteDownloadIdleTimeoutInterceptor(
+      Duration timeout, ScheduledExecutorService scheduler, LongSupplier nanoTime) {
+    this.timeoutNanos = timeout.toNanos();
+    this.scheduler = scheduler;
+    this.nanoTime = nanoTime;
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+    ClientCall<ReqT, RespT> call = next.newCall(method, callOptions);
+    if (method != ByteStreamGrpc.getReadMethod()) {
+      return call;
+    }
+    return new IdleTimeoutCall<>(
+        call, method.getFullMethodName(), timeoutNanos, scheduler, nanoTime);
+  }
+
+  private static final class IdleTimeoutCall<ReqT, RespT>
+      extends ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT> {
+
+    private final String methodName;
+    private final long timeoutNanos;
+    private final ScheduledExecutorService scheduler;
+    private final LongSupplier nanoTime;
+    private final Object lock = new Object();
+
+    @Nullable private ScheduledFuture<?> timeoutFuture;
+    private long deadlineNanos;
+    private boolean closed;
+    private boolean timedOut;
+
+    IdleTimeoutCall(
+        ClientCall<ReqT, RespT> delegate,
+        String methodName,
+        long timeoutNanos,
+        ScheduledExecutorService scheduler,
+        LongSupplier nanoTime) {
+      super(delegate);
+      this.methodName = methodName;
+      this.timeoutNanos = timeoutNanos;
+      this.scheduler = scheduler;
+      this.nanoTime = nanoTime;
+    }
+
+    @Override
+    public void start(Listener<RespT> responseListener, Metadata headers) {
+      super.start(
+          new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(
+              responseListener) {
+            @Override
+            public void onHeaders(Metadata headers) {
+              try {
+                resetTimeout();
+              } finally {
+                super.onHeaders(headers);
+              }
+            }
+
+            @Override
+            public void onMessage(RespT message) {
+              try {
+                resetTimeout();
+              } finally {
+                super.onMessage(message);
+              }
+            }
+
+            @Override
+            public void onClose(Status status, Metadata trailers) {
+              Status statusToForward = status;
+              synchronized (lock) {
+                if (timedOut && status.getCode() == Status.Code.CANCELLED) {
+                  statusToForward =
+                      Status.DEADLINE_EXCEEDED
+                          .withDescription(timeoutMessage())
+                          .withCause(status.getCause());
+                }
+              }
+              try {
+                closeTimeout();
+              } finally {
+                super.onClose(statusToForward, trailers);
+              }
+            }
+          },
+          headers);
+      resetTimeout();
+    }
+
+    @Override
+    public void sendMessage(ReqT message) {
+      try {
+        resetTimeout();
+      } finally {
+        super.sendMessage(message);
+      }
+    }
+
+    @Override
+    public void halfClose() {
+      try {
+        resetTimeout();
+      } finally {
+        super.halfClose();
+      }
+    }
+
+    @Override
+    public void cancel(@Nullable String message, @Nullable Throwable cause) {
+      try {
+        closeTimeout();
+      } finally {
+        super.cancel(message, cause);
+      }
+    }
+
+    private void resetTimeout() {
+      synchronized (lock) {
+        if (closed || timedOut) {
+          return;
+        }
+        deadlineNanos = nanoTime.getAsLong() + timeoutNanos;
+        if (timeoutFuture == null) {
+          timeoutFuture = scheduler.schedule(this::onTimeout, timeoutNanos, NANOSECONDS);
+        }
+      }
+    }
+
+    private void closeTimeout() {
+      synchronized (lock) {
+        closed = true;
+        if (timeoutFuture != null) {
+          timeoutFuture.cancel(false);
+          timeoutFuture = null;
+        }
+      }
+    }
+
+    private void onTimeout() {
+      synchronized (lock) {
+        if (closed || timedOut) {
+          return;
+        }
+        long remainingNanos = deadlineNanos - nanoTime.getAsLong();
+        if (remainingNanos > 0) {
+          timeoutFuture = null;
+          timeoutFuture = scheduler.schedule(this::onTimeout, remainingNanos, NANOSECONDS);
+          return;
+        }
+        timedOut = true;
+        timeoutFuture = null;
+      }
+      String message = timeoutMessage();
+      super.cancel(message, Status.DEADLINE_EXCEEDED.withDescription(message).asRuntimeException());
+    }
+
+    private String timeoutMessage() {
+      return "Remote download idle timeout exceeded after "
+          + Duration.ofNanos(timeoutNanos)
+          + " for "
+          + methodName;
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -666,6 +666,12 @@ public final class RemoteModule extends BlazeModule {
           "Invalid --remote_grpc_service_config: " + e.getMessage(),
           FailureDetails.RemoteOptions.Code.REMOTE_GRPC_SERVICE_CONFIG_INVALID);
     }
+    ClientInterceptor downloadIdleTimeoutInterceptor = null;
+    if (!remoteOptions.getRemoteGrpcDownloadIdleTimeout().isZero()) {
+      downloadIdleTimeoutInterceptor =
+          new RemoteDownloadIdleTimeoutInterceptor(
+              remoteOptions.getRemoteGrpcDownloadIdleTimeout(), retryScheduler);
+    }
 
     if (!Strings.isNullOrEmpty(remoteOptions.getRemoteOutputService())) {
       var bazelOutputServiceChannel =
@@ -676,6 +682,7 @@ public final class RemoteModule extends BlazeModule {
               Options.getDefaults(AuthAndTLSOptions.class),
               null,
               null,
+              downloadIdleTimeoutInterceptor,
               remoteGrpcServiceConfig,
               channelFactory,
               remoteOptions.getRemoteOutputService(),
@@ -729,7 +736,6 @@ public final class RemoteModule extends BlazeModule {
       }
       loggingInterceptor = new LoggingInterceptor(rpcLogFile, env.getRuntime().getClock());
     }
-
     CallCredentialsProvider callCredentialsProvider =
         GoogleAuthUtils.newCallCredentialsProvider(credentials);
     CallCredentials callCredentials = callCredentialsProvider.getCallCredentials();
@@ -764,6 +770,7 @@ public final class RemoteModule extends BlazeModule {
                   TracingMetadataUtils.newExecHeadersInterceptor(
                       remoteOptions.getRemoteHeaders(), remoteOptions.getRemoteExecHeaders()),
                   loggingInterceptor,
+                  downloadIdleTimeoutInterceptor,
                   remoteGrpcServiceConfig,
                   channelFactory,
                   remoteOptions.getRemoteExecutor(),
@@ -785,6 +792,7 @@ public final class RemoteModule extends BlazeModule {
                   TracingMetadataUtils.newExecHeadersInterceptor(
                       remoteOptions.getRemoteHeaders(), remoteOptions.getRemoteExecHeaders()),
                   loggingInterceptor,
+                  downloadIdleTimeoutInterceptor,
                   remoteGrpcServiceConfig,
                   channelFactory,
                   remoteOptions.getRemoteExecutor(),
@@ -808,6 +816,7 @@ public final class RemoteModule extends BlazeModule {
                 TracingMetadataUtils.newCacheHeadersInterceptor(
                     remoteOptions.getRemoteHeaders(), remoteOptions.getRemoteCacheHeaders()),
                 loggingInterceptor,
+                downloadIdleTimeoutInterceptor,
                 remoteGrpcServiceConfig,
                 channelFactory,
                 remoteOptions.getRemoteCache(),
@@ -928,6 +937,7 @@ public final class RemoteModule extends BlazeModule {
                 authAndTlsOptions,
                 /* headersInterceptor= */ null,
                 loggingInterceptor,
+                downloadIdleTimeoutInterceptor,
                 remoteGrpcServiceConfig,
                 channelFactory,
                 remoteOptions.getRemoteDownloader(),
@@ -967,6 +977,7 @@ public final class RemoteModule extends BlazeModule {
       AuthAndTLSOptions authAndTlsOptions,
       @Nullable ClientInterceptor headersInterceptor,
       @Nullable ClientInterceptor loggingInterceptor,
+      @Nullable ClientInterceptor downloadIdleTimeoutInterceptor,
       Map<String, ?> serviceConfig,
       ChannelFactory channelFactory,
       String target,
@@ -984,6 +995,9 @@ public final class RemoteModule extends BlazeModule {
     }
     if (loggingInterceptor != null) {
       interceptors.add(loggingInterceptor);
+    }
+    if (downloadIdleTimeoutInterceptor != null) {
+      interceptors.add(downloadIdleTimeoutInterceptor);
     }
     var channel =
         new ReferenceCountedChannel(

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -284,6 +284,19 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
   public abstract PathFragment getRemoteGrpcServiceConfig();
 
   @Option(
+      name = "remote_grpc_download_idle_timeout",
+      defaultValue = "60s",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      converter = RemoteDurationConverter.class,
+      help =
+          "The maximum amount of time a remote gRPC download may go without receiving response"
+              + " data before Bazel cancels and retries the download. This applies to ByteStream"
+              + " Read. The value 0 disables the timeout. If the unit is omitted, the value is"
+              + " interpreted as seconds.")
+  public abstract Duration getRemoteGrpcDownloadIdleTimeout();
+
+  @Option(
       name = "remote_bytestream_uri_prefix",
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.REMOTE,

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -143,6 +143,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote:remote_server_capabilities",
         "//src/main/java/com/google/devtools/build/lib/remote:remote_spawn_cache",
         "//src/main/java/com/google/devtools/build/lib/remote:remote_spawn_runner",
+        "//src/main/java/com/google/devtools/build/lib/remote:remote_download_idle_timeout_interceptor",
         "//src/main/java/com/google/devtools/build/lib/remote:scrubber",
         "//src/main/java/com/google/devtools/build/lib/remote:store",
         "//src/main/java/com/google/devtools/build/lib/remote:upload_manifest",

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -16,14 +16,18 @@ package com.google.devtools.build.lib.remote;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.AdditionalAnswers.answerVoid;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionCacheGrpc.ActionCacheImplBase;
@@ -120,6 +124,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -127,8 +132,11 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.junit.After;
@@ -168,6 +176,14 @@ public class GrpcCacheClientTest {
 
   private GrpcCacheClient newClient(RemoteOptions remoteOptions, Supplier<Backoff> backoffSupplier)
       throws IOException {
+    return newClient(remoteOptions, backoffSupplier, ImmutableList.of());
+  }
+
+  private GrpcCacheClient newClient(
+      RemoteOptions remoteOptions,
+      Supplier<Backoff> backoffSupplier,
+      ImmutableList<ClientInterceptor> extraInterceptors)
+      throws IOException {
     AuthAndTLSOptions authTlsOptions = Options.getDefaults(AuthAndTLSOptions.class);
     authTlsOptions.setUseGoogleDefaultCredentials(true);
     authTlsOptions.setGoogleCredentials("/execroot/main/creds.json");
@@ -198,15 +214,16 @@ public class GrpcCacheClientTest {
             new ChannelConnectionWithServerCapabilitiesFactory() {
               @Override
               public Single<ChannelConnectionWithServerCapabilities> create() {
-                ManagedChannel ch =
+                InProcessChannelBuilder channelBuilder =
                     InProcessChannelBuilder.forName(fakeServerName)
                         .directExecutor()
                         .intercept(new CallCredentialsInterceptor(creds))
                         .intercept(
                             TracingMetadataUtils.newCacheHeadersInterceptor(
                                 remoteOptions.getRemoteHeaders(),
-                                remoteOptions.getRemoteCacheHeaders()))
-                        .build();
+                                remoteOptions.getRemoteCacheHeaders()));
+                extraInterceptors.forEach(channelBuilder::intercept);
+                ManagedChannel ch = channelBuilder.build();
                 return Single.just(
                     new ChannelConnectionWithServerCapabilities(
                         ch, Single.just(ServerCapabilities.getDefaultInstance())));
@@ -1279,6 +1296,73 @@ public class GrpcCacheClientTest {
           }
         });
     assertThat(new String(downloadBlob(context, client, digest), UTF_8)).isEqualTo("abcdefg");
+    Mockito.verify(mockBackoff, Mockito.never()).nextDelayMillis(any(Exception.class));
+  }
+
+  @Test
+  public void downloadBlobIdleTimeoutIsRetriedWithProgress()
+      throws IOException, InterruptedException {
+    // Unexpected failures without progress should stop immediately. The idle-timeout retry below
+    // is allowed only because receiving the prefix resets ProgressiveBackoff.
+    Backoff mockBackoff = Mockito.mock(Backoff.class);
+    when(mockBackoff.nextDelayMillis(any(Exception.class))).thenReturn(-1L);
+    // Capture the interceptor's timer task so the test controls exactly when the stream becomes
+    // idle, without involving a real scheduler or wall-clock delay.
+    ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+    AtomicReference<Runnable> timeoutTask = new AtomicReference<>();
+    when(scheduler.schedule(any(Runnable.class), anyLong(), eq(NANOSECONDS)))
+        .thenAnswer(
+            invocation -> {
+              timeoutTask.set(invocation.getArgument(0));
+              return mock(ScheduledFuture.class);
+            });
+    AtomicLong nanoTime = new AtomicLong();
+    Duration idleTimeout = Duration.ofSeconds(60);
+    RemoteDownloadIdleTimeoutInterceptor idleTimeoutInterceptor =
+        new RemoteDownloadIdleTimeoutInterceptor(idleTimeout, scheduler, nanoTime::get);
+    GrpcCacheClient client =
+        newClient(
+            Options.getDefaults(RemoteOptions.class),
+            () -> mockBackoff,
+            ImmutableList.of(idleTimeoutInterceptor));
+    Digest digest = DIGEST_UTIL.computeAsUtf8("abcdefg");
+    AtomicInteger readCalls = new AtomicInteger();
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+            assertThat(request.getResourceName()).contains(digest.getHash());
+            ByteString data = ByteString.copyFromUtf8("abcdefg");
+            int offset = (int) request.getReadOffset();
+            int readCall = readCalls.getAndIncrement();
+            if (readCall == 0) {
+              // Send a prefix without closing the stream. Only the idle-timeout interceptor can
+              // terminate this attempt and cause GrpcCacheClient to retry.
+              assertThat(offset).isEqualTo(0);
+              responseObserver.onNext(
+                  ReadResponse.newBuilder().setData(data.substring(0, 1)).build());
+              return;
+            }
+            // GrpcCacheClient must resume after the byte already written to the output stream.
+            assertThat(readCall).isEqualTo(1);
+            assertThat(offset).isEqualTo(1);
+            responseObserver.onNext(
+                ReadResponse.newBuilder().setData(data.substring(offset)).build());
+            responseObserver.onCompleted();
+          }
+        });
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ListenableFuture<Void> download = client.downloadBlob(context, digest, out);
+    assertThat(timeoutTask.get()).isNotNull();
+
+    // Fire the timeout deterministically rather than sleeping for the 60-second production value.
+    nanoTime.set(idleTimeout.toNanos());
+    timeoutTask.get().run();
+
+    getFromFuture(download);
+    assertThat(new String(out.toByteArray(), UTF_8)).isEqualTo("abcdefg");
+    assertThat(readCalls.get()).isEqualTo(2);
     Mockito.verify(mockBackoff, Mockito.never()).nextDelayMillis(any(Exception.class));
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteDownloadIdleTimeoutInterceptorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteDownloadIdleTimeoutInterceptorTest.java
@@ -1,0 +1,279 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.bytestream.ByteStreamGrpc;
+import com.google.bytestream.ByteStreamProto.ReadRequest;
+import com.google.bytestream.ByteStreamProto.ReadResponse;
+import com.google.bytestream.ByteStreamProto.WriteRequest;
+import com.google.bytestream.ByteStreamProto.WriteResponse;
+import com.google.common.collect.ImmutableList;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link RemoteDownloadIdleTimeoutInterceptor}. */
+@RunWith(JUnit4.class)
+public final class RemoteDownloadIdleTimeoutInterceptorTest {
+
+  @Test
+  public void byteStreamWrite_doesNotScheduleTimeout() {
+    // ByteStream.Write is an upload RPC, so it must not inherit the download idle timeout even
+    // though it belongs to the same gRPC service as ByteStream.Read.
+    FakeClientCall<WriteRequest, WriteResponse> delegate = new FakeClientCall<>();
+    FakeChannel channel = new FakeChannel(delegate);
+    ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+    RemoteDownloadIdleTimeoutInterceptor interceptor =
+        new RemoteDownloadIdleTimeoutInterceptor(Duration.ofSeconds(3), scheduler);
+
+    ClientCall<WriteRequest, WriteResponse> call =
+        interceptor.interceptCall(ByteStreamGrpc.getWriteMethod(), CallOptions.DEFAULT, channel);
+    call.start(new ClientCall.Listener<>() {}, new Metadata());
+    call.sendMessage(WriteRequest.getDefaultInstance());
+
+    verify(scheduler, never()).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+    assertThat(delegate.cancelled).isFalse();
+  }
+
+  @Test
+  public void byteStreamRead_cancelsWhenIdleTimeoutFires() {
+    // A ByteStream.Read with no response activity for the full timeout should be canceled so the
+    // cache client can retry it rather than waiting forever.
+    FakeClientCall<ReadRequest, ReadResponse> delegate = new FakeClientCall<>();
+    FakeChannel channel = new FakeChannel(delegate);
+    ScheduledTasks scheduledTasks = new ScheduledTasks();
+    AtomicLong nanoTime = new AtomicLong();
+    AtomicReference<Status> closedStatus = new AtomicReference<>();
+    RemoteDownloadIdleTimeoutInterceptor interceptor =
+        new RemoteDownloadIdleTimeoutInterceptor(
+            Duration.ofSeconds(3), scheduledTasks.scheduler, nanoTime::get);
+
+    ClientCall<ReadRequest, ReadResponse> call =
+        interceptor.interceptCall(ByteStreamGrpc.getReadMethod(), CallOptions.DEFAULT, channel);
+    call.start(
+        new ClientCall.Listener<>() {
+          @Override
+          public void onClose(Status status, Metadata trailers) {
+            closedStatus.set(status);
+          }
+        },
+        new Metadata());
+    // Advance the controlled clock to the deadline and run the captured timeout synchronously.
+    nanoTime.set(Duration.ofSeconds(3).toNanos());
+    scheduledTasks.tasks.get(0).run();
+
+    assertThat(scheduledTasks.delaysNanos).containsExactly(Duration.ofSeconds(3).toNanos());
+    assertThat(delegate.cancelled).isTrue();
+    assertThat(delegate.cancelMessage)
+        .isEqualTo(
+            "Remote download idle timeout exceeded after PT3S for"
+                + " google.bytestream.ByteStream/Read");
+    assertThat(Status.fromThrowable(delegate.cancelCause).getCode())
+        .isEqualTo(Status.Code.DEADLINE_EXCEEDED);
+    // ClientCall.cancel normally closes the listener with CANCELLED. The interceptor translates
+    // its own timeout-driven close so retry classification sees DEADLINE_EXCEEDED instead.
+    assertThat(closedStatus.get().getCode()).isEqualTo(Status.Code.DEADLINE_EXCEEDED);
+  }
+
+  @Test
+  public void byteStreamRead_defersTimeoutWithoutQueueingTasksForEachMessage() {
+    // Activity should only move the monotonic deadline. Replacing the scheduled task for every
+    // message would retain canceled tasks in the shared scheduler and grow its queue.
+    FakeClientCall<ReadRequest, ReadResponse> delegate = new FakeClientCall<>();
+    FakeChannel channel = new FakeChannel(delegate);
+    ScheduledTasks scheduledTasks = new ScheduledTasks();
+    AtomicLong nanoTime = new AtomicLong();
+    RemoteDownloadIdleTimeoutInterceptor interceptor =
+        new RemoteDownloadIdleTimeoutInterceptor(
+            Duration.ofSeconds(3), scheduledTasks.scheduler, nanoTime::get);
+    ImmutableList.Builder<ReadResponse> responses = ImmutableList.builder();
+
+    ClientCall<ReadRequest, ReadResponse> call =
+        interceptor.interceptCall(ByteStreamGrpc.getReadMethod(), CallOptions.DEFAULT, channel);
+    call.start(
+        new ClientCall.Listener<>() {
+          @Override
+          public void onMessage(ReadResponse message) {
+            responses.add(message);
+          }
+        },
+        new Metadata());
+    ScheduledFuture<?> firstTimeout = scheduledTasks.futures.get(0);
+
+    // The request at t=1 and response at t=2 move the deadline to t=5, but the original task for
+    // t=3 remains the only task in the scheduler.
+    nanoTime.set(Duration.ofSeconds(1).toNanos());
+    call.sendMessage(ReadRequest.getDefaultInstance());
+
+    nanoTime.set(Duration.ofSeconds(2).toNanos());
+    ReadResponse response = ReadResponse.getDefaultInstance();
+    delegate.listener.onMessage(response);
+
+    assertThat(scheduledTasks.tasks).hasSize(1);
+    // When the original task runs at t=3, it observes two seconds of remaining idle time and
+    // schedules exactly one successor. Closing the call cancels that successor.
+    nanoTime.set(Duration.ofSeconds(3).toNanos());
+    scheduledTasks.tasks.get(0).run();
+    ScheduledFuture<?> deferredTimeout = scheduledTasks.futures.get(1);
+    delegate.listener.onClose(Status.OK, new Metadata());
+
+    verify(firstTimeout, never()).cancel(false);
+    verify(deferredTimeout).cancel(false);
+    assertThat(scheduledTasks.tasks).hasSize(2);
+    assertThat(scheduledTasks.delaysNanos)
+        .containsExactly(Duration.ofSeconds(3).toNanos(), Duration.ofSeconds(2).toNanos())
+        .inOrder();
+    assertThat(responses.build()).containsExactly(response);
+    assertThat(delegate.cancelled).isFalse();
+  }
+
+  @Test
+  public void byteStreamRead_forwardsCallbacksWhenResetTimeoutFails() {
+    // Timeout bookkeeping is secondary to the gRPC call. Make every attempt to schedule the
+    // timeout fail, then verify the request and response still cross the interceptor boundary.
+    FakeClientCall<ReadRequest, ReadResponse> delegate = new FakeClientCall<>();
+    FakeChannel channel = new FakeChannel(delegate);
+    ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+    RuntimeException resetFailure = new RuntimeException("reset failed");
+    when(scheduler.schedule(any(Runnable.class), anyLong(), eq(NANOSECONDS)))
+        .thenThrow(resetFailure);
+    RemoteDownloadIdleTimeoutInterceptor interceptor =
+        new RemoteDownloadIdleTimeoutInterceptor(Duration.ofSeconds(3), scheduler);
+    ImmutableList.Builder<ReadResponse> responses = ImmutableList.builder();
+
+    ClientCall<ReadRequest, ReadResponse> call =
+        interceptor.interceptCall(ByteStreamGrpc.getReadMethod(), CallOptions.DEFAULT, channel);
+    // start() installs the wrapped listener before the initial timeout reset fails.
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            call.start(
+                new ClientCall.Listener<>() {
+                  @Override
+                  public void onMessage(ReadResponse message) {
+                    responses.add(message);
+                  }
+                },
+                new Metadata()));
+
+    ReadRequest request = ReadRequest.getDefaultInstance();
+    // sendMessage() resets before forwarding, so the finally block is what preserves the request.
+    assertThrows(RuntimeException.class, () -> call.sendMessage(request));
+
+    ReadResponse response = ReadResponse.getDefaultInstance();
+    // onMessage() follows the same rule: surface the reset failure without swallowing the data.
+    assertThrows(RuntimeException.class, () -> delegate.listener.onMessage(response));
+
+    assertThat(delegate.sentMessages).containsExactly(request);
+    assertThat(responses.build()).containsExactly(response);
+  }
+
+  private static final class FakeChannel extends Channel {
+    private final ClientCall<?, ?> call;
+
+    private FakeChannel(ClientCall<?, ?> call) {
+      this.call = call;
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(
+        MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions) {
+      @SuppressWarnings("unchecked")
+      ClientCall<ReqT, RespT> typedCall = (ClientCall<ReqT, RespT>) call;
+      return typedCall;
+    }
+
+    @Override
+    public String authority() {
+      return "test";
+    }
+  }
+
+  private static final class FakeClientCall<ReqT, RespT> extends ClientCall<ReqT, RespT> {
+    private Listener<RespT> listener;
+    private final List<ReqT> sentMessages = new ArrayList<>();
+    private boolean cancelled;
+    private String cancelMessage;
+    private Throwable cancelCause;
+
+    @Override
+    public void start(Listener<RespT> responseListener, Metadata headers) {
+      this.listener = responseListener;
+    }
+
+    @Override
+    public void request(int numMessages) {}
+
+    @Override
+    public void cancel(String message, Throwable cause) {
+      this.cancelled = true;
+      this.cancelMessage = message;
+      this.cancelCause = cause;
+      listener.onClose(Status.CANCELLED.withDescription(message).withCause(cause), new Metadata());
+    }
+
+    @Override
+    public void halfClose() {}
+
+    @Override
+    public void sendMessage(ReqT message) {
+      sentMessages.add(message);
+    }
+  }
+
+  private static final class ScheduledTasks {
+    private final ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+    private final List<Runnable> tasks = new ArrayList<>();
+    private final List<ScheduledFuture<?>> futures = new ArrayList<>();
+    private final List<Long> delaysNanos = new ArrayList<>();
+
+    ScheduledTasks() {
+      when(scheduler.schedule(any(Runnable.class), anyLong(), eq(NANOSECONDS)))
+          .thenAnswer(
+              invocation -> {
+                tasks.add(invocation.getArgument(0));
+                delaysNanos.add(invocation.getArgument(1));
+                ScheduledFuture<?> future = mock(ScheduledFuture.class);
+                futures.add(future);
+                return future;
+              });
+    }
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
@@ -95,6 +95,15 @@ public class RemoteOptionsTest {
   }
 
   @Test
+  public void remoteGrpcDownloadIdleTimeout_defaultsTo60Seconds() {
+    // Keep gRPC downloads protected by default with the same timeout used by the HTTP remote
+    // cache. Users can still explicitly set the option to zero to disable it.
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+
+    assertThat(options.getRemoteGrpcDownloadIdleTimeout()).isEqualTo(Duration.ofSeconds(60));
+  }
+
+  @Test
   public void testRemoteGrpcLogWithEmptyString() throws Exception {
     OptionsParser parser = OptionsParser.builder().optionsClasses(RemoteOptions.class).build();
     parser.parse("--remote_grpc_log=test.log", "--remote_grpc_log=");


### PR DESCRIPTION
The gRPC service-config support from #29912 is now on master. It lets users lengthen the whole-call deadline for `ByteStream.Read` so large downloads can keep running while they make progress. A longer deadline also lets a stalled stream wait just as long, because a total RPC deadline cannot distinguish progress from inactivity.

This adds `--remote_grpc_download_idle_timeout` as an independent inactivity limit for `ByteStream.Read`. It defaults to 60 seconds to match the existing HTTP remote-cache default; setting it to `0` disables it. When a read goes idle, Bazel cancels it and translates the timeout-owned `CANCELLED` closure to `DEADLINE_EXCEEDED` so the normal cache retrier can resume from the received offset. Other RPCs, including `ByteStream.Write`, `Execute`, and `WaitExecution`, are unaffected.

Timeout tracking uses a monotonic deadline and at most one scheduled task per call. This avoids retaining a canceled task for every response and prevents a timer from canceling a read that has since made progress. Normal gRPC forwarding stays in `finally` blocks so timeout bookkeeping failures cannot suppress messages or callbacks.

Tests cover:

- the 60-second option default and exclusion of `ByteStream.Write`;
- cancellation status and single-task scheduling as reads make progress;
- request and response forwarding when timeout bookkeeping fails; and
- an in-process `ByteStream` flow that sends a prefix, stalls, fires the timeout deterministically, and verifies that the retry resumes from the next offset.

The interceptor currently applies only to `ByteStream.Read`. The download-specific option name leaves room to cover future server-streaming download RPCs such as [`SplitChunks`](https://github.com/bazelbuild/remote-apis/pull/377) without implying that every remote stream should share this timeout.
