### PR TITLE
remote: accept uncompressed size as committed_size for compressed uploads

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -273,10 +273,18 @@ final class ByteStreamUploader {
           return;
         }
 
+        // The spec leaves the non-dedup committed_size for a compressed write
+        // underspecified, so accept the uncompressed blob size that some servers
+        // report on success.
+        if (committedSize == chunker.getUncompressedSize()) {
+          return;
+        }
+
         throw new IOException(
             format(
-                "compressed write incomplete: committed_size %d is neither -1 nor total %d - %s",
-                committedSize, expected, resourceName));
+                "compressed write incomplete: committed_size %d is neither -1, total %d, nor"
+                    + " uncompressed size %d - %s",
+                committedSize, expected, chunker.getUncompressedSize(), resourceName));
       }
 
       // Uncompressed upload failed.

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -1668,6 +1668,116 @@ public class ByteStreamUploaderTest {
     assertThat(numUploads.get()).isEqualTo(1);
   }
 
+  @Test
+  public void compressedUploadAcceptsUncompressedSizeAsCommittedSize() throws Exception {
+    // Some servers (e.g. Google's RBE, Kajiya) report the uncompressed blob size as the
+    // committed_size of a successful compressed write rather than the compressed byte count. The
+    // uploader must accept this and not fail with "compressed write incomplete".
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(
+            () -> mockBackoff, (e) -> Result.TRANSIENT_FAILURE, retryService);
+    ByteStreamUploader uploader =
+        new ByteStreamUploader(
+            INSTANCE_NAME,
+            referenceCountedChannel,
+            CallCredentialsProvider.NO_CREDENTIALS,
+            /* callTimeoutSecs= */ 60,
+            retrier,
+            /* maximumOpenFiles= */ -1,
+            /* digestFunction= */ DigestFunction.Value.SHA256);
+
+    // Random data is incompressible, so the compressed byte count exceeds the uncompressed size.
+    // That keeps the two distinct, so a committed_size equal to the uncompressed size genuinely
+    // exercises the new acceptance branch rather than the compressed-count check.
+    byte[] blob = new byte[CHUNK_SIZE * 2 + 1];
+    new Random().nextBytes(blob);
+
+    Chunker chunker =
+        Chunker.builder().setInput(blob).setCompressed(true).setChunkSize(CHUNK_SIZE).build();
+    Digest digest = DIGEST_UTIL.compute(blob);
+
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public StreamObserver<WriteRequest> write(StreamObserver<WriteResponse> streamObserver) {
+            return new StreamObserver<WriteRequest>() {
+              @Override
+              public void onNext(WriteRequest writeRequest) {}
+
+              @Override
+              public void onError(Throwable throwable) {
+                fail("onError should never be called.");
+              }
+
+              @Override
+              public void onCompleted() {
+                // Respond with the uncompressed size rather than the compressed byte count.
+                streamObserver.onNext(
+                    WriteResponse.newBuilder().setCommittedSize(blob.length).build());
+                streamObserver.onCompleted();
+              }
+            };
+          }
+        });
+
+    uploadBlob(uploader, context, digest, chunker);
+
+    // This test should not have triggered any retries.
+    Mockito.verifyNoInteractions(mockBackoff);
+  }
+
+  @Test
+  public void compressedUploadRejectsUnexpectedCommittedSize() throws Exception {
+    // A committed_size that is neither -1, the compressed byte count, nor the uncompressed size is
+    // still rejected as an incomplete write.
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(
+            () -> mockBackoff, (e) -> Result.TRANSIENT_FAILURE, retryService);
+    ByteStreamUploader uploader =
+        new ByteStreamUploader(
+            INSTANCE_NAME,
+            referenceCountedChannel,
+            CallCredentialsProvider.NO_CREDENTIALS,
+            /* callTimeoutSecs= */ 60,
+            retrier,
+            /* maximumOpenFiles= */ -1,
+            /* digestFunction= */ DigestFunction.Value.SHA256);
+
+    byte[] blob = new byte[CHUNK_SIZE * 2 + 1];
+    new Random().nextBytes(blob);
+
+    Chunker chunker =
+        Chunker.builder().setInput(blob).setCompressed(true).setChunkSize(CHUNK_SIZE).build();
+    Digest digest = DIGEST_UTIL.compute(blob);
+
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public StreamObserver<WriteRequest> write(StreamObserver<WriteResponse> streamObserver) {
+            return new StreamObserver<WriteRequest>() {
+              @Override
+              public void onNext(WriteRequest writeRequest) {}
+
+              @Override
+              public void onError(Throwable throwable) {
+                fail("onError should never be called.");
+              }
+
+              @Override
+              public void onCompleted() {
+                streamObserver.onNext(
+                    WriteResponse.newBuilder().setCommittedSize(blob.length + 1).build());
+                streamObserver.onCompleted();
+              }
+            };
+          }
+        });
+
+    IOException e =
+        assertThrows(IOException.class, () -> uploadBlob(uploader, context, digest, chunker));
+    assertThat(e).hasMessageThat().contains("compressed write incomplete");
+  }
+
   /**
    * Uploads a BLOB, as provided by the {@link Chunker}, to the remote {@code ByteStream} service.
    * The call blocks until the upload is complete, or throws an {@link Exception} in case of error.


### PR DESCRIPTION
This makes --remote_cache_compression work with Google's RBE and Kajiya.

For context: For a successful compressed ByteStream Write, the REAPI spec only clearly defines the "committed_size" in the dedup case (-1); the correct value to return for the normal case is left undefined: The base ByteStream proto only calls it "the number of bytes processed". REAPI's explanation of the meaning of "write_offset" when compression is used counts compressed bytes, so the compressed byte count is the natural reading -- but it was never mandated, and implementations diverge.

A survey of the REAPI ecosystem shows three different success values in the wild:
- Buildbarn and bazel-remote report the compressed bytes received.
- RBE and Kajiya report the uncompressed size.
- Buildfarm returns -1 for every compressed write, success or dedup.

Clients disagree too:
- Bazel and buck2 accept the compressed count or -1.
- Siso only accepts the uncompressed size.
- reclient / remote-apis-sdks' older UploadIfMissing path ignores the field entirely, while its newer cas/upload.go path only accepts the uncompressed size.

For servers that reported the uncompressed size, Bazel failed with "compressed write incomplete". By accepting the uncompressed size, too, the check now covers every value a real server emits while still strictly validating the uncompressed path, where the spec does define the value.

RELNOTES: None
