### PR TITLE
Update `//third_party:fastutil-stripped.jar` to use the new  `proguard_jar` rule

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,7 +1,8 @@
-load("@rules_java//java:defs.bzl", "java_binary", "java_import", "java_library", "java_plugin")
+load("@rules_java//java:defs.bzl", "java_import", "java_library", "java_plugin")
 load("@rules_license//rules:license.bzl", "license")
 load("//src/tools/bzlmod:utils.bzl", "get_repo_root")
 load("//tools/distributions:distribution_rules.bzl", "distrib_jar_filegroup", "distrib_java_import")
+load("//tools/build_defs/proguard:proguard.bzl", "proguard_jar")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -317,50 +318,19 @@ alias(
 # When using new classes from this dependency, make sure to update fastutil.proguard.
 java_import(
     name = "fastutil",
-    jars = [":fastutil_stripped_jar"],
+    jars = [":fastutil-stripped.jar"],
 )
 
-genrule(
-    name = "fastutil_stripped_jar",
+proguard_jar(
+    name = "fastutil_proguard",
     srcs = [
         "@maven//:it_unimi_dsi_fastutil_file",
+    ],
+    out = "fastutil-stripped.jar",
+    proguard_spec = "fastutil.proguard",
+    deps = [
         "@rules_java//toolchains:platformclasspath_nostrip",
     ],
-    outs = ["fastutil-stripped.jar"],
-    # ProGuard output is silenced below because it prints
-    # ...
-    # Caused by: java.net.UnknownHostException: bk-docker-3gmr: Temporary failure in name resolution
-    # ...
-    # when running in the Bazel sandbox, which throws off bazel_determinism_test.
-    cmd = """
-    $(location :proguard_bin) \
-        -injars $(execpath @maven//:it_unimi_dsi_fastutil_file) \
-        -outjars $@ \
-        -libraryjars $(execpath @rules_java//toolchains:platformclasspath_nostrip) \
-        @$(location //tools:fastutil.proguard) > /dev/null
-    # Null out the file times stored in the jar to make the output reproducible.
-    TMPDIR=$$(mktemp -d)
-    trap 'rm -rf $$TMPDIR' EXIT
-    unzip -q $@ -d $$TMPDIR
-    rm $@
-    find $$TMPDIR -type f -print0 | xargs -0 touch -t 198001010000.00
-    OUTPUT="$$(pwd)/$@"
-    (cd $$TMPDIR && find . -type f | LC_ALL=C sort | zip -qDX0r@ "$$OUTPUT")
-    """,
-    tools = [
-        ":proguard_bin",
-        "//tools:fastutil.proguard",
-    ],
-)
-
-java_binary(
-    name = "proguard_bin",
-    jvm_flags = [
-        # Prevent ProGuard from calling out to the internet through log4j.
-        "-Dlog4j.rootLogger=OFF",
-    ],
-    main_class = "proguard.ProGuard",
-    runtime_deps = ["@maven//:com_guardsquare_proguard_base"],
 )
 
 java_library(

--- a/third_party/fastutil.proguard
+++ b/third_party/fastutil.proguard
@@ -1,0 +1,10 @@
+-dontobfuscate
+-dontoptimize
+-keep ,includedescriptorclasses class it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap { *; }
+-keep ,includedescriptorclasses class it.unimi.dsi.fastutil.ints.IntArrayList { *; }
+-keep ,includedescriptorclasses class it.unimi.dsi.fastutil.ints.IntArrays { *; }
+-keep ,includedescriptorclasses class it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap { *; }
+-keep ,includedescriptorclasses class it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap { *; }
+# These classes access a `getChannel()` on InputStream subclasses via reflection.
+-dontnote it.unimi.dsi.fastutil.io.FastBufferedInputStream
+-dontnote it.unimi.dsi.fastutil.io.FastBufferedOutputStream


### PR DESCRIPTION
Update `//third_party:fastutil-stripped.jar` to use the new `proguard_jar` rule.
    
Part 2 of removing the dependence on a non-hermetic `unzip` binary.
    
The last step will remove the now-unused `//tools:fastutil.proguard` file.

RELNOTES: None.