### PR TITLE
Move --experimental_java_test_auto_create_deploy_jar to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -589,6 +589,16 @@ public final class BazelRulesModule extends BlazeModule {
         help = "Deprecated no-op.")
     public abstract boolean getDisableLegacyCcProvider();
 
+    @Deprecated
+    @Option(
+        name = "experimental_java_test_auto_create_deploy_jar",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.EXPERIMENTAL, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getJavaTestAutoCreateDeployJar();
+
     @Option(
         name = "python_path",
         defaultValue = "",

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
@@ -100,7 +100,6 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
   private final boolean experimentalEnableJspecify;
   private final boolean multiReleaseDeployJars;
   private final boolean disallowJavaImportExports;
-  private final boolean autoCreateDeployJarForJavaTests;
 
   public JavaConfiguration(BuildOptions buildOptions) throws InvalidConfigurationException {
     JavaOptions javaOptions = buildOptions.get(JavaOptions.class);
@@ -130,7 +129,6 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
     this.runAndroidLint = javaOptions.getRunAndroidLint();
     this.multiReleaseDeployJars = javaOptions.getMultiReleaseDeployJars();
     this.disallowJavaImportExports = javaOptions.getDisallowJavaImportExports();
-    this.autoCreateDeployJarForJavaTests = javaOptions.getAutoCreateDeployJarForJavaTests();
     Map<String, Label> optimizers = javaOptions.getBytecodeOptimizers();
     if (optimizers.size() != 1) {
       throw new InvalidConfigurationException(
@@ -411,7 +409,7 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
   @Override
   public boolean autoCreateJavaTestDeployJars(StarlarkThread thread) throws EvalException {
     BuiltinRestriction.failIfCalledOutsideDefaultAllowlist(thread);
-    return autoCreateDeployJarForJavaTests;
+    return false;
   }
 
   // TODO: b/417791104 - Remove this method once usages are removed.

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -442,13 +442,4 @@ public abstract class JavaOptions extends FragmentOptions {
       metadataTags = {OptionMetadataTag.EXPERIMENTAL},
       help = "Enable experimental jspecify integration.")
   public abstract boolean getExperimentalEnableJspecify();
-
-  @Option(
-      name = "experimental_java_test_auto_create_deploy_jar",
-      defaultValue = "false",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
-      help = "DO NOT USE")
-  public abstract boolean getAutoCreateDeployJarForJavaTests();
 }

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -342,7 +342,6 @@ bazel_fragments["JavaOptions"] = fragment(
         "//command_line_option:incompatible_multi_release_deploy_jars",
         "//command_line_option:incompatible_disallow_java_import_exports",
         "//command_line_option:experimental_enable_jspecify",
-        "//command_line_option:experimental_java_test_auto_create_deploy_jar",
         "//command_line_option:experimental_run_android_lint_on_java_rules",
     ],
     outputs = [


### PR DESCRIPTION
## Summary

--experimental_java_test_auto_create_deploy_jar was introduced disabled in December 2023 by 103830fd64 as a temporary workaround for bazelbuild/intellij#5845. IntelliJ removed its only known consumer in September 2025 through bazelbuild/intellij#7868.

This removes the native option and exec-transition propagation. The private Starlark field temporarily returns false for compatibility with released rules_java versions, and a deprecated graveyard no-op preserves command-line parsing.

## Impact

The unused hidden auto deploy jar behavior is removed. Existing command lines using the flag remain accepted.

## Validation

- //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest
- //src/test/java/com/google/devtools/build/lib/analysis/starlark:StarlarkAttrTransitionProviderTest
- //src/test/java/com/google/devtools/build/lib/starlark:StarlarkIntegrationTest