### PR TITLE
[8.8.0] Fix loading symlinked `.bzl` files from the remote repo contents cache (https://github.com/bazelbuild/bazel/pull/30031)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -661,6 +661,11 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
 
     @Override
     public synchronized InputStream getInputStream(PathFragment path) throws IOException {
+      // .bzl and REPO.bazel files are prefetched to the native file system during injection, but
+      // only if they are regular files, a symlink with such a name is kept in the in-memory overlay
+      // only. We thus need to follow symlinks before attempting to read a supposedly prefetched
+      // file.
+      path = resolveSymbolicLinks(path).asFragment();
       if (shouldPrefetch(path)) {
         return nativeFs.getInputStream(path);
       }

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -791,6 +791,121 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
         os.path.exists(os.path.join(repo_dir, 'subdir/more_nested.bzl'))
     )
 
+  def testBzlSymlinkLoadedByBuildFile(self):
+    # Regression test for
+    # https://github.com/bazelbuild/bazel/issues/29656#issuecomment-4808145049.
+    #
+    # A repo's BUILD file loads a .bzl file that is a symlink. On a remote repo
+    # contents cache hit, the repo is injected into the overlay file system but
+    # not materialized on disk. Reads of .bzl (and REPO.bazel) files are
+    # redirected to the native file system on the assumption that they were
+    # prefetched during injection, but symlinks are not prefetched, only their
+    # target if they match the name pattern.
+    if self.IsWindows():
+      self.ScratchFile(
+          '.bazelrc',
+          ['startup --windows_enable_symlinks'],
+          mode='a',
+      )
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            '  rctx.file("BUILD", """',
+            'load(":helper.bzl", "the_name")',
+            'filegroup(name = the_name)',
+            '""")',
+            '  rctx.file("real_helper.bzl", \'the_name = "haha"\')',
+            '  rctx.symlink("real_helper.bzl", "helper.bzl")',
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(_repo_impl)',
+        ],
+    )
+
+    repo_dir = self.RepoDir('my_repo')
+
+    # First fetch: not cached
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertTrue(os.path.islink(os.path.join(repo_dir, 'helper.bzl')))
+
+    # After expunging: cached. The repo is injected but not materialized; the
+    # symlinked .bzl file loaded by the BUILD file must still be readable.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertFalse(os.path.exists(os.path.join(repo_dir, 'helper.bzl')))
+
+  def testBzlSymlinkToOtherRepoLoadedByBuildFile(self):
+    # Regression test for
+    # https://github.com/bazelbuild/bazel/issues/29656#issuecomment-4808145049.
+    #
+    # Cross-repo variant of testBzlSymlinkLoadedByBuildFile.
+    if self.IsWindows():
+      self.ScratchFile(
+          '.bazelrc',
+          ['startup --windows_enable_symlinks'],
+          mode='a',
+      )
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'helper_repo = use_repo_rule("//:helper_repo.bzl", "helper_repo")',
+            'helper_repo(name = "helper_repo")',
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'helper_repo.bzl',
+        [
+            'def _helper_repo_impl(rctx):',
+            '  rctx.file("BUILD", "exports_files([\'helper.bzl\'])")',
+            '  rctx.file("helper.bzl", \'the_name = "haha"\')',
+            '  print("JUST FETCHED HELPER")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'helper_repo = repository_rule(_helper_repo_impl)',
+        ],
+    )
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            '  rctx.file("BUILD", """',
+            'load(":helper.bzl", "the_name")',
+            'filegroup(name = the_name)',
+            '""")',
+            '  rctx.symlink(Label("@helper_repo//:helper.bzl"), "helper.bzl")',
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(_repo_impl)',
+        ],
+    )
+
+    repo_dir = self.RepoDir('my_repo')
+
+    # First fetch: not cached
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertTrue(os.path.islink(os.path.join(repo_dir, 'helper.bzl')))
+
+    # After expunging: cached. my_repo is injected but not materialized; the
+    # cross-repo symlinked .bzl loaded by the BUILD file must still be readable.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertFalse(os.path.exists(os.path.join(repo_dir, 'helper.bzl')))
+
   def testRun(self):
     self.ScratchFile(
         'MODULE.bazel',


### PR DESCRIPTION
### Description

When a repo is restored from the remote repo contents cache, its files are injected into the in-memory overlay file system and `.bzl`/`REPO.bazel` files are additionally prefetched to the native file system as regular files. `RemoteExternalFileSystem#getInputStream` relies on this by redirecting reads of such files to the native file system, but didn't follow symlinks before doing so.

### Motivation

Fixes https://github.com/bazelbuild/bazel/issues/29656#issuecomment-4808145049
### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Fixed spurious "No such file" errors with the remote repo contents cache when a repo contains a symlink to a `.bzl` file.

Closes #30031.

PiperOrigin-RevId: 938614073
Change-Id: I1decc39029a973cf1984d7518242d0ffc56c0711

Commit https://github.com/bazelbuild/bazel/commit/ad1793f494bfef28ea6ac4a528e456f2f9115aea