### PR TITLE
Add --experimental_prioritize_test_by_size for local test scheduling

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
@@ -38,6 +38,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -205,8 +207,10 @@ public class ResourceManager implements ResourceEstimator {
   // be initialized to 1 during creation in the acquire() method.
   // We use LinkedList because we will need to remove elements from the middle frequently in the
   // middle of iterating through the list.
+  // localRequests is kept sorted by scheduling priority (highest first) so that
+  // processWaitingRequests can try to satisfy higher-priority requests first.
   @SuppressWarnings("JdkObsolete")
-  private final Deque<WaitingRequest> localRequests = new LinkedList<>();
+  private final List<WaitingRequest> localRequests = new LinkedList<>();
 
   @SuppressWarnings("JdkObsolete")
   private final Deque<WaitingRequest> dynamicWorkerRequests = new LinkedList<>();
@@ -262,6 +266,9 @@ public class ResourceManager implements ResourceEstimator {
   private int runningActions = 0;
   // Collects the information about the load of a machine.
   private MachineLoadProvider machineLoadProvider;
+
+  /** If set, tests with larger size are given priority in resource acquisition. */
+  private boolean prioritizeTestBySize;
 
   public void initializeCpuLoadFunctionality(
       MachineLoadProvider machineLoadProvider, boolean cpuLoadScheduling, Duration windowSize) {
@@ -357,6 +364,11 @@ public class ResourceManager implements ResourceEstimator {
       ResourcePriority getPriority,
       int getId) {}
   ;
+
+  /** Sets whether to prioritize tests by size in resource allocation. */
+  public void setPrioritizeTestBySize(boolean prioritizeTestBySize) {
+    this.prioritizeTestBySize = prioritizeTestBySize;
+  }
 
   /**
    * Acquires requested resource set. Permanently insufficient requests fail on initial acquisition
@@ -517,14 +529,17 @@ public class ResourceManager implements ResourceEstimator {
         checkResourceAvailable(availableResources.get(key), requested, key);
       }
     }
-    if (areResourcesAvailable(resources)) {
+    // Fast path: grant immediately only when no higher-priority requests are waiting.
+    // This ensures that during a burst of requests, the priority queue is respected.
+    if (areResourcesAvailable(resources)
+        && (!prioritizeTestBySize || !hasHigherPriorityWaiting(resources, request.getPriority()))) {
       Worker worker = incrementResources(request);
       return new ResourceLatch(/* latch= */ null, worker);
     }
     WaitingRequest waitingRequest =
         new WaitingRequest(request, new ResourceLatch(new CountDownLatch(1), /* worker= */ null));
     switch (request.getPriority()) {
-      case LOCAL -> localRequests.addLast(waitingRequest);
+      case LOCAL -> enqueueLocal(waitingRequest);
       case DYNAMIC_WORKER ->
           // Dynamic requests should be LIFO, because we are more likely to win the race on newer
           // actions.
@@ -534,7 +549,63 @@ public class ResourceManager implements ResourceEstimator {
           // actions.
           dynamicStandaloneRequests.addFirst(waitingRequest);
     }
+    if (prioritizeTestBySize && areResourcesAvailable(resources)) {
+      processAllWaitingRequests();
+    }
     return waitingRequest.getResourceLatch();
+  }
+
+  private void enqueueLocal(WaitingRequest request) {
+    if (prioritizeTestBySize) {
+      insertByPriority(localRequests, request);
+    } else {
+      localRequests.add(request);
+    }
+  }
+
+  private boolean hasHigherPriorityWaiting(ResourceSet resources, ResourcePriority priority) {
+    if (priority != ResourcePriority.LOCAL || localRequests.isEmpty()) {
+      return false;
+    }
+    int myPriority = resources.getSchedulingPriority();
+    if (myPriority == 0) {
+      return false;
+    }
+    return localRequests
+            .get(0)
+            .getResourceRequest()
+            .getResourceSet()
+            .getSchedulingPriority()
+        > myPriority;
+  }
+
+  /**
+   * Inserts a request into the list maintaining descending order by scheduling priority. Requests
+   * with the same priority preserve FIFO order among themselves.
+   *
+   * <p>{@code insertByPriority} is O(n) per insert, so a burst of waiters can be O(n^2) in the
+   * worst case. We chose a sorted {@link LinkedList} over a {@link java.util.PriorityQueue} because
+   * {@link #processWaitingRequests} scans the queue in priority order and may satisfy requests out
+   * of order as different resources become available. A priority queue would not preserve that
+   * traversal order, and head-only polling would change the behavior.
+   *
+   * <p>The waiting queue is bounded by local parallelism, so we expect it to stay small.
+   */
+  private static void insertByPriority(List<WaitingRequest> requests, WaitingRequest request) {
+    int priority = request.getResourceRequest().getResourceSet().getSchedulingPriority();
+    if (priority == 0) {
+      requests.add(request);
+      return;
+    }
+    ListIterator<WaitingRequest> it = requests.listIterator();
+    while (it.hasNext()) {
+      if (it.next().getResourceRequest().getResourceSet().getSchedulingPriority() < priority) {
+        it.previous();
+        it.add(request);
+        return;
+      }
+    }
+    requests.add(request);
   }
 
   /** Release resources and process the queues of waiting threads. */
@@ -577,12 +648,8 @@ public class ResourceManager implements ResourceEstimator {
     processWaitingRequests(dynamicStandaloneRequests);
   }
 
-  private synchronized void processWaitingRequests(Deque<WaitingRequest> requests)
+  private synchronized void processWaitingRequests(Iterable<WaitingRequest> requests)
       throws IOException, InterruptedException {
-    if (requests.isEmpty()) {
-      return;
-    }
-
     Iterator<WaitingRequest> iterator = requests.iterator();
     while (iterator.hasNext()) {
       WaitingRequest request = iterator.next();

--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
@@ -38,6 +38,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -205,8 +207,10 @@ public class ResourceManager implements ResourceEstimator {
   // be initialized to 1 during creation in the acquire() method.
   // We use LinkedList because we will need to remove elements from the middle frequently in the
   // middle of iterating through the list.
+  // localRequests is kept sorted by scheduling priority (highest first) so that
+  // processWaitingRequests can try to satisfy higher-priority requests first.
   @SuppressWarnings("JdkObsolete")
-  private final Deque<WaitingRequest> localRequests = new LinkedList<>();
+  private final List<WaitingRequest> localRequests = new LinkedList<>();
 
   @SuppressWarnings("JdkObsolete")
   private final Deque<WaitingRequest> dynamicWorkerRequests = new LinkedList<>();
@@ -266,6 +270,8 @@ public class ResourceManager implements ResourceEstimator {
   private int runningActions = 0;
   // Collects the information about the load of a machine.
   private MachineLoadProvider machineLoadProvider;
+  // If set, tests with larger size are given priority in resource acquisition.
+  private boolean prioritizeTestBySize;
 
   public void initializeLoadFunctionality(
       MachineLoadProvider machineLoadProvider,
@@ -367,6 +373,11 @@ public class ResourceManager implements ResourceEstimator {
       ResourcePriority getPriority,
       int getId) {}
   ;
+
+  /** Sets whether to prioritize tests by size in resource allocation. */
+  public void setPrioritizeTestBySize(boolean prioritizeTestBySize) {
+    this.prioritizeTestBySize = prioritizeTestBySize;
+  }
 
   /**
    * Acquires requested resource set. Permanently insufficient requests fail on initial acquisition
@@ -528,14 +539,17 @@ public class ResourceManager implements ResourceEstimator {
         checkResourceAvailable(availableResources.get(key), requested, key);
       }
     }
-    if (areResourcesAvailable(resources)) {
+    // Fast path: grant immediately only when no higher-priority requests are waiting.
+    // This ensures that during a burst of requests, the priority queue is respected.
+    if (areResourcesAvailable(resources)
+        && (!prioritizeTestBySize || !hasHigherPriorityWaiting(resources, request.getPriority()))) {
       Worker worker = incrementResources(request);
       return new ResourceLatch(/* latch= */ null, worker);
     }
     WaitingRequest waitingRequest =
         new WaitingRequest(request, new ResourceLatch(new CountDownLatch(1), /* worker= */ null));
     switch (request.getPriority()) {
-      case LOCAL -> localRequests.addLast(waitingRequest);
+      case LOCAL -> enqueueLocal(waitingRequest);
       case DYNAMIC_WORKER ->
           // Dynamic requests should be LIFO, because we are more likely to win the race on newer
           // actions.
@@ -545,7 +559,63 @@ public class ResourceManager implements ResourceEstimator {
           // actions.
           dynamicStandaloneRequests.addFirst(waitingRequest);
     }
+    if (prioritizeTestBySize && areResourcesAvailable(resources)) {
+      processAllWaitingRequests();
+    }
     return waitingRequest.getResourceLatch();
+  }
+
+  private void enqueueLocal(WaitingRequest request) {
+    if (prioritizeTestBySize) {
+      insertByPriority(localRequests, request);
+    } else {
+      localRequests.add(request);
+    }
+  }
+
+  private boolean hasHigherPriorityWaiting(ResourceSet resources, ResourcePriority priority) {
+    if (priority != ResourcePriority.LOCAL || localRequests.isEmpty()) {
+      return false;
+    }
+    int myPriority = resources.getSchedulingPriority();
+    if (myPriority == 0) {
+      return false;
+    }
+    return localRequests
+            .get(0)
+            .getResourceRequest()
+            .getResourceSet()
+            .getSchedulingPriority()
+        > myPriority;
+  }
+
+  /**
+   * Inserts a request into the list maintaining descending order by scheduling priority. Requests
+   * with the same priority preserve FIFO order among themselves.
+   *
+   * <p>{@code insertByPriority} is O(n) per insert, so a burst of waiters can be O(n^2) in the
+   * worst case. We chose a sorted {@link LinkedList} over a {@link java.util.PriorityQueue} because
+   * {@link #processWaitingRequests} scans the queue in priority order and may satisfy requests out
+   * of order as different resources become available. A priority queue would not preserve that
+   * traversal order, and head-only polling would change the behavior.
+   *
+   * <p>The waiting queue is bounded by local parallelism, so we expect it to stay small.
+   */
+  private static void insertByPriority(List<WaitingRequest> requests, WaitingRequest request) {
+    int priority = request.getResourceRequest().getResourceSet().getSchedulingPriority();
+    if (priority == 0) {
+      requests.add(request);
+      return;
+    }
+    ListIterator<WaitingRequest> it = requests.listIterator();
+    while (it.hasNext()) {
+      if (it.next().getResourceRequest().getResourceSet().getSchedulingPriority() < priority) {
+        it.previous();
+        it.add(request);
+        return;
+      }
+    }
+    requests.add(request);
   }
 
   /** Release resources and process the queues of waiting threads. */
@@ -589,12 +659,8 @@ public class ResourceManager implements ResourceEstimator {
     processWaitingRequests(dynamicStandaloneRequests);
   }
 
-  private synchronized void processWaitingRequests(Deque<WaitingRequest> requests)
+  private synchronized void processWaitingRequests(Iterable<WaitingRequest> requests)
       throws IOException, InterruptedException {
-    if (requests.isEmpty()) {
-      return;
-    }
-
     Iterator<WaitingRequest> iterator = requests.iterator();
     while (iterator.hasNext()) {
       WaitingRequest request = iterator.next();

--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceSet.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceSet.java
@@ -36,18 +36,22 @@ import javax.annotation.Nullable;
  *     the resource to a value.
  * @param localTestCount The number of local tests.
  * @param workerKey The workerKey of used worker. Null if no worker is used.
+ * @param schedulingPriority Scheduling priority for resource acquisition. Higher values get
+ *     resources first when multiple requests are waiting. Default is 0 (no priority).
  */
 @AutoCodec
 @Immutable
 public record ResourceSet(
-    ImmutableMap<String, Double> resources, int localTestCount, @Nullable WorkerKey workerKey)
+    ImmutableMap<String, Double> resources,
+    int localTestCount,
+    @Nullable WorkerKey workerKey,
+    int schedulingPriority)
     implements ResourceSetOrBuilder {
   public static final String CPU = "cpu";
   public static final String MEMORY = "memory";
 
   /** For actions that consume negligible resources. */
-  public static final ResourceSet ZERO = new ResourceSet(ImmutableMap.of(), 0, null);
-
+  public static final ResourceSet ZERO = create(ImmutableMap.of(), 0, null, 0);
   public static ResourceSet createWithRamCpu(double memoryMb, double cpu) {
     return create(ImmutableMap.of(MEMORY, memoryMb, CPU, cpu));
   }
@@ -70,7 +74,12 @@ public record ResourceSet(
 
   public static ResourceSet create(
       ImmutableMap<String, Double> resources, int localTestCount, @Nullable WorkerKey workerKey) {
-    return new ResourceSet(resources, localTestCount, workerKey);
+    return new ResourceSet(resources, localTestCount, workerKey, 0);
+  }
+
+  public static ResourceSet createWithSchedulingPriority(
+      ImmutableMap<String, Double> resources, int localTestCount, int schedulingPriority) {
+    return new ResourceSet(resources, localTestCount, null, schedulingPriority);
   }
 
   /**
@@ -96,7 +105,15 @@ public record ResourceSet(
     for (ImmutableMap<String, Double> override : overrides) {
       builder.putAll(override);
     }
-    return create(builder.buildKeepingLast(), localTestCount, workerKey);
+    return new ResourceSet(builder.buildKeepingLast(), localTestCount, workerKey, schedulingPriority);
+  }
+
+  /** Returns a copy of this resource set with the given scheduling priority. */
+  public ResourceSet withSchedulingPriority(int schedulingPriority) {
+    if (this.schedulingPriority == schedulingPriority) {
+      return this;
+    }
+    return new ResourceSet(resources, localTestCount, workerKey, schedulingPriority);
   }
 
   public double get(String resource) {
@@ -129,6 +146,11 @@ public record ResourceSet(
     return localTestCount;
   }
 
+  /** Returns the scheduling priority. Higher values get resources first when waiting. */
+  public int getSchedulingPriority() {
+    return schedulingPriority;
+  }
+
   @Override
   public String toString() {
     return "Resources: \n"
@@ -146,6 +168,9 @@ public record ResourceSet(
                 StringBuilder::append)
         + "Local tests: "
         + localTestCount
+        + "\n"
+        + "Scheduling priority: "
+        + schedulingPriority
         + "\n";
   }
 

--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceSet.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceSet.java
@@ -51,7 +51,7 @@ public record ResourceSet(
   public static final String MEMORY = "memory";
 
   /** For actions that consume negligible resources. */
-  public static final ResourceSet ZERO = create(ImmutableMap.of(), 0, null, 0);
+  public static final ResourceSet ZERO = createWithSchedulingPriority(ImmutableMap.of(), 0, 0);
   public static ResourceSet createWithRamCpu(double memoryMb, double cpu) {
     return create(ImmutableMap.of(MEMORY, memoryMb, CPU, cpu));
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
@@ -57,6 +57,10 @@ public class TestTargetProperties {
     };
   }
 
+  private static int getSchedulingPriorityFromSize(TestSize size) {
+    return (size.ordinal() + 1) * 10;
+  }
+
   private final TestSize size;
   private final TestTimeout timeout;
   private final List<String> tags;
@@ -155,14 +159,16 @@ public class TestTargetProperties {
 
   public ResourceSet getLocalResourceUsage(Label label, boolean usingLocalTestJobs)
       throws UserExecException {
+    int schedulingPriority = getSchedulingPriorityFromSize(size);
     if (usingLocalTestJobs) {
-      return LOCAL_TEST_JOBS_BASED_RESOURCES;
+      return LOCAL_TEST_JOBS_BASED_RESOURCES.withSchedulingPriority(schedulingPriority);
     }
 
     ResourceSet defaultResources = getResourceSetFromSize(size);
     ImmutableMap<String, Double> configResources =
         testConfiguration == null ? ImmutableMap.of() : testConfiguration.getTestResources(size);
-    return defaultResources.withResourceOverrides(configResources);
+    return defaultResources.withResourceOverrides(configResources)
+        .withSchedulingPriority(schedulingPriority);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -986,6 +986,7 @@ public class ExecutionTool {
   @VisibleForTesting
   public static void configureResourceManager(ResourceManager resourceMgr, BuildRequest request) {
     ExecutionOptions options = request.getOptions(ExecutionOptions.class);
+    resourceMgr.setPrioritizeTestBySize(options.getPrioritizeTestBySize());
     resourceMgr.setAvailableResources(
         ResourceSet.create(
             options.getLocalResources(),

--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -996,6 +996,7 @@ public class ExecutionTool {
   @VisibleForTesting
   public static void configureResourceManager(ResourceManager resourceMgr, BuildRequest request) {
     ExecutionOptions options = request.getOptions(ExecutionOptions.class);
+    resourceMgr.setPrioritizeTestBySize(options.getPrioritizeTestBySize());
     resourceMgr.setAvailableResources(
         ResourceSet.create(
             options.getLocalResources(),

--- a/src/main/java/com/google/devtools/build/lib/buildtool/SkyframeBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/SkyframeBuilder.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.analysis.test.TestProvider;
 import com.google.devtools.build.lib.bugreport.BugReporter;
 import com.google.devtools.build.lib.buildtool.buildevent.ExecutionProgressReceiverAvailableEvent;
 import com.google.devtools.build.lib.events.Reporter;
+import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.runtime.KeepGoingOption;
@@ -55,6 +56,8 @@ import com.google.devtools.build.skyframe.EvaluationResult;
 import com.google.devtools.common.options.OptionsProvider;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -165,6 +168,23 @@ public class SkyframeBuilder implements Builder {
     parallelTests = Sets.difference(parallelTests, targetsToSkip);
     exclusiveTests = Sets.difference(exclusiveTests, targetsToSkip);
 
+    // Sort parallel tests by timeout descending so that longer-running tests are enqueued first.
+    // TestParams exposes timeout but not size; timeout is a proxy for expected duration here.
+    // ResourceManager uses TestSize-derived schedulingPriority (see TestTargetProperties).
+    Set<ConfiguredTarget> orderedParallelTests = parallelTests;
+    ExecutionOptions executionOptions = options.getOptions(ExecutionOptions.class);
+    if (executionOptions != null && executionOptions.getPrioritizeTestBySize()) {
+      List<ConfiguredTarget> sorted = new ArrayList<>(parallelTests);
+      sorted.sort(
+          Comparator.comparingInt(
+                  (ConfiguredTarget ct) -> {
+                    TestProvider p = ct.getProvider(TestProvider.class);
+                    return p != null ? p.getTestParams().getTimeout().ordinal() : 0;
+                  })
+              .reversed());
+      orderedParallelTests = new LinkedHashSet<>(sorted);
+    }
+
     try {
       result =
           skyframeExecutor.buildArtifacts(
@@ -174,7 +194,7 @@ public class SkyframeBuilder implements Builder {
               artifactsToBuild,
               targetsToBuild,
               aspects,
-              parallelTests,
+              orderedParallelTests,
               exclusiveTests,
               options,
               actionCacheChecker,

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -421,6 +421,17 @@ public abstract class ExecutionOptions extends OptionsBase {
   }
 
   @Option(
+      name = "experimental_prioritize_test_by_size",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+      effectTags = {OptionEffectTag.EXECUTION},
+      help =
+          "If set, larger / longer-running tests are scheduled before smaller ones. Skyframe"
+              + " enqueues by test timeout; local resource acquisition uses test size priority."
+              + " This can reduce wall-clock time by starting long-running tests earlier.")
+  public abstract boolean getPrioritizeTestBySize();
+
+  @Option(
       name = "cache_computed_file_digests",
       defaultValue = "50000",
       documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -431,6 +431,17 @@ public abstract class ExecutionOptions extends OptionsBase {
   }
 
   @Option(
+      name = "experimental_prioritize_test_by_size",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+      effectTags = {OptionEffectTag.EXECUTION},
+      help =
+          "If set, larger / longer-running tests are scheduled before smaller ones. Skyframe"
+              + " enqueues by test timeout; local resource acquisition uses test size priority."
+              + " This can reduce wall-clock time by starting long-running tests earlier.")
+  public abstract boolean getPrioritizeTestBySize();
+
+  @Option(
       name = "cache_computed_file_digests",
       defaultValue = "50000",
       documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,

--- a/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
@@ -56,6 +56,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import org.junit.Before;
@@ -910,6 +911,147 @@ public final class ResourceManagerTest {
 
   synchronized boolean isAvailable(ResourceManager rm, double ram, double cpu, int localTestCount) {
     return rm.areResourcesAvailable(ResourceSet.create(ram, cpu, localTestCount));
+  }
+
+  @Test
+  @SuppressWarnings("ThreadPriorityCheck")
+  public void testSchedulingPriorityOrdersWaitingRequests() throws Exception {
+    assertThat(manager.inUse()).isFalse();
+    manager.setPrioritizeTestBySize(true);
+
+    // Occupy all CPU so subsequent requests will block.
+    ResourceHandle blocker = acquire(0, 1, 0);
+
+    AtomicInteger order = new AtomicInteger(0);
+
+    // Each needs full CPU (1.0) so they are mutually exclusive, making wake-up order observable.
+    // Low-priority request enqueued first.
+    TestThread lowPriorityThread =
+        new TestThread(
+            () -> {
+              try (ResourceHandle handle =
+                  manager.acquireResources(
+                      resourceOwner, cpuWithPriority(10), ResourcePriority.LOCAL)) {
+                assertThat(order.incrementAndGet()).isEqualTo(2);
+              }
+            });
+
+    // High-priority request enqueued second.
+    TestThread highPriorityThread =
+        new TestThread(
+            () -> {
+              try (ResourceHandle handle =
+                  manager.acquireResources(
+                      resourceOwner, cpuWithPriority(30), ResourcePriority.LOCAL)) {
+                assertThat(order.incrementAndGet()).isEqualTo(1);
+              }
+            });
+
+    lowPriorityThread.start();
+    while (manager.getWaitCount() == 0) {
+      Thread.yield();
+    }
+
+    highPriorityThread.start();
+    while (manager.getWaitCount() < 2) {
+      Thread.yield();
+    }
+
+    // Release the blocker. Both need 1.0 CPU, only 1.0 available, so they run sequentially.
+    // The high-priority request (priority=30) should be satisfied before low (priority=10).
+    blocker.close();
+
+    highPriorityThread.joinAndAssertState(5000);
+    lowPriorityThread.joinAndAssertState(5000);
+    assertThat(manager.inUse()).isFalse();
+  }
+
+  @Test
+  @SuppressWarnings("ThreadPriorityCheck")
+  public void testSchedulingPriorityDisabled_unrelatedResourceAcquiresImmediately() throws Exception {
+    manager.setPrioritizeTestBySize(false);
+
+    ResourceHandle blocker = acquire(0, 1, 0);
+
+    TestThread cpuWaiter =
+        new TestThread(
+            () -> {
+              try (ResourceHandle handle = acquire(0, 1, 0)) {
+                // Blocked waiting for CPU.
+              }
+            });
+    cpuWaiter.start();
+    while (manager.getWaitCount() == 0) {
+      Thread.yield();
+    }
+
+    // Memory is available and unrelated to the waiting CPU request; should not enter the queue.
+    AtomicBoolean memoryAcquired = new AtomicBoolean(false);
+    TestThread memoryThread =
+        new TestThread(
+            () -> {
+              try (ResourceHandle handle =
+                  manager.acquireResources(
+                      resourceOwner, ResourceSet.create(100, 0, 0), ResourcePriority.LOCAL)) {
+                memoryAcquired.set(true);
+              }
+            });
+    memoryThread.start();
+    memoryThread.joinAndAssertState(5000);
+    assertThat(memoryAcquired.get()).isTrue();
+    assertThat(manager.getWaitCount()).isEqualTo(1);
+
+    blocker.close();
+    cpuWaiter.joinAndAssertState(5000);
+  }
+
+  @Test
+  @SuppressWarnings("ThreadPriorityCheck")
+  public void testSchedulingPrioritySamePriority_fifoOrder() throws Exception {
+    manager.setPrioritizeTestBySize(true);
+
+    ResourceHandle blocker = acquire(0, 1, 0);
+    AtomicInteger order = new AtomicInteger(0);
+
+    TestThread firstThread =
+        new TestThread(
+            () -> {
+              try (ResourceHandle handle =
+                  manager.acquireResources(
+                      resourceOwner, cpuWithPriority(20), ResourcePriority.LOCAL)) {
+                assertThat(order.incrementAndGet()).isEqualTo(1);
+              }
+            });
+
+    TestThread secondThread =
+        new TestThread(
+            () -> {
+              try (ResourceHandle handle =
+                  manager.acquireResources(
+                      resourceOwner, cpuWithPriority(20), ResourcePriority.LOCAL)) {
+                assertThat(order.incrementAndGet()).isEqualTo(2);
+              }
+            });
+
+    firstThread.start();
+    while (manager.getWaitCount() == 0) {
+      Thread.yield();
+    }
+    secondThread.start();
+    while (manager.getWaitCount() < 2) {
+      Thread.yield();
+    }
+
+    blocker.close();
+
+    firstThread.joinAndAssertState(5000);
+    secondThread.joinAndAssertState(5000);
+    assertThat(manager.inUse()).isFalse();
+  }
+
+  private static ResourceSet cpuWithPriority(int priority) {
+    return ResourceSet.createWithSchedulingPriority(
+        ImmutableMap.of(ResourceSet.CPU, 1.0), 0, priority);
   }
 
   private static class ResourceOwnerStub implements ActionExecutionMetadata {

--- a/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
@@ -56,6 +56,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import org.junit.Before;
@@ -1046,6 +1047,147 @@ public final class ResourceManagerTest {
 
   synchronized boolean isAvailable(ResourceManager rm, double ram, double cpu, int localTestCount) {
     return rm.areResourcesAvailable(ResourceSet.create(ram, cpu, localTestCount));
+  }
+
+  @Test
+  @SuppressWarnings("ThreadPriorityCheck")
+  public void testSchedulingPriorityOrdersWaitingRequests() throws Exception {
+    assertThat(manager.inUse()).isFalse();
+    manager.setPrioritizeTestBySize(true);
+
+    // Occupy all CPU so subsequent requests will block.
+    ResourceHandle blocker = acquire(0, 1, 0);
+
+    AtomicInteger order = new AtomicInteger(0);
+
+    // Each needs full CPU (1.0) so they are mutually exclusive, making wake-up order observable.
+    // Low-priority request enqueued first.
+    TestThread lowPriorityThread =
+        new TestThread(
+            () -> {
+              try (ResourceHandle handle =
+                  manager.acquireResources(
+                      resourceOwner, cpuWithPriority(10), ResourcePriority.LOCAL)) {
+                assertThat(order.incrementAndGet()).isEqualTo(2);
+              }
+            });
+
+    // High-priority request enqueued second.
+    TestThread highPriorityThread =
+        new TestThread(
+            () -> {
+              try (ResourceHandle handle =
+                  manager.acquireResources(
+                      resourceOwner, cpuWithPriority(30), ResourcePriority.LOCAL)) {
+                assertThat(order.incrementAndGet()).isEqualTo(1);
+              }
+            });
+
+    lowPriorityThread.start();
+    while (manager.getWaitCount() == 0) {
+      Thread.yield();
+    }
+
+    highPriorityThread.start();
+    while (manager.getWaitCount() < 2) {
+      Thread.yield();
+    }
+
+    // Release the blocker. Both need 1.0 CPU, only 1.0 available, so they run sequentially.
+    // The high-priority request (priority=30) should be satisfied before low (priority=10).
+    blocker.close();
+
+    highPriorityThread.joinAndAssertState(5000);
+    lowPriorityThread.joinAndAssertState(5000);
+    assertThat(manager.inUse()).isFalse();
+  }
+
+  @Test
+  @SuppressWarnings("ThreadPriorityCheck")
+  public void testSchedulingPriorityDisabled_unrelatedResourceAcquiresImmediately() throws Exception {
+    manager.setPrioritizeTestBySize(false);
+
+    ResourceHandle blocker = acquire(0, 1, 0);
+
+    TestThread cpuWaiter =
+        new TestThread(
+            () -> {
+              try (ResourceHandle handle = acquire(0, 1, 0)) {
+                // Blocked waiting for CPU.
+              }
+            });
+    cpuWaiter.start();
+    while (manager.getWaitCount() == 0) {
+      Thread.yield();
+    }
+
+    // Memory is available and unrelated to the waiting CPU request; should not enter the queue.
+    AtomicBoolean memoryAcquired = new AtomicBoolean(false);
+    TestThread memoryThread =
+        new TestThread(
+            () -> {
+              try (ResourceHandle handle =
+                  manager.acquireResources(
+                      resourceOwner, ResourceSet.create(100, 0, 0), ResourcePriority.LOCAL)) {
+                memoryAcquired.set(true);
+              }
+            });
+    memoryThread.start();
+    memoryThread.joinAndAssertState(5000);
+    assertThat(memoryAcquired.get()).isTrue();
+    assertThat(manager.getWaitCount()).isEqualTo(1);
+
+    blocker.close();
+    cpuWaiter.joinAndAssertState(5000);
+  }
+
+  @Test
+  @SuppressWarnings("ThreadPriorityCheck")
+  public void testSchedulingPrioritySamePriority_fifoOrder() throws Exception {
+    manager.setPrioritizeTestBySize(true);
+
+    ResourceHandle blocker = acquire(0, 1, 0);
+    AtomicInteger order = new AtomicInteger(0);
+
+    TestThread firstThread =
+        new TestThread(
+            () -> {
+              try (ResourceHandle handle =
+                  manager.acquireResources(
+                      resourceOwner, cpuWithPriority(20), ResourcePriority.LOCAL)) {
+                assertThat(order.incrementAndGet()).isEqualTo(1);
+              }
+            });
+
+    TestThread secondThread =
+        new TestThread(
+            () -> {
+              try (ResourceHandle handle =
+                  manager.acquireResources(
+                      resourceOwner, cpuWithPriority(20), ResourcePriority.LOCAL)) {
+                assertThat(order.incrementAndGet()).isEqualTo(2);
+              }
+            });
+
+    firstThread.start();
+    while (manager.getWaitCount() == 0) {
+      Thread.yield();
+    }
+    secondThread.start();
+    while (manager.getWaitCount() < 2) {
+      Thread.yield();
+    }
+
+    blocker.close();
+
+    firstThread.joinAndAssertState(5000);
+    secondThread.joinAndAssertState(5000);
+    assertThat(manager.inUse()).isFalse();
+  }
+
+  private static ResourceSet cpuWithPriority(int priority) {
+    return ResourceSet.createWithSchedulingPriority(
+        ImmutableMap.of(ResourceSet.CPU, 1.0), 0, priority);
   }
 
   private static class ResourceOwnerStub implements ActionExecutionMetadata {

--- a/src/test/java/com/google/devtools/build/lib/actions/ResourceSetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ResourceSetTest.java
@@ -140,4 +140,38 @@ public class ResourceSetTest {
             ImmutableMap.of(), ImmutableMap.of("cpu", 4.0), ImmutableMap.of());
     assertThat(result.getCpuUsage()).isEqualTo(4.0);
   }
+
+  @Test
+  public void create_defaultSchedulingPriorityIsZero() {
+    assertThat(ResourceSet.createWithRamCpu(100, 1).getSchedulingPriority()).isEqualTo(0);
+  }
+
+  @Test
+  public void withSchedulingPriority_setsPriority() {
+    ResourceSet rs = ResourceSet.createWithRamCpu(100, 1).withSchedulingPriority(30);
+    assertThat(rs.getSchedulingPriority()).isEqualTo(30);
+  }
+
+  @Test
+  public void withSchedulingPriority_sameValue_returnsSameInstance() {
+    ResourceSet base = ResourceSet.createWithRamCpu(100, 1).withSchedulingPriority(20);
+    assertThat(base.withSchedulingPriority(20)).isSameInstanceAs(base);
+  }
+
+  @Test
+  public void withResourceOverrides_preservesSchedulingPriority() {
+    ResourceSet base = ResourceSet.createWithRamCpu(100, 1).withSchedulingPriority(30);
+    ResourceSet result = base.withResourceOverrides(ImmutableMap.of("cpu", 4.0));
+    assertThat(result.getSchedulingPriority()).isEqualTo(30);
+    assertThat(result.getCpuUsage()).isEqualTo(4.0);
+  }
+
+  @Test
+  public void createWithSchedulingPriority_setsPriority() {
+    ResourceSet rs =
+        ResourceSet.createWithSchedulingPriority(
+            ImmutableMap.of(ResourceSet.CPU, 1.0), 0, 40);
+    assertThat(rs.getSchedulingPriority()).isEqualTo(40);
+    assertThat(rs.getCpuUsage()).isEqualTo(1.0);
+  }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

When enabled, larger tests are scheduled earlier via two mechanisms:
1. SkyframeBuilder enqueues parallel tests in descending TestTimeout order
2. ResourceManager prioritizes waiting local requests by schedulingPriority

Priority is derived from test size: (TestSize.ordinal() + 1) * 10. Default is off; non-test actions keep schedulingPriority=0 and are unaffected.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

After moving from our internal test framework to bazel test, we hit a clear long-tail problem: long-running tests often started late under parallel execution, leaving workers idle while stragglers finished. This PR adds `--experimental_prioritize_test_by_size` to schedule larger / longer-running tests earlier using existing size/timeout metadata, cutting wall-clock time by ~11% on our 236-test benchmark without changing BUILD files.

Scope:
- Local test execution only (not build actions or remote execution)
- Opt-in via `--experimental_prioritize_test_by_size`
- Partially related to bazelbuild/bazel#24903 (no per-target priority attribute)

Benchmark (236 tests):
- Share of LARGE tests in the first 60 slots: 22% -> 74% (+52 pp)
- LARGE average rank (n=236): 147.5 -> 127.3 (20 ranks earlier)
- MEDIUM average rank: 81.5 -> 110.8 (29 ranks later, yielding to larger tests)
- Total wall clock: 412s -> 368s (-10.7%)



### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

Add `--experimental_prioritize_test_by_size`

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES[NEW]: Added `--experimental_prioritize_test_by_size` flag. When enabled, larger tests are scheduled earlier during local execution by assigning higher scheduling priority based on test size (LARGE > MEDIUM > SMALL). 
