### PR TITLE
Add null check for label in cache key scrubber

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/Scrubber.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Scrubber.java
@@ -151,7 +151,8 @@ public final class Scrubber {
     private boolean matches(Spawn spawn) {
       String mnemonic = spawn.getMnemonic();
       ActionOwner actionOwner = spawn.getResourceOwner().getOwner();
-      String label = actionOwner.getLabel().getCanonicalForm();
+      String label =
+          actionOwner.getLabel() != null ? actionOwner.getLabel().getCanonicalForm() : "";
       String kind = actionOwner.getTargetKind();
       boolean isForTool = actionOwner.isBuildConfigurationForTool();
 

--- a/src/test/java/com/google/devtools/build/lib/exec/util/FakeOwner.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/FakeOwner.java
@@ -40,7 +40,7 @@ import net.starlark.java.syntax.Location;
 public class FakeOwner implements ActionExecutionMetadata {
   private final String mnemonic;
   private final String progressMessage;
-  private final String ownerLabel;
+  @Nullable private final String ownerLabel;
   private final String ownerRuleKind;
   @Nullable private final Artifact primaryOutput;
   @Nullable private final PlatformInfo platform;
@@ -58,7 +58,7 @@ public class FakeOwner implements ActionExecutionMetadata {
       boolean isBuiltForToolConfiguration) {
     this.mnemonic = mnemonic;
     this.progressMessage = progressMessage;
-    this.ownerLabel = checkNotNull(ownerLabel);
+    this.ownerLabel = ownerLabel;
     this.ownerRuleKind = checkNotNull(ownerRuleKind);
     this.primaryOutput = primaryOutput;
     this.platform = platform;
@@ -85,8 +85,9 @@ public class FakeOwner implements ActionExecutionMetadata {
 
   @Override
   public ActionOwner getOwner() {
+    Label parsedLabel = ownerLabel != null ? Label.parseCanonicalUnchecked(ownerLabel) : null;
     return ActionOwner.createDummy(
-        Label.parseCanonicalUnchecked(ownerLabel),
+        parsedLabel,
         new Location("dummy-file", 0, 0),
         ownerRuleKind,
         mnemonic,

--- a/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
@@ -41,7 +41,7 @@ import javax.annotation.Nullable;
 public final class SpawnBuilder {
   private String mnemonic = "Mnemonic";
   private String progressMessage = "progress message";
-  private String ownerLabel = "//dummy:label";
+  @Nullable private String ownerLabel = "//dummy:label";
   private String ownerRuleKind = "dummy-target-kind";
   @Nullable private Artifact ownerPrimaryOutput;
   @Nullable private PlatformInfo platform;
@@ -107,6 +107,13 @@ public final class SpawnBuilder {
   @CanIgnoreReturnValue
   public SpawnBuilder withOwnerLabel(String ownerLabel) {
     this.ownerLabel = checkNotNull(ownerLabel);
+    return this;
+  }
+
+  /** Sets the owner to have no label, simulating synthetic actions (e.g. coverage aggregation). */
+  @CanIgnoreReturnValue
+  public SpawnBuilder withNullOwnerLabel() {
+    this.ownerLabel = null;
     return this;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/ScrubberTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ScrubberTest.java
@@ -447,6 +447,35 @@ public class ScrubberTest {
     assertThat(spawnScrubber.transformArgument("foospam")).isEqualTo("fooeggs");
   }
 
+  @Test
+  public void nullOwnerLabelDoesNotThrow() {
+    // Synthetic Bazel actions (e.g. CoverageReportKeySingleton) have a null label on their
+    // ActionOwner. The scrubber must not throw NPE and should treat the label as empty.
+    var scrubber =
+        new Scrubber(
+            Config.newBuilder()
+                .addRules(
+                    Config.Rule.newBuilder()
+                        .setMatcher(Config.Matcher.newBuilder().setMnemonic("CoverageReport")))
+                .build());
+
+    assertThat(scrubber.forSpawn(createSpawnWithNullLabel("CoverageReport"))).isNotNull();
+  }
+
+  @Test
+  public void nullOwnerLabelDoesNotMatchLabelFilter() {
+    // When the action owner has no label, it should not match a specific label pattern.
+    var scrubber =
+        new Scrubber(
+            Config.newBuilder()
+                .addRules(
+                    Config.Rule.newBuilder()
+                        .setMatcher(Config.Matcher.newBuilder().setLabel("//foo:bar")))
+                .build());
+
+    assertThat(scrubber.forSpawn(createSpawnWithNullLabel("CoverageReport"))).isNull();
+  }
+
   private static Spawn createSpawn() {
     return createSpawn("//foo:bar", "Foo");
   }
@@ -463,5 +492,13 @@ public class ScrubberTest {
         .withOwnerRuleKind(ruleKind)
         .setBuiltForToolConfiguration(forTool)
         .build();
+  }
+
+  /**
+   * Creates a spawn whose action owner has no label, simulating synthetic Bazel actions such as
+   * {@code CoverageReportKeySingleton}.
+   */
+  private static Spawn createSpawnWithNullLabel(String mnemonic) {
+    return new SpawnBuilder("cmd").withNullOwnerLabel().withMnemonic(mnemonic).build();
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

Prior to this commit, there was an access to `.getCanonicalForm()` with no null check for `getLabel()` first. `--combined_report=lcov` creates an action with no label, causing a crash when the cache key scrubbing tries to determine whether to scrub the action.

In this commit we add a null check to avoid the crash.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

Fixes a bug where cache key scrubbing will cause a crash for actions with no corresponding label, such as the `CoverageReportKeySingleton` action created by the `--combined_report=lcov` flag.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [X] I have added tests for the new use cases (if any).
- [X] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

### Reproduction and Verification 

Reproduction steps:


Add the following dummy cache scrubber config:

```
rules {
  matcher {
    mnemonic: "Javac"
  }
  transform {
    omitted_inputs: ".*\\.params"
  }
}
```

Start a remote cache server on the local machine:

```
docker run -d -p 9092:9092 buchgr/bazel-remote-cache --max_size=1
```


Run coverage without the combined report:

```
bazel coverage --experimental_remote_scrubbing_config=/tmp/demo_scrub.cfg --remote_cache=grpc://localhost:9092 --noremote_accept_cached //src/test/java/com/google/devtools/build/lib/util:ResourceFileLoaderTest
```

Command should succeed:

```
$ bazel coverage --experimental_remote_scrubbing_config=/tmp/demo_scrub.cfg --remote_cache=grpc://localhost:9092 --noremote_accept_cached //src/test/java/com/google/devtools/build/lib/util:ResourceFileLoaderTest
INFO: Invocation ID: e696577f-3b1f-49cd-a901-817889c6dc40
INFO: Using default value for --instrumentation_filter: "^//src/main/java/com/google/devtools/build/lib/util[/:]".
INFO: Override the above default with --instrumentation_filter
INFO: Analyzed target //src/test/java/com/google/devtools/build/lib/util:ResourceFileLoaderTest (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //src/test/java/com/google/devtools/build/lib/util:ResourceFileLoaderTest up-to-date:
  bazel-bin/src/test/java/com/google/devtools/build/lib/util/ResourceFileLoaderTest
  bazel-bin/src/test/java/com/google/devtools/build/lib/util/runtime_classpath_for_coverage/ResourceFileLoaderTest/runtime_classpath.txt
  bazel-bin/src/test/java/com/google/devtools/build/lib/util/ResourceFileLoaderTest.jar
INFO: Elapsed time: 0.122s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//src/test/java/com/google/devtools/build/lib/util:ResourceFileLoaderTest (cached) PASSED in 0.5s
  /home/user/.cache/bazel/_bazel_cjk/879119e34b4ead467dc81e49968e3792/execroot/_main/bazel-out/k8-fastbuild/testlogs/src/test/java/com/google/devtools/build/lib/util/ResourceFileLoaderTest/coverage.dat

Executed 0 out of 1 test: 1 test passes.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```

Run coverage with the combined report:

```
bazel coverage --combined_report=lcov --experimental_remote_scrubbing_config=/tmp/demo_scrub.cfg --remote_cache=grpc://localhost:9092 --noremote_accept_cached //src/test/java/com/google/devtools/build/lib/util:ResourceFileLoaderTest
```

Bazel will crash:

```
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.IllegalStateException: java.lang.RuntimeException: Unrecoverable error while evaluating node 'UnshareableActionLookupData{actionLookupKey=CoverageReportKeySingleton, actionIndex=1}' (requested by nodes )
	at com.google.devtools.build.lib.skyframe.SkyframeExecutor.evaluateSkyKeys(SkyframeExecutor.java:1857)
	at com.google.devtools.build.lib.skyframe.SkyframeBuildView.analyzeAndExecuteTargets(SkyframeBuildView.java:732)
	at com.google.devtools.build.lib.analysis.BuildView.update(BuildView.java:292)
	at com.google.devtools.build.lib.buildtool.AnalysisAndExecutionPhaseRunner.runAnalysisAndExecutionPhase(AnalysisAndExecutionPhaseRunner.java:241)
	at com.google.devtools.build.lib.buildtool.AnalysisAndExecutionPhaseRunner.execute(AnalysisAndExecutionPhaseRunner.java:139)
	at com.google.devtools.build.lib.buildtool.BuildTool.buildTargetsWithMergedAnalysisExecution(BuildTool.java:305)
	at com.google.devtools.build.lib.buildtool.BuildTool.buildTargets(BuildTool.java:173)
	at com.google.devtools.build.lib.buildtool.BuildTool.processRequest(BuildTool.java:510)
	at com.google.devtools.build.lib.buildtool.BuildTool.processRequest(BuildTool.java:478)
	at com.google.devtools.build.lib.runtime.commands.TestCommand.doTest(TestCommand.java:163)
	at com.google.devtools.build.lib.runtime.commands.TestCommand.exec(TestCommand.java:116)
	at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.execExclusively(BlazeCommandDispatcher.java:664)
	at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.exec(BlazeCommandDispatcher.java:244)
	at com.google.devtools.build.lib.server.GrpcServerImpl.executeCommand(GrpcServerImpl.java:573)
	at com.google.devtools.build.lib.server.GrpcServerImpl.lambda$run$1(GrpcServerImpl.java:644)
	at io.grpc.Context$1.run(Context.java:566)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: java.lang.RuntimeException: Unrecoverable error while evaluating node 'UnshareableActionLookupData{actionLookupKey=CoverageReportKeySingleton, actionIndex=1}' (requested by nodes )
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:550)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:414)
	at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: java.lang.NullPointerException: Cannot invoke "com.google.devtools.build.lib.cmdline.Label.getCanonicalForm()" because the return value of "com.google.devtools.build.lib.actions.ActionOwner.getLabel()" is null
	at com.google.devtools.build.lib.remote.Scrubber$SpawnScrubber.matches(Scrubber.java:137)
	at com.google.devtools.build.lib.remote.Scrubber.forSpawn(Scrubber.java:92)
	at com.google.devtools.build.lib.remote.RemoteExecutionService.buildRemoteAction(RemoteExecutionService.java:550)
	at com.google.devtools.build.lib.remote.RemoteSpawnCache.lookup(RemoteSpawnCache.java:94)
	at com.google.devtools.build.lib.exec.AbstractSpawnStrategy.exec(AbstractSpawnStrategy.java:152)
	at com.google.devtools.build.lib.exec.AbstractSpawnStrategy.exec(AbstractSpawnStrategy.java:119)
	at com.google.devtools.build.lib.exec.SpawnStrategyResolver.exec(SpawnStrategyResolver.java:45)
	at com.google.devtools.build.lib.bazel.coverage.CoverageReportActionBuilder$CoverageReportAction.execute(CoverageReportActionBuilder.java:140)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor$ActionRunner.executeAction(SkyframeActionExecutor.java:1144)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor$ActionRunner.run(SkyframeActionExecutor.java:1061)
	at com.google.devtools.build.lib.skyframe.ActionExecutionState.runStateMachine(ActionExecutionState.java:165)
	at com.google.devtools.build.lib.skyframe.ActionExecutionState.getResultOrDependOnFuture(ActionExecutionState.java:94)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor.executeAction(SkyframeActionExecutor.java:558)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.checkCacheAndExecuteIfNeeded(ActionExecutionFunction.java:859)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.computeInternal(ActionExecutionFunction.java:333)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.compute(ActionExecutionFunction.java:171)
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:461)
	... 7 more
```


Verify the fix:

Build a bazel binary from source:

```
bazel build //src:bazel-bin
```

Use new binary to run previous command successfully:

```
$ bazel-bin/src/bazel coverage --combined_report=lcov --experimental_remote_scrubbing_config=/tmp/demo_scrub.cfg --remote_cache=grpc://localhost:9092 --noremote_accept_cached //src/test/java/com/google/devtools/build/lib/util:ResourceFileLoaderTest
INFO: Invocation ID: e82cf6ed-af20-4dca-bdc0-705bbcaf80af
INFO: Using default value for --instrumentation_filter: "^//src/main/java/com/google/devtools/build/lib/util[/:]".
INFO: Override the above default with --instrumentation_filter
INFO: Analyzed target //src/test/java/com/google/devtools/build/lib/util:ResourceFileLoaderTest (150 packages loaded, 2716 targets configured).
INFO: From Building src/main/java/com/google/devtools/build/lib/unsafe/libunsafe-provider.jar (1 source file):
src/main/java/com/google/devtools/build/lib/unsafe/UnsafeProvider.java:50: warning: [removal] AccessController in java.security has been deprecated and marked for removal
      return AccessController.doPrivileged(
             ^
INFO: From Building external/protobuf~/java/core/liblite_runtime_only.jar (91 source files):
external/protobuf~/java/core/src/main/java/com/google/protobuf/UnsafeUtil.java:293: warning: [removal] AccessController in java.security has been deprecated and marked for removal
          AccessController.doPrivileged(
          ^
INFO: LCOV coverage report is located at /home/user/.cache/bazel/_bazel_cjk/879119e34b4ead467dc81e49968e3792/execroot/_main/bazel-out/_coverage/_coverage_report.dat
 and execpath is bazel-out/_coverage/_coverage_report.dat
INFO: From Coverage report generation:
Jun 24, 2026 4:59:40 PM com.google.devtools.coverageoutputgenerator.Main getTracefiles
INFO: Found 1 tracefiles.
Jun 24, 2026 4:59:40 PM com.google.devtools.coverageoutputgenerator.Main parseFilesSequentially
INFO: Parsing file bazel-out/k8-fastbuild/testlogs/src/test/java/com/google/devtools/build/lib/util/ResourceFileLoaderTest/coverage.dat
Jun 24, 2026 4:59:40 PM com.google.devtools.coverageoutputgenerator.Main getGcovInfoFiles
INFO: No gcov info file found.
Jun 24, 2026 4:59:40 PM com.google.devtools.coverageoutputgenerator.Main getGcovJsonInfoFiles
INFO: No gcov json file found.
Jun 24, 2026 4:59:40 PM com.google.devtools.coverageoutputgenerator.Main getProfdataFileOrNull
INFO: No .profdata file found.
INFO: Found 1 test target...
Target //src/test/java/com/google/devtools/build/lib/util:ResourceFileLoaderTest up-to-date:
  bazel-bin/src/test/java/com/google/devtools/build/lib/util/ResourceFileLoaderTest
  bazel-bin/src/test/java/com/google/devtools/build/lib/util/runtime_classpath_for_coverage/ResourceFileLoaderTest/runtime_classpath.txt
  bazel-bin/src/test/java/com/google/devtools/build/lib/util/ResourceFileLoaderTest.jar
INFO: Elapsed time: 13.505s, Critical Path: 12.88s
INFO: 281 processes: 6 internal, 218 processwrapper-sandbox, 57 worker.
INFO: Build completed successfully, 281 total actions
//src/test/java/com/google/devtools/build/lib/util:ResourceFileLoaderTest PASSED in 0.5s
  /home/user/.cache/bazel/_bazel_cjk/879119e34b4ead467dc81e49968e3792/execroot/_main/bazel-out/k8-fastbuild/testlogs/src/test/java/com/google/devtools/build/lib/util/ResourceFileLoaderTest/coverage.dat

Executed 1 out of 1 test: 1 test passes.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```

