### PR TITLE
Reapply protobuf patch to reduce proto message sizes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,6 +56,10 @@ common:windows --host_per_file_copt=external/.*@/wd4047,/wd4624,/wd4267,/wd4244,
 # Enable Protobuf MSVC support on Windows
 common:windows --define=protobuf_allow_msvc=true
 
+# Build protoc from source instead of using the prebuilt binary so we can apply
+# patches.
+common --@com_google_protobuf//bazel/flags:prefer_prebuilt_protoc=false
+
 # Enable Java 21 language features and compile for a Java 25 runtime, matching
 # version of the embedded JDK.
 # Keep in sync with //:java_toolchain_%d.

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -141,7 +141,6 @@ import com.google.devtools.common.options.Options;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.Message;
-import com.google.protobuf.RuntimeVersion;
 import com.google.testing.junit.testparameterinjector.TestParameter;
 import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.io.IOException;
@@ -868,11 +867,9 @@ public class RemoteExecutionServiceTest {
       //   basename for file nodes), and Integers (referencing intermediate segments of Artifact
       //   exec paths for most directory nodes).
       // TODO: Get this number down.
-      // expected size is 4136 for 35.1 (OSS major 4, minor 35), and 4064 for 34.1.
-      boolean isProto35 =
-          RuntimeVersion.MAJOR == 35 || (RuntimeVersion.MAJOR == 4 && RuntimeVersion.MINOR == 35);
-      int expectedStableRetainedSize = isProto35 ? 4136 : 4064;
-      assertThat(stableRetainedSize).isEqualTo(expectedStableRetainedSize);
+      // NOTE: Don't just increase this number if the test fails, it directly corresponds to the
+      // memory usage of Bazel's (but not Blaze's) remote execution implementation.
+      assertThat(stableRetainedSize).isEqualTo(4064);
     }
   }
 

--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -257,6 +257,9 @@ py_test(
     name = "bazel_tools_proto_test",
     size = "medium",
     srcs = ["bazel_tools_proto_test.py"],
+    tags = [
+        "requires-network",
+    ],
     deps = [":test_base"],
 )
 

--- a/third_party/protobuf.patch
+++ b/third_party/protobuf.patch
@@ -46,6 +46,60 @@ index 426bf9124..fd17ac96c 100644
  
  upb_amalgamation(
 
+diff --git a/src/google/protobuf/compiler/java/full/message.cc b/src/google/protobuf/compiler/java/full/message.cc
+index 819f20a44b..e3f7b82701 100644
+--- a/src/google/protobuf/compiler/java/full/message.cc
++++ b/src/google/protobuf/compiler/java/full/message.cc
+@@ -875,32 +875,26 @@ void ImmutableMessageGenerator::GenerateIsInitialized(io::Printer* printer) {
+   // Memoizes whether the protocol buffer is fully initialized (has all
+   // required fields). -1 means not yet computed. 0 means false and 1 means
+   // true.
+-  if (internal::IsOss()) {
+-    // Leave this as non-transient in OSS to avoid breaking customers that are
+-    // holding GSON wrong.
+-    // TODO: Remove this in a future PBJ breaking release.
+-    printer->Print("private byte memoizedIsInitialized = -1;\n");
+-  } else {
+-    // If the message transitively has no required fields or extensions,
+-    // isInitialized() is always true.
+-    if (!HasRequiredFields(descriptor_)) {
+-      printer->Print(
+-          "/**\n"
+-          "  * @deprecated This always returns true for this type as it \n"
+-          "  *   does not transitively contain any required fields.\n"
+-          "  */\n"
+-          "@java.lang.Deprecated\n"
+-          "@java.lang.Override\n"
+-          "public final boolean isInitialized() {\n"
+-          "  return true;\n"
+-          "}\n"
+-          "\n");
+-      return;
+-    }
+
+-    printer->Print("private transient byte memoizedIsInitialized = -1;\n");
++  // If the message transitively has no required fields or extensions,
++  // isInitialized() is always true.
++  if (!HasRequiredFields(descriptor_)) {
++    printer->Print(
++        "/**\n"
++        "  * @deprecated This always returns true for this type as it \n"
++        "  *   does not transitively contain any required fields.\n"
++        "  */\n"
++        "@java.lang.Deprecated\n"
++        "@java.lang.Override\n"
++        "public final boolean isInitialized() {\n"
++        "  return true;\n"
++        "}\n"
++        "\n");
++    return;
+   }
+
++  printer->Print("private transient byte memoizedIsInitialized = -1;\n");
++
+   printer->Print(
+       "@java.lang.Override\n"
+       "public final boolean isInitialized() {\n");
 diff --git a/upb_generator/minitable/generator.cc b/upb_generator/minitable/generator.cc
 --- a/upb_generator/minitable/generator.cc
 +++ b/upb_generator/minitable/generator.cc


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
This was dropped in e79fdcff4ef74d3d1d3bcf6d06399ee8116216d3.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
