### PR TITLE
Move --incompatible_validate_top_level_header_inclusions to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -684,6 +684,16 @@ public final class BazelRulesModule extends BlazeModule {
 
     @Deprecated
     @Option(
+        name = "incompatible_validate_top_level_header_inclusions",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getValidateTopLevelHeaderInclusions();
+
+    @Deprecated
+    @Option(
         name = "experimental_post_profile_started_event",
         defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -825,16 +825,6 @@ public abstract class CppOptions extends FragmentOptions {
       help = "This flag is a noop and scheduled for removal.")
   public abstract boolean getRequireCtxInConfigureFeatures();
 
-  @Deprecated
-  @Option(
-      name = "incompatible_validate_top_level_header_inclusions",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.INPUT_STRICTNESS,
-      effectTags = {OptionEffectTag.NO_OP},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
-      help = "This flag is a noop and scheduled for removal.")
-  public abstract boolean getValidateTopLevelHeaderInclusions();
-
   @Option(
       name = "incompatible_remove_legacy_whole_archive",
       defaultValue = "true",

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -270,7 +270,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:incompatible_make_thinlto_command_lines_standalone",
         "//command_line_option:incompatible_use_specific_tool_files",
         "//command_line_option:incompatible_disable_nocopts",
-        "//command_line_option:incompatible_validate_top_level_header_inclusions",
         "//command_line_option:strict_system_includes",
         "//command_line_option:experimental_use_cpp_compile_action_args_params_file",
         "//command_line_option:cc_include_scanning",


### PR DESCRIPTION
`--incompatible_validate_top_level_header_inclusions` was introduced disabled in October 2019 by [566a7e6340](https://github.com/bazelbuild/bazel/commit/566a7e63401636e2f8a04ea1e07760d3d6a9f6b6) and enabled by default in March 2020 by [858a4b1a44](https://github.com/bazelbuild/bazel/commit/858a4b1a44f1058f5bbec9ea778421038ef34f10). The legacy top-level header inclusion behavior was removed in December 2023 by [351b9a079d](https://github.com/bazelbuild/bazel/commit/351b9a079d528b073d1f1405597d5bc11f6a8dbd), leaving the flag without a consumer.

This removes the flag from `CppOptions` and exec-transition propagation. A deprecated graveyard no-op keeps existing command lines accepted.

Validation: `bazel test --jobs=3 --disk_cache=/private/tmp/bazel-pr-disk-cache //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest`.