### PR TITLE
[8.8.0] Add `facts_version` parameter to `module_extension`

### DIFF
--- a/scripts/bazel-lockfile-merge.jq
+++ b/scripts/bazel-lockfile-merge.jq
@@ -34,6 +34,28 @@ def shallow_merge(f):
     # lockFileVersion.
     (map(.lockFileVersion) | max) as $maxVersion
     | map(select(.lockFileVersion == $maxVersion))
+    # Compute the maximum factsVersion observed across lockfiles per extension
+    # ID. Missing entries default to 0.
+    | (
+        map(.factsVersions // {} | to_entries) | flatten
+        | if length > 0 then
+            group_by(.key)
+            | map({key: .[0].key, value: (map(.value) | max)})
+            | from_entries
+          else {} end
+      ) as $maxFactsVersions
+    # Within each lockfile, drop facts entries whose own factsVersion does not
+    # match the global maximum: those are at an outdated schema and cannot be
+    # merged with newer-schema entries.
+    | map(
+        if has("facts") then
+          (.factsVersions // {}) as $fv
+          | .facts |= with_entries(
+              .key as $k
+              | select((($fv[$k]) // 0) == (($maxFactsVersions[$k]) // 0))
+            )
+        else . end
+      )
     | {
         lockFileVersion: $maxVersion,
         registryFileHashes: shallow_merge(.registryFileHashes),
@@ -43,15 +65,19 @@ def shallow_merge(f):
         moduleExtensions:  (map(.moduleExtensions | to_entries)
                            | flatten
                            | if length > 0 then group_by(.key) | shallow_merge({(.[0].key): shallow_merge(.value)}) else {} end),
-        # Group facts by extension ID across all lockfiles with shallowly
-        # merged top-level keys, then shallowly merge the results. Handle the
-        # case where some lockfiles do not have a facts key.
+        # Group facts by extension ID across all lockfiles (already filtered to
+        # the latest factsVersion above) and shallowly merge their dicts.
         facts: (if any(has("facts")) then
                   map(.facts // {} | to_entries) | flatten |
                   if length > 0 then group_by(.key) | shallow_merge({(.[0].key): shallow_merge(.value)}) else {} end
                 else null end),
+        # Keep only non-zero versions, mirroring how Bazel writes the lockfile.
+        factsVersions: (if ($maxFactsVersions | with_entries(select(.value != 0)) | length) > 0 then
+                          $maxFactsVersions | with_entries(select(.value != 0))
+                        else null end),
     }
-    # Filter out null values for missing top-level keys such as facts.
+    # Filter out null values for missing top-level keys such as facts and
+    # factsVersions.
     | with_entries(select(.value != null))
 )? //
     # We get here if the lockfiles with the highest lockFileVersion could not be

--- a/scripts/bazel_lockfile_merge_test.sh
+++ b/scripts/bazel_lockfile_merge_test.sh
@@ -273,7 +273,7 @@ EOF
 function test_merge_facts() {
   cat > base <<'EOF'
 {
-  "lockFileVersion": 22,
+  "lockFileVersion": 28,
   "registryFileHashes": {
     "https://example.org/modules/foo/1.0/MODULE.bazel": "1234"
   },
@@ -283,7 +283,7 @@ function test_merge_facts() {
 EOF
   cat > left <<'EOF'
 {
-  "lockFileVersion": 22,
+  "lockFileVersion": 28,
   "registryFileHashes": {
     "https://example.org/modules/foo/1.0/MODULE.bazel": "1234"
   },
@@ -311,7 +311,7 @@ EOF
 EOF
   cat > right <<'EOF'
 {
-  "lockFileVersion": 22,
+  "lockFileVersion": 28,
   "registryFileHashes": {
     "https://example.org/modules/foo/1.0/MODULE.bazel": "1234"
   },
@@ -339,7 +339,7 @@ EOF
 EOF
   cat > expected <<'EOF'
 {
-  "lockFileVersion": 22,
+  "lockFileVersion": 28,
   "registryFileHashes": {
     "https://example.org/modules/foo/1.0/MODULE.bazel": "1234"
   },
@@ -372,6 +372,72 @@ EOF
         "url": "https://example.org/xml_foo/3.0.zip"
       }
     }
+  }
+}
+EOF
+
+  do_merge base left right
+  diff -u expected left || fail "output differs"
+}
+
+# When two lockfiles have facts at different schema versions (tracked in the
+# parallel factsVersions map), only the entries at the highest version survive
+# for each extension: facts at a lower version would be misinterpreted under
+# the new schema.
+function test_merge_facts_with_mismatched_versions() {
+  cat > base <<'EOF'
+{
+  "lockFileVersion": 28,
+  "registryFileHashes": {},
+  "selectedYankedVersions": {},
+  "moduleExtensions": {}
+}
+EOF
+  cat > left <<'EOF'
+{
+  "lockFileVersion": 28,
+  "registryFileHashes": {},
+  "selectedYankedVersions": {},
+  "moduleExtensions": {},
+  "facts": {
+    "@@rules_foo+//:foo_deps.bzl%foo_deps": {
+      "old_key": "old_value"
+    }
+  },
+  "factsVersions": {
+    "@@rules_foo+//:foo_deps.bzl%foo_deps": 1
+  }
+}
+EOF
+  cat > right <<'EOF'
+{
+  "lockFileVersion": 28,
+  "registryFileHashes": {},
+  "selectedYankedVersions": {},
+  "moduleExtensions": {},
+  "facts": {
+    "@@rules_foo+//:foo_deps.bzl%foo_deps": {
+      "new_key": "new_value"
+    }
+  },
+  "factsVersions": {
+    "@@rules_foo+//:foo_deps.bzl%foo_deps": 2
+  }
+}
+EOF
+  cat > expected <<'EOF'
+{
+  "lockFileVersion": 28,
+  "registryFileHashes": {},
+  "selectedYankedVersions": {},
+  "moduleExtensions": {},
+  "facts": {
+    "@@rules_foo+//:foo_deps.bzl%foo_deps": {
+      "new_key": "new_value"
+    }
+  },
+  "factsVersions": {
+    "@@rules_foo+//:foo_deps.bzl%foo_deps": 2
   }
 }
 EOF

--- a/site/en/external/extension.md
+++ b/site/en/external/extension.md
@@ -282,6 +282,14 @@ version. The first time the extension is evaluated, it can fetch this mapping
 from the network, but on later evaluations it can use the mapping from `facts`
 to avoid the network requests.
 
+If you need to make a backwards-incompatible change to the schema of the values
+your extension stores in `facts`, set the
+[`facts_version`](/rules/lib/globals/bzl#module_extension.facts_version)
+parameter on `module_extension` to a higher integer than its previous value.
+Bazel persists `facts_version` in the lockfile alongside the facts and discards
+any persisted facts when the recorded version differs from the current one,
+making sure your extension only ever observes facts produced by the same schema.
+
 ### Specify dependence on operating system and architecture
 
 If your extension relies on the operating system or its architecture type,

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -120,6 +120,8 @@ public class BazelLockFileModule extends BlazeModule {
         new HashMap<ModuleExtensionId, LockFileModuleExtension.WithFactors>(numExtensions);
     var combinedFacts = new HashMap<ModuleExtensionId, Facts>(numExtensions);
     combinedFacts.putAll(oldLockfile.getFacts());
+    var combinedFactsVersions = new HashMap<ModuleExtensionId, Integer>(numExtensions);
+    combinedFactsVersions.putAll(oldLockfile.getFactsVersions());
     var doneValues = evaluator.getDoneValues();
     for (var extensionId : depGraphValue.getExtensionUsagesTable().rowKeySet()) {
       if (extensionId.isInnate()) {
@@ -130,6 +132,7 @@ public class BazelLockFileModule extends BlazeModule {
       if (value != null) {
         newExtensionInfos.put(extensionId, value.lockFileInfo().get());
         combinedFacts.put(extensionId, value.facts());
+        combinedFactsVersions.put(extensionId, value.factsVersion());
       }
     }
     var relevantFacts =
@@ -139,6 +142,16 @@ public class BazelLockFileModule extends BlazeModule {
                 entry ->
                     depGraphValue.getExtensionUsagesTable().containsRow(entry.getKey())
                         && !entry.getValue().equals(Facts.EMPTY)),
+            ModuleExtensionId.LEXICOGRAPHIC_COMPARATOR);
+    // Only store non-zero versions for extensions that have facts persisted; the default is 0.
+    var relevantFactsVersions =
+        ImmutableSortedMap.copyOf(
+            Maps.filterEntries(
+                combinedFactsVersions,
+                entry ->
+                    relevantFacts.containsKey(entry.getKey())
+                        && entry.getValue() != null
+                        && entry.getValue() != 0),
             ModuleExtensionId.LEXICOGRAPHIC_COMPARATOR);
 
     Thread updateLockfile =
@@ -171,6 +184,7 @@ public class BazelLockFileModule extends BlazeModule {
                       .setSelectedYankedVersions(moduleResolutionValue.getSelectedYankedVersions())
                       .setModuleExtensions(notReproducibleExtensionInfos)
                       .setFacts(relevantFacts)
+                      .setFactsVersions(relevantFactsVersions)
                       .build();
 
               // Write the new values to the files, but only if needed. This is not just a
@@ -200,6 +214,7 @@ public class BazelLockFileModule extends BlazeModule {
                       .setSelectedYankedVersions(ImmutableMap.of())
                       .setModuleExtensions(reproducibleExtensionInfos)
                       .setFacts(relevantFacts)
+                      .setFactsVersions(relevantFactsVersions)
                       .build();
 
               if (!newHiddenLockfile.equals(oldHiddenLockfileFinal)) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -47,7 +47,7 @@ public abstract class BazelLockFileValue implements SkyValue {
   // https://cs.opensource.google/bazel/bazel/+/release-7.3.0:src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java;l=120-127;drc=5f5355b75c7c93fba1e15f6658f308953f4baf51
   // While this hack exists on 7.x, lockfile version increments should be done 2 at a time (i.e.
   // keep this number even).
-  public static final int LOCK_FILE_VERSION = 26;
+  public static final int LOCK_FILE_VERSION = 28;
 
   /** A valid empty lockfile. */
   public static final BazelLockFileValue EMPTY_LOCKFILE = builder().build();
@@ -112,7 +112,8 @@ public abstract class BazelLockFileValue implements SkyValue {
         .setRegistryFileHashes(ImmutableMap.of())
         .setSelectedYankedVersions(ImmutableMap.of())
         .setModuleExtensions(ImmutableMap.of())
-        .setFacts(ImmutableMap.of());
+        .setFacts(ImmutableMap.of())
+        .setFactsVersions(ImmutableMap.of());
   }
 
   /** Current version of the lock file */
@@ -132,7 +133,25 @@ public abstract class BazelLockFileValue implements SkyValue {
           ModuleExtensionId, ImmutableMap<ModuleExtensionEvalFactors, LockFileModuleExtension>>
       getModuleExtensions();
 
+  /**
+   * Per-extension perpetually true facts that are passed to extensions at evaluation time without
+   * any invalidation (except for {@link #getFactsVersions()}).
+   *
+   * <p>These are not stored in LockFileModuleExtension as they are intended to be independent of
+   * the eval factors.
+   */
   public abstract ImmutableMap<ModuleExtensionId, Facts> getFacts();
+
+  /**
+   * The {@code factsVersion} parameter that {@code module_extension} declared at the time the
+   * corresponding {@link #getFacts()} entry was written. Compared against the current value before
+   * an extension runs; on mismatch the persisted facts are discarded and the extension is invoked
+   * with empty facts. Missing entries default to version 0.
+   *
+   * <p>This is not stored in Facts to ensure a legible, mergeable JSON representation for facts
+   * that is only as indented as absolutely necessary.
+   */
+  public abstract ImmutableMap<ModuleExtensionId, Integer> getFactsVersions();
 
   public abstract Builder toBuilder();
 
@@ -152,6 +171,8 @@ public abstract class BazelLockFileValue implements SkyValue {
             value);
 
     public abstract Builder setFacts(ImmutableMap<ModuleExtensionId, Facts> value);
+
+    public abstract Builder setFactsVersions(ImmutableMap<ModuleExtensionId, Integer> value);
 
     public abstract BazelLockFileValue build();
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InnateRunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InnateRunnableExtension.java
@@ -148,6 +148,11 @@ final class InnateRunnableExtension implements RunnableExtension {
   }
 
   @Override
+  public int getFactsVersion() {
+    return 0;
+  }
+
+  @Override
   public RunModuleExtensionResult run(
       Environment env,
       SingleExtensionUsagesValue usagesValue,

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtension.java
@@ -42,7 +42,8 @@ public record ModuleExtension(
     Location location,
     ImmutableList<String> envVariables,
     boolean osDependent,
-    boolean archDependent)
+    boolean archDependent,
+    int factsVersion)
     implements StarlarkValue {
   public ModuleExtension {
     requireNonNull(implementation, "implementation");
@@ -75,6 +76,8 @@ public record ModuleExtension(
     public abstract Builder setOsDependent(boolean osDependent);
 
     public abstract Builder setArchDependent(boolean archDependent);
+
+    public abstract Builder setFactsVersion(int factsVersion);
 
     public abstract ModuleExtension build();
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
@@ -210,6 +210,11 @@ final class RegularRunnableExtension implements RunnableExtension {
     return BazelModuleContext.of(bzlLoadValue.getModule()).bzlTransitiveDigest();
   }
 
+  @Override
+  public int getFactsVersion() {
+    return extension.factsVersion();
+  }
+
   @Nullable
   @Override
   public RunModuleExtensionResult run(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RunnableExtension.java
@@ -39,6 +39,13 @@ interface RunnableExtension {
 
   byte[] getBzlTransitiveDigest();
 
+  /**
+   * The current schema version of the facts produced by this extension. Persisted in the lockfile
+   * alongside the facts and compared against the value before the extension runs: if they differ,
+   * the persisted facts are discarded and the extension is invoked with empty facts.
+   */
+  int getFactsVersion();
+
   /** Runs the extension. Returns null if a Skyframe restart is required. */
   @Nullable
   RunModuleExtensionResult run(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -142,6 +142,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
 
     // Check the lockfile first for that module extension
     LockfileMode lockfileMode = BazelLockFileFunction.LOCKFILE_MODE.get(env);
+    int currentFactsVersion = extension.getFactsVersion();
     Facts lockfileFacts = Facts.EMPTY;
     // Store workspace lockfile facts separately for validation in ERROR mode
     Facts workspaceLockfileFacts = Facts.EMPTY;
@@ -156,11 +157,21 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       if (workspaceLockfile == null || hiddenLockfile == null) {
         return null;
       }
-      workspaceLockfileFacts = workspaceLockfile.getFacts().get(extensionId);
-      lockfileFacts = workspaceLockfileFacts;
-      if (lockfileFacts == null) {
-        lockfileFacts = hiddenLockfile.getFacts().getOrDefault(extensionId, Facts.EMPTY);
-        workspaceLockfileFacts = Facts.EMPTY;
+      // Prefer the workspace lockfile facts when present, falling back to the hidden lockfile.
+      // In both cases, facts whose stored factsVersion differs from the current extension's
+      // facts_version are discarded: the extension's schema may have changed.
+      if (workspaceLockfile.getFacts().containsKey(extensionId)) {
+        int workspaceFactsVersion =
+            workspaceLockfile.getFactsVersions().getOrDefault(extensionId, 0);
+        if (workspaceFactsVersion == currentFactsVersion) {
+          workspaceLockfileFacts = workspaceLockfile.getFacts().get(extensionId);
+          lockfileFacts = workspaceLockfileFacts;
+        }
+      } else {
+        int hiddenFactsVersion = hiddenLockfile.getFactsVersions().getOrDefault(extensionId, 0);
+        if (hiddenFactsVersion == currentFactsVersion) {
+          lockfileFacts = hiddenLockfile.getFacts().getOrDefault(extensionId, Facts.EMPTY);
+        }
       }
       var lockedExtensionMap = workspaceLockfile.getModuleExtensions().get(extensionId);
       var lockedExtension =
@@ -292,6 +303,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
         usagesValue,
         lockFileInfo,
         newFacts,
+        currentFactsVersion,
         env);
   }
 
@@ -352,6 +364,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
           usagesValue,
           Optional.of(new LockFileModuleExtension.WithFactors(evalFactors, lockedExtension)),
           facts,
+          extension.getFactsVersion(),
           env);
     }
     // Reproducible extensions are always locked in the hidden lockfile to provide best-effort
@@ -410,6 +423,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       SingleExtensionUsagesValue usagesValue,
       Optional<LockFileModuleExtension.WithFactors> lockFileInfo,
       Facts facts,
+      int factsVersion,
       Environment env)
       throws SingleExtensionEvalFunctionException {
     Optional<RootModuleFileFixup> fixup = Optional.empty();
@@ -446,7 +460,8 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                     Function.identity())),
         lockFileInfo,
         fixup,
-        facts);
+        facts,
+        factsVersion);
   }
 
   private static SingleExtensionEvalFunctionException createOutdatedLockfileException(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionValue.java
@@ -50,7 +50,8 @@ public record SingleExtensionValue(
     ImmutableBiMap<RepositoryName, String> canonicalRepoNameToInternalNames,
     Optional<LockFileModuleExtension.WithFactors> lockFileInfo,
     Optional<RootModuleFileFixup> fixup,
-    Facts facts)
+    Facts facts,
+    int factsVersion)
     implements SkyValue {
   public SingleExtensionValue {
     requireNonNull(generatedRepoSpecs, "generatedRepoSpecs");

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
@@ -54,6 +54,7 @@ import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.Sequence;
 import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkCallable;
+import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.Tuple;
 import net.starlark.java.syntax.Location;
@@ -330,8 +331,13 @@ rule. Created by \
       Sequence<?> environ, // <String>
       boolean osDependent,
       boolean archDependent,
+      StarlarkInt factsVersion,
       StarlarkThread thread)
       throws EvalException {
+    int factsVersionInt = factsVersion.toInt("facts_version");
+    if (factsVersionInt < 0) {
+      throw Starlark.errorf("facts_version must be non-negative, got %d", factsVersionInt);
+    }
     return ModuleExtension.builder()
         .setImplementation(implementation)
         .setTagClasses(
@@ -343,6 +349,7 @@ rule. Created by \
         .setLocation(thread.getCallerLocation())
         .setOsDependent(osDependent)
         .setArchDependent(archDependent)
+        .setFactsVersion(factsVersionInt)
         .build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/repository/RepositoryModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/repository/RepositoryModuleApi.java
@@ -27,6 +27,7 @@ import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.NoneType;
 import net.starlark.java.eval.Sequence;
 import net.starlark.java.eval.StarlarkCallable;
+import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.StarlarkValue;
 
@@ -202,6 +203,24 @@ public interface RepositoryModuleApi {
             defaultValue = "False",
             doc = "Indicates whether this extension is architecture-dependent or not",
             named = true,
+            positional = false),
+        @Param(
+            name = "facts_version",
+            defaultValue = "0",
+            doc =
+                """
+                The schema version of the <code>facts</code> dict returned by this extension's \
+                implementation function via <code><a \
+                href="../builtins/module_ctx.html#extension_metadata">extension_metadata</a>\
+                </code>. The version is persisted in the lockfile alongside the facts and \
+                compared against the current value before the extension runs: if they differ, \
+                the persisted facts are discarded and the extension is invoked with an empty \
+                <code><a href="../builtins/module_ctx.html#facts">module_ctx.facts</a></code>. \
+                Increment this value whenever the extension changes the schema of the facts in \
+                a backwards-incompatible way so that older facts are not interpreted with the \
+                new schema.
+                """,
+            named = true,
             positional = false)
       },
       useStarlarkThread = true)
@@ -212,6 +231,7 @@ public interface RepositoryModuleApi {
       Sequence<?> environ, // <String>
       boolean osDependent,
       boolean archDependent,
+      StarlarkInt factsVersion,
       StarlarkThread thread)
       throws EvalException;
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
@@ -60,7 +60,8 @@ public class StarlarkBazelModuleTest {
         .setImplementation(() -> "maven")
         .setEnvVariables(ImmutableList.of())
         .setOsDependent(false)
-        .setArchDependent(false);
+        .setArchDependent(false)
+        .setFactsVersion(0);
   }
 
   @Test

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -3148,6 +3148,139 @@ class BazelLockfileTest(test_base.TestBase):
     facts = lockfile['facts']
     self.assertEqual(len(facts), 2)
 
+  def testFactsVersionDiscardedOnMismatch(self):
+    """facts_version is persisted in the lockfile and discards stale facts."""
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'lockfile_ext = use_extension("extension.bzl", "lockfile_ext")',
+            'use_repo(lockfile_ext, "hello")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def impl(ctx):',
+            '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
+            'repo_rule = repository_rule(',
+            '    implementation = impl,',
+            '    attrs = {"hash": attr.string()},',
+            ')',
+            'def _mod_ext_impl(ctx):',
+            '    if "hello" in ctx.facts:',
+            '        print("Reusing facts")',
+            '    else:',
+            '        print("No facts")',
+            '    repo_rule(name = "hello", hash = "h")',
+            '    return ctx.extension_metadata(',
+            '        reproducible = False,',
+            '        facts = {"hello": "h"},',
+            '    )',
+            'lockfile_ext = module_extension(',
+            '    implementation = _mod_ext_impl,',
+            '    facts_version = 1,',
+            ')',
+        ],
+    )
+    _, _, stderr = self.RunBazel(['build', '@hello//:all'])
+    self.assertIn('No facts', ''.join(stderr))
+
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read())
+    ext_id = '//:extension.bzl%lockfile_ext'
+    self.assertIn(ext_id, lockfile['facts'])
+    self.assertIn('factsVersions', lockfile)
+    self.assertEqual(lockfile['factsVersions'].get(ext_id), 1)
+
+    # Reevaluation at the same facts_version reuses the facts.
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def impl(ctx):',
+            '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
+            'repo_rule = repository_rule(',
+            '    implementation = impl,',
+            '    attrs = {"hash": attr.string()},',
+            ')',
+            'def _mod_ext_impl(ctx):',
+            '    if "hello" in ctx.facts:',
+            '        print("Reusing facts")',
+            '    else:',
+            '        print("No facts")',
+            '    repo_rule(name = "hello", hash = "h2")',
+            '    return ctx.extension_metadata(',
+            '        reproducible = False,',
+            '        facts = {"hello": "h"},',
+            '    )',
+            'lockfile_ext = module_extension(',
+            '    implementation = _mod_ext_impl,',
+            '    facts_version = 1,',
+            ')',
+        ],
+    )
+    _, _, stderr = self.RunBazel(['build', '@hello//:all'])
+    self.assertIn('Reusing facts', ''.join(stderr))
+
+    # Bumping facts_version discards the previously persisted facts.
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def impl(ctx):',
+            '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
+            'repo_rule = repository_rule(',
+            '    implementation = impl,',
+            '    attrs = {"hash": attr.string()},',
+            ')',
+            'def _mod_ext_impl(ctx):',
+            '    if "hello" in ctx.facts:',
+            '        print("Reusing facts")',
+            '    else:',
+            '        print("No facts")',
+            '    repo_rule(name = "hello", hash = "h3")',
+            '    return ctx.extension_metadata(',
+            '        reproducible = False,',
+            '        facts = {"hello": {"hash": "h"}},',
+            '    )',
+            'lockfile_ext = module_extension(',
+            '    implementation = _mod_ext_impl,',
+            '    facts_version = 2,',
+            ')',
+        ],
+    )
+    _, _, stderr = self.RunBazel(['build', '@hello//:all'])
+    self.assertIn('No facts', ''.join(stderr))
+
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read())
+    self.assertEqual(lockfile['factsVersions'].get(ext_id), 2)
+
+  def testFactsVersionRejectsNegative(self):
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'lockfile_ext = use_extension("extension.bzl", "lockfile_ext")',
+            'use_repo(lockfile_ext, "hello")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def _mod_ext_impl(ctx):',
+            '    pass',
+            'lockfile_ext = module_extension(',
+            '    implementation = _mod_ext_impl,',
+            '    facts_version = -1,',
+            ')',
+        ],
+    )
+    exit_code, _, stderr = self.RunBazel(
+        ['build', '@hello//:all'], allow_failure=True
+    )
+    self.assertNotEqual(exit_code, 0)
+    self.assertIn('facts_version must be non-negative', ''.join(stderr))
+
   def testFactsWithLockfileModeErrorAfterRollback(self):
     """Test that ERROR mode doesn't fail when rolling back to a version without facts.
 

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 26,
+  "lockFileVersion": 28,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",


### PR DESCRIPTION
Adds a new integer `facts_version` parameter to `module_extension(...)` that is persisted in the lockfile alongside the facts and checked against the current value before the extension runs. If the stored version does not match, the persisted facts are discarded and the extension is invoked with an empty `module_ctx.facts`.

Versions are stored in a new top-level lockfile object. The jq merge driver is taught to drop facts from any lockfile whose own `factsVersions` entry for an extension is lower than the maximum observed across all input lockfiles before performing the shallow merge, preserving only the entries written by the newest schema.

Fixes #29483.

RELNOTES: `module_extension(...)` now accepts a `facts_version` integer parameter. Bumping it invalidates the facts persisted in `MODULE.bazel.lock` for that extension, allowing extension authors to make breaking changes to the facts schema without risking misinterpretation by older code paths.

Closes #29556.

PiperOrigin-RevId: 921924739
Change-Id: I514f5e1b21a6c51fd88633a462d220d33a78d180
(cherry picked from commit https://github.com/bazelbuild/bazel/commit/87f096a2c6b21b1214955caf127b4975c5a58a88)

Fixes #29626
