### PR TITLE
[9.2.0] Fix enabling TCP keepalive on Linux. (https://github.com/bazelbuild/b…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -40,6 +40,7 @@ import io.grpc.netty.NettyChannelBuilder;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.epoll.EpollDomainSocketChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.kqueue.KQueue;
@@ -104,21 +105,28 @@ public final class GoogleAuthUtils {
       boolean isUnixSocketChannel = targetUrl.startsWith("unix:") || !Strings.isNullOrEmpty(proxy);
       if (options.grpcTcpKeepalive && !isUnixSocketChannel) {
         builder.withOption(ChannelOption.SO_KEEPALIVE, true);
+        boolean epoll = Epoll.isAvailable();
         long idleSeconds = options.grpcTcpKeepaliveTime.toSeconds();
         if (idleSeconds > 0) {
           builder.withOption(
-              NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPIDLE),
+              epoll
+                  ? EpollChannelOption.TCP_KEEPIDLE
+                  : NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPIDLE),
               Math.toIntExact(idleSeconds));
         }
         long intervalSeconds = options.grpcTcpKeepaliveInterval.toSeconds();
         if (intervalSeconds > 0) {
           builder.withOption(
-              NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPINTERVAL),
+              epoll
+                  ? EpollChannelOption.TCP_KEEPINTVL
+                  : NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPINTERVAL),
               Math.toIntExact(intervalSeconds));
         }
         if (options.grpcTcpKeepaliveCount > 0) {
           builder.withOption(
-              NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPCOUNT),
+              epoll
+                  ? EpollChannelOption.TCP_KEEPCNT
+                  : NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPCOUNT),
               options.grpcTcpKeepaliveCount);
         }
       }


### PR DESCRIPTION
…azel/pull/29902)

On Linux, gRPC defaults to epoll which uses a different set of options.

https://github.com/bazelbuild/bazel/pull/29879 worked on Mac but was a no-op on Linux.

Closes #29902.

PiperOrigin-RevId: 936173912
Change-Id: I3796427c6f9fe887b0557bb56466e176af25f160

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/46c5e789f84c7bf4ba1edb105eefa7bc4ebc841b