### PR TITLE
Move --incompatible_dont_enable_host_nonhost_crosstool_features to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -589,6 +589,16 @@ public final class BazelRulesModule extends BlazeModule {
         help = "Deprecated no-op.")
     public abstract boolean getDisableLegacyCcProvider();
 
+    @Deprecated
+    @Option(
+        name = "incompatible_dont_enable_host_nonhost_crosstool_features",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getDontEnableHostNonhostCrosstoolFeatures();
+
     @Option(
         name = "python_path",
         defaultValue = "",

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCommon.java
@@ -172,14 +172,6 @@ public final class CcCommon {
       allFeatures.addAll(OBJC_ACTIONS);
     }
 
-    if (!cppConfiguration.dontEnableHostNonhost()) {
-      if (toolchain.isToolConfiguration()) {
-        allFeatures.add("host");
-      } else {
-        allFeatures.add("nonhost");
-      }
-    }
-
     allFeatures.addAll(getCoverageFeatures(cppConfiguration));
 
     if (!allUnsupportedFeatures.contains(CppRuleClasses.FDO_INSTRUMENT)) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -781,7 +781,7 @@ public final class CppConfiguration extends Fragment
 
   @StarlarkMethod(name = "_dont_enable_host_nonhost", documented = false, structField = true)
   public boolean dontEnableHostNonhost() {
-    return cppOptions.getDontEnableHostNonhost();
+    return true;
   }
 
   public boolean collectCodeCoverage() {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -794,17 +794,6 @@ public abstract class CppOptions extends FragmentOptions {
               + "gcov when collect_code_coverage is enabled.")
   public abstract boolean getUseLLVMCoverageMapFormat();
 
-  @Option(
-      name = "incompatible_dont_enable_host_nonhost_crosstool_features",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "If true, Bazel will not enable 'host' and 'nonhost' features in the c++ toolchain "
-              + "(see https://github.com/bazelbuild/bazel/issues/7407 for more information).")
-  public abstract boolean getDontEnableHostNonhost();
-
   @Deprecated
   @Option(
       name = "incompatible_make_thinlto_command_lines_standalone",

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -263,7 +263,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:experimental_inmemory_dotd_files",
         "//command_line_option:incompatible_enable_cc_toolchain_resolution",
         "//command_line_option:incompatible_remove_legacy_whole_archive",
-        "//command_line_option:incompatible_dont_enable_host_nonhost_crosstool_features",
         "//command_line_option:incompatible_require_ctx_in_configure_features",
         "//command_line_option:incompatible_make_thinlto_command_lines_standalone",
         "//command_line_option:incompatible_use_specific_tool_files",


### PR DESCRIPTION
`--incompatible_dont_enable_host_nonhost_crosstool_features` was introduced disabled in February 2019 by [8814b6cfca](https://github.com/bazelbuild/bazel/commit/8814b6cfcac7154f9f25d7198e12a91e6f8b55d9) and enabled by default in May 2019 by [aec9f99d20](https://github.com/bazelbuild/bazel/commit/aec9f99d2014e6d94e602288f4bedf5153dd16bc). The enabled behavior has been the default since Bazel 0.26.

This removes the legacy `host` and `nonhost` feature injection from the Java compatibility implementation. The private Starlark compatibility accessor returns `true`, and a deprecated graveyard no-op keeps existing command lines accepted.

Validation: `bazel test --jobs=3 --disk_cache=/private/tmp/bazel-pr-disk-cache //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest //src/test/java/com/google/devtools/build/lib/rules/cpp:CcCommonTest`.
