### PR TITLE
Move --incompatible_require_ctx_in_configure_features to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -664,6 +664,16 @@ public final class BazelRulesModule extends BlazeModule {
 
     @Deprecated
     @Option(
+        name = "incompatible_require_ctx_in_configure_features",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getRequireCtxInConfigureFeatures();
+
+    @Deprecated
+    @Option(
         name = "force_ignore_dash_static",
         defaultValue = "false",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -815,16 +815,6 @@ public abstract class CppOptions extends FragmentOptions {
       help = "This flag is a noop and scheduled for removal.")
   public abstract boolean getUseStandaloneLtoIndexingCommandLines();
 
-  @Deprecated
-  @Option(
-      name = "incompatible_require_ctx_in_configure_features",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
-      effectTags = {OptionEffectTag.NO_OP},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
-      help = "This flag is a noop and scheduled for removal.")
-  public abstract boolean getRequireCtxInConfigureFeatures();
-
   @Option(
       name = "incompatible_remove_legacy_whole_archive",
       defaultValue = "true",

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -264,7 +264,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:incompatible_enable_cc_toolchain_resolution",
         "//command_line_option:incompatible_remove_legacy_whole_archive",
         "//command_line_option:incompatible_dont_enable_host_nonhost_crosstool_features",
-        "//command_line_option:incompatible_require_ctx_in_configure_features",
         "//command_line_option:incompatible_make_thinlto_command_lines_standalone",
         "//command_line_option:incompatible_use_specific_tool_files",
         "//command_line_option:incompatible_disable_nocopts",


### PR DESCRIPTION
`--incompatible_require_ctx_in_configure_features` was introduced disabled in March 2019 by [9474b1ef75](https://github.com/bazelbuild/bazel/commit/9474b1ef754e800277a7db399d31447d11fd307b) and enabled by default in May 2019 by [1bfedba2fa](https://github.com/bazelbuild/bazel/commit/1bfedba2fa4acdcf5b09bb8b9810e305a40af4f9). The legacy `cc_common.configure_features` behavior was removed in December 2023 by [bc883d8d6d](https://github.com/bazelbuild/bazel/commit/bc883d8d6d18a66d64042effaf24e85ead2fb625), leaving the flag without a consumer.

This removes the flag from `CppOptions` and exec-transition propagation. A deprecated graveyard no-op keeps existing command lines accepted.

Validation: `bazel test --jobs=3 --disk_cache=/private/tmp/bazel-pr-disk-cache //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest`.