### PR TITLE
Remove --incompatible_do_not_split_linking_cmdline

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -458,18 +458,6 @@ public abstract class BuildLanguageOptions extends OptionsBase {
   public abstract boolean getInternalStarlarkFlagTestCanary();
 
   @Option(
-      name = "incompatible_do_not_split_linking_cmdline",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "When true, Bazel no longer modifies command line flags used for linking, and also "
-              + "doesn't selectively decide which flags go to the param file and which don't.  "
-              + "See https://github.com/bazelbuild/bazel/issues/7670 for details.")
-  public abstract boolean getIncompatibleDoNotSplitLinkingCmdline();
-
-  @Option(
       name = "incompatible_unambiguous_label_stringification",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
@@ -892,9 +880,6 @@ public abstract class BuildLanguageOptions extends OptionsBase {
                 INCOMPATIBLE_REQUIRE_MNEMONIC_FOR_RUN_ACTIONS,
                 getIncompatibleRequireMnemonicForRunActions())
             .setBool(StarlarkSemantics.PRINT_TEST_MARKER, getInternalStarlarkFlagTestCanary())
-            .setBool(
-                INCOMPATIBLE_DO_NOT_SPLIT_LINKING_CMDLINE,
-                getIncompatibleDoNotSplitLinkingCmdline())
             .set(INCOMPATIBLE_ENFORCE_STARLARK_UTF8, getIncompatibleEnforceStarlarkUtf8())
             .setBool(
                 INCOMPATIBLE_UNAMBIGUOUS_LABEL_STRINGIFICATION,
@@ -1074,8 +1059,6 @@ public abstract class BuildLanguageOptions extends OptionsBase {
       FlagConstants.INCOMPATIBLE_PACKAGE_GROUP_HAS_PUBLIC_SYNTAX;
   public static final String INCOMPATIBLE_FIX_PACKAGE_GROUP_REPOROOT_SYNTAX =
       FlagConstants.INCOMPATIBLE_FIX_PACKAGE_GROUP_REPOROOT_SYNTAX;
-  public static final String INCOMPATIBLE_DO_NOT_SPLIT_LINKING_CMDLINE =
-      "+incompatible_do_not_split_linking_cmdline";
   public static final String INCOMPATIBLE_JAVA_INFO_MERGE_RUNTIME_MODULE_FLAGS =
       "-incompatible_java_info_merge_runtime_module_flags";
   public static final String INCOMPATIBLE_NO_ATTR_LICENSE = "+incompatible_no_attr_license";

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -142,7 +142,6 @@ public class ConsistencyTest {
         "--force_starlark_stack_trace=" + rand.nextBoolean(),
         "--incompatible_always_check_depset_elements=" + rand.nextBoolean(),
         "--incompatible_disallow_empty_glob=" + rand.nextBoolean(),
-        "--incompatible_do_not_split_linking_cmdline=" + rand.nextBoolean(),
         "--incompatible_enable_deprecated_label_apis=" + rand.nextBoolean(),
         "--incompatible_enforce_starlark_utf8="
             + BuildLanguageOptions.Utf8EnforcementMode.values()[
@@ -188,7 +187,6 @@ public class ConsistencyTest {
         .setBool(StarlarkSemantics.FORCE_STARLARK_STACK_TRACE, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_ALWAYS_CHECK_DEPSET_ELEMENTS, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_DISALLOW_EMPTY_GLOB, rand.nextBoolean())
-        .setBool(BuildLanguageOptions.INCOMPATIBLE_DO_NOT_SPLIT_LINKING_CMDLINE, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_ENABLE_DEPRECATED_LABEL_APIS, rand.nextBoolean())
         .set(
             BuildLanguageOptions.INCOMPATIBLE_ENFORCE_STARLARK_UTF8,


### PR DESCRIPTION
`--incompatible_do_not_split_linking_cmdline` was introduced disabled in March 2019 by [3010e57805](https://github.com/bazelbuild/bazel/commit/3010e578055a8cbe080bbe54e3137aca4cd8579d) to migrate C++ linking away from GCC-specific command-line splitting; [#7670](https://github.com/bazelbuild/bazel/issues/7670) and [#7687](https://github.com/bazelbuild/bazel/issues/7687) tracked the migration. It was enabled by default in May 2019 by [28c8a8c91f](https://github.com/bazelbuild/bazel/commit/28c8a8c91f704e15e28f931347a789d5a1e8fdef). The conditional implementation and legacy behavior were removed in February 2021 by [4d75da6323](https://github.com/bazelbuild/bazel/commit/4d75da6323758390a7b8e6c3725081da4e9ba668), leaving the option with no consumer beyond Starlark semantics bookkeeping.

This removes the option, semantics key, and consistency-test rows.

Validation: `bazel test --jobs=4 --disk_cache=/private/tmp/bazel-pr-disk-cache //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest`.