### PR TITLE
Move --incompatible_enable_cc_toolchain_resolution to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -589,6 +589,16 @@ public final class BazelRulesModule extends BlazeModule {
         help = "Deprecated no-op.")
     public abstract boolean getDisableLegacyCcProvider();
 
+    @Deprecated
+    @Option(
+        name = "incompatible_enable_cc_toolchain_resolution",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getEnableCcToolchainResolution();
+
     @Option(
         name = "python_path",
         defaultValue = "",

--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigGlobalLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigGlobalLibrary.java
@@ -195,8 +195,7 @@ public class ConfigGlobalLibrary implements ConfigGlobalLibraryApi {
       return false;
     }
 
-    if (optionName.equals("incompatible_enable_cc_toolchain_resolution")
-        || optionName.equals("incompatible_enable_apple_toolchain_resolution")) {
+    if (optionName.equals("incompatible_enable_apple_toolchain_resolution")) {
       // This is specifically allowed.
       return true;
     } else if (optionName.startsWith("incompatible_")) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -837,15 +837,6 @@ public abstract class CppOptions extends FragmentOptions {
   public abstract boolean getRemoveLegacyWholeArchive();
 
   @Option(
-      name = "incompatible_enable_cc_toolchain_resolution",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help = "No-op flag. Will be removed in a future release.")
-  public abstract boolean getEnableCcToolchainResolutionNoOp();
-
-  @Option(
       name = "experimental_save_feature_state",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.OUTPUT_SELECTION,

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -261,7 +261,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:experimental_cpp_modules",
         "//command_line_option:start_end_lib",
         "//command_line_option:experimental_inmemory_dotd_files",
-        "//command_line_option:incompatible_enable_cc_toolchain_resolution",
         "//command_line_option:incompatible_remove_legacy_whole_archive",
         "//command_line_option:incompatible_dont_enable_host_nonhost_crosstool_features",
         "//command_line_option:incompatible_require_ctx_in_configure_features",

--- a/src/test/java/com/google/devtools/build/lib/analysis/AutoExecGroupsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/AutoExecGroupsTest.java
@@ -239,8 +239,7 @@ public class AutoExecGroupsTest extends BuildViewTestCase {
     String[] flags = {
       "--extra_toolchains=//toolchain:foo_toolchain,//toolchain:bar_toolchain,//toolchain:baz_toolchain,//toolchain:quz_toolchain,toolchain:qux_toolchain",
       "--platforms=//platforms:platform_1",
-      "--extra_execution_platforms=//platforms:platform_1,//platforms:platform_2,//platforms:platform_3,//platforms:platform_4",
-      "--incompatible_enable_cc_toolchain_resolution"
+      "--extra_execution_platforms=//platforms:platform_1,//platforms:platform_2,//platforms:platform_3,//platforms:platform_4"
     };
 
     super.useConfiguration(ObjectArrays.concat(flags, args, String.class));

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrTransitionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrTransitionProviderTest.java
@@ -1194,8 +1194,8 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
 
   @Test
   public void testBannedNativeOptionOutput() throws Exception {
-    // Just picked an arbitrary incompatible_ flag; however, could be any flag
-    // besides incompatible_enable_cc_toolchain_resolution (and might not even need to be real).
+    // Just picked an arbitrary incompatible_ flag; however, this could be any incompatible flag
+    // besides incompatible_enable_apple_toolchain_resolution and might not even need to be real.
     scratch.file(
         "test/starlark/my_rule.bzl",
         """

--- a/src/test/java/com/google/devtools/build/lib/rules/ToolchainTypeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/ToolchainTypeTest.java
@@ -66,7 +66,6 @@ public class ToolchainTypeTest extends BuildViewTestCase {
 
     scratch.file("a/cc_toolchain_config.bzl", MockCcSupport.EMPTY_CC_TOOLCHAIN);
     useConfiguration(
-        "--incompatible_enable_cc_toolchain_resolution",
         "--experimental_platforms=//a:mock-platform",
         "--extra_toolchains=//a:toolchain_b");
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcImportBaseConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcImportBaseConfiguredTargetTest.java
@@ -161,9 +161,7 @@ public abstract class CcImportBaseConfiguredTargetTest extends BuildViewTestCase
 
   @Test
   public void testCcImportWithSharedLibrary() throws Exception {
-    useConfiguration(
-        "--platforms=" + TestConstants.PLATFORM_LABEL,
-        "--noincompatible_enable_cc_toolchain_resolution");
+    useConfiguration("--platforms=" + TestConstants.PLATFORM_LABEL);
     ConfiguredTarget target =
         scratchConfiguredTarget(
             "a",
@@ -188,9 +186,7 @@ public abstract class CcImportBaseConfiguredTargetTest extends BuildViewTestCase
 
   @Test
   public void testCcImportWithVersionedSharedLibrary() throws Exception {
-    useConfiguration(
-        "--platforms=" + TestConstants.PLATFORM_LABEL,
-        "--noincompatible_enable_cc_toolchain_resolution");
+    useConfiguration("--platforms=" + TestConstants.PLATFORM_LABEL);
     ConfiguredTarget target =
         scratchConfiguredTarget(
             "a",
@@ -215,9 +211,7 @@ public abstract class CcImportBaseConfiguredTargetTest extends BuildViewTestCase
 
   @Test
   public void testCcImportWithVersionedSharedLibraryWithDotInTheName() throws Exception {
-    useConfiguration(
-        "--platforms=" + TestConstants.PLATFORM_LABEL,
-        "--noincompatible_enable_cc_toolchain_resolution");
+    useConfiguration("--platforms=" + TestConstants.PLATFORM_LABEL);
 
     ConfiguredTarget target =
         scratchConfiguredTarget(
@@ -270,9 +264,7 @@ public abstract class CcImportBaseConfiguredTargetTest extends BuildViewTestCase
 
   @Test
   public void testCcImportWithInterfaceSharedLibrary() throws Exception {
-    useConfiguration(
-        "--platforms=" + TestConstants.PLATFORM_LABEL,
-        "--noincompatible_enable_cc_toolchain_resolution");
+    useConfiguration("--platforms=" + TestConstants.PLATFORM_LABEL);
     ConfiguredTarget target =
         scratchConfiguredTarget(
             "b",
@@ -298,9 +290,7 @@ public abstract class CcImportBaseConfiguredTargetTest extends BuildViewTestCase
 
   @Test
   public void testCcImportWithBothStaticAndSharedLibraries() throws Exception {
-    useConfiguration(
-        "--platforms=" + TestConstants.PLATFORM_LABEL,
-        "--noincompatible_enable_cc_toolchain_resolution");
+    useConfiguration("--platforms=" + TestConstants.PLATFORM_LABEL);
     ConfiguredTarget target =
         scratchConfiguredTarget(
             "a",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainSelectionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainSelectionTest.java
@@ -45,7 +45,6 @@ public class CcToolchainSelectionTest extends BuildViewTestCase {
   @Test
   public void testResolvedCcToolchain() throws Exception {
     useConfiguration(
-        "--incompatible_enable_cc_toolchain_resolution",
         "--experimental_platforms=//mock_platform:mock-k8-platform",
         "--extra_toolchains=//mock_platform:toolchain_cc-compiler-k8");
     ConfiguredTarget target =
@@ -66,7 +65,6 @@ public class CcToolchainSelectionTest extends BuildViewTestCase {
   @Test
   public void testToolchainSelectionWithPlatforms() throws Exception {
     useConfiguration(
-        "--incompatible_enable_cc_toolchain_resolution",
         "--experimental_platforms=//mock_platform:mock-k8-platform",
         "--extra_toolchains=//mock_platform:toolchain_cc-compiler-k8");
     ConfiguredTarget target =
@@ -110,7 +108,6 @@ public class CcToolchainSelectionTest extends BuildViewTestCase {
     mockToolsConfig.append("mock_platform/BUILD", "platform(name = 'mock-piii-platform')");
 
     useConfiguration(
-        "--incompatible_enable_cc_toolchain_resolution",
         "--experimental_platforms=//mock_platform:mock-piii-platform",
         "--extra_toolchains=//incomplete_toolchain:incomplete_toolchain_cc-compiler-piii");
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariablesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariablesTest.java
@@ -230,8 +230,7 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
   public void testTargetSysrootWithoutPlatforms() throws Exception {
     useConfiguration(
         "--grte_top=//target_libc",
-        "--host_grte_top=//host_libc",
-        "--noincompatible_enable_cc_toolchain_resolution");
+        "--host_grte_top=//host_libc");
 
     scratch.file(
         "x/BUILD",
@@ -254,7 +253,6 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
     useConfiguration(
         "--experimental_platforms=//mock_platform:mock-k8-platform",
         "--extra_toolchains=//mock_platform:toolchain_cc-compiler-k8",
-        "--incompatible_enable_cc_toolchain_resolution",
         "--grte_top=//target_libc",
         "--host_grte_top=//host_libc");
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollectorTest.java
@@ -119,7 +119,6 @@ public final class LibrariesToLinkCollectorTest extends BuildViewTestCase {
     useConfiguration(
         "--extra_toolchains=//toolchain:toolchain",
         "--dynamic_mode=fully",
-        "--incompatible_enable_cc_toolchain_resolution",
         "--platforms=" + TestConstants.PLATFORM_LABEL,
         "--experimental_platform_in_output_dir",
         String.format(
@@ -233,7 +232,6 @@ public final class LibrariesToLinkCollectorTest extends BuildViewTestCase {
     useConfiguration(
         "--extra_toolchains=@@toolchain+//:toolchain",
         "--dynamic_mode=fully",
-        "--incompatible_enable_cc_toolchain_resolution",
         "--platforms=" + TestConstants.PLATFORM_LABEL,
         "--experimental_platform_in_output_dir",
         String.format(

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkAspectsToolchainPropagationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkAspectsToolchainPropagationTest.java
@@ -1965,8 +1965,7 @@ public final class StarlarkAspectsToolchainPropagationTest extends AnalysisTestC
     useConfiguration(
         "--extra_toolchains=//toolchain:foo_toolchain_exec_1,//toolchain:foo_toolchain_exec_2",
         "--extra_execution_platforms=//platforms:platform_1,//platforms:platform_2",
-        "--incompatible_auto_exec_groups=True",
-        "--incompatible_enable_cc_toolchain_resolution");
+        "--incompatible_auto_exec_groups=True");
 
     var analysisResult = update(ImmutableList.of("//test:defs.bzl%my_aspect"), "//test:t1");
 
@@ -2043,8 +2042,7 @@ public final class StarlarkAspectsToolchainPropagationTest extends AnalysisTestC
     useConfiguration(
         "--extra_toolchains=//toolchain:foo_toolchain_exec_1,//toolchain:foo_toolchain_exec_2",
         "--extra_execution_platforms=//platforms:platform_1,//platforms:platform_2",
-        "--incompatible_auto_exec_groups=False",
-        "--incompatible_enable_cc_toolchain_resolution");
+        "--incompatible_auto_exec_groups=False");
 
     var analysisResult = update(ImmutableList.of("//test:defs.bzl%my_aspect"), "//test:t1");
 
@@ -2122,8 +2120,7 @@ public final class StarlarkAspectsToolchainPropagationTest extends AnalysisTestC
     useConfiguration(
         "--extra_toolchains=//toolchain:foo_toolchain_exec_1,//toolchain:foo_toolchain_exec_2",
         "--extra_execution_platforms=//platforms:platform_1,//platforms:platform_2",
-        "--incompatible_auto_exec_groups=" + autoExecGroups,
-        "--incompatible_enable_cc_toolchain_resolution");
+        "--incompatible_auto_exec_groups=" + autoExecGroups);
 
     var analysisResult = update(ImmutableList.of("//test:defs.bzl%my_aspect"), "//test:t1");
 
@@ -2205,8 +2202,7 @@ public final class StarlarkAspectsToolchainPropagationTest extends AnalysisTestC
     useConfiguration(
         "--extra_toolchains=//toolchain:foo_toolchain",
         "--extra_execution_platforms=//platforms:platform_1,//platforms:platform_2",
-        "--incompatible_auto_exec_groups=" + autoExecGroups,
-        "--incompatible_enable_cc_toolchain_resolution");
+        "--incompatible_auto_exec_groups=" + autoExecGroups);
 
     var unused = update(ImmutableList.of("//test:defs.bzl%toolchain_aspect"), "//test:t1");
 

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkDefinedAspectsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkDefinedAspectsTest.java
@@ -402,9 +402,7 @@ MyAspect = aspect(
 
   @Test
   public void aspectsPropagatingForDefaultAndImplicit() throws Exception {
-    useConfiguration(
-        "--experimental_builtins_injection_override=+cc_library",
-        "--incompatible_enable_cc_toolchain_resolution");
+    useConfiguration("--experimental_builtins_injection_override=+cc_library");
     scratch.file(
         "test/aspect.bzl",
         """

--- a/src/test/shell/bazel/bazel_proto_library_test.sh
+++ b/src/test/shell/bazel/bazel_proto_library_test.sh
@@ -535,39 +535,6 @@ EOF
   bazel build //a:c || fail "build failed"
 }
 
-function test_cc_proto_library_with_toolchain_resolution() {
-  add_rules_cc MODULE.bazel
-
-  mkdir -p a
-  cat > a/BUILD <<EOF
-load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
-load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
-load("@rules_cc//cc:cc_library.bzl", "cc_library")
-
-proto_library(name='p', srcs=['p.proto'])
-cc_proto_library(name='cp', deps=[':p'])
-cc_library(name='c', srcs=['c.cc'], deps=[':cp'])
-EOF
-
-  cat > a/p.proto <<EOF
-syntax = "proto2";
-package a;
-message A {
-  optional int32 a = 1;
-}
-EOF
-
-  cat > a/c.cc <<EOF
-#include "a/p.pb.h"
-
-void f() {
-  a::A a;
-}
-EOF
-
-  bazel build --incompatible_enable_cc_toolchain_resolution //a:c || fail "build failed"
-}
-
 function test_cc_proto_library_import_prefix_stripping() {
   add_rules_cc MODULE.bazel
   mkdir -p a/dir

--- a/src/test/shell/bazel/bazel_windows_example_test.sh
+++ b/src/test/shell/bazel/bazel_windows_example_test.sh
@@ -133,8 +133,8 @@ function test_cpp_with_msys_gcc() {
   ./bazel-bin/${cpp_pkg}/hello-world foo >& $TEST_log \
     || fail "./bazel-bin/${cpp_pkg}/hello-world foo execution failed"
   expect_log "Hello foo"
-  assert_test_ok "//examples/cpp:hello-success_test" --compiler=msys-gcc --noincompatible_enable_cc_toolchain_resolution
-  assert_test_fails "//examples/cpp:hello-fail_test" --compiler=msys-gcc --noincompatible_enable_cc_toolchain_resolution
+  assert_test_ok "//examples/cpp:hello-success_test" --compiler=msys-gcc
+  assert_test_fails "//examples/cpp:hello-fail_test" --compiler=msys-gcc
 }
 
 function test_cpp_with_mingw_gcc() {

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1982,27 +1982,18 @@ my_rule = rule(
 EOF
 }
 
-function test_find_optional_cpp_toolchain_present_without_toolchain_resolution() {
+function test_find_optional_cpp_toolchain_present() {
   setup_find_optional_cpp_toolchain
 
-  bazel build //pkg:my_rule --noincompatible_enable_cc_toolchain_resolution \
-    &> "$TEST_log" || fail "Build failed"
+  bazel build //pkg:my_rule &> "$TEST_log" || fail "Build failed"
   assert_contains "Toolchain found" bazel-bin/pkg/my_rule
 }
 
-function test_find_optional_cpp_toolchain_present_with_toolchain_resolution() {
+function test_find_optional_cpp_toolchain_not_present() {
   setup_find_optional_cpp_toolchain
 
-  bazel build //pkg:my_rule --incompatible_enable_cc_toolchain_resolution \
+  bazel build //pkg:my_rule --platforms=//pkg:exotic_platform \
     &> "$TEST_log" || fail "Build failed"
-  assert_contains "Toolchain found" bazel-bin/pkg/my_rule
-}
-
-function test_find_optional_cpp_toolchain_not_present_with_toolchain_resolution() {
-  setup_find_optional_cpp_toolchain
-
-  bazel build //pkg:my_rule --incompatible_enable_cc_toolchain_resolution \
-    --platforms=//pkg:exotic_platform &> "$TEST_log" || fail "Build failed"
   assert_contains "Toolchain not found" bazel-bin/pkg/my_rule
 }
 


### PR DESCRIPTION
`--incompatible_enable_cc_toolchain_resolution` was introduced disabled in January 2019 by [2bfb470ca2](https://github.com/bazelbuild/bazel/commit/2bfb470ca2ad7edd42e638afbbfda1ee66b78ec9), enabled by default in September 2023 by [1be55d8add](https://github.com/bazelbuild/bazel/commit/1be55d8add84c2d04c3353b7e481a7866a92eac7), and made a no-op in December 2023 by [e116bae821](https://github.com/bazelbuild/bazel/commit/e116bae8213ca31ae590a60748c1b6d505a4f819).

This removes the flag from `CppOptions`, exec-transition propagation, and the user-defined transition exception. A deprecated graveyard no-op keeps existing command lines accepted.

Validation: `bazel test --jobs=3 --disk_cache=/private/tmp/bazel-pr-disk-cache //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest //src/test/java/com/google/devtools/build/lib/analysis/starlark:StarlarkAttrTransitionProviderTest`.
