### PR TITLE
Change deprefixing of links to only deprefix absolute or known extraction-root cases

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
@@ -130,7 +130,9 @@ public abstract class CompressedTarFunction implements Decompressor {
                 maybeDeprefixSymlink(
                     toRawBytesString(entry.getLinkName()).getBytes(ISO_8859_1),
                     prefix,
-                    descriptor.destinationPath());
+                    descriptor.destinationPath(),
+                    // Hard link target paths should be relative to the extraction directory.
+                    /* forceExtractRootRelative= */ entry.isLink());
 
             Path resolvedTargetPath =
                 (entry.isSymbolicLink()

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPath.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPath.java
@@ -84,15 +84,42 @@ public final class StripPrefixedPath {
 
   public static PathFragment maybeDeprefixSymlink(
       byte[] rawTarget, Optional<String> prefix, Path root) {
+    return maybeDeprefixSymlink(rawTarget, prefix, root, false);
+  }
+
+  /**
+   * Normalizes and possibly deprefixes a target link.
+   *
+   * <p>A target link will only be deprefixed and relative to the given root if any of the
+   * following:
+   *
+   * <ul>
+   *   <li>The link is absolute
+   *   <li>The link is known to be relative to the root (<code>forceExtractRootRelative</code>)
+   * </ul>
+   *
+   * Otherwise, no deprefixing will occur.
+   *
+   * @param rawTarget The target path for the link.
+   * @param prefix The prefix to remove.
+   * @param root The path for absolute or <code>forceExtractRootRelative</code> to be relative to.
+   * @param forceExtractRootRelative Forces the given <code>rawTarget</code> to be relative to the
+   *     <code>root</code>.
+   * @return The normalized and possibly deprefixed link target.
+   */
+  public static PathFragment maybeDeprefixSymlink(
+      byte[] rawTarget, Optional<String> prefix, Path root, boolean forceExtractRootRelative) {
     boolean wasAbsolute = createPathFragment(rawTarget).isAbsolute();
-    // Strip the prefix from the link path if set.
-    PathFragment linkPathFragment = maybeDeprefix(rawTarget, prefix).getPathFragment();
-    if (wasAbsolute) {
+    if (wasAbsolute || forceExtractRootRelative) {
+      // Strip the prefix from the link path if set
+      PathFragment linkPathFragment = maybeDeprefix(rawTarget, prefix).getPathFragment();
       // Recover the path to an absolute path as maybeDeprefix() relativize the path
       // even if the prefix is not set
       return root.getRelative(linkPathFragment).asFragment();
+    } else {
+      // No deprefixing needed if not relative to extraction root.
+      return relativize(rawTarget);
     }
-    return linkPathFragment;
   }
 
   public PathFragment getPathFragment() {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
@@ -168,7 +168,10 @@ public class ZipDecompressor implements Decompressor {
                 + new String(buffer, UTF_8));
       }
 
-      symlinks.put(outputPath, maybeDeprefixSymlink(buffer, prefix, destinationDirectory));
+      symlinks.put(
+          outputPath,
+          maybeDeprefixSymlink(
+              buffer, prefix, destinationDirectory, /* forceExtractRootRelative= */ false));
     } else {
       try (InputStream input = reader.getInputStream(entry);
           OutputStream output = outputPath.getOutputStream()) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunctionTest.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.bazel.repository.decompressor;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.devtools.build.lib.bazel.repository.decompressor.TestArchiveDescriptor.INNER_FOLDER_NAME;
 import static com.google.devtools.build.lib.bazel.repository.decompressor.TestArchiveDescriptor.ROOT_FOLDER_NAME;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -22,12 +23,14 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.util.FileSystems;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.zip.GZIPInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -206,5 +209,79 @@ public class CompressedTarFunctionTest {
     assertThat(thrown)
         .hasMessageThat()
         .contains("Tar entries cannot refer to files outside of their directory");
+  }
+
+  @Test
+  public void decompressTarWithSymlinkSharingStripPrefix() throws Exception {
+    // Creates the example archive described in https://github.com/bazelbuild/bazel/issues/30015.
+    FileSystem fs = FileSystems.getNativeFileSystem();
+    File archive = folder.newFile("symlink_with_same_strip_prefix.tar.gz");
+    try (FileOutputStream fos = new FileOutputStream(archive);
+        GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(fos);
+        TarArchiveOutputStream tos = new TarArchiveOutputStream(gzos)) {
+
+      // Create two directory entries:
+      //  - a_prefix
+      //  - a_prefix/a_prefix
+      TarArchiveEntry directory = new TarArchiveEntry("a_prefix/");
+      tos.putArchiveEntry(directory);
+      tos.closeArchiveEntry();
+      TarArchiveEntry subdirectory = new TarArchiveEntry("a_prefix/a_prefix/");
+      tos.putArchiveEntry(subdirectory);
+      tos.closeArchiveEntry();
+
+      // Create the two regular files:
+      // - a_prefix/regular_file
+      // - a_prefix/a_prefix/other_file
+      TarArchiveEntry regularFile = new TarArchiveEntry("a_prefix/regular_file");
+      byte[] regularFileContents = "hello".getBytes();
+      regularFile.setSize(regularFileContents.length);
+      tos.putArchiveEntry(regularFile);
+      tos.write(regularFileContents);
+      tos.closeArchiveEntry();
+
+      TarArchiveEntry otherFile = new TarArchiveEntry("a_prefix/a_prefix/other_file");
+      byte[] otherFileContents = "world".getBytes();
+      otherFile.setSize(otherFileContents.length);
+      tos.putArchiveEntry(otherFile);
+      tos.write(otherFileContents);
+      tos.closeArchiveEntry();
+
+      // Create the symbolic link pointing to other_file:
+      // - a_prefix/symbolic_file -> a_prefix/other_file
+      TarArchiveEntry symbolicFile =
+          new TarArchiveEntry("a_prefix/symbolic_file", TarArchiveEntry.LF_SYMLINK);
+      symbolicFile.setLinkName("a_prefix/other_file");
+      symbolicFile.setSize(0);
+      tos.putArchiveEntry(symbolicFile);
+      tos.closeArchiveEntry();
+    }
+    Path archivePath = fs.getPath(archive.getAbsolutePath());
+    Path extractPath = fs.getPath(folder.newFolder().getAbsolutePath());
+
+    DecompressorDescriptor descriptor =
+        DecompressorDescriptor.builder()
+            .setArchivePath(archivePath)
+            .setDestinationPath(extractPath)
+            .setPrefix("a_prefix")
+            .build();
+    Path outputDir = decompress(descriptor);
+
+    Path outputSymbolicFile = outputDir.getRelative("symbolic_file");
+    assertWithMessage("symbolic_file should exist")
+        .that(outputSymbolicFile.exists(Symlinks.NOFOLLOW))
+        .isTrue();
+
+    Path symlinkTarget = outputDir.getRelative(outputSymbolicFile.readSymbolicLink());
+    assertWithMessage("symbolic_file target should exist: " + symlinkTarget.toString())
+        .that(symlinkTarget.exists())
+        .isTrue();
+
+    assertWithMessage("a_prefix/other_file and symbolic_file should be the same file")
+        .that(
+            Files.isSameFile(
+                java.nio.file.Paths.get(outputDir.getRelative("a_prefix/other_file").toString()),
+                java.nio.file.Paths.get(outputDir.getRelative("symbolic_file").toString())))
+        .isTrue();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPathTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPathTest.java
@@ -110,7 +110,13 @@ public class StripPrefixedPathTest {
     PathFragment relativePrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
             "root/a/b".getBytes(UTF_8), Optional.of("root"), fileSystem.getPath("/usr"));
-    // there is no attempt to get absolute path for the relative symlinks target path
-    assertThat(relativePrefix).isEqualTo(PathFragment.create("a/b"));
+    // Only absolute paths or paths relative to extraction root are deprefixed.
+    assertThat(relativePrefix).isEqualTo(PathFragment.create("root/a/b"));
+
+    PathFragment forceDeprefixRelativePrefix =
+        StripPrefixedPath.maybeDeprefixSymlink(
+            "root/a/b".getBytes(UTF_8), Optional.of("root"), fileSystem.getPath("/usr"), true);
+    // Forced deprefixing into root relative path.
+    assertThat(forceDeprefixRelativePrefix).isEqualTo(PathFragment.create("/usr/a/b"));
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
Before:
When there were symlinks in archives, they were always deprefixed when there was a `strip_prefix` value. This was incorrect as shown in https://github.com/bazelbuild/bazel/issues/30015 where a symlink should not have been deprefixed.

After:
This changes the behavior so that deprefixing of links only occurs:

- when the link path is absolute (this already was happening)
- when the link path is known to be relative to the extraction directory (tar hard links are relative to the extraction directory)

Otherwise, deprefixing will not occur. With this change, an archive like the following will now be extracted correctly:

```
a_prefix/regular_file
a_prefix/a_prefix/other_file
a_prefix/symbolic_file -> a_prefix/other_file
```

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->
Fixes #30015

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

This fixes an issue, it should not be a breaking change.  However, it has been like this for awhile - so people could have relied on this bug (it seems like it would be a rare thing).  

### Checklist

- [X] I have added tests for the new use cases (if any).
- [N/A] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

I don't think this requires a release notes.  Please feel free to edit/change if it does.
