### PR TITLE
Split mandatory/discovered action cache check for C++20 module compiles

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/Action.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Action.java
@@ -194,6 +194,17 @@ public interface Action extends ActionExecutionMetadata {
   void resetDiscoveredInputs();
 
   /**
+   * Whether to split mandatory and discovered inputs during action cache checking.
+   *
+   * <p>When true, the action cache checker validates mandatory inputs before loading previously
+   * discovered inputs from the cache. This avoids dependency cycles when discovered input
+   * relationships change between builds.
+   */
+  default boolean usesSplitMandatoryInputsActionCacheCheck() {
+    return false;
+  }
+
+  /**
    * Returns the set of artifacts that can possibly be inputs. It will be called iff {@link
    * #inputsKnown} is false for the given action instance and there is a related cache entry in the
    * action cache.

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
@@ -121,7 +121,10 @@ public class ActionCacheChecker {
     this.cacheConfig =
         cacheConfig != null
             ? cacheConfig
-            : CacheConfig.builder().setEnabled(true).setStoreOutputMetadata(false).build();
+            : CacheConfig.builder()
+                .setEnabled(true)
+                .setStoreOutputMetadata(false)
+                .build();
     if (this.cacheConfig.enabled()) {
       this.actionCache = Preconditions.checkNotNull(actionCache);
     } else {
@@ -188,6 +191,7 @@ public class ActionCacheChecker {
    * @param actionInputs the action inputs; usually action.getInputs(), but might be a previously
    *     cached set of discovered inputs for actions that discover them.
    * @param outputMetadataStore metadata provider for action outputs.
+   * @param mandatoryInputsDigest the digest of mandatory inputs for split cache checking, or null.
    * @param cachedOutputMetadata cached metadata that should be used instead of {@code
    *     outputMetadataStore}.
    * @param outputChecker used to check whether remote metadata should be trusted.
@@ -204,6 +208,7 @@ public class ActionCacheChecker {
       NestedSet<Artifact> actionInputs,
       InputMetadataProvider inputMetadataProvider,
       OutputMetadataStore outputMetadataStore,
+      @Nullable byte[] mandatoryInputsDigest,
       @Nullable CachedOutputMetadata cachedOutputMetadata,
       @Nullable OutputChecker outputChecker,
       ImmutableMap<String, String> effectiveEnvironment,
@@ -219,6 +224,9 @@ public class ActionCacheChecker {
             actionExecutionSalt,
             outputPermissions,
             useArchivedTreeArtifacts);
+    if (mandatoryInputsDigest != null) {
+      builder.setMandatoryInputsDigest(mandatoryInputsDigest);
+    }
 
     for (Artifact artifact : action.getOutputs()) {
       if (artifact.isTreeArtifact()) {
@@ -245,9 +253,14 @@ public class ActionCacheChecker {
         }
       }
     }
+    ImmutableSet<Artifact> mandatoryInputs =
+        mandatoryInputsDigest != null ? action.getMandatoryInputs().toSet() : ImmutableSet.of();
     for (Artifact artifact : actionInputs.toList()) {
-      FileArtifactValue inputMetadata = getInputMetadataMaybe(inputMetadataProvider, artifact);
-      builder.addInputFile(artifact, inputMetadata);
+      FileArtifactValue inputMetadata = MandatoryInputsDigestUtils.getInputMetadataMaybe(inputMetadataProvider, artifact);
+      builder.addInputFile(
+          artifact,
+          inputMetadata,
+          /* saveExecPath= */ mandatoryInputsDigest != null && !mandatoryInputs.contains(artifact));
     }
     return Arrays.equals(entry.getDigest(), builder.build().getDigest());
   }
