### PR TITLE
[8.8.0] Materialize RRCC symlinks via prefetching

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -45,6 +45,7 @@ import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
 import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValueWithMaterializationData;
 import com.google.devtools.build.lib.actions.FileContentsProxy;
+import com.google.devtools.build.lib.actions.FileStateType;
 import com.google.devtools.build.lib.actions.cache.OutputMetadataStore;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
@@ -248,6 +249,17 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
   }
 
   /**
+   * Returns whether the given path lives under the external repository root. Unlike {@link
+   * #execRoot()}, this can be evaluated during external repository materialization, where the exec
+   * root isn't available yet.
+   */
+  private boolean isUnderExternalRepoRoot(Path path) {
+    return path.asFragment()
+        .startsWith(
+            outputBase.getRelative(LabelConstants.EXTERNAL_REPOSITORY_LOCATION).asFragment());
+  }
+
+  /**
    * Resolves an exec path to an absolute path, avoiding evaluation of execRoot() if possible as it
    * isn't available during server startup. This logic is unique to Bazel 8.x as it still names the
    * exec root based on the name set in WORKSPACE, which is gone from HEAD and Bazel 9.x.
@@ -412,7 +424,19 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       PathFragment execPath = input.getExecPath();
 
       FileArtifactValue metadata = metadataSupplier.getMetadata(input);
-      if (metadata == null || !canDownloadFile(resolveExecPath(execPath), metadata)) {
+      if (metadata == null) {
+        return immediateVoidFuture();
+      }
+      Path inputPath = resolveExecPath(execPath);
+      if (metadata.getType() == FileStateType.SYMLINK && isUnderExternalRepoRoot(inputPath)) {
+        return toListenableFuture(
+            plantUnresolvedSymlink(
+                inputPath.forHostFileSystem(),
+                PathFragment.create(
+                    ((FileArtifactValue.UnresolvedSymlinkArtifactValue) metadata)
+                        .getSymlinkTarget())));
+      }
+      if (!canDownloadFile(inputPath, metadata)) {
         return immediateVoidFuture();
       }
 
@@ -750,6 +774,17 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
               return Completable.complete();
             }),
         forceRefetch(resolveExecPath(symlink.linkExecPath())));
+  }
+
+  private Completable plantUnresolvedSymlink(Path linkPath, PathFragment target) {
+    return downloadCache.executeIfNot(
+        linkPath,
+        Completable.defer(
+            () -> {
+              linkPath.delete();
+              linkPath.createSymbolicLink(target);
+              return Completable.complete();
+            }));
   }
 
   public ImmutableSet<Path> downloadedFiles() {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -326,12 +326,8 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
     }
     prefetch(walkResult.files());
     // Create symlinks last as some platforms don't allow creating a symlink to a non-existent
-    // target. A symlink may have already been created as an input to an action.
-    for (var remoteSymlink : walkResult.symlinks()) {
-      var nativeSymlink = nativeFs.getPath(remoteSymlink);
-      FileSystemUtils.ensureSymbolicLink(
-          nativeSymlink, externalFs.getPath(remoteSymlink).readSymbolicLink());
-    }
+    // target.
+    prefetch(walkResult.symlinks());
 
     // After the repo has been copied, atomically materialize the marker file. This ensures that the
     // repo doesn't have to be refetched after the next server restart.
@@ -679,9 +675,11 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
     }
 
     private FileArtifactValue getMetadata(PathFragment path) throws IOException {
-      var info =
-          (RemoteActionFileSystem.RemoteInMemoryFileInfo) stat(path, /* followSymlinks= */ true);
-      return info.getMetadata();
+      var status = stat(path, /* followSymlinks= */ false);
+      if (!status.isSymbolicLink()) {
+        return ((RemoteActionFileSystem.RemoteInMemoryFileInfo) status).getMetadata();
+      }
+      return FileArtifactValue.createForUnresolvedSymlink(externalFs.getPath(path));
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -274,9 +274,6 @@ public class UploadManifest {
             addFile(digestUtil.compute(file, statFollow), file, statNoFollow);
           } else {
             // Symlink to file uploaded as a symlink.
-            if (target.isAbsolute()) {
-              checkAbsoluteSymlinkAllowed(file, target);
-            }
             addFileSymbolicLink(file, target);
           }
           continue;
@@ -287,9 +284,6 @@ public class UploadManifest {
             addDirectory(file);
           } else {
             // Symlink to directory uploaded as a symlink.
-            if (target.isAbsolute()) {
-              checkAbsoluteSymlinkAllowed(file, target);
-            }
             addDirectorySymbolicLink(file, target);
           }
           continue;


### PR DESCRIPTION
When using the remote repo contents cache, repo materialization now uses the same code path as local action input prefetching for symlinks. This ensures that each symlink is only materialized once and that there are no races in case symlinking is not atomic (on Windows with default settings).

Along the way, remove unreachable code from `UploadManifest`.

8.x adaptation: `AbstractActionInputPrefetcher` on 8.x resolves input paths via the Bazel 8.x-specific `resolveExecPath(execPath)` helper (which avoids evaluating the WORKSPACE-named exec root when possible) and exposes the exec root through the `execRoot()` method rather than an `execRoot` field, so the new symlink branch is expressed in those terms. Because `execRoot()` is not available during external repository materialization, the branch detects external repo paths via a new `isUnderExternalRepoRoot` helper (mirroring `DirectoryTracker.setWritable`) instead of `!inputPath.startsWith(execRoot())`, and reads the symlink target from `UnresolvedSymlinkArtifactValue#getSymlinkTarget` (8.x has no `FileArtifactValue#getUnresolvedSymlinkTarget`). Only the `FileStateType` import is added; the other imports touched upstream don't apply because 8.x resolves `VirtualActionInput` to `actions.cache.VirtualActionInput`.

The three symlink-materialization tests added upstream are deferred to the chains-of-symlinks backport (#29767): on 8.x, repo files are materialized lazily through `RemoteExternalOverlayFileSystem`, and faithfully reproducing (chains of) symlinks on disk only works with that later change, not with this commit's single-link prefetching alone.

Fixes #28575.

Closes #28683.

PiperOrigin-RevId: 893359962
Change-Id: If0eb64e41858a4b9298c2609d83160b0ecbfd451
(cherry picked from commit 90eb56ec1dc70e38192b8c93bca236d0dcebcf6e)
