### PR TITLE
Fix unexpectedly hidden Starlark methods

### DIFF
--- a/src/main/java/net/starlark/java/eval/CallUtils.java
+++ b/src/main/java/net/starlark/java/eval/CallUtils.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.StarlarkAnnotations;
@@ -306,19 +307,19 @@ public final class CallUtils {
 
   private static ClassDescriptor buildClassDescriptor(BuiltinManager manager, Class<?> clazz) {
     MethodDescriptor selfCall = null;
-    ImmutableMap.Builder<String, MethodDescriptor> methodsBuilder = ImmutableMap.builder();
+    LinkedHashMap<String, MethodDescriptor> methods = new LinkedHashMap<>();
 
     TypeConstructor typeConstructor = getAssociatedTypeConstructor(clazz);
 
-    // Sort methods by Java name, for determinism.
+    // Sort non-synthetic methods ahead of synthetic ones, then by Java name for determinism. A
+    // public method inherited from a non-public superclass is exposed by Class.getMethods() only as
+    // a synthetic bridge, so synthetic methods must not be skipped outright; processing
+    // non-synthetic methods first lets a real method (with its non-erased signature) win over its
+    // bridge, while a bridge still provides any name no non-synthetic method does.
     Method[] classMethods = clazz.getMethods();
-    Arrays.sort(classMethods, Comparator.comparing(Method::getName));
+    Arrays.sort(
+        classMethods, Comparator.comparing(Method::isSynthetic).thenComparing(Method::getName));
     for (Method method : classMethods) {
-      // Synthetic methods lead to false multiple matches
-      if (method.isSynthetic()) {
-        continue;
-      }
-
       // annotated?
       StarlarkMethod callable = StarlarkAnnotations.getStarlarkMethod(method);
       if (callable == null) {
@@ -337,23 +338,25 @@ public final class CallUtils {
 
       // self-call method?
       if (callable.selfCall()) {
-        if (selfCall != null) {
+        if (selfCall == null) {
+          selfCall = descriptor;
+        } else if (!method.isSynthetic()) {
+          // Two distinct selfCall methods. (A synthetic bridge of the same method -- e.g. from a
+          // covariant return override -- is not a conflict and is simply ignored.)
           throw new IllegalArgumentException(
               String.format("Class %s has two selfCall methods defined", clazz.getName()));
         }
-        selfCall = descriptor;
         continue;
       }
 
       // regular method
-      methodsBuilder.put(callable.name(), descriptor);
+      methods.putIfAbsent(callable.name(), descriptor);
     }
-    ImmutableMap<String, MethodDescriptor> methods = methodsBuilder.buildOrThrow();
 
     ClassDescriptor classDescriptor = new ClassDescriptor();
     classDescriptor.manager = manager;
     classDescriptor.selfCall = selfCall;
-    classDescriptor.methods = methods;
+    classDescriptor.methods = ImmutableMap.copyOf(methods);
     classDescriptor.typeConstructor = typeConstructor;
     if (wantClassStarlarkType(clazz)) {
       classDescriptor.classStarlarkTypeSupertypes =

--- a/src/test/java/net/starlark/java/eval/StarlarkEvaluationTest.java
+++ b/src/test/java/net/starlark/java/eval/StarlarkEvaluationTest.java
@@ -500,6 +500,28 @@ public final class StarlarkEvaluationTest {
         .testLookup("result", "bar");
   }
 
+  // A @StarlarkMethod implementation declared in a non-public class and inherited (not overridden)
+  // by a public subclass.
+  abstract static class NonPublicMethodBase implements StarlarkValue {
+    @StarlarkMethod(name = "inherited_method", documented = false)
+    public String inheritedMethod() {
+      return "inherited";
+    }
+  }
+
+  public static final class InheritsNonPublicMethod extends NonPublicMethodBase {}
+
+  // Verifies that a @StarlarkMethod inherited (not overridden) from a non-public superclass remains
+  // callable. Class.getMethods() surfaces such a method on the public subclass only as a synthetic
+  // bridge; CallUtils must register the method from that bridge rather than dropping it.
+  @Test
+  public void testMethodInheritedFromNonPublicSuperclass() throws Exception {
+    ev.new Scenario()
+        .update("mock", new InheritsNonPublicMethod())
+        .setUp("result = mock.inherited_method()")
+        .testLookup("result", "inherited");
+  }
+
   @Test
   public void testSimpleIf() throws Exception {
     ev.new Scenario()


### PR DESCRIPTION

### Description
The Starlark method lookup silently ignored overrides of public, annotated methods in non-public parent classes of public classes, which caused unintentional losses of Starlark API while modifying the class hierarchy as the reflection-based logic filtered out the synthetic bridge method created by `javac` for such cases.

This is fixed by allowing synthetic methods in `CallUtils`.

### Motivation
Regressed in ae4d2d610e for `ImmutableKeyTrackingDict` and 9d2a4edb25 for `LazyImmutableStarlarkList`.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None