### PR TITLE
Move --incompatible_make_thinlto_command_lines_standalone to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -615,6 +615,16 @@ public final class BazelRulesModule extends BlazeModule {
 
     @Deprecated
     @Option(
+        name = "incompatible_make_thinlto_command_lines_standalone",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getUseStandaloneLtoIndexingCommandLines();
+
+    @Deprecated
+    @Option(
         name = "incompatible_load_python_rules_from_bzl",
         defaultValue = "false",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -807,16 +807,6 @@ public abstract class CppOptions extends FragmentOptions {
 
   @Deprecated
   @Option(
-      name = "incompatible_make_thinlto_command_lines_standalone",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
-      effectTags = {OptionEffectTag.NO_OP},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
-      help = "This flag is a noop and scheduled for removal.")
-  public abstract boolean getUseStandaloneLtoIndexingCommandLines();
-
-  @Deprecated
-  @Option(
       name = "incompatible_require_ctx_in_configure_features",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.TOOLCHAIN,

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -267,7 +267,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:incompatible_remove_legacy_whole_archive",
         "//command_line_option:incompatible_dont_enable_host_nonhost_crosstool_features",
         "//command_line_option:incompatible_require_ctx_in_configure_features",
-        "//command_line_option:incompatible_make_thinlto_command_lines_standalone",
         "//command_line_option:incompatible_use_specific_tool_files",
         "//command_line_option:incompatible_disable_nocopts",
         "//command_line_option:incompatible_validate_top_level_header_inclusions",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcBinaryThinLtoObjDirTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcBinaryThinLtoObjDirTest.java
@@ -864,7 +864,6 @@ public class CcBinaryThinLtoObjDirTest extends BuildViewTestCase {
     setupThinLTOCrosstool(CppRuleClasses.SUPPORTS_PIC);
     useConfiguration(
         "--ltoindexopt=anltoindexopt",
-        "--incompatible_make_thinlto_command_lines_standalone",
         "--features=thin_lto",
         "--features=use_lto_native_object_directory");
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcBinaryThinLtoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcBinaryThinLtoTest.java
@@ -842,10 +842,7 @@ public class CcBinaryThinLtoTest extends BuildViewTestCase {
     createBuildFiles();
 
     setupThinLTOCrosstool(CppRuleClasses.SUPPORTS_PIC);
-    useConfiguration(
-        "--ltoindexopt=anltoindexopt",
-        "--incompatible_make_thinlto_command_lines_standalone",
-        "--features=thin_lto");
+    useConfiguration("--ltoindexopt=anltoindexopt", "--features=thin_lto");
 
     /*
     We follow the chain from the final product backwards.


### PR DESCRIPTION
`--incompatible_make_thinlto_command_lines_standalone` was introduced disabled in April 2019 by [cd53bd6e4a](https://github.com/bazelbuild/bazel/commit/cd53bd6e4a9b9259d3693396c497c3f695d13a3c) and enabled by default in August 2019 by [40c3ab3410](https://github.com/bazelbuild/bazel/commit/40c3ab341049c40ddda6bff8e9f433dab0fdd067). The legacy ThinLTO command-line behavior was removed in March 2024 by [6788347e42](https://github.com/bazelbuild/bazel/commit/6788347e42b62426f1f721249d37890c3bb7c10b), leaving the flag without a consumer.

This removes the flag from `CppOptions` and exec-transition propagation and removes redundant test arguments. A deprecated graveyard no-op keeps existing command lines accepted.

Validation: `bazel test --jobs=3 --disk_cache=/private/tmp/bazel-pr-disk-cache //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest //src/test/java/com/google/devtools/build/lib/rules/cpp:CcBinaryThinLtoTest //src/test/java/com/google/devtools/build/lib/rules/cpp:CcBinaryThinLtoObjDirTest`.