### PR TITLE
Optimizations to reduce retained memory when using `BuildEventStreamer`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/AspectCompleteEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AspectCompleteEvent.java
@@ -45,7 +45,6 @@ public final class AspectCompleteEvent
     implements SkyValue, BuildEventWithOrderConstraint, EventReportingArtifacts {
   private final AspectKey aspectKey;
   private final NestedSet<Cause> rootCauses;
-  private final Collection<BuildEventId> postedAfter;
   private final CompletionContext completionContext;
   private final ImmutableMap<String, ArtifactsInOutputGroup> artifactOutputGroups;
   private final boolean printToMasterLog;
@@ -59,11 +58,6 @@ public final class AspectCompleteEvent
     this.aspectKey = aspectKey;
     this.rootCauses =
         (rootCauses == null) ? NestedSetBuilder.emptySet(Order.STABLE_ORDER) : rootCauses;
-    ImmutableList.Builder<BuildEventId> postedAfterBuilder = ImmutableList.builder();
-    for (Cause cause : this.rootCauses.toList()) {
-      postedAfterBuilder.add(cause.getIdProto());
-    }
-    this.postedAfter = postedAfterBuilder.build();
     this.completionContext = completionContext;
     this.artifactOutputGroups = artifactOutputGroups;
     this.printToMasterLog = printToMasterLog;
@@ -149,7 +143,11 @@ public final class AspectCompleteEvent
 
   @Override
   public Collection<BuildEventId> postedAfter() {
-    return postedAfter;
+    ImmutableList.Builder<BuildEventId> postedAfter = ImmutableList.builder();
+    for (Cause cause : rootCauses.toList()) {
+      postedAfter.add(cause.getIdProto());
+    }
+    return postedAfter.build();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/AspectCompleteEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AspectCompleteEvent.java
@@ -45,7 +45,6 @@ public final class AspectCompleteEvent
     implements SkyValue, BuildEventWithOrderConstraint, EventReportingArtifacts {
   private final AspectKey aspectKey;
   private final NestedSet<Cause> rootCauses;
-  private final Collection<BuildEventId> postedAfter;
   private final CompletionContext completionContext;
   private final ImmutableMap<String, ArtifactsInOutputGroup> artifactOutputGroups;
   private final boolean printToMasterLog;
@@ -59,11 +58,6 @@ public final class AspectCompleteEvent
     this.aspectKey = aspectKey;
     this.rootCauses =
         (rootCauses == null) ? NestedSetBuilder.emptySet(Order.STABLE_ORDER) : rootCauses;
-    ImmutableList.Builder<BuildEventId> postedAfterBuilder = ImmutableList.builder();
-    for (Cause cause : this.rootCauses.toList()) {
-      postedAfterBuilder.add(cause.getIdProto());
-    }
-    this.postedAfter = postedAfterBuilder.build();
     this.completionContext = completionContext;
     this.artifactOutputGroups = artifactOutputGroups;
     this.printToMasterLog = printToMasterLog;
@@ -149,7 +143,14 @@ public final class AspectCompleteEvent
 
   @Override
   public Collection<BuildEventId> postedAfter() {
-    return postedAfter;
+    if (rootCauses.isEmpty()) {
+      return ImmutableList.of();
+    }
+    ImmutableList.Builder<BuildEventId> postedAfter = ImmutableList.builder();
+    for (Cause cause : rootCauses.toList()) {
+      postedAfter.add(cause.getIdProto());
+    }
+    return postedAfter.build();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/TargetCompleteEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/TargetCompleteEvent.java
@@ -115,7 +115,6 @@ public final class TargetCompleteEvent
   private final Label label;
   private final ConfiguredTargetKey configuredTargetKey;
   private final NestedSet<Cause> rootCauses;
-  private final ImmutableList<BuildEventId> postedAfter;
   private final CompletionContext completionContext;
   private final ImmutableMap<String, ArtifactsInOutputGroup> outputs;
   // The label as appeared in the BUILD file.
@@ -140,18 +139,15 @@ public final class TargetCompleteEvent
     this.rootCauses =
         (rootCauses == null) ? NestedSetBuilder.emptySet(Order.STABLE_ORDER) : rootCauses;
     this.executableTargetData = new ExecutableTargetData(targetAndData);
-    ImmutableList.Builder<BuildEventId> postedAfterBuilder = ImmutableList.builder();
     this.label = targetAndData.getConfiguredTarget().getLabel();
     this.originalLabel = targetAndData.getConfiguredTarget().getOriginalLabel();
     this.configuredTargetKey =
         ConfiguredTargetKey.fromConfiguredTarget(targetAndData.getConfiguredTarget());
-    postedAfterBuilder.add(BuildEventIdUtil.targetConfigured(originalLabel));
     DetailedExitCode mostImportantDetailedExitCode = null;
     for (Cause cause : this.rootCauses.toList()) {
       mostImportantDetailedExitCode =
           DetailedExitCodeComparator.chooseMoreImportantWithFirstIfTie(
               mostImportantDetailedExitCode, cause.getDetailedExitCode());
-      postedAfterBuilder.add(cause.getIdProto());
     }
     detailedExitCode = mostImportantDetailedExitCode;
     this.completionContext = completionContext;
@@ -166,7 +162,6 @@ public final class TargetCompleteEvent
         isTest
             ? targetAndData.getConfiguredTarget().getProvider(TestProvider.class).getTestParams()
             : null;
-    this.postedAfter = postedAfterBuilder.build();
     this.tags = targetAndData.getRuleTags();
   }
 
@@ -466,7 +461,12 @@ public final class TargetCompleteEvent
 
   @Override
   public ImmutableList<BuildEventId> postedAfter() {
-    return postedAfter;
+    ImmutableList.Builder<BuildEventId> postedAfter = ImmutableList.builder();
+    postedAfter.add(BuildEventIdUtil.targetConfigured(originalLabel));
+    for (Cause cause : rootCauses.toList()) {
+      postedAfter.add(cause.getIdProto());
+    }
+    return postedAfter.build();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/TargetCompleteEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/TargetCompleteEvent.java
@@ -115,7 +115,6 @@ public final class TargetCompleteEvent
   private final Label label;
   private final ConfiguredTargetKey configuredTargetKey;
   private final NestedSet<Cause> rootCauses;
-  private final ImmutableList<BuildEventId> postedAfter;
   private final CompletionContext completionContext;
   private final ImmutableMap<String, ArtifactsInOutputGroup> outputs;
   // The label as appeared in the BUILD file.
@@ -140,18 +139,15 @@ public final class TargetCompleteEvent
     this.rootCauses =
         (rootCauses == null) ? NestedSetBuilder.emptySet(Order.STABLE_ORDER) : rootCauses;
     this.executableTargetData = new ExecutableTargetData(targetAndData);
-    ImmutableList.Builder<BuildEventId> postedAfterBuilder = ImmutableList.builder();
     this.label = targetAndData.getConfiguredTarget().getLabel();
     this.originalLabel = targetAndData.getConfiguredTarget().getOriginalLabel();
     this.configuredTargetKey =
         ConfiguredTargetKey.fromConfiguredTarget(targetAndData.getConfiguredTarget());
-    postedAfterBuilder.add(BuildEventIdUtil.targetConfigured(originalLabel));
     DetailedExitCode mostImportantDetailedExitCode = null;
     for (Cause cause : this.rootCauses.toList()) {
       mostImportantDetailedExitCode =
           DetailedExitCodeComparator.chooseMoreImportantWithFirstIfTie(
               mostImportantDetailedExitCode, cause.getDetailedExitCode());
-      postedAfterBuilder.add(cause.getIdProto());
     }
     detailedExitCode = mostImportantDetailedExitCode;
     this.completionContext = completionContext;
@@ -166,7 +162,6 @@ public final class TargetCompleteEvent
         isTest
             ? targetAndData.getConfiguredTarget().getProvider(TestProvider.class).getTestParams()
             : null;
-    this.postedAfter = postedAfterBuilder.build();
     this.tags = targetAndData.getRuleTags();
   }
 
@@ -470,7 +465,16 @@ public final class TargetCompleteEvent
 
   @Override
   public ImmutableList<BuildEventId> postedAfter() {
-    return postedAfter;
+    var targetConfiguredEventId = BuildEventIdUtil.targetConfigured(originalLabel);
+    if (rootCauses.isEmpty()) {
+      return ImmutableList.of(targetConfiguredEventId);
+    }
+    ImmutableList.Builder<BuildEventId> postedAfter = ImmutableList.builder();
+    postedAfter.add(targetConfiguredEventId);
+    for (Cause cause : rootCauses.toList()) {
+      postedAfter.add(cause.getIdProto());
+    }
+    return postedAfter.build();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -148,6 +148,9 @@ public class BuildConfigurationValue
   @Nullable // lazily initialized
   private transient volatile BuildConfigurationEvent buildEvent;
 
+  @Nullable // lazily initialized
+  private transient volatile BuildEventId buildEventId;
+
   /**
    * Validates the options for this BuildConfigurationValue. Issues warnings for the use of
    * deprecated options, and warnings or errors for any option settings that conflict.
@@ -967,7 +970,14 @@ public class BuildConfigurationValue
   }
 
   public BuildEventId getEventId() {
-    return BuildEventIdUtil.configurationId(checksum());
+    if (buildEventId == null) {
+      synchronized (this) {
+        if (buildEventId == null) {
+          buildEventId = BuildEventIdUtil.configurationId(checksum());
+        }
+      }
+    }
+    return buildEventId;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -144,6 +144,9 @@ public class BuildConfigurationValue
   @Nullable // lazily initialized
   private transient volatile BuildConfigurationEvent buildEvent;
 
+  @Nullable // lazily initialized
+  private transient volatile BuildEventId buildEventId;
+
   /**
    * Validates the options for this BuildConfigurationValue. Issues warnings for the use of
    * deprecated options, and warnings or errors for any option settings that conflict.
@@ -935,7 +938,14 @@ public class BuildConfigurationValue
   }
 
   public BuildEventId getEventId() {
-    return BuildEventIdUtil.configurationId(checksum());
+    if (buildEventId == null) {
+      synchronized (this) {
+        if (buildEventId == null) {
+          buildEventId = BuildEventIdUtil.configurationId(checksum());
+        }
+      }
+    }
+    return buildEventId;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEventIdUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEventIdUtil.java
@@ -34,6 +34,17 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public final class BuildEventIdUtil {
+  private static String internLabel(Label label) {
+    return label.toString().intern();
+  }
+  private static String internLabel(String label) {
+    return label.intern();
+  }
+
+  private static String internConfiguration(String configuration) {
+    return configuration.intern();
+  }
+
   private static final ConfigurationId NULL_CONFIGURATION_ID_MESSAGE =
       configurationIdMessage("none");
   private static final BuildEventId NULL_CONFIGURATION_ID =
@@ -120,7 +131,7 @@ public final class BuildEventIdUtil {
   }
 
   public static ConfigurationId configurationIdMessage(String checksum) {
-    return ConfigurationId.newBuilder().setId(checksum).build();
+    return ConfigurationId.newBuilder().setId(internConfiguration(checksum)).build();
   }
 
   public static BuildEventId execRequestId() {
@@ -159,14 +170,14 @@ public final class BuildEventIdUtil {
 
   public static BuildEventId targetConfigured(Label label) {
     BuildEventId.TargetConfiguredId configuredId =
-        BuildEventId.TargetConfiguredId.newBuilder().setLabel(label.toString()).build();
+        BuildEventId.TargetConfiguredId.newBuilder().setLabel(internLabel(label)).build();
     return BuildEventId.newBuilder().setTargetConfigured(configuredId).build();
   }
 
   public static BuildEventId aspectConfigured(Label label, String aspect) {
     BuildEventId.TargetConfiguredId configuredId =
         BuildEventId.TargetConfiguredId.newBuilder()
-            .setLabel(label.toString())
+            .setLabel(internLabel(label))
             .setAspect(aspect)
             .build();
     return BuildEventId.newBuilder().setTargetConfigured(configuredId).build();
@@ -176,7 +187,7 @@ public final class BuildEventIdUtil {
     BuildEventId.ConfigurationId configId = configuration.getConfiguration();
     BuildEventId.TargetCompletedId targetId =
         BuildEventId.TargetCompletedId.newBuilder()
-            .setLabel(target.toString())
+            .setLabel(internLabel(target))
             .setConfiguration(configId)
             .build();
     return BuildEventId.newBuilder().setTargetCompleted(targetId).build();
@@ -186,7 +197,7 @@ public final class BuildEventIdUtil {
       Label label, BuildEventId.ConfigurationId configurationId) {
     BuildEventId.ConfiguredLabelId labelId =
         BuildEventId.ConfiguredLabelId.newBuilder()
-            .setLabel(label.toString())
+            .setLabel(internLabel(label))
             .setConfiguration(configurationId)
             .build();
     return BuildEventId.newBuilder().setConfiguredLabel(labelId).build();
@@ -194,7 +205,7 @@ public final class BuildEventIdUtil {
 
   public static BuildEventId unconfiguredLabelId(Label label) {
     BuildEventId.UnconfiguredLabelId labelId =
-        BuildEventId.UnconfiguredLabelId.newBuilder().setLabel(label.toString()).build();
+        BuildEventId.UnconfiguredLabelId.newBuilder().setLabel(internLabel(label)).build();
     return BuildEventId.newBuilder().setUnconfiguredLabel(labelId).build();
   }
 
@@ -203,7 +214,7 @@ public final class BuildEventIdUtil {
     BuildEventId.ConfigurationId configId = configuration.getConfiguration();
     BuildEventId.TargetCompletedId targetId =
         BuildEventId.TargetCompletedId.newBuilder()
-            .setLabel(target.toString())
+            .setLabel(internLabel(target))
             .setConfiguration(configId)
             .setAspect(aspect)
             .build();
@@ -219,10 +230,10 @@ public final class BuildEventIdUtil {
     ActionCompletedId.Builder actionId =
         ActionCompletedId.newBuilder().setPrimaryOutput(path.toString());
     if (label != null) {
-      actionId.setLabel(label.toString());
+      actionId.setLabel(internLabel(label));
     }
     if (configurationChecksum != null) {
-      actionId.setConfiguration(ConfigurationId.newBuilder().setId(configurationChecksum));
+      actionId.setConfiguration(ConfigurationId.newBuilder().setId(internConfiguration(configurationChecksum)));
     }
     return BuildEventId.newBuilder().setActionCompleted(actionId).build();
   }
@@ -238,7 +249,7 @@ public final class BuildEventIdUtil {
     BuildEventId.ConfigurationId configId = configuration.getConfiguration();
     BuildEventId.TestResultId resultId =
         BuildEventId.TestResultId.newBuilder()
-            .setLabel(target.toString())
+            .setLabel(internLabel(target))
             .setConfiguration(configId)
             .setRun(run + 1)
             .setShard(shard + 1)
@@ -262,7 +273,7 @@ public final class BuildEventIdUtil {
     return BuildEventId.newBuilder()
         .setTestProgress(
             BuildEventId.TestProgressId.newBuilder()
-                .setLabel(label)
+                .setLabel(internLabel(label))
                 .setConfiguration(configId)
                 .setRun(run)
                 .setShard(shard)
@@ -275,7 +286,7 @@ public final class BuildEventIdUtil {
     BuildEventId.ConfigurationId configId = configuration.getConfiguration();
     BuildEventId.TestSummaryId summaryId =
         BuildEventId.TestSummaryId.newBuilder()
-            .setLabel(target.toString())
+            .setLabel(internLabel(target))
             .setConfiguration(configId)
             .build();
     return BuildEventId.newBuilder().setTestSummary(summaryId).build();
@@ -285,7 +296,7 @@ public final class BuildEventIdUtil {
     BuildEventId.ConfigurationId configId = configuration.getConfiguration();
     BuildEventId.TargetSummaryId summaryId =
         BuildEventId.TargetSummaryId.newBuilder()
-            .setLabel(target.toString())
+            .setLabel(internLabel(target))
             .setConfiguration(configId)
             .build();
     return BuildEventId.newBuilder().setTargetSummary(summaryId).build();

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEventIdUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEventIdUtil.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.buildeventstream;
 
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId.ActionCompletedId;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId.ConfigurationId;
@@ -41,8 +43,10 @@ public final class BuildEventIdUtil {
     return label.intern();
   }
 
-  private static String internConfiguration(String configuration) {
-    return configuration.intern();
+  private static final Interner<ConfigurationId> CONFIGURATION_ID_INTERNER =
+      Interners.newWeakInterner();
+  private static ConfigurationId internConfigurationId(ConfigurationId id) {
+    return CONFIGURATION_ID_INTERNER.intern(id);
   }
 
   private static final ConfigurationId NULL_CONFIGURATION_ID_MESSAGE =
@@ -131,7 +135,7 @@ public final class BuildEventIdUtil {
   }
 
   public static ConfigurationId configurationIdMessage(String checksum) {
-    return ConfigurationId.newBuilder().setId(internConfiguration(checksum)).build();
+    return internConfigurationId(ConfigurationId.newBuilder().setId(checksum).build());
   }
 
   public static BuildEventId execRequestId() {
@@ -233,7 +237,7 @@ public final class BuildEventIdUtil {
       actionId.setLabel(internLabel(label));
     }
     if (configurationChecksum != null) {
-      actionId.setConfiguration(ConfigurationId.newBuilder().setId(internConfiguration(configurationChecksum)));
+      actionId.setConfiguration(configurationIdMessage(configurationChecksum));
     }
     return BuildEventId.newBuilder().setActionCompleted(actionId).build();
   }

--- a/src/main/java/com/google/devtools/build/lib/causes/ActionFailed.java
+++ b/src/main/java/com/google/devtools/build/lib/causes/ActionFailed.java
@@ -16,10 +16,8 @@ package com.google.devtools.build.lib.causes;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
+import com.google.devtools.build.lib.buildeventstream.BuildEventIdUtil;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
-import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId;
-import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId.ActionCompletedId;
-import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId.ConfigurationId;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -69,14 +67,6 @@ public class ActionFailed implements Cause {
 
   @Override
   public BuildEventStreamProtos.BuildEventId getIdProto() {
-    ActionCompletedId.Builder actionId =
-        ActionCompletedId.newBuilder().setPrimaryOutput(execPath.toString());
-    if (label != null) {
-      actionId.setLabel(label.toString());
-    }
-    if (configurationChecksum != null) {
-      actionId.setConfiguration(ConfigurationId.newBuilder().setId(configurationChecksum));
-    }
-    return BuildEventId.newBuilder().setActionCompleted(actionId).build();
+    return BuildEventIdUtil.actionCompleted(execPath, label, configurationChecksum);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/causes/LabelCause.java
+++ b/src/main/java/com/google/devtools/build/lib/causes/LabelCause.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.causes;
 
 import com.google.common.base.MoreObjects;
+import com.google.devtools.build.lib.buildeventstream.BuildEventIdUtil;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.util.DetailedExitCode;
@@ -53,12 +54,7 @@ public class LabelCause implements Cause {
 
   @Override
   public BuildEventStreamProtos.BuildEventId getIdProto() {
-    return BuildEventStreamProtos.BuildEventId.newBuilder()
-        .setUnconfiguredLabel(
-            BuildEventStreamProtos.BuildEventId.UnconfiguredLabelId.newBuilder()
-                .setLabel(label.toString())
-                .build())
-        .build();
+    return BuildEventIdUtil.unconfiguredLabelId(label);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/runtime/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BUILD
@@ -878,6 +878,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/transports",
         "//src/main/java/com/google/devtools/build/lib/buildtool:build_request",
         "//src/main/java/com/google/devtools/build/lib/buildtool/buildevent",
+        "//src/main/java/com/google/devtools/build/lib/collect/compacthashset",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
         "//src/main/java/com/google/devtools/build/lib/pkgcache",

--- a/src/main/java/com/google/devtools/build/lib/runtime/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BUILD
@@ -873,6 +873,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/transports",
         "//src/main/java/com/google/devtools/build/lib/buildtool:build_request",
         "//src/main/java/com/google/devtools/build/lib/buildtool/buildevent",
+        "//src/main/java/com/google/devtools/build/lib/collect/compacthashset",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
         "//src/main/java/com/google/devtools/build/lib/pkgcache",

--- a/src/main/java/com/google/devtools/build/lib/runtime/BuildEventStreamer.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BuildEventStreamer.java
@@ -105,9 +105,19 @@ public class BuildEventStreamer {
   private final OutputGroupFileModes outputGroupFileModes;
   private final boolean publishTargetSummaries;
 
+  /**
+   * Tracks all events that have been announced.
+   * Notable exceptions:
+   * - Only the first and next (unposted) progress event is tracked.
+   */
   @GuardedBy("this")
   private Set<BuildEventId> announcedEvents;
 
+  /**
+   * Tracks all events that have been posted.
+   * Notable exceptions:
+   * - Only the first progress event is tracked.
+   */
   @GuardedBy("this")
   private final Set<BuildEventId> postedEvents = new HashSet<>();
 
@@ -338,7 +348,10 @@ public class BuildEventStreamer {
               finalLinkEvents.add(progressEvent);
               progressCount++;
               maybeRegisterAnnouncedEvents(progressEvent.getChildrenEvents());
-              postedEvents.add(progressEvent.getEventId());
+              // Discard produced progress event from announced list as it is no longer needed:
+              // - Only the initial progress event is waited on.
+              // - Progress event has been posted.
+              announcedEvents.remove(progressEvent.getEventId());
             });
       }
     }
@@ -738,7 +751,10 @@ public class BuildEventStreamer {
     BuildEvent updateEvent = ProgressEvent.progressUpdate(progressCount, out, err);
     progressCount++;
     maybeRegisterAnnouncedEvents(updateEvent.getChildrenEvents());
-    postedEvents.add(updateEvent.getEventId());
+    // Discard produced progress event from announced list as it is no longer needed:
+    // - Only the initial progress event is waited on.
+    // - Progress event has been posted.
+    announcedEvents.remove(updateEvent.getEventId());
     return updateEvent;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/BuildEventStreamer.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BuildEventStreamer.java
@@ -62,6 +62,7 @@ import com.google.devtools.build.lib.buildtool.buildevent.BuildStartingEvent;
 import com.google.devtools.build.lib.buildtool.buildevent.NoAnalyzeEvent;
 import com.google.devtools.build.lib.buildtool.buildevent.NoExecutionEvent;
 import com.google.devtools.build.lib.buildtool.buildevent.ReleaseReplaceableBuildEvent;
+import com.google.devtools.build.lib.collect.compacthashset.CompactHashSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadCompatible;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
@@ -119,7 +120,7 @@ public class BuildEventStreamer {
    * - Only the first progress event is tracked.
    */
   @GuardedBy("this")
-  private final Set<BuildEventId> postedEvents = new HashSet<>();
+  private final Set<BuildEventId> postedEvents = CompactHashSet.create();
 
   @GuardedBy("this")
   private final Set<BuildEventId> configurationsPosted = new HashSet<>();

--- a/src/main/java/com/google/devtools/build/lib/runtime/BuildEventStreamer.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BuildEventStreamer.java
@@ -106,12 +106,12 @@ public class BuildEventStreamer {
   private final boolean publishTargetSummaries;
 
   /**
-   * Tracks all events that have been announced.
+   * Tracks all events that have been announced, but not yet posted.
    * Notable exceptions:
    * - Only the first and next (unposted) progress event is tracked.
    */
   @GuardedBy("this")
-  private Set<BuildEventId> announcedEvents;
+  private Set<BuildEventId> frontierEvents;
 
   /**
    * Tracks all events that have been posted.
@@ -260,7 +260,7 @@ public class BuildEventStreamer {
     this.besOptions = options;
     this.outputGroupFileModes = outputGroupFileModes;
     this.publishTargetSummaries = publishTargetSummaries;
-    this.announcedEvents = null;
+    this.frontierEvents = null;
     this.progressCount = 0;
     this.artifactGroupNamer = artifactGroupNamer;
     this.oomMessage = oomMessage;
@@ -277,7 +277,10 @@ public class BuildEventStreamer {
       return;
     }
 
-    announcedEvents.add(id);
+    if (postedEvents.contains(id)) {
+      return;
+    }
+    frontierEvents.add(id);
   }
 
   // This exists to nop out the announcement of new events after #buildComplete
@@ -286,7 +289,8 @@ public class BuildEventStreamer {
       return;
     }
 
-    announcedEvents.addAll(ids);
+    Set<BuildEventId> unpostedIds = Sets.difference(Sets.newHashSet(ids), postedEvents);
+    frontierEvents.addAll(unpostedIds);
   }
 
   /**
@@ -305,8 +309,8 @@ public class BuildEventStreamer {
     List<BuildEvent> flushEvents = null;
     boolean lastEvent = false;
 
-    if (announcedEvents == null) {
-      announcedEvents = new HashSet<>();
+    if (frontierEvents == null) {
+      frontierEvents = new HashSet<>();
       // The very first event of a stream is implicitly announced by the convention that
       // a complete stream has to have at least one entry. In this way we keep the invariant
       // that the set of posted events is always a subset of the set of announced events.
@@ -318,7 +322,6 @@ public class BuildEventStreamer {
         maybeRegisterAnnouncedEvents(progress.getChildrenEvents());
         // the new first event in the stream, implicitly announced by the fact that complete
         // stream may not be empty.
-        maybeRegisterAnnouncedEvent(progress.getEventId());
         postedEvents.add(progress.getEventId());
       }
 
@@ -330,7 +333,7 @@ public class BuildEventStreamer {
       }
       bufferedStdoutStderrPairs = null;
     } else {
-      if (!announcedEvents.contains(id)) {
+      if (!frontierEvents.contains(id) && !postedEvents.contains(id)) {
         Iterable<String> allOut = ImmutableList.of();
         Iterable<String> allErr = ImmutableList.of();
         if (outErrProvider != null) {
@@ -348,10 +351,10 @@ public class BuildEventStreamer {
               finalLinkEvents.add(progressEvent);
               progressCount++;
               maybeRegisterAnnouncedEvents(progressEvent.getChildrenEvents());
-              // Discard produced progress event from announced list as it is no longer needed:
-              // - Only the initial progress event is waited on.
-              // - Progress event has been posted.
-              announcedEvents.remove(progressEvent.getEventId());
+              // Discard produced progress event ID as it is no longer needed:
+              // 1. Only the initial progress event is ever waited on (and needs to exist in `postedEvents`).
+              // 2. Progress event chain is tracked cheaply via `progressCount`.
+              frontierEvents.remove(progressEvent.getEventId());
             });
       }
     }
@@ -365,10 +368,9 @@ public class BuildEventStreamer {
     }
 
     postedEvents.add(id);
+    frontierEvents.remove(id);
     maybeRegisterAnnouncedEvents(event.getChildrenEvents());
-    // We keep as an invariant that postedEvents is a subset of announced events, so this is a
-    // cheaper test for equality
-    if (announcedEvents.size() == postedEvents.size()) {
+    if (frontierEvents.isEmpty()) {
       lastEvent = true;
     }
 
@@ -431,7 +433,8 @@ public class BuildEventStreamer {
         // AbortedEvent.
         ImmutableList.Builder<BuildEventId> children = ImmutableList.builder();
         for (BuildEventId bufferedId : bufferedEventsPendingOnThisType) {
-          if (announcedEvents == null || !announcedEvents.contains(bufferedId)) {
+          if (frontierEvents == null
+              || (!frontierEvents.contains(bufferedId) && !postedEvents.contains(bufferedId))) {
             children.add(bufferedId);
           }
         }
@@ -442,16 +445,16 @@ public class BuildEventStreamer {
   }
 
   /**
-   * Clear all events that are still announced; events not naturally closed by the expected event
-   * normally only occur if the build is aborted.
+   * Clear all events that are announced but not posted; events not naturally closed by the
+   * expected event normally only occur if the build is aborted.
    */
-  private synchronized void clearAnnouncedEvents(Collection<BuildEventId> dontclear) {
-    if (announcedEvents != null) {
+  private synchronized void clearFrontierEvents(Collection<BuildEventId> dontclear) {
+    if (frontierEvents != null) {
       // create a copy of the identifiers to clear, as the post method
-      // will change the set of already announced events.
+      // will change the frontier (announced but not posted) set.
       Set<BuildEventId> ids;
       synchronized (this) {
-        ids = Sets.difference(announcedEvents, postedEvents);
+        ids = Sets.newHashSet(frontierEvents);
       }
       for (BuildEventId id : ids) {
         if (!dontclear.contains(id)) {
@@ -740,6 +743,7 @@ public class BuildEventStreamer {
         // Pretend we posted this event so a target summary arriving after this test summary (which
         // is common) doesn't get erroneously buffered in bufferUntilPrerequisitesReceived().
         postedEvents.add(eventId);
+        frontierEvents.remove(eventId);
       }
       for (BuildEvent freedEvent : blockedEventsFifo) {
         buildEvent(freedEvent);
@@ -751,10 +755,10 @@ public class BuildEventStreamer {
     BuildEvent updateEvent = ProgressEvent.progressUpdate(progressCount, out, err);
     progressCount++;
     maybeRegisterAnnouncedEvents(updateEvent.getChildrenEvents());
-    // Discard produced progress event from announced list as it is no longer needed:
-    // - Only the initial progress event is waited on.
-    // - Progress event has been posted.
-    announcedEvents.remove(updateEvent.getEventId());
+    // Discard produced progress event ID as it is no longer needed:
+    // 1. Only the initial progress event is ever waited on (and needs to exist in `postedEvents`).
+    // 2. Progress event chain is tracked cheaply via `progressCount`.
+    frontierEvents.remove(updateEvent.getEventId());
     return updateEvent;
   }
 
@@ -789,7 +793,7 @@ public class BuildEventStreamer {
         // If we've already announced the final events, we cannot add more progress events. Stdout
         // and stderr are truncated from the event log.
         consumeAsPairsofStrings(allOut, allErr, (s1, s2) -> {});
-      } else if (announcedEvents != null) {
+      } else if (frontierEvents != null) {
         updateEvents = new ArrayList<>();
         List<BuildEvent> finalUpdateEvents = updateEvents;
         consumeAsPairsofStrings(
@@ -890,14 +894,13 @@ public class BuildEventStreamer {
         allErr,
         (s1, s2) -> post(flushStdoutStderrEvent(s1, s2)),
         (s1, s2) -> post(ProgressEvent.finalProgressUpdate(progressCount++, s1, s2)));
-    clearAnnouncedEvents(event == null ? ImmutableList.of() : event.getChildrenEvents());
+    clearFrontierEvents(event == null ? ImmutableList.of() : event.getChildrenEvents());
   }
 
   private synchronized void buildComplete(ChainableEvent event) {
     clearEventsAndPostFinalProgress(event);
 
-    finalEventsToCome = new HashSet<>(announcedEvents);
-    finalEventsToCome.removeAll(postedEvents);
+    finalEventsToCome = new HashSet<>(frontierEvents);
     if (finalEventsToCome.isEmpty()) {
       close();
     }

--- a/src/main/java/com/google/devtools/build/lib/runtime/BuildEventStreamer.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BuildEventStreamer.java
@@ -106,12 +106,12 @@ public class BuildEventStreamer {
   private final boolean publishTargetSummaries;
 
   /**
-   * Tracks all events that have been announced.
+   * Tracks all events that have been announced, but not yet posted.
    * Notable exceptions:
    * - Only the first and next (unposted) progress event is tracked.
    */
   @GuardedBy("this")
-  private Set<BuildEventId> announcedEvents;
+  private Set<BuildEventId> frontierEvents;
 
   /**
    * Tracks all events that have been posted.
@@ -260,7 +260,7 @@ public class BuildEventStreamer {
     this.besOptions = options;
     this.outputGroupFileModes = outputGroupFileModes;
     this.publishTargetSummaries = publishTargetSummaries;
-    this.announcedEvents = null;
+    this.frontierEvents = null;
     this.progressCount = 0;
     this.artifactGroupNamer = artifactGroupNamer;
     this.oomMessage = oomMessage;
@@ -277,7 +277,10 @@ public class BuildEventStreamer {
       return;
     }
 
-    announcedEvents.add(id);
+    if (postedEvents.contains(id)) {
+      return;
+    }
+    frontierEvents.add(id);
   }
 
   // This exists to nop out the announcement of new events after #buildComplete
@@ -286,7 +289,11 @@ public class BuildEventStreamer {
       return;
     }
 
-    announcedEvents.addAll(ids);
+    for (BuildEventId id : ids) {
+      if (!postedEvents.contains(id)) {
+        frontierEvents.add(id);
+      }
+    }
   }
 
   /**
@@ -305,8 +312,8 @@ public class BuildEventStreamer {
     List<BuildEvent> flushEvents = null;
     boolean lastEvent = false;
 
-    if (announcedEvents == null) {
-      announcedEvents = new HashSet<>();
+    if (frontierEvents == null) {
+      frontierEvents = new HashSet<>();
       // The very first event of a stream is implicitly announced by the convention that
       // a complete stream has to have at least one entry. In this way we keep the invariant
       // that the set of posted events is always a subset of the set of announced events.
@@ -318,7 +325,6 @@ public class BuildEventStreamer {
         maybeRegisterAnnouncedEvents(progress.getChildrenEvents());
         // the new first event in the stream, implicitly announced by the fact that complete
         // stream may not be empty.
-        maybeRegisterAnnouncedEvent(progress.getEventId());
         postedEvents.add(progress.getEventId());
       }
 
@@ -330,7 +336,7 @@ public class BuildEventStreamer {
       }
       bufferedStdoutStderrPairs = null;
     } else {
-      if (!announcedEvents.contains(id)) {
+      if (!frontierEvents.contains(id) && !postedEvents.contains(id)) {
         Iterable<String> allOut = ImmutableList.of();
         Iterable<String> allErr = ImmutableList.of();
         if (outErrProvider != null) {
@@ -348,10 +354,10 @@ public class BuildEventStreamer {
               finalLinkEvents.add(progressEvent);
               progressCount++;
               maybeRegisterAnnouncedEvents(progressEvent.getChildrenEvents());
-              // Discard produced progress event from announced list as it is no longer needed:
-              // - Only the initial progress event is waited on.
-              // - Progress event has been posted.
-              announcedEvents.remove(progressEvent.getEventId());
+              // Discard produced progress event ID as it is no longer needed:
+              // 1. Only the initial progress event is ever waited on (and needs to exist in `postedEvents`).
+              // 2. Progress event chain is tracked cheaply via `progressCount`.
+              frontierEvents.remove(progressEvent.getEventId());
             });
       }
     }
@@ -365,10 +371,9 @@ public class BuildEventStreamer {
     }
 
     postedEvents.add(id);
+    frontierEvents.remove(id);
     maybeRegisterAnnouncedEvents(event.getChildrenEvents());
-    // We keep as an invariant that postedEvents is a subset of announced events, so this is a
-    // cheaper test for equality
-    if (announcedEvents.size() == postedEvents.size()) {
+    if (frontierEvents.isEmpty()) {
       lastEvent = true;
     }
 
@@ -431,7 +436,8 @@ public class BuildEventStreamer {
         // AbortedEvent.
         ImmutableList.Builder<BuildEventId> children = ImmutableList.builder();
         for (BuildEventId bufferedId : bufferedEventsPendingOnThisType) {
-          if (announcedEvents == null || !announcedEvents.contains(bufferedId)) {
+          if (frontierEvents == null
+              || (!frontierEvents.contains(bufferedId) && !postedEvents.contains(bufferedId))) {
             children.add(bufferedId);
           }
         }
@@ -442,16 +448,16 @@ public class BuildEventStreamer {
   }
 
   /**
-   * Clear all events that are still announced; events not naturally closed by the expected event
-   * normally only occur if the build is aborted.
+   * Clear all events that are announced but not posted; events not naturally closed by the
+   * expected event normally only occur if the build is aborted.
    */
-  private synchronized void clearAnnouncedEvents(Collection<BuildEventId> dontclear) {
-    if (announcedEvents != null) {
+  private synchronized void clearFrontierEvents(Collection<BuildEventId> dontclear) {
+    if (frontierEvents != null) {
       // create a copy of the identifiers to clear, as the post method
-      // will change the set of already announced events.
+      // will change the frontier (announced but not posted) set.
       Set<BuildEventId> ids;
       synchronized (this) {
-        ids = Sets.difference(announcedEvents, postedEvents);
+        ids = Sets.newHashSet(frontierEvents);
       }
       for (BuildEventId id : ids) {
         if (!dontclear.contains(id)) {
@@ -740,6 +746,7 @@ public class BuildEventStreamer {
         // Pretend we posted this event so a target summary arriving after this test summary (which
         // is common) doesn't get erroneously buffered in bufferUntilPrerequisitesReceived().
         postedEvents.add(eventId);
+        frontierEvents.remove(eventId);
       }
       for (BuildEvent freedEvent : blockedEventsFifo) {
         buildEvent(freedEvent);
@@ -751,10 +758,10 @@ public class BuildEventStreamer {
     BuildEvent updateEvent = ProgressEvent.progressUpdate(progressCount, out, err);
     progressCount++;
     maybeRegisterAnnouncedEvents(updateEvent.getChildrenEvents());
-    // Discard produced progress event from announced list as it is no longer needed:
-    // - Only the initial progress event is waited on.
-    // - Progress event has been posted.
-    announcedEvents.remove(updateEvent.getEventId());
+    // Discard produced progress event ID as it is no longer needed:
+    // 1. Only the initial progress event is ever waited on (and needs to exist in `postedEvents`).
+    // 2. Progress event chain is tracked cheaply via `progressCount`.
+    frontierEvents.remove(updateEvent.getEventId());
     return updateEvent;
   }
 
@@ -789,7 +796,7 @@ public class BuildEventStreamer {
         // If we've already announced the final events, we cannot add more progress events. Stdout
         // and stderr are truncated from the event log.
         consumeAsPairsofStrings(allOut, allErr, (s1, s2) -> {});
-      } else if (announcedEvents != null) {
+      } else if (frontierEvents != null) {
         updateEvents = new ArrayList<>();
         List<BuildEvent> finalUpdateEvents = updateEvents;
         consumeAsPairsofStrings(
@@ -890,14 +897,13 @@ public class BuildEventStreamer {
         allErr,
         (s1, s2) -> post(flushStdoutStderrEvent(s1, s2)),
         (s1, s2) -> post(ProgressEvent.finalProgressUpdate(progressCount++, s1, s2)));
-    clearAnnouncedEvents(event == null ? ImmutableList.of() : event.getChildrenEvents());
+    clearFrontierEvents(event == null ? ImmutableList.of() : event.getChildrenEvents());
   }
 
   private synchronized void buildComplete(ChainableEvent event) {
     clearEventsAndPostFinalProgress(event);
 
-    finalEventsToCome = new HashSet<>(announcedEvents);
-    finalEventsToCome.removeAll(postedEvents);
+    finalEventsToCome = new HashSet<>(frontierEvents);
     if (finalEventsToCome.isEmpty()) {
       close();
     }


### PR DESCRIPTION
Several memory optimizations to reduce BEP overhead.

> [!NOTE] 
> Included statistics are captured from OOM heap dumps in a stress test (50k genrule targets) with limited memory (`-Xmx256M`). With each successive change Bazel is able to make it further through the stress test before succumbing to an OOM (GC fighting for scraps for longer each time), so results are not perfectly comparable but good enough to show a clear difference with each highlighted change. `SpawnMetrics` instance counts help to contextualise the impact (increases proportional to build progress).

"Net related memory" is the total of all build-event-streamer-related allocations: event IDs (the `BuildEventId` proto graph), the strings they reference, the interners, and the `postedEvents`/`announcedEvents`/`frontierEvents` set scaffolding (nodes/backing arrays, excluding the IDs they hold).
In aggregate it falls **64.5 → 29.8 MB (−34.8 MB, −53.8%)**.

1. Discard chained progress event IDs.
   Only the initial progress event ID is returned by any `postedAfter()` method, all others are safe to discard. The next progress event ID is kept to maintain invariants (announced but not yet posted).
   - `ProgressId` instances: **96,600 → 3**
     1. `ProgressEvent.INITIAL_PROGRESS_UPDATE` constant.
     2. `ProgressId(0)` produced by `BuildEventStreamer` when `progressCount == 0`.
     3. Next progress ID.
   - `BuildEventId` instances: 367,365 → 264,821
   - Net related memory: **64.5 → 52.1 MB (−12.4 MB)**
   - `SpawnMetrics` instances: 24,150 → 22,960
   - Duration: 142 → 240s
2. Prune posted event IDs from the announced set.
   A posted event is implicitly announced, less memory is required (e.g. for hashmap nodes) by exploiting this detail. This leaves the posted events set as the largest BEP related data structure.
   To reflect the changed meaning of the announced set, it is not referred to as the frontier as it only contains event IDs that have been announced but not yet posted.
   - Set-related memory: **18.2 → 10.9 MB (−7.3 MB)**
   - Net related memory: **52.1 → 43.2 MB (−8.9 MB)**
   - `SpawnMetrics` instances: **22,960 → 36,744**
   - Duration: 240 → 251s
3. Interning highly repeated strings.
   To avoid penalizing string sets with few unique entries (e.g. aspect names and configurations), separate interners are used for each type.
   1. Labels, each of which will be repeated a handful of times in separate event IDs.
   2. Configuration hashes, of which there are generally few but highly repeated (configured target event IDs).
   - String memory: **8.9 → 3.9 MB (−5.0 MB)**
   - Interner memory: 0.03 → 2.6 MB (captured before moving from `WeakInterner` to `String.intern`)
   - Net related memory: **43.2 → 42.4 MB (−0.8 MB)**
   - `SpawnMetrics` instances: **36,744 → 40,463**
   - Duration: 251 → 277s
4. Switch `postedEvents` from `HashSet` to `CompactHashSet`.
   - `HashMap$Node`: **−180,803 nodes, 10.3 → 2.7 MB (−7.6 MB)**
   - Net related memory: **42.4 → 37.8 MB (−4.6 MB)**
   - `SpawnMetrics` instances: 40,463 → 41,705
   - Duration: 288 → 283s
5. Make event IDs from 2 `postedAfter()` methods lazily generated.
   Target complete and aspect complete events were eagerly generating their `postedAfter()` return value, leading to duplicate `BuildEventId`s (equal value, different instance) occupying memory. This reduces retained memory, especially when multiple of these events are all waiting on the same events to be posted.
   - `BuildEventId` instances: 266,856 → 232,264 (−34.6k)
   - Net related memory: **37.8 → 34.7 MB (−3.1 MB)**
   - `SpawnMetrics` instances: **41,705 → 44,083**
   - Duration: 283s → 301s
6. Intern `BuildEventId.ConfigurationId`.
   These are highly repeated, meaning the interner memory overhead (higher for objects) is quickly offset.
   - `ConfigurationId` instances: **94,087 → 5**
   - Net related memory: **34.7 → 31.5 MB (−3.2 MB)**
   - `SpawnMetrics` instances: 44,083 → 45,714
   - Duration: 301 → 300s
7. Cache configuration `BuildEventId`.
   `BuildConfigurationValue.configurationId()` is a hot path that calls `[[BuildConfigurationValue]].getEventId()`, where configuration specific `BuildEventId`s (not `BuildEventId.ConfigrationId` but rather the event ID for the configuration itself) are produced. Caching these (currently lazily) reduces the number of duplicates without interner overhead.
   - `BuildEventId`: **237,176 → 193,344 (−43.8k outer config-id wrappers)**
   - Net related memory: **31.5 → 29.8 MB (−1.7 MB)**
   - `SpawnMetrics` instances: 45,714 → 46,663
   - Duration: 300 → 298s
   - Duration (with `-Xmx2g`): 54s (matches baseline)

Some ideas that were investigated, but did not pan out.
- Interning every `BuildEventId`.
  There are not enough retained duplicate `BuildEventId`s to overcome the interner's own memory overhead. Most of the potential wins have been realized via string interning.

### Motivation

As noted in #21540, the build event streamer retains every `BuildEventId` it encounters in order to meet the BEP specification.
- Every announced event (e.g. children) must be posted. In the case of an abort, stubs are produced for any event not yet posted.
- Every event must be directly or indirectly connected to the first (root) event. That is, BEP is a rooted DAG.

Retention of `BuildEventId`s means build event streamer scales it's memory requirement with the size of builds. These changes are intended to trim this down to the minimum.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
