### PR TITLE
Remove deprecated macOS install-name configuration field

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -896,11 +896,6 @@ public final class CppConfiguration extends Fragment
     return cppOptions.getExperimentalCppCompileResourcesEstimation();
   }
 
-  @Override
-  public boolean macosSetInstallName() {
-    return true;
-  }
-
   private static void checkInExpandedApiAllowlist(StarlarkThread thread, String feature)
       throws EvalException {
     try {

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CppConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CppConfigurationApi.java
@@ -97,14 +97,6 @@ public interface CppConfigurationApi<InvalidConfigurationExceptionT extends Exce
   @Nullable
   Label customMalloc();
 
-  @StarlarkMethod(
-      name = "do_not_use_macos_set_install_name",
-      structField = true,
-      // Only for migration purposes. Intentionally not documented.
-      documented = false,
-      doc = "Deprecated, always true")
-  boolean macosSetInstallName();
-
   @StarlarkMethod(name = "force_pic", documented = false, useStarlarkThread = true)
   boolean forcePicStarlark(StarlarkThread thread) throws EvalException;
 


### PR DESCRIPTION
## Summary

Remove the private `ctx.fragments.cpp.do_not_use_macos_set_install_name` field and its `CppConfiguration` implementation. Keep `--incompatible_macos_set_install_name` in the graveyard so existing command lines continue to parse.

The flag was introduced in November 2020 in cf47f90090121509d868fac04615626c3ad9a55b, enabled by default in September 2024 in 62dc3b5b3b31fe53e25d253f501eeed21ab4ae48, and moved to the graveyard in March 2025 in b9db4602affe5a45d776eb78f215e11a86ab3b24. Since the graveyard move, the private field has always returned `true`. `rules_cc` already gracefully handles the absence of this field via `getattr(.., True)`

## Validation

- `bazel test //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest //src/main/java/com/google/devtools/build/lib/rules/cpp:cpp //src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp:cpp --jobs=4`
