### PR TITLE
Move --incompatible_multi_release_deploy_jars to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -609,6 +609,16 @@ public final class BazelRulesModule extends BlazeModule {
         help = "Deprecated no-op.")
     public abstract boolean getUseSpecificToolFiles();
 
+    @Deprecated
+    @Option(
+        name = "incompatible_multi_release_deploy_jars",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getMultiReleaseDeployJars();
+
     @Option(
         name = "python_path",
         defaultValue = "",

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
@@ -98,7 +98,6 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
   private final boolean experimentalTurbineAnnotationProcessing;
   private final int experimentalTurbineCpuReservation;
   private final boolean experimentalEnableJspecify;
-  private final boolean multiReleaseDeployJars;
   private final boolean disallowJavaImportExports;
   private final boolean autoCreateDeployJarForJavaTests;
 
@@ -128,7 +127,6 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
     this.explicitJavaTestDeps = javaOptions.getExplicitJavaTestDeps();
     this.addTestSupportToCompileTimeDeps = javaOptions.getAddTestSupportToCompileTimeDeps();
     this.runAndroidLint = javaOptions.getRunAndroidLint();
-    this.multiReleaseDeployJars = javaOptions.getMultiReleaseDeployJars();
     this.disallowJavaImportExports = javaOptions.getDisallowJavaImportExports();
     this.autoCreateDeployJarForJavaTests = javaOptions.getAutoCreateDeployJarForJavaTests();
     Map<String, Label> optimizers = javaOptions.getBytecodeOptimizers();
@@ -353,7 +351,7 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
 
   @Override
   public boolean multiReleaseDeployJars() {
-    return multiReleaseDeployJars;
+    return true;
   }
 
   /** Returns true if java_import exports are not allowed. */

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -417,15 +417,6 @@ public abstract class JavaOptions extends FragmentOptions {
   public abstract String getHostJavaLanguageVersion();
 
   @Option(
-      name = "incompatible_multi_release_deploy_jars",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help = "When enabled, java_binary creates Multi-Release deploy jars.")
-  public abstract boolean getMultiReleaseDeployJars();
-
-  @Option(
       name = "incompatible_disallow_java_import_exports",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaConfigurationApi.java
@@ -98,7 +98,7 @@ public interface JavaConfigurationApi extends StarlarkValue {
   @StarlarkMethod(
       name = "multi_release_deploy_jars",
       structField = true,
-      doc = "The value of the --incompatible_multi_release_deploy_jars flag.")
+      doc = "Always true. Java deploy jars preserve multi-release entries.")
   boolean multiReleaseDeployJars();
 
   @StarlarkMethod(

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -337,7 +337,6 @@ bazel_fragments["JavaOptions"] = fragment(
         "//command_line_option:tool_java_language_version",
         "//command_line_option:experimental_turbine_annotation_processing",
         "//command_line_option:experimental_turbine_cpu_reservation",
-        "//command_line_option:incompatible_multi_release_deploy_jars",
         "//command_line_option:incompatible_disallow_java_import_exports",
         "//command_line_option:experimental_enable_jspecify",
         "//command_line_option:experimental_java_test_auto_create_deploy_jar",


### PR DESCRIPTION
## Summary

--incompatible_multi_release_deploy_jars was introduced disabled in March 2022 by 7f75df2d29 and enabled by default in November 2023 by 1d7af7ea70. The rollout issue was closed in March 2024 after the behavior had run in Blaze for roughly a year without known problems.

This makes multi-release deploy jars unconditional, removes the native option and exec-transition propagation, and retains a deprecated graveyard no-op. The private Starlark field temporarily returns true for compatibility with released rules_java versions.

## Impact

Java deploy jars always preserve multi-release entries. Existing command lines using the flag remain accepted.

## Validation

- //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest
- //src/test/java/com/google/devtools/build/lib/rules/java:JavaConfigurationTest
- //src/test/java/com/google/devtools/build/lib/analysis/starlark:StarlarkAttrTransitionProviderTest