### PR TITLE
Unset Android env on `macos` CI

### DIFF
--- a/.bazelci/build_bazel_binaries.yml
+++ b/.bazelci/build_bazel_binaries.yml
@@ -29,6 +29,9 @@ platforms:
       - "-c"
       - "opt"
   macos:
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -128,6 +128,9 @@ tasks:
       - mkdir $HOME/bazeltest
       - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
       - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
     build_flags:
       - "--config=ci-macos"
     build_targets:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -131,6 +131,9 @@ tasks:
       - build
       - test
   macos:
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest


### PR DESCRIPTION
Regular `macos` images are not compatible with the Android SDK installed in BazelCI due to a technical limitation in the underlying system, so null-out the Android env for those jobs.

Unblocks #29854