### PR TITLE
Add `--skyframe=key` mode to `bazel dump`.

### DIFF
--- a/docs/reference/skyframe-debugging.mdx
+++ b/docs/reference/skyframe-debugging.mdx
@@ -28,9 +28,10 @@ The `--skyframe` flag takes an argument detailing what information to report:
   Skyframe.
 - [`--skyframe=count`](#count-mode): A report on the number of values for each
   SkyFunction type.
+- [`--skyframe=keys`](#keys-mode): The keys in Skyframe.
 - [`--skyframe=value`](#value-mode): The full value in Skyframe.
 - [`--skyframe=deps`](#deps-mode): The dependencies of the value in Skyframe.
-- [`--skyframe=rdeps`](#reverse-dps-mode): Other values in Skyframe with a
+- [`--skyframe=rdeps`](#reverse-deps-mode): Other values in Skyframe with a
   dependency on the value.
 
 ### Filtering by SkyKey
@@ -83,6 +84,18 @@ Commonly used types are:
 - `ARTIFACT`: The number of output files known in Skyframe.
 - `PACKAGE`: The numbe of packages loading into Skyframe.
 - `BUILD_CONFIGURATION`: The number of distinct configurations.
+
+## Keys Mode
+
+The `baze dump --skyframe=keys --skykey_filter=FOO` command will show keys
+available that match the filter. This can be quite extensive unless the key is
+very specific.
+
+The format is one line per key, the result of calling `.toString()` on the key.
+
+This can be helpful to identify specific keys to investigate with
+[`--skyframe=value`](#value-mode), [`--skyframe=deps`](#deps-mode), or
+[`--skyframe=rdeps`](#reverse-deps-mode).
 
 ## Value Mode
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/DumpCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/DumpCommand.java
@@ -326,8 +326,8 @@ public class DumpCommand implements BlazeCommand {
         documentationCategory = OptionDocumentationCategory.OUTPUT_SELECTION,
         effectTags = {OptionEffectTag.BAZEL_MONITORING},
         help =
-            "Regex filter of SkyKey names to output. Only used with --skyframe=value, deps, rdeps,"
-                + " function_graph.")
+            "Regex filter of SkyKey names to output. Only used with --skyframe=keys, value, deps,"
+                + " rdeps, function_graph.")
     public abstract RegexFilter getSkyKeyFilter();
 
     @Option(
@@ -361,6 +361,7 @@ public class DumpCommand implements BlazeCommand {
     OFF,
     SUMMARY,
     COUNT,
+    KEYS,
     VALUE,
     DEPS,
     RDEPS,
@@ -522,6 +523,7 @@ public class DumpCommand implements BlazeCommand {
       switch (dumpOptions.getDumpSkyframe()) {
         case SUMMARY -> evaluator.dumpSummary(out);
         case COUNT -> evaluator.dumpCount(out);
+        case KEYS -> evaluator.dumpKeys(out, dumpOptions.getSkyKeyFilter());
         case VALUE -> evaluator.dumpValues(out, dumpOptions.getSkyKeyFilter());
         case DEPS -> evaluator.dumpDeps(out, dumpOptions.getSkyKeyFilter());
         case RDEPS -> evaluator.dumpRdeps(out, dumpOptions.getSkyKeyFilter());
@@ -585,9 +587,7 @@ public class DumpCommand implements BlazeCommand {
   }
 
   private static void dumpRuleStats(
-      BlazeWorkspace workspace,
-      SkyframeExecutor executor,
-      PrintStream out)
+      BlazeWorkspace workspace, SkyframeExecutor executor, PrintStream out)
       throws InterruptedException {
     SkyframeStats skyframeStats = executor.getSkyframeStats();
     if (skyframeStats.ruleStats().isEmpty()) {

--- a/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
@@ -335,6 +335,18 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
   }
 
   @Override
+  public final void dumpKeys(PrintStream out, Predicate<String> filter)
+      throws InterruptedException {
+    processGraphForDumpCommand(
+        filter,
+        out,
+        entry -> {
+          out.println(entry.getKey().getCanonicalName());
+          out.println();
+        });
+  }
+
+  @Override
   public final void dumpValues(PrintStream out, Predicate<String> filter)
       throws InterruptedException {
     processGraphForDumpCommand(

--- a/src/main/java/com/google/devtools/build/skyframe/MemoizingEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/MemoizingEvaluator.java
@@ -68,8 +68,8 @@ public interface MemoizingEvaluator {
   void delete(BiPredicate<SkyKey, SkyValue> pred);
 
   /**
-   * Marks dirty values for deletion if they have been dirty for at least as many graph versions
-   * as the specified limit.
+   * Marks dirty values for deletion if they have been dirty for at least as many graph versions as
+   * the specified limit.
    *
    * <p>This ensures that after the next completed {@link #evaluate} call, all such values, along
    * with all values that transitively depend on them, will be removed from the value cache. Values
@@ -117,8 +117,6 @@ public interface MemoizingEvaluator {
    * #noteEvaluationsAtSameVersionMayBeFinished}.
    */
   default void postLoggingStats(ExtendedEventHandler eventHandler) {}
-
-
 
   /**
    * Returns the done (without error) values in the graph.
@@ -224,6 +222,15 @@ public interface MemoizingEvaluator {
    */
   @ThreadHostile
   void dumpCount(PrintStream out);
+
+  /**
+   * Writes the keys in the graph to the given output stream. For each keys matching the given
+   * filter, prints the key name.
+   *
+   * <p>Not necessarily thread-safe. Use only for debugging purposes.
+   */
+  @ThreadHostile
+  void dumpKeys(PrintStream out, Predicate<String> filter) throws InterruptedException;
 
   /**
    * Writes a detailed summary of the graph to the given output stream. For each key matching the


### PR DESCRIPTION
### Description
Adds a new mode to `bazel dump --skyframe` that only reports keys, as opposed to `--skyframe=value`, which reports keys and full values. Full values can be very long and so it is difficult to identify keys of interest.

### Release Notes

RELNOTES: Adds `bazel dump --skyframe=keys` to report only the keys available in SkyFrame. Always use with `--skykey_filter` to limit the number of keys reported.
