### PR TITLE
Fix dropped netrc/auth credentials on same-host redirects

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/StaticCredentials.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/StaticCredentials.java
@@ -15,7 +15,9 @@
 package com.google.devtools.build.lib.authandtls;
 
 import com.google.auth.Credentials;
+import com.google.common.base.Ascii;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import java.net.URI;
 import java.util.List;
@@ -42,7 +44,19 @@ public final class StaticCredentials extends Credentials {
   public Map<String, List<String>> getRequestMetadata(URI uri) {
     Preconditions.checkNotNull(uri);
 
-    return credentials.getOrDefault(uri, ImmutableMap.of());
+    Map<String, List<String>> metadata = credentials.get(uri);
+    if (metadata != null) {
+      return metadata;
+    }
+    // On a same-host, same-scheme redirect to a different path the request URI is not an exact key.
+    // Fall back to credentials registered for the same endpoint, mirroring the per-host behavior of
+    // `curl --netrc` and `wget`. Credentials are never reused across hosts, schemes or ports.
+    for (Map.Entry<URI, Map<String, List<String>>> entry : credentials.entrySet()) {
+      if (sameEndpoint(uri, entry.getKey())) {
+        return entry.getValue();
+      }
+    }
+    return ImmutableMap.of();
   }
 
   @Override
@@ -58,5 +72,16 @@ public final class StaticCredentials extends Credentials {
   @Override
   public void refresh() {
     // Can't refresh static credentials.
+  }
+
+  /**
+   * Returns whether {@code a} and {@code b} address the same endpoint, i.e. have an equal port and a
+   * case-insensitively equal scheme and host (per RFC 3986).
+   */
+  private static boolean sameEndpoint(URI a, URI b) {
+    return a.getPort() == b.getPort()
+        && Ascii.equalsIgnoreCase(
+            Strings.nullToEmpty(a.getScheme()), Strings.nullToEmpty(b.getScheme()))
+        && Ascii.equalsIgnoreCase(Strings.nullToEmpty(a.getHost()), Strings.nullToEmpty(b.getHost()));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/authandtls/StaticCredentialsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/StaticCredentialsTest.java
@@ -1,0 +1,115 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.authandtls;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link StaticCredentials}. */
+@RunWith(JUnit4.class)
+public class StaticCredentialsTest {
+
+  private static final Map<String, List<String>> AUTH =
+      ImmutableMap.of("Authorization", ImmutableList.of("Basic dTpw"));
+  private static final Map<String, List<String>> OTHER_AUTH =
+      ImmutableMap.of("Authorization", ImmutableList.of("Basic eDp5"));
+
+  @Test
+  public void getRequestMetadata_exactMatch_returnsCredentials() throws Exception {
+    StaticCredentials credentials =
+        new StaticCredentials(ImmutableMap.of(new URI("http://example.com/start"), AUTH));
+
+    assertThat(credentials.getRequestMetadata(new URI("http://example.com/start"))).isEqualTo(AUTH);
+  }
+
+  @Test
+  public void getRequestMetadata_sameHostDifferentPath_returnsCredentials() throws Exception {
+    StaticCredentials credentials =
+        new StaticCredentials(ImmutableMap.of(new URI("http://example.com/start"), AUTH));
+
+    assertThat(credentials.getRequestMetadata(new URI("http://example.com/protected")))
+        .isEqualTo(AUTH);
+  }
+
+  @Test
+  public void getRequestMetadata_sameHostMatchingIsCaseInsensitive() throws Exception {
+    StaticCredentials credentials =
+        new StaticCredentials(ImmutableMap.of(new URI("http://Example.COM/start"), AUTH));
+
+    assertThat(credentials.getRequestMetadata(new URI("http://example.com/protected")))
+        .isEqualTo(AUTH);
+  }
+
+  @Test
+  public void getRequestMetadata_differentHost_returnsEmpty() throws Exception {
+    StaticCredentials credentials =
+        new StaticCredentials(ImmutableMap.of(new URI("http://example.com/start"), AUTH));
+
+    assertThat(credentials.getRequestMetadata(new URI("http://other.example.com/protected")))
+        .isEmpty();
+  }
+
+  @Test
+  public void getRequestMetadata_differentScheme_returnsEmpty() throws Exception {
+    StaticCredentials credentials =
+        new StaticCredentials(ImmutableMap.of(new URI("http://example.com/start"), AUTH));
+
+    assertThat(credentials.getRequestMetadata(new URI("https://example.com/start"))).isEmpty();
+  }
+
+  @Test
+  public void getRequestMetadata_differentPort_returnsEmpty() throws Exception {
+    StaticCredentials credentials =
+        new StaticCredentials(ImmutableMap.of(new URI("http://example.com:8080/start"), AUTH));
+
+    assertThat(credentials.getRequestMetadata(new URI("http://example.com:9090/protected")))
+        .isEmpty();
+  }
+
+  @Test
+  public void getRequestMetadata_exactMatchTakesPrecedenceOverSameHostFallback() throws Exception {
+    // Exact-path matches keep their own credentials; only an unknown path on the same host falls
+    // back (to the first registered entry for that host).
+    StaticCredentials credentials =
+        new StaticCredentials(
+            ImmutableMap.of(
+                new URI("http://example.com/a"), AUTH,
+                new URI("http://example.com/b"), OTHER_AUTH));
+
+    assertThat(credentials.getRequestMetadata(new URI("http://example.com/a"))).isEqualTo(AUTH);
+    assertThat(credentials.getRequestMetadata(new URI("http://example.com/b")))
+        .isEqualTo(OTHER_AUTH);
+    assertThat(credentials.getRequestMetadata(new URI("http://example.com/c"))).isEqualTo(AUTH);
+  }
+
+  @Test
+  public void getRequestMetadata_sameHostMultiplePaths_returnsCredentials() throws Exception {
+    StaticCredentials credentials =
+        new StaticCredentials(
+            ImmutableMap.of(
+                new URI("http://example.com/a"), AUTH,
+                new URI("http://example.com/b"), AUTH));
+
+    assertThat(credentials.getRequestMetadata(new URI("http://example.com/c"))).isEqualTo(AUTH);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java
@@ -183,6 +183,16 @@ public class HttpConnectorMultiplexerTest {
             "Authentication",
             ImmutableList.of("Zm9vOmZvb3NlY3JldA=="));
 
+    // Same host, different path (e.g. a same-host redirect): auth headers are reapplied.
+    assertThat(headerFunction.apply(URI.create("http://hosting.example.com/user/bar/other.txt")))
+        .containsExactly(
+            "Accept-Encoding",
+            ImmutableList.of("gzip"),
+            "User-Agent",
+            ImmutableList.of("Bazel/testing"),
+            "Authentication",
+            ImmutableList.of("Zm9vOmZvb3NlY3JldA=="));
+
     // Other hosts
     assertThat(headerFunction.apply(URI.create("http://hosting2.example.com/user/foo/file.txt")))
         .containsExactly(


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
http_archive/http_file lost their ~/.netrc (or auth) credentials when a download redirected to a different path on the same host, because StaticCredentials matched credentials by exact request URI. The redirected, unauthenticated request then failed with 401.

StaticCredentials.getRequestMetadata now falls back to credentials registered for the same scheme+host+port when there is no exact-URI match, mirroring curl --netrc/wget. Cross-host, cross-scheme, and cross-port redirects still receive no credentials.



### Motivation
Fixes https://github.com/bazelbuild/bazel/issues/30013


### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Keep StaticCredentials auth (netrc) on same-host redirects
