### PR TITLE
Move --incompatible_disable_nocopts to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -589,6 +589,16 @@ public final class BazelRulesModule extends BlazeModule {
         help = "Deprecated no-op.")
     public abstract boolean getDisableLegacyCcProvider();
 
+    @Deprecated
+    @Option(
+        name = "incompatible_disable_nocopts",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getDisableNoCopts();
+
     @Option(
         name = "python_path",
         defaultValue = "",

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -683,6 +683,16 @@ public final class BazelRulesModule extends BlazeModule {
         help = "Deprecated no-op.")
     public abstract boolean getJavaTestAutoCreateDeployJar();
 
+    @Deprecated
+    @Option(
+        name = "incompatible_disable_nocopts",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getDisableNoCopts();
+
     @Option(
         name = "python_path",
         defaultValue = "",

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -806,7 +806,7 @@ public final class CppConfiguration extends Fragment
   }
 
   public boolean disableNoCopts() {
-    return cppOptions.getDisableNoCopts();
+    return true;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -799,7 +799,7 @@ public final class CppConfiguration extends Fragment
   }
 
   public boolean disableNoCopts() {
-    return cppOptions.getDisableNoCopts();
+    return true;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -866,17 +866,6 @@ public abstract class CppOptions extends FragmentOptions {
   public abstract boolean getUseSpecificToolFiles();
 
   @Option(
-      name = "incompatible_disable_nocopts",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.ACTION_COMMAND_LINES},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "When enabled, it removes nocopts attribute from C++ rules. See"
-              + " https://github.com/bazelbuild/bazel/issues/8706 for details.")
-  public abstract boolean getDisableNoCopts();
-
-  @Option(
       name = "apple_generate_dsym",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.OUTPUT_SELECTION,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -816,17 +816,6 @@ public abstract class CppOptions extends FragmentOptions {
   public abstract boolean getSaveFeatureState();
 
   @Option(
-      name = "incompatible_disable_nocopts",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.ACTION_COMMAND_LINES},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "When enabled, it removes nocopts attribute from C++ rules. See"
-              + " https://github.com/bazelbuild/bazel/issues/8706 for details.")
-  public abstract boolean getDisableNoCopts();
-
-  @Option(
       name = "apple_generate_dsym",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.OUTPUT_SELECTION,

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -267,7 +267,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:incompatible_require_ctx_in_configure_features",
         "//command_line_option:incompatible_make_thinlto_command_lines_standalone",
         "//command_line_option:incompatible_use_specific_tool_files",
-        "//command_line_option:incompatible_disable_nocopts",
         "//command_line_option:strict_system_includes",
         "//command_line_option:experimental_use_cpp_compile_action_args_params_file",
         "//command_line_option:cc_include_scanning",

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -258,7 +258,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:experimental_inmemory_dotd_files",
         "//command_line_option:incompatible_remove_legacy_whole_archive",
         "//command_line_option:incompatible_dont_enable_host_nonhost_crosstool_features",
-        "//command_line_option:incompatible_disable_nocopts",
         "//command_line_option:strict_system_includes",
         "//command_line_option:experimental_use_cpp_compile_action_args_params_file",
         "//command_line_option:cc_include_scanning",


### PR DESCRIPTION
`--incompatible_disable_nocopts` was introduced disabled in June 2019 by [b7c0858e9f](https://github.com/bazelbuild/bazel/commit/b7c0858e9fa3701236510ec9a2501a1634b94780) and enabled by default in August 2019 by [8b840e18c4](https://github.com/bazelbuild/bazel/commit/8b840e18c424b7dc9971fb163bb07f7ac33ff2a1). Starlark nocopts handling was removed in May 2026 by [1c526107e6](https://github.com/bazelbuild/bazel/commit/1c526107e64d89235297bd51126095bcd74c3ead), and the remaining Java handling was removed in June 2026 by [7fc823b090](https://github.com/bazelbuild/bazel/commit/7fc823b090a43b2cc05a2adae4e5409bbefbc8a3), leaving the flag without a consumer.

This removes the flag from `CppOptions` and exec-transition propagation. The private compatibility accessor returns `true`, and a deprecated graveyard no-op keeps existing command lines accepted.

Validation: `bazel test --jobs=3 --disk_cache=/private/tmp/bazel-pr-disk-cache //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest`.
