### PR TITLE
[9.2.0] skyframe: report top-level aspect failures (https://github.com/bazelbuild/bazel/pull/29850)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeErrorProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeErrorProcessor.java
@@ -424,6 +424,16 @@ public final class SkyframeErrorProcessor {
     }
 
     Preconditions.checkNotNull(eventBus);
+    // Top-level aspect failures may be the only processed error in nokeep_going Skymeld.
+    if (errorKey instanceof TopLevelAspectsKey topLevelAspectsKey) {
+      if (individualErrorProcessingResult.isAnalysisError()) {
+        eventBus.post(
+            AnalysisFailureEvent.whileAnalyzingTarget(
+                topLevelAspectsKey.getBaseConfiguredTargetKey(),
+                individualErrorProcessingResult.analysisRootCauses()));
+      }
+      return;
+    }
     if (!(errorKey instanceof ConfiguredTargetKey)) {
       return;
     }

--- a/src/test/shell/integration/build_event_stream_test.sh
+++ b/src/test/shell/integration/build_event_stream_test.sh
@@ -908,9 +908,9 @@ function test_aspect_analysis_failure_no_target_summary() {
   expect_log 'last_message: true'
   expect_log_once '^build_tool_logs'
   expect_log_once '^completed '  # target completes due to -k
-  # One "aborted" for failed aspect analysis, another for target_summary_id
-  # announced by "completed" event asserted above
-  expect_log_n 'aborted' 2
+  # One "aborted" for failed aspect analysis, one for the target_configured
+  # event, and one for the target_summary_id announced by "completed" above.
+  expect_log_n '^aborted' 3
   expect_not_log '^target_summary '  # no summary due to analysis failure
 }
 


### PR DESCRIPTION
OutputArtifactConflictTest flakes under Skymeld + nokeep_going because
evaluation can abort with a TopLevelAspectsKey as the only processed
analysis error.

A local stress run on origin/master reproduced the flake with:

```text
bazel test --nocache_test_results --runs_per_test=50 \
  --test_filter=testConflictErrorAndUnfinishedAspectAnalysis_mergedAnalysisExecution \
  //src/test/java/com/google/devtools/build/lib/buildtool:OutputArtifactConflictTest
```

The failing run looked like this:

```text
FAIL: ...OutputArtifactConflictTest (shard 3 of 3, run 32 of 50)
testConflictErrorAndUnfinishedAspectAnalysis_mergedAnalysisExecution
[skymeld=true,minimizeMemory=true,keepGoing=false]
expected to contain any of:
  [//x:y, //x/y:y, //x:fail_analysis]
but was                   : []
```

The existing error processor skipped non-configured-target keys in this
path, so BEP consumers could miss the AnalysisFailureEvent even though the
analysis error was reported to the event handler.

Report failures against the top-level aspect's base configured target so
the failure is emitted on the same path used for configured target keys.
Update the BEP integration test expectation for the additional aborted
event that is now reported.

Local validation:
- Reproduced the baseline flake on origin/master
  (a300dd5bb97283ce734b756cbafecb8312e8c3aa): failed on run 32/50
  with empty `analysisFailures`.
- Verified the CopyOnWriteArrayList-only test-listener change still failed
  on run 10/50 with the same empty-list assertion.
- Verified this patch without the listener-list change passed 50/50 and
  100/100 local stress runs of the same filtered test.

Closes #29850.

PiperOrigin-RevId: 936417007
Change-Id: If2ea9a4b157fb6d646608a8adfb2c5f4d12de5c4

Commit https://github.com/bazelbuild/bazel/commit/8d8826c8cc98ad5de8d103a17d68990f7e6ea111