### PR TITLE
Move --experimental_add_test_support_to_compile_time_deps to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -589,6 +589,16 @@ public final class BazelRulesModule extends BlazeModule {
         help = "Deprecated no-op.")
     public abstract boolean getDisableLegacyCcProvider();
 
+    @Deprecated
+    @Option(
+        name = "experimental_add_test_support_to_compile_time_deps",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.EXPERIMENTAL, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getAddTestSupportToCompileTimeDeps();
+
     @Option(
         name = "python_path",
         defaultValue = "",

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
@@ -93,7 +93,6 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
   private final boolean enforceProguardFileExtension;
   private final boolean runAndroidLint;
   private final boolean explicitJavaTestDeps;
-  private final boolean addTestSupportToCompileTimeDeps;
   private final ImmutableList<Label> pluginList;
   private final boolean experimentalTurbineAnnotationProcessing;
   private final int experimentalTurbineCpuReservation;
@@ -126,7 +125,6 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
     this.enforceOneVersion = javaOptions.getEnforceOneVersion();
     this.enforceOneVersionOnJavaTests = javaOptions.getEnforceOneVersionOnJavaTests();
     this.explicitJavaTestDeps = javaOptions.getExplicitJavaTestDeps();
-    this.addTestSupportToCompileTimeDeps = javaOptions.getAddTestSupportToCompileTimeDeps();
     this.runAndroidLint = javaOptions.getRunAndroidLint();
     this.multiReleaseDeployJars = javaOptions.getMultiReleaseDeployJars();
     this.disallowJavaImportExports = javaOptions.getDisallowJavaImportExports();
@@ -379,11 +377,6 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
   @Override
   public boolean enforceOneVersionOnJavaTests() {
     return enforceOneVersionOnJavaTests;
-  }
-
-  @Override
-  public boolean addTestSupportToCompileTimeDeps() {
-    return addTestSupportToCompileTimeDeps;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -335,17 +335,6 @@ public abstract class JavaOptions extends FragmentOptions {
   public abstract boolean getEnforceOneVersionOnJavaTests();
 
   @Option(
-      name = "experimental_add_test_support_to_compile_time_deps",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
-      help =
-          "Flag to help transition away from adding test support libraries to the compile-time"
-              + " deps of Java test rules.")
-  public abstract boolean getAddTestSupportToCompileTimeDeps();
-
-  @Option(
       name = "experimental_run_android_lint_on_java_rules",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaConfigurationApi.java
@@ -80,9 +80,6 @@ public interface JavaConfigurationApi extends StarlarkValue {
       documented = false)
   boolean enforceOneVersionOnJavaTests();
 
-  @StarlarkMethod(name = "add_test_support_to_compile_deps", structField = true, documented = false)
-  boolean addTestSupportToCompileTimeDeps();
-
   @StarlarkMethod(
       name = "run_android_lint",
       structField = true,

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -324,7 +324,6 @@ bazel_fragments["JavaOptions"] = fragment(
         "//command_line_option:experimental_fix_deps_tool",
         "//command_line_option:experimental_one_version_enforcement",
         "//command_line_option:one_version_enforcement_on_java_tests",
-        "//command_line_option:experimental_add_test_support_to_compile_time_deps",
         "//command_line_option:java_runtime_version",
         "//command_line_option:java_language_version",
         "//command_line_option:bytecode_optimizers",


### PR DESCRIPTION
## Summary

--experimental_add_test_support_to_compile_time_deps was introduced enabled in August 2018 by 54e31ac836. Its only remaining rule consumer was removed in March 2023 by fbdf2c1add, when explicit_java_test_deps became the sole control for Java test support compile-time dependencies.

This removes the option, Java configuration field, private Starlark accessor, and exec-transition propagation. A deprecated graveyard no-op keeps existing command lines accepted.

## Impact

The flag no longer changes Java rule behavior. This removes dead native configuration and transition state without changing Java test compile-time dependencies.

## Validation

- //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest
- //src/test/java/com/google/devtools/build/lib/analysis/starlark:StarlarkAttrTransitionProviderTest
- //src/test/java/com/google/devtools/build/lib/starlark:StarlarkIntegrationTest