### PR TITLE
Stop propagating --experimental_run_android_lint_on_java_rules to exec

### DIFF
--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -343,7 +343,6 @@ bazel_fragments["JavaOptions"] = fragment(
         "//command_line_option:incompatible_disallow_java_import_exports",
         "//command_line_option:experimental_enable_jspecify",
         "//command_line_option:experimental_java_test_auto_create_deploy_jar",
-        "//command_line_option:experimental_run_android_lint_on_java_rules",
     ],
     outputs = [
         "//command_line_option:jvmopt",

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/ExecutionTransitionFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/ExecutionTransitionFactoryTest.java
@@ -234,6 +234,8 @@ public class ExecutionTransitionFactoryTest extends BuildViewTestCase {
             // Skipping this explicitly as propagating it causes a cycle when compiling
             // the optimizer itself.
             .filter(o -> !o.getKey().equals("experimental_local_java_optimizations"))
+            // Android lint validation actions do not run in exec configurations.
+            .filter(o -> !o.getKey().equals("experimental_run_android_lint_on_java_rules"))
             // A rare (only?) case of a flag named "--experimental_..." that isn't
             // actually experimental.
             .filter(o -> !o.getKey().equals("experimental_deps_ok"))


### PR DESCRIPTION
## Summary

--experimental_run_android_lint_on_java_rules was introduced disabled in December 2020 by 909bec5afe. Its native exec transition intentionally did not propagate the flag because Android lint validation actions do not run in exec configurations.

The propagation entry was added mechanically in October 2024 by 8cbd6a3034. Current rules_java explicitly skips Android lint for tool configurations, so this removes transition state with no exec-configuration consumer and documents the exception in ExecutionTransitionFactoryTest.

## Impact

Target-configuration Android lint behavior is unchanged. Exec configurations use the false default, matching the original native transition and current rules_java behavior.

## Validation

- //src/test/java/com/google/devtools/build/lib/analysis/config:ExecutionTransitionFactoryTest