### PR TITLE
Fix carriage return handling for posix compatibility

### DIFF
--- a/src/main/cpp/generate_jvm_module_options.sh
+++ b/src/main/cpp/generate_jvm_module_options.sh
@@ -46,7 +46,7 @@ if [[ -f "${JAR_FILE}" ]]; then
   # We first join continuation lines in the manifest, then grep for the headers we
   # care about, and then process them.
   unzip -p "${JAR_FILE}" META-INF/MANIFEST.MF 2>/dev/null | \
-      sed -e 's/\r$//' | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n / /g' | \
+      tr -d '\r' | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n / /g' | \
       grep -E '^(Add-Exports|Add-Opens):' | \
       while read -r line; do
           if [[ "$line" =~ ^Add-Exports: ]]; then


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

Replace `sed -e 's/\r$//'` with `tr -d '\r'` in src/main/cpp/generate_jvm_module_options.sh for POSIX portability.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

The \r escape sequence is unspecified in POSIX sed, causing failures on OpenBSD and other BSD variants.  
Use tr -d '\r' instead for portable carriage return removal.  

Fixes #28981

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