@@ -469,6 +482,7 @@ public class ActionCacheChecker {
   public Token getTokenIfNeedToExecute(
       Action action,
       List<Artifact> resolvedCacheArtifacts,
+      @Nullable byte[] mandatoryInputsDigest,
       Map<String, String> clientEnv,
       OutputPermissions outputPermissions,
       EventHandler handler,
@@ -528,6 +542,7 @@ public class ActionCacheChecker {
         clientEnv,
         outputPermissions,
         actionExecutionSalt,
+        mandatoryInputsDigest,
         cachedOutputMetadata,
         outputChecker,
         useArchivedTreeArtifacts)) {
@@ -562,6 +577,7 @@ public class ActionCacheChecker {
       Map<String, String> clientEnv,
       OutputPermissions outputPermissions,
       String actionExecutionSalt,
+      @Nullable byte[] mandatoryInputsDigest,
       @Nullable CachedOutputMetadata cachedOutputMetadata,
       @Nullable OutputChecker outputChecker,
       boolean useArchivedTreeArtifacts)
@@ -598,6 +614,7 @@ public class ActionCacheChecker {
         actionInputs,
         inputMetadataProvider,
         outputMetadataStore,
+        mandatoryInputsDigest,
         cachedOutputMetadata,
         outputChecker,
         effectiveEnvironment,
@@ -613,14 +630,6 @@ public class ActionCacheChecker {
     return false;
   }
 
-  private static FileArtifactValue getInputMetadataOrConstant(
-      InputMetadataProvider inputMetadataProvider, Artifact artifact) throws IOException {
-    FileArtifactValue metadata = inputMetadataProvider.getInputMetadata(artifact);
-    return (metadata != null && artifact.isConstantMetadata())
-        ? FileArtifactValue.ConstantMetadataValue.INSTANCE
-        : metadata;
-  }
-
   private static FileArtifactValue getOutputMetadataOrConstant(
       OutputMetadataStore outputMetadataStore, Artifact artifact)
       throws IOException, InterruptedException {
@@ -628,19 +637,6 @@ public class ActionCacheChecker {
     return (metadata != null && artifact.isConstantMetadata())
         ? FileArtifactValue.ConstantMetadataValue.INSTANCE
         : metadata;
-  }
-
-  // TODO(ulfjack): It's unclear to me why we're ignoring all IOExceptions. In some cases, we want
-  // to trigger a re-execution, so we should catch the IOException explicitly there. In others, we
-  // should propagate the exception, because it is unexpected (e.g., bad file system state).
-  @Nullable
-  private static FileArtifactValue getInputMetadataMaybe(
-      InputMetadataProvider inputMetadataProvider, Artifact artifact) {
-    try {
-      return getInputMetadataOrConstant(inputMetadataProvider, artifact);
-    } catch (IOException e) {
-      return null;
-    }
   }
 
   // TODO(ulfjack): It's unclear to me why we're ignoring all IOExceptions. In some cases, we want
@@ -676,7 +672,8 @@ public class ActionCacheChecker {
       Map<String, String> clientEnv,
       OutputPermissions outputPermissions,
       String actionExecutionSalt,
-      boolean useArchivedTreeArtifacts)
+      boolean useArchivedTreeArtifacts,
+      @Nullable byte[] mandatoryInputsDigest)
       throws IOException, InterruptedException {
     checkState(cacheConfig.enabled(), "cache unexpectedly disabled, action: %s", action);
     Preconditions.checkArgument(token != null, "token unexpectedly null, action: %s", action);
@@ -705,6 +702,9 @@ public class ActionCacheChecker {
                 outputPermissions,
                 useArchivedTreeArtifacts)
             .setPrunedInputs(action.prunedInputs());
+    if (mandatoryInputsDigest != null) {
+      builder.setMandatoryInputsDigest(mandatoryInputsDigest);
+    }
 
     for (Artifact output : action.getOutputs()) {
       // Remove old records from the cache if they used different key.
@@ -737,11 +737,24 @@ public class ActionCacheChecker {
     for (Artifact input : action.getInputs().toList()) {
       builder.addInputFile(
           input,
-          getInputMetadataMaybe(inputMetadataProvider, input),
+          MandatoryInputsDigestUtils.getInputMetadataMaybe(inputMetadataProvider, input),
           /* saveExecPath= */ !excludePathsFromActionCache.contains(input));
     }
 
     actionCache.put(key, builder.build());
+  }
+
+  public boolean mandatoryInputsMatch(Action action, byte[] mandatoryInputsDigest) {
+    checkArgument(action.discoversInputs());
+    ActionCache.Entry entry = getCacheEntry(action);
+    return entry != null
+        && !entry.isCorrupted()
+        && entry.getMandatoryInputsDigest() != null
+        && Arrays.equals(entry.getMandatoryInputsDigest(), mandatoryInputsDigest);
+  }
+
+  public boolean useSplitMandatoryInputsActionCacheCheck(Action action) {
+    return action.usesSplitMandatoryInputsActionCacheCheck();
   }
 
   @Nullable
@@ -817,6 +830,7 @@ public class ActionCacheChecker {
   public Token getTokenUnconditionallyAfterFailureToRecordActionCacheHit(
       Action action,
       List<Artifact> resolvedCacheArtifacts,
+      @Nullable byte[] mandatoryInputsDigest,
       Map<String, String> clientEnv,
       OutputPermissions outputPermissions,
       EventHandler handler,
@@ -832,6 +846,7 @@ public class ActionCacheChecker {
     return getTokenIfNeedToExecute(
         action,
         resolvedCacheArtifacts,
+        mandatoryInputsDigest,
         clientEnv,
         outputPermissions,
         handler,

--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -61,6 +61,7 @@ java_library(
         "ActionLogBufferPathGenerator.java",
         "ActionLookupValue.java",
         "ActionProgressEvent.java",
+        "MandatoryInputsDigestUtils.java",
         "ActionRegistry.java",
         "ActionResultReceivedEvent.java",
         "ActionScanningCompletedEvent.java",

--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -65,6 +65,7 @@ java_library(
         "ActionLogBufferPathGenerator.java",
         "ActionLookupValue.java",
         "ActionProgressEvent.java",
+        "MandatoryInputsDigestUtils.java",
         "ActionRegistry.java",
         "ActionResultReceivedEvent.java",
         "ActionScanningCompletedEvent.java",

--- a/src/main/java/com/google/devtools/build/lib/actions/MandatoryInputsDigestUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/MandatoryInputsDigestUtils.java
@@ -1,0 +1,54 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.actions;
+
+import com.google.devtools.build.lib.actions.cache.MetadataDigestUtils;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/** Computes digests of mandatory action inputs for split action cache checking. */
+public final class MandatoryInputsDigestUtils {
+  private MandatoryInputsDigestUtils() {}
+
+  public static byte[] fromMetadataMap(Map<String, FileArtifactValue> inputMap) {
+    return MetadataDigestUtils.fromMetadata(inputMap);
+  }
+
+  public static byte[] fromMandatoryArtifacts(
+      InputMetadataProvider inputMetadataProvider, Iterable<Artifact> mandatoryInputs)
+      throws IOException {
+    Map<String, FileArtifactValue> inputMap = new HashMap<>();
+    for (Artifact artifact : mandatoryInputs) {
+      inputMap.put(
+          artifact.getExecPathString(), getInputMetadataMaybe(inputMetadataProvider, artifact));
+    }
+    return fromMetadataMap(inputMap);
+  }
+
+  @Nullable
+  public static FileArtifactValue getInputMetadataMaybe(
+      InputMetadataProvider inputMetadataProvider, Artifact artifact) {
+    try {
+      FileArtifactValue metadata = inputMetadataProvider.getInputMetadata(artifact);
+      return (metadata != null && artifact.isConstantMetadata())
+          ? FileArtifactValue.ConstantMetadataValue.INSTANCE
+          : metadata;
+    } catch (IOException e) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/ActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/ActionCache.java
@@ -82,11 +82,21 @@ public interface ActionCache {
   final class Entry {
     /** Unique instance standing for a corrupted cache entry. */
     public static final ActionCache.Entry CORRUPTED =
-        new Entry(null, null, false, ImmutableMap.of(), ImmutableMap.of(), ImmutableList.of());
+        new Entry(
+            null,
+            null,
+            null,
+            /* prunedInputs= */ false,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableList.of());
 
     // Digest of all relevant properties of the action for cache invalidation purposes.
     // Null if the entry is corrupted.
     @Nullable private final byte[] digest;
+
+    // Digest of mandatory inputs for actions that split mandatory/discovered cache checking.
+    @Nullable private final byte[] mandatoryInputsDigest;
 
     // List of input paths discovered by the action.
     // Null if the action does not discover inputs.
@@ -102,6 +112,7 @@ public interface ActionCache {
 
     Entry(
         @Nullable byte[] digest,
+        @Nullable byte[] mandatoryInputsDigest,
         @Nullable ImmutableList<String> discoveredInputPaths,
         boolean prunedInputs,
         ImmutableMap<String, FileArtifactValue> outputFileMetadata,
@@ -111,6 +122,7 @@ public interface ActionCache {
           !prunedInputs || discoveredInputPaths != null,
           "Action had unused inputs but no discovered inputs");
       this.digest = digest;
+      this.mandatoryInputsDigest = mandatoryInputsDigest;
       this.discoveredInputPaths = discoveredInputPaths;
       this.prunedInputs = prunedInputs;
       this.outputFileMetadata = outputFileMetadata;
@@ -156,6 +168,13 @@ public interface ActionCache {
     public ImmutableList<String> getDiscoveredInputPaths() {
       checkState(!isCorrupted());
       return discoveredInputPaths;
+    }
+
+    /** Returns the digest of mandatory inputs, or null if not stored. */
+    @Nullable
+    public byte[] getMandatoryInputsDigest() {
+      checkState(!isCorrupted());
+      return mandatoryInputsDigest;
     }
 
     /** Gets the metadata of an output file. */
@@ -205,6 +224,7 @@ public interface ActionCache {
       return MoreObjects.toStringHelper(this)
           .add("digest", digest)
           .add("discoveredInputPaths", discoveredInputPaths)
+          .add("mandatoryInputsDigest", mandatoryInputsDigest)
           .add("outputFileMetadata", outputFileMetadata)
           .add("outputTreeMetadata", outputTreeMetadata)
           .add("proxyOutputs", proxyOutputs)
@@ -222,6 +242,9 @@ public interface ActionCache {
         for (String path : ImmutableList.sortedCopyOf(discoveredInputPaths)) {
           out.format("    %s\n", path);
         }
+      }
+      if (mandatoryInputsDigest != null) {
+        out.format("  mandatoryInputsDigest = %s\n", formatDigest(mandatoryInputsDigest));
       }
 
       if (!outputFileMetadata.isEmpty()) {
@@ -295,6 +318,7 @@ public interface ActionCache {
       // Null if the action does not discover inputs.
       @Nullable private final ImmutableList.Builder<String> discoveredInputPaths;
       private boolean prunedInputs = false;
+      @Nullable private byte[] mandatoryInputsDigest;
 
       private final ImmutableMap.Builder<String, FileArtifactValue> outputFileMetadata =
           ImmutableMap.builder();
@@ -329,6 +353,13 @@ public interface ActionCache {
         this.useArchivedTreeArtifacts = useArchivedTreeArtifacts;
       }
 
+      /** Sets the digest of mandatory inputs for split mandatory/discovered cache checking. */
+      @CanIgnoreReturnValue
+      public Builder setMandatoryInputsDigest(@Nullable byte[] mandatoryInputsDigest) {
+        this.mandatoryInputsDigest = mandatoryInputsDigest;
+        return this;
+      }
+
       /** Adds metadata of an input file. */
       @CanIgnoreReturnValue
       public Builder addInputFile(Artifact artifact, FileArtifactValue metadata) {
@@ -344,7 +375,9 @@ public interface ActionCache {
         if (discoveredInputPaths != null && saveExecPath) {
           discoveredInputPaths.add(execPath);
         }
-        metadataMap.put(execPath, metadata);
+        if (mandatoryInputsDigest == null || saveExecPath) {
+          metadataMap.put(execPath, metadata);
+        }
         return this;
       }
 
@@ -411,11 +444,13 @@ public interface ActionCache {
             computeDigest(
                 actionKey,
                 discoveredInputPaths != null,
+                mandatoryInputsDigest,
                 metadataMap,
                 clientEnv,
                 actionExecutionSalt,
                 outputPermissions,
                 useArchivedTreeArtifacts),
+            mandatoryInputsDigest,
             discoveredInputPaths != null ? discoveredInputPaths.build() : null,
             prunedInputs,
             outputFileMetadata.buildOrThrow(),
@@ -426,6 +461,7 @@ public interface ActionCache {
       private static byte[] computeDigest(
           String actionKey,
           boolean discoversInputs,
+          @Nullable byte[] mandatoryInputsDigest,
           Map<String, FileArtifactValue> metadataMap,
           Map<String, String> clientEnv,
           String actionExecutionSalt,
@@ -434,6 +470,9 @@ public interface ActionCache {
         Fingerprint fp = new Fingerprint();
         fp.addString(actionKey);
         fp.addBoolean(discoversInputs);
+        if (mandatoryInputsDigest != null) {
+          fp.addBytes(mandatoryInputsDigest);
+        }
         fp.addBytes(MetadataDigestUtils.fromMetadata(metadataMap));
         fp.addBytes(computeMapDigest(clientEnv));
         fp.addString(actionExecutionSalt);

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -856,7 +856,9 @@ public class CompactPersistentActionCache implements ActionCache {
     int maxDiscoveredInputsSize = 1; // presence marker
     if (entry.discoversInputs()) {
       maxDiscoveredInputsSize +=
-          1 // pruned inputs presence marker
+          1 // mandatory inputs digest presence marker
+              + (entry.getMandatoryInputsDigest() != null ? 1 + DigestUtils.ESTIMATED_SIZE : 0)
+              + 1 // pruned inputs presence marker
               + VarInt.MAX_VARINT_SIZE // length
               + (VarInt.MAX_VARINT_SIZE // execPath
                   * entry.getDiscoveredInputPaths().size());
@@ -910,6 +912,12 @@ public class CompactPersistentActionCache implements ActionCache {
     VarInt.putVarInt(entry.discoversInputs() ? 1 : 0, sink);
     if (entry.discoversInputs()) {
       VarInt.putVarInt(entry.prunedInputs() ? 1 : 0, sink);
+      if (entry.getMandatoryInputsDigest() != null) {
+        VarInt.putVarInt(1, sink);
+        MetadataDigestUtils.write(entry.getMandatoryInputsDigest(), sink);
+      } else {
+        VarInt.putVarInt(0, sink);
+      }
       ImmutableList<String> discoveredInputPaths = entry.getDiscoveredInputPaths();
       VarInt.putVarInt(discoveredInputPaths.size(), sink);
       for (String discoveredInputPath : discoveredInputPaths) {
@@ -989,6 +997,7 @@ public class CompactPersistentActionCache implements ActionCache {
 
       ImmutableList<String> discoveredInputPaths = null;
       boolean prunedInputs = false;
+      byte[] mandatoryInputsDigest = null;
       int discoveredInputsPresenceMarker = VarInt.getVarInt(source);
       if (discoveredInputsPresenceMarker != 0) {
         if (discoveredInputsPresenceMarker != 1) {
@@ -1001,6 +1010,18 @@ public class CompactPersistentActionCache implements ActionCache {
             throw new IOException("Invalid marker for pruned inputs: " + prunedInputsMarker);
           }
           prunedInputs = true;
+        }
+        int mandatoryDigestPresenceMarker = VarInt.getVarInt(source);
+        if (mandatoryDigestPresenceMarker != 0) {
+          if (mandatoryDigestPresenceMarker != 1) {
+            throw new IOException(
+                "Invalid presence marker for mandatory inputs digest: "
+                    + mandatoryDigestPresenceMarker);
+          }
+          mandatoryInputsDigest = MetadataDigestUtils.read(source);
+          if (mandatoryInputsDigest.length != digest.length) {
+            throw new IOException("Corrupted mandatory inputs digest");
+          }
         }
         int numDiscoveredInputs = VarInt.getVarInt(source);
         if (numDiscoveredInputs < 0) {
@@ -1023,6 +1044,7 @@ public class CompactPersistentActionCache implements ActionCache {
         }
         return new ActionCache.Entry(
             digest,
+            mandatoryInputsDigest,
             discoveredInputPaths,
             prunedInputs,
             /* outputFileMetadata= */ ImmutableMap.of(),
@@ -1105,6 +1127,7 @@ public class CompactPersistentActionCache implements ActionCache {
       }
       return new ActionCache.Entry(
           digest,
+          mandatoryInputsDigest,
           discoveredInputPaths,
           prunedInputs,
           outputFiles.buildOrThrow(),

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/MetadataDigestUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/MetadataDigestUtils.java
@@ -28,6 +28,8 @@ import javax.annotation.Nullable;
 public final class MetadataDigestUtils {
   private MetadataDigestUtils() {}
 
+  private static final byte[] EMPTY_DIGEST = new Fingerprint().digestAndReset();
+
   /**
    * @param source the byte buffer source.
    * @return the digest from the given buffer.
@@ -54,7 +56,7 @@ public final class MetadataDigestUtils {
    * @param mdMap A collection of (execPath, FileArtifactValue) pairs. Values may be null.
    */
   public static byte[] fromMetadata(Map<String, FileArtifactValue> mdMap) {
-    byte[] result = new byte[1]; // reserve the empty string
+    byte[] result = EMPTY_DIGEST.clone();
     // Profiling showed that MessageDigest engine instantiation was a hotspot, so create one
     // instance for this computation to amortize its cost.
     Fingerprint fp = new Fingerprint();

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -362,6 +362,13 @@ public class StarlarkAction extends SpawnAction {
     }
 
     @Override
+    public boolean usesSplitMandatoryInputsActionCacheCheck() {
+      return shadowedAction
+          .map(Action::usesSplitMandatoryInputsActionCacheCheck)
+          .orElse(false);
+    }
+
+    @Override
     public NestedSet<Artifact> getAllowedDerivedInputs() {
       if (shadowedAction.isPresent()) {
         return createInputs(shadowedAction.get().getAllowedDerivedInputs(), getInputs());

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -2128,4 +2128,9 @@ public class CppCompileAction extends AbstractAction
     return actionName.equals(CppActionNames.CPP20_MODULE_COMPILE)
         || actionName.equals(CppActionNames.CPP20_MODULE_CODEGEN);
   }
+
+  @Override
+  public boolean usesSplitMandatoryInputsActionCacheCheck() {
+    return isCpp20ModuleCompilationAction(actionName);
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -2144,4 +2144,9 @@ public class CppCompileAction extends AbstractAction
     return actionName.equals(CppActionNames.CPP20_MODULE_COMPILE)
         || actionName.equals(CppActionNames.CPP20_MODULE_CODEGEN);
   }
+
+  @Override
+  public boolean usesSplitMandatoryInputsActionCacheCheck() {
+    return isCpp20ModuleCompilationAction(actionName);
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
@@ -33,6 +33,7 @@ import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.SetMultimap;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.actions.Action;
+import com.google.devtools.build.lib.actions.ActionCacheChecker;
 import com.google.devtools.build.lib.actions.ActionCacheChecker.Token;
 import com.google.devtools.build.lib.actions.ActionCompletionEvent;
 import com.google.devtools.build.lib.actions.ActionExecutedEvent.ErrorTiming;
@@ -53,6 +54,7 @@ import com.google.devtools.build.lib.actions.PackageRootResolver;
 import com.google.devtools.build.lib.actions.RichArtifactData;
 import com.google.devtools.build.lib.actions.RichDataProducingAction;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
+import com.google.devtools.build.lib.actions.MandatoryInputsDigestUtils;
 import com.google.devtools.build.lib.actions.cache.OutputMetadataStore;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.bugreport.BugReport;
@@ -584,6 +586,74 @@ public class ActionExecutionFunction implements SkyFunction {
   }
 
   /**
+   * Computes the digest of the action's mandatory inputs. Callers should check for missing values
+   * before using the result, which may be null in error cases.
+   */
+  @Nullable
+  private byte[] computeMandatoryInputsDigest(Action action, Environment env)
+      throws InterruptedException, ActionExecutionException {
+    NestedSet<Artifact> mandatoryInputsSet = action.getMandatoryInputs();
+    ImmutableSet.Builder<SkyKey> mandatoryInputsKeysBuilder = ImmutableSet.builder();
+    for (Artifact leaf : mandatoryInputsSet.getLeaves()) {
+      mandatoryInputsKeysBuilder.add(Artifact.key(leaf));
+    }
+    for (NestedSet<Artifact> nonLeaf : mandatoryInputsSet.getNonLeaves()) {
+      mandatoryInputsKeysBuilder.add(ArtifactNestedSetKey.create(nonLeaf));
+    }
+    ImmutableSet<SkyKey> mandatoryInputsKeys = mandatoryInputsKeysBuilder.build();
+    SkyframeLookupResult lookupResult = env.getValuesAndExceptions(mandatoryInputsKeys);
+    if (env.valuesMissing() && !env.inErrorBubbling()) {
+      return null;
+    }
+    ImmutableList<Artifact> mandatoryInputs = mandatoryInputsSet.toList();
+    ActionExecutionFunctionExceptionHandler actionExecutionFunctionExceptionHandler =
+        new ActionExecutionFunctionExceptionHandler(
+            Suppliers.memoize(
+                () -> {
+                  SetMultimap<SkyKey, Artifact> skyKeyToArtifactSet =
+                      MultimapBuilder.hashKeys().hashSetValues().build();
+                  mandatoryInputs.forEach(
+                      input -> {
+                        SkyKey key = Artifact.key(input);
+                        if (key != input) {
+                          skyKeyToArtifactSet.put(key, input);
+                        }
+                      });
+                  return skyKeyToArtifactSet;
+                }),
+            lookupResult,
+            action,
+            Predicates.alwaysTrue(),
+            mandatoryInputsKeys);
+    actionExecutionFunctionExceptionHandler.accumulateAndMaybeThrowExceptions();
+    if (env.valuesMissing() && !env.inErrorBubbling()) {
+      return null;
+    }
+    ActionInputMap inputArtifactData = new ActionInputMap(mandatoryInputs.size());
+    Map<String, FileArtifactValue> inputMap = new HashMap<>(mandatoryInputs.size());
+    for (Artifact artifact : mandatoryInputs) {
+      SkyValue value =
+          getAndCheckInputSkyValue(
+              env,
+              action,
+              artifact,
+              mandatoryInputsKeys,
+              Predicates.alwaysTrue(),
+              actionExecutionFunctionExceptionHandler);
+      if (value == null || value instanceof MissingArtifactValue) {
+        return null;
+      }
+      ActionInputMapHelper.addToMap(
+          inputArtifactData, artifact, value, MetadataConsumerForMetrics.NO_OP);
+      inputMap.put(
+          artifact.getExecPathString(),
+          MandatoryInputsDigestUtils.getInputMetadataMaybe(inputArtifactData, artifact));
+    }
+    actionExecutionFunctionExceptionHandler.maybeThrowException();
+    return MandatoryInputsDigestUtils.fromMetadataMap(inputMap);
+  }
+
+  /**
    * An action's inputs needed for execution. May not just be the result of Action#getInputs(). If
    * the action cache's view of this action contains additional inputs, it will request metadata for
    * them, so we consider those inputs as dependencies of this action as well. Returns null if some
@@ -591,9 +661,30 @@ public class ActionExecutionFunction implements SkyFunction {
    */
   @Nullable
   private AllInputs collectInputs(Action action, Environment env)
-      throws InterruptedException, AlreadyReportedActionExecutionException {
+      throws InterruptedException, ActionExecutionFunctionException,
+          AlreadyReportedActionExecutionException {
+    byte[] mandatoryInputsDigest = null;
+    if (skyframeActionExecutor.useSplitMandatoryInputsActionCacheCheck(action)) {
+      // When the mandatory inputs of an action have changed, it will certainly have to be
+      // reexecuted. It is important that we detect this before requesting the previously discovered
+      // inputs from Skyframe as that could result in cycles that otherwise would not occur.
+      try {
+        mandatoryInputsDigest = computeMandatoryInputsDigest(action, env);
+      } catch (ActionExecutionException e) {
+        throw new ActionExecutionFunctionException(e);
+      }
+      if (env.valuesMissing()) {
+        return null;
+      }
+      if (mandatoryInputsDigest == null
+          || !skyframeActionExecutor.mandatoryInputsMatch(action, mandatoryInputsDigest)) {
+        action.resetDiscoveredInputs();
+        return new AllInputs(action.getInputs(), mandatoryInputsDigest);
+      }
+    }
+
     if (action.inputsKnown()) {
-      return new AllInputs(action.getInputs());
+      return new AllInputs(action.getInputs(), mandatoryInputsDigest);
     }
 
     checkState(action.discoversInputs(), action);
@@ -609,21 +700,31 @@ public class ActionExecutionFunction implements SkyFunction {
     // the full set of original inputs. We'll request them later on if there is no action cache hit.
     NestedSet<Artifact> allKnownInputs =
         action.prunedInputs() ? NestedSetBuilder.emptySet(Order.STABLE_ORDER) : action.getInputs();
-    return new AllInputs(allKnownInputs, actionCacheInputs);
+    return new AllInputs(allKnownInputs, actionCacheInputs, mandatoryInputsDigest);
   }
 
   static class AllInputs {
     final NestedSet<Artifact> defaultInputs;
     @Nullable final List<Artifact> actionCacheInputs;
+    @Nullable final byte[] mandatoryInputsDigest;
 
     AllInputs(NestedSet<Artifact> defaultInputs) {
-      this.defaultInputs = checkNotNull(defaultInputs);
-      this.actionCacheInputs = null;
+      this(defaultInputs, null, null);
     }
 
-    AllInputs(NestedSet<Artifact> defaultInputs, List<Artifact> actionCacheInputs) {
+    AllInputs(NestedSet<Artifact> defaultInputs, @Nullable byte[] mandatoryInputsDigest) {
+      this.defaultInputs = checkNotNull(defaultInputs);
+      this.actionCacheInputs = null;
+      this.mandatoryInputsDigest = mandatoryInputsDigest;
+    }
+
+    AllInputs(
+        NestedSet<Artifact> defaultInputs,
+        List<Artifact> actionCacheInputs,
+        @Nullable byte[] mandatoryInputsDigest) {
       this.defaultInputs = checkNotNull(defaultInputs);
       this.actionCacheInputs = checkNotNull(actionCacheInputs);
+      this.mandatoryInputsDigest = mandatoryInputsDigest;
     }
 
     /** Compute the inputs to request from Skyframe. */
@@ -773,6 +874,7 @@ public class ActionExecutionFunction implements SkyFunction {
               pathResolver,
               actionStartTime,
               state.allInputs.actionCacheInputs,
+              state.allInputs.mandatoryInputsDigest,
               clientEnv);
     }
 
@@ -876,7 +978,14 @@ public class ActionExecutionFunction implements SkyFunction {
       }
       checkState(!env.valuesMissing(), action);
       skyframeActionExecutor.updateActionCache(
-          action, inputMetadataProvider, outputMetadataStore, state.token, clientEnv);
+          action,
+          inputMetadataProvider,
+          outputMetadataStore,
+          state.token,
+          clientEnv,
+          skyframeActionExecutor.useSplitMandatoryInputsActionCacheCheck(action)
+              ? state.allInputs.mandatoryInputsDigest
+              : null);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
@@ -33,6 +33,7 @@ import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.SetMultimap;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.actions.Action;
+import com.google.devtools.build.lib.actions.ActionCacheChecker;
 import com.google.devtools.build.lib.actions.ActionCacheChecker.Token;
 import com.google.devtools.build.lib.actions.ActionCompletionEvent;
 import com.google.devtools.build.lib.actions.ActionExecutedEvent.ErrorTiming;
@@ -53,6 +54,7 @@ import com.google.devtools.build.lib.actions.PackageRootResolver;
 import com.google.devtools.build.lib.actions.RichArtifactData;
 import com.google.devtools.build.lib.actions.RichDataProducingAction;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
+import com.google.devtools.build.lib.actions.MandatoryInputsDigestUtils;
 import com.google.devtools.build.lib.actions.cache.OutputMetadataStore;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.bugreport.BugReport;
@@ -584,6 +586,74 @@ public class ActionExecutionFunction implements SkyFunction {
   }
 
   /**
+   * Computes the digest of the action's mandatory inputs. Callers should check for missing values
+   * before using the result, which may be null in error cases.
+   */
+  @Nullable
+  private byte[] computeMandatoryInputsDigest(Action action, Environment env)
+      throws InterruptedException, ActionExecutionException {
+    NestedSet<Artifact> mandatoryInputsSet = action.getMandatoryInputs();
+    ImmutableSet.Builder<SkyKey> mandatoryInputsKeysBuilder = ImmutableSet.builder();
+    for (Artifact leaf : mandatoryInputsSet.getLeaves()) {
+      mandatoryInputsKeysBuilder.add(Artifact.key(leaf));
+    }
+    for (NestedSet<Artifact> nonLeaf : mandatoryInputsSet.getNonLeaves()) {
+      mandatoryInputsKeysBuilder.add(ArtifactNestedSetKey.create(nonLeaf));
+    }
+    ImmutableSet<SkyKey> mandatoryInputsKeys = mandatoryInputsKeysBuilder.build();
+    SkyframeLookupResult lookupResult = env.getValuesAndExceptions(mandatoryInputsKeys);
+    if (env.valuesMissing() && !env.inErrorBubbling()) {
+      return null;
+    }
+    ImmutableList<Artifact> mandatoryInputs = mandatoryInputsSet.toList();
+    ActionExecutionFunctionExceptionHandler actionExecutionFunctionExceptionHandler =
+        new ActionExecutionFunctionExceptionHandler(
+            Suppliers.memoize(
+                () -> {
+                  SetMultimap<SkyKey, Artifact> skyKeyToArtifactSet =
+                      MultimapBuilder.hashKeys().hashSetValues().build();
+                  mandatoryInputs.forEach(
+                      input -> {
+                        SkyKey key = Artifact.key(input);
+                        if (key != input) {
+                          skyKeyToArtifactSet.put(key, input);
+                        }
+                      });
+                  return skyKeyToArtifactSet;
+                }),
+            lookupResult,
+            action,
+            Predicates.alwaysTrue(),
+            mandatoryInputsKeys);
+    actionExecutionFunctionExceptionHandler.accumulateAndMaybeThrowExceptions();
+    if (env.valuesMissing() && !env.inErrorBubbling()) {
+      return null;
+    }
+    ActionInputMap inputArtifactData = new ActionInputMap(mandatoryInputs.size());
+    Map<String, FileArtifactValue> inputMap = new HashMap<>(mandatoryInputs.size());
+    for (Artifact artifact : mandatoryInputs) {
+      SkyValue value =
+          getAndCheckInputSkyValue(
+              env,
+              action,
+              artifact,
+              mandatoryInputsKeys,
+              Predicates.alwaysTrue(),
+              actionExecutionFunctionExceptionHandler);
+      if (value == null || value instanceof MissingArtifactValue) {
+        return null;
+      }
+      ActionInputMapHelper.addToMap(
+          inputArtifactData, artifact, value, MetadataConsumerForMetrics.NO_OP);
+      inputMap.put(
+          artifact.getExecPathString(),
+          MandatoryInputsDigestUtils.getInputMetadataMaybe(inputArtifactData, artifact));
+    }
+    actionExecutionFunctionExceptionHandler.maybeThrowException();
+    return MandatoryInputsDigestUtils.fromMetadataMap(inputMap);
+  }
+
+  /**
    * An action's inputs needed for execution. May not just be the result of Action#getInputs(). If
    * the action cache's view of this action contains additional inputs, it will request metadata for
    * them, so we consider those inputs as dependencies of this action as well. Returns null if some
@@ -591,9 +661,30 @@ public class ActionExecutionFunction implements SkyFunction {
    */
   @Nullable
   private AllInputs collectInputs(Action action, Environment env)
-      throws InterruptedException, AlreadyReportedActionExecutionException {
+      throws InterruptedException, ActionExecutionFunctionException,
+          AlreadyReportedActionExecutionException {
+    byte[] mandatoryInputsDigest = null;
+    if (skyframeActionExecutor.useSplitMandatoryInputsActionCacheCheck(action)) {
+      // When the mandatory inputs of an action have changed, it will certainly have to be
+      // reexecuted. It is important that we detect this before requesting the previously discovered
+      // inputs from Skyframe as that could result in cycles that otherwise would not occur.
+      try {
+        mandatoryInputsDigest = computeMandatoryInputsDigest(action, env);
+      } catch (ActionExecutionException e) {
+        throw new ActionExecutionFunctionException(e);
+      }
+      if (env.valuesMissing()) {
+        return null;
+      }
+      if (mandatoryInputsDigest == null
+          || !skyframeActionExecutor.mandatoryInputsMatch(action, mandatoryInputsDigest)) {
+        action.resetDiscoveredInputs();
+        return new AllInputs(action.getInputs(), mandatoryInputsDigest);
+      }
+    }
+
     if (action.inputsKnown()) {
-      return new AllInputs(action.getInputs());
+      return new AllInputs(action.getInputs(), mandatoryInputsDigest);
     }
 
     checkState(action.discoversInputs(), action);
@@ -609,21 +700,31 @@ public class ActionExecutionFunction implements SkyFunction {
     // the full set of original inputs. We'll request them later on if there is no action cache hit.
     NestedSet<Artifact> allKnownInputs =
         action.prunedInputs() ? NestedSetBuilder.emptySet(Order.STABLE_ORDER) : action.getInputs();
-    return new AllInputs(allKnownInputs, actionCacheInputs);
+    return new AllInputs(allKnownInputs, actionCacheInputs, mandatoryInputsDigest);
   }
 
   static class AllInputs {
     final NestedSet<Artifact> defaultInputs;
     @Nullable final List<Artifact> actionCacheInputs;
+    @Nullable final byte[] mandatoryInputsDigest;
 
     AllInputs(NestedSet<Artifact> defaultInputs) {
-      this.defaultInputs = checkNotNull(defaultInputs);
-      this.actionCacheInputs = null;
+      this(defaultInputs, null, null);
     }
 
-    AllInputs(NestedSet<Artifact> defaultInputs, List<Artifact> actionCacheInputs) {
+    AllInputs(NestedSet<Artifact> defaultInputs, @Nullable byte[] mandatoryInputsDigest) {
+      this.defaultInputs = checkNotNull(defaultInputs);
+      this.actionCacheInputs = null;
+      this.mandatoryInputsDigest = mandatoryInputsDigest;
+    }
+
+    AllInputs(
+        NestedSet<Artifact> defaultInputs,
+        List<Artifact> actionCacheInputs,
+        @Nullable byte[] mandatoryInputsDigest) {
       this.defaultInputs = checkNotNull(defaultInputs);
       this.actionCacheInputs = checkNotNull(actionCacheInputs);
+      this.mandatoryInputsDigest = mandatoryInputsDigest;
     }
 
     /** Compute the inputs to request from Skyframe. */
@@ -773,6 +874,7 @@ public class ActionExecutionFunction implements SkyFunction {
               pathResolver,
               actionStartTime,
               state.allInputs.actionCacheInputs,
+              state.allInputs.mandatoryInputsDigest,
               clientEnv);
     }
 
@@ -880,7 +982,10 @@ public class ActionExecutionFunction implements SkyFunction {
           state.inputMetadataProviderIncludingLateDiscoveredInputs(inputMetadataProvider),
           outputMetadataStore,
           state.token,
-          clientEnv);
+          clientEnv,
+          skyframeActionExecutor.useSplitMandatoryInputsActionCacheCheck(action)
+              ? state.allInputs.mandatoryInputsDigest
+              : null);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -762,6 +762,14 @@ public final class SkyframeActionExecutor {
    * if the action is up to date, and non-null if it needs to be executed, in which case that token
    * should be provided to the ActionCacheChecker after execution.
    */
+  boolean useSplitMandatoryInputsActionCacheCheck(Action action) {
+    return actionCacheChecker.useSplitMandatoryInputsActionCacheCheck(action);
+  }
+
+  boolean mandatoryInputsMatch(Action action, byte[] mandatoryInputsDigest) {
+    return actionCacheChecker.mandatoryInputsMatch(action, mandatoryInputsDigest);
+  }
+
   Token checkActionCache(
       ExtendedEventHandler eventHandler,
       Action action,
@@ -770,6 +778,7 @@ public final class SkyframeActionExecutor {
       ArtifactPathResolver artifactPathResolver,
       long actionStartTime,
       List<Artifact> resolvedCacheArtifacts,
+      @Nullable byte[] mandatoryInputsDigest,
       Map<String, String> clientEnv)
       throws ActionExecutionException, InterruptedException {
     Token token;
@@ -796,6 +805,7 @@ public final class SkyframeActionExecutor {
           actionCacheChecker.getTokenIfNeedToExecute(
               action,
               resolvedCacheArtifacts,
+              mandatoryInputsDigest,
               clientEnv,
               getOutputPermissions(),
               handler,
@@ -838,6 +848,7 @@ public final class SkyframeActionExecutor {
                 actionCacheChecker.getTokenUnconditionallyAfterFailureToRecordActionCacheHit(
                     action,
                     resolvedCacheArtifacts,
+                    mandatoryInputsDigest,
                     clientEnv,
                     getOutputPermissions(),
                     handler,
@@ -876,7 +887,8 @@ public final class SkyframeActionExecutor {
       InputMetadataProvider inputMetadataProvider,
       OutputMetadataStore outputMetadataStore,
       Token token,
-      Map<String, String> clientEnv)
+      Map<String, String> clientEnv,
+      @Nullable byte[] mandatoryInputsDigest)
       throws ActionExecutionException, InterruptedException {
     if (!actionCacheChecker.enabled()) {
       return;
@@ -891,7 +903,8 @@ public final class SkyframeActionExecutor {
           clientEnv,
           getOutputPermissions(),
           actionExecutionSalt,
-          useArchivedTreeArtifacts(action));
+          useArchivedTreeArtifacts(action),
+          mandatoryInputsDigest);
     } catch (IOException e) {
       // Skyframe has already done all the filesystem access needed for outputs and swallows
       // IOExceptions for inputs. So an IOException is impossible here.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -766,6 +766,14 @@ public final class SkyframeActionExecutor {
    * if the action is up to date, and non-null if it needs to be executed, in which case that token
    * should be provided to the ActionCacheChecker after execution.
    */
+  boolean useSplitMandatoryInputsActionCacheCheck(Action action) {
+    return actionCacheChecker.useSplitMandatoryInputsActionCacheCheck(action);
+  }
+
+  boolean mandatoryInputsMatch(Action action, byte[] mandatoryInputsDigest) {
+    return actionCacheChecker.mandatoryInputsMatch(action, mandatoryInputsDigest);
+  }
+
   Token checkActionCache(
       ExtendedEventHandler eventHandler,
       Action action,
@@ -774,6 +782,7 @@ public final class SkyframeActionExecutor {
       ArtifactPathResolver artifactPathResolver,
       long actionStartTime,
       List<Artifact> resolvedCacheArtifacts,
+      @Nullable byte[] mandatoryInputsDigest,
       Map<String, String> clientEnv)
       throws ActionExecutionException, InterruptedException {
     Token token;
@@ -800,6 +809,7 @@ public final class SkyframeActionExecutor {
           actionCacheChecker.getTokenIfNeedToExecute(
               action,
               resolvedCacheArtifacts,
+              mandatoryInputsDigest,
               clientEnv,
               getOutputPermissions(),
               handler,
@@ -842,6 +852,7 @@ public final class SkyframeActionExecutor {
                 actionCacheChecker.getTokenUnconditionallyAfterFailureToRecordActionCacheHit(
                     action,
                     resolvedCacheArtifacts,
+                    mandatoryInputsDigest,
                     clientEnv,
                     getOutputPermissions(),
                     handler,
@@ -880,7 +891,8 @@ public final class SkyframeActionExecutor {
       InputMetadataProvider inputMetadataProvider,
       OutputMetadataStore outputMetadataStore,
       Token token,
-      Map<String, String> clientEnv)
+      Map<String, String> clientEnv,
+      @Nullable byte[] mandatoryInputsDigest)
       throws ActionExecutionException, InterruptedException {
     if (!actionCacheChecker.enabled()) {
       return;
@@ -895,7 +907,8 @@ public final class SkyframeActionExecutor {
           clientEnv,
           getOutputPermissions(),
           actionExecutionSalt,
-          useArchivedTreeArtifacts(action));
+          useArchivedTreeArtifacts(action),
+          mandatoryInputsDigest);
     } catch (IOException e) {
       // Skyframe has already done all the filesystem access needed for outputs and swallows
       // IOExceptions for inputs. So an IOException is impossible here.

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.ActionCacheChecker.Token;
 import com.google.devtools.build.lib.actions.Artifact.ArchivedTreeArtifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
@@ -47,8 +48,12 @@ import com.google.devtools.build.lib.actions.util.ActionsTestUtil.FakeArtifactRe
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil.FakeInputMetadataHandlerBase;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil.MissDetailsBuilder;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil.NullAction;
+import com.google.devtools.build.lib.actions.util.TestAction;
 import com.google.devtools.build.lib.clock.Clock;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.events.NullEventHandler;
 import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
 import com.google.devtools.build.lib.testutil.ManualClock;
@@ -240,6 +245,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             clientEnv,
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -314,7 +320,8 @@ public final class ActionCacheCheckerTest {
           clientEnv,
           OutputPermissions.READONLY,
           actionExecutionSalt,
-          useArchivedTreeArtifacts);
+          useArchivedTreeArtifacts,
+          /* mandatoryInputsDigest= */ null);
     }
   }
 
@@ -534,6 +541,7 @@ public final class ActionCacheCheckerTest {
             cacheChecker.getTokenIfNeedToExecute(
                 action,
                 /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
                 /* clientEnv= */ ImmutableMap.of(),
                 OutputPermissions.READONLY,
                 /* handler= */ null,
@@ -691,6 +699,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -725,6 +734,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -754,6 +764,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -815,6 +826,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1011,6 +1023,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1116,6 +1129,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1176,6 +1190,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1249,6 +1264,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1314,6 +1330,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1358,6 +1375,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1410,6 +1428,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1454,6 +1473,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1785,9 +1805,213 @@ public final class ActionCacheCheckerTest {
     assertThat(entry.getProxyOutputs()).containsExactly(output.getExecPathString());
   }
 
+  @Test
+  public void mandatoryInputsMatch_returnsFalseWhenNoCacheEntry() throws Exception {
+    SplitCacheActionSetup setup = createSplitCacheActionSetup("content");
+    assertThat(
+            cacheChecker.mandatoryInputsMatch(
+                setup.action(), computeMandatoryInputsDigest(setup.mandatory(), setup.handler())))
+        .isFalse();
+  }
+
+  @Test
+  public void mandatoryInputsMatch_returnsTrueWhenDigestMatches() throws Exception {
+    SplitCacheActionSetup setup = createSplitCacheActionSetup("content");
+    byte[] mandatoryInputsDigest =
+        computeMandatoryInputsDigest(setup.mandatory(), setup.handler());
+
+    runActionWithMandatoryInputsDigest(
+        setup.action(), mandatoryInputsDigest, setup.handler());
+
+    assertThat(cacheChecker.mandatoryInputsMatch(setup.action(), mandatoryInputsDigest))
+        .isTrue();
+  }
+
+  @Test
+  public void mandatoryInputsMatch_returnsFalseWhenDigestDiffers() throws Exception {
+    SplitCacheActionSetup setup = createSplitCacheActionSetup("content");
+    byte[] mandatoryInputsDigest =
+        computeMandatoryInputsDigest(setup.mandatory(), setup.handler());
+
+    runActionWithMandatoryInputsDigest(
+        setup.action(), mandatoryInputsDigest, setup.handler());
+
+    writeIsoLatin1(setup.mandatory().getPath(), "changed");
+    assertThat(
+            cacheChecker.mandatoryInputsMatch(
+                setup.action(), computeMandatoryInputsDigest(setup.mandatory(), setup.handler())))
+        .isFalse();
+  }
+
+  @Test
+  public void mandatoryInputsMatch_returnsFalseWhenCacheEntryHasNoDigest() throws Exception {
+    SplitCacheActionSetup setup = createSplitCacheActionSetup("content");
+    runAction(
+        setup.action(),
+        ImmutableMap.of(),
+        "",
+        setup.handler(),
+        setup.handler());
+
+    assertThat(
+            cacheChecker.mandatoryInputsMatch(
+                setup.action(), computeMandatoryInputsDigest(setup.mandatory(), setup.handler())))
+        .isFalse();
+  }
+
+  @Test
+  public void useSplitMandatoryInputsActionCacheCheck_respectsActionOptIn() throws Exception {
+    SplitCacheActionSetup setup = createSplitCacheActionSetup("content");
+    Action regularAction =
+        new TestAction(
+            TestAction.NO_EFFECT,
+            NestedSetBuilder.create(Order.STABLE_ORDER, setup.mandatory()),
+            ImmutableSet.of(setup.output()));
+
+    assertThat(cacheChecker.useSplitMandatoryInputsActionCacheCheck(setup.action())).isTrue();
+    assertThat(cacheChecker.useSplitMandatoryInputsActionCacheCheck(regularAction)).isFalse();
+  }
+
+  @Test
+  public void cacheHit_withMandatoryInputsDigest() throws Exception {
+    SplitCacheActionSetup setup = createSplitCacheActionSetup("content");
+    byte[] mandatoryInputsDigest =
+        computeMandatoryInputsDigest(setup.mandatory(), setup.handler());
+
+    runActionWithMandatoryInputsDigest(
+        setup.action(), mandatoryInputsDigest, setup.handler());
+    Token token =
+        cacheChecker.getTokenIfNeedToExecute(
+            setup.action(),
+            /* resolvedCacheArtifacts= */ null,
+            mandatoryInputsDigest,
+            /* clientEnv= */ ImmutableMap.of(),
+            OutputPermissions.READONLY,
+            /* handler= */ null,
+            setup.handler(),
+            setup.handler(),
+            /* actionExecutionSalt= */ "",
+            OutputChecker.TRUST_ALL,
+            /* useArchivedTreeArtifacts= */ false);
+
+    assertThat(token).isNull();
+    assertStatistics(1, new MissDetailsBuilder().set(MissReason.NOT_CACHED, 1).build());
+  }
+
+  @Test
+  public void cacheMiss_whenMandatoryInputsDigestDiffers() throws Exception {
+    SplitCacheActionSetup setup = createSplitCacheActionSetup("content");
+    byte[] mandatoryInputsDigest =
+        computeMandatoryInputsDigest(setup.mandatory(), setup.handler());
+
+    runActionWithMandatoryInputsDigest(
+        setup.action(), mandatoryInputsDigest, setup.handler());
+
+    writeIsoLatin1(setup.mandatory().getPath(), "changed");
+    byte[] updatedMandatoryInputsDigest =
+        computeMandatoryInputsDigest(setup.mandatory(), setup.handler());
+    Token token =
+        cacheChecker.getTokenIfNeedToExecute(
+            setup.action(),
+            /* resolvedCacheArtifacts= */ null,
+            updatedMandatoryInputsDigest,
+            /* clientEnv= */ ImmutableMap.of(),
+            OutputPermissions.READONLY,
+            /* handler= */ null,
+            setup.handler(),
+            setup.handler(),
+            /* actionExecutionSalt= */ "",
+            OutputChecker.TRUST_ALL,
+            /* useArchivedTreeArtifacts= */ false);
+
+    assertThat(token).isNotNull();
+  }
+
+  private record SplitCacheActionSetup(
+      Action action, Artifact mandatory, Artifact output, FakeInputMetadataHandler handler) {}
+
+  private SplitCacheActionSetup createSplitCacheActionSetup(String mandatoryContent)
+      throws IOException {
+    Artifact mandatory = createArtifact(artifactRoot, "mandatory.txt");
+    Artifact discovered = createArtifact(artifactRoot, "discovered.extra.optional");
+    Artifact output = createArtifact(artifactRoot, "out.o");
+    writeIsoLatin1(mandatory.getPath(), mandatoryContent);
+    writeIsoLatin1(discovered.getPath(), "discovered");
+    FakeInputMetadataHandler metadataHandler = new FakeInputMetadataHandler();
+    Action action =
+        new SplitCacheTestAction(
+            TestAction.NO_EFFECT,
+            NestedSetBuilder.create(Order.STABLE_ORDER, mandatory, discovered),
+            ImmutableSet.of(output));
+    return new SplitCacheActionSetup(action, mandatory, output, metadataHandler);
+  }
+
+  private static byte[] computeMandatoryInputsDigest(
+      Artifact mandatory, FakeInputMetadataHandler metadataHandler) throws IOException {
+    return MandatoryInputsDigestUtils.fromMandatoryArtifacts(
+        metadataHandler, ImmutableList.of(mandatory));
+  }
+
+  private void runActionWithMandatoryInputsDigest(
+      Action action,
+      byte[] mandatoryInputsDigest,
+      FakeInputMetadataHandler metadataHandler)
+      throws Exception {
+    Token token =
+        cacheChecker.getTokenIfNeedToExecute(
+            action,
+            /* resolvedCacheArtifacts= */ null,
+            mandatoryInputsDigest,
+            /* clientEnv= */ ImmutableMap.of(),
+            OutputPermissions.READONLY,
+            /* handler= */ null,
+            metadataHandler,
+            metadataHandler,
+            /* actionExecutionSalt= */ "",
+            OutputChecker.TRUST_ALL,
+            /* useArchivedTreeArtifacts= */ false);
+    if (token == null) {
+      return;
+    }
+    for (Artifact artifact : action.getOutputs()) {
+      Path path = artifact.getPath();
+      filesToDelete.add(path);
+      Path parent = path.getParentDirectory();
+      if (parent != null) {
+        parent.createDirectoryAndParents();
+      }
+    }
+    ActionExecutionContext context = mock(ActionExecutionContext.class);
+    when(context.getOutputMetadataStore()).thenReturn(metadataHandler);
+    action.execute(context);
+    cacheChecker.updateActionCache(
+        action,
+        token,
+        metadataHandler,
+        metadataHandler,
+        ImmutableMap.of(),
+        OutputPermissions.READONLY,
+        "",
+        /* useArchivedTreeArtifacts= */ false,
+        mandatoryInputsDigest);
+  }
+
   // TODO(tjgq): Add tests for cached tree artifacts with a materialization path. They should take
   // into account every combination of entirely/partially remote metadata and symlink present/not
   // present in the filesystem.
+
+  /** {@link TestAction} that opts in to split mandatory/discovered action cache checking. */
+  private static final class SplitCacheTestAction extends TestAction {
+    SplitCacheTestAction(
+        Runnable effect, NestedSet<Artifact> inputs, ImmutableSet<Artifact> outputs) {
+      super(effect, inputs, outputs);
+    }
+
+    @Override
+    public boolean usesSplitMandatoryInputsActionCacheCheck() {
+      return true;
+    }
+  }
 
   /** An {@link ActionCache} that allows injecting corruption for testing. */
   private static final class CorruptibleActionCache implements ActionCache {

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.ActionCacheChecker.Token;
 import com.google.devtools.build.lib.actions.Artifact.ArchivedTreeArtifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
@@ -47,8 +48,12 @@ import com.google.devtools.build.lib.actions.util.ActionsTestUtil.FakeArtifactRe
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil.FakeInputMetadataHandlerBase;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil.MissDetailsBuilder;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil.NullAction;
+import com.google.devtools.build.lib.actions.util.TestAction;
 import com.google.devtools.build.lib.clock.Clock;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.events.NullEventHandler;
 import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
 import com.google.devtools.build.lib.testutil.ManualClock;
@@ -240,6 +245,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             clientEnv,
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -314,7 +320,8 @@ public final class ActionCacheCheckerTest {
           clientEnv,
           OutputPermissions.READONLY,
           actionExecutionSalt,
-          useArchivedTreeArtifacts);
+          useArchivedTreeArtifacts,
+          /* mandatoryInputsDigest= */ null);
     }
   }
 
@@ -534,6 +541,7 @@ public final class ActionCacheCheckerTest {
             cacheChecker.getTokenIfNeedToExecute(
                 action,
                 /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
                 /* clientEnv= */ ImmutableMap.of(),
                 OutputPermissions.READONLY,
                 /* handler= */ null,
@@ -691,6 +699,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -725,6 +734,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -754,6 +764,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -815,6 +826,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1012,6 +1024,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1117,6 +1130,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1177,6 +1191,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1252,6 +1267,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1317,6 +1333,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1361,6 +1378,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1413,6 +1431,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1457,6 +1476,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1788,9 +1808,213 @@ public final class ActionCacheCheckerTest {
     assertThat(entry.getProxyOutputs()).containsExactly(output.getExecPathString());
   }
 
+  @Test
+  public void mandatoryInputsMatch_returnsFalseWhenNoCacheEntry() throws Exception {
+    SplitCacheActionSetup setup = createSplitCacheActionSetup("content");
+    assertThat(
+            cacheChecker.mandatoryInputsMatch(
+                setup.action(), computeMandatoryInputsDigest(setup.mandatory(), setup.handler())))
+        .isFalse();
+  }
+
+  @Test
+  public void mandatoryInputsMatch_returnsTrueWhenDigestMatches() throws Exception {
+    SplitCacheActionSetup setup = createSplitCacheActionSetup("content");
+    byte[] mandatoryInputsDigest =
+        computeMandatoryInputsDigest(setup.mandatory(), setup.handler());
+
+    runActionWithMandatoryInputsDigest(
+        setup.action(), mandatoryInputsDigest, setup.handler());
+
+    assertThat(cacheChecker.mandatoryInputsMatch(setup.action(), mandatoryInputsDigest))
+        .isTrue();
+  }
+
+  @Test
+  public void mandatoryInputsMatch_returnsFalseWhenDigestDiffers() throws Exception {
+    SplitCacheActionSetup setup = createSplitCacheActionSetup("content");
+    byte[] mandatoryInputsDigest =
+        computeMandatoryInputsDigest(setup.mandatory(), setup.handler());
+
+    runActionWithMandatoryInputsDigest(
+        setup.action(), mandatoryInputsDigest, setup.handler());
+
+    writeIsoLatin1(setup.mandatory().getPath(), "changed");
+    assertThat(
+            cacheChecker.mandatoryInputsMatch(
+                setup.action(), computeMandatoryInputsDigest(setup.mandatory(), setup.handler())))
+        .isFalse();
+  }
+
+  @Test
+  public void mandatoryInputsMatch_returnsFalseWhenCacheEntryHasNoDigest() throws Exception {
+    SplitCacheActionSetup setup = createSplitCacheActionSetup("content");
+    runAction(
+        setup.action(),
+        ImmutableMap.of(),
+        "",
+        setup.handler(),
+        setup.handler());
+
+    assertThat(
+            cacheChecker.mandatoryInputsMatch(
+                setup.action(), computeMandatoryInputsDigest(setup.mandatory(), setup.handler())))
+        .isFalse();
+  }
+
+  @Test
+  public void useSplitMandatoryInputsActionCacheCheck_respectsActionOptIn() throws Exception {
+    SplitCacheActionSetup setup = createSplitCacheActionSetup("content");
+    Action regularAction =
+        new TestAction(
+            TestAction.NO_EFFECT,
+            NestedSetBuilder.create(Order.STABLE_ORDER, setup.mandatory()),
+            ImmutableSet.of(setup.output()));
+
+    assertThat(cacheChecker.useSplitMandatoryInputsActionCacheCheck(setup.action())).isTrue();
+    assertThat(cacheChecker.useSplitMandatoryInputsActionCacheCheck(regularAction)).isFalse();
+  }
+
+  @Test
+  public void cacheHit_withMandatoryInputsDigest() throws Exception {
+    SplitCacheActionSetup setup = createSplitCacheActionSetup("content");
+    byte[] mandatoryInputsDigest =
+        computeMandatoryInputsDigest(setup.mandatory(), setup.handler());
+
+    runActionWithMandatoryInputsDigest(
+        setup.action(), mandatoryInputsDigest, setup.handler());
+    Token token =
+        cacheChecker.getTokenIfNeedToExecute(
+            setup.action(),
+            /* resolvedCacheArtifacts= */ null,
+            mandatoryInputsDigest,
+            /* clientEnv= */ ImmutableMap.of(),
+            OutputPermissions.READONLY,
+            /* handler= */ null,
+            setup.handler(),
+            setup.handler(),
+            /* actionExecutionSalt= */ "",
+            OutputChecker.TRUST_ALL,
+            /* useArchivedTreeArtifacts= */ false);
+
+    assertThat(token).isNull();
+    assertStatistics(1, new MissDetailsBuilder().set(MissReason.NOT_CACHED, 1).build());
+  }
+
+  @Test
+  public void cacheMiss_whenMandatoryInputsDigestDiffers() throws Exception {
+    SplitCacheActionSetup setup = createSplitCacheActionSetup("content");
+    byte[] mandatoryInputsDigest =
+        computeMandatoryInputsDigest(setup.mandatory(), setup.handler());
+
+    runActionWithMandatoryInputsDigest(
+        setup.action(), mandatoryInputsDigest, setup.handler());
+
+    writeIsoLatin1(setup.mandatory().getPath(), "changed");
+    byte[] updatedMandatoryInputsDigest =
+        computeMandatoryInputsDigest(setup.mandatory(), setup.handler());
+    Token token =
+        cacheChecker.getTokenIfNeedToExecute(
+            setup.action(),
+            /* resolvedCacheArtifacts= */ null,
+            updatedMandatoryInputsDigest,
+            /* clientEnv= */ ImmutableMap.of(),
+            OutputPermissions.READONLY,
+            /* handler= */ null,
+            setup.handler(),
+            setup.handler(),
+            /* actionExecutionSalt= */ "",
+            OutputChecker.TRUST_ALL,
+            /* useArchivedTreeArtifacts= */ false);
+
+    assertThat(token).isNotNull();
+  }
+
+  private record SplitCacheActionSetup(
+      Action action, Artifact mandatory, Artifact output, FakeInputMetadataHandler handler) {}
+
+  private SplitCacheActionSetup createSplitCacheActionSetup(String mandatoryContent)
+      throws IOException {
+    Artifact mandatory = createArtifact(artifactRoot, "mandatory.txt");
+    Artifact discovered = createArtifact(artifactRoot, "discovered.extra.optional");
+    Artifact output = createArtifact(artifactRoot, "out.o");
+    writeIsoLatin1(mandatory.getPath(), mandatoryContent);
+    writeIsoLatin1(discovered.getPath(), "discovered");
+    FakeInputMetadataHandler metadataHandler = new FakeInputMetadataHandler();
+    Action action =
+        new SplitCacheTestAction(
+            TestAction.NO_EFFECT,
+            NestedSetBuilder.create(Order.STABLE_ORDER, mandatory, discovered),
+            ImmutableSet.of(output));
+    return new SplitCacheActionSetup(action, mandatory, output, metadataHandler);
+  }
+
+  private static byte[] computeMandatoryInputsDigest(
+      Artifact mandatory, FakeInputMetadataHandler metadataHandler) throws IOException {
+    return MandatoryInputsDigestUtils.fromMandatoryArtifacts(
+        metadataHandler, ImmutableList.of(mandatory));
+  }
+
+  private void runActionWithMandatoryInputsDigest(
+      Action action,
+      byte[] mandatoryInputsDigest,
+      FakeInputMetadataHandler metadataHandler)
+      throws Exception {
+    Token token =
+        cacheChecker.getTokenIfNeedToExecute(
+            action,
+            /* resolvedCacheArtifacts= */ null,
+            mandatoryInputsDigest,
+            /* clientEnv= */ ImmutableMap.of(),
+            OutputPermissions.READONLY,
+            /* handler= */ null,
+            metadataHandler,
+            metadataHandler,
+            /* actionExecutionSalt= */ "",
+            OutputChecker.TRUST_ALL,
+            /* useArchivedTreeArtifacts= */ false);
+    if (token == null) {
+      return;
+    }
+    for (Artifact artifact : action.getOutputs()) {
+      Path path = artifact.getPath();
+      filesToDelete.add(path);
+      Path parent = path.getParentDirectory();
+      if (parent != null) {
+        parent.createDirectoryAndParents();
+      }
+    }
+    ActionExecutionContext context = mock(ActionExecutionContext.class);
+    when(context.getOutputMetadataStore()).thenReturn(metadataHandler);
+    action.execute(context);
+    cacheChecker.updateActionCache(
+        action,
+        token,
+        metadataHandler,
+        metadataHandler,
+        ImmutableMap.of(),
+        OutputPermissions.READONLY,
+        "",
+        /* useArchivedTreeArtifacts= */ false,
+        mandatoryInputsDigest);
+  }
+
   // TODO(tjgq): Add tests for cached tree artifacts with a materialization path. They should take
   // into account every combination of entirely/partially remote metadata and symlink present/not
   // present in the filesystem.
+
+  /** {@link TestAction} that opts in to split mandatory/discovered action cache checking. */
+  private static final class SplitCacheTestAction extends TestAction {
+    SplitCacheTestAction(
+        Runnable effect, NestedSet<Artifact> inputs, ImmutableSet<Artifact> outputs) {
+      super(effect, inputs, outputs);
+    }
+
+    @Override
+    public boolean usesSplitMandatoryInputsActionCacheCheck() {
+      return true;
+    }
+  }
 
   /** An {@link ActionCache} that allows injecting corruption for testing. */
   private static final class CorruptibleActionCache implements ActionCache {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1669,6 +1669,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/skyframe:action_output_metadata_store",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",
+        "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/skyframe",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1727,6 +1727,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/skyframe:action_output_metadata_store",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",
+        "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/skyframe",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactMetadataTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactMetadataTest.java
@@ -41,6 +41,7 @@ import com.google.devtools.build.lib.actions.util.TestAction.DummyAction;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.events.NullEventHandler;
+import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileStatusWithDigestAdapter;
 import com.google.devtools.build.lib.vfs.Path;
@@ -110,11 +111,8 @@ public final class TreeArtifactMetadataTest extends ArtifactFunctionTestCase {
   @Test
   public void testEmptyTreeArtifacts() throws Exception {
     TreeArtifactValue value = doTestTreeArtifacts(ImmutableList.of());
-    // Additional test, only for this test method: we expect the FileArtifactValue is equal to
-    // the digest [0]
     assertThat(value.getMetadata().getDigest()).isEqualTo(value.getDigest());
-    // Java zero-fills arrays.
-    assertThat(value.getDigest()).isEqualTo(new byte[1]);
+    assertThat(value.getDigest()).isEqualTo(new Fingerprint().digestAndReset());
   }
 
   @Test

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1263,6 +1263,110 @@ EOF
   expect_log "17 disk cache hit"
 }
 
+function test_cpp20_modules_change_ab_to_ba_no_cycle() {
+  type -P clang || return 0
+  local -r clang_version=$(clang --version | head -n1 | grep -oE '[0-9]+\.[0-9]+' | head -n1)
+  if [[ -n "$clang_version" ]]; then
+    local -r major_version=$(echo "$clang_version" | cut -d. -f1)
+    if [[ "$major_version" -lt 17 ]]; then
+      return 0
+    fi
+  fi
+
+  if is_darwin; then
+    return 0
+  fi
+
+  add_rules_cc "MODULE.bazel"
+
+  cat > BUILD.bazel <<'EOF'
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(features = ["cpp_modules"])
+
+cc_library(
+  name = "lib",
+  module_interfaces = ["a.cppm", "b.cppm"],
+)
+EOF
+  cat > a.cppm <<'EOF'
+export module a;
+import b;
+EOF
+  cat > b.cppm <<'EOF'
+export module b;
+EOF
+
+  local -r flags="--experimental_cpp_modules --repo_env=CC=clang --copt=-std=c++20"
+  bazel build //:lib ${flags} &> $TEST_log || fail "Expected build C++20 Modules success with compiler 'clang'"
+
+  cat > a.cppm <<'EOF'
+export module a;
+EOF
+  cat > b.cppm <<'EOF'
+export module b;
+import a;
+EOF
+
+  bazel build //:lib ${flags} &> $TEST_log || fail "Expected build C++20 Modules success with compiler 'clang'"
+}
+
+function test_cpp20_modules_change_abc_to_acb_no_cycle() {
+  type -P clang || return 0
+  local -r clang_version=$(clang --version | head -n1 | grep -oE '[0-9]+\.[0-9]+' | head -n1)
+  if [[ -n "$clang_version" ]]; then
+    local -r major_version=$(echo "$clang_version" | cut -d. -f1)
+    if [[ "$major_version" -lt 17 ]]; then
+      return 0
+    fi
+  fi
+
+  if is_darwin; then
+    return 0
+  fi
+
+  add_rules_cc "MODULE.bazel"
+
+  cat > BUILD.bazel <<'EOF'
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(features = ["cpp_modules"])
+
+cc_library(
+  name = "lib",
+  module_interfaces = ["a.cppm", "b.cppm", "c.cppm"],
+)
+EOF
+  cat > a.cppm <<'EOF'
+export module a;
+import b;
+EOF
+  cat > b.cppm <<'EOF'
+export module b;
+import c;
+EOF
+  cat > c.cppm <<'EOF'
+export module c;
+EOF
+
+  local -r flags="--experimental_cpp_modules --repo_env=CC=clang --copt=-std=c++20"
+  bazel build //:lib ${flags} &> $TEST_log || fail "Expected build C++20 Modules success with compiler 'clang'"
+
+  cat > a.cppm <<'EOF'
+export module a;
+import c;
+EOF
+  cat > b.cppm <<'EOF'
+export module b;
+EOF
+  cat > c.cppm <<'EOF'
+export module c;
+import b;
+EOF
+
+  bazel build //:lib ${flags} &> $TEST_log || fail "Expected build C++20 Modules success with compiler 'clang'"
+}
+
 function test_external_repo_lto() {
   add_rules_cc "MODULE.bazel"
   REPO_PATH=$TEST_TMPDIR/repo


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

When a cc_library defines multiple C++20 module interfaces and their import relationships change between builds, Bazel can hit a Skyframe dependency cycle: action cache lookup reloads previously discovered .pcm inputs before mandatory inputs are validated, creating stale edges in the import graph.

Fix this by splitting action cache checking for C++20 module compile/codegen actions: compute and compare a mandatory inputs digest before loading cached discovered inputs. If mandatory inputs changed, reset discovered inputs and skip the cached discovered input paths.

Unlike bazelbuild/bazel#27492 (rolled back in #28190 for a performance regression), the split check is limited to actions that opt in via Action#usesSplitMandatoryInputsActionCacheCheck() (CppCompileAction module compile/codegen only), rather than all discoversInputs() actions.


### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

Relates to #27492.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
