### PR TITLE
Fixes ConcurrentModificationException in RemoteActionFileSystem

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -62,13 +62,11 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.SeekableByteChannel;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
@@ -113,7 +111,7 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
   private final FileSystem localFs;
   private final RemoteInMemoryFileSystem remoteOutputTree;
   // Concurrent access is rare and most builds don't have lost inputs.
-  private final List<LostArtifacts> lostInputs = Collections.synchronizedList(new ArrayList<>(0));
+  private final Set<LostArtifacts> lostInputs = ConcurrentHashMap.newKeySet();
 
   @Nullable private ActionExecutionMetadata action = null;
 


### PR DESCRIPTION
The full stack trace is

    java.lang.RuntimeException: Unrecoverable error while evaluating node 'ActionLookupData1{actionLookupKey=ConfiguredTargetKey{label=[redacted], config=BuildConfigurationKey[8a221ab759f7b1588dd87e4cd2c33fd6434b1a29cb96fe492597c8485176b329]}, actionIndex=1}' (requested by nodes 'ArtifactNestedSetKey[12]@512616727', 'ArtifactNestedSetKey[12]@1309248355')
            at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:552)
            at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:435)
            at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(Unknown Source)
            at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(Unknown Source)
            at java.base/java.util.concurrent.ForkJoinTask$InterruptibleTask.exec(Unknown Source)
            at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
            at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
            at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
            at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
    Caused by: java.util.ConcurrentModificationException
            at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source)
            at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
            at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
            at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)
            at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
            at java.base/java.util.stream.ReferencePipeline.reduce(Unknown Source)
            at com.google.devtools.build.lib.remote.RemoteActionFileSystem.checkForLostInputs(RemoteActionFileSystem.java:921)

lostInputs was a Collections.synchronizedList, whose stream()/iteration is not internally synchronized. A concurrent add() from getInputStream() on another input-fetch thread could race with the stream traversal in checkForLostInputs, throwing ConcurrentModificationException and crashing the build.

### Description

this fixes a bazel crash 

### Motivation

crashes are bad

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
