### PR TITLE
Move --split_bytecode_optimization_pass to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -589,6 +589,16 @@ public final class BazelRulesModule extends BlazeModule {
         help = "Deprecated no-op.")
     public abstract boolean getDisableLegacyCcProvider();
 
+    @Deprecated
+    @Option(
+        name = "split_bytecode_optimization_pass",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getSplitBytecodeOptimizationPass();
+
     @Option(
         name = "python_path",
         defaultValue = "",

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
@@ -88,7 +88,6 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
   private final NamedLabel bytecodeOptimizer;
   private final boolean runLocalJavaOptimizations;
   private final Label localJavaOptimizationConfiguration;
-  private final boolean splitBytecodeOptimizationPass;
   private final int bytecodeOptimizationPassActions;
   private final boolean enforceProguardFileExtension;
   private final boolean runAndroidLint;
@@ -120,7 +119,6 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
     this.proguardBinary = javaOptions.getProguard();
     this.runLocalJavaOptimizations = javaOptions.getRunLocalJavaOptimizations();
     this.localJavaOptimizationConfiguration = javaOptions.getLocalJavaOptimizationConfiguration();
-    this.splitBytecodeOptimizationPass = javaOptions.getSplitBytecodeOptimizationPass();
     this.bytecodeOptimizationPassActions = javaOptions.getBytecodeOptimizationPassActions();
     this.enforceProguardFileExtension = javaOptions.getEnforceProguardFileExtension();
     this.enforceOneVersion = javaOptions.getEnforceOneVersion();
@@ -254,19 +252,15 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
     return proguardBinary;
   }
 
-  /**
-   * Returns whether the OPTIMIZATION stage of the bytecode optimizer will be split across two
-   * actions.
-   */
+  /** Returns false for Starlark API compatibility. */
   @Override
   public boolean splitBytecodeOptimizationPass() {
-    return splitBytecodeOptimizationPass;
+    return false;
   }
 
   /**
    * This specifies the number of actions to divide the OPTIMIZATION stage of the bytecode optimizer
-   * into. Note that if split_bytecode_optimization_pass is set, this will only change behavior if
-   * it is > 2.
+   * into.
    */
   @Override
   public int bytecodeOptimizationPassActions() {

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -277,20 +277,9 @@ public abstract class JavaOptions extends FragmentOptions {
       help = "Do not use.")
   public abstract Label getLocalJavaOptimizationConfiguration();
 
-  // TODO(b/237004872) Remove this after rollout of bytecode_optimization_pass_actions.
-  /** If true, the OPTIMIZATION stage of the bytecode optimizer will be split across two actions. */
-  @Option(
-      name = "split_bytecode_optimization_pass",
-      defaultValue = "false",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      help = "Do not use.")
-  public abstract boolean getSplitBytecodeOptimizationPass();
-
   /**
    * This specifies the number of actions to divide the OPTIMIZATION stage of the bytecode optimizer
-   * into. Note that if split_bytecode_optimization_pass is set, bytecode_optimization_pass_actions
-   * will only effectively change build behavior if it is > 2.
+   * into.
    */
   @Option(
       name = "bytecode_optimization_pass_actions",

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaConfigurationApi.java
@@ -134,9 +134,7 @@ public interface JavaConfigurationApi extends StarlarkValue {
   @StarlarkMethod(
       name = "split_bytecode_optimization_pass",
       structField = true,
-      doc =
-          "Returns whether the OPTIMIZATION stage of the bytecode optimizer will be split across"
-              + " two actions.")
+      doc = "Deprecated. Always false; use bytecode_optimization_pass_actions.")
   boolean splitBytecodeOptimizationPass();
 
   @StarlarkMethod(
@@ -144,8 +142,7 @@ public interface JavaConfigurationApi extends StarlarkValue {
       structField = true,
       doc =
           "This specifies the number of actions to divide the OPTIMIZATION stage of the bytecode"
-              + " optimizer into. Note that if split_bytecode_optimization_pass is set, this will"
-              + " only change behavior if it is > 2.")
+              + " optimizer into.")
   int bytecodeOptimizationPassActions();
 
   @StarlarkMethod(

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -328,7 +328,6 @@ bazel_fragments["JavaOptions"] = fragment(
         "//command_line_option:java_runtime_version",
         "//command_line_option:java_language_version",
         "//command_line_option:bytecode_optimizers",
-        "//command_line_option:split_bytecode_optimization_pass",
         "//command_line_option:bytecode_optimization_pass_actions",
         "//command_line_option:enforce_proguard_file_extension",
         "//command_line_option:proguard_top",


### PR DESCRIPTION
## Summary

--split_bytecode_optimization_pass was introduced disabled in August 2020 by a5842e765c. It was superseded in July 2022 by 2b44482eb7, which added --bytecode_optimization_pass_actions and a TODO to remove the boolean after rollout.

This removes the native option and exec-transition propagation. The private Starlark field temporarily returns false for compatibility with released rules_android versions, and a deprecated graveyard no-op preserves command-line parsing.

## Impact

Users that need two optimizer actions should use --bytecode_optimization_pass_actions=2. The replacement supports the general N-action behavior.

## Validation

- //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest
- //src/test/java/com/google/devtools/build/lib/rules/java:JavaConfigurationTest
- //src/test/java/com/google/devtools/build/lib/analysis/starlark:StarlarkAttrTransitionProviderTest