### PR TITLE
Don't GC dirty nodes that change pruning would verify clean

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/AnalysisOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AnalysisOptions.java
@@ -110,6 +110,19 @@ public abstract class AnalysisOptions extends OptionsBase {
   public abstract long getVersionWindowForDirtyNodeGc();
 
   @Option(
+      name = "experimental_keep_change_prunable_nodes_during_gc",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      metadataTags = OptionMetadataTag.EXPERIMENTAL,
+      effectTags = {OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS},
+      help =
+          "If enabled, the dirty node garbage collection triggered by"
+              + " --version_window_for_dirty_node_gc keeps dirty nodes that change pruning would"
+              + " mark clean when they are next requested, at the cost of a scan over all dirty"
+              + " nodes at the end of the build.")
+  public abstract boolean getKeepChangePrunableNodesDuringGc();
+
+  @Option(
       name = "experimental_skyframe_cpu_heavy_skykeys_thread_pool_size",
       defaultValue = ResourceConverter.HOST_CPUS_KEYWORD,
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java
@@ -427,7 +427,9 @@ public class BuildTool {
         // Delete dirty nodes to ensure that they do not accumulate indefinitely.
         long versionWindow = request.getViewOptions().getVersionWindowForDirtyNodeGc();
         if (versionWindow != -1) {
-          env.getSkyframeExecutor().deleteOldNodes(versionWindow);
+          env.getSkyframeExecutor()
+              .deleteOldNodes(
+                  versionWindow, request.getViewOptions().getKeepChangePrunableNodesDuringGc());
         }
         // The workspace status actions will not run with certain flags, or if an error occurs early
         // in the build. Ensure that build info is posted on every build.

--- a/src/main/java/com/google/devtools/build/lib/buildtool/PostAnalysisQueryProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/PostAnalysisQueryProcessor.java
@@ -89,7 +89,8 @@ public abstract class PostAnalysisQueryProcessor<T> implements BuildTool.Analysi
     //  reproducible at the level of a single command. Either tolerate, or wipe the analysis graph
     //  beforehand if this option is specified, or add another option to wipe if desired
     //  (SkyframeExecutor#handleAnalysisInvalidatingChange should be sufficient).
-    env.getSkyframeExecutor().deleteOldNodes(/* versionWindowForDirtyGc= */ 0);
+    env.getSkyframeExecutor()
+        .deleteOldNodes(/* versionWindowForDirtyGc= */ 0, /* keepChangePrunableNodes= */ false);
     env.getSkyframeExecutor().applyInvalidation(env.getReporter());
     if (!env.getSkyframeExecutor().tracksStateForIncrementality()) {
       throw new ExitException(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
@@ -800,11 +800,11 @@ public class SequencedSkyframeExecutor extends SkyframeExecutor {
   }
 
   @Override
-  public void deleteOldNodes(long versionWindowForDirtyGc) {
+  public void deleteOldNodes(long versionWindowForDirtyGc, boolean keepChangePrunableNodes) {
     // TODO(bazel-team): perhaps we should come up with a separate GC class dedicated to maintaining
     // value garbage. If we ever do so, this logic should be moved there.
     if (trackIncrementalState) {
-      memoizingEvaluator.deleteDirty(versionWindowForDirtyGc);
+      memoizingEvaluator.deleteDirty(versionWindowForDirtyGc, keepChangePrunableNodes);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -3178,8 +3178,12 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
    * <p>Specifying a value N means, if the current version is V and a value was dirtied (and has
    * remained so) in version U, and U + N &lt;= V, then the value will be marked for deletion and
    * purged in version V+1.
+   *
+   * <p>If {@code keepChangePrunableNodes} is true, dirty values that change pruning would mark
+   * clean when they are next requested are exempt from deletion.
    */
-  public abstract void deleteOldNodes(long versionWindowForDirtyGc);
+  public abstract void deleteOldNodes(
+      long versionWindowForDirtyGc, boolean keepChangePrunableNodes);
 
   @Nullable
   public PackageProgressReceiver getPackageProgressReceiver() {

--- a/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
@@ -23,6 +23,7 @@ import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multisets;
 import com.google.common.collect.Sets;
@@ -39,6 +40,7 @@ import com.google.devtools.build.skyframe.InvalidatingNodeVisitor.DirtyingInvali
 import com.google.devtools.build.skyframe.InvalidatingNodeVisitor.InvalidationState;
 import com.google.devtools.build.skyframe.SkyframeGraphStatsEvent.EvaluationStats;
 import com.google.errorprone.annotations.ForOverride;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.io.PrintStream;
 import java.time.Duration;
 import java.util.ArrayDeque;
@@ -253,9 +255,9 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
     // Keep dirty nodes that change pruning would verify clean without rebuilding as their value is
     // still valid, they just weren't in scope for the last evaluation. Keeping them matches the
     // behavior for done but unrequested nodes.
-    HashMultiset<SkyKey> remainingDirtyDeps = HashMultiset.create();
-    HashMultimap<SkyKey, SkyKey> dirtyRdeps = HashMultimap.create();
-    ArrayDeque<SkyKey> ready = new ArrayDeque<>();
+    var remainingDirtyDeps = new Object2IntOpenHashMap<SkyKey>();
+    var dirtyRdeps = MultimapBuilder.hashKeys().arrayListValues(2).<SkyKey, SkyKey>build();
+    var ready = new ArrayDeque<SkyKey>();
     for (SkyKey skyKey : candidates) {
       if (!(graph.getIfPresent(skyKey) instanceof IncrementalInMemoryNodeEntry entry)) {
         continue;
@@ -270,15 +272,20 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
       for (SkyKey dep : lastBuildDeps) {
         NodeEntry depEntry = graph.getIfPresent(dep);
         // A dep must be present and unchanged since this node was last evaluated (mirrors
-        // childVersion.atMost(version.lastEvaluated()) in signalDep). A dep that is itself dirty must
-        // additionally be kept; the worklist decides that (a dirty dep that is never kept leaves this
-        // node's count above zero, so it is not kept either -- including non-candidate dirty deps,
-        // which are never processed below).
+        // childVersion.atMost(version.lastEvaluated()) in signalDep). A dep that is itself dirty
+        // must additionally be kept; the worklist below decides that for candidate dirty deps. A
+        // dirty dep that is not a candidate is never processed by the worklist and so can never be
+        // kept, which makes this node unkeepable too -- short-circuit instead of tracking a count
+        // that can never reach zero.
         if (depEntry == null || !depEntry.getVersion().atMost(lastEvaluated)) {
           keepable = false;
           break;
         }
         if (!depEntry.isDone()) {
+          if (!candidates.contains(dep)) {
+            keepable = false;
+            break;
+          }
           dirtyDepsBuilder.add(dep);
         }
       }
@@ -289,7 +296,7 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
       if (dirtyDeps.isEmpty()) {
         ready.add(skyKey); // All deps already done and unchanged.
       } else {
-        remainingDirtyDeps.add(skyKey, dirtyDeps.size());
+        remainingDirtyDeps.addTo(skyKey, dirtyDeps.size());
         for (SkyKey dirtyDep : dirtyDeps) {
           dirtyRdeps.put(dirtyDep, skyKey);
         }
@@ -300,7 +307,7 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
       SkyKey skyKey = ready.poll();
       kept.add(skyKey);
       for (SkyKey rdep : dirtyRdeps.get(skyKey)) {
-        if (remainingDirtyDeps.remove(rdep, 1) == 1) {
+        if (remainingDirtyDeps.addTo(rdep, -1) == 1) {
           ready.add(rdep);
         }
       }

--- a/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
@@ -16,12 +16,10 @@ package com.google.devtools.build.skyframe;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static java.lang.Math.min;
 
 import com.google.common.base.Predicates;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.HashMultiset;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -29,8 +27,6 @@ import com.google.common.collect.Multiset;
 import com.google.common.collect.Multisets;
 import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.concurrent.AbstractQueueVisitor;
-import com.google.devtools.build.lib.concurrent.ForkJoinQuiescingExecutor;
-import com.google.devtools.build.lib.concurrent.NamedForkJoinPool;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.profiler.AutoProfiler;
 import com.google.devtools.build.lib.profiler.GoogleAutoProfilerUtils;
@@ -46,21 +42,16 @@ import com.google.devtools.build.skyframe.SkyframeGraphStatsEvent.EvaluationStat
 import com.google.errorprone.annotations.ForOverride;
 import java.io.PrintStream;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -284,135 +275,6 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
               checkState(entry.isDirty(), skyKey);
               return entry.getVersion().atMost(threshold);
             }));
-  }
-
-  /**
-   * Finds the dirty nodes that change pruning would verify clean if it ran, which it doesn't purely
-   * because these nodes weren't in scope for the current evaluation.
-   *
-   * <p>Operates in two phases: a parallel scan over all candidates that builds a DAG of dirty but
-   * unchanged deletion candidates and their dirty rdeps, followed by a traversal of the DAG that
-   * keeps all nodes whose dirty deps are also kept. The scan performs all graph accesses and its
-   * cost scales with the total number of candidates, so it runs on multiple threads; the traversal
-   * only visits the nodes that end up being kept.
-   */
-  private static final class ChangePrunableNodesFinder {
-    private static final int SCAN_THREAD_COUNT = Runtime.getRuntime().availableProcessors();
-
-    private final InMemoryGraph graph;
-    private final ImmutableSet<SkyKey> candidates;
-
-    // The DAG built by the scan phase: for each candidate with at least one dirty dep, the number
-    // of its dirty deps not yet known to be kept, together with the reverse edges. Candidates
-    // without dirty deps start out ready. Each entry in remainingDirtyDeps is written by a single
-    // scan thread, whereas dirtyRdeps values may receive edges from multiple threads.
-    private final ConcurrentHashMap<SkyKey, AtomicInteger> remainingDirtyDeps =
-        new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<SkyKey, ArrayList<SkyKey>> dirtyRdeps =
-        new ConcurrentHashMap<>();
-    private final ConcurrentLinkedQueue<SkyKey> ready = new ConcurrentLinkedQueue<>();
-
-    ChangePrunableNodesFinder(InMemoryGraph graph, ImmutableSet<SkyKey> candidates) {
-      this.graph = graph;
-      this.candidates = candidates;
-    }
-
-    ImmutableSet<SkyKey> find() {
-      ImmutableList<SkyKey> candidateList = candidates.asList();
-      if (candidateList.isEmpty()) {
-        return ImmutableSet.of();
-      }
-
-      var executor =
-          ForkJoinQuiescingExecutor.newBuilder()
-              .withOwnershipOf(
-                  NamedForkJoinPool.newNamedPool("find-change-prunable-nodes", SCAN_THREAD_COUNT))
-              .build();
-      long listSize = candidateList.size();
-      long numJobs = min(SCAN_THREAD_COUNT, listSize);
-      for (long i = 0; i < numJobs; i++) {
-        int startIndex = (int) ((i * listSize) / numJobs);
-        int endIndex = (int) (((i + 1) * listSize) / numJobs);
-        List<SkyKey> chunk = candidateList.subList(startIndex, endIndex);
-        executor.execute(() -> scanCandidates(chunk));
-      }
-      try {
-        executor.awaitQuiescence(/* interruptWorkers= */ true);
-      } catch (InterruptedException e) {
-        // Keeping no nodes is always safe, it merely GCs more aggressively.
-        Thread.currentThread().interrupt();
-        return ImmutableSet.of();
-      }
-
-      // Now visit the DAG, keeping all nodes whose dirty deps are also kept.
-      var toKeep = ImmutableSet.<SkyKey>builder();
-      SkyKey readyKey;
-      while ((readyKey = ready.poll()) != null) {
-        toKeep.add(readyKey);
-        var rdeps = dirtyRdeps.get(readyKey);
-        if (rdeps == null) {
-          continue;
-        }
-        for (var rdep : rdeps) {
-          if (remainingDirtyDeps.get(rdep).decrementAndGet() == 0) {
-            // The last dirty dep of rdep is now known to be kept.
-            ready.add(rdep);
-          }
-        }
-      }
-      return toKeep.build();
-    }
-
-    private void scanCandidates(List<SkyKey> chunk) {
-      skipCandidate:
-      for (var skyKey : chunk) {
-        if (Thread.currentThread().isInterrupted()) {
-          // A partial scan only ever results in fewer nodes being kept, which is always safe.
-          return;
-        }
-        if (!(graph.getIfPresent(skyKey) instanceof IncrementalInMemoryNodeEntry entry)) {
-          continue;
-        }
-        Iterable<SkyKey> lastBuildDeps = entry.lastBuildDepsIfChangePrunable();
-        if (lastBuildDeps == null) {
-          continue;
-        }
-        Version lastEvaluated = entry.lastEvaluatedVersion();
-        var dirtyDeps = new ArrayList<SkyKey>();
-        for (var dep : lastBuildDeps) {
-          NodeEntry depEntry = graph.getIfPresent(dep);
-          // A dep must be present and unchanged since this node was last evaluated to be
-          // potentially change-prunable. Undone deps that aren't unenqueued dirty deps will never
-          // be considered below and thus make an entry not change-prunable.
-          if (depEntry == null || !depEntry.getVersion().atMost(lastEvaluated)) {
-            continue skipCandidate;
-          }
-          if (depEntry.isDone()) {
-            continue;
-          }
-          if (!candidates.contains(dep)) {
-            continue skipCandidate;
-          }
-          dirtyDeps.add(dep);
-        }
-        if (dirtyDeps.isEmpty()) {
-          ready.add(skyKey);
-        } else {
-          remainingDirtyDeps.put(skyKey, new AtomicInteger(dirtyDeps.size()));
-          for (var dirtyDep : dirtyDeps) {
-            dirtyRdeps.compute(
-                dirtyDep,
-                (unusedKey, rdeps) -> {
-                  if (rdeps == null) {
-                    rdeps = new ArrayList<>();
-                  }
-                  rdeps.add(skyKey);
-                  return rdeps;
-                });
-          }
-        }
-      }
-    }
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.base.Predicates;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multiset;
@@ -40,6 +41,7 @@ import com.google.devtools.build.skyframe.SkyframeGraphStatsEvent.EvaluationStat
 import com.google.errorprone.annotations.ForOverride;
 import java.io.PrintStream;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -245,11 +247,73 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
   public final void deleteDirty(long versionAgeLimit) {
     checkArgument(versionAgeLimit >= 0, versionAgeLimit);
     Version threshold = IntVersion.of(lastGraphVersion.getVal() - versionAgeLimit);
+    var graph = getInMemoryGraph();
+    Set<SkyKey> candidates = progressReceiver.getUnenqueuedDirtyKeys();
+
+    // Keep dirty nodes that change pruning would verify clean without rebuilding as their value is
+    // still valid, they just weren't in scope for the last evaluation. Keeping them matches the
+    // behavior for done but unrequested nodes.
+    HashMultiset<SkyKey> remainingDirtyDeps = HashMultiset.create();
+    HashMultimap<SkyKey, SkyKey> dirtyRdeps = HashMultimap.create();
+    ArrayDeque<SkyKey> ready = new ArrayDeque<>();
+    for (SkyKey skyKey : candidates) {
+      if (!(graph.getIfPresent(skyKey) instanceof IncrementalInMemoryNodeEntry entry)) {
+        continue;
+      }
+      Iterable<SkyKey> lastBuildDeps = entry.lastBuildDepsIfChangePrunable();
+      if (lastBuildDeps == null) {
+        continue; // Not change-prunable -> eligible for deletion.
+      }
+      Version lastEvaluated = entry.lastEvaluatedVersion();
+      ImmutableList.Builder<SkyKey> dirtyDepsBuilder = ImmutableList.builder();
+      boolean keepable = true;
+      for (SkyKey dep : lastBuildDeps) {
+        NodeEntry depEntry = graph.getIfPresent(dep);
+        // A dep must be present and unchanged since this node was last evaluated (mirrors
+        // childVersion.atMost(version.lastEvaluated()) in signalDep). A dep that is itself dirty must
+        // additionally be kept; the worklist decides that (a dirty dep that is never kept leaves this
+        // node's count above zero, so it is not kept either -- including non-candidate dirty deps,
+        // which are never processed below).
+        if (depEntry == null || !depEntry.getVersion().atMost(lastEvaluated)) {
+          keepable = false;
+          break;
+        }
+        if (!depEntry.isDone()) {
+          dirtyDepsBuilder.add(dep);
+        }
+      }
+      if (!keepable) {
+        continue;
+      }
+      ImmutableList<SkyKey> dirtyDeps = dirtyDepsBuilder.build();
+      if (dirtyDeps.isEmpty()) {
+        ready.add(skyKey); // All deps already done and unchanged.
+      } else {
+        remainingDirtyDeps.add(skyKey, dirtyDeps.size());
+        for (SkyKey dirtyDep : dirtyDeps) {
+          dirtyRdeps.put(dirtyDep, skyKey);
+        }
+      }
+    }
+    Set<SkyKey> kept = new HashSet<>();
+    while (!ready.isEmpty()) {
+      SkyKey skyKey = ready.poll();
+      kept.add(skyKey);
+      for (SkyKey rdep : dirtyRdeps.get(skyKey)) {
+        if (remainingDirtyDeps.remove(rdep, 1) == 1) {
+          ready.add(rdep);
+        }
+      }
+    }
+
     valuesToDelete.addAll(
         Sets.filter(
-            progressReceiver.getUnenqueuedDirtyKeys(),
+            candidates,
             skyKey -> {
-              NodeEntry entry = checkNotNull(getInMemoryGraph().getIfPresent(skyKey), skyKey);
+              if (kept.contains(skyKey)) {
+                return false;
+              }
+              NodeEntry entry = checkNotNull(graph.getIfPresent(skyKey), skyKey);
               checkState(entry.isDirty(), skyKey);
               return entry.getVersion().atMost(threshold);
             }));

--- a/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
@@ -253,20 +253,25 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
   }
 
   @Override
-  public final void deleteDirty(long versionAgeLimit) {
+  public final void deleteDirty(long versionAgeLimit, boolean keepChangePrunableNodes) {
     checkArgument(versionAgeLimit >= 0, versionAgeLimit);
     Version threshold = IntVersion.of(lastGraphVersion.getVal() - versionAgeLimit);
     var graph = getInMemoryGraph();
 
     var dirtyKeys = progressReceiver.getUnenqueuedDirtyKeys();
-    long profilerStartNanos = Profiler.instance().nanoTimeMaybe();
-    var toKeep = new ChangePrunableNodesFinder(graph, dirtyKeys).find();
-    Profiler.instance()
-        .completeTask(
-            profilerStartNanos,
-            ProfilerTask.INFO,
-            "Resurrected %d out of %d dirty nodes during GC"
-                .formatted(toKeep.size(), dirtyKeys.size()));
+    ImmutableSet<SkyKey> toKeep;
+    if (keepChangePrunableNodes) {
+      long profilerStartNanos = Profiler.instance().nanoTimeMaybe();
+      toKeep = new ChangePrunableNodesFinder(graph, dirtyKeys).find();
+      Profiler.instance()
+          .completeTask(
+              profilerStartNanos,
+              ProfilerTask.INFO,
+              "Resurrected %d out of %d dirty nodes during GC"
+                  .formatted(toKeep.size(), dirtyKeys.size()));
+    } else {
+      toKeep = ImmutableSet.of();
+    }
 
     valuesToDelete.addAll(
         Sets.filter(
@@ -318,8 +323,6 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
         return ImmutableSet.of();
       }
 
-      // To avoid contention and scheduling too many jobs for our #cpus, we start
-      // SCAN_THREAD_COUNT jobs, each scanning a chunk of the candidates.
       var executor =
           ForkJoinQuiescingExecutor.newBuilder()
               .withOwnershipOf(
@@ -328,8 +331,6 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
       long listSize = candidateList.size();
       long numJobs = min(SCAN_THREAD_COUNT, listSize);
       for (long i = 0; i < numJobs; i++) {
-        // Use long multiplication to avoid possible overflow, as numJobs * listSize might be
-        // larger than max int.
         int startIndex = (int) ((i * listSize) / numJobs);
         int endIndex = (int) (((i + 1) * listSize) / numJobs);
         List<SkyKey> chunk = candidateList.subList(startIndex, endIndex);

--- a/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
@@ -20,8 +20,8 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.base.Predicates;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.HashMultiset;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Multiset;
@@ -32,6 +32,7 @@ import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.profiler.AutoProfiler;
 import com.google.devtools.build.lib.profiler.GoogleAutoProfilerUtils;
 import com.google.devtools.build.lib.profiler.Profiler;
+import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.skyframe.Differencer.Diff;
 import com.google.devtools.build.skyframe.Differencer.DiffWithDelta.Delta;
@@ -44,6 +45,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.io.PrintStream;
 import java.time.Duration;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -250,80 +252,91 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
     checkArgument(versionAgeLimit >= 0, versionAgeLimit);
     Version threshold = IntVersion.of(lastGraphVersion.getVal() - versionAgeLimit);
     var graph = getInMemoryGraph();
-    Set<SkyKey> candidates = progressReceiver.getUnenqueuedDirtyKeys();
 
-    // Keep dirty nodes that change pruning would verify clean without rebuilding as their value is
-    // still valid, they just weren't in scope for the last evaluation. Keeping them matches the
-    // behavior for done but unrequested nodes.
-    var remainingDirtyDeps = new Object2IntOpenHashMap<SkyKey>();
-    var dirtyRdeps = MultimapBuilder.hashKeys().arrayListValues(2).<SkyKey, SkyKey>build();
-    var ready = new ArrayDeque<SkyKey>();
-    for (SkyKey skyKey : candidates) {
-      if (!(graph.getIfPresent(skyKey) instanceof IncrementalInMemoryNodeEntry entry)) {
-        continue;
-      }
-      Iterable<SkyKey> lastBuildDeps = entry.lastBuildDepsIfChangePrunable();
-      if (lastBuildDeps == null) {
-        continue; // Not change-prunable -> eligible for deletion.
-      }
-      Version lastEvaluated = entry.lastEvaluatedVersion();
-      ImmutableList.Builder<SkyKey> dirtyDepsBuilder = ImmutableList.builder();
-      boolean keepable = true;
-      for (SkyKey dep : lastBuildDeps) {
-        NodeEntry depEntry = graph.getIfPresent(dep);
-        // A dep must be present and unchanged since this node was last evaluated (mirrors
-        // childVersion.atMost(version.lastEvaluated()) in signalDep). A dep that is itself dirty
-        // must additionally be kept; the worklist below decides that for candidate dirty deps. A
-        // dirty dep that is not a candidate is never processed by the worklist and so can never be
-        // kept, which makes this node unkeepable too -- short-circuit instead of tracking a count
-        // that can never reach zero.
-        if (depEntry == null || !depEntry.getVersion().atMost(lastEvaluated)) {
-          keepable = false;
-          break;
-        }
-        if (!depEntry.isDone()) {
-          if (!candidates.contains(dep)) {
-            keepable = false;
-            break;
-          }
-          dirtyDepsBuilder.add(dep);
-        }
-      }
-      if (!keepable) {
-        continue;
-      }
-      ImmutableList<SkyKey> dirtyDeps = dirtyDepsBuilder.build();
-      if (dirtyDeps.isEmpty()) {
-        ready.add(skyKey); // All deps already done and unchanged.
-      } else {
-        remainingDirtyDeps.addTo(skyKey, dirtyDeps.size());
-        for (SkyKey dirtyDep : dirtyDeps) {
-          dirtyRdeps.put(dirtyDep, skyKey);
-        }
-      }
-    }
-    Set<SkyKey> kept = new HashSet<>();
-    while (!ready.isEmpty()) {
-      SkyKey skyKey = ready.poll();
-      kept.add(skyKey);
-      for (SkyKey rdep : dirtyRdeps.get(skyKey)) {
-        if (remainingDirtyDeps.addTo(rdep, -1) == 1) {
-          ready.add(rdep);
-        }
-      }
-    }
+    var dirtyKeys = progressReceiver.getUnenqueuedDirtyKeys();
+    long profilerStartNanos = Profiler.instance().nanoTimeMaybe();
+    var toKeep = findChangePrunableNodes(graph, dirtyKeys);
+    Profiler.instance()
+        .completeTask(
+            profilerStartNanos,
+            ProfilerTask.INFO,
+            "Resurrected %d out of %d dirty nodes during GC"
+                .formatted(toKeep.size(), dirtyKeys.size()));
 
     valuesToDelete.addAll(
         Sets.filter(
-            candidates,
+            dirtyKeys,
             skyKey -> {
-              if (kept.contains(skyKey)) {
+              if (toKeep.contains(skyKey)) {
                 return false;
               }
               NodeEntry entry = checkNotNull(graph.getIfPresent(skyKey), skyKey);
               checkState(entry.isDirty(), skyKey);
               return entry.getVersion().atMost(threshold);
             }));
+  }
+
+  /**
+   * Returns the dirty nodes that change pruning would verify clean if it ran, which it doesn't
+   * purely because these nodes weren't in scope for the current evaluation.
+   */
+  private static ImmutableSet<SkyKey> findChangePrunableNodes(
+      InMemoryGraph graph, Set<SkyKey> candidates) {
+    // The first step is to build a DAG of dirty but unchanged deletion candidates and their dirty
+    // rdeps.
+    var remainingDirtyDeps = new Object2IntOpenHashMap<SkyKey>();
+    var dirtyRdeps = MultimapBuilder.hashKeys().arrayListValues().<SkyKey, SkyKey>build();
+    var ready = new ArrayDeque<SkyKey>();
+    skipCandidate:
+    for (var skyKey : candidates) {
+      if (!(graph.getIfPresent(skyKey) instanceof IncrementalInMemoryNodeEntry entry)) {
+        continue;
+      }
+      Iterable<SkyKey> lastBuildDeps = entry.lastBuildDepsIfChangePrunable();
+      if (lastBuildDeps == null) {
+        continue;
+      }
+      Version lastEvaluated = entry.lastEvaluatedVersion();
+      var dirtyDeps = new ArrayList<SkyKey>();
+      for (var dep : lastBuildDeps) {
+        NodeEntry depEntry = graph.getIfPresent(dep);
+        // A dep must be present and unchanged since this node was last evaluated to be potentially
+        // change-prunable. Undone deps that aren't unenqueued dirty deps will never be considered
+        // below and thus make an entry not change-prunable.
+        if (depEntry == null || !depEntry.getVersion().atMost(lastEvaluated)) {
+          continue skipCandidate;
+        }
+        if (depEntry.isDone()) {
+          continue;
+        }
+        if (!candidates.contains(dep)) {
+          continue skipCandidate;
+        }
+        dirtyDeps.add(dep);
+      }
+      if (dirtyDeps.isEmpty()) {
+        ready.add(skyKey);
+      } else {
+        remainingDirtyDeps.addTo(skyKey, dirtyDeps.size());
+        for (var dirtyDep : dirtyDeps) {
+          dirtyRdeps.put(dirtyDep, skyKey);
+        }
+      }
+    }
+
+    // Now visit the DAG, keeping all nodes whose dirty deps are also kept.
+    var toKeep = ImmutableSet.<SkyKey>builder();
+    SkyKey readyKey;
+    while ((readyKey = ready.poll()) != null) {
+      toKeep.add(readyKey);
+      for (var rdep : dirtyRdeps.get(readyKey)) {
+        if (remainingDirtyDeps.addTo(rdep, -1) == 1) {
+          // The last dirty dep of rdep is now known to be kept.
+          ready.add(rdep);
+        }
+      }
+    }
+    return toKeep.build();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
@@ -16,18 +16,21 @@ package com.google.devtools.build.skyframe;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.min;
 
 import com.google.common.base.Predicates;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multisets;
 import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.concurrent.AbstractQueueVisitor;
+import com.google.devtools.build.lib.concurrent.ForkJoinQuiescingExecutor;
+import com.google.devtools.build.lib.concurrent.NamedForkJoinPool;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.profiler.AutoProfiler;
 import com.google.devtools.build.lib.profiler.GoogleAutoProfilerUtils;
@@ -41,21 +44,23 @@ import com.google.devtools.build.skyframe.InvalidatingNodeVisitor.DirtyingInvali
 import com.google.devtools.build.skyframe.InvalidatingNodeVisitor.InvalidationState;
 import com.google.devtools.build.skyframe.SkyframeGraphStatsEvent.EvaluationStats;
 import com.google.errorprone.annotations.ForOverride;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.io.PrintStream;
 import java.time.Duration;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -255,7 +260,7 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
 
     var dirtyKeys = progressReceiver.getUnenqueuedDirtyKeys();
     long profilerStartNanos = Profiler.instance().nanoTimeMaybe();
-    var toKeep = findChangePrunableNodes(graph, dirtyKeys);
+    var toKeep = new ChangePrunableNodesFinder(graph, dirtyKeys).find();
     Profiler.instance()
         .completeTask(
             profilerStartNanos,
@@ -277,66 +282,136 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
   }
 
   /**
-   * Returns the dirty nodes that change pruning would verify clean if it ran, which it doesn't
-   * purely because these nodes weren't in scope for the current evaluation.
+   * Finds the dirty nodes that change pruning would verify clean if it ran, which it doesn't purely
+   * because these nodes weren't in scope for the current evaluation.
+   *
+   * <p>Operates in two phases: a parallel scan over all candidates that builds a DAG of dirty but
+   * unchanged deletion candidates and their dirty rdeps, followed by a traversal of the DAG that
+   * keeps all nodes whose dirty deps are also kept. The scan performs all graph accesses and its
+   * cost scales with the total number of candidates, so it runs on multiple threads; the traversal
+   * only visits the nodes that end up being kept.
    */
-  private static ImmutableSet<SkyKey> findChangePrunableNodes(
-      InMemoryGraph graph, Set<SkyKey> candidates) {
-    // The first step is to build a DAG of dirty but unchanged deletion candidates and their dirty
-    // rdeps.
-    var remainingDirtyDeps = new Object2IntOpenHashMap<SkyKey>();
-    var dirtyRdeps = MultimapBuilder.hashKeys().arrayListValues().<SkyKey, SkyKey>build();
-    var ready = new ArrayDeque<SkyKey>();
-    skipCandidate:
-    for (var skyKey : candidates) {
-      if (!(graph.getIfPresent(skyKey) instanceof IncrementalInMemoryNodeEntry entry)) {
-        continue;
-      }
-      Iterable<SkyKey> lastBuildDeps = entry.lastBuildDepsIfChangePrunable();
-      if (lastBuildDeps == null) {
-        continue;
-      }
-      Version lastEvaluated = entry.lastEvaluatedVersion();
-      var dirtyDeps = new ArrayList<SkyKey>();
-      for (var dep : lastBuildDeps) {
-        NodeEntry depEntry = graph.getIfPresent(dep);
-        // A dep must be present and unchanged since this node was last evaluated to be potentially
-        // change-prunable. Undone deps that aren't unenqueued dirty deps will never be considered
-        // below and thus make an entry not change-prunable.
-        if (depEntry == null || !depEntry.getVersion().atMost(lastEvaluated)) {
-          continue skipCandidate;
-        }
-        if (depEntry.isDone()) {
-          continue;
-        }
-        if (!candidates.contains(dep)) {
-          continue skipCandidate;
-        }
-        dirtyDeps.add(dep);
-      }
-      if (dirtyDeps.isEmpty()) {
-        ready.add(skyKey);
-      } else {
-        remainingDirtyDeps.addTo(skyKey, dirtyDeps.size());
-        for (var dirtyDep : dirtyDeps) {
-          dirtyRdeps.put(dirtyDep, skyKey);
-        }
-      }
+  private static final class ChangePrunableNodesFinder {
+    private static final int SCAN_THREAD_COUNT = Runtime.getRuntime().availableProcessors();
+
+    private final InMemoryGraph graph;
+    private final ImmutableSet<SkyKey> candidates;
+
+    // The DAG built by the scan phase: for each candidate with at least one dirty dep, the number
+    // of its dirty deps not yet known to be kept, together with the reverse edges. Candidates
+    // without dirty deps start out ready. Each entry in remainingDirtyDeps is written by a single
+    // scan thread, whereas dirtyRdeps values may receive edges from multiple threads.
+    private final ConcurrentHashMap<SkyKey, AtomicInteger> remainingDirtyDeps =
+        new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<SkyKey, ArrayList<SkyKey>> dirtyRdeps =
+        new ConcurrentHashMap<>();
+    private final ConcurrentLinkedQueue<SkyKey> ready = new ConcurrentLinkedQueue<>();
+
+    ChangePrunableNodesFinder(InMemoryGraph graph, ImmutableSet<SkyKey> candidates) {
+      this.graph = graph;
+      this.candidates = candidates;
     }
 
-    // Now visit the DAG, keeping all nodes whose dirty deps are also kept.
-    var toKeep = ImmutableSet.<SkyKey>builder();
-    SkyKey readyKey;
-    while ((readyKey = ready.poll()) != null) {
-      toKeep.add(readyKey);
-      for (var rdep : dirtyRdeps.get(readyKey)) {
-        if (remainingDirtyDeps.addTo(rdep, -1) == 1) {
-          // The last dirty dep of rdep is now known to be kept.
-          ready.add(rdep);
+    ImmutableSet<SkyKey> find() {
+      ImmutableList<SkyKey> candidateList = candidates.asList();
+      if (candidateList.isEmpty()) {
+        return ImmutableSet.of();
+      }
+
+      // To avoid contention and scheduling too many jobs for our #cpus, we start
+      // SCAN_THREAD_COUNT jobs, each scanning a chunk of the candidates.
+      var executor =
+          ForkJoinQuiescingExecutor.newBuilder()
+              .withOwnershipOf(
+                  NamedForkJoinPool.newNamedPool("find-change-prunable-nodes", SCAN_THREAD_COUNT))
+              .build();
+      long listSize = candidateList.size();
+      long numJobs = min(SCAN_THREAD_COUNT, listSize);
+      for (long i = 0; i < numJobs; i++) {
+        // Use long multiplication to avoid possible overflow, as numJobs * listSize might be
+        // larger than max int.
+        int startIndex = (int) ((i * listSize) / numJobs);
+        int endIndex = (int) (((i + 1) * listSize) / numJobs);
+        List<SkyKey> chunk = candidateList.subList(startIndex, endIndex);
+        executor.execute(() -> scanCandidates(chunk));
+      }
+      try {
+        executor.awaitQuiescence(/* interruptWorkers= */ true);
+      } catch (InterruptedException e) {
+        // Keeping no nodes is always safe, it merely GCs more aggressively.
+        Thread.currentThread().interrupt();
+        return ImmutableSet.of();
+      }
+
+      // Now visit the DAG, keeping all nodes whose dirty deps are also kept.
+      var toKeep = ImmutableSet.<SkyKey>builder();
+      SkyKey readyKey;
+      while ((readyKey = ready.poll()) != null) {
+        toKeep.add(readyKey);
+        var rdeps = dirtyRdeps.get(readyKey);
+        if (rdeps == null) {
+          continue;
+        }
+        for (var rdep : rdeps) {
+          if (remainingDirtyDeps.get(rdep).decrementAndGet() == 0) {
+            // The last dirty dep of rdep is now known to be kept.
+            ready.add(rdep);
+          }
+        }
+      }
+      return toKeep.build();
+    }
+
+    private void scanCandidates(List<SkyKey> chunk) {
+      skipCandidate:
+      for (var skyKey : chunk) {
+        if (Thread.currentThread().isInterrupted()) {
+          // A partial scan only ever results in fewer nodes being kept, which is always safe.
+          return;
+        }
+        if (!(graph.getIfPresent(skyKey) instanceof IncrementalInMemoryNodeEntry entry)) {
+          continue;
+        }
+        Iterable<SkyKey> lastBuildDeps = entry.lastBuildDepsIfChangePrunable();
+        if (lastBuildDeps == null) {
+          continue;
+        }
+        Version lastEvaluated = entry.lastEvaluatedVersion();
+        var dirtyDeps = new ArrayList<SkyKey>();
+        for (var dep : lastBuildDeps) {
+          NodeEntry depEntry = graph.getIfPresent(dep);
+          // A dep must be present and unchanged since this node was last evaluated to be
+          // potentially change-prunable. Undone deps that aren't unenqueued dirty deps will never
+          // be considered below and thus make an entry not change-prunable.
+          if (depEntry == null || !depEntry.getVersion().atMost(lastEvaluated)) {
+            continue skipCandidate;
+          }
+          if (depEntry.isDone()) {
+            continue;
+          }
+          if (!candidates.contains(dep)) {
+            continue skipCandidate;
+          }
+          dirtyDeps.add(dep);
+        }
+        if (dirtyDeps.isEmpty()) {
+          ready.add(skyKey);
+        } else {
+          remainingDirtyDeps.put(skyKey, new AtomicInteger(dirtyDeps.size()));
+          for (var dirtyDep : dirtyDeps) {
+            dirtyRdeps.compute(
+                dirtyDep,
+                (unusedKey, rdeps) -> {
+                  if (rdeps == null) {
+                    rdeps = new ArrayList<>();
+                  }
+                  rdeps.add(skyKey);
+                  return rdeps;
+                });
+          }
         }
       }
     }
-    return toKeep.build();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/skyframe/BUILD
@@ -95,7 +95,6 @@ java_library(
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:auto_value",
         "//third_party:caffeine",
-        "//third_party:fastutil",
         "//third_party:flogger",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/skyframe/BUILD
@@ -95,6 +95,7 @@ java_library(
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:auto_value",
         "//third_party:caffeine",
+        "//third_party:fastutil",
         "//third_party:flogger",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/skyframe/ChangePrunableNodesFinder.java
+++ b/src/main/java/com/google/devtools/build/skyframe/ChangePrunableNodesFinder.java
@@ -1,0 +1,152 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.skyframe;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.concurrent.ForkJoinQuiescingExecutor;
+import com.google.devtools.build.lib.concurrent.NamedForkJoinPool;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Finds the dirty nodes that change pruning would verify clean if it ran, which it doesn't purely
+ * because these nodes weren't in scope for the current evaluation.
+ *
+ * <p>Operates in two phases: a parallel scan over all candidates that builds a DAG of dirty but
+ * unchanged deletion candidates and their dirty rdeps, followed by a traversal of the DAG that
+ * keeps all nodes whose dirty deps are also kept. The scan performs all graph accesses and its cost
+ * scales with the total number of candidates, so it runs on multiple threads; the traversal only
+ * visits the nodes that end up being kept.
+ */
+final class ChangePrunableNodesFinder {
+  private static final int SCAN_THREAD_COUNT = Runtime.getRuntime().availableProcessors();
+
+  private final InMemoryGraph graph;
+  private final ImmutableSet<SkyKey> candidates;
+
+  // The DAG built by the scan phase: for each candidate with at least one dirty dep, the number
+  // of its dirty deps not yet known to be kept, together with the reverse edges. Candidates
+  // without dirty deps start out ready. Each entry in remainingDirtyDeps is written by a single
+  // scan thread, whereas dirtyRdeps values may receive edges from multiple threads.
+  private final ConcurrentHashMap<SkyKey, AtomicInteger> remainingDirtyDeps =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<SkyKey, ArrayList<SkyKey>> dirtyRdeps = new ConcurrentHashMap<>();
+  private final ConcurrentLinkedQueue<SkyKey> ready = new ConcurrentLinkedQueue<>();
+
+  ChangePrunableNodesFinder(InMemoryGraph graph, ImmutableSet<SkyKey> candidates) {
+    this.graph = graph;
+    this.candidates = candidates;
+  }
+
+  ImmutableSet<SkyKey> find() {
+    ImmutableList<SkyKey> candidateList = candidates.asList();
+    if (candidateList.isEmpty()) {
+      return ImmutableSet.of();
+    }
+
+    var executor =
+        ForkJoinQuiescingExecutor.newBuilder()
+            .withOwnershipOf(
+                NamedForkJoinPool.newNamedPool("find-change-prunable-nodes", SCAN_THREAD_COUNT))
+            .build();
+    long listSize = candidateList.size();
+    long numJobs = Math.min(SCAN_THREAD_COUNT, listSize);
+    for (long i = 0; i < numJobs; i++) {
+      int startIndex = (int) ((i * listSize) / numJobs);
+      int endIndex = (int) (((i + 1) * listSize) / numJobs);
+      List<SkyKey> chunk = candidateList.subList(startIndex, endIndex);
+      executor.execute(() -> scanCandidates(chunk));
+    }
+    try {
+      executor.awaitQuiescence(/* interruptWorkers= */ true);
+    } catch (InterruptedException e) {
+      // Keeping no nodes is always safe, it merely GCs more aggressively.
+      Thread.currentThread().interrupt();
+      return ImmutableSet.of();
+    }
+
+    // Now visit the DAG, keeping all nodes whose dirty deps are also kept.
+    var toKeep = ImmutableSet.<SkyKey>builder();
+    SkyKey readyKey;
+    while ((readyKey = ready.poll()) != null) {
+      toKeep.add(readyKey);
+      var rdeps = dirtyRdeps.get(readyKey);
+      if (rdeps == null) {
+        continue;
+      }
+      for (var rdep : rdeps) {
+        if (remainingDirtyDeps.get(rdep).decrementAndGet() == 0) {
+          // The last dirty dep of rdep is now known to be kept.
+          ready.add(rdep);
+        }
+      }
+    }
+    return toKeep.build();
+  }
+
+  private void scanCandidates(List<SkyKey> chunk) {
+    skipCandidate:
+    for (var skyKey : chunk) {
+      if (Thread.currentThread().isInterrupted()) {
+        // A partial scan only ever results in fewer nodes being kept, which is always safe.
+        return;
+      }
+      if (!(graph.getIfPresent(skyKey) instanceof IncrementalInMemoryNodeEntry entry)) {
+        continue;
+      }
+      Iterable<SkyKey> lastBuildDeps = entry.lastBuildDepsIfChangePrunable();
+      if (lastBuildDeps == null) {
+        continue;
+      }
+      Version lastEvaluated = entry.lastEvaluatedVersion();
+      var dirtyDeps = new ArrayList<SkyKey>();
+      for (var dep : lastBuildDeps) {
+        NodeEntry depEntry = graph.getIfPresent(dep);
+        // A dep must be present and unchanged since this node was last evaluated to be
+        // potentially change-prunable. Undone deps that aren't unenqueued dirty deps will never
+        // be considered below and thus make an entry not change-prunable.
+        if (depEntry == null || !depEntry.getVersion().atMost(lastEvaluated)) {
+          continue skipCandidate;
+        }
+        if (depEntry.isDone()) {
+          continue;
+        }
+        if (!candidates.contains(dep)) {
+          continue skipCandidate;
+        }
+        dirtyDeps.add(dep);
+      }
+      if (dirtyDeps.isEmpty()) {
+        ready.add(skyKey);
+      } else {
+        remainingDirtyDeps.put(skyKey, new AtomicInteger(dirtyDeps.size()));
+        for (var dirtyDep : dirtyDeps) {
+          dirtyRdeps.compute(
+              dirtyDep,
+              (unusedKey, rdeps) -> {
+                if (rdeps == null) {
+                  rdeps = new ArrayList<>();
+                }
+                rdeps.add(skyKey);
+                return rdeps;
+              });
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/skyframe/IncrementalInMemoryNodeEntry.java
+++ b/src/main/java/com/google/devtools/build/skyframe/IncrementalInMemoryNodeEntry.java
@@ -381,6 +381,35 @@ public class IncrementalInMemoryNodeEntry extends AbstractInMemoryNodeEntry<Dirt
     return version.lastChanged();
   }
 
+  /**
+   * For dirty-node garbage collection: if change pruning could verify this node clean without
+   * rebuilding it -- it is dirty, was built incrementally, and is not {@linkplain DirtyType#CHANGE
+   * changed} -- returns its direct deps from the last evaluation so the caller can check them;
+   * otherwise returns {@code null}. The node may be kept iff every dep is present and was not changed
+   * more recently than {@link #lastEvaluatedVersion} (each dep is either done, or a dirty node that
+   * is itself kept), the same condition {@link DirtyBuildingState#signalDep} uses to reach {@link
+   * LifecycleState#VERIFIED_CLEAN}.
+   */
+  @Nullable
+  final synchronized Iterable<SkyKey> lastBuildDepsIfChangePrunable() {
+    // Check isIncremental first so that non-incremental dirty nodes (those being built for the first
+    // time) bail out before any further work.
+    if (dirtyBuildingState == null || !dirtyBuildingState.isIncremental() || isChanged()) {
+      return null;
+    }
+    try {
+      return dirtyBuildingState.getLastBuildDirectDeps().getAllElementsAsIterable();
+    } catch (InterruptedException e) {
+      // An incremental dirty state returns its stored deps without blocking.
+      throw new IllegalStateException(e);
+    }
+  }
+
+  /** Returns the version at which this node was last evaluated; see {@link NodeVersion}. */
+  final Version lastEvaluatedVersion() {
+    return version.lastEvaluated();
+  }
+
   @Override
   public final synchronized ImmutableSet<SkyKey> getAllDirectDepsForIncompleteNode()
       throws InterruptedException {

--- a/src/main/java/com/google/devtools/build/skyframe/IncrementalInMemoryNodeEntry.java
+++ b/src/main/java/com/google/devtools/build/skyframe/IncrementalInMemoryNodeEntry.java
@@ -382,23 +382,20 @@ public class IncrementalInMemoryNodeEntry extends AbstractInMemoryNodeEntry<Dirt
   }
 
   /**
-   * For dirty-node garbage collection: if change pruning could verify this node clean without
-   * rebuilding it -- it is dirty, was built incrementally, and is not {@linkplain DirtyType#CHANGE
-   * changed} -- returns its direct deps from the last evaluation so the caller can check them;
-   * otherwise returns {@code null}. The node may be kept iff every dep is present and was not changed
-   * more recently than {@link #lastEvaluatedVersion} (each dep is either done, or a dirty node that
-   * is itself kept), the same condition {@link DirtyBuildingState#signalDep} uses to reach {@link
-   * LifecycleState#VERIFIED_CLEAN}.
+   * Returns this node's direct deps from the last evaluation if the node may be resurrected by
+   * change pruning; otherwise returns {@code null}. The node may be kept iff every returned dep is
+   * still present and was not changed more recently than {@link #lastEvaluatedVersion}.
    */
   @Nullable
-  final synchronized Iterable<SkyKey> lastBuildDepsIfChangePrunable() {
-    // Check isIncremental first so that non-incremental dirty nodes (those being built for the first
-    // time) bail out before any further work.
-    if (dirtyBuildingState == null || !dirtyBuildingState.isIncremental() || isChanged()) {
+  final Iterable<SkyKey> lastBuildDepsIfChangePrunable() {
+    var localDirtyBuildingState = dirtyBuildingState;
+    if (localDirtyBuildingState == null
+        || !localDirtyBuildingState.isIncremental()
+        || isChanged()) {
       return null;
     }
     try {
-      return dirtyBuildingState.getLastBuildDirectDeps().getAllElementsAsIterable();
+      return localDirtyBuildingState.getLastBuildDirectDeps().getAllElementsAsIterable();
     } catch (InterruptedException e) {
       // An incremental dirty state returns its stored deps without blocking.
       throw new IllegalStateException(e);

--- a/src/main/java/com/google/devtools/build/skyframe/MemoizingEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/MemoizingEvaluator.java
@@ -79,8 +79,12 @@ public interface MemoizingEvaluator {
    * be recomputed and the new values stored in the cache again.
    *
    * <p>To delete all dirty values, you can specify 0 for the limit.
+   *
+   * <p>If {@code keepChangePrunableNodes} is true, dirty values that change pruning would mark
+   * clean when they are next requested are exempt from deletion, regardless of how long they have
+   * been dirty.
    */
-  void deleteDirty(long versionAgeLimit);
+  void deleteDirty(long versionAgeLimit, boolean keepChangePrunableNodes);
 
   /**
    * Returns the values in the graph.

--- a/src/test/java/com/google/devtools/build/skyframe/MemoizingEvaluatorTest.java
+++ b/src/test/java/com/google/devtools/build/skyframe/MemoizingEvaluatorTest.java
@@ -486,14 +486,14 @@ public abstract class MemoizingEvaluatorTest {
         .containsExactly(skyKey("top"), skyKey("d1"), d2Key, ErrorTransienceValue.KEY);
 
     String[] noKeys = {};
-    tester.evaluator.deleteDirty(2);
+    tester.evaluator.deleteDirty(2, /* keepChangePrunableNodes= */ false);
     tester.eval(true, noKeys);
 
     // The top node's value is dirty, but less than two generations old, so it wasn't deleted.
     assertThat(tester.evaluator.getValues().keySet())
         .containsExactly(skyKey("top"), skyKey("d1"), d2Key, ErrorTransienceValue.KEY);
 
-    tester.evaluator.deleteDirty(2);
+    tester.evaluator.deleteDirty(2, /* keepChangePrunableNodes= */ false);
     tester.eval(true, noKeys);
 
     // The top node's value was dirty, and was two generations old, so it was deleted.
@@ -510,7 +510,7 @@ public abstract class MemoizingEvaluatorTest {
 
     assertThat(tester.evalAndGet(/*keepGoing=*/ false, topKey)).isEqualTo(new StringValue("value"));
     failBuildAndRemoveValue(leafKey);
-    tester.evaluator.deleteDirty(0);
+    tester.evaluator.deleteDirty(0, /* keepChangePrunableNodes= */ false);
   }
 
   @Test
@@ -553,7 +553,7 @@ public abstract class MemoizingEvaluatorTest {
 
     // Run dirty-node GC with the smallest possible version window.
     String[] noKeys = {};
-    tester.evaluator.deleteDirty(0);
+    tester.evaluator.deleteDirty(0, /* keepChangePrunableNodes= */ true);
     tester.eval(/* keepGoing= */ false, noKeys);
 
     // d's only dep b change-pruned, so d is verifiable-clean and is kept rather than deleted.
@@ -565,6 +565,38 @@ public abstract class MemoizingEvaluatorTest {
     dEvaluated.set(false);
     assertThat(tester.evalAndGet(/* keepGoing= */ false, d)).isEqualTo(fixedB);
     assertThat(dEvaluated.get()).isFalse();
+  }
+
+  @Test
+  public void deleteDirtyDeletesChangePrunableNodeIfNotKeeping() throws Exception {
+    // Same setup as deleteDirtyKeepsChangePrunableNode, but without keepChangePrunableNodes, the
+    // dirty node d is deleted even though change pruning would verify it clean.
+    SkyKey a = nonHermeticKey("a");
+    SkyKey b = skyKey("b");
+    SkyKey c = skyKey("c");
+    SkyKey d = skyKey("d");
+    StringValue fixedB = new StringValue("fixed-b");
+
+    tester.set(a, new StringValue("a1"));
+    // b depends on a but always returns the same value, so it change-prunes when a changes.
+    tester.getOrCreate(b).setBuilder((skyKey, env) -> env.getValue(a) == null ? null : fixedB);
+    tester.getOrCreate(c).addDependency(b).setComputedValue(COPY);
+    tester.getOrCreate(d).addDependency(b).setComputedValue(COPY);
+
+    tester.eval(/* keepGoing= */ false, c, d);
+    assertThat(tester.evaluator.getValues().keySet()).containsAtLeast(a, b, c, d);
+
+    // Change a (b re-evaluates to the same value) and evaluate only c, leaving d dirty.
+    tester.set(a, new StringValue("a2"));
+    tester.invalidate();
+    tester.eval(/* keepGoing= */ false, c);
+    assertThat(tester.getDirtyKeys()).contains(d);
+
+    String[] noKeys = {};
+    tester.evaluator.deleteDirty(0, /* keepChangePrunableNodes= */ false);
+    tester.eval(/* keepGoing= */ false, noKeys);
+
+    assertThat(tester.evaluator.getValues().keySet()).doesNotContain(d);
   }
 
   @Test
@@ -608,7 +640,7 @@ public abstract class MemoizingEvaluatorTest {
 
     // Run dirty-node GC with the smallest possible version window.
     String[] noKeys = {};
-    tester.evaluator.deleteDirty(0);
+    tester.evaluator.deleteDirty(0, /* keepChangePrunableNodes= */ true);
     tester.eval(/* keepGoing= */ false, noKeys);
 
     // The whole chain is verifiable-clean, so both bPrime and (transitively) d are kept, not deleted.
@@ -646,7 +678,7 @@ public abstract class MemoizingEvaluatorTest {
     assertThat(tester.getDirtyKeys()).containsAtLeast(b, d);
 
     String[] noKeys = {};
-    tester.evaluator.deleteDirty(0);
+    tester.evaluator.deleteDirty(0, /* keepChangePrunableNodes= */ true);
     tester.eval(/* keepGoing= */ false, noKeys);
 
     // b needs a rebuild to discover that it would prune, so it (and its rdep d) are still GC'd.

--- a/src/test/java/com/google/devtools/build/skyframe/MemoizingEvaluatorTest.java
+++ b/src/test/java/com/google/devtools/build/skyframe/MemoizingEvaluatorTest.java
@@ -571,9 +571,7 @@ public abstract class MemoizingEvaluatorTest {
   public void deleteDirtyKeepsChangePrunableChain() throws Exception {
     // d -> bPrime -> b -> a, and c -> b. Changing a so that b change-prunes and evaluating only c
     // leaves bPrime and d as unenqueued dirty orphans. bPrime is verifiable-clean because its dep b
-    // is done and unchanged; d is verifiable-clean only because bPrime is itself kept. The deps-first
-    // fixpoint keeps the whole chain -- a single pass that required deps to be done would keep bPrime
-    // but delete d (whose dep bPrime is kept dirty, not done).
+    // is done and unchanged; d is verifiable-clean only because bPrime is itself kept.
     SkyKey a = nonHermeticKey("a");
     SkyKey b = skyKey("b");
     SkyKey bPrime = skyKey("bPrime");
@@ -626,8 +624,7 @@ public abstract class MemoizingEvaluatorTest {
   public void deleteDirtyDeletesNodeNeedingRebuildToPrune() throws Exception {
     // b -> a, d -> b, plus an unrelated direct consumer e -> a. Changing a and evaluating only e
     // leaves b dirty (its dep a changed) and never recomputed, so b cannot be verified clean without
-    // a rebuild. The GC therefore deletes b and its rdep d even with rescue. This is the residual
-    // case that the per-variable RepoEnvironmentFunction injection fix is needed for.
+    // a rebuild. The GC therefore deletes b and its rdep d even with rescue.
     SkyKey a = nonHermeticKey("a");
     SkyKey b = skyKey("b");
     SkyKey d = skyKey("d");

--- a/src/test/java/com/google/devtools/build/skyframe/MemoizingEvaluatorTest.java
+++ b/src/test/java/com/google/devtools/build/skyframe/MemoizingEvaluatorTest.java
@@ -514,6 +514,149 @@ public abstract class MemoizingEvaluatorTest {
   }
 
   @Test
+  public void deleteDirtyKeepsChangePrunableNode() throws Exception {
+    // d -> b, c -> b, b -> a. Changing a so that b change-prunes and then evaluating only c leaves d
+    // dirty, even though change pruning would verify it clean (its only dep b is unchanged). Without
+    // rescue, the dirty-node GC deletes d and it must be recomputed the next time it is requested;
+    // with rescue, d survives and is verified clean.
+    SkyKey a = nonHermeticKey("a");
+    SkyKey b = skyKey("b");
+    SkyKey c = skyKey("c");
+    SkyKey d = skyKey("d");
+    StringValue fixedB = new StringValue("fixed-b");
+    AtomicBoolean dEvaluated = new AtomicBoolean(false);
+
+    tester.set(a, new StringValue("a1"));
+    // b depends on a but always returns the same value, so it change-prunes when a changes.
+    tester.getOrCreate(b).setBuilder((skyKey, env) -> env.getValue(a) == null ? null : fixedB);
+    tester.getOrCreate(c).addDependency(b).setComputedValue(COPY);
+    tester
+        .getOrCreate(d)
+        .setBuilder(
+            (skyKey, env) -> {
+              dEvaluated.set(true);
+              return env.getValue(b);
+            });
+
+    // The initial evaluation computes a, b, c and d.
+    tester.eval(/* keepGoing= */ false, c, d);
+    assertThat(tester.evaluator.getValues().keySet()).containsAtLeast(a, b, c, d);
+
+    // Change a (b re-evaluates to the same value) and evaluate only c. b change-prunes, c is
+    // verified clean, and d is left dirty without being touched.
+    tester.set(a, new StringValue("a2"));
+    tester.invalidate();
+    dEvaluated.set(false);
+    tester.eval(/* keepGoing= */ false, c);
+    assertThat(dEvaluated.get()).isFalse();
+    assertThat(tester.getDirtyKeys()).contains(d);
+
+    // Run dirty-node GC with the smallest possible version window.
+    String[] noKeys = {};
+    tester.evaluator.deleteDirty(0);
+    tester.eval(/* keepGoing= */ false, noKeys);
+
+    // d's only dep b change-pruned, so d is verifiable-clean and is kept rather than deleted.
+    assertThat(tester.evaluator.getValues().keySet()).contains(d);
+    // It is kept dirty (not eagerly recomputed), so it has no done value yet.
+    assertThat(tester.evaluator.getExistingValue(d)).isNull();
+
+    // Requesting d now verifies it clean via change pruning without recomputing it.
+    dEvaluated.set(false);
+    assertThat(tester.evalAndGet(/* keepGoing= */ false, d)).isEqualTo(fixedB);
+    assertThat(dEvaluated.get()).isFalse();
+  }
+
+  @Test
+  public void deleteDirtyKeepsChangePrunableChain() throws Exception {
+    // d -> bPrime -> b -> a, and c -> b. Changing a so that b change-prunes and evaluating only c
+    // leaves bPrime and d as unenqueued dirty orphans. bPrime is verifiable-clean because its dep b
+    // is done and unchanged; d is verifiable-clean only because bPrime is itself kept. The deps-first
+    // fixpoint keeps the whole chain -- a single pass that required deps to be done would keep bPrime
+    // but delete d (whose dep bPrime is kept dirty, not done).
+    SkyKey a = nonHermeticKey("a");
+    SkyKey b = skyKey("b");
+    SkyKey bPrime = skyKey("bPrime");
+    SkyKey c = skyKey("c");
+    SkyKey d = skyKey("d");
+    StringValue fixedB = new StringValue("fixed-b");
+    AtomicBoolean dEvaluated = new AtomicBoolean(false);
+
+    tester.set(a, new StringValue("a1"));
+    // b depends on a but always returns the same value, so it change-prunes when a changes.
+    tester.getOrCreate(b).setBuilder((skyKey, env) -> env.getValue(a) == null ? null : fixedB);
+    tester.getOrCreate(bPrime).addDependency(b).setComputedValue(COPY);
+    tester.getOrCreate(c).addDependency(b).setComputedValue(COPY);
+    tester
+        .getOrCreate(d)
+        .setBuilder(
+            (skyKey, env) -> {
+              dEvaluated.set(true);
+              return env.getValue(bPrime);
+            });
+
+    // The initial evaluation computes a, b, bPrime, c and d.
+    tester.eval(/* keepGoing= */ false, c, d);
+    assertThat(tester.evaluator.getValues().keySet()).containsAtLeast(a, b, bPrime, c, d);
+
+    // Change a (b re-evaluates to the same value) and evaluate only c. b change-prunes; bPrime and d
+    // are left dirty without being touched.
+    tester.set(a, new StringValue("a2"));
+    tester.invalidate();
+    dEvaluated.set(false);
+    tester.eval(/* keepGoing= */ false, c);
+    assertThat(dEvaluated.get()).isFalse();
+    assertThat(tester.getDirtyKeys()).containsAtLeast(bPrime, d);
+
+    // Run dirty-node GC with the smallest possible version window.
+    String[] noKeys = {};
+    tester.evaluator.deleteDirty(0);
+    tester.eval(/* keepGoing= */ false, noKeys);
+
+    // The whole chain is verifiable-clean, so both bPrime and (transitively) d are kept, not deleted.
+    assertThat(tester.evaluator.getValues().keySet()).containsAtLeast(bPrime, d);
+
+    // Requesting d now verifies the chain clean without recomputing d.
+    dEvaluated.set(false);
+    assertThat(tester.evalAndGet(/* keepGoing= */ false, d)).isEqualTo(fixedB);
+    assertThat(dEvaluated.get()).isFalse();
+  }
+
+  @Test
+  public void deleteDirtyDeletesNodeNeedingRebuildToPrune() throws Exception {
+    // b -> a, d -> b, plus an unrelated direct consumer e -> a. Changing a and evaluating only e
+    // leaves b dirty (its dep a changed) and never recomputed, so b cannot be verified clean without
+    // a rebuild. The GC therefore deletes b and its rdep d even with rescue. This is the residual
+    // case that the per-variable RepoEnvironmentFunction injection fix is needed for.
+    SkyKey a = nonHermeticKey("a");
+    SkyKey b = skyKey("b");
+    SkyKey d = skyKey("d");
+    SkyKey e = skyKey("e");
+    StringValue fixedB = new StringValue("fixed-b");
+
+    tester.set(a, new StringValue("a1"));
+    tester.getOrCreate(b).setBuilder((skyKey, env) -> env.getValue(a) == null ? null : fixedB);
+    tester.getOrCreate(d).addDependency(b).setComputedValue(COPY);
+    tester.getOrCreate(e).addDependency(a).setComputedValue(COPY);
+
+    tester.eval(/* keepGoing= */ false, d, e);
+    assertThat(tester.evaluator.getValues().keySet()).containsAtLeast(a, b, d, e);
+
+    // Change a and evaluate only e, which recomputes e but not b or d.
+    tester.set(a, new StringValue("a2"));
+    tester.invalidate();
+    tester.eval(/* keepGoing= */ false, e);
+    assertThat(tester.getDirtyKeys()).containsAtLeast(b, d);
+
+    String[] noKeys = {};
+    tester.evaluator.deleteDirty(0);
+    tester.eval(/* keepGoing= */ false, noKeys);
+
+    // b needs a rebuild to discover that it would prune, so it (and its rdep d) are still GC'd.
+    assertThat(tester.evaluator.getValues().keySet()).containsNoneOf(b, d);
+  }
+
+  @Test
   public void deleteNonexistentValues() throws Exception {
     tester.getOrCreate("d1").setConstantValue(new StringValue("1"));
     tester.delete("d1");

--- a/src/test/shell/integration/loading_phase_test.sh
+++ b/src/test/shell/integration/loading_phase_test.sh
@@ -270,7 +270,8 @@ function test_unrelated_glob_change_pruned() {
     echo '[filegroup(name = "t%d" % i, srcs = glob(["data/*.txt"])) for i in range(21)]' \
         > "$pkg/BUILD"
 
-    bazel build "//$pkg:all" >& "$TEST_log" || fail "Expected initial build to succeed"
+    local -r gc_flag="--experimental_keep_change_prunable_nodes_during_gc"
+    bazel build "$gc_flag" "//$pkg:all" >& "$TEST_log" || fail "Expected initial build to succeed"
     local before="$(bazel dump --skyframe=count 2>/dev/null \
         | awk '/^CONFIGURED_TARGET/{print $2}')"
 
@@ -278,8 +279,8 @@ function test_unrelated_glob_change_pruned() {
     # build only one target (orphaning the other 20), then a no-op build to flush the dirty-node
     # GC's deferred deletions.
     echo unrelated > "$pkg/data/notes.md"
-    bazel build "//$pkg:t0" >& "$TEST_log" || fail "Expected build of t0 to succeed"
-    bazel build "//$pkg:t0" >& "$TEST_log" || fail "Expected flush build to succeed"
+    bazel build "$gc_flag" "//$pkg:t0" >& "$TEST_log" || fail "Expected build of t0 to succeed"
+    bazel build "$gc_flag" "//$pkg:t0" >& "$TEST_log" || fail "Expected flush build to succeed"
     local after="$(bazel dump --skyframe=count 2>/dev/null \
         | awk '/^CONFIGURED_TARGET/{print $2}')"
 

--- a/src/test/shell/integration/loading_phase_test.sh
+++ b/src/test/shell/integration/loading_phase_test.sh
@@ -260,13 +260,9 @@ function test_glob_with_subpackage() {
     assert_equals "3" $(wc -l "$TEST_log")
 }
 
-function test_dirty_node_gc_keeps_change_prunable_nodes() {
-    # The dirty-node GC (--version_window_for_dirty_node_gc, run after every build) must not delete
-    # dirty nodes that change pruning would verify clean. Many targets glob the same directory.
+function test_unrelated_glob_change_pruned() {
     # Adding a file that the glob does not match changes the directory listing and thus dirties the
-    # shared glob, but the glob re-evaluates to the same matches and change-prunes. Building one
-    # target re-evaluates (and change-prunes) the glob; the other targets are left as verifiable
-    # clean orphans that the GC must keep rather than delete (and re-analyze).
+    # shared glob, but the glob re-evaluates to the same matches and change-prunes.
     local -r pkg="${FUNCNAME}"
     mkdir -p "$pkg/data" || fail "could not create \"$pkg/data\""
     echo a > "$pkg/data/f0.txt"

--- a/src/test/shell/integration/loading_phase_test.sh
+++ b/src/test/shell/integration/loading_phase_test.sh
@@ -260,6 +260,36 @@ function test_glob_with_subpackage() {
     assert_equals "3" $(wc -l "$TEST_log")
 }
 
+function test_dirty_node_gc_keeps_change_prunable_nodes() {
+    # The dirty-node GC (--version_window_for_dirty_node_gc, run after every build) must not delete
+    # dirty nodes that change pruning would verify clean. Many targets glob the same directory.
+    # Adding a file that the glob does not match changes the directory listing and thus dirties the
+    # shared glob, but the glob re-evaluates to the same matches and change-prunes. Building one
+    # target re-evaluates (and change-prunes) the glob; the other targets are left as verifiable
+    # clean orphans that the GC must keep rather than delete (and re-analyze).
+    local -r pkg="${FUNCNAME}"
+    mkdir -p "$pkg/data" || fail "could not create \"$pkg/data\""
+    echo a > "$pkg/data/f0.txt"
+    echo b > "$pkg/data/f1.txt"
+    echo '[filegroup(name = "t%d" % i, srcs = glob(["data/*.txt"])) for i in range(21)]' \
+        > "$pkg/BUILD"
+
+    bazel build "//$pkg:all" >& "$TEST_log" || fail "Expected initial build to succeed"
+    local before="$(bazel dump --skyframe=count 2>/dev/null \
+        | awk '/^CONFIGURED_TARGET/{print $2}')"
+
+    # Add a file not matched by the glob (dirties the directory listing; the glob change-prunes),
+    # build only one target (orphaning the other 20), then a no-op build to flush the dirty-node
+    # GC's deferred deletions.
+    echo unrelated > "$pkg/data/notes.md"
+    bazel build "//$pkg:t0" >& "$TEST_log" || fail "Expected build of t0 to succeed"
+    bazel build "//$pkg:t0" >& "$TEST_log" || fail "Expected flush build to succeed"
+    local after="$(bazel dump --skyframe=count 2>/dev/null \
+        | awk '/^CONFIGURED_TARGET/{print $2}')"
+
+    assert_equals "$before" "$after"
+}
+
 function test_glob_with_subpackage2() {
     local -r pkg="${FUNCNAME}"
     mkdir -p "$pkg" || fail "could not create \"$pkg\""


### PR DESCRIPTION
### Description

The dirty-node garbage collector (`--version_window_for_dirty_node_gc`, run after every build via `BuildTool`) deletes dirty nodes that were not part of the build. A dirty node whose direct deps all turned out unchanged would be verified clean by change pruning the next time it is requested, but still ended up being deleted simply for not being part of the current evaluation.

`AbstractInMemoryMemoizingEvaluator.deleteDirty` now keeps any dirty node that change pruning would verify clean if the new `--experimental_keep_change_prunable_nodes_during_gc` is enabled.

### Motivation

This is motivated by https://github.com/bazelbuild/bazel/issues/29956, but doesn't quite fix it by itself (see https://github.com/bazelbuild/bazel/pull/29946#issuecomment-4797081830 and `deleteDirtyDeletesNodeNeedingRebuildToPrune`). It does help any change-prunable `SkyValue` (see the new integration test `test_unrelated_glob_change_pruned`).

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES[NEW]: With the new `--experimental_keep_change_prunable_nodes_during_gc` flag, Skyframe will keep computed nodes that aren't requested by the current evaluation but whose dependencies would be verified clean after change pruning.
