### PR TITLE
Add measured spawn memory to SpawnMetrics and execution log

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/SpawnMetrics.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SpawnMetrics.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /** Timing, size, and memory statistics for a Spawn execution. */
 @SuppressWarnings("GoodTime") // Use ints instead of Durations to improve build time (cl/505728570)
@@ -45,6 +46,7 @@ public class SpawnMetrics {
     this.inputBytes = builder.inputBytes;
     this.inputFiles = builder.inputFiles;
     this.memoryEstimateBytes = builder.memoryEstimateBytes;
+    this.memoryBytes = builder.memoryBytes;
   }
 
   /** Indicates whether the metrics correspond to the remote, local or worker execution. */
@@ -85,15 +87,29 @@ public class SpawnMetrics {
   private final long inputBytes;
   private final long inputFiles;
   private final long memoryEstimateBytes;
+  private final long memoryBytes;
 
   /** Any non-important stats < than 10% will not be shown in the summary. */
   private static final double STATS_SHOW_THRESHOLD = 0.10;
 
   static SpawnMetrics forLocalExecution(int wallTimeInMs) {
+    return forLocalExecution(wallTimeInMs, /* memoryInKb= */ null);
+  }
+
+  static SpawnMetrics forLocalExecution(int wallTimeInMs, @Nullable Long memoryInKb) {
     return SpawnMetrics.Builder.forLocalExec()
         .setTotalTimeInMs(wallTimeInMs)
         .setExecutionWallTimeInMs(wallTimeInMs)
+        .setMemoryBytes(memoryKbToBytes(memoryInKb))
         .build();
+  }
+
+  /** Converts measured memory in KB to bytes, or returns 0 if unavailable. */
+  public static long memoryKbToBytes(@Nullable Long memoryInKb) {
+    if (memoryInKb == null || memoryInKb <= 0) {
+      return 0;
+    }
+    return memoryInKb * 1024L;
   }
 
   /**
@@ -121,7 +137,8 @@ public class SpawnMetrics {
     if (!summary) {
       stats.add("input files: " + inputFiles);
       stats.add("input bytes: " + inputBytes);
-      stats.add("memory bytes: " + memoryEstimateBytes);
+      stats.add("memory estimate bytes: " + memoryEstimateBytes);
+      stats.add("memory bytes: " + memoryBytes);
     }
     Joiner.on(", ").appendTo(sb, stats);
     sb.append("]");
@@ -271,6 +288,11 @@ public class SpawnMetrics {
     return memoryEstimateBytes;
   }
 
+  /** Actual measured peak memory usage in bytes or 0 if unavailable. */
+  public long memoryBytes() {
+    return memoryBytes;
+  }
+
   /** Limit of total size in bytes of inputs or 0 if unavailable. */
   public long inputBytesLimit() {
     return 0;
@@ -317,6 +339,7 @@ public class SpawnMetrics {
     private long inputBytes = 0;
     private long inputFiles = 0;
     private long memoryEstimateBytes = 0;
+    private long memoryBytes = 0;
     long inputBytesLimit = 0;
     long inputFilesLimit = 0;
     long outputBytesLimit = 0;
@@ -525,6 +548,12 @@ public class SpawnMetrics {
     }
 
     @CanIgnoreReturnValue
+    public Builder setMemoryBytes(long memoryBytes) {
+      this.memoryBytes = memoryBytes;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
     public Builder setInputBytesLimit(long inputBytesLimit) {
       this.inputBytesLimit = inputBytesLimit;
       return this;
@@ -582,6 +611,7 @@ public class SpawnMetrics {
       inputFiles += metric.inputFiles();
       inputBytes += metric.inputBytes();
       memoryEstimateBytes += metric.memoryEstimate();
+      memoryBytes += metric.memoryBytes();
       inputFilesLimit += metric.inputFilesLimit();
       inputBytesLimit += metric.inputBytesLimit();
       outputFilesLimit += metric.outputFilesLimit();
@@ -596,6 +626,7 @@ public class SpawnMetrics {
       inputFiles = Long.max(inputFiles, metric.inputFiles());
       inputBytes = Long.max(inputBytes, metric.inputBytes());
       memoryEstimateBytes = Long.max(memoryEstimateBytes, metric.memoryEstimate());
+      memoryBytes = Long.max(memoryBytes, metric.memoryBytes());
       inputFilesLimit = Long.max(inputFilesLimit, metric.inputFilesLimit());
       inputBytesLimit = Long.max(inputBytesLimit, metric.inputBytesLimit());
       outputFilesLimit = Long.max(outputFilesLimit, metric.outputFilesLimit());

--- a/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
@@ -319,7 +319,9 @@ public interface SpawnResult {
       this.spawnMetrics =
           builder.spawnMetrics != null
               ? builder.spawnMetrics
-              : SpawnMetrics.forLocalExecution(builder.wallTimeInMs);
+              : SpawnMetrics.forLocalExecution(
+                  builder.wallTimeInMs,
+                  builder.populateMeasuredMemoryInSpawnMetrics ? builder.memoryInKb : null);
       this.startTime = builder.startTime;
       this.wallTimeInMs = builder.wallTimeInMs;
       this.userTimeInMs = builder.userTimeInMs;
@@ -634,6 +636,7 @@ public interface SpawnResult {
 
     private boolean remote;
     private Digest digest;
+    private boolean populateMeasuredMemoryInSpawnMetrics;
 
     public SpawnResult build() {
       Preconditions.checkArgument(!runnerName.isEmpty());
@@ -709,6 +712,13 @@ public interface SpawnResult {
     }
 
     @CanIgnoreReturnValue
+    public Builder setPopulateMeasuredMemoryInSpawnMetrics(
+        boolean populateMeasuredMemoryInSpawnMetrics) {
+      this.populateMeasuredMemoryInSpawnMetrics = populateMeasuredMemoryInSpawnMetrics;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
     public Builder setStartTime(Instant startTime) {
       this.startTime = startTime;
       return this;
@@ -753,6 +763,19 @@ public interface SpawnResult {
     @CanIgnoreReturnValue
     public Builder setMemoryInKb(long memoryInKb) {
       this.memoryInKb = memoryInKb;
+      return this;
+    }
+
+    /**
+     * Copies measured memory from resource usage statistics into {@code spawnMetricsBuilder}.
+     *
+     * <p>No-op if memory usage was not recorded.
+     */
+    @CanIgnoreReturnValue
+    public Builder populateMeasuredMemoryInto(SpawnMetrics.Builder spawnMetricsBuilder) {
+      if (memoryInKb != null && memoryInKb > 0) {
+        spawnMetricsBuilder.setMemoryBytes(SpawnMetrics.memoryKbToBytes(memoryInKb));
+      }
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -539,6 +539,18 @@ public abstract class ExecutionOptions extends OptionsBase {
   public abstract RegexFilter getExecutionLogMnemonicFilter();
 
   @Option(
+      name = "experimental_spawn_measured_memory_metrics",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {OptionEffectTag.EXECUTION},
+      help =
+          "If set, record measured peak memory (SpawnMetrics.memory_bytes) in spawn metrics and"
+              + " the execution log using execution statistics from process-wrapper or"
+              + " linux-sandbox (stats.out). Requires local or sandbox execution with statistics"
+              + " collection enabled. Remote and worker execution are not supported.")
+  public abstract boolean getExperimentalSpawnMeasuredMemoryMetrics();
+
+  @Option(
       // TODO: when this flag is moved to non-experimental, rename it to a more general name
       // to reflect the new logic - it's not only about cache evictions.
       name = "experimental_remote_cache_eviction_retries",

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -262,6 +262,9 @@ public abstract class SpawnLogContext implements ActionContext {
     builder.setInputBytes(metrics.inputBytes());
     builder.setInputFiles(metrics.inputFiles());
     builder.setMemoryEstimateBytes(metrics.memoryEstimate());
+    if (metrics.memoryBytes() != 0) {
+      builder.setMemoryBytes(metrics.memoryBytes());
+    }
     builder.setInputBytesLimit(metrics.inputBytesLimit());
     builder.setInputFilesLimit(metrics.inputFilesLimit());
     builder.setOutputBytesLimit(metrics.outputBytesLimit());

--- a/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
@@ -98,6 +98,7 @@ public class LocalSpawnRunner implements SpawnRunner {
   private final BinTools binTools;
 
   private final RunfilesTreeUpdater runfilesTreeUpdater;
+  private final boolean experimentalSpawnMeasuredMemoryMetrics;
 
   public LocalSpawnRunner(
       Path execRoot,
@@ -106,7 +107,8 @@ public class LocalSpawnRunner implements SpawnRunner {
       LocalEnvProvider localEnvProvider,
       BinTools binTools,
       ProcessWrapper processWrapper,
-      RunfilesTreeUpdater runfilesTreeUpdater) {
+      RunfilesTreeUpdater runfilesTreeUpdater,
+      boolean experimentalSpawnMeasuredMemoryMetrics) {
     this.execRoot = execRoot;
     this.processWrapper = processWrapper;
     this.localExecutionOptions = Preconditions.checkNotNull(localExecutionOptions);
@@ -115,6 +117,7 @@ public class LocalSpawnRunner implements SpawnRunner {
     this.localEnvProvider = localEnvProvider;
     this.binTools = binTools;
     this.runfilesTreeUpdater = runfilesTreeUpdater;
+    this.experimentalSpawnMeasuredMemoryMetrics = experimentalSpawnMeasuredMemoryMetrics;
   }
 
   @Override
@@ -464,6 +467,9 @@ public class LocalSpawnRunner implements SpawnRunner {
         }
         if (statisticsPath != null) {
           spawnResultBuilder.setResourceUsageFromProto(statisticsPath);
+          if (experimentalSpawnMeasuredMemoryMetrics) {
+            spawnResultBuilder.populateMeasuredMemoryInto(spawnMetrics);
+          }
         }
         spawnMetrics.setTotalTime(totalTimeStopwatch.elapsed());
         spawnResultBuilder.setSpawnMetrics(spawnMetrics.build());

--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -74,6 +74,7 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
   private final SandboxOptions sandboxOptions;
   private final boolean verboseFailures;
   private final boolean expandParamFiles;
+  private final boolean experimentalSpawnMeasuredMemoryMetrics;
   private final ImmutableSet<Path> inaccessiblePaths;
   protected final BinTools binTools;
   private final Path execRoot;
@@ -82,10 +83,12 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
   protected final ImmutableMap<String, String> clientEnv;
 
   public AbstractSandboxSpawnRunner(CommandEnvironment cmdEnv) {
-    this.sandboxOptions = cmdEnv.getOptions().getOptions(SandboxOptions.class);
     ExecutionOptions executionOptions = cmdEnv.getOptions().getOptions(ExecutionOptions.class);
+    this.sandboxOptions = cmdEnv.getOptions().getOptions(SandboxOptions.class);
     this.verboseFailures = executionOptions.getVerboseFailures();
     this.expandParamFiles = executionOptions.getExpandParamFiles();
+    this.experimentalSpawnMeasuredMemoryMetrics =
+        executionOptions.getExperimentalSpawnMeasuredMemoryMetrics();
     this.inaccessiblePaths =
         sandboxOptions.getInaccessiblePaths(cmdEnv.getRuntime().getFileSystem());
     this.binTools = cmdEnv.getBlazeWorkspace().getBinTools();
@@ -325,6 +328,9 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
     Path statisticsPath = sandbox.getStatisticsPath();
     if (statisticsPath != null) {
       spawnResultBuilder.setResourceUsageFromProto(statisticsPath);
+      if (experimentalSpawnMeasuredMemoryMetrics) {
+        spawnResultBuilder.setPopulateMeasuredMemoryInSpawnMetrics(true);
+      }
     }
 
     return spawnResultBuilder.build();

--- a/src/main/java/com/google/devtools/build/lib/standalone/StandaloneModule.java
+++ b/src/main/java/com/google/devtools/build/lib/standalone/StandaloneModule.java
@@ -79,6 +79,8 @@ public class StandaloneModule extends BlazeModule {
   @Override
   public void registerSpawnStrategies(
       SpawnStrategyRegistry.Builder registryBuilder, CommandEnvironment env) {
+    ExecutionOptions executionOptions =
+        checkNotNull(env.getOptions().getOptions(ExecutionOptions.class));
     SpawnRunner localSpawnRunner =
         new LocalSpawnRunner(
             env.getExecRoot(),
@@ -87,10 +89,8 @@ public class StandaloneModule extends BlazeModule {
             LocalEnvProvider.forCurrentOs(env.getClientEnv()),
             env.getBlazeWorkspace().getBinTools(),
             ProcessWrapper.fromCommandEnvironment(env),
-            RunfilesTreeUpdater.forCommandEnvironment(env));
-
-    ExecutionOptions executionOptions =
-        checkNotNull(env.getOptions().getOptions(ExecutionOptions.class));
+            RunfilesTreeUpdater.forCommandEnvironment(env),
+            executionOptions.getExperimentalSpawnMeasuredMemoryMetrics());
     // Order of strategies passed to builder is significant - when there are many strategies that
     // could potentially be used and a spawnActionContext doesn't specify which one it wants, the
     // last one from strategies list will be used

--- a/src/main/protobuf/spawn.proto
+++ b/src/main/protobuf/spawn.proto
@@ -114,6 +114,8 @@ message SpawnMetrics {
   google.protobuf.Duration time_limit = 19;
   // Instant when the spawn started to execute.
   google.protobuf.Timestamp start_time = 20;
+  // Actual measured peak memory usage in bytes or 0 if unavailable.
+  int64 memory_bytes = 21;
 }
 
 // Details of an executed spawn.

--- a/src/test/java/com/google/devtools/build/lib/actions/SpawnMetricsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/SpawnMetricsTest.java
@@ -24,6 +24,14 @@ import org.junit.runners.JUnit4;
 public final class SpawnMetricsTest {
 
   @Test
+  public void memoryKbToBytes() {
+    assertThat(SpawnMetrics.memoryKbToBytes(null)).isEqualTo(0);
+    assertThat(SpawnMetrics.memoryKbToBytes(0L)).isEqualTo(0);
+    assertThat(SpawnMetrics.memoryKbToBytes(-1L)).isEqualTo(0);
+    assertThat(SpawnMetrics.memoryKbToBytes(346692L)).isEqualTo(346692L * 1024L);
+  }
+
+  @Test
   public void builder_addDurationsNonDurations() throws Exception {
     SpawnMetrics metrics1 =
         SpawnMetrics.Builder.forRemoteExec()
@@ -32,6 +40,7 @@ public final class SpawnMetricsTest {
             .setInputBytes(10)
             .setInputFiles(20)
             .setMemoryEstimateBytes(30)
+            .setMemoryBytes(35)
             .setInputBytesLimit(20)
             .setInputFilesLimit(40)
             .setOutputBytesLimit(50)
@@ -46,6 +55,7 @@ public final class SpawnMetricsTest {
             .setInputBytes(100)
             .setInputFiles(200)
             .setMemoryEstimateBytes(300)
+            .setMemoryBytes(300)
             .setInputBytesLimit(200)
             .setInputFilesLimit(400)
             .setOutputBytesLimit(500)
@@ -67,6 +77,7 @@ public final class SpawnMetricsTest {
     assertThat(result.inputBytes()).isEqualTo(110);
     assertThat(result.inputFiles()).isEqualTo(220);
     assertThat(result.memoryEstimate()).isEqualTo(330);
+    assertThat(result.memoryBytes()).isEqualTo(335);
     assertThat(result.inputBytesLimit()).isEqualTo(220);
     assertThat(result.inputFilesLimit()).isEqualTo(440);
     assertThat(result.outputBytesLimit()).isEqualTo(550);
@@ -84,6 +95,7 @@ public final class SpawnMetricsTest {
             .setInputBytes(10)
             .setInputFiles(20)
             .setMemoryEstimateBytes(30)
+            .setMemoryBytes(35)
             .setInputBytesLimit(20)
             .setInputFilesLimit(40)
             .setOutputBytesLimit(50)
@@ -98,6 +110,7 @@ public final class SpawnMetricsTest {
             .setInputBytes(100)
             .setInputFiles(200)
             .setMemoryEstimateBytes(300)
+            .setMemoryBytes(300)
             .setInputBytesLimit(200)
             .setInputFilesLimit(400)
             .setOutputBytesLimit(500)
@@ -119,6 +132,7 @@ public final class SpawnMetricsTest {
     assertThat(result.inputBytes()).isEqualTo(100);
     assertThat(result.inputFiles()).isEqualTo(200);
     assertThat(result.memoryEstimate()).isEqualTo(300);
+    assertThat(result.memoryBytes()).isEqualTo(300);
     assertThat(result.inputBytesLimit()).isEqualTo(200);
     assertThat(result.inputFilesLimit()).isEqualTo(400);
     assertThat(result.outputBytesLimit()).isEqualTo(500);

--- a/src/test/java/com/google/devtools/build/lib/actions/SpawnResultTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/SpawnResultTest.java
@@ -63,6 +63,57 @@ public final class SpawnResultTest {
   }
 
   @Test
+  public void defaultSpawnMetricsOmitsMemoryWhenNotEnabled() {
+    SpawnResult result =
+        new SpawnResult.Builder()
+            .setStatus(Status.SUCCESS)
+            .setExitCode(0)
+            .setRunnerName("linux-sandbox")
+            .setWallTimeInMs(5089)
+            .setMemoryInKb(346692)
+            .build();
+
+    assertThat(result.getMemoryInKb()).isEqualTo(346692);
+    assertThat(result.getMetrics().memoryBytes()).isEqualTo(0);
+  }
+
+  @Test
+  public void defaultSpawnMetricsIncludesMemoryFromResourceUsageWhenEnabled() {
+    SpawnResult result =
+        new SpawnResult.Builder()
+            .setStatus(Status.SUCCESS)
+            .setExitCode(0)
+            .setRunnerName("linux-sandbox")
+            .setWallTimeInMs(5089)
+            .setMemoryInKb(346692)
+            .setPopulateMeasuredMemoryInSpawnMetrics(true)
+            .build();
+
+    assertThat(result.getMemoryInKb()).isEqualTo(346692);
+    assertThat(result.getMetrics().memoryBytes()).isEqualTo(346692L * 1024L);
+  }
+
+  @Test
+  public void explicitSpawnMetricsOverridesDefaultMemoryPopulation() {
+    SpawnResult result =
+        new SpawnResult.Builder()
+            .setStatus(Status.SUCCESS)
+            .setExitCode(0)
+            .setRunnerName("local")
+            .setWallTimeInMs(100)
+            .setMemoryInKb(346692)
+            .setSpawnMetrics(
+                SpawnMetrics.Builder.forLocalExec()
+                    .setTotalTimeInMs(100)
+                    .setExecutionWallTimeInMs(100)
+                    .setMemoryBytes(123)
+                    .build())
+            .build();
+
+    assertThat(result.getMetrics().memoryBytes()).isEqualTo(123);
+  }
+
+  @Test
   public void inMemoryContents() {
     ActionInput output = ActionInputHelper.fromPath("/foo/bar");
     ByteString contents = ByteString.copyFromUtf8("hello world");

--- a/src/test/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunnerTest.java
@@ -112,7 +112,8 @@ public class LocalSpawnRunnerTest {
           localEnvProvider,
           /* binTools= */ null,
           processWrapper,
-          Mockito.mock(RunfilesTreeUpdater.class));
+          Mockito.mock(RunfilesTreeUpdater.class),
+          /* experimentalSpawnMeasuredMemoryMetrics= */ false);
     }
 
     // Rigged to act on supplied filesystem (e.g. InMemoryFileSystem) for testing purposes
@@ -617,7 +618,8 @@ public class LocalSpawnRunnerTest {
             LocalEnvProvider.forCurrentOs(ImmutableMap.of()),
             /* binTools= */ null,
             /* processWrapper= */ null,
-            Mockito.mock(RunfilesTreeUpdater.class));
+            Mockito.mock(RunfilesTreeUpdater.class),
+            /* experimentalSpawnMeasuredMemoryMetrics= */ false);
     FileOutErr fileOutErr =
         new FileOutErr(tempDir.getRelative("stdout"), tempDir.getRelative("stderr"));
 
@@ -887,7 +889,8 @@ public class LocalSpawnRunnerTest {
                 ActionInputHelper.fromPath(processWrapperPath.asFragment()),
                 /* killDelay= */ Duration.ZERO,
                 /* gracefulSigterm= */ false),
-            Mockito.mock(RunfilesTreeUpdater.class));
+            Mockito.mock(RunfilesTreeUpdater.class),
+            /* experimentalSpawnMeasuredMemoryMetrics= */ false);
 
     Spawn spawn =
         new SpawnBuilder(
@@ -916,6 +919,7 @@ public class LocalSpawnRunnerTest {
     assertThat(spawnResult.getNumBlockOutputOperations()).isAtLeast(0L);
     assertThat(spawnResult.getNumBlockInputOperations()).isAtLeast(0L);
     assertThat(spawnResult.getNumInvoluntaryContextSwitches()).isAtLeast(0L);
+    assertThat(spawnResult.getMetrics().memoryBytes()).isEqualTo(0);
   }
 
   // Check that relative paths in the Spawn are absolutized relative to the execroot passed to the

--- a/src/test/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunnerTest.java
@@ -170,6 +170,30 @@ public final class LinuxSandboxedSpawnRunnerTest extends SandboxedSpawnRunnerTes
   }
 
   @Test
+  public void exec_collectsMeasuredMemoryWhenFlagEnabled() throws Exception {
+    runtimeWrapper.addOptions("--experimental_spawn_measured_memory_metrics");
+    CommandEnvironment commandEnvironment = createCommandEnvironment();
+    LinuxSandboxedSpawnRunner runner = setupSandboxAndCreateRunner(commandEnvironment);
+    Path cpuTimeSpenderPath =
+        SpawnRunnerTestUtil.copyCpuTimeSpenderIntoPath(commandEnvironment.getExecRoot());
+    Spawn spawn =
+        new SpawnBuilder(
+                cpuTimeSpenderPath.getPathString(),
+                /* userSeconds= */ "10",
+                /* systemSeconds= */ "0")
+            .build();
+    SpawnExecutionContextForTesting policy = createSpawnExecutionContext(spawn);
+
+    SpawnResult spawnResult = runner.exec(spawn, policy);
+
+    assertThat(spawnResult.status()).isEqualTo(SpawnResult.Status.SUCCESS);
+    // linux-sandbox wait4 collects rusage for the sandbox init (pid1), not necessarily the
+    // action subprocess peak RSS. This test only verifies stats.out is wired to SpawnMetrics.
+    assertThat(spawnResult.getMemoryInKb()).isGreaterThan(0L);
+    assertThat(spawnResult.getMetrics().memoryBytes()).isGreaterThan(0L);
+  }
+
+  @Test
   public void hermeticTmp_tmpCreatedAndMounted() throws Exception {
     CommandEnvironment commandEnvironment = createCommandEnvironment();
     LinuxSandboxedSpawnRunner runner = setupSandboxAndCreateRunner(commandEnvironment);

--- a/src/test/java/com/google/devtools/build/lib/standalone/StandaloneSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/standalone/StandaloneSpawnStrategyTest.java
@@ -149,7 +149,8 @@ public class StandaloneSpawnStrategyTest {
                 (env, binTools1, fallbackTmpDir) -> ImmutableMap.copyOf(env),
                 binTools,
                 /* processWrapper= */ null,
-                Mockito.mock(RunfilesTreeUpdater.class)),
+                Mockito.mock(RunfilesTreeUpdater.class),
+                /* experimentalSpawnMeasuredMemoryMetrics= */ false),
             Options.getDefaults(ExecutionOptions.class));
     this.executor =
         new TestExecutorBuilder(fileSystem, directories)


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

- Add `memory_bytes` (proto field 21) to `SpawnMetrics` and the execution log for measured peak RSS from execution statistics (`stats.out`).
- Gate the feature behind `--experimental_spawn_measured_memory_metrics` (default `false`).
- Populate metrics for local execution and sandbox runners when statistics are available.

Measured memory is peak resident set size (RSS) from `getrusage(2)` via `stats.out`.

- **Local** and **processwrapper-sandbox**: statistics are collected for the action process wrapped by process-wrapper.
- **linux-sandbox**: statistics are written when the sandbox is invoked with `-S stats.out`. The outer `wait4` waits for the sandbox init (pid1); `ru_maxrss` reflects kernel accounting for that waited process and may differ from the action subprocess peak RSS.
- **Remote** and **worker**: not supported; `memoryBytes` stays 0.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

Fixes #29872

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

Yes, add `--experimental_spawn_measured_memory_metrics` (default `false`)

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
