### PR TITLE
Apply shebang portability fix to newly added shell scripts

### DIFF
--- a/src/main/cpp/generate_jvm_module_options.sh
+++ b/src/main/cpp/generate_jvm_module_options.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 The Bazel Authors. All rights reserved.
 #


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->
Change the shebang in `src/main/cpp/generate_jvm_module_options.sh` from `#!/bin/bash` to `#!/usr/bin/env bash`.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->
On systems like OpenBSD where bash is not located at `/bin/bash`, build failures occur due to this issue.  
Other shell scripts in the repository already use `#!/usr/bin/env bash`, and this script should  align with that convention.

Fixes #28979
Related 11717a16b8ecf4e1e601c39c8b4cfe4728954634

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
