### PR TITLE
[8.8.0] Fix sandbox policy injection via unescaped paths in darwin-sandbox

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
@@ -263,6 +263,14 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     };
   }
 
+  /** Escapes quotes and backslashes for Apple SBPL Scheme string literals. */
+  private static String escapeSchemeString(String s) {
+    if (s == null) {
+      return "";
+    }
+    return s.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
   private void writeConfig(
       Path sandboxConfigPath,
       Set<Path> writableDirs,
@@ -292,10 +300,10 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
       out.println("(allow file-write*");
       for (Path path : writableDirs) {
-        out.println("    (subpath \"" + path.getPathString() + "\")");
+        out.println("    (subpath \"" + escapeSchemeString(path.getPathString()) + "\")");
       }
       if (statisticsPath != null) {
-        out.println("    (literal \"" + statisticsPath.getPathString() + "\")");
+        out.println("    (literal \"" + escapeSchemeString(statisticsPath.getPathString()) + "\")");
       }
       out.println(")");
 
@@ -304,7 +312,7 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
         // The sandbox configuration file is not part of a cache key and sandbox-exec doesn't care
         // about ordering of paths in expressions, so it's fine if the iteration order is random.
         for (Path inaccessiblePath : inaccessiblePaths) {
-          out.println("    (subpath \"" + inaccessiblePath + "\")");
+          out.println("    (subpath \"" + escapeSchemeString(inaccessiblePath.toString()) + "\")");
         }
         out.println(")");
       }


### PR DESCRIPTION
…ttps://github.com/bazelbuild/bazel/pull/29702)

Fix for #29427 - Escape quote and backslash characters in path strings before writing them into Apple SBPL sandbox configuration files.

The `writeConfig()` method in `DarwinSandboxedSpawnRunner.java` writes path strings directly into double-quoted SBPL string literals without escaping metacharacters. A workspace directory containing quote characters can inject arbitrary sandbox policy directives, breaking sandbox containment.

**Affected versions:** Regression between Bazel 6.5.0 and 7.0.0. Confirmed in 7.0.0, 7.7.0, 8.4.0, 9.1.0.

Added `escapeSchemeString()` helper that escapes backslash and quote characters in path strings before interpolation into SBPL config. Applied to all three dynamic path insertion points in `writeConfig()`:
- Writable directory paths (line 287)
- Statistics path (line 290)
- Inaccessible paths (line 299)

Without this fix, an attacker with control over workspace directory names can escape the Bazel sandbox on macOS, enabling writes to arbitrary filesystem locations.

The fix is minimal and targeted - it only adds escaping to string interpolation. It does not change any sandbox policy logic or path resolution behavior.

Fixes #29427

Closes #29702.

PiperOrigin-RevId: 933765135
Change-Id: Ib66d70fc11a45a85ac928c222b5a41b1ae51dfd0

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/bcc75aab5fb67447569e1fb09749ceba41184dda