### PR TITLE
[9.2.0] Add measured peak memory to SpawnMetrics and execution log

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/SpawnMetrics.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SpawnMetrics.java
@@ -45,6 +45,7 @@ public class SpawnMetrics {
     this.inputBytes = builder.inputBytes;
     this.inputFiles = builder.inputFiles;
     this.memoryEstimateBytes = builder.memoryEstimateBytes;
+    this.measuredMemoryPeakBytes = builder.measuredMemoryPeakBytes;
   }
 
   /** Indicates whether the metrics correspond to the remote, local or worker execution. */
@@ -85,6 +86,7 @@ public class SpawnMetrics {
   private final long inputBytes;
   private final long inputFiles;
   private final long memoryEstimateBytes;
+  private final long measuredMemoryPeakBytes;
 
   /** Any non-important stats < than 10% will not be shown in the summary. */
   private static final double STATS_SHOW_THRESHOLD = 0.10;
@@ -271,6 +273,15 @@ public class SpawnMetrics {
     return memoryEstimateBytes;
   }
 
+  /** Measured peak memory usage in bytes, or 0 if unavailable. */
+  public long measuredMemoryPeak() {
+    return measuredMemoryPeakBytes;
+  }
+
+  public Builder toBuilder() {
+    return Builder.forExec(execKind).addDurations(this).addNonDurations(this);
+  }
+
   /** Limit of total size in bytes of inputs or 0 if unavailable. */
   public long inputBytesLimit() {
     return 0;
@@ -317,6 +328,7 @@ public class SpawnMetrics {
     private long inputBytes = 0;
     private long inputFiles = 0;
     private long memoryEstimateBytes = 0;
+    private long measuredMemoryPeakBytes = 0;
     long inputBytesLimit = 0;
     long inputFilesLimit = 0;
     long outputBytesLimit = 0;
@@ -525,6 +537,12 @@ public class SpawnMetrics {
     }
 
     @CanIgnoreReturnValue
+    public Builder setMeasuredMemoryPeakBytes(long measuredMemoryPeakBytes) {
+      this.measuredMemoryPeakBytes = measuredMemoryPeakBytes;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
     public Builder setInputBytesLimit(long inputBytesLimit) {
       this.inputBytesLimit = inputBytesLimit;
       return this;
@@ -582,6 +600,7 @@ public class SpawnMetrics {
       inputFiles += metric.inputFiles();
       inputBytes += metric.inputBytes();
       memoryEstimateBytes += metric.memoryEstimate();
+      measuredMemoryPeakBytes += metric.measuredMemoryPeak();
       inputFilesLimit += metric.inputFilesLimit();
       inputBytesLimit += metric.inputBytesLimit();
       outputFilesLimit += metric.outputFilesLimit();
@@ -596,6 +615,7 @@ public class SpawnMetrics {
       inputFiles = Long.max(inputFiles, metric.inputFiles());
       inputBytes = Long.max(inputBytes, metric.inputBytes());
       memoryEstimateBytes = Long.max(memoryEstimateBytes, metric.memoryEstimate());
+      measuredMemoryPeakBytes = Long.max(measuredMemoryPeakBytes, metric.measuredMemoryPeak());
       inputFilesLimit = Long.max(inputFilesLimit, metric.inputFilesLimit());
       inputBytesLimit = Long.max(inputBytesLimit, metric.inputBytesLimit());
       outputFilesLimit = Long.max(outputFilesLimit, metric.outputFilesLimit());

--- a/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
@@ -316,10 +316,14 @@ public interface SpawnResult {
       this.executorHostName = builder.executorHostName;
       this.runnerName = builder.runnerName;
       this.runnerSubtype = builder.runnerSubtype;
-      this.spawnMetrics =
+      SpawnMetrics metrics =
           builder.spawnMetrics != null
               ? builder.spawnMetrics
               : SpawnMetrics.forLocalExecution(builder.wallTimeInMs);
+      if (builder.memoryInKb != null) {
+        metrics = metrics.toBuilder().setMeasuredMemoryPeakBytes(builder.memoryInKb * 1024).build();
+      }
+      this.spawnMetrics = metrics;
       this.startTime = builder.startTime;
       this.wallTimeInMs = builder.wallTimeInMs;
       this.userTimeInMs = builder.userTimeInMs;

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -250,6 +250,7 @@ public abstract class SpawnLogContext implements ActionContext {
     builder.setInputBytes(metrics.inputBytes());
     builder.setInputFiles(metrics.inputFiles());
     builder.setMemoryEstimateBytes(metrics.memoryEstimate());
+    builder.setMeasuredMemoryPeakBytes(metrics.measuredMemoryPeak());
     builder.setInputBytesLimit(metrics.inputBytesLimit());
     builder.setInputFilesLimit(metrics.inputFilesLimit());
     builder.setOutputBytesLimit(metrics.outputBytesLimit());

--- a/src/main/protobuf/spawn.proto
+++ b/src/main/protobuf/spawn.proto
@@ -114,6 +114,8 @@ message SpawnMetrics {
   google.protobuf.Duration time_limit = 19;
   // Instant when the spawn started to execute.
   google.protobuf.Timestamp start_time = 20;
+  // Measured peak memory usage in bytes, or 0 if unavailable.
+  int64 measured_memory_peak_bytes = 21;
 }
 
 // Details of an executed spawn.

--- a/src/main/tools/linux-sandbox.cc
+++ b/src/main/tools/linux-sandbox.cc
@@ -58,7 +58,10 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <atomic>
+#include <cinttypes>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -214,6 +217,25 @@ static pid_t SpawnPid1() {
   return child_pid;
 }
 
+static int64_t ReadCgroupsMemoryPeak(
+    const std::vector<std::string>& cgroups_dirs) {
+  int64_t max_value = -1;
+  for (const std::string& dir : cgroups_dirs) {
+    for (const char* fname : {"/memory.peak", "/memory.max_usage_in_bytes"}) {
+      int64_t value = -1;
+      std::string path = dir + fname;
+      FILE* f = fopen(path.c_str(), "r");
+      if (f != nullptr) {
+        if (fscanf(f, "%" SCNd64, &value) == 1) {
+          max_value = std::max(value, max_value);
+        }
+        fclose(f);
+      }
+    }
+  }
+  return max_value;
+}
+
 static int WaitForPid1(const pid_t child_pid) {
   // Wait for the child to exit, obtaining usage information. Restart in the
   // case of a signal interrupting us.
@@ -239,6 +261,10 @@ static int WaitForPid1(const pid_t child_pid) {
 
   // If we're supposed to write stats to a file, do so now.
   if (!opt.stats_path.empty()) {
+    int64_t cgroups_memory_peak = ReadCgroupsMemoryPeak(opt.cgroups_dirs);
+    if (cgroups_memory_peak > 0) {
+      child_rusage.ru_maxrss = cgroups_memory_peak / 1024;
+    }
     WriteStatsToFile(&child_rusage, opt.stats_path);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/actions/SpawnMetricsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/SpawnMetricsTest.java
@@ -32,6 +32,7 @@ public final class SpawnMetricsTest {
             .setInputBytes(10)
             .setInputFiles(20)
             .setMemoryEstimateBytes(30)
+            .setMeasuredMemoryPeakBytes(35)
             .setInputBytesLimit(20)
             .setInputFilesLimit(40)
             .setOutputBytesLimit(50)
@@ -46,6 +47,7 @@ public final class SpawnMetricsTest {
             .setInputBytes(100)
             .setInputFiles(200)
             .setMemoryEstimateBytes(300)
+            .setMeasuredMemoryPeakBytes(300)
             .setInputBytesLimit(200)
             .setInputFilesLimit(400)
             .setOutputBytesLimit(500)
@@ -67,6 +69,7 @@ public final class SpawnMetricsTest {
     assertThat(result.inputBytes()).isEqualTo(110);
     assertThat(result.inputFiles()).isEqualTo(220);
     assertThat(result.memoryEstimate()).isEqualTo(330);
+    assertThat(result.measuredMemoryPeak()).isEqualTo(335);
     assertThat(result.inputBytesLimit()).isEqualTo(220);
     assertThat(result.inputFilesLimit()).isEqualTo(440);
     assertThat(result.outputBytesLimit()).isEqualTo(550);
@@ -84,6 +87,7 @@ public final class SpawnMetricsTest {
             .setInputBytes(10)
             .setInputFiles(20)
             .setMemoryEstimateBytes(30)
+            .setMeasuredMemoryPeakBytes(35)
             .setInputBytesLimit(20)
             .setInputFilesLimit(40)
             .setOutputBytesLimit(50)
@@ -98,6 +102,7 @@ public final class SpawnMetricsTest {
             .setInputBytes(100)
             .setInputFiles(200)
             .setMemoryEstimateBytes(300)
+            .setMeasuredMemoryPeakBytes(300)
             .setInputBytesLimit(200)
             .setInputFilesLimit(400)
             .setOutputBytesLimit(500)
@@ -119,6 +124,7 @@ public final class SpawnMetricsTest {
     assertThat(result.inputBytes()).isEqualTo(100);
     assertThat(result.inputFiles()).isEqualTo(200);
     assertThat(result.memoryEstimate()).isEqualTo(300);
+    assertThat(result.measuredMemoryPeak()).isEqualTo(300);
     assertThat(result.inputBytesLimit()).isEqualTo(200);
     assertThat(result.inputFilesLimit()).isEqualTo(400);
     assertThat(result.outputBytesLimit()).isEqualTo(500);

--- a/src/test/java/com/google/devtools/build/lib/actions/SpawnResultTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/SpawnResultTest.java
@@ -79,4 +79,18 @@ public final class SpawnResultTest {
     assertThat(r.getInMemoryOutput(null)).isEqualTo(null);
     assertThat(r.getInMemoryOutput(ActionInputHelper.fromPath("/does/not/exist"))).isEqualTo(null);
   }
+
+  @Test
+  public void defaultSpawnMetricsIncludesMeasuredMemoryFromResourceUsage() {
+    SpawnResult result =
+        new SpawnResult.Builder()
+            .setStatus(Status.SUCCESS)
+            .setExitCode(0)
+            .setRunnerName("test")
+            .setWallTimeInMs(100)
+            .setMemoryInKb(1000L)
+            .build();
+
+    assertThat(result.getMetrics().measuredMemoryPeak()).isEqualTo(1000L * 1024L);
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
@@ -2075,7 +2075,11 @@ public abstract class SpawnLogContextTestBase {
 
   @Test
   public void testSpawnMetrics() throws Exception {
-    SpawnMetrics metrics = SpawnMetrics.Builder.forLocalExec().setTotalTimeInMs(1).build();
+    SpawnMetrics metrics =
+        SpawnMetrics.Builder.forLocalExec()
+            .setTotalTimeInMs(1)
+            .setMeasuredMemoryPeakBytes(42L)
+            .build();
 
     SpawnLogContext context = createSpawnLogContext();
 
@@ -2094,6 +2098,7 @@ public abstract class SpawnLogContextTestBase {
             .setMetrics(
                 Protos.SpawnMetrics.newBuilder()
                     .setTotalTime(millisToProto(1))
+                    .setMeasuredMemoryPeakBytes(42L)
                     .setStartTime(Timestamps.fromDate(Date.from(now))))
             .build());
   }

--- a/src/test/shell/integration/linux-sandbox_test.sh
+++ b/src/test/shell/integration/linux-sandbox_test.sh
@@ -483,6 +483,96 @@ EOF
   expect_not_log "hi there"
 }
 
+function test_cgroups_v2_peak_memory_mock() {
+  local local_tmp="$(mktemp -d "${OUT_DIR}/test_cgroups_v2_peak_memory_mockXXXX")"
+  local stats_out_path="${local_tmp}/statsfile"
+  local stats_out_decoded_path="${local_tmp}/statsfile.decoded"
+
+  # Create a mock cgroup directory
+  local mock_cgroup_dir="${local_tmp}/mock_cgroup"
+  mkdir -p "${mock_cgroup_dir}"
+
+  # Write a mock peak memory value (40MB = 41943040 bytes)
+  echo "41943040" > "${mock_cgroup_dir}/memory.peak"
+
+  # Run sandbox pointing to the mock cgroup directory
+  local code=0
+  "${linux_sandbox}" \
+      -W "${SANDBOX_DIR}" \
+      -S "${stats_out_path}" \
+      -C "${mock_cgroup_dir}" \
+      -- /bin/true \
+      &> "${TEST_log}" || code="$?"
+
+  assert_equals 0 "${code}"
+
+  if ! [[ -e "${stats_out_path}" ]]; then
+    fail "Stats file not found: '${stats_out_path}'"
+  fi
+
+  # Decode stats
+  "${protoc_compiler}" --proto_path="${STATS_PROTO_DIR}" \
+      --decode tools.protos.ExecutionStatistics execution_statistics.proto \
+      < "${stats_out_path}" > "${stats_out_decoded_path}"
+
+  if ! [[ -e "${stats_out_decoded_path}" ]]; then
+    fail "Decoded stats file not found: '${stats_out_decoded_path}'"
+  fi
+
+  # Assert maxrss is reported and matches the mock value (40MB = 40960 KB)
+  local maxrss=0
+  if grep -q maxrss "${stats_out_decoded_path}"; then
+    maxrss="$(grep maxrss "${stats_out_decoded_path}" | cut -f2 -d':' | tr -dc '0-9')"
+  fi
+
+  assert_equals 40960 "${maxrss}"
+}
+
+function test_cgroups_v1_peak_memory_mock() {
+  local local_tmp="$(mktemp -d "${OUT_DIR}/test_cgroups_v1_peak_memory_mockXXXX")"
+  local stats_out_path="${local_tmp}/statsfile"
+  local stats_out_decoded_path="${local_tmp}/statsfile.decoded"
+
+  # Create a mock cgroup directory
+  local mock_cgroup_dir="${local_tmp}/mock_cgroup"
+  mkdir -p "${mock_cgroup_dir}"
+
+  # Write a mock peak memory value (40MB = 41943040 bytes)
+  echo "41943040" > "${mock_cgroup_dir}/memory.max_usage_in_bytes"
+
+  # Run sandbox pointing to the mock cgroup directory
+  local code=0
+  "${linux_sandbox}" \
+      -W "${SANDBOX_DIR}" \
+      -S "${stats_out_path}" \
+      -C "${mock_cgroup_dir}" \
+      -- /bin/true \
+      &> "${TEST_log}" || code="$?"
+
+  assert_equals 0 "${code}"
+
+  if ! [[ -e "${stats_out_path}" ]]; then
+    fail "Stats file not found: '${stats_out_path}'"
+  fi
+
+  # Decode stats
+  "${protoc_compiler}" --proto_path="${STATS_PROTO_DIR}" \
+      --decode tools.protos.ExecutionStatistics execution_statistics.proto \
+      < "${stats_out_path}" > "${stats_out_decoded_path}"
+
+  if ! [[ -e "${stats_out_decoded_path}" ]]; then
+    fail "Decoded stats file not found: '${stats_out_decoded_path}'"
+  fi
+
+  # Assert maxrss is reported and matches the mock value (40MB = 40960 KB)
+  local maxrss=0
+  if grep -q maxrss "${stats_out_decoded_path}"; then
+    maxrss="$(grep maxrss "${stats_out_decoded_path}" | cut -f2 -d':' | tr -dc '0-9')"
+  fi
+
+  assert_equals 40960 "${maxrss}"
+}
+
 # The test shouldn't fail if the environment doesn't support running it.
 is_linux || exit 0
 check_sandbox_allowed || exit 0


### PR DESCRIPTION
This change introduces measured peak memory usage (peak RSS) to the SpawnMetrics
and exposes it in the execution log.

Fixes #29872

Specifically:
- Updates spawn.proto to add measured_memory_peak_bytes to SpawnMetrics.
- Updates SpawnMetrics (Java) to store and propagate measuredMemoryPeakBytes.
- Updates SpawnResult to populate this metric from the parsed execution statistics (memoryInKb).
- Updates SpawnLogContext to write this metric to the execution log proto.
- Updates linux-sandbox (C++) to read peak memory from cgroups (if available) and override the rusage maxrss value, providing high-accuracy aggregate memory usage for sandboxed actions on Linux.
- Updates SpawnLogContextTestBase to verify the metric is correctly logged.
PiperOrigin-RevId: 937171286
Change-Id: I4f563c7b8a361bb778f97e20cb3cd2ce9266f469

Commit https://github.com/bazelbuild/bazel/commit/b3126b539ef6ba4a6ebb67db623e25a15b9adf5b