### PR TITLE
[8.8.0] Fix remote repo content caching for non-gRPC backends

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -323,6 +323,43 @@ public final class RemoteModule extends BlazeModule {
         outputPermissions);
   }
 
+  /**
+   * Initializes the repository remote helpers factory and primes the {@link
+   * RemoteExternalOverlayFileSystem} (when one is in use) with the per-build state it needs.
+   */
+  private void initRepoHelpersAndOverlayFs(
+      CommandEnvironment env, String buildRequestId, String invocationId, boolean verboseFailures) {
+    if (actionContextProvider == null) {
+      return;
+    }
+    CombinedCache combinedCache = actionContextProvider.getCombinedCache();
+    if (combinedCache == null) {
+      return;
+    }
+    repositoryRemoteHelpersFactoryDelegate.init(
+        new RepositoryRemoteHelpersFactoryImpl(
+            env.getDirectories(),
+            combinedCache,
+            actionContextProvider.getRemoteExecutionClient(),
+            buildRequestId,
+            invocationId,
+            remoteOptions.remoteInstanceName,
+            remoteOptions.remoteAcceptCached,
+            remoteOptions.remoteUploadLocalResults,
+            verboseFailures));
+    if (env.getDirectories().getOutputBase().getFileSystem()
+        instanceof RemoteExternalOverlayFileSystem remoteFs) {
+      remoteFs.beforeCommand(
+          combinedCache,
+          actionInputFetcher,
+          env.getReporter(),
+          buildRequestId,
+          invocationId,
+          env.getSkyframeExecutor().getEvaluator(),
+          remoteOptions.remoteCacheTtl);
+    }
+  }
+
   @Override
   public void workspaceInit(
       BlazeRuntime runtime, BlazeDirectories directories, WorkspaceBuilder builder) {
@@ -585,6 +622,7 @@ public final class RemoteModule extends BlazeModule {
 
     if ((enableHttpCache || enableDiskCache) && !enableGrpcCache) {
       initHttpAndDiskCache(env, credentials, authAndTlsOptions, remoteOptions, digestUtil);
+      initRepoHelpersAndOverlayFs(env, buildRequestId, invocationId, verboseFailures);
       return true;
     }
 
@@ -774,28 +812,7 @@ public final class RemoteModule extends BlazeModule {
 
     actionInputFetcher = createActionInputFetcher(actionContextProvider.getCombinedCache());
 
-    repositoryRemoteHelpersFactoryDelegate.init(
-        new RepositoryRemoteHelpersFactoryImpl(
-            env.getDirectories(),
-            actionContextProvider.getCombinedCache(),
-            actionContextProvider.getRemoteExecutionClient(),
-            buildRequestId,
-            invocationId,
-            remoteOptions.remoteInstanceName,
-            remoteOptions.remoteAcceptCached,
-            remoteOptions.remoteUploadLocalResults,
-            verboseFailures));
-    if (env.getDirectories().getOutputBase().getFileSystem()
-        instanceof RemoteExternalOverlayFileSystem remoteFs) {
-      remoteFs.beforeCommand(
-          actionContextProvider.getCombinedCache(),
-          actionInputFetcher,
-          env.getReporter(),
-          buildRequestId,
-          invocationId,
-          env.getSkyframeExecutor().getEvaluator(),
-          remoteOptions.remoteCacheTtl);
-    }
+    initRepoHelpersAndOverlayFs(env, buildRequestId, invocationId, verboseFailures);
 
     buildEventArtifactUploaderFactoryDelegate.init(
         new ByteStreamBuildEventArtifactUploaderFactory(
@@ -1246,6 +1263,11 @@ public final class RemoteModule extends BlazeModule {
   @VisibleForTesting
   RemoteActionContextProvider getActionContextProvider() {
     return actionContextProvider;
+  }
+
+  @VisibleForTesting
+  RepositoryRemoteHelpersFactory getRepositoryRemoteHelpersFactoryDelegate() {
+    return repositoryRemoteHelpersFactoryDelegate;
   }
 
   @VisibleForTesting

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -611,6 +611,20 @@ public final class RemoteModuleTest {
         .isEqualTo(new CollectionPolicy(Optional.of(1234567890L), Optional.of(Duration.ofDays(7))));
   }
 
+  @Test
+  public void repositoryRemoteHelpersFactory_initializedForDiskCacheOnlyPath() throws Exception {
+    // Regression test: non-gRPC caches must still register the
+    // RepositoryRemoteHelpersFactory delegate so repo rules can use the remote
+    // contents cache.
+    var diskCacheDir = TestUtils.createUniqueTmpDir(null);
+    remoteOptions.diskCache = diskCacheDir.asFragment();
+
+    beforeCommand();
+
+    assertThat(remoteModule.getRepositoryRemoteHelpersFactoryDelegate().createRepoContentsCache())
+        .isNotNull();
+  }
+
   @CanIgnoreReturnValue
   private CommandEnvironment beforeCommand() throws IOException, AbruptExitException {
     CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);


### PR DESCRIPTION
> **Note:** Supersedes the standalone bot cherry-pick #29781, integrating the same fix into the stacked RRCC backport lineage. #29781 can be closed in favor of this PR.

This change extracts setup logic for remote repo content caching from the gRPC path so it can be shared with the HTTP/disk path.

Remote repo content caching is currently only initialized for gRPC cache backends. The `--experimental_remote_repo_contents_cache` flag is a no-op when using a cache backend like GCS.

8.x adaptation: `initHttpAndDiskCache` on 8.x does not take a `diskCachePath` parameter, so the new `initRepoHelpersAndOverlayFs` call is added after the existing 8.x invocation. The extracted helper uses the 8.x `RemoteOptions` field accessors (`remoteInstanceName`, `remoteAcceptCached`, `remoteUploadLocalResults`, `remoteCacheTtl`) and the 8.x `RepositoryRemoteHelpersFactoryImpl` constructor, which has no workspace-name parameter. The regression test assigns the public `diskCache` field instead of calling a setter.

Closes #29744.

PiperOrigin-RevId: 928545624
Change-Id: Ib811c85d0c2462f91a8a8114640d58edf5b4c0a3
(cherry picked from commit d1e894e106d43bd27427eaad1799f7959b3ec847)
