### PR TITLE
Move --incompatible_disable_legacy_cc_provider to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -579,6 +579,16 @@ public final class BazelRulesModule extends BlazeModule {
   /** This is where deprecated Bazel-specific options only used by the build command go to die. */
   @OptionsClass
   public abstract static class BazelBuildGraveyardOptions extends BuildGraveyardOptions {
+    @Deprecated
+    @Option(
+        name = "incompatible_disable_legacy_cc_provider",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getDisableLegacyCcProvider();
+
     @Option(
         name = "python_path",
         defaultValue = "",

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -847,15 +847,6 @@ public abstract class CppOptions extends FragmentOptions {
   public abstract boolean getRemoveLegacyWholeArchive();
 
   @Option(
-      name = "incompatible_disable_legacy_cc_provider",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help = "No-op flag. Will be removed in a future release.")
-  public abstract boolean getDisableLegacyCcProvider();
-
-  @Option(
       name = "incompatible_enable_cc_toolchain_resolution",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -262,7 +262,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:experimental_cpp_modules",
         "//command_line_option:start_end_lib",
         "//command_line_option:experimental_inmemory_dotd_files",
-        "//command_line_option:incompatible_disable_legacy_cc_provider",
         "//command_line_option:incompatible_enable_cc_toolchain_resolution",
         "//command_line_option:incompatible_remove_legacy_whole_archive",
         "//command_line_option:incompatible_dont_enable_host_nonhost_crosstool_features",


### PR DESCRIPTION
`--incompatible_disable_legacy_cc_provider` was introduced disabled in January 2019 by [a60b6ce2d0](https://github.com/bazelbuild/bazel/commit/a60b6ce2d099576e81381a5cf8e568de3aff435b) and enabled by default in March 2019 by [cca5779216](https://github.com/bazelbuild/bazel/commit/cca5779216a22cd30857da2cf1da6c7e344919dc). The legacy struct C++ provider was removed in February 2023 by [1cd86d36a2](https://github.com/bazelbuild/bazel/commit/1cd86d36a20d0a7fa3fe32cdb44ac0979ff00013), leaving the flag without a consumer.

This removes the flag from `CppOptions` and exec-transition propagation. A deprecated graveyard no-op keeps existing command lines accepted.

Validation: `bazel test --jobs=3 --disk_cache=/private/tmp/bazel-pr-disk-cache //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest`.