### PR TITLE
Remove --experimental_disable_external_package

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/LabelConstants.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/LabelConstants.java
@@ -27,16 +27,10 @@ public class LabelConstants {
   public static final PathFragment MODULE_EXTENSION_WORKING_DIRECTORY_LOCATION =
       PathFragment.create("modextwd");
 
-  /**
-   * The name of the package that contains the targets representing external repositories. Only
-   * works if {@code --experimental_disable_external_package} is not in effect.
-   */
+  /** The reserved package name used for legacy external-repository labels and path handling. */
   public static final PathFragment EXTERNAL_PACKAGE_NAME = PathFragment.create("external");
 
-  /**
-   * The identifier of the package that contains the targets representing external repositories.
-   * Only works if {@code --experimental_disable_external_package} is not in effect.
-   */
+  /** The package identifier corresponding to {@link #EXTERNAL_PACKAGE_NAME}. */
   public static final PackageIdentifier EXTERNAL_PACKAGE_IDENTIFIER =
       PackageIdentifier.createInMainRepo(EXTERNAL_PACKAGE_NAME);
 

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -284,20 +284,6 @@ public abstract class BuildLanguageOptions extends OptionsBase {
   public abstract boolean getExperimentalRepoRemoteExec();
 
   @Option(
-      name = "experimental_disable_external_package",
-      defaultValue = "false",
-      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS, OptionEffectTag.LOSES_INCREMENTAL_STATE},
-      metadataTags = {
-        OptionMetadataTag.EXPERIMENTAL,
-      },
-      help =
-          "If set to true, the auto-generated //external package will not be available anymore. "
-              + "Bazel will still be unable to parse the file 'external/BUILD', but globs reaching "
-              + "into external/ from the unnamed package will work.")
-  public abstract boolean getExperimentalDisableExternalPackage();
-
-  @Option(
       name = "experimental_sibling_repository_layout",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
@@ -868,7 +854,6 @@ public abstract class BuildLanguageOptions extends OptionsBase {
             .setBool(EXPERIMENTAL_PLATFORMS_API, getExperimentalPlatformsApi())
             .setBool(EXPERIMENTAL_CC_SHARED_LIBRARY, getExperimentalCcSharedLibrary())
             .setBool(EXPERIMENTAL_REPO_REMOTE_EXEC, getExperimentalRepoRemoteExec())
-            .setBool(EXPERIMENTAL_DISABLE_EXTERNAL_PACKAGE, getExperimentalDisableExternalPackage())
             .setBool(
                 EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT, getExperimentalSiblingRepositoryLayout())
             .setBool(
@@ -1047,8 +1032,6 @@ public abstract class BuildLanguageOptions extends OptionsBase {
   public static final String ALLOW_EXPERIMENTAL_LOADS = "-allow_experimental_loads";
   public static final String CHECK_BZL_VISIBILITY = "+check_bzl_visibility";
   public static final String EXPERIMENTAL_CC_SHARED_LIBRARY = "-experimental_cc_shared_library";
-  public static final String EXPERIMENTAL_DISABLE_EXTERNAL_PACKAGE =
-      "-experimental_disable_external_package";
   public static final String EXPERIMENTAL_ENABLE_ANDROID_MIGRATION_APIS =
       "-experimental_enable_android_migration_apis";
   public static final String EXPERIMENTAL_SINGLE_PACKAGE_TOOLCHAIN_BINDING =

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -124,7 +124,6 @@ public class ConsistencyTest {
   private static BuildLanguageOptions buildRandomOptions(Random rand) throws Exception {
     return parseOptions(
         // <== Add new options here in alphabetic order ==>
-        "--experimental_disable_external_package=" + rand.nextBoolean(),
         "--experimental_sibling_repository_layout=" + rand.nextBoolean(),
         "--experimental_builtins_bzl_path=" + rand.nextDouble(),
         "--experimental_builtins_dummy=" + rand.nextBoolean(),
@@ -168,7 +167,6 @@ public class ConsistencyTest {
   private static StarlarkSemantics buildRandomSemantics(Random rand) {
     return StarlarkSemantics.builder()
         // <== Add new options here in alphabetic order ==>
-        .setBool(BuildLanguageOptions.EXPERIMENTAL_DISABLE_EXTERNAL_PACKAGE, rand.nextBoolean())
         .setBool(BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT, rand.nextBoolean())
         .set(BuildLanguageOptions.EXPERIMENTAL_BUILTINS_BZL_PATH, String.valueOf(rand.nextDouble()))
         .setBool(BuildLanguageOptions.EXPERIMENTAL_BUILTINS_DUMMY, rand.nextBoolean())

--- a/src/test/shell/bazel/execroot_test.sh
+++ b/src/test/shell/bazel/execroot_test.sh
@@ -156,7 +156,6 @@ genrule(name="g", srcs=[":f"], outs=["go"], cmd="cat $(locations :f) > $@")
 EOF
 
   bazel build //:g \
-    --experimental_disable_external_package \
     --experimental_sibling_repository_layout \
     || fail "build failed"
   assert_contains file_ab bazel-bin/go
@@ -179,7 +178,6 @@ int main(void) {
 EOF
 
   bazel build //external/a:a \
-    --experimental_disable_external_package \
     --experimental_sibling_repository_layout \
     || fail "build failed"
 }
@@ -202,7 +200,6 @@ public class A {
 EOF
 
   bazel build //external/java/a:a \
-    --experimental_disable_external_package \
     --experimental_sibling_repository_layout \
     || fail "build failed"
 }


### PR DESCRIPTION
`--experimental_disable_external_package` was introduced disabled in February 2020 by [015f586fcb](https://github.com/bazelbuild/bazel/commit/015f586fcb2e127ed13691b573de42cd9dba8508) as an opt-in way to disable the generated `//external` package. The option was never flipped. In May 2025, [668ec117af](https://github.com/bazelbuild/bazel/commit/668ec117af6bc293389cab611353bc4105c6518a) removed `WorkspaceFileFunction` and `ExternalPackageFunction` and made `//external` package lookup unconditionally return no BUILD file, leaving the flag without a runtime consumer.

This removes the option and semantics bookkeeping, removes redundant `execroot_test` arguments, and updates `LabelConstants` comments.

Validation: `//src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest` passes, `bash -n src/test/shell/bazel/execroot_test.sh` passes, and the removed flag has no remaining references under `src`. The affected `execroot_test` cases could not complete because their nested Bazel invocations failed to access `https://bcr.bazel.build/` with `No route to host` before reaching the tested builds.