### PR TITLE
[9.2.0] remote: trust in-memory outputs across incremental builds

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -130,6 +130,15 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
    */
   public void setContentsProxy(FileContentsProxy proxy) {}
 
+  /**
+   * Returns whether this metadata describes an in-memory output (e.g. a file kept in memory by
+   * {@code --experimental_inmemory_dotd_files} or {@code --experimental_inmemory_jdeps_files}) that
+   * is never written to the local filesystem.
+   */
+  public boolean isInMemoryOutput() {
+    return false;
+  }
+
   @Nullable
   public byte[] getValueFingerprint() {
     // TODO(janakr): return fingerprint in other cases: symlink, directory.
@@ -405,9 +414,13 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
   }
 
   public static FileArtifactValue createForRemoteFileWithMaterializationData(
-      byte[] digest, long size, int locationIndex, @Nullable Instant expirationTime) {
+      byte[] digest,
+      long size,
+      int locationIndex,
+      @Nullable Instant expirationTime,
+      boolean inMemoryOutput) {
     return new RemoteFileArtifactValueWithMaterializationData(
-        digest, size, locationIndex, expirationTime);
+        digest, size, locationIndex, expirationTime, inMemoryOutput);
   }
 
   public static FileArtifactValue createFromExistingWithResolvedPath(
@@ -798,11 +811,17 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
       extends RemoteFileArtifactValue {
     private long expirationTime;
     @Nullable private FileContentsProxy proxy;
+    private final boolean inMemoryOutput;
 
     private RemoteFileArtifactValueWithMaterializationData(
-        byte[] digest, long size, int locationIndex, @Nullable Instant expirationTime) {
+        byte[] digest,
+        long size,
+        int locationIndex,
+        @Nullable Instant expirationTime,
+        boolean inMemoryOutput) {
       super(digest, size, locationIndex);
       this.expirationTime = toEpochMilli(expirationTime);
+      this.inMemoryOutput = inMemoryOutput;
     }
 
     private static long toEpochMilli(@Nullable Instant expirationTime) {
@@ -847,6 +866,11 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     }
 
     @Override
+    public boolean isInMemoryOutput() {
+      return inMemoryOutput;
+    }
+
+    @Override
     public boolean equals(Object o) {
       if (this == o) {
         return true;
@@ -873,6 +897,7 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
           .add("locationIndex", getLocationIndex())
           .add("expirationTime", fromEpochMilli(expirationTime))
           .add("proxy", proxy)
+          .add("inMemoryOutput", inMemoryOutput)
           .toString();
     }
   }
@@ -931,6 +956,11 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     @Override
     public void setContentsProxy(FileContentsProxy proxy) {
       delegate.setContentsProxy(proxy);
+    }
+
+    @Override
+    public boolean isInMemoryOutput() {
+      return delegate.isInMemoryOutput();
     }
 
     @Override
@@ -1276,6 +1306,11 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     @Override
     public void setContentsProxy(FileContentsProxy proxy) {
       delegate.setContentsProxy(proxy);
+    }
+
+    @Override
+    public boolean isInMemoryOutput() {
+      return delegate.isInMemoryOutput();
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -75,7 +75,8 @@ public class CompactPersistentActionCache implements ActionCache {
   // cache records.
   private static final int VALIDATION_KEY = -10;
 
-  private static final int VERSION = 23;
+  // Padded with 900 to distinguish the Bazel 9.x release line from future versions at HEAD.
+  private static final int VERSION = 90024;
 
   /**
    * A timestamp, represented as the number of minutes since the Unix epoch.
@@ -789,6 +790,8 @@ public class CompactPersistentActionCache implements ActionCache {
     VarInt.putVarLong(
         value.getExpirationTime() != null ? value.getExpirationTime().toEpochMilli() : -1, sink);
 
+    VarInt.putVarInt(value.isInMemoryOutput() ? 1 : 0, sink);
+
     PathFragment resolvedPath = value.getResolvedPath();
     if (resolvedPath != null) {
       VarInt.putVarInt(1, sink);
@@ -803,6 +806,7 @@ public class CompactPersistentActionCache implements ActionCache {
           + VarInt.MAX_VARLONG_SIZE // size
           + VarInt.MAX_VARINT_SIZE // locationIndex
           + VarInt.MAX_VARLONG_SIZE // expirationTime
+          + VarInt.MAX_VARINT_SIZE // inMemoryOutput
           + (1 + VarInt.MAX_VARINT_SIZE); // resolvedPath
 
   private FileArtifactValue decodeRemoteMetadata(ByteBuffer source) throws IOException {
@@ -814,6 +818,8 @@ public class CompactPersistentActionCache implements ActionCache {
 
     long expirationTimeEpochMilli = VarInt.getVarLong(source);
 
+    boolean inMemoryOutput = VarInt.getVarInt(source) != 0;
+
     PathFragment resolvedPath = null;
     int numResolvedPath = VarInt.getVarInt(source);
     if (numResolvedPath > 0) {
@@ -823,12 +829,16 @@ public class CompactPersistentActionCache implements ActionCache {
       resolvedPath = PathFragment.create(getStringForIndex(indexer, VarInt.getVarInt(source)));
     }
 
-    FileArtifactValue metadata =
-        FileArtifactValue.createForRemoteFileWithMaterializationData(
-            digest,
-            size,
-            locationIndex,
-            expirationTimeEpochMilli >= 0 ? Instant.ofEpochMilli(expirationTimeEpochMilli) : null);
+    FileArtifactValue metadata;
+    if (expirationTimeEpochMilli >= 0 || inMemoryOutput) {
+      Instant expirationTime =
+          expirationTimeEpochMilli >= 0 ? Instant.ofEpochMilli(expirationTimeEpochMilli) : null;
+      metadata =
+          FileArtifactValue.createForRemoteFileWithMaterializationData(
+              digest, size, locationIndex, expirationTime, inMemoryOutput);
+    } else {
+      metadata = FileArtifactValue.createForRemoteFile(digest, size, locationIndex);
+    }
 
     if (resolvedPath != null) {
       metadata = FileArtifactValue.createFromExistingWithResolvedPath(metadata, resolvedPath);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -305,14 +305,15 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
     this.action = action;
   }
 
-  void injectRemoteFile(PathFragment path, byte[] digest, long size, Instant expirationTime)
+  void injectRemoteFile(
+      PathFragment path, byte[] digest, long size, Instant expirationTime, boolean inMemoryOutput)
       throws IOException {
     if (!isOutput(path)) {
       return;
     }
     var metadata =
         FileArtifactValue.createForRemoteFileWithMaterializationData(
-            digest, size, /* locationIndex= */ 1, expirationTime);
+            digest, size, /* locationIndex= */ 1, expirationTime, inMemoryOutput);
     remoteOutputTree.injectFile(path, metadata);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1275,7 +1275,8 @@ public class RemoteExecutionService {
                   file.path().asFragment(),
                   DigestUtil.toBinaryDigest(file.digest()),
                   file.digest().getSizeBytes(),
-                  expirationTime);
+                  expirationTime,
+                  isInMemoryOutputFile);
         }
 
         if (isInMemoryOutputFile) {
@@ -1329,7 +1330,8 @@ public class RemoteExecutionService {
                   file.path().asFragment(),
                   DigestUtil.toBinaryDigest(file.digest()),
                   file.digest().getSizeBytes(),
-                  expirationTime);
+                  expirationTime,
+                  /* inMemoryOutput= */ false);
         }
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -253,7 +253,8 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
               DigestUtil.toBinaryDigest(file.getDigest()),
               file.getDigest().getSizeBytes(),
               /* locationIndex= */ 1,
-              expirationTime));
+              expirationTime,
+              /* inMemoryOutput= */ false));
       fs.setExecutable(filePath, file.getIsExecutable());
       // The RE API does not track whether a file is readable or writable. We choose to make all
       // files readable and not writable to ensure that other repo rules can't accidentally modify

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputChecker.java
@@ -343,20 +343,24 @@ public class RemoteOutputChecker implements OutputChecker {
       return true;
     }
 
-    // If Bazel should download this file, but it does not exist locally, returns false to rerun
-    // the generating action to trigger the download (just like in the normal build, when local
-    // outputs are missing).
+    // An in-memory output (e.g. --experimental_inmemory_{dotd,jdeps}_files) is never written to
+    // disk, so a "should download" verdict must not force a re-execution to materialize it; trust
+    // it via its TTL instead. See https://github.com/bazelbuild/bazel/issues/29313.
+    if (!metadata.isInMemoryOutput()) {
+      // If Bazel should download this file, but it does not exist locally, returns false to rerun
+      // the generating action to trigger the download (just like in the normal build, when local
+      // outputs are missing).
+      if (lastRemoteOutputChecker != null) {
+        // This is an incremental build. If the file was downloaded by previous build and is now
+        // missing, invalidate the action.
+        if (lastRemoteOutputChecker.shouldDownloadOutput(file, metadata)) {
+          return false;
+        }
+      }
 
-    if (lastRemoteOutputChecker != null) {
-      // This is an incremental build. If the file was downloaded by previous build and is now
-      // missing, invalidate the action.
-      if (lastRemoteOutputChecker.shouldDownloadOutput(file, metadata)) {
+      if (shouldDownloadOutput(file, metadata)) {
         return false;
       }
-    }
-
-    if (shouldDownloadOutput(file, metadata)) {
-      return false;
     }
 
     if (clock != null) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -1357,6 +1357,7 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
       @Nullable InputMetadataProvider inputMetadataProvider,
       Fingerprint fp)
       throws CommandLineExpansionException, InterruptedException {
+    fp.addBoolean(getDotdFile() != null && useInMemoryDotdFiles());
     computeKey(
         actionKeyContext,
         fp,

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -235,6 +235,9 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
     actionKeyContext.addNestedSetToFingerprint(fp, transitiveInputs);
     getEnvironment().addTo(fp);
     fp.addStringMap(executionInfo);
+    fp.addBoolean(
+        outputDepsProto != null
+            && configuration.getFragment(JavaConfiguration.class).inmemoryJdepsFiles());
     PathMappers.addToFingerprint(
         getMnemonic(),
         getExecutionInfo(),

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -517,7 +517,11 @@ public final class ActionCacheCheckerTest {
     byte[] bytes = content.getBytes(UTF_8);
     FileArtifactValue metadata =
         FileArtifactValue.createForRemoteFileWithMaterializationData(
-            digest(bytes), bytes.length, 1, /* expirationTime= */ null);
+            digest(bytes),
+            bytes.length,
+            1,
+            /* expirationTime= */ null,
+            /* inMemoryOutput= */ false);
     if (resolvedPath != null) {
       metadata = FileArtifactValue.createFromExistingWithResolvedPath(metadata, resolvedPath);
     }
@@ -529,7 +533,7 @@ public final class ActionCacheCheckerTest {
     byte[] bytes = content.getBytes(UTF_8);
     FileArtifactValue metadata =
         FileArtifactValue.createForRemoteFileWithMaterializationData(
-            digest(bytes), bytes.length, 1, expirationTime);
+            digest(bytes), bytes.length, 1, expirationTime, /* inMemoryOutput= */ false);
     if (resolvedPath != null) {
       metadata = FileArtifactValue.createFromExistingWithResolvedPath(metadata, resolvedPath);
     }

--- a/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
@@ -78,7 +78,7 @@ public class CompactPersistentActionCacheTest {
   private final EventHandler eventHandler = spy(EventHandler.class);
 
   @Before
-  public final void createFiles() throws Exception  {
+  public final void createFiles() throws Exception {
     execRoot = scratch.resolve("/output");
     cacheRoot = scratch.resolve("/cache_root");
     corruptedCacheRoot = scratch.resolve("/corrupted_cache_root");
@@ -509,7 +509,7 @@ public class CompactPersistentActionCacheTest {
             .asBytes();
     FileArtifactValue metadata =
         FileArtifactValue.createForRemoteFileWithMaterializationData(
-            digest, bytes.length, 1, expirationTime);
+            digest, bytes.length, 1, expirationTime, /* inMemoryOutput= */ false);
     if (resolvedPath != null) {
       metadata = FileArtifactValue.createFromExistingWithResolvedPath(metadata, resolvedPath);
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -160,7 +160,8 @@ public abstract class ActionInputPrefetcherTestBase {
             hashCode.asBytes(),
             contentsBytes.length,
             /* locationIndex= */ 1,
-            /* expirationTime= */ null);
+            /* expirationTime= */ null,
+            /* inMemoryOutput= */ false);
     if (resolvedPath != null) {
       f = FileArtifactValue.createFromExistingWithResolvedPath(f, resolvedPath);
     }
@@ -219,7 +220,8 @@ public abstract class ActionInputPrefetcherTestBase {
               hashCode.asBytes(),
               contents.length,
               /* locationIndex= */ 1,
-              /* expirationTime= */ null);
+              /* expirationTime= */ null,
+              /* inMemoryOutput= */ false);
       treeBuilder.putChild(child, childValue);
       metadata.put(child, childValue);
       cas.put(hashCode, contents);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -1152,9 +1152,14 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     byte[] digest = getDigest(content);
     int size = Utf8.encodedLength(content);
     ((RemoteActionFileSystem) actionFs)
-        .injectRemoteFile(path, digest, size, /* expirationTime= */ null);
+        .injectRemoteFile(
+            path, digest, size, /* expirationTime= */ null, /* inMemoryOutput= */ false);
     return FileArtifactValue.createForRemoteFileWithMaterializationData(
-        digest, size, /* locationIndex= */ 1, /* expirationTime= */ null);
+        digest,
+        size,
+        /* locationIndex= */ 1,
+        /* expirationTime= */ null,
+        /* inMemoryOutput= */ false);
   }
 
   @Override
@@ -1174,7 +1179,8 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
             getDigest(content),
             Utf8.encodedLength(content),
             /* locationIndex= */ 1,
-            /* expirationTime= */ null);
+            /* expirationTime= */ null,
+            /* inMemoryOutput= */ false);
     inputs.put(a, f);
     return a;
   }
@@ -1199,7 +1205,8 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
               getDigest(content),
               Utf8.encodedLength(content),
               /* locationIndex= */ 0,
-              /* expirationTime= */ null);
+              /* expirationTime= */ null,
+              /* inMemoryOutput= */ false);
       builder.putChild(child, childMeta);
     }
     return builder.build();

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
@@ -102,12 +102,14 @@ public final class FileArtifactValueTest {
                 toBytes("00112233445566778899AABBCCDDEEFF"),
                 /* size= */ 1,
                 /* locationIndex= */ 1,
-                /* expirationTime= */ Instant.ofEpochMilli(1)),
+                /* expirationTime= */ Instant.ofEpochMilli(1),
+                /* inMemoryOutput= */ false),
             FileArtifactValue.createForRemoteFileWithMaterializationData(
                 toBytes("00112233445566778899AABBCCDDEEFF"),
                 /* size= */ 1,
                 /* locationIndex= */ 1,
-                /* expirationTime= */ Instant.ofEpochMilli(2)))
+                /* expirationTime= */ Instant.ofEpochMilli(2),
+                /* inMemoryOutput= */ false))
         .addEqualityGroup(
             // A ResolvedSymlinkArtifactValue is not equal to the FileArtifactValue it wraps.
             FileArtifactValue.createFromExistingWithResolvedPath(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
@@ -1385,7 +1385,7 @@ public final class FilesystemValueCheckerTest {
     DigestHashFunction hashFn = fs.getDigestFunction();
     HashCode hash = hashFn.getHashFunction().hashBytes(data);
     return FileArtifactValue.createForRemoteFileWithMaterializationData(
-        hash.asBytes(), data.length, -1, expirationTime);
+        hash.asBytes(), data.length, -1, expirationTime, /* inMemoryOutput= */ false);
   }
 
   @Test

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -1951,6 +1951,190 @@ EOF
   assert_exists ${dotd_file}
 }
 
+function test_inmemory_dotd_files_no_rebuild_on_incremental_build() {
+  # Regression test for https://github.com/bazelbuild/bazel/issues/29313: under
+  # --remote_download_outputs=all, an action whose .d file is kept in memory
+  # (--experimental_inmemory_dotd_files) must not be re-executed on a later
+  # build, on both a warm and a cold (post-restart) server.
+  stop_worker
+  start_worker
+
+  add_rules_cc MODULE.bazel
+  cat > BUILD <<'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+cc_library(name="foo", srcs=["foo.c"])
+EOF
+  touch foo.c
+
+  # Populate the remote cache.
+  bazel build \
+      --remote_upload_local_results \
+      --remote_cache=grpc://localhost:"${worker_port}" \
+      //:foo &> "$TEST_log" \
+      || fail "Expected success from uploading invocation"
+
+  # Drop the local outputs so the next build fetches them from the cache and
+  # the action's outputs get remote metadata.
+  bazel clean
+
+  # Build, fetching outputs from the cache and keeping the .d file in memory.
+  bazel build \
+      --experimental_inmemory_dotd_files \
+      --remote_download_outputs=all \
+      --remote_cache=grpc://localhost:"${worker_port}" \
+      //:foo &> "$TEST_log" \
+      || fail "Expected success from downloading invocation"
+
+  # Build again without changing anything: the compile action must be up to date.
+  bazel build \
+      --experimental_inmemory_dotd_files \
+      --remote_download_outputs=all \
+      --remote_cache=grpc://localhost:"${worker_port}" \
+      --explain="${TEST_TMPDIR}/explain_warm.txt" \
+      //:foo &> "$TEST_log" \
+      || fail "Expected success from warm incremental invocation"
+
+  assert_not_contains "Compiling foo.c" "${TEST_TMPDIR}/explain_warm.txt"
+
+  # Restart the server and build again: a cold server decides up-to-dateness
+  # from the persisted action cache, so the in-memory output must be recognized
+  # purely from its (never-materialized) metadata.
+  bazel shutdown
+  bazel build \
+      --experimental_inmemory_dotd_files \
+      --remote_download_outputs=all \
+      --remote_cache=grpc://localhost:"${worker_port}" \
+      --explain="${TEST_TMPDIR}/explain_cold.txt" \
+      //:foo &> "$TEST_log" \
+      || fail "Expected success from cold incremental invocation"
+
+  assert_not_contains "Compiling foo.c" "${TEST_TMPDIR}/explain_cold.txt"
+}
+
+function test_download_all_after_minimal_materializes_intermediate_output() {
+  # An unmaterialized remote output and an in-memory output both lack a local
+  # presence, so recognizing in-memory outputs must not also match ordinary
+  # remote outputs left unmaterialized by an earlier build: switching
+  # --remote_download_outputs from minimal to all must still materialize them.
+  setup_genrule_with_dep
+
+  # Build with minimal: the intermediate output stays remote, not on disk.
+  bazel build \
+    --genrule_strategy=remote \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_download_outputs=minimal \
+    //a:foobar >& "$TEST_log" || fail "Failed to build //a:foobar (minimal)"
+
+  if [[ -f bazel-bin/a/foo.txt ]]; then
+    fail "Expected intermediate output to not be downloaded under minimal"
+  fi
+
+  # Switch to all: the intermediate output must now be materialized on disk.
+  bazel build \
+    --genrule_strategy=remote \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_download_outputs=all \
+    //a:foobar >& "$TEST_log" || fail "Failed to build //a:foobar (all)"
+
+  if ! [[ -f bazel-bin/a/foo.txt ]]; then
+    fail "Expected intermediate output bazel-bin/a/foo.txt to be downloaded after switching to --remote_download_outputs=all"
+  fi
+}
+
+function test_disabling_inmemory_dotd_materializes_dotd_after_restart() {
+  # An in-memory marker recorded by an earlier build must not keep the .d off
+  # disk when a later build disables in-memory mode and requests all outputs:
+  # the marker describes how a previous invocation handled the output, not what
+  # the current flags require.
+  stop_worker
+  start_worker
+
+  add_rules_cc MODULE.bazel
+  cat > BUILD <<'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+cc_library(name="foo", srcs=["foo.c"])
+EOF
+  touch foo.c
+
+  # Populate the remote cache, then drop the local outputs.
+  bazel build \
+      --remote_upload_local_results \
+      --remote_cache=grpc://localhost:"${worker_port}" \
+      //:foo &> "$TEST_log" || fail "Expected success from uploading invocation"
+  bazel clean
+
+  # Build with in-memory dotd enabled: the .d is kept in memory and recorded as
+  # an in-memory output in the action cache.
+  bazel build \
+      --experimental_inmemory_dotd_files \
+      --remote_download_outputs=all \
+      --remote_cache=grpc://localhost:"${worker_port}" \
+      //:foo &> "$TEST_log" || fail "Expected success from in-memory invocation"
+
+  # Restart, then build with in-memory dotd disabled. The current flags require
+  # the .d on disk, so it must be materialized despite the persisted marker.
+  bazel shutdown
+  bazel build \
+      --noexperimental_inmemory_dotd_files \
+      --remote_download_outputs=all \
+      --remote_cache=grpc://localhost:"${worker_port}" \
+      //:foo &> "$TEST_log" || fail "Expected success from on-disk invocation"
+
+  local -r dotd_file="$(find -L bazel-bin -type f -name 'foo*.d' | head -n1)"
+  if [[ -z "$dotd_file" ]]; then
+    fail "Expected the .d file to be materialized on disk after disabling --experimental_inmemory_dotd_files"
+  fi
+}
+
+function test_disabling_inmemory_jdeps_materializes_jdeps_after_restart() {
+  # An in-memory marker recorded by an earlier build must not keep the .jdeps
+  # off disk when a later build disables in-memory mode and requests all
+  # outputs: the marker describes how a previous invocation handled the output,
+  # not what the current flags require.
+  stop_worker
+  start_worker
+
+  add_rules_java MODULE.bazel
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+load("@rules_java//java:java_library.bzl", "java_library")
+java_library(name="lib", srcs=["Library.java"])
+EOF
+  cat > a/Library.java <<'EOF'
+public class Library {
+  public static boolean TEST = true;
+}
+EOF
+
+  # Populate the remote cache, then drop the local outputs.
+  bazel build \
+      --remote_upload_local_results \
+      --remote_cache=grpc://localhost:"${worker_port}" \
+      //a:lib &> "$TEST_log" || fail "Expected success from uploading invocation"
+  bazel clean
+
+  # Build with in-memory jdeps enabled: the .jdeps is kept in memory and
+  # recorded as an in-memory output in the action cache.
+  bazel build \
+      --experimental_inmemory_jdeps_files \
+      --remote_download_outputs=all \
+      --remote_cache=grpc://localhost:"${worker_port}" \
+      //a:lib &> "$TEST_log" || fail "Expected success from in-memory invocation"
+
+  # Restart, then build with in-memory jdeps disabled. The current flags require
+  # the .jdeps on disk, so it must be materialized despite the persisted marker.
+  bazel shutdown
+  bazel build \
+      --noexperimental_inmemory_jdeps_files \
+      --remote_download_outputs=all \
+      --remote_cache=grpc://localhost:"${worker_port}" \
+      //a:lib &> "$TEST_log" || fail "Expected success from on-disk invocation"
+
+  if [[ ! -e "bazel-bin/a/liblib.jdeps" ]]; then
+    fail "Expected the .jdeps file to be materialized on disk after disabling --experimental_inmemory_jdeps_files"
+  fi
+}
+
 function test_remote_download_regex() {
   add_rules_java "MODULE.bazel"
   mkdir -p a


### PR DESCRIPTION
Modified from the original via:
* using a distinct version for the action cache that can't collide with future versions at HEAD
* including https://github.com/bazelbuild/bazel/commit/741ee016bd45aa3df7ea8dde109e2fe3d0b5e972 (see https://github.com/bazelbuild/bazel/issues/29976 for context)

Original commit message follows:

In-memory outputs (--experimental_inmemory_{dotd,jdeps}_files) are kept only in memory and never written to disk. shouldTrustMetadata() gates trust of a remote output's metadata on shouldDownloadOutput(), which under --remote_download_outputs=all is unconditionally true, so an in-memory output's still-alive remote metadata is distrusted and its action is re-executed on every incremental build (e.g. every CppCompile, which emits a .d, and every Java compile, which emits a .jdeps): the action re-executes, hits the remote cache, and re-downloads its outputs, turning a no-op build into a full re-validation pass.

This is a regression from #27291, which moved these outputs from on-disk (local, always trusted) to in-memory (remote) metadata.

An in-memory output is indistinguishable from an ordinary remote output that an earlier build left unmaterialized (e.g. under --remote_download_outputs=minimal): both are remote with no contents proxy. So mark in-memory outputs when their metadata is injected, carry the bit through the action cache (bumping its version), and trust a marked output via its TTL in shouldTrustMetadata(). This is read from the metadata alone, so it holds in both ActionCacheChecker and FilesystemValueChecker, and on a cold server. Ordinary unmaterialized remote outputs stay unmarked and are still re-fetched, so switching to --remote_download_outputs=all correctly materializes them.

The regression test covers a warm rebuild, a rebuild after a server restart, and the minimal -> all transition. Also manually tested with a full Chromium build - the second build with a warm server went from re-executing 72k compile actions in ~216s down to ~0.9s with 0 actions. Verified again with a cold server, which also re-ran 0 actions.

Fixes #29313

RELNOTES: None

Closes #29993.

PiperOrigin-RevId: 937976000
Change-Id: I1fb24ae4db407101ebb4f4c203f258bd7c15f51f
(cherry picked from commit 4c929580dc50a02398fde9a0c9046bd8bf982960)

Fixes #29995

