### PR TITLE
Remove --experimental_enable_android_migration_apis

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -174,14 +174,6 @@ public abstract class BuildLanguageOptions extends OptionsBase {
   public abstract List<String> getExperimentalCcStarlarkApiEnabledPackages();
 
   @Option(
-      name = "experimental_enable_android_migration_apis",
-      defaultValue = "false",
-      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
-      effectTags = OptionEffectTag.BUILD_FILE_SEMANTICS,
-      help = "If set to true, enables the APIs required to support the Android Starlark migration.")
-  public abstract boolean getExperimentalEnableAndroidMigrationApis();
-
-  @Option(
       name = "experimental_enable_first_class_macros",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
@@ -853,9 +845,6 @@ public abstract class BuildLanguageOptions extends OptionsBase {
             .setBool(ALLOW_EXPERIMENTAL_LOADS, getAllowExperimentalLoads())
             .setBool(CHECK_BZL_VISIBILITY, getCheckBzlVisibility())
             .setBool(
-                EXPERIMENTAL_ENABLE_ANDROID_MIGRATION_APIS,
-                getExperimentalEnableAndroidMigrationApis())
-            .setBool(
                 EXPERIMENTAL_SINGLE_PACKAGE_TOOLCHAIN_BINDING,
                 getExperimentalSinglePackageToolchainBinding())
             .setBool(
@@ -1049,8 +1038,6 @@ public abstract class BuildLanguageOptions extends OptionsBase {
   public static final String EXPERIMENTAL_CC_SHARED_LIBRARY = "-experimental_cc_shared_library";
   public static final String EXPERIMENTAL_DISABLE_EXTERNAL_PACKAGE =
       "-experimental_disable_external_package";
-  public static final String EXPERIMENTAL_ENABLE_ANDROID_MIGRATION_APIS =
-      "-experimental_enable_android_migration_apis";
   public static final String EXPERIMENTAL_SINGLE_PACKAGE_TOOLCHAIN_BINDING =
       "-experimental_single_package_toolchain_binding";
   public static final String EXPERIMENTAL_ENABLE_FIRST_CLASS_MACROS =

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -129,7 +129,6 @@ public class ConsistencyTest {
         "--experimental_builtins_bzl_path=" + rand.nextDouble(),
         "--experimental_builtins_dummy=" + rand.nextBoolean(),
         "--experimental_bzl_visibility=" + rand.nextBoolean(),
-        "--experimental_enable_android_migration_apis=" + rand.nextBoolean(),
         "--experimental_single_package_toolchain_binding=" + rand.nextBoolean(),
         "--experimental_isolated_extension_usages=" + rand.nextBoolean(),
         "--incompatible_no_implicit_watch_label=" + rand.nextBoolean(),
@@ -173,8 +172,6 @@ public class ConsistencyTest {
         .set(BuildLanguageOptions.EXPERIMENTAL_BUILTINS_BZL_PATH, String.valueOf(rand.nextDouble()))
         .setBool(BuildLanguageOptions.EXPERIMENTAL_BUILTINS_DUMMY, rand.nextBoolean())
         .setBool(BuildLanguageOptions.EXPERIMENTAL_BZL_VISIBILITY, rand.nextBoolean())
-        .setBool(
-            BuildLanguageOptions.EXPERIMENTAL_ENABLE_ANDROID_MIGRATION_APIS, rand.nextBoolean())
         .setBool(
             BuildLanguageOptions.EXPERIMENTAL_SINGLE_PACKAGE_TOOLCHAIN_BINDING, rand.nextBoolean())
         .setBool(BuildLanguageOptions.EXPERIMENTAL_ISOLATED_EXTENSION_USAGES, rand.nextBoolean())


### PR DESCRIPTION
`--experimental_enable_android_migration_apis` was introduced disabled in October 2018 by [c2cd9574bd](https://github.com/bazelbuild/bazel/commit/c2cd9574bd21c476043234b317b1730c5600bad0) to guard APIs used by the Android Starlark migration. [#19770](https://github.com/bazelbuild/bazel/pull/19770) proposed enabling it by default but closed unmerged, so the flag never persistently flipped. The final guarded API was removed in January 2025 by [71490c375b](https://github.com/bazelbuild/bazel/commit/71490c375b1cef726a5c06b69dae3b975bb77514) after its `rules_android` consumer migrated.

This removes the option, semantics key, and consistency-test rows.

Validation: `bazel test --jobs=4 --disk_cache=/private/tmp/bazel-pr-disk-cache //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest`.