### PR TITLE
Collect flag aliases on BazelDepGraphValue

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
@@ -43,6 +43,8 @@ import com.google.devtools.build.skyframe.SkyFunctionException;
 import com.google.devtools.build.skyframe.SkyFunctionException.Transience;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import javax.annotation.Nullable;
 
@@ -90,8 +92,75 @@ public class BazelDepGraphFunction implements SkyFunction {
               depGraph,
               extensionUsagesById,
               extensionUniqueNames.inverse(),
-              canonicalRepoNameLookup));
+              canonicalRepoNameLookup),
+          collectFlagAliases(depGraph));
     }
+  }
+
+  /** Canonical Starlark flag aliases for {@code PythonOptions} flags. */
+  // TODO: b/453809359 - Remove when Bazel 9+ can read Python flag alias definitions straight from
+  // rules_python's MODULE.bazel.
+  private static final ImmutableMap<String, String> PY_FLAG_ALIASES =
+      ImmutableMap.of(
+          "build_python_zip",
+          "@@rules_python+//python/config_settings:build_python_zip",
+          "incompatible_default_to_explicit_init_py",
+          "@@rules_python+//python/config_settings:incompatible_default_to_explicit_init_py");
+
+  /** Canonical Starlark flag aliases for {@code BazelPythonConfiguration} flags. */
+  // TODO: b/453809359 - Remove when Bazel 9+ can read Python flag alias definitions straight from
+  // rules_python's MODULE.bazel.
+  private static final ImmutableMap<String, String> BAZEL_PY_FLAG_ALIASES =
+      ImmutableMap.of(
+          "python_path",
+          "@@rules_python+//python/config_settings:python_path",
+          "experimental_python_import_all_repositories",
+          "@@rules_python+//python/config_settings:experimental_python_import_all_repositories");
+
+  /**
+   * Collects the flag aliases declared via {@code flag_alias()} across all modules, mapping each
+   * short flag name to the canonical label of the Starlark flag it aliases.
+   */
+  private static ImmutableMap<String, String> collectFlagAliases(
+      ImmutableMap<ModuleKey, Module> depGraph) {
+    LinkedHashMap<String, String> aliasesMap = new LinkedHashMap<>();
+    Module rootModule = depGraph.values().iterator().next();
+    for (Entry<ModuleKey, Module> module : depGraph.entrySet()) {
+      ImmutableMap<String, String> flagAliases = module.getValue().getFlagAliases();
+      for (Entry<String, String> flagAlias : flagAliases.entrySet()) {
+        aliasesMap.put(
+            flagAlias.getKey(),
+            flagAlias.getValue().startsWith("//")
+                ? module.getKey().getCanonicalRepoNameWithoutVersion() + flagAlias.getValue()
+                : flagAlias.getValue());
+      }
+      if (!module.getValue().getName().equals("rules_python")) {
+        continue;
+      }
+      // Don't apply hard-coded aliases if rules_python uses MODULE.bazel aliases.
+      if (!module.getValue().getFlagAliases().isEmpty()) {
+        continue;
+      }
+      // Add Python flags that haven't already been added by rules_python's MODULE.bazel.
+      PY_FLAG_ALIASES.entrySet().stream()
+          .filter(e -> !flagAliases.containsKey(e.getKey()))
+          .map(
+              e ->
+                  rootModule.getName().equals("rules_python")
+                      ? Map.entry(e.getKey(), e.getValue().substring(e.getValue().indexOf("/")))
+                      : e)
+          .forEach(e -> aliasesMap.put(e.getKey(), e.getValue()));
+      // Add Bazel Python flags that haven't already been added by rules_python's MODULE.bazel.
+      BAZEL_PY_FLAG_ALIASES.entrySet().stream()
+          .filter(e -> !flagAliases.containsKey(e.getKey()))
+          .map(
+              e ->
+                  rootModule.getName().equals("rules_python")
+                      ? Map.entry(e.getKey(), e.getValue().substring(e.getValue().indexOf("/")))
+                      : e)
+          .forEach(e -> aliasesMap.put(e.getKey(), e.getValue()));
+    }
+    return ImmutableMap.copyOf(aliasesMap);
   }
 
   private static ImmutableTable<ModuleExtensionId, ModuleKey, ModuleExtensionUsage>

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphValue.java
@@ -42,14 +42,16 @@ public abstract class BazelDepGraphValue implements SkyValue {
       ImmutableList<AbridgedModule> abridgedModules,
       ImmutableTable<ModuleExtensionId, ModuleKey, ModuleExtensionUsage> extensionUsagesTable,
       ImmutableMap<ModuleExtensionId, String> extensionUniqueNames,
-      ImmutableTable<ModuleExtensionId, String, RepositoryName> repoOverrides) {
+      ImmutableTable<ModuleExtensionId, String, RepositoryName> repoOverrides,
+      ImmutableMap<String, String> flagAliases) {
     return new AutoValue_BazelDepGraphValue(
         depGraph,
         ImmutableBiMap.copyOf(canonicalRepoNameLookup),
         abridgedModules,
         extensionUsagesTable,
         extensionUniqueNames,
-        repoOverrides);
+        repoOverrides,
+        flagAliases);
   }
 
   public static BazelDepGraphValue createEmptyDepGraph() {
@@ -75,7 +77,8 @@ public abstract class BazelDepGraphValue implements SkyValue {
         ImmutableList.of(),
         ImmutableTable.of(),
         ImmutableMap.of(),
-        ImmutableTable.of());
+        ImmutableTable.of(),
+        ImmutableMap.of());
   }
 
   /**
@@ -112,6 +115,14 @@ public abstract class BazelDepGraphValue implements SkyValue {
    * canonical name of the repo that should override it (if any).
    */
   public abstract ImmutableTable<ModuleExtensionId, String, RepositoryName> getRepoOverrides();
+
+  /**
+   * The flag aliases declared via {@code flag_alias()} in {@code MODULE.bazel} files, mapping each
+   * short flag name to the canonical label of the Starlark flag it aliases. These, along with
+   * whatever is set in {@code --flag_alias}, rewrite {@code --foo}-style command line flags to
+   * canonical Starlark flags.
+   */
+  public abstract ImmutableMap<String, String> getFlagAliases();
 
   /**
    * Returns the full {@link RepositoryMapping} for the given module, including repos from Bazel

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -39,7 +39,6 @@ import com.google.devtools.build.lib.buildeventstream.BuildEventProtocolOptions;
 import com.google.devtools.build.lib.buildtool.buildevent.MainRepoMappingComputationStartingEvent;
 import com.google.devtools.build.lib.buildtool.buildevent.ProfilerStartedEvent;
 import com.google.devtools.build.lib.clock.BlazeClock;
-import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.events.ExtendedEventHandler.Postable;
@@ -58,6 +57,7 @@ import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.IdleTask;
 import com.google.devtools.build.lib.skyframe.RepositoryMappingValue.RepositoryMappingResolutionException;
+import com.google.devtools.build.lib.skyframe.SkyframeExecutor.MainRepoMappingAndFlagAliases;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.AnsiStrippingOutputStream;
 import com.google.devtools.build.lib.util.DebugLoggerConfigurator;
@@ -632,9 +632,12 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
         env.getEventBus().post(new MainRepoMappingComputationStartingEvent());
         try (SilentCloseable c =
             Profiler.instance().profile(ProfilerTask.BZLMOD, "compute main repo mapping")) {
-          RepositoryMapping mainRepoMapping =
-              env.getSkyframeExecutor().getMainRepoMapping(reporter);
-          optionsParser = optionsParser.toBuilder().withConversionContext(mainRepoMapping).build();
+          MainRepoMappingAndFlagAliases mainRepoMappingAndFlagAliases =
+              env.getSkyframeExecutor().getMainRepoMappingAndFlagAliases(reporter);
+          optionsParser =
+              optionsParser.toBuilder()
+                  .withConversionContext(mainRepoMappingAndFlagAliases.mainRepoMapping())
+                  .build();
           // Collect MODULE.bazel flag_alias(name = "foo", starlark_flag = "//bar") entries, so when
           // builds set "--foo=1", that maps to "--//bar=1". Inject this as an implicit
           // "--flag_alias=foo=//bar" flag. This is because select()s and configuration transitions
@@ -643,7 +646,7 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
           optionsParser.parse(
               PriorityCategory.RC_FILE,
               "module resolution",
-              env.getSkyframeExecutor().getFlagAliases(reporter).entrySet().stream()
+              mainRepoMappingAndFlagAliases.flagAliases().entrySet().stream()
                   .map(e -> String.format("--flag_alias=%s=%s", e.getKey(), e.getValue()))
                   .collect(toImmutableList()));
         } catch (InterruptedException e) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -3308,81 +3308,6 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     return detailedExitCode;
   }
 
-  /** Canonical Starlark flag aliases for {@link PythonOptions} flags. */
-  // TODO: b/453809359 - Remove when Bazel 9+ can read Python flag alias definitions straight from
-  // rules_python's MODULE.bazel.
-  private static final ImmutableMap<String, String> PY_FLAG_ALIASES =
-      ImmutableMap.of(
-          "build_python_zip",
-          "@@rules_python+//python/config_settings:build_python_zip",
-          "incompatible_default_to_explicit_init_py",
-          "@@rules_python+//python/config_settings:incompatible_default_to_explicit_init_py");
-
-  /** Canonical Starlark flag aliases for {@link BazelPythonConfiguration} flags. */
-  // TODO: b/453809359 - Remove when Bazel 9+ can read Python flag alias definitions straight from
-  // rules_python's MODULE.bazel.
-  private static final ImmutableMap<String, String> BAZEL_PY_FLAG_ALIASES =
-      ImmutableMap.of(
-          "python_path",
-          "@@rules_python+//python/config_settings:python_path",
-          "experimental_python_import_all_repositories",
-          "@@rules_python+//python/config_settings:experimental_python_import_all_repositories");
-
-  /**
-   * Returns flag aliases from {@code MODULE.bazel} {@code flag_alias()} definitions.
-   *
-   * <p>These, along with whatever is set in {@code --flag_alias}, rewrite {@code --foo}-style
-   * command line flags to canonical Starlark flags.
-   *
-   * @param eventHandler handler for Skyframe events
-   */
-  public Map<String, String> getFlagAliases(ExtendedEventHandler eventHandler)
-      throws InterruptedException {
-    EvaluationResult<BazelDepGraphValue> evalResult =
-        evaluate(
-            ImmutableList.of(BazelDepGraphValue.KEY), false, DEFAULT_THREAD_COUNT, eventHandler);
-    var bzlmodDepGraph = evalResult.get(BazelDepGraphValue.KEY).getDepGraph();
-    LinkedHashMap<String, String> aliasesMap = new LinkedHashMap<>();
-    var rootModule = bzlmodDepGraph.entrySet().iterator().next().getValue();
-    for (var module : bzlmodDepGraph.entrySet()) {
-      ImmutableMap<String, String> flagAliases = module.getValue().getFlagAliases();
-      for (var flagAlias : flagAliases.entrySet()) {
-        aliasesMap.put(
-            flagAlias.getKey(),
-            flagAlias.getValue().startsWith("//")
-                ? module.getKey().getCanonicalRepoNameWithoutVersion() + flagAlias.getValue()
-                : flagAlias.getValue());
-      }
-      if (!module.getValue().getName().equals("rules_python")) {
-        continue;
-      }
-      // Don't apply hard-coded aliases if rules_python uses MODULE.bazel aliases.
-      if (!module.getValue().getFlagAliases().isEmpty()) {
-        continue;
-      }
-      // Add Python flags that haven't already been added by rules_python's MODULE.bazel.
-      PY_FLAG_ALIASES.entrySet().stream()
-          .filter(e -> !flagAliases.containsKey(e.getKey()))
-          .map(
-              e ->
-                  rootModule.getName().equals("rules_python")
-                      ? Map.entry(e.getKey(), e.getValue().substring(e.getValue().indexOf("/")))
-                      : e)
-          .forEach(e -> aliasesMap.put(e.getKey(), e.getValue()));
-      // Add Bazel Python flags that haven't already been added by rules_python's MODULE.bazel.
-      BAZEL_PY_FLAG_ALIASES.entrySet().stream()
-          .filter(e -> !flagAliases.containsKey(e.getKey()))
-          .map(
-              e ->
-                  rootModule.getName().equals("rules_python")
-                      ? Map.entry(e.getKey(), e.getValue().substring(e.getValue().indexOf("/")))
-                      : e)
-          .forEach(e -> aliasesMap.put(e.getKey(), e.getValue()));
-    }
-
-    return ImmutableMap.copyOf(aliasesMap);
-  }
-
   public RepositoryMapping getMainRepoMapping(ExtendedEventHandler eventHandler)
       throws InterruptedException, RepositoryMappingResolutionException {
     return getMainRepoMapping(false, DEFAULT_THREAD_COUNT, eventHandler);
@@ -3396,41 +3321,83 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
         evaluate(
             ImmutableList.of(mainRepoMappingKey), keepGoing, loadingPhaseThreads, eventHandler);
     if (evalResult.hasError()) {
-      ErrorInfo errorInfo = evalResult.getError(mainRepoMappingKey);
-      Exception e = errorInfo.getException();
-      if (e == null && !errorInfo.getCycleInfo().isEmpty()) {
-        cyclesReporter.reportCycles(errorInfo.getCycleInfo(), mainRepoMappingKey, eventHandler);
-        throw new RepositoryMappingResolutionException(
-            DetailedExitCode.of(
-                FailureDetail.newBuilder()
-                    .setExternalRepository(
-                        FailureDetails.ExternalRepository.newBuilder()
-                            .setCode(ExternalRepository.Code.REPOSITORY_MAPPING_RESOLUTION_FAILED)
-                            .build())
-                    .setMessage("cycles detected during computation of main repo mapping")
-                    .build()));
-      }
-      if (e instanceof DetailedException) {
-        throw new RepositoryMappingResolutionException(
-            ((DetailedException) e).getDetailedExitCode(), e);
-      }
-      // An IOException at this early stage is often due to transient infrastructure issues. We
-      // give such failures a specific error code so that they can be retried.
-      FailureDetails.ExternalRepository externalRepoDetail =
-          e instanceof IOException
-              ? FailureDetails.ExternalRepository.newBuilder()
-                  .setCode(ExternalRepository.Code.REPOSITORY_MAPPING_IO_EXCEPTION)
-                  .build()
-              : FailureDetails.ExternalRepository.getDefaultInstance();
-      throw new RepositoryMappingResolutionException(
-          DetailedExitCode.of(
-              FailureDetail.newBuilder()
-                  .setExternalRepository(externalRepoDetail)
-                  .setMessage("error during computation of main repo mapping: " + e.getMessage())
-                  .build()),
-          e);
+      throw mainRepoMappingResolutionException(evalResult, mainRepoMappingKey, eventHandler);
     }
     return evalResult.get(mainRepoMappingKey).repositoryMapping();
+  }
+
+  /**
+   * The main repo mapping together with the flag aliases defined via {@code flag_alias()} in {@code
+   * MODULE.bazel} files. Both are needed to reparse the command line with correct values for
+   * label-typed and aliased flags.
+   */
+  public record MainRepoMappingAndFlagAliases(
+      RepositoryMapping mainRepoMapping, ImmutableMap<String, String> flagAliases) {}
+
+  /**
+   * Computes the {@linkplain #getMainRepoMapping main repo mapping} and the {@linkplain
+   * BazelDepGraphValue#getFlagAliases flag aliases} in a single Skyframe evaluation. The dep graph
+   * holding the flag aliases is already computed as part of the main repo mapping, so obtaining both
+   * together avoids a redundant evaluation.
+   */
+  public MainRepoMappingAndFlagAliases getMainRepoMappingAndFlagAliases(
+      ExtendedEventHandler eventHandler)
+      throws InterruptedException, RepositoryMappingResolutionException {
+    SkyKey mainRepoMappingKey = RepositoryMappingValue.key(RepositoryName.MAIN);
+    EvaluationResult<SkyValue> evalResult =
+        evaluate(
+            ImmutableList.of(mainRepoMappingKey, BazelDepGraphValue.KEY),
+            /* keepGoing= */ false,
+            DEFAULT_THREAD_COUNT,
+            eventHandler);
+    if (evalResult.hasError()) {
+      throw mainRepoMappingResolutionException(evalResult, mainRepoMappingKey, eventHandler);
+    }
+    return new MainRepoMappingAndFlagAliases(
+        ((RepositoryMappingValue) evalResult.get(mainRepoMappingKey)).repositoryMapping(),
+        ((BazelDepGraphValue) evalResult.get(BazelDepGraphValue.KEY)).getFlagAliases());
+  }
+
+  private RepositoryMappingResolutionException mainRepoMappingResolutionException(
+      EvaluationResult<? extends SkyValue> evalResult,
+      SkyKey mainRepoMappingKey,
+      ExtendedEventHandler eventHandler) {
+    ErrorInfo errorInfo = evalResult.getError(mainRepoMappingKey);
+    if (errorInfo == null) {
+      errorInfo = evalResult.getError();
+    }
+    Exception e = errorInfo.getException();
+    if (e == null && !errorInfo.getCycleInfo().isEmpty()) {
+      cyclesReporter.reportCycles(errorInfo.getCycleInfo(), mainRepoMappingKey, eventHandler);
+      return new RepositoryMappingResolutionException(
+          DetailedExitCode.of(
+              FailureDetail.newBuilder()
+                  .setExternalRepository(
+                      FailureDetails.ExternalRepository.newBuilder()
+                          .setCode(ExternalRepository.Code.REPOSITORY_MAPPING_RESOLUTION_FAILED)
+                          .build())
+                  .setMessage("cycles detected during computation of main repo mapping")
+                  .build()));
+    }
+    if (e instanceof DetailedException) {
+      return new RepositoryMappingResolutionException(
+          ((DetailedException) e).getDetailedExitCode(), e);
+    }
+    // An IOException at this early stage is often due to transient infrastructure issues. We
+    // give such failures a specific error code so that they can be retried.
+    FailureDetails.ExternalRepository externalRepoDetail =
+        e instanceof IOException
+            ? FailureDetails.ExternalRepository.newBuilder()
+                .setCode(ExternalRepository.Code.REPOSITORY_MAPPING_IO_EXCEPTION)
+                .build()
+            : FailureDetails.ExternalRepository.getDefaultInstance();
+    return new RepositoryMappingResolutionException(
+        DetailedExitCode.of(
+            FailureDetail.newBuilder()
+                .setExternalRepository(externalRepoDetail)
+                .setMessage("error during computation of main repo mapping: " + e.getMessage())
+                .build()),
+        e);
   }
 
   @Nullable


### PR DESCRIPTION
`MODULE.bazel` `flag_alias()` entries were aggregated by a standalone `SkyframeExecutor#getFlagAliases` method that ran its own `BazelDepGraphValue` evaluation, with the `rules_python` fallback aliases hard-coded next to it. `BlazeCommandDispatcher` then evaluated the dep graph a second time, immediately after computing the main repo mapping for option reparsing.

This change:

- Moves the alias aggregation (and the `rules_python` fallbacks) into `BazelDepGraphFunction`, exposing the result as a new `BazelDepGraphValue#getFlagAliases` field.
- Adds `SkyframeExecutor#getMainRepoMappingAndFlagAliases`, which returns the main repo mapping and the flag aliases from a single Skyframe evaluation. The dep graph is already a transitive dependency of the main repo mapping, so the previously separate `getFlagAliases` evaluation is no longer needed.
- Removes `getFlagAliases` and the hard-coded Python alias constants from `SkyframeExecutor`.

No behavior change: the alias map, canonicalization, and `rules_python` fallback logic are preserved verbatim.