### PR TITLE
[codex] Move legacy whole-archive flags to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -589,6 +589,26 @@ public final class BazelRulesModule extends BlazeModule {
         help = "Deprecated no-op.")
     public abstract boolean getDisableLegacyCcProvider();
 
+    @Deprecated
+    @Option(
+        name = "legacy_whole_archive",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getLegacyWholeArchive();
+
+    @Deprecated
+    @Option(
+        name = "incompatible_remove_legacy_whole_archive",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getRemoveLegacyWholeArchive();
+
     @Option(
         name = "python_path",
         defaultValue = "",

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -486,7 +486,7 @@ public final class CppConfiguration extends Fragment
   @StarlarkMethod(name = "legacy_whole_archive", documented = false, useStarlarkThread = true)
   public boolean legacyWholeArchiveForStarlark(StarlarkThread thread) throws EvalException {
     CcModule.checkPrivateStarlarkificationAllowlist(thread);
-    return cppOptions.getLegacyWholeArchive();
+    return true;
   }
 
   @StarlarkMethod(
@@ -495,7 +495,7 @@ public final class CppConfiguration extends Fragment
       useStarlarkThread = true)
   public boolean removeLegacyWholeArchiveForStarlark(StarlarkThread thread) throws EvalException {
     CcModule.checkPrivateStarlarkificationAllowlist(thread);
-    return cppOptions.getRemoveLegacyWholeArchive();
+    return true;
   }
 
   public boolean getInmemoryDotdFiles() {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -361,24 +361,6 @@ public abstract class CppOptions extends FragmentOptions {
       converter = LabelConverter.class)
   public abstract Label getCustomMalloc();
 
-  // @Deprecated
-  // TODO(https://github.com/bazelbuild/bazel/pull/26854): figure out how to deprecate
-  // this without warning spam because of a globally set bazelrc.
-  @Option(
-      name = "legacy_whole_archive",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.ACTION_COMMAND_LINES, OptionEffectTag.AFFECTS_OUTPUTS},
-      metadataTags = {OptionMetadataTag.HIDDEN},
-      help =
-          "Deprecated, superseded by --incompatible_remove_legacy_whole_archive "
-              + "(see https://github.com/bazelbuild/bazel/issues/7362 for details). "
-              + "When on, use --whole-archive for cc_binary rules that have "
-              + "linkshared=True and either linkstatic=True or '-static' in linkopts. "
-              + "This is for backwards compatibility only. "
-              + "A better alternative is to use alwayslink=1 where required.")
-  public abstract boolean getLegacyWholeArchive();
-
   @Option(
       name = "strip",
       defaultValue = "sometimes",
@@ -824,17 +806,6 @@ public abstract class CppOptions extends FragmentOptions {
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
       help = "This flag is a noop and scheduled for removal.")
   public abstract boolean getRequireCtxInConfigureFeatures();
-
-  @Option(
-      name = "incompatible_remove_legacy_whole_archive",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "If true, Bazel will not link library dependencies as whole archive by default "
-              + "(see https://github.com/bazelbuild/bazel/issues/7362 for migration instructions).")
-  public abstract boolean getRemoveLegacyWholeArchive();
 
   @Option(
       name = "incompatible_enable_cc_toolchain_resolution",

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -262,7 +262,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:start_end_lib",
         "//command_line_option:experimental_inmemory_dotd_files",
         "//command_line_option:incompatible_enable_cc_toolchain_resolution",
-        "//command_line_option:incompatible_remove_legacy_whole_archive",
         "//command_line_option:incompatible_dont_enable_host_nonhost_crosstool_features",
         "//command_line_option:incompatible_require_ctx_in_configure_features",
         "//command_line_option:incompatible_make_thinlto_command_lines_standalone",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
@@ -207,7 +207,7 @@ toolchain(name = "toolchain", toolchain = ":cc_toolchain", toolchain_type = '\
   }
 
   @Test
-  public void testLegacyWholeArchiveHasNoEffectOnDynamicModeDynamicLibraries() throws Exception {
+  public void testDynamicModeDynamicLibrariesDoNotUseWholeArchive() throws Exception {
     getAnalysisMock()
         .ccSupport()
         .setupCcToolchainConfig(
@@ -224,7 +224,6 @@ toolchain(name = "toolchain", toolchain = ":cc_toolchain", toolchain_type = '\
             linkstatic = 0,
         )
         """);
-    useConfiguration("--legacy_whole_archive");
     assertThat(getLibfooArguments()).doesNotContain("-Wl,-whole-archive");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LibraryLinkingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LibraryLinkingTest.java
@@ -46,16 +46,14 @@ public final class LibraryLinkingTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testGeneratedLib() throws Exception {
+  public void testGeneratedLibraryLinkedWithoutWholeArchive() throws Exception {
     getAnalysisMock()
         .ccSupport()
         .setupCcToolchainConfig(
             mockToolsConfig,
             CcToolchainConfig.builder().withFeatures(CppRuleClasses.SUPPORTS_DYNAMIC_LINKER));
 
-    useConfiguration(
-        "--platforms=" + TestConstants.PLATFORM_LABEL,
-        "--noincompatible_remove_legacy_whole_archive");
+    useConfiguration("--platforms=" + TestConstants.PLATFORM_LABEL);
     ConfiguredTarget genlib =
         scratchConfiguredTarget(
             "genrule",
@@ -79,9 +77,7 @@ public final class LibraryLinkingTest extends BuildViewTestCase {
         "-shared",
         "-o",
         analysisMock.getProductName() + "-out/.+/genrule/thebinary.so",
-        "-Wl,-whole-archive",
-        analysisMock.getProductName() + "-out/.+/genrule/genlib.a",
-        "-Wl,-no-whole-archive");
+        analysisMock.getProductName() + "-out/.+/genrule/genlib.a");
   }
 
   /**


### PR DESCRIPTION
`--incompatible_remove_legacy_whole_archive` was introduced disabled in February 2019 by [e5735fd27d](https://github.com/bazelbuild/bazel/commit/e5735fd27d7ab72ef1793a10977316b4bdf52020) and enabled by default in September 2019 by [799328f8e0](https://github.com/bazelbuild/bazel/commit/799328f8e02c891376853c31129ac723a7914c51). `--legacy_whole_archive` was retained as a rollback control and only affected builds that explicitly restored the pre-migration behavior.

This moves both flags out of `CppOptions`, returns the established values from the private Starlark compatibility accessors, and retains deprecated graveyard no-ops so existing command lines remain accepted. The linking tests now cover the established behavior without rollback flags.

The rules_cc dead-code cleanup is [bazelbuild/rules_cc#768](https://github.com/bazelbuild/rules_cc/pull/768).

Validation: `bazel test --jobs=3 --disk_cache=/private/tmp/bazel-pr-disk-cache //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest //src/test/java/com/google/devtools/build/lib/rules/cpp:CppLinkActionTest //src/test/java/com/google/devtools/build/lib/rules/cpp:LibraryLinkingTest`.
