### PR TITLE
Add support for multiple module interfaces per `cc_library`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
@@ -244,19 +244,28 @@ public class ActionCacheChecker {
         }
       }
     }
-    // A non-null mandatoryInputsDigest is the digest of the action's mandatory inputs, seeded into
-    // the entry digest by the builder; skip those inputs here to avoid hashing them a second time.
-    // It is only non-null for non-pruning input-discovering actions, mirroring the write path in
-    // updateActionCache.
-    boolean excludeMandatoryInputs = mandatoryInputsDigest != null;
-    ImmutableSet<Artifact> mandatoryInputs =
-        excludeMandatoryInputs ? action.getMandatoryInputs().toSet() : ImmutableSet.of();
-    for (Artifact artifact : actionInputs.toList()) {
-      if (excludeMandatoryInputs && mandatoryInputs.contains(artifact)) {
-        continue;
+    if (mandatoryInputsDigest != null) {
+      // The mandatory inputs are covered by mandatoryInputsDigest, which the builder folds into the
+      // entry digest as a seed. Fold only the discovered inputs, which the cache entry already
+      // enumerates by exec path, so the mandatory inputs are neither hashed a second time nor
+      // flattened into a set just to be skipped. mandatoryInputsDigest is only set for non-pruning
+      // input-discovering actions, so the entry is one too.
+      if (!entry.discoversInputs()) {
+        return false;
       }
-      FileArtifactValue inputMetadata = getInputMetadataMaybe(inputMetadataProvider, artifact);
-      builder.addInputFile(artifact, inputMetadata);
+      for (String execPath : entry.getDiscoveredInputPaths()) {
+        ActionInput input = inputMetadataProvider.getInput(PathFragment.create(execPath));
+        if (input == null) {
+          // A previously discovered input is no longer among the action's inputs.
+          return false;
+        }
+        builder.addInputFile(
+            (Artifact) input, getInputMetadataMaybe(inputMetadataProvider, (Artifact) input));
+      }
+    } else {
+      for (Artifact artifact : actionInputs.toList()) {
+        builder.addInputFile(artifact, getInputMetadataMaybe(inputMetadataProvider, artifact));
+      }
     }
     return Arrays.equals(entry.getDigest(), builder.build().getDigest());
   }

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
@@ -178,6 +178,9 @@ public class ActionCacheChecker {
    * @param actionKey the action key previously obtained from action.getKey()
    * @param actionInputs the action inputs; usually action.getInputs(), but might be a previously
    *     cached set of discovered inputs for actions that discover them.
+   * @param mandatoryInputsDigest the digest of the action's mandatory inputs, or null if the action
+   *     doesn't discover inputs or pruned them. When set, it is used as a proxy for the mandatory
+   *     inputs so that they are not hashed a second time.
    * @param outputMetadataStore metadata provider for action outputs.
    * @param cachedOutputMetadata cached metadata that should be used instead of {@code
    *     outputMetadataStore}.
@@ -193,6 +196,7 @@ public class ActionCacheChecker {
       Action action,
       String actionKey,
       NestedSet<Artifact> actionInputs,
+      @Nullable byte[] mandatoryInputsDigest,
       InputMetadataProvider inputMetadataProvider,
       OutputMetadataStore outputMetadataStore,
       @Nullable CachedOutputMetadata cachedOutputMetadata,
@@ -206,10 +210,14 @@ public class ActionCacheChecker {
         new ActionCache.Entry.Builder(
             actionKey,
             action.discoversInputs(),
+            mandatoryInputsDigest,
             effectiveEnvironment,
             actionExecutionSalt,
             outputPermissions,
             useArchivedTreeArtifacts);
+    // Mirror how the cached entry was written: if it pruned its inputs, the mandatory inputs digest
+    // is not used as a seed and all inputs are hashed (see updateActionCache).
+    builder.setPrunedInputs(entry.prunedInputs());
 
     for (Artifact artifact : action.getOutputs()) {
       if (artifact.isTreeArtifact()) {
@@ -236,7 +244,17 @@ public class ActionCacheChecker {
         }
       }
     }
+    // A non-null mandatoryInputsDigest is the digest of the action's mandatory inputs, seeded into
+    // the entry digest by the builder; skip those inputs here to avoid hashing them a second time.
+    // It is only non-null for non-pruning input-discovering actions, mirroring the write path in
+    // updateActionCache.
+    boolean excludeMandatoryInputs = mandatoryInputsDigest != null;
+    ImmutableSet<Artifact> mandatoryInputs =
+        excludeMandatoryInputs ? action.getMandatoryInputs().toSet() : ImmutableSet.of();
     for (Artifact artifact : actionInputs.toList()) {
+      if (excludeMandatoryInputs && mandatoryInputs.contains(artifact)) {
+        continue;
+      }
       FileArtifactValue inputMetadata = getInputMetadataMaybe(inputMetadataProvider, artifact);
       builder.addInputFile(artifact, inputMetadata);
     }
@@ -452,6 +470,7 @@ public class ActionCacheChecker {
   public Token getTokenIfNeedToExecute(
       Action action,
       List<Artifact> resolvedCacheArtifacts,
+      @Nullable byte[] mandatoryInputsDigest,
       Map<String, String> clientEnv,
       OutputPermissions outputPermissions,
       EventHandler handler,
@@ -508,6 +527,7 @@ public class ActionCacheChecker {
         inputMetadataProvider,
         outputMetadataStore,
         actionInputs,
+        mandatoryInputsDigest,
         clientEnv,
         outputPermissions,
         actionExecutionSalt,
@@ -542,6 +562,7 @@ public class ActionCacheChecker {
       InputMetadataProvider inputMetadataProvider,
       OutputMetadataStore outputMetadataStore,
       NestedSet<Artifact> actionInputs,
+      @Nullable byte[] mandatoryInputsDigest,
       Map<String, String> clientEnv,
       OutputPermissions outputPermissions,
       String actionExecutionSalt,
@@ -580,6 +601,7 @@ public class ActionCacheChecker {
         action,
         actionKey,
         actionInputs,
+        mandatoryInputsDigest,
         inputMetadataProvider,
         outputMetadataStore,
         cachedOutputMetadata,
@@ -618,7 +640,7 @@ public class ActionCacheChecker {
   // to trigger a re-execution, so we should catch the IOException explicitly there. In others, we
   // should propagate the exception, because it is unexpected (e.g., bad file system state).
   @Nullable
-  private static FileArtifactValue getInputMetadataMaybe(
+  public static FileArtifactValue getInputMetadataMaybe(
       InputMetadataProvider inputMetadataProvider, Artifact artifact) {
     try {
       return getInputMetadataOrConstant(inputMetadataProvider, artifact);
@@ -655,6 +677,7 @@ public class ActionCacheChecker {
   public void updateActionCache(
       Action action,
       Token token,
+      @Nullable byte[] mandatoryInputsDigest,
       InputMetadataProvider inputMetadataProvider,
       OutputMetadataStore outputMetadataStore,
       Map<String, String> clientEnv,
@@ -684,6 +707,7 @@ public class ActionCacheChecker {
         new ActionCache.Entry.Builder(
                 actionKey,
                 action.discoversInputs(),
+                mandatoryInputsDigest,
                 effectiveEnvironment,
                 actionExecutionSalt,
                 outputPermissions,
@@ -713,19 +737,38 @@ public class ActionCacheChecker {
       }
     }
 
-    ImmutableSet<Artifact> excludePathsFromActionCache =
-        action.discoversInputs() && !action.prunedInputs()
-            ? action.getMandatoryInputs().toSet()
-            : ImmutableSet.of();
+    // When mandatoryInputsDigest is set, the builder seeds the entry digest with it (the mandatory
+    // inputs are not pruned), so omit those inputs here: they are neither hashed again nor recorded
+    // as discovered inputs. The read path (isUpToDate) performs the mirror-image skip.
+    boolean excludeMandatoryInputs = mandatoryInputsDigest != null && !action.prunedInputs();
+    ImmutableSet<Artifact> mandatoryInputs =
+        excludeMandatoryInputs ? action.getMandatoryInputs().toSet() : ImmutableSet.of();
 
     for (Artifact input : action.getInputs().toList()) {
+      if (excludeMandatoryInputs && mandatoryInputs.contains(input)) {
+        continue;
+      }
       builder.addInputFile(
           input,
           getInputMetadataMaybe(inputMetadataProvider, input),
-          /* saveExecPath= */ !excludePathsFromActionCache.contains(input));
+          /* saveExecPath= */ action.discoversInputs());
     }
 
     actionCache.put(key, builder.build());
+  }
+
+  /**
+   * Returns the action's cached entry if it exists and is not corrupted, or null otherwise.
+   *
+   * <p>Used by the cheap first phase of the action cache lookup for input-discovering actions, which
+   * compares the entry's {@linkplain ActionCache.Entry#getMandatoryInputsDigest mandatory inputs
+   * digest} before requesting the previously discovered inputs (which could otherwise reintroduce a
+   * stale dependency edge and form a phantom cycle).
+   */
+  @Nullable
+  public ActionCache.Entry getUsableCacheEntry(Action action) {
+    ActionCache.Entry entry = getCacheEntry(action);
+    return (entry == null || entry.isCorrupted()) ? null : entry;
   }
 
   @Nullable
@@ -801,6 +844,7 @@ public class ActionCacheChecker {
   public Token getTokenUnconditionallyAfterFailureToRecordActionCacheHit(
       Action action,
       List<Artifact> resolvedCacheArtifacts,
+      @Nullable byte[] mandatoryInputsDigest,
       Map<String, String> clientEnv,
       OutputPermissions outputPermissions,
       EventHandler handler,
@@ -816,6 +860,7 @@ public class ActionCacheChecker {
     return getTokenIfNeedToExecute(
         action,
         resolvedCacheArtifacts,
+        mandatoryInputsDigest,
         clientEnv,
         outputPermissions,
         handler,

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/ActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/ActionCache.java
@@ -82,7 +82,7 @@ public interface ActionCache {
   final class Entry {
     /** Unique instance standing for a corrupted cache entry. */
     public static final ActionCache.Entry CORRUPTED =
-        new Entry(null, null, false, ImmutableMap.of(), ImmutableMap.of(), ImmutableList.of());
+        new Entry(null, null, null, false, ImmutableMap.of(), ImmutableMap.of(), ImmutableList.of());
 
     // Digest of all relevant properties of the action for cache invalidation purposes.
     // Null if the entry is corrupted.
@@ -91,6 +91,12 @@ public interface ActionCache {
     // List of input paths discovered by the action.
     // Null if the action does not discover inputs.
     @Nullable private final ImmutableList<String> discoveredInputPaths;
+
+    // Digest of the action's mandatory inputs, used to cheaply detect whether they changed before
+    // requesting the previously discovered inputs (which can introduce phantom cycles). Also used as
+    // the seed of the full input/output digest so that mandatory inputs are not hashed twice. Only
+    // set for input-discovering actions that did not prune their inputs; null otherwise.
+    @Nullable private final byte[] mandatoryInputsDigest;
 
     private final boolean prunedInputs;
 
@@ -103,6 +109,7 @@ public interface ActionCache {
     Entry(
         @Nullable byte[] digest,
         @Nullable ImmutableList<String> discoveredInputPaths,
+        @Nullable byte[] mandatoryInputsDigest,
         boolean prunedInputs,
         ImmutableMap<String, FileArtifactValue> outputFileMetadata,
         ImmutableMap<String, SerializableTreeArtifactValue> outputTreeMetadata,
@@ -110,8 +117,14 @@ public interface ActionCache {
       checkArgument(
           !prunedInputs || discoveredInputPaths != null,
           "Action had unused inputs but no discovered inputs");
+      // The mandatory inputs digest is only used (as a seed that avoids re-hashing) for
+      // input-discovering actions that did not prune their inputs; it is left null otherwise.
+      checkArgument(
+          mandatoryInputsDigest == null || (discoveredInputPaths != null && !prunedInputs),
+          "mandatoryInputsDigest may only be set for non-pruning input-discovering actions");
       this.digest = digest;
       this.discoveredInputPaths = discoveredInputPaths;
+      this.mandatoryInputsDigest = mandatoryInputsDigest;
       this.prunedInputs = prunedInputs;
       this.outputFileMetadata = outputFileMetadata;
       this.outputTreeMetadata = outputTreeMetadata;
@@ -156,6 +169,16 @@ public interface ActionCache {
     public ImmutableList<String> getDiscoveredInputPaths() {
       checkState(!isCorrupted());
       return discoveredInputPaths;
+    }
+
+    /**
+     * Returns the digest of the action's mandatory inputs, or null if the action does not discover
+     * inputs.
+     */
+    @Nullable
+    public byte[] getMandatoryInputsDigest() {
+      checkState(!isCorrupted());
+      return mandatoryInputsDigest;
     }
 
     /** Gets the metadata of an output file. */
@@ -205,6 +228,7 @@ public interface ActionCache {
       return MoreObjects.toStringHelper(this)
           .add("digest", digest)
           .add("discoveredInputPaths", discoveredInputPaths)
+          .add("mandatoryInputsDigest", mandatoryInputsDigest)
           .add("outputFileMetadata", outputFileMetadata)
           .add("outputTreeMetadata", outputTreeMetadata)
           .add("proxyOutputs", proxyOutputs)
@@ -222,6 +246,9 @@ public interface ActionCache {
         for (String path : ImmutableList.sortedCopyOf(discoveredInputPaths)) {
           out.format("    %s\n", path);
         }
+      }
+      if (mandatoryInputsDigest != null) {
+        out.format("  mandatoryInputsDigest = %s\n", formatDigest(mandatoryInputsDigest));
       }
 
       if (!outputFileMetadata.isEmpty()) {
@@ -294,6 +321,11 @@ public interface ActionCache {
       // Discovered inputs.
       // Null if the action does not discover inputs.
       @Nullable private final ImmutableList.Builder<String> discoveredInputPaths;
+      // Digest of the action's mandatory inputs, as computed by the caller for an input-discovering
+      // action. Unless the action pruned its inputs, it is stored on the entry and used as the seed
+      // of the input/output digest so that the mandatory inputs are not hashed again; for pruning
+      // actions it is dropped (see build()).
+      @Nullable private final byte[] mandatoryInputsDigest;
       private boolean prunedInputs = false;
 
       private final ImmutableMap.Builder<String, FileArtifactValue> outputFileMetadata =
@@ -311,20 +343,27 @@ public interface ActionCache {
        * Creates a new builder.
        *
        * @param discoversInputs whether the action discovers inputs.
+       * @param mandatoryInputsDigest the digest of the action's mandatory inputs for an
+       *     input-discovering action, or null otherwise.
        * @param outputPermissions the requested output permissions.
        * @param useArchivedTreeArtifacts whether archived tree artifacts are enabled.
        */
       public Builder(
           String actionKey,
           boolean discoversInputs,
+          @Nullable byte[] mandatoryInputsDigest,
           ImmutableMap<String, String> clientEnv,
           String actionExecutionSalt,
           OutputPermissions outputPermissions,
           boolean useArchivedTreeArtifacts) {
+        checkArgument(
+            mandatoryInputsDigest == null || discoversInputs,
+            "mandatoryInputsDigest may only be set for input-discovering actions");
         this.actionKey = actionKey;
         this.clientEnv = clientEnv;
         this.actionExecutionSalt = actionExecutionSalt;
         this.discoveredInputPaths = discoversInputs ? ImmutableList.builder() : null;
+        this.mandatoryInputsDigest = mandatoryInputsDigest;
         this.outputPermissions = outputPermissions;
         this.useArchivedTreeArtifacts = useArchivedTreeArtifacts;
       }
@@ -407,16 +446,21 @@ public interface ActionCache {
       }
 
       public Entry build() {
+        // The mandatory inputs digest is only meaningful for non-pruning input-discovering actions;
+        // pruning actions store all used inputs and hash them directly.
+        byte[] storedMandatoryInputsDigest = prunedInputs ? null : mandatoryInputsDigest;
         return new Entry(
             computeDigest(
                 actionKey,
                 discoveredInputPaths != null,
                 metadataMap,
+                /* inputDigestSeed= */ storedMandatoryInputsDigest,
                 clientEnv,
                 actionExecutionSalt,
                 outputPermissions,
                 useArchivedTreeArtifacts),
             discoveredInputPaths != null ? discoveredInputPaths.build() : null,
+            storedMandatoryInputsDigest,
             prunedInputs,
             outputFileMetadata.buildOrThrow(),
             outputTreeMetadata.buildOrThrow(),
@@ -427,6 +471,7 @@ public interface ActionCache {
           String actionKey,
           boolean discoversInputs,
           Map<String, FileArtifactValue> metadataMap,
+          @Nullable byte[] inputDigestSeed,
           Map<String, String> clientEnv,
           String actionExecutionSalt,
           OutputPermissions outputPermissions,
@@ -434,7 +479,10 @@ public interface ActionCache {
         Fingerprint fp = new Fingerprint();
         fp.addString(actionKey);
         fp.addBoolean(discoversInputs);
-        fp.addBytes(MetadataDigestUtils.fromMetadata(metadataMap));
+        fp.addBytes(
+            inputDigestSeed != null
+                ? MetadataDigestUtils.fromMetadata(metadataMap, inputDigestSeed)
+                : MetadataDigestUtils.fromMetadata(metadataMap));
         fp.addBytes(computeMapDigest(clientEnv));
         fp.addString(actionExecutionSalt);
         fp.addInt(outputPermissions.getPermissionsMode());

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -76,7 +76,7 @@ public class CompactPersistentActionCache implements ActionCache {
   // cache records.
   private static final int VALIDATION_KEY = -10;
 
-  private static final int VERSION = 25;
+  private static final int VERSION = 26;
 
   /**
    * A timestamp, represented as the number of minutes since the Unix epoch.
@@ -848,6 +848,8 @@ public class CompactPersistentActionCache implements ActionCache {
     if (entry.discoversInputs()) {
       maxDiscoveredInputsSize +=
           1 // pruned inputs presence marker
+              + 1 // mandatoryInputsDigest presence marker
+              + (1 + DigestUtils.ESTIMATED_SIZE) // mandatoryInputsDigest length + digest
               + VarInt.MAX_VARINT_SIZE // length
               + (VarInt.MAX_VARINT_SIZE // execPath
                   * entry.getDiscoveredInputPaths().size());
@@ -901,6 +903,11 @@ public class CompactPersistentActionCache implements ActionCache {
     VarInt.putVarInt(entry.discoversInputs() ? 1 : 0, sink);
     if (entry.discoversInputs()) {
       VarInt.putVarInt(entry.prunedInputs() ? 1 : 0, sink);
+      byte[] mandatoryInputsDigest = entry.getMandatoryInputsDigest();
+      VarInt.putVarInt(mandatoryInputsDigest != null ? 1 : 0, sink);
+      if (mandatoryInputsDigest != null) {
+        MetadataDigestUtils.write(mandatoryInputsDigest, sink);
+      }
       ImmutableList<String> discoveredInputPaths = entry.getDiscoveredInputPaths();
       VarInt.putVarInt(discoveredInputPaths.size(), sink);
       for (String discoveredInputPath : discoveredInputPaths) {
@@ -979,6 +986,7 @@ public class CompactPersistentActionCache implements ActionCache {
       byte[] digest = MetadataDigestUtils.read(source);
 
       ImmutableList<String> discoveredInputPaths = null;
+      byte[] mandatoryInputsDigest = null;
       boolean prunedInputs = false;
       int discoveredInputsPresenceMarker = VarInt.getVarInt(source);
       if (discoveredInputsPresenceMarker != 0) {
@@ -992,6 +1000,18 @@ public class CompactPersistentActionCache implements ActionCache {
             throw new IOException("Invalid marker for pruned inputs: " + prunedInputsMarker);
           }
           prunedInputs = true;
+        }
+        int mandatoryInputsDigestMarker = VarInt.getVarInt(source);
+        if (mandatoryInputsDigestMarker != 0) {
+          if (mandatoryInputsDigestMarker != 1) {
+            throw new IOException(
+                "Invalid presence marker for mandatory inputs digest: "
+                    + mandatoryInputsDigestMarker);
+          }
+          mandatoryInputsDigest = MetadataDigestUtils.read(source);
+          if (mandatoryInputsDigest.length != digest.length) {
+            throw new IOException("Corrupted mandatory inputs digest");
+          }
         }
         int numDiscoveredInputs = VarInt.getVarInt(source);
         if (numDiscoveredInputs < 0) {
@@ -1015,6 +1035,7 @@ public class CompactPersistentActionCache implements ActionCache {
         return new ActionCache.Entry(
             digest,
             discoveredInputPaths,
+            mandatoryInputsDigest,
             prunedInputs,
             /* outputFileMetadata= */ ImmutableMap.of(),
             /* outputTreeMetadata= */ ImmutableMap.of(),
@@ -1097,6 +1118,7 @@ public class CompactPersistentActionCache implements ActionCache {
       return new ActionCache.Entry(
           digest,
           discoveredInputPaths,
+          mandatoryInputsDigest,
           prunedInputs,
           outputFiles.buildOrThrow(),
           outputTrees.buildOrThrow(),

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/MetadataDigestUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/MetadataDigestUtils.java
@@ -29,6 +29,12 @@ public final class MetadataDigestUtils {
   private MetadataDigestUtils() {}
 
   /**
+   * An empty digest of the same length as a real metadata digest, used as the seed (and additive
+   * identity for {@link DigestUtils#combineUnordered}) of {@link #fromMetadata}.
+   */
+  private static final byte[] EMPTY_DIGEST = new Fingerprint().digestAndReset();
+
+  /**
    * @param source the byte buffer source.
    * @return the digest from the given buffer.
    */
@@ -54,7 +60,27 @@ public final class MetadataDigestUtils {
    * @param mdMap A collection of (execPath, FileArtifactValue) pairs. Values may be null.
    */
   public static byte[] fromMetadata(Map<String, FileArtifactValue> mdMap) {
-    byte[] result = new byte[1]; // reserve the empty string
+    return fromMetadata(mdMap, EMPTY_DIGEST);
+  }
+
+  /**
+   * Computes an order-independent digest from the given (path, metadata) pairs, combined into the
+   * given seed digest.
+   *
+   * <p>Because {@link DigestUtils#combineUnordered} is commutative and associative, folding one
+   * disjoint subset of entries into {@link #EMPTY_DIGEST} and then folding the remaining entries
+   * into that result yields the same digest as folding all entries at once. The action cache
+   * exploits this to avoid re-hashing an action's mandatory inputs: it seeds with the precomputed
+   * mandatory-inputs digest (itself a {@code fromMetadata} over just those inputs) and folds in only
+   * the discovered inputs and outputs.
+   *
+   * @param mdMap A collection of (execPath, FileArtifactValue) pairs. Values may be null.
+   * @param seed the digest to combine the entries into; not mutated.
+   */
+  public static byte[] fromMetadata(Map<String, FileArtifactValue> mdMap, byte[] seed) {
+    // combineUnordered may clobber its longer argument, so start from a copy of the seed to avoid
+    // mutating a digest that the caller may retain (e.g., a stored mandatory-inputs digest).
+    byte[] result = seed.clone();
     // Profiling showed that MessageDigest engine instantiation was a hotspot, so create one
     // instance for this computation to amortize its cost.
     Fingerprint fp = new Fingerprint();

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
@@ -33,6 +33,7 @@ import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.SetMultimap;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.actions.Action;
+import com.google.devtools.build.lib.actions.ActionCacheChecker;
 import com.google.devtools.build.lib.actions.ActionCacheChecker.Token;
 import com.google.devtools.build.lib.actions.ActionCompletionEvent;
 import com.google.devtools.build.lib.actions.ActionExecutedEvent.ErrorTiming;
@@ -53,6 +54,8 @@ import com.google.devtools.build.lib.actions.PackageRootResolver;
 import com.google.devtools.build.lib.actions.RichArtifactData;
 import com.google.devtools.build.lib.actions.RichDataProducingAction;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
+import com.google.devtools.build.lib.actions.cache.ActionCache;
+import com.google.devtools.build.lib.actions.cache.MetadataDigestUtils;
 import com.google.devtools.build.lib.actions.cache.OutputMetadataStore;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.bugreport.BugReport;
@@ -104,6 +107,7 @@ import com.google.devtools.build.skyframe.SkyframeLookupResult;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -280,7 +284,7 @@ public final class ActionExecutionFunction implements SkyFunction {
     if (!state.hasCollectedInputs()) {
       try {
         state.allInputs = collectInputs(action, env);
-      } catch (AlreadyReportedActionExecutionException e) {
+      } catch (ActionExecutionException e) {
         throw new ActionExecutionFunctionException(e);
       }
       if (state.allInputs == null) {
@@ -583,6 +587,69 @@ public final class ActionExecutionFunction implements SkyFunction {
   }
 
   /**
+   * Computes the digest of the action's mandatory inputs, mirroring the per-input metadata digest
+   * that {@link com.google.devtools.build.lib.actions.cache.ActionCache.Entry.Builder} stores.
+   *
+   * <p>Requests the mandatory inputs' Skyframe values; if any are missing this returns null and the
+   * caller should restart (unless in error bubbling). Returns null without restarting if a mandatory
+   * input is missing or undone, which means the current execution attempt cannot proceed; the caller
+   * surfaces the underlying error when it later requests all inputs.
+   */
+  @Nullable
+  private byte[] computeMandatoryInputsDigest(Action action, Environment env)
+      throws InterruptedException, ActionExecutionException {
+    NestedSet<Artifact> mandatoryInputsSet = action.getMandatoryInputs();
+    var mandatoryInputsKeysBuilder = ImmutableSet.<SkyKey>builder();
+    for (Artifact leaf : mandatoryInputsSet.getLeaves()) {
+      mandatoryInputsKeysBuilder.add(Artifact.key(leaf));
+    }
+    for (NestedSet<Artifact> nonLeaf : mandatoryInputsSet.getNonLeaves()) {
+      mandatoryInputsKeysBuilder.add(ArtifactNestedSetKey.create(nonLeaf));
+    }
+    var mandatoryInputsKeys = mandatoryInputsKeysBuilder.build();
+    var lookupResult = env.getValuesAndExceptions(mandatoryInputsKeys);
+    if (env.valuesMissing() && !env.inErrorBubbling()) {
+      return null;
+    }
+    var mandatoryInputs = mandatoryInputsSet.toList();
+    var inputArtifactData = new ActionInputMap(mandatoryInputs.size());
+    var inputMap = new HashMap<String, FileArtifactValue>(mandatoryInputs.size());
+    var actionExecutionFunctionExceptionHandler =
+        createActionExecutionFunctionExceptionHandler(
+            action,
+            lookupResult,
+            mandatoryInputsKeys,
+            () -> mandatoryInputs,
+            /* isMandatoryInput= */ Predicates.alwaysTrue());
+    var unused = actionExecutionFunctionExceptionHandler.accumulateAndMaybeThrowExceptions();
+    if (env.valuesMissing() && !env.inErrorBubbling()) {
+      return null;
+    }
+    for (var artifact : mandatoryInputs) {
+      SkyValue value =
+          getAndCheckInputSkyValue(
+              env,
+              action,
+              artifact,
+              mandatoryInputsKeys,
+              /* isMandatoryInput= */ Predicates.alwaysTrue(),
+              actionExecutionFunctionExceptionHandler);
+      if (value == null || value instanceof MissingArtifactValue) {
+        // This can happen with rewinding or in keep-going builds and is always an indication to
+        // halt the current action execution attempt - we do not have to compute a digest.
+        return null;
+      }
+      ActionInputMapHelper.addToMap(
+          inputArtifactData, artifact, value, MetadataConsumerForMetrics.NO_OP);
+      inputMap.put(
+          artifact.getExecPathString(),
+          ActionCacheChecker.getInputMetadataMaybe(inputArtifactData, artifact));
+    }
+    actionExecutionFunctionExceptionHandler.maybeThrowException();
+    return MetadataDigestUtils.fromMetadata(inputMap);
+  }
+
+  /**
    * An action's inputs needed for execution. May not just be the result of Action#getInputs(). If
    * the action cache's view of this action contains additional inputs, it will request metadata for
    * them, so we consider those inputs as dependencies of this action as well. Returns null if some
@@ -590,9 +657,38 @@ public final class ActionExecutionFunction implements SkyFunction {
    */
   @Nullable
   private AllInputs collectInputs(Action action, Environment env)
-      throws InterruptedException, AlreadyReportedActionExecutionException {
+      throws InterruptedException, ActionExecutionException {
+    byte[] mandatoryInputsDigest = null;
+    // Input pruning (e.g. unused_inputs_list) is deliberately excluded: such actions store all used
+    // inputs as "discovered" and must not depend on the pruned-away inputs for cache checking
+    // (those may no longer be buildable), and they can't form the phantom cycles this guards
+    // against. We check the cached entry rather than action.prunedInputs() so that this also holds
+    // after a server restart, when the action instance no longer remembers that it pruned.
+    if (action.discoversInputs() && !action.prunedInputs()) {
+      ActionCache.Entry cacheEntry = skyframeActionExecutor.getActionCacheEntry(action);
+      if (cacheEntry == null || !cacheEntry.prunedInputs()) {
+        // When the mandatory inputs of an action have changed, it will certainly have to be
+        // reexecuted. It is important that we detect this before requesting the previously
+        // discovered inputs from Skyframe as that could result in cycles that otherwise would not
+        // occur. Note that this approach does not guarantee the absence of such "phantom" cycles in
+        // general, it just happens to work for all current use cases in Bazel. A theoretically sound
+        // solution would require checking the discovered inputs for changes one by one, in the order
+        // in which they were originally discovered.
+        mandatoryInputsDigest = computeMandatoryInputsDigest(action, env);
+        if (env.valuesMissing()) {
+          return null;
+        }
+        if (mandatoryInputsDigest == null
+            || cacheEntry == null
+            || !Arrays.equals(cacheEntry.getMandatoryInputsDigest(), mandatoryInputsDigest)) {
+          action.resetDiscoveredInputs();
+          return new AllInputs(action.getInputs(), mandatoryInputsDigest);
+        }
+      }
+    }
+
     if (action.inputsKnown()) {
-      return new AllInputs(action.getInputs());
+      return new AllInputs(action.getInputs(), mandatoryInputsDigest);
     }
 
     checkState(action.discoversInputs(), action);
@@ -608,21 +704,29 @@ public final class ActionExecutionFunction implements SkyFunction {
     // the full set of original inputs. We'll request them later on if there is no action cache hit.
     NestedSet<Artifact> allKnownInputs =
         action.prunedInputs() ? NestedSetBuilder.emptySet(Order.STABLE_ORDER) : action.getInputs();
-    return new AllInputs(allKnownInputs, actionCacheInputs);
+    return new AllInputs(allKnownInputs, actionCacheInputs, mandatoryInputsDigest);
   }
 
   static class AllInputs {
     final NestedSet<Artifact> defaultInputs;
     @Nullable final List<Artifact> actionCacheInputs;
+    // Digest of the action's mandatory inputs, or null if the action doesn't discover inputs or
+    // pruned them.
+    @Nullable final byte[] mandatoryInputsDigest;
 
-    AllInputs(NestedSet<Artifact> defaultInputs) {
+    AllInputs(NestedSet<Artifact> defaultInputs, @Nullable byte[] mandatoryInputsDigest) {
       this.defaultInputs = checkNotNull(defaultInputs);
       this.actionCacheInputs = null;
+      this.mandatoryInputsDigest = mandatoryInputsDigest;
     }
 
-    AllInputs(NestedSet<Artifact> defaultInputs, List<Artifact> actionCacheInputs) {
+    AllInputs(
+        NestedSet<Artifact> defaultInputs,
+        List<Artifact> actionCacheInputs,
+        @Nullable byte[] mandatoryInputsDigest) {
       this.defaultInputs = checkNotNull(defaultInputs);
       this.actionCacheInputs = checkNotNull(actionCacheInputs);
+      this.mandatoryInputsDigest = mandatoryInputsDigest;
     }
 
     /** Compute the inputs to request from Skyframe. */
@@ -772,6 +876,7 @@ public final class ActionExecutionFunction implements SkyFunction {
               pathResolver,
               actionStartTime,
               state.allInputs.actionCacheInputs,
+              state.allInputs.mandatoryInputsDigest,
               clientEnv);
     }
 
@@ -875,7 +980,12 @@ public final class ActionExecutionFunction implements SkyFunction {
       }
       checkState(!env.valuesMissing(), action);
       skyframeActionExecutor.updateActionCache(
-          action, inputMetadataProvider, outputMetadataStore, state.token, clientEnv);
+          action,
+          inputMetadataProvider,
+          outputMetadataStore,
+          state.token,
+          state.allInputs.mandatoryInputsDigest,
+          clientEnv);
     }
   }
 
@@ -1003,30 +1113,11 @@ public final class ActionExecutionFunction implements SkyFunction {
       throws ActionExecutionException, InterruptedException, UndoneInputsException {
     Predicate<Artifact> isMandatoryInput = makeMandatoryInputPredicate(action);
 
+    Supplier<Iterable<Artifact>> allDeps =
+        () -> Iterables.concat(allInputs.toList(), action.getSchedulingDependencies().toList());
     ActionExecutionFunctionExceptionHandler actionExecutionFunctionExceptionHandler =
-        new ActionExecutionFunctionExceptionHandler(
-            Suppliers.memoize(
-                () -> {
-                  ImmutableSet<Artifact> allInputsSet =
-                      ImmutableSet.<Artifact>builder()
-                          .addAll(allInputs.toList())
-                          .addAll(action.getSchedulingDependencies().toList())
-                          .build();
-                  SetMultimap<SkyKey, Artifact> skyKeyToArtifactSet =
-                      MultimapBuilder.hashKeys().hashSetValues().build();
-                  allInputsSet.forEach(
-                      input -> {
-                        SkyKey key = Artifact.key(input);
-                        if (key != input) {
-                          skyKeyToArtifactSet.put(key, input);
-                        }
-                      });
-                  return skyKeyToArtifactSet;
-                }),
-            inputDepsResult,
-            action,
-            isMandatoryInput,
-            inputDepKeys);
+        createActionExecutionFunctionExceptionHandler(
+            action, inputDepsResult, inputDepKeys, allDeps, isMandatoryInput);
     boolean hasMissingInputs =
         actionExecutionFunctionExceptionHandler.accumulateAndMaybeThrowExceptions();
 
@@ -1106,6 +1197,31 @@ public final class ActionExecutionFunction implements SkyFunction {
     actionExecutionFunctionExceptionHandler.maybeThrowException();
 
     return new CheckInputResults(inputArtifactData);
+  }
+
+  private ActionExecutionFunctionExceptionHandler createActionExecutionFunctionExceptionHandler(
+      Action action,
+      SkyframeLookupResult inputDepsResult,
+      ImmutableSet<SkyKey> inputDepKeys,
+      Supplier<Iterable<Artifact>> allDeps,
+      Predicate<Artifact> isMandatoryInput) {
+    return new ActionExecutionFunctionExceptionHandler(
+        Suppliers.memoize(
+            () -> {
+              SetMultimap<SkyKey, Artifact> skyKeyToArtifactSet =
+                  MultimapBuilder.hashKeys().hashSetValues().build();
+              for (Artifact input : allDeps.get()) {
+                SkyKey key = Artifact.key(input);
+                if (key != input) {
+                  skyKeyToArtifactSet.put(key, input);
+                }
+              }
+              return skyKeyToArtifactSet;
+            }),
+        inputDepsResult,
+        action,
+        isMandatoryInput,
+        inputDepKeys);
   }
 
   @CanIgnoreReturnValue

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -80,6 +80,7 @@ import com.google.devtools.build.lib.actions.SpawnActionExecutionException;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.StoppedScanningActionEvent;
 import com.google.devtools.build.lib.actions.ThreadStateReceiver;
+import com.google.devtools.build.lib.actions.cache.ActionCache;
 import com.google.devtools.build.lib.actions.cache.OutputMetadataStore;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.bugreport.BugReport;
@@ -739,6 +740,7 @@ public final class SkyframeActionExecutor {
       ArtifactPathResolver artifactPathResolver,
       long actionStartTime,
       List<Artifact> resolvedCacheArtifacts,
+      @Nullable byte[] mandatoryInputsDigest,
       Map<String, String> clientEnv)
       throws ActionExecutionException, InterruptedException {
     Token token;
@@ -765,6 +767,7 @@ public final class SkyframeActionExecutor {
           actionCacheChecker.getTokenIfNeedToExecute(
               action,
               resolvedCacheArtifacts,
+              mandatoryInputsDigest,
               clientEnv,
               getOutputPermissions(),
               handler,
@@ -807,6 +810,7 @@ public final class SkyframeActionExecutor {
                 actionCacheChecker.getTokenUnconditionallyAfterFailureToRecordActionCacheHit(
                     action,
                     resolvedCacheArtifacts,
+                    mandatoryInputsDigest,
                     clientEnv,
                     getOutputPermissions(),
                     handler,
@@ -845,6 +849,7 @@ public final class SkyframeActionExecutor {
       InputMetadataProvider inputMetadataProvider,
       OutputMetadataStore outputMetadataStore,
       Token token,
+      @Nullable byte[] mandatoryInputsDigest,
       Map<String, String> clientEnv)
       throws ActionExecutionException, InterruptedException {
     if (!actionCacheChecker.enabled()) {
@@ -855,6 +860,7 @@ public final class SkyframeActionExecutor {
       actionCacheChecker.updateActionCache(
           action,
           token,
+          mandatoryInputsDigest,
           inputMetadataProvider,
           outputMetadataStore,
           clientEnv,
@@ -870,6 +876,11 @@ public final class SkyframeActionExecutor {
               + ", but all outputs should already have been checked",
           e);
     }
+  }
+
+  @Nullable
+  ActionCache.Entry getActionCacheEntry(Action action) {
+    return actionCacheChecker.getUsableCacheEntry(action);
   }
 
   @Nullable

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.actions.FileArtifactValue.ProxyFileArtifact
 import com.google.devtools.build.lib.actions.cache.ActionCache;
 import com.google.devtools.build.lib.actions.cache.ActionCache.Entry.SerializableTreeArtifactValue;
 import com.google.devtools.build.lib.actions.cache.CompactPersistentActionCache;
+import com.google.devtools.build.lib.actions.cache.MetadataDigestUtils;
 import com.google.devtools.build.lib.actions.cache.OutputMetadataStore;
 import com.google.devtools.build.lib.actions.cache.Protos.ActionCacheStatistics;
 import com.google.devtools.build.lib.actions.cache.Protos.ActionCacheStatistics.MissDetail;
@@ -221,6 +222,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             clientEnv,
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -290,6 +292,7 @@ public final class ActionCacheCheckerTest {
       cacheChecker.updateActionCache(
           action,
           token,
+          /* mandatoryInputsDigest= */ null,
           inputMetadataProvider,
           outputMetadataStore,
           clientEnv,
@@ -489,6 +492,7 @@ public final class ActionCacheCheckerTest {
             cacheChecker.getTokenIfNeedToExecute(
                 action,
                 /* resolvedCacheArtifacts= */ null,
+                /* mandatoryInputsDigest= */ null,
                 /* clientEnv= */ ImmutableMap.of(),
                 OutputPermissions.READONLY,
                 /* handler= */ null,
@@ -506,6 +510,35 @@ public final class ActionCacheCheckerTest {
     FileSystemUtils.writeContentAsLatin1(artifact.getPath(), content);
     return new ProxyFileArtifactValue(
         FileArtifactValue.createForTesting(artifact), artifact.getPath());
+  }
+
+  @Test
+  public void mandatoryInputsDigest_seedingEqualsHashingAllInputsAtOnce() {
+    // The action cache avoids re-hashing an input-discovering action's mandatory inputs by storing
+    // their digest and using it as the seed of the full input/output digest, folding in only the
+    // discovered inputs and outputs. Because the underlying combination is commutative and
+    // associative, this must be byte-identical to hashing all inputs and outputs in a single pass.
+    Map<String, FileArtifactValue> mandatory =
+        ImmutableMap.of(
+            "bin/source.cc", createRemoteMetadata("source"),
+            "bin/module.modmap", createRemoteMetadata("modmap"));
+    Map<String, FileArtifactValue> discoveredAndOutputs =
+        ImmutableMap.of(
+            "bin/discovered.pcm", createRemoteMetadata("discovered"),
+            "bin/out.o", createRemoteMetadata("output"));
+    Map<String, FileArtifactValue> all =
+        ImmutableMap.<String, FileArtifactValue>builder()
+            .putAll(mandatory)
+            .putAll(discoveredAndOutputs)
+            .buildOrThrow();
+
+    byte[] mandatoryInputsDigest = MetadataDigestUtils.fromMetadata(mandatory);
+    byte[] proxySeeded =
+        MetadataDigestUtils.fromMetadata(discoveredAndOutputs, mandatoryInputsDigest);
+
+    assertThat(proxySeeded).isEqualTo(MetadataDigestUtils.fromMetadata(all));
+    // Seeding must not mutate the (retained) mandatory inputs digest.
+    assertThat(mandatoryInputsDigest).isEqualTo(MetadataDigestUtils.fromMetadata(mandatory));
   }
 
   private FileArtifactValue createRemoteMetadata(String content) {
@@ -642,6 +675,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -676,6 +710,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -705,6 +740,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -766,6 +802,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -962,6 +999,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1067,6 +1105,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1127,6 +1166,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1200,6 +1240,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1265,6 +1306,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1309,6 +1351,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1361,6 +1404,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,
@@ -1405,6 +1449,7 @@ public final class ActionCacheCheckerTest {
         cacheChecker.getTokenIfNeedToExecute(
             action,
             /* resolvedCacheArtifacts= */ null,
+            /* mandatoryInputsDigest= */ null,
             /* clientEnv= */ ImmutableMap.of(),
             OutputPermissions.READONLY,
             /* handler= */ null,

--- a/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.events.NullEventHandler;
 import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
 import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.testutil.Scratch;
+import com.google.devtools.build.lib.vfs.DigestUtils;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.OutputPermissions;
 import com.google.devtools.build.lib.vfs.Path;
@@ -231,7 +232,7 @@ public class CompactPersistentActionCacheTest {
 
     // Remove entries that discover inputs and flush the journal.
     cache.removeIf(Entry::discoversInputs);
-    assertFullSave();
+    assertIncrementalSave(cache);
 
     // Check that the entries that discover inputs are gone, and the rest are still there.
     for (int i = 0; i < 100; i++) {
@@ -767,6 +768,8 @@ public class CompactPersistentActionCacheTest {
     return new ActionCache.Entry.Builder(
         actionKey,
         discoversInputs,
+        // Must be non-null iff the action discovers inputs.
+        discoversInputs ? new byte[DigestUtils.ESTIMATED_SIZE] : null,
         /* clientEnv= */ ImmutableMap.of(),
         /* actionExecutionSalt= */ "",
         OutputPermissions.READONLY,

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1661,6 +1661,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/skyframe:action_output_metadata_store",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",
+        "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/skyframe",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactMetadataTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactMetadataTest.java
@@ -41,6 +41,7 @@ import com.google.devtools.build.lib.actions.util.TestAction.DummyAction;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.events.NullEventHandler;
+import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileStatusWithDigestAdapter;
 import com.google.devtools.build.lib.vfs.Path;
@@ -111,10 +112,9 @@ public final class TreeArtifactMetadataTest extends ArtifactFunctionTestCase {
   public void testEmptyTreeArtifacts() throws Exception {
     TreeArtifactValue value = doTestTreeArtifacts(ImmutableList.of());
     // Additional test, only for this test method: we expect the FileArtifactValue is equal to
-    // the digest [0]
+    // the hash of the empty byte array.
     assertThat(value.getMetadata().getDigest()).isEqualTo(value.getDigest());
-    // Java zero-fills arrays.
-    assertThat(value.getDigest()).isEqualTo(new byte[1]);
+    assertThat(value.getDigest()).isEqualTo(new Fingerprint().digestAndReset());
   }
 
   @Test

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -2292,6 +2292,110 @@ EOF
   expect_log "17 disk cache hit"
 }
 
+function test_cpp20_modules_change_ab_to_ba_no_cycle() {
+  type -P clang || return 0
+  # Check if clang version is less than 17
+  local -r clang_version=$(clang --version | head -n1 | grep -oE '[0-9]+\.[0-9]+' | head -n1)
+  if [[ -n "$clang_version" ]]; then
+    local -r major_version=$(echo "$clang_version" | cut -d. -f1)
+    if [[ "$major_version" -lt 17 ]]; then
+      return 0
+    fi
+  fi
+
+  if is_darwin; then
+    return 0
+  fi
+
+  add_rules_cc "MODULE.bazel"
+
+  cat > BUILD.bazel <<'EOF'
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
+
+package(features = ["cpp_modules"])
+
+cc_library(
+  name = "lib",
+  module_interfaces = ["a.cppm", "b.cppm"],
+)
+EOF
+  cat > a.cppm <<'EOF'
+export module a;
+import b;
+EOF
+  cat > b.cppm <<'EOF'
+export module b;
+EOF
+
+  bazel build //:lib --experimental_cpp_modules --repo_env=CC=clang --copt=-std=c++20 &> $TEST_log || fail "Expected build C++20 Modules success with compiler 'clang'"
+
+  cat > a.cppm <<'EOF'
+export module a;
+EOF
+  cat > bar.cppm <<'EOF'
+export module b;
+import a;
+EOF
+
+  bazel build //:lib --experimental_cpp_modules --repo_env=CC=clang --copt=-std=c++20 &> $TEST_log || fail "Expected build C++20 Modules success with compiler 'clang'"
+}
+
+function test_cpp20_modules_change_abc_to_acb_no_cycle() {
+  type -P clang || return 0
+  # Check if clang version is less than 17
+  local -r clang_version=$(clang --version | head -n1 | grep -oE '[0-9]+\.[0-9]+' | head -n1)
+  if [[ -n "$clang_version" ]]; then
+    local -r major_version=$(echo "$clang_version" | cut -d. -f1)
+    if [[ "$major_version" -lt 17 ]]; then
+      return 0
+    fi
+  fi
+
+  if is_darwin; then
+    return 0
+  fi
+
+  add_rules_cc "MODULE.bazel"
+
+  cat > BUILD.bazel <<'EOF'
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
+
+package(features = ["cpp_modules"])
+
+cc_library(
+  name = "lib",
+  module_interfaces = ["a.cppm", "b.cppm", "c.cppm"],
+)
+EOF
+  cat > a.cppm <<'EOF'
+export module a;
+import b;
+EOF
+  cat > b.cppm <<'EOF'
+export module b;
+import c;
+EOF
+  cat > c.cppm <<'EOF'
+export module c;
+EOF
+
+  bazel build //:lib --experimental_cpp_modules --repo_env=CC=clang --copt=-std=c++20 &> $TEST_log || fail "Expected build C++20 Modules success with compiler 'clang'"
+
+  cat > a.cppm <<'EOF'
+export module a;
+import c;
+EOF
+  cat > b.cppm <<'EOF'
+export module b;
+EOF
+  cat > c.cppm <<'EOF'
+export module c;
+import b;
+EOF
+
+  bazel build //:lib --experimental_cpp_modules --repo_env=CC=clang --copt=-std=c++20 &> $TEST_log || fail "Expected build C++20 Modules success with compiler 'clang'"
+}
+
 function test_external_repo_lto() {
   add_rules_cc "MODULE.bazel"
   REPO_PATH=$TEST_TMPDIR/repo


### PR DESCRIPTION
### Description

This is fixed by not requesting the previously discovered inputs (either retained in memory or in the action cache) if the mandatory inputs changed. In the case of C++20 modules, this is sufficient since the modmap file, which lists all transitive `.pcm` files required for compilation, is a mandatory input.

To that end, `ActionExecutionFunction` collects the inputs of an input-discovering action whose action cache entry may still be valid in two steps: it first requests and checks only the mandatory inputs, compares their digest with the one stored in the entry and only then requests the previously discovered inputs, which are added to the same input metadata map. The action cache entry stores the digest of the mandatory inputs and uses it as the seed of its input/output digest. Since the per-input digests are combined with the commutative and associative `DigestUtils.combineUnordered`, seeding is byte-identical to hashing all inputs at once, but the mandatory inputs are hashed only once per cache check (#27492 hashed them twice and was rolled back for its performance impact). The action cache entry is also decoded only once per action.

As part of this change, `MetadataDigestUtils.fromMetadata` had to be modified to always return a byte array of proper digest length, even if called with an empty map, to match the assumptions of the action cache.

### Motivation

Relands #27492

When multiple `module_interfaces` are specified on a single `cc_library`, the individual compilation actions form a DAG based on `import`s between these modules. Consider the following situation:

* `a.cppm` imports `b.cppm`, both of which are in the `module_interfaces` of a single `cc_library`.
* Building the target populates the action cache with an entry for `a.pcm` that stores `b.pcm` as a discovered input.
* Now edit `a.cppm` and `b.cppm` so that `b.cppm` imports `a.cppm` and `a.cppm` no longer imports `b.cppm`.
* Build again (optionally after a shutdown).

Before this commit, this resulted in an action cycle since during action cache checking, Bazel would reuse or look up the inputs discovered in the previous build, thus introducing an edge from `a.pcm` to `b.pcm`. Together with the newly discovered edge from `b.pcm` to `a.pcm`, this resulted in a cycle.

### Build API Changes

No

### Release Notes

RELNOTES: `cc_library`'s `module_interfaces` parameter now accepts multiple files.
