### PR TITLE
build: add --cquery flag to build configured-target query matches

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/AnalysisResult.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AnalysisResult.java
@@ -156,6 +156,35 @@ public class AnalysisResult {
   }
 
   /**
+   * Returns an equivalent {@link AnalysisResult} with {@code targetsToBuild} replaced by the given
+   * set. Used by {@code build --cquery} to restrict the execution phase to only the
+   * cquery-matched configured targets.
+   *
+   * <p>Note: {@code artifactsToBuild} (coverage / extra-action / build-info artifacts) is left
+   * unchanged. The execution phase derives each target's top-level output artifacts from {@code
+   * targetsToBuild} (see {@code TopLevelArtifactHelper.findAllTopLevelArtifacts}), so for a plain
+   * {@code build --cquery} the filtering is effective; the supplementary {@code artifactsToBuild}
+   * set may still reference non-matched targets under coverage / extra actions.
+   */
+  public AnalysisResult withFilteredTargets(ImmutableSet<ConfiguredTarget> filteredTargets) {
+    return new AnalysisResult(
+        configuration,
+        filteredTargets,
+        aspects,
+        targetsToTest,
+        targetsToSkip,
+        failureDetail,
+        actionGraph,
+        artifactsToBuild,
+        parallelTests,
+        exclusiveTests,
+        exclusiveIfLocalTests,
+        topLevelContext,
+        packageRoots,
+        topLevelTargetsWithConfigs);
+  }
+
+  /**
    * Returns an equivalent {@link AnalysisResult}, except with exclusive tests treated as parallel
    * tests.
    */

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildCqueryProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildCqueryProcessor.java
@@ -1,0 +1,161 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.buildtool;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.analysis.AnalysisResult;
+import com.google.devtools.build.lib.analysis.ConfiguredAspect;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.ViewCreationFailedException;
+import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
+import com.google.devtools.build.lib.buildtool.BuildTool.ExitException;
+import com.google.devtools.build.lib.cmdline.TargetPattern;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
+import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment.TopLevelConfigurations;
+import com.google.devtools.build.lib.query2.common.CommonQueryOptions;
+import com.google.devtools.build.lib.query2.common.CqueryNode;
+import com.google.devtools.build.lib.query2.cquery.ConfiguredTargetQueryEnvironment;
+import com.google.devtools.build.lib.query2.cquery.CqueryOptions;
+import com.google.devtools.build.lib.query2.engine.QueryEnvironment.QueryFunction;
+import com.google.devtools.build.lib.query2.engine.QueryException;
+import com.google.devtools.build.lib.query2.engine.QueryExpression;
+import com.google.devtools.build.lib.runtime.BlazeRuntime;
+import com.google.devtools.build.lib.runtime.CommandEnvironment;
+import com.google.devtools.build.lib.server.FailureDetails.ConfigurableQuery;
+import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
+import com.google.devtools.build.lib.skyframe.AspectKeyCreator;
+import com.google.devtools.build.lib.util.DetailedExitCode;
+import com.google.devtools.build.skyframe.WalkableGraph;
+import com.google.devtools.common.options.Options;
+import java.io.IOException;
+import java.util.Set;
+import net.starlark.java.eval.StarlarkSemantics;
+
+/**
+ * {@link BuildTool.AnalysisPostProcessor} for {@code build --cquery}: evaluates a cquery expression
+ * over the post-analysis configured-target graph and returns a filtered {@link AnalysisResult}
+ * containing only the matched configured targets, so the execution phase builds only those.
+ *
+ * <p>Unlike {@link CqueryProcessor} (used by the standalone {@code cquery} command), this processor
+ * writes no query output to stdout; it uses the query result purely to restrict what gets built.
+ *
+ * <p>Code sharing with {@link CqueryProcessor}: both extend {@link PostAnalysisQueryProcessor} and
+ * build the same {@link ConfiguredTargetQueryEnvironment}. Because the {@code build} command does
+ * not register {@link CqueryOptions}, this processor falls back to default cquery options.
+ */
+public final class BuildCqueryProcessor extends PostAnalysisQueryProcessor<CqueryNode> {
+
+  public BuildCqueryProcessor(
+      QueryExpression queryExpression, TargetPattern.Parser mainRepoTargetParser) {
+    super(queryExpression, mainRepoTargetParser);
+  }
+
+  private static CqueryOptions defaultCqueryOptions() {
+    return Options.getDefaults(CqueryOptions.class);
+  }
+
+  @Override
+  protected CommonQueryOptions getQueryOptions(CommandEnvironment env) {
+    CqueryOptions options = env.getOptions().getOptions(CqueryOptions.class);
+    return options != null ? options : defaultCqueryOptions();
+  }
+
+  @Override
+  protected ConfiguredTargetQueryEnvironment getQueryEnvironment(
+      BuildRequest request,
+      CommandEnvironment env,
+      TopLevelConfigurations configurations,
+      ImmutableMap<String, BuildConfigurationValue> transitiveConfigurations,
+      ImmutableMap<AspectKeyCreator.AspectKey, ConfiguredAspect> topLevelAspects,
+      WalkableGraph walkableGraph) {
+    ImmutableList<QueryFunction> extraFunctions =
+        ImmutableList.<QueryFunction>builder()
+            .addAll(ConfiguredTargetQueryEnvironment.CQUERY_FUNCTIONS)
+            .addAll(env.getRuntime().getQueryFunctions())
+            .build();
+    CqueryOptions cqueryOptions = request.getOptions(CqueryOptions.class);
+    if (cqueryOptions == null) {
+      cqueryOptions = defaultCqueryOptions();
+    }
+    StarlarkSemantics starlarkSemantics =
+        env.getSkyframeExecutor()
+            .getEffectiveStarlarkSemantics(env.getOptions().getOptions(BuildLanguageOptions.class));
+    return new ConfiguredTargetQueryEnvironment(
+        request.getKeepGoing(),
+        env.getReporter(),
+        extraFunctions,
+        configurations,
+        transitiveConfigurations,
+        topLevelAspects,
+        mainRepoTargetParser,
+        env.getPackageManager().getPackagePath(),
+        () -> walkableGraph,
+        cqueryOptions,
+        request.getTopLevelArtifactContext(),
+        cqueryOptions.getLabelPrinter(starlarkSemantics, mainRepoTargetParser.getRepoMapping()));
+  }
+
+  /**
+   * Evaluates the cquery expression against the post-analysis graph and returns a copy of {@code
+   * analysisResult} restricted to only the configured targets matched by the query.
+   */
+  @Override
+  public AnalysisResult process(
+      BuildRequest request,
+      CommandEnvironment env,
+      BlazeRuntime runtime,
+      AnalysisResult analysisResult)
+      throws InterruptedException, ViewCreationFailedException, ExitException {
+    env.getSkyframeExecutor().deleteOldNodes(/* versionWindowForDirtyGc= */ 0);
+    env.getSkyframeExecutor().applyInvalidation(env.getReporter());
+
+    Set<CqueryNode> matchedNodes;
+    try {
+      matchedNodes =
+          evaluateQueryNodes(
+              request,
+              env,
+              new TopLevelConfigurations(analysisResult.getTopLevelTargetsWithConfigs()),
+              analysisResult.getAspectsMap(),
+              env.getSkyframeExecutor().getTransitiveConfigurationKeys(),
+              queryExpression);
+    } catch (QueryException e) {
+      String errorMessage = "Error evaluating --cquery expression";
+      if (!request.getKeepGoing()) {
+        throw new ViewCreationFailedException(errorMessage, e.getFailureDetail(), e);
+      }
+      env.getReporter().error(null, errorMessage + ": " + e.getFailureDetail().getMessage());
+      return analysisResult;
+    } catch (IOException e) {
+      FailureDetail failureDetail =
+          FailureDetail.newBuilder()
+              .setMessage("I/O error evaluating --cquery expression: " + e.getMessage())
+              .setConfigurableQuery(
+                  ConfigurableQuery.newBuilder()
+                      .setCode(ConfigurableQuery.Code.CONFIGURABLE_QUERY_UNKNOWN))
+              .build();
+      throw new ExitException(DetailedExitCode.of(failureDetail));
+    }
+
+    ImmutableSet<ConfiguredTarget> filteredTargets =
+        matchedNodes.stream()
+            .filter(ConfiguredTarget.class::isInstance)
+            .map(ConfiguredTarget.class::cast)
+            .collect(ImmutableSet.toImmutableSet());
+
+    return analysisResult.withFilteredTargets(filteredTargets);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java
@@ -157,11 +157,17 @@ public class BuildTool {
   private static final String SKYFRAME_MEMORY_DUMP_FILE = "skyframe_memory.json";
 
   private static final AnalysisPostProcessor NOOP_POST_PROCESSOR =
-      (unusedRequest, unusedEnv, unusedRuntime, unusedAnalysisResult) -> {};
+      (unusedRequest, unusedEnv, unusedRuntime, analysisResult) -> analysisResult;
 
-  /** Hook for inserting extra post-analysis-phase processing. Used for implementing {a,c}query. */
+  /**
+   * Hook for inserting extra post-analysis-phase processing. Used for implementing {a,c}query.
+   *
+   * <p>Returns the {@link AnalysisResult} the execution phase should use. Implementations may
+   * return the given {@code analysisResult} unchanged, or a modified copy (e.g. with a filtered
+   * set of targets to build, as {@code build --cquery} does).
+   */
   public interface AnalysisPostProcessor {
-    void process(
+    AnalysisResult process(
         BuildRequest request,
         CommandEnvironment env,
         BlazeRuntime runtime,
@@ -564,12 +570,15 @@ public class BuildTool {
         }
 
         result.setBuildConfiguration(analysisResult.getConfiguration());
-        result.setActualTargets(analysisResult.getTargetsToBuild());
-        result.setTestTargets(analysisResult.getTargetsToTest());
 
         try (SilentCloseable c = Profiler.instance().profile("analysisPostProcessor.process")) {
-          analysisPostProcessor.process(request, env, runtime, analysisResult);
+          analysisResult = analysisPostProcessor.process(request, env, runtime, analysisResult);
         }
+
+        // Record the targets to build/test after the post-processor runs, so a processor that
+        // filters the set (e.g. build --cquery) determines what the execution phase builds.
+        result.setActualTargets(analysisResult.getTargetsToBuild());
+        result.setTestTargets(analysisResult.getTargetsToTest());
 
         if (needsExecutionPhase(request.getBuildOptions())) {
           try (SilentCloseable closeable = Profiler.instance().profile("ExecutionTool.init")) {

--- a/src/main/java/com/google/devtools/build/lib/buildtool/PostAnalysisQueryProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/PostAnalysisQueryProcessor.java
@@ -60,7 +60,7 @@ import java.util.function.Function;
  */
 public abstract class PostAnalysisQueryProcessor<T> implements BuildTool.AnalysisPostProcessor {
 
-  private final QueryExpression queryExpression;
+  protected final QueryExpression queryExpression;
   protected final TargetPattern.Parser mainRepoTargetParser;
 
   PostAnalysisQueryProcessor(
@@ -70,14 +70,14 @@ public abstract class PostAnalysisQueryProcessor<T> implements BuildTool.Analysi
   }
 
   @Override
-  public void process(
+  public AnalysisResult process(
       BuildRequest request,
       CommandEnvironment env,
       BlazeRuntime runtime,
       AnalysisResult analysisResult)
       throws InterruptedException, ViewCreationFailedException, ExitException {
     if (queryExpression == null) {
-      return;
+      return analysisResult;
     }
 
     // This query will operate over the graph as constructed by analysis, but will also pick up
@@ -143,6 +143,40 @@ public abstract class PostAnalysisQueryProcessor<T> implements BuildTool.Analysi
                       ActionQuery.newBuilder().setCode(ActionQuery.Code.INCORRECT_ARGUMENTS))
                   .build()));
     }
+    return analysisResult;
+  }
+
+  /**
+   * Evaluates the given query expression against the post-analysis graph and returns the matched
+   * nodes, without writing any query output. Used by {@code build --cquery} to collect the set of
+   * configured targets to build.
+   */
+  protected Set<T> evaluateQueryNodes(
+      BuildRequest request,
+      CommandEnvironment env,
+      TopLevelConfigurations topLevelConfigurations,
+      ImmutableMap<AspectKeyCreator.AspectKey, ConfiguredAspect> topLevelAspects,
+      Collection<SkyKey> transitiveConfigurationKeys,
+      QueryExpression queryExpression)
+      throws InterruptedException, QueryException, IOException {
+    WalkableGraph walkableGraph =
+        SkyframeExecutorWrappingWalkableGraph.of(env.getSkyframeExecutor());
+    ImmutableMap<String, BuildConfigurationValue> transitiveConfigurations =
+        getTransitiveConfigurations(transitiveConfigurationKeys, walkableGraph);
+
+    PostAnalysisQueryEnvironment<T> postAnalysisQueryEnvironment =
+        getQueryEnvironment(
+            request,
+            env,
+            topLevelConfigurations,
+            transitiveConfigurations,
+            topLevelAspects,
+            walkableGraph);
+
+    AggregateAllOutputFormatterCallback<T, Set<T>> aggregateResultsCallback =
+        QueryUtil.newOrderedAggregateAllOutputFormatterCallback(postAnalysisQueryEnvironment);
+    postAnalysisQueryEnvironment.evaluateQuery(queryExpression, aggregateResultsCallback);
+    return aggregateResultsCallback.getResult();
   }
 
   protected abstract CommonQueryOptions getQueryOptions(CommandEnvironment env);

--- a/src/main/java/com/google/devtools/build/lib/query2/common/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/query2/common/BUILD
@@ -54,6 +54,7 @@ java_library(
     srcs = [
         "CommonQueryOptions.java",
         "FlagConstants.java",
+        "UniverseScopeOptions.java",
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/cmdline",

--- a/src/main/java/com/google/devtools/build/lib/query2/common/CommonQueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/common/CommonQueryOptions.java
@@ -36,23 +36,9 @@ import net.starlark.java.eval.StarlarkSemantics;
 @OptionsClass
 public abstract class CommonQueryOptions extends OptionsBase {
 
-  @Option(
-      name = "universe_scope",
-      defaultValue = "",
-      documentationCategory = OptionDocumentationCategory.QUERY,
-      converter = Converters.CommaSeparatedOptionListConverter.class,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-      help =
-          "A comma-separated set of target patterns (additive and subtractive). The query may be"
-              + " performed in the universe defined by the transitive closure of the specified"
-              + " targets. This option is used for the query and cquery commands.\n"
-              + "For cquery, the input to this option is the targets all answers are built under"
-              + " and so this option may affect configurations and transitions. If this option is"
-              + " not specified, the top-level targets are assumed to be the targets parsed from"
-              + " the query expression. Note: For cquery, not specifying this option may cause the"
-              + " build to break if targets parsed from the query expression are not buildable"
-              + " with top-level options.")
-  public abstract List<String> getUniverseScope();
+  // Note: --universe_scope lives in its own UniverseScopeOptions class (shared by the query,
+  // cquery, aquery and build commands) rather than here, to avoid an option-name collision when
+  // cquery/aquery inherit the build command's options.
 
   @Option(
       name = "line_terminator_null",

--- a/src/main/java/com/google/devtools/build/lib/query2/common/UniverseScopeOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/common/UniverseScopeOptions.java
@@ -1,0 +1,54 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.query2.common;
+
+import com.google.devtools.common.options.Converters;
+import com.google.devtools.common.options.Option;
+import com.google.devtools.common.options.OptionDocumentationCategory;
+import com.google.devtools.common.options.OptionEffectTag;
+import com.google.devtools.common.options.OptionsBase;
+import com.google.devtools.common.options.OptionsClass;
+import java.util.List;
+
+/**
+ * The {@code --universe_scope} option, in its own options class so it can be shared by the {@code
+ * query}, {@code cquery}, {@code aquery} and {@code build} commands without colliding.
+ *
+ * <p>It is deliberately <em>not</em> declared in {@link CommonQueryOptions}: the {@code cquery} and
+ * {@code aquery} commands inherit the {@code build} command's options, so if {@code build} and the
+ * query commands each surfaced their own {@code --universe_scope} (one via this class, one via
+ * {@code CommonQueryOptions}) the option name would collide. Keeping a single definition that every
+ * command references avoids that.
+ */
+@OptionsClass
+public abstract class UniverseScopeOptions extends OptionsBase {
+
+  @Option(
+      name = "universe_scope",
+      defaultValue = "",
+      documentationCategory = OptionDocumentationCategory.QUERY,
+      converter = Converters.CommaSeparatedOptionListConverter.class,
+      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+      help =
+          "A comma-separated set of target patterns (additive and subtractive). The query may be"
+              + " performed in the universe defined by the transitive closure of the specified"
+              + " targets. This option is used for the query, cquery and build commands.\n"
+              + "For cquery and build, the input to this option is the targets all answers are built"
+              + " under and so this option may affect configurations and transitions. If this option"
+              + " is not specified, the top-level targets are assumed to be the targets parsed from"
+              + " the query expression. Note: For cquery, not specifying this option may cause the"
+              + " build to break if targets parsed from the query expression are not buildable with"
+              + " top-level options.")
+  public abstract List<String> getUniverseScope();
+}

--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/BUILD
@@ -38,6 +38,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/query2",
         "//src/main/java/com/google/devtools/build/lib/query2/common:abstract-blaze-query-env",
+        "//src/main/java/com/google/devtools/build/lib/query2/common:options",
         "//src/main/java/com/google/devtools/build/lib/query2/common:universe-scope",
         "//src/main/java/com/google/devtools/build/lib/query2/engine",
         "//src/main/java/com/google/devtools/build/lib/query2/query/output",

--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
@@ -71,6 +71,7 @@ import com.google.devtools.build.lib.query2.engine.QueryUtil.AggregateAllOutputF
 import com.google.devtools.build.lib.query2.engine.SkyframeRestartQueryException;
 import com.google.devtools.build.lib.query2.query.output.OutputFormatter;
 import com.google.devtools.build.lib.query2.query.output.OutputFormatters;
+import com.google.devtools.build.lib.query2.common.UniverseScopeOptions;
 import com.google.devtools.build.lib.query2.query.output.QueryOptions;
 import com.google.devtools.build.lib.query2.query.output.QueryOptions.OrderOutput;
 import com.google.devtools.build.lib.query2.query.output.QueryOutputUtils;
@@ -119,7 +120,8 @@ public class GenQuery implements RuleConfiguredTargetFactory {
 
     OptionsParser optionsParser =
         OptionsParser.builder()
-            .optionsClasses(QueryOptions.class, KeepGoingOption.class)
+            .optionsClasses(
+                QueryOptions.class, UniverseScopeOptions.class, KeepGoingOption.class)
             .allowResidue(false)
             .withConversionContext(
                 Label.RepoContext.of(
@@ -141,7 +143,7 @@ public class GenQuery implements RuleConfiguredTargetFactory {
       ruleContext.attributeError("opts", "option --keep_going is not allowed");
       return null;
     }
-    if (!queryOptions.getUniverseScope().isEmpty()) {
+    if (!optionsParser.getOptions(UniverseScopeOptions.class).getUniverseScope().isEmpty()) {
       ruleContext.attributeError("opts", "option --universe_scope is not allowed");
       return null;
     }

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/AqueryCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/AqueryCommand.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.cmdline.TargetPattern.Parser;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.query2.aquery.ActionGraphQueryEnvironment;
 import com.google.devtools.build.lib.query2.aquery.AqueryOptions;
+import com.google.devtools.build.lib.query2.common.UniverseScopeOptions;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.QueryFunction;
 import com.google.devtools.build.lib.query2.engine.QueryException;
 import com.google.devtools.build.lib.query2.engine.QueryExpression;
@@ -129,7 +130,9 @@ public final class AqueryCommand implements BlazeCommand {
     try {
       topLevelTargets =
           QueryCommandUtils.getTopLevelTargets(
-              aqueryOptions.getUniverseScope(), expr, queryCurrentSkyframeState);
+              options.getOptions(UniverseScopeOptions.class).getUniverseScope(),
+              expr,
+              queryCurrentSkyframeState);
     } catch (QueryException e) {
       env.getReporter().handle(Event.error(e.getMessage()));
       return createFailureResult(

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/BuildCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/BuildCommand.java
@@ -15,11 +15,17 @@ package com.google.devtools.build.lib.runtime.commands;
 
 import static com.google.devtools.build.lib.runtime.Command.BuildPhase.EXECUTES;
 
+import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.analysis.AnalysisOptions;
 import com.google.devtools.build.lib.buildeventstream.BuildEventProtocolOptions;
+import com.google.devtools.build.lib.buildtool.BuildCqueryProcessor;
 import com.google.devtools.build.lib.buildtool.BuildRequest;
 import com.google.devtools.build.lib.buildtool.BuildRequestOptions;
 import com.google.devtools.build.lib.buildtool.BuildTool;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
+import com.google.devtools.build.lib.cmdline.TargetPattern;
+import com.google.devtools.build.lib.cmdline.TargetPattern.Parser;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.local.LocalExecutionOptions;
@@ -27,6 +33,12 @@ import com.google.devtools.build.lib.pkgcache.LoadingOptions;
 import com.google.devtools.build.lib.pkgcache.PackageOptions;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
+import com.google.devtools.build.lib.query2.common.UniverseScopeOptions;
+import com.google.devtools.build.lib.query2.cquery.ConfiguredTargetQueryEnvironment;
+import com.google.devtools.build.lib.query2.engine.QueryEnvironment.QueryFunction;
+import com.google.devtools.build.lib.query2.engine.QueryExpression;
+import com.google.devtools.build.lib.query2.engine.QueryParser;
+import com.google.devtools.build.lib.query2.engine.QuerySyntaxException;
 import com.google.devtools.build.lib.runtime.BlazeCommand;
 import com.google.devtools.build.lib.runtime.BlazeCommandResult;
 import com.google.devtools.build.lib.runtime.BlazeRuntime;
@@ -34,10 +46,20 @@ import com.google.devtools.build.lib.runtime.Command;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.runtime.KeepGoingOption;
 import com.google.devtools.build.lib.runtime.LoadingPhaseThreadsOption;
+import com.google.devtools.build.lib.server.FailureDetails.ConfigurableQuery;
+import com.google.devtools.build.lib.server.FailureDetails.ConfigurableQuery.Code;
+import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
+import com.google.devtools.build.lib.skyframe.RepositoryMappingValue.RepositoryMappingResolutionException;
 import com.google.devtools.build.lib.skyframe.SkyfocusOptions;
 import com.google.devtools.build.lib.skyframe.serialization.analysis.RemoteAnalysisCachingOptions;
 import com.google.devtools.build.lib.util.DetailedExitCode;
+import com.google.devtools.build.lib.util.InterruptedFailureDetails;
+import com.google.devtools.common.options.OptionPriority.PriorityCategory;
+import com.google.devtools.common.options.OptionsParser;
+import com.google.devtools.common.options.OptionsParsingException;
 import com.google.devtools.common.options.OptionsParsingResult;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 /**
@@ -49,6 +71,8 @@ import java.util.List;
     buildPhase = EXECUTES,
     options = {
       BuildRequestOptions.class,
+      BuildCqueryOptions.class,
+      UniverseScopeOptions.class,
       ExecutionOptions.class,
       LocalExecutionOptions.class,
       PackageOptions.class,
@@ -68,8 +92,43 @@ import java.util.List;
 public final class BuildCommand implements BlazeCommand {
 
   @Override
+  public void editOptions(OptionsParser optionsParser) {
+    BuildCqueryOptions cqueryOptions = optionsParser.getOptions(BuildCqueryOptions.class);
+    UniverseScopeOptions universeScopeOptions =
+        optionsParser.getOptions(UniverseScopeOptions.class);
+    if (cqueryOptions == null
+        || universeScopeOptions == null
+        || !isCqueryMode(cqueryOptions, universeScopeOptions)) {
+      return;
+    }
+    // The post-analysis cquery filter requires a completed analysis phase before execution, so
+    // analysis and execution can't be merged (Skymeld).
+    try {
+      optionsParser.parse(
+          PriorityCategory.SOFTWARE_REQUIREMENT,
+          "build --cquery requires sequential analysis and execution phases",
+          ImmutableList.of("--noexperimental_merged_skyframe_analysis_execution"));
+    } catch (OptionsParsingException e) {
+      throw new IllegalStateException("build --cquery option failed to parse", e);
+    }
+  }
+
+  private static boolean isCqueryMode(
+      BuildCqueryOptions cqueryOptions, UniverseScopeOptions universeScopeOptions) {
+    return !cqueryOptions.getCquery().isEmpty()
+        || !universeScopeOptions.getUniverseScope().isEmpty();
+  }
+
+  @Override
   public BlazeCommandResult exec(CommandEnvironment env, OptionsParsingResult options) {
     BlazeRuntime runtime = env.getRuntime();
+    BuildCqueryOptions cqueryOptions = options.getOptions(BuildCqueryOptions.class);
+    UniverseScopeOptions universeScopeOptions = options.getOptions(UniverseScopeOptions.class);
+
+    if (isCqueryMode(cqueryOptions, universeScopeOptions)) {
+      return execCquery(env, options, cqueryOptions, universeScopeOptions);
+    }
+
     List<String> targets;
     try {
       targets = TargetPatternsHelper.readFrom(env, options);
@@ -108,5 +167,130 @@ public final class BuildCommand implements BlazeCommand {
     DetailedExitCode detailedExitCode =
         new BuildTool(env).processRequest(request, null, options).getDetailedExitCode();
     return BlazeCommandResult.detailedExitCode(detailedExitCode);
+  }
+
+  /**
+   * Handles {@code build --cquery} / {@code build --universe_scope}: analyzes a universe, evaluates
+   * a cquery over the resulting configured-target graph, and builds only the matched configured
+   * targets.
+   */
+  private BlazeCommandResult execCquery(
+      CommandEnvironment env,
+      OptionsParsingResult options,
+      BuildCqueryOptions cqueryOptions,
+      UniverseScopeOptions universeScopeOptions) {
+    BlazeRuntime runtime = env.getRuntime();
+    String cqueryExpression = cqueryOptions.getCquery();
+    List<String> universeScope = universeScopeOptions.getUniverseScope();
+    List<String> residue = options.getResidue();
+
+    if (!options.getOptions(BuildRequestOptions.class).getTargetPatternFile().isEmpty()) {
+      return failure(
+          env, "--cquery/--universe_scope cannot be combined with --target_pattern_file");
+    }
+
+    TargetPattern.Parser mainRepoTargetParser;
+    try {
+      RepositoryMapping repoMapping =
+          env.getSkyframeExecutor()
+              .getMainRepoMapping(
+                  options.getOptions(KeepGoingOption.class).getKeepGoing(),
+                  options.getOptions(LoadingPhaseThreadsOption.class).getThreads(),
+                  env.getReporter());
+      mainRepoTargetParser =
+          new Parser(env.getRelativeWorkingDirectory(), RepositoryName.MAIN, repoMapping);
+    } catch (RepositoryMappingResolutionException e) {
+      env.getReporter().handle(Event.error(e.getMessage()));
+      return BlazeCommandResult.detailedExitCode(e.getDetailedExitCode());
+    } catch (InterruptedException e) {
+      String errorMessage = "Interrupted while resolving repository mapping for --cquery";
+      env.getReporter().handle(Event.error(errorMessage));
+      return BlazeCommandResult.detailedExitCode(
+          InterruptedFailureDetails.detailedExitCode(errorMessage));
+    }
+
+    // Build the effective expression to evaluate over the analyzed universe:
+    //  - --cquery alone        -> the cquery expression
+    //  - residue alone         -> union of the residue labels
+    //  - both                  -> (cquery) intersect (union of residue labels)
+    //  - neither (scope only)  -> union of the universe-scope labels (build the whole universe)
+    boolean hasCquery = !cqueryExpression.isEmpty();
+    boolean hasResidue = !residue.isEmpty();
+    String effectiveExpression;
+    if (hasCquery && hasResidue) {
+      effectiveExpression = "(" + cqueryExpression + ") intersect (" + union(residue) + ")";
+    } else if (hasCquery) {
+      effectiveExpression = cqueryExpression;
+    } else if (hasResidue) {
+      effectiveExpression = union(residue);
+    } else {
+      effectiveExpression = union(universeScope);
+    }
+
+    QueryExpression expr;
+    try {
+      expr = QueryParser.parse(effectiveExpression, cqueryFunctions(env));
+    } catch (QuerySyntaxException e) {
+      return failure(
+          env,
+          String.format(
+              "Error while parsing --cquery '%s': %s",
+              QueryExpression.truncate(effectiveExpression), e.getMessage()));
+    }
+
+    List<String> universeTargets;
+    if (!universeScope.isEmpty()) {
+      universeTargets = ImmutableList.copyOf(universeScope);
+    } else {
+      LinkedHashSet<String> patterns = new LinkedHashSet<>();
+      expr.collectTargetPatterns(patterns);
+      universeTargets = ImmutableList.copyOf(patterns);
+    }
+
+    BuildRequest request;
+    try (SilentCloseable closeable = Profiler.instance().profile("BuildRequest.create")) {
+      request =
+          BuildRequest.builder()
+              .setCommandName(getClass().getAnnotation(Command.class).name())
+              .setId(env.getCommandId())
+              .setOptions(options)
+              .setStartupOptions(runtime.getStartupOptionsProvider())
+              .setOutErr(env.getReporter().getOutErr())
+              .setTargets(universeTargets)
+              .setStartTimeMillis(env.getCommandStartTime())
+              .build();
+    }
+    QueryCommandUtils.resetDeserializedKeysFromRemoteAnalysisCache(env);
+    DetailedExitCode detailedExitCode =
+        new BuildTool(env, new BuildCqueryProcessor(expr, mainRepoTargetParser))
+            .processRequest(request, /* validator= */ null, options)
+            .getDetailedExitCode();
+    return BlazeCommandResult.detailedExitCode(detailedExitCode);
+  }
+
+  /** Joins target patterns into an additive query union expression. */
+  private static String union(List<String> patterns) {
+    return String.join(" + ", patterns);
+  }
+
+  private static HashMap<String, QueryFunction> cqueryFunctions(CommandEnvironment env) {
+    HashMap<String, QueryFunction> functions = new HashMap<>();
+    for (QueryFunction queryFunction : ConfiguredTargetQueryEnvironment.FUNCTIONS) {
+      functions.put(queryFunction.getName(), queryFunction);
+    }
+    for (QueryFunction queryFunction : env.getRuntime().getQueryFunctions()) {
+      functions.put(queryFunction.getName(), queryFunction);
+    }
+    return functions;
+  }
+
+  private static BlazeCommandResult failure(CommandEnvironment env, String message) {
+    env.getReporter().handle(Event.error(message));
+    return BlazeCommandResult.failureDetail(
+        FailureDetail.newBuilder()
+            .setMessage(message)
+            .setConfigurableQuery(
+                ConfigurableQuery.newBuilder().setCode(Code.EXPRESSION_PARSE_FAILURE))
+            .build());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/BuildCqueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/BuildCqueryOptions.java
@@ -1,0 +1,44 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.runtime.commands;
+
+import com.google.devtools.common.options.Option;
+import com.google.devtools.common.options.OptionDocumentationCategory;
+import com.google.devtools.common.options.OptionEffectTag;
+import com.google.devtools.common.options.OptionsBase;
+import com.google.devtools.common.options.OptionsClass;
+
+/**
+ * The {@code --cquery} option for the {@code build} command. {@code --universe_scope} is provided
+ * separately by {@link com.google.devtools.build.lib.query2.common.UniverseScopeOptions} (shared
+ * with the query commands).
+ */
+@OptionsClass
+public abstract class BuildCqueryOptions extends OptionsBase {
+
+  @Option(
+      name = "cquery",
+      defaultValue = "",
+      documentationCategory = OptionDocumentationCategory.GENERIC_INPUTS,
+      effectTags = {OptionEffectTag.CHANGES_INPUTS},
+      help =
+          "If set, build evaluates this cquery expression over the post-analysis configured-target"
+              + " graph and builds only the matched configured targets. The targets analyzed (the"
+              + " universe) are taken from --universe_scope if set, otherwise inferred from the"
+              + " patterns in this expression. Command-line target patterns, if any, restrict the"
+              + " build to those labels (the expression then selects which of their configured"
+              + " instances to build, e.g. via config()). Command-line patterns must be plain"
+              + " labels: only --cquery accepts a cquery expression.")
+  public abstract String getCquery();
+}

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CqueryCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CqueryCommand.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.cmdline.TargetPattern;
 import com.google.devtools.build.lib.cmdline.TargetPattern.Parser;
 import com.google.devtools.build.lib.events.Event;
+import com.google.devtools.build.lib.query2.common.UniverseScopeOptions;
 import com.google.devtools.build.lib.query2.cquery.ConfiguredTargetQueryEnvironment;
 import com.google.devtools.build.lib.query2.cquery.CqueryOptions;
 import com.google.devtools.build.lib.query2.engine.AllPathsFunction;
@@ -165,7 +166,8 @@ public final class CqueryCommand implements BlazeCommand {
       return createFailureResult(message, Code.EXPRESSION_PARSE_FAILURE);
     }
 
-    List<String> topLevelTargets = options.getOptions(CqueryOptions.class).getUniverseScope();
+    List<String> topLevelTargets =
+        options.getOptions(UniverseScopeOptions.class).getUniverseScope();
     LinkedHashSet<String> targetPatternSet = new LinkedHashSet<>();
     ImmutableList<String> targetsForProjectResolution = null;
     if (topLevelTargets.isEmpty()) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/QueryCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/QueryCommand.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.lib.pkgcache.PackageOptions;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.query2.common.AbstractBlazeQueryEnvironment;
+import com.google.devtools.build.lib.query2.common.UniverseScopeOptions;
 import com.google.devtools.build.lib.query2.engine.QueryEvalResult;
 import com.google.devtools.build.lib.query2.engine.QueryException;
 import com.google.devtools.build.lib.query2.engine.QueryExpression;
@@ -62,6 +63,7 @@ import java.util.Set;
       CoreOptions.class, // for --action_env, which affects the repo env
       PackageOptions.class,
       QueryOptions.class,
+      UniverseScopeOptions.class,
       KeepGoingOption.class,
       LoadingPhaseThreadsOption.class
     },

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/QueryEnvironmentBasedCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/QueryEnvironmentBasedCommand.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.profiler.ProfilePhase;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.query2.common.AbstractBlazeQueryEnvironment;
 import com.google.devtools.build.lib.query2.common.UniverseScope;
+import com.google.devtools.build.lib.query2.common.UniverseScopeOptions;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.Setting;
 import com.google.devtools.build.lib.query2.engine.QueryEvalResult;
@@ -178,7 +179,10 @@ public abstract class QueryEnvironmentBasedCommand implements BlazeCommand {
               !streamResults,
               env.getSkyframeExecutor()
                   .maybeGetHardcodedUniverseScope()
-                  .orElse(getUniverseScope(queryOptions)),
+                  .orElse(
+                      getUniverseScope(
+                          queryOptions,
+                          env.getOptions().getOptions(UniverseScopeOptions.class))),
               threadsOption.getThreads(),
               settings,
               useGraphlessQuery,
@@ -220,10 +224,11 @@ public abstract class QueryEnvironmentBasedCommand implements BlazeCommand {
     }
   }
 
-  private static UniverseScope getUniverseScope(QueryOptions queryOptions) {
-    if (!queryOptions.getUniverseScope().isEmpty()) {
+  private static UniverseScope getUniverseScope(
+      QueryOptions queryOptions, UniverseScopeOptions universeScopeOptions) {
+    if (!universeScopeOptions.getUniverseScope().isEmpty()) {
       return UniverseScope.fromUniverseScopeList(
-          ImmutableList.copyOf(queryOptions.getUniverseScope()));
+          ImmutableList.copyOf(universeScopeOptions.getUniverseScope()));
     }
     return queryOptions.getInferUniverseScope()
         ? UniverseScope.INFER_FROM_QUERY_EXPRESSION

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -826,6 +826,15 @@ sh_test(
 )
 
 sh_test(
+    name = "build_cquery_test",
+    srcs = ["build_cquery_test.sh"],
+    data = [
+        ":test-deps",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
+sh_test(
     name = "target_compatible_with_test",
     timeout = "long",
     srcs = ["target_compatible_with_test.sh"],

--- a/src/test/shell/integration/build_cquery_test.sh
+++ b/src/test/shell/integration/build_cquery_test.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Integration tests for `bazel build --cquery` / `--universe_scope`.
+
+# --- begin runfiles.bash initialization ---
+set -euo pipefail
+
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+add_to_bazelrc "build --package_path=%workspace%"
+
+#### SETUP #############################################################
+
+# Creates a package $pkg with:
+#   //pkg:flavor  - a string build setting (default "default")
+#   //pkg:lib     - reads :flavor and writes its value to lib.txt
+#   //pkg:wrapper - depends on :lib through a transition that sets :flavor=variant
+# So //pkg:lib produces "default" as a top-level target and "variant" when reached
+# through //pkg:wrapper.
+function setup_multiconfig_pkg() {
+  local pkg="$1"
+  mkdir -p "$pkg"
+  cat > "$pkg/defs.bzl" <<EOF
+FlavorInfo = provider(fields = ["value"])
+
+def _flavor_impl(ctx):
+    return [FlavorInfo(value = ctx.build_setting_value)]
+
+flavor = rule(
+    implementation = _flavor_impl,
+    build_setting = config.string(flag = True),
+)
+
+def _flavor_transition_impl(settings, attr):
+    return {"//$pkg:flavor": "variant"}
+
+_flavor_transition = transition(
+    implementation = _flavor_transition_impl,
+    inputs = [],
+    outputs = ["//$pkg:flavor"],
+)
+
+def _lib_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name + ".txt")
+    ctx.actions.write(out, ctx.attr._flavor[FlavorInfo].value)
+    return [DefaultInfo(files = depset([out]))]
+
+lib = rule(
+    implementation = _lib_impl,
+    attrs = {"_flavor": attr.label(default = "//$pkg:flavor")},
+)
+
+def _wrapper_impl(ctx):
+    return [DefaultInfo(
+        files = depset(transitive = [d[DefaultInfo].files for d in ctx.attr.deps]),
+    )]
+
+wrapper = rule(
+    implementation = _wrapper_impl,
+    attrs = {
+        "deps": attr.label_list(cfg = _flavor_transition),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)
+EOF
+  cat > "$pkg/BUILD" <<EOF
+load(":defs.bzl", "flavor", "lib", "wrapper")
+
+flavor(name = "flavor", build_setting_default = "default")
+
+lib(name = "lib")
+
+wrapper(name = "wrapper", deps = [":lib"])
+EOF
+}
+
+# Echoes the (sorted, unique) contents of all lib.txt outputs across all
+# configurations. Uses `find -L` because bazel-out is a symlink (and outputs of
+# transitioned configs live under bazel-out/<config>/bin, not under bazel-bin).
+function lib_contents() {
+  local pkg="$1"
+  find -L bazel-out -name "lib.txt" -path "*$pkg*" -exec cat {} \; 2>/dev/null | sort -u
+}
+
+function clean_lib_outputs() {
+  local pkg="$1"
+  find -L bazel-out -name "lib.txt" -path "*$pkg*" -exec rm -f {} \; 2>/dev/null || true
+}
+
+#### TESTS #############################################################
+
+# --cquery alone: builds the matched target in its top-level (default) config.
+function test_build_cquery_single_target() {
+  local pkg=test_build_cquery_single_target
+  setup_multiconfig_pkg "$pkg"
+
+  bazel build --cquery="//$pkg:lib" >& "$TEST_log" || fail "Expected success"
+  assert_equals "default" "$(lib_contents "$pkg")"
+}
+
+# Residue is the build set; --universe_scope is the analysis universe. Building
+# //pkg:lib in the //pkg:wrapper universe produces the transitioned (variant)
+# output, unlike a plain top-level build of //pkg:lib (see single_target above,
+# which yields "default").
+function test_build_cquery_residue_built_in_universe() {
+  local pkg=test_build_cquery_residue_built_in_universe
+  setup_multiconfig_pkg "$pkg"
+
+  # Universe scope = wrapper => lib is reached through the variant transition.
+  bazel build --universe_scope="//$pkg:wrapper" "//$pkg:lib" >& "$TEST_log" \
+      || fail "Expected success with universe scope"
+  assert_equals "variant" "$(lib_contents "$pkg")"
+}
+
+# config() narrows a label that exists in multiple configurations to a single
+# configured instance. In the {wrapper, lib} universe :lib appears in two configs
+# (default as a top-level target, variant via wrapper's transition);
+# config(//pkg:lib, target) selects the top-level (default) instance only.
+function test_build_cquery_config_function_selects_instance() {
+  local pkg=test_build_cquery_config_function_selects_instance
+  setup_multiconfig_pkg "$pkg"
+
+  bazel build --cquery="config(//$pkg:lib, target)" \
+      --universe_scope="//$pkg:wrapper,//$pkg:lib" >& "$TEST_log" \
+      || fail "Expected success selecting the target-config instance"
+  # config() must pick exactly the default (target-config) instance, not both.
+  assert_equals "default" "$(lib_contents "$pkg")"
+}
+
+# A cquery that matches nothing builds nothing and still succeeds.
+function test_build_cquery_empty_result() {
+  local pkg=test_build_cquery_empty_result
+  setup_multiconfig_pkg "$pkg"
+  clean_lib_outputs "$pkg"
+
+  bazel build --cquery="//$pkg:lib intersect //$pkg:wrapper" >& "$TEST_log" \
+      || fail "Expected success on empty result"
+  assert_equals "" "$(lib_contents "$pkg")"
+}
+
+# A malformed cquery expression fails cleanly.
+function test_build_cquery_syntax_error() {
+  local pkg=test_build_cquery_syntax_error
+  setup_multiconfig_pkg "$pkg"
+
+  bazel build --cquery="//$pkg:lib +" >& "$TEST_log" && fail "Expected failure"
+  expect_log "Error while parsing --cquery"
+}
+
+# Regression: build's --universe_scope lives in a build-only options class, so it
+# must not collide with the identically-named query option when `bazel help
+# completion` aggregates every command's options.
+function test_help_completion_has_no_option_collision() {
+  bazel help completion >& "$TEST_log" || fail "bazel help completion crashed"
+  # And the standalone cquery command (which also defines --universe_scope) still loads.
+  bazel help cquery >& "$TEST_log" || fail "bazel help cquery crashed"
+}
+
+# The shared --universe_scope must still work on the standalone cquery command.
+function test_cquery_universe_scope_still_works() {
+  local pkg=test_cquery_universe_scope_still_works
+  setup_multiconfig_pkg "$pkg"
+  bazel cquery --universe_scope="//$pkg:wrapper,//$pkg:lib" "//$pkg:lib" >& "$TEST_log" \
+      || fail "cquery --universe_scope failed"
+  expect_log "^//$pkg:lib ("
+}
+
+run_suite "Tests for 'bazel build --cquery'"


### PR DESCRIPTION
## Summary

Adds two options to the `build` command so a build can be driven (and configuration-filtered) by a cquery expression:

- **`--cquery=<expr>`** — evaluates a cquery expression over the post-analysis configured-target graph and builds only the matched configured targets.
- **`--universe_scope=<labels>`** — sets the set of targets to analyze (the universe); building is restricted to the cquery matches and/or the command-line labels found within that universe. Passing it implicitly enables cquery mode.

The primary motivation is to build a target in a non-default configuration — e.g. the configuration that a top-level target's transition applies to a dependency — and to let `config(target, hash)` pick an exact configured instance.

## Semantics

- Command-line patterns are always plain **labels** (the build set); only `--cquery` accepts a cquery expression.
- The analyzed **universe** is `--universe_scope` if set, otherwise the patterns inferred from the `--cquery` expression.
- The configured targets **built** are the result of an effective expression: the cquery alone, the union of the command-line labels alone, or their `intersect` when both are given.

Examples:

```
# Build //app:bin's transitioned view of //lib:lib (variant config), not the default one:
bazel build --universe_scope=//app:bin //lib:lib

# Build exactly the configured instance of //lib:lib with a given config hash:
bazel build --cquery="config(//lib:lib, <hash>)" --universe_scope=//app:bin,//lib:lib
```

## Implementation

Reuses the existing post-analysis query stack (`PostAnalysisQueryProcessor`, `ConfiguredTargetQueryEnvironment`, the cquery functions incl. `config()`) via a new `BuildCqueryProcessor` that filters the `AnalysisResult`'s targets-to-build. `AnalysisPostProcessor.process` now returns the (possibly filtered) `AnalysisResult`. Post-analysis filtering needs sequential analysis→execution, so `--noexperimental_merged_skyframe_analysis_execution` is set automatically in cquery mode.

### `--universe_scope` sharing

`cquery`/`aquery` inherit the build command's options (cquery → test → build, aquery → build), and they already define `--universe_scope` via `CommonQueryOptions`. To avoid an option-name collision (which otherwise breaks `bazel cquery`/`bazel aquery` and `bazel help completion`), `--universe_scope` is extracted out of `CommonQueryOptions` into a new standalone `UniverseScopeOptions` class referenced explicitly by the `query`, `cquery`, `aquery` and `build` commands (and `genquery`). This keeps a single option definition shared across all of them.

## Testing

New `src/test/shell/integration/build_cquery_test.sh` (7 cases, all passing): single-target build, building a dependency in a transitioned configuration via `--universe_scope`, `config()` instance selection, empty results, syntax errors, a regression test that the shared `--universe_scope` does not collide (`bazel help completion` / `bazel help cquery`), and that standalone `cquery --universe_scope` still works. Verified end-to-end against Bazel 9.1.0 built from this branch.

---

*Opened as a draft.*
