### PR TITLE
Fix handling of symbolic/hard links when using `strip_components`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
@@ -72,6 +72,7 @@ public abstract class CompressedTarFunction implements Decompressor {
       throw new InterruptedException();
     }
     Optional<String> prefix = descriptor.prefix();
+    int stripComponents = descriptor.stripComponents();
     Map<String, String> renameFiles = descriptor.renameFiles();
     boolean foundPrefix = false;
     Set<String> availablePrefixes = new HashSet<>();
@@ -92,7 +93,8 @@ public abstract class CompressedTarFunction implements Decompressor {
         String entryName = toRawBytesString(entry.getName());
         entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath =
-            StripPrefixedPath.maybeDeprefix(entryName.getBytes(ISO_8859_1), prefix);
+            StripPrefixedPath.maybeDeprefix(
+                entryName.getBytes(ISO_8859_1), prefix, stripComponents);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
 
         if (prefix.isPresent() && !foundPrefix) {
@@ -111,11 +113,6 @@ public abstract class CompressedTarFunction implements Decompressor {
                   "Failed to extract %s, tarred paths cannot be absolute", strippedRelativePath));
         }
 
-        strippedRelativePath = strippedRelativePath.stripComponents(descriptor.stripComponents());
-        if (Objects.equals(strippedRelativePath, PathFragment.EMPTY_FRAGMENT)) {
-          continue;
-        }
-
         Path filePath = descriptor.destinationPath().getRelative(strippedRelativePath);
         if (!filePath.startsWith(descriptor.destinationPath())) {
           throw new IOException(
@@ -132,6 +129,7 @@ public abstract class CompressedTarFunction implements Decompressor {
                 maybeDeprefixSymlink(
                     toRawBytesString(entry.getLinkName()).getBytes(ISO_8859_1),
                     prefix,
+                    stripComponents,
                     descriptor.destinationPath(),
                     // Hard link target paths should be relative to the extraction directory.
                     /* forceExtractRootRelative= */ entry.isLink());

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
@@ -94,7 +94,7 @@ public abstract class CompressedTarFunction implements Decompressor {
         entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath =
             StripPrefixedPath.maybeDeprefix(
-                entryName.getBytes(ISO_8859_1), prefix, stripComponents);
+                entryName.getBytes(ISO_8859_1), prefix.orElse(""), stripComponents);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
 
         if (prefix.isPresent() && !foundPrefix) {
@@ -128,7 +128,7 @@ public abstract class CompressedTarFunction implements Decompressor {
             PathFragment targetName =
                 maybeDeprefixSymlink(
                     toRawBytesString(entry.getLinkName()).getBytes(ISO_8859_1),
-                    prefix,
+                    prefix.orElse(""),
                     stripComponents,
                     descriptor.destinationPath(),
                     // Hard link target paths should be relative to the extraction directory.

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
@@ -132,7 +132,9 @@ public abstract class CompressedTarFunction implements Decompressor {
                 maybeDeprefixSymlink(
                     toRawBytesString(entry.getLinkName()).getBytes(ISO_8859_1),
                     prefix,
-                    descriptor.destinationPath());
+                    descriptor.destinationPath(),
+                    // Hard link target paths should be relative to the extraction directory.
+                    /* forceExtractRootRelative= */ entry.isLink());
 
             Path resolvedTargetPath =
                 (entry.isSymbolicLink()

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
@@ -71,7 +71,7 @@ public abstract class CompressedTarFunction implements Decompressor {
     if (Thread.interrupted()) {
       throw new InterruptedException();
     }
-    Optional<String> prefix = descriptor.prefix();
+    String prefix = descriptor.prefix();
     int stripComponents = descriptor.stripComponents();
     Map<String, String> renameFiles = descriptor.renameFiles();
     boolean foundPrefix = false;
@@ -94,10 +94,10 @@ public abstract class CompressedTarFunction implements Decompressor {
         entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath =
             StripPrefixedPath.maybeDeprefix(
-                entryName.getBytes(ISO_8859_1), prefix.orElse(""), stripComponents);
+                entryName.getBytes(ISO_8859_1), prefix, stripComponents);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
 
-        if (prefix.isPresent() && !foundPrefix) {
+        if (!prefix.isEmpty() && !foundPrefix) {
           CouldNotFindPrefixException.maybeMakePrefixSuggestion(entryPath.getPathFragment())
               .ifPresent(availablePrefixes::add);
         }
@@ -128,7 +128,7 @@ public abstract class CompressedTarFunction implements Decompressor {
             PathFragment targetName =
                 maybeDeprefixSymlink(
                     toRawBytesString(entry.getLinkName()).getBytes(ISO_8859_1),
-                    prefix.orElse(""),
+                    prefix,
                     stripComponents,
                     descriptor.destinationPath(),
                     // Hard link target paths should be relative to the extraction directory.
@@ -198,8 +198,8 @@ public abstract class CompressedTarFunction implements Decompressor {
         FileSystemUtils.ensureSymbolicLink(linkPath, symlink.getValue());
       }
 
-      if (prefix.isPresent() && !foundPrefix) {
-        throw new CouldNotFindPrefixException(prefix.get(), availablePrefixes);
+      if (!prefix.isEmpty() && !foundPrefix) {
+        throw new CouldNotFindPrefixException(prefix, availablePrefixes);
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/DecompressorDescriptor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/DecompressorDescriptor.java
@@ -32,7 +32,7 @@ public record DecompressorDescriptor(
     String context,
     Path archivePath,
     Path destinationPath,
-    Optional<String> prefix,
+    String prefix,
     int stripComponents,
     ImmutableMap<String, String> renameFiles) {
   public DecompressorDescriptor {
@@ -46,6 +46,7 @@ public record DecompressorDescriptor(
   public static Builder builder() {
     return new AutoBuilder_DecompressorDescriptor_Builder()
         .setContext("")
+        .setPrefix("")
         .setStripComponents(0)
         .setRenameFiles(ImmutableMap.of());
   }
@@ -73,7 +74,7 @@ public record DecompressorDescriptor(
       if (d.stripComponents() < 0) {
         throw new IllegalArgumentException("'strip_components' must be non-negative");
       }
-      if (d.stripComponents() != 0 && d.prefix().isPresent() && !d.prefix().get().isEmpty()) {
+      if (d.stripComponents() != 0 && !d.prefix().isEmpty()) {
         throw new IllegalArgumentException(
             "Only one of 'strip_prefix' or 'strip_components' can be set");
       }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressor.java
@@ -83,7 +83,7 @@ public class SevenZDecompressor implements Decompressor {
         }
         entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath =
-            StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix, stripComponents);
+            StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix.orElse(""), stripComponents);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
         if (entryPath.skip()) {
           continue;
@@ -95,7 +95,7 @@ public class SevenZDecompressor implements Decompressor {
         Set<String> prefixes = new HashSet<>();
         for (SevenZArchiveEntry entry : entries) {
           StripPrefixedPath entryPath =
-              StripPrefixedPath.maybeDeprefix(entry.getName().getBytes(UTF_8), Optional.empty(), 0);
+              StripPrefixedPath.maybeDeprefix(entry.getName().getBytes(UTF_8), "", 0);
           CouldNotFindPrefixException.maybeMakePrefixSuggestion(entryPath.getPathFragment())
               .ifPresent(prefixes::add);
         }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressor.java
@@ -48,7 +48,7 @@ public class SevenZDecompressor implements Decompressor {
   public Path decompress(DecompressorDescriptor descriptor)
       throws IOException, RepositoryFunctionException, InterruptedException {
     Path destinationDirectory = descriptor.destinationPath();
-    Optional<String> prefix = descriptor.prefix();
+    String prefix = descriptor.prefix();
     int stripComponents = descriptor.stripComponents();
     ImmutableMap<String, String> renameFiles = descriptor.renameFiles();
     boolean foundPrefix = false;
@@ -83,7 +83,7 @@ public class SevenZDecompressor implements Decompressor {
         }
         entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath =
-            StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix.orElse(""), stripComponents);
+            StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix, stripComponents);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
         if (entryPath.skip()) {
           continue;
@@ -91,7 +91,7 @@ public class SevenZDecompressor implements Decompressor {
         extract7zEntry(sevenZFile, entry, destinationDirectory, entryPath.getPathFragment());
       }
 
-      if (prefix.isPresent() && !foundPrefix) {
+      if (!prefix.isEmpty() && !foundPrefix) {
         Set<String> prefixes = new HashSet<>();
         for (SevenZArchiveEntry entry : entries) {
           StripPrefixedPath entryPath =
@@ -99,7 +99,7 @@ public class SevenZDecompressor implements Decompressor {
           CouldNotFindPrefixException.maybeMakePrefixSuggestion(entryPath.getPathFragment())
               .ifPresent(prefixes::add);
         }
-        throw new CouldNotFindPrefixException(prefix.get(), prefixes);
+        throw new CouldNotFindPrefixException(prefix, prefixes);
       }
     }
     return destinationDirectory;

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressor.java
@@ -49,6 +49,7 @@ public class SevenZDecompressor implements Decompressor {
       throws IOException, RepositoryFunctionException, InterruptedException {
     Path destinationDirectory = descriptor.destinationPath();
     Optional<String> prefix = descriptor.prefix();
+    int stripComponents = descriptor.stripComponents();
     ImmutableMap<String, String> renameFiles = descriptor.renameFiles();
     boolean foundPrefix = false;
 
@@ -82,24 +83,19 @@ public class SevenZDecompressor implements Decompressor {
         }
         entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath =
-            StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix);
+            StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix, stripComponents);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
         if (entryPath.skip()) {
           continue;
         }
-        PathFragment pathFragment =
-            entryPath.getPathFragment().stripComponents(descriptor.stripComponents());
-        if (Objects.equals(pathFragment, PathFragment.EMPTY_FRAGMENT)) {
-          continue;
-        }
-        extract7zEntry(sevenZFile, entry, destinationDirectory, pathFragment);
+        extract7zEntry(sevenZFile, entry, destinationDirectory, entryPath.getPathFragment());
       }
 
       if (prefix.isPresent() && !foundPrefix) {
         Set<String> prefixes = new HashSet<>();
         for (SevenZArchiveEntry entry : entries) {
           StripPrefixedPath entryPath =
-              StripPrefixedPath.maybeDeprefix(entry.getName().getBytes(UTF_8), Optional.empty());
+              StripPrefixedPath.maybeDeprefix(entry.getName().getBytes(UTF_8), Optional.empty(), 0);
           CouldNotFindPrefixException.maybeMakePrefixSuggestion(entryPath.getPathFragment())
               .ifPresent(prefixes::add);
         }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPath.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPath.java
@@ -20,30 +20,51 @@ import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.concurrent.ThreadSafety;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
  * Utility class for removing a prefix from an archive's path.
+ *
+ * <p>A "prefix" can be a string of path segments or an integer representing the number of path
+ * segments to remove. Given an example path <code>/tmp/path/to/file</code>, removing the string
+ * prefix <code>/tmp/path</code> or stripping two components will result in the same de-prefixed
+ * path: <code>to/file</code>
  */
 @ThreadSafety.Immutable
 public final class StripPrefixedPath {
   private final PathFragment pathFragment;
-  private final boolean found;
+  private final boolean foundPrefix;
   private final boolean skip;
 
   /**
-   * If a prefix is given, it will be removed from the entry's path. This also turns absolute paths
-   * into relative paths (e.g., /usr/bin/bash will become usr/bin/bash, same as unzip's default
-   * behavior) and normalizes the paths (foo/../bar////baz will become bar/baz). Note that this
-   * could cause collisions, if a zip file had one entry for bin/some-binary and another entry for
-   * /bin/some-binary.
+   * Removes the given prefix or the specified number of components.
+   *
+   * If a prefix of number of components is given, it will be removed from the entry's path. This
+   * also turns absolute paths into relative paths (e.g., /usr/bin/bash will become usr/bin/bash,
+   * same as unzip's default behavior) and normalizes the paths (foo/../bar////baz will become
+   * bar/baz). Note that this could cause collisions, if a zip file had one entry for
+   * bin/some-binary and another entry for /bin/some-binary.
    *
    * <p>Note that the prefix is stripped to move the files up one level, so if you have an entry
    * "foo/../bar" and a prefix of "foo", the result will be "bar" not "../bar".
+   *
+   * Only one of <code>prefix</code> or <code>stripComponents</code> is allowed.
    */
-  public static StripPrefixedPath maybeDeprefix(byte[] entry, Optional<String> prefix) {
+  public static StripPrefixedPath maybeDeprefix(byte[] entry, Optional<String> prefix, int stripComponents) {
     Preconditions.checkNotNull(entry);
+    Preconditions.checkArgument(!(prefix.isPresent() && !prefix.get().isEmpty() && stripComponents != 0),
+        "Only one of prefix or strip_components can be set.");
+
     PathFragment entryPath = relativize(entry);
+    if (stripComponents != 0) {
+      return maybeStripComponent(entryPath, stripComponents);
+    } else {
+      return maybeStripPrefix(entryPath, prefix);
+    }
+  }
+
+  private static StripPrefixedPath maybeStripPrefix(PathFragment entryPath, Optional<String> prefix) {
     if (prefix.isEmpty()) {
       return new StripPrefixedPath(entryPath, false, false);
     }
@@ -65,6 +86,18 @@ public final class StripPrefixedPath {
     return new StripPrefixedPath(entryPath, found, skip);
   }
 
+  private static StripPrefixedPath maybeStripComponent(PathFragment entryPath, int stripComponents) {
+    if (stripComponents == 0) {
+      return new StripPrefixedPath(entryPath, /* foundPrefix= */ false, false);
+    }
+    PathFragment strippedPath = entryPath.stripComponents(stripComponents);
+    boolean skipEntry = false;
+    if (Objects.equals(strippedPath, PathFragment.EMPTY_FRAGMENT)) {
+      skipEntry = true;
+    }
+    return new StripPrefixedPath(strippedPath, /* foundPrefix= */ false, skipEntry);
+  }
+
   /**
    * Normalize the path and, if it is absolute, make it relative (e.g., /foo/bar becomes foo/bar).
    */
@@ -76,15 +109,15 @@ public final class StripPrefixedPath {
     return entryPath;
   }
 
-  private StripPrefixedPath(PathFragment pathFragment, boolean found, boolean skip) {
+  private StripPrefixedPath(PathFragment pathFragment, boolean foundPrefix, boolean skip) {
     this.pathFragment = pathFragment;
-    this.found = found;
+    this.foundPrefix = foundPrefix;
     this.skip = skip;
   }
 
   public static PathFragment maybeDeprefixSymlink(
-      byte[] rawTarget, Optional<String> prefix, Path root) {
-    return maybeDeprefixSymlink(rawTarget, prefix, root, false);
+      byte[] rawTarget, Optional<String> prefix, int stripComponents, Path root) {
+    return maybeDeprefixSymlink(rawTarget, prefix, stripComponents, root, false);
   }
 
   /**
@@ -101,18 +134,26 @@ public final class StripPrefixedPath {
    * Otherwise, no deprefixing will occur.
    *
    * @param rawTarget The target path for the link.
-   * @param prefix The prefix to remove.
+   * @param prefix The prefix to remove. If set, <code>stripComponents</code> must be 0.
+   * @param stripComponents The number of path segements to remove. If nonzero, <code>prefix</code>
+   *     must be Optional.empty().
    * @param root The path for absolute or <code>forceExtractRootRelative</code> to be relative to.
    * @param forceExtractRootRelative Forces the given <code>rawTarget</code> to be relative to the
    *     <code>root</code>.
    * @return The normalized and possibly deprefixed link target.
    */
   public static PathFragment maybeDeprefixSymlink(
-      byte[] rawTarget, Optional<String> prefix, Path root, boolean forceExtractRootRelative) {
+      byte[] rawTarget,
+      Optional<String> prefix,
+      int stripComponents,
+      Path root,
+      boolean forceExtractRootRelative) {
+    Preconditions.checkArgument(!(prefix.isPresent() && !prefix.get().isEmpty() && stripComponents != 0),
+        "Only one of prefix or strip_components can be set.");
     boolean wasAbsolute = createPathFragment(rawTarget).isAbsolute();
     if (wasAbsolute || forceExtractRootRelative) {
       // Strip the prefix from the link path if set
-      PathFragment linkPathFragment = maybeDeprefix(rawTarget, prefix).getPathFragment();
+      PathFragment linkPathFragment = maybeDeprefix(rawTarget, prefix, stripComponents).getPathFragment();
       // Recover the path to an absolute path as maybeDeprefix() relativize the path
       // even if the prefix is not set
       return root.getRelative(linkPathFragment).asFragment();
@@ -127,7 +168,7 @@ public final class StripPrefixedPath {
   }
 
   public boolean foundPrefix() {
-    return found;
+    return foundPrefix;
   }
 
   public boolean skip() {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPath.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPath.java
@@ -53,7 +53,7 @@ public final class StripPrefixedPath {
    */
   public static StripPrefixedPath maybeDeprefix(byte[] entry, String prefix, int stripComponents) {
     Preconditions.checkNotNull(entry);
-    Preconditions.checkArgument(!(!prefix.isEmpty() && stripComponents != 0),
+    Preconditions.checkArgument(prefix.isEmpty() || stripComponents == 0,
         "Only one of prefix or strip_components can be set.");
 
     PathFragment entryPath = relativize(entry);
@@ -148,7 +148,7 @@ public final class StripPrefixedPath {
       int stripComponents,
       Path root,
       boolean forceExtractRootRelative) {
-    Preconditions.checkArgument(!(!prefix.isEmpty() && stripComponents != 0),
+    Preconditions.checkArgument(prefix.isEmpty() || stripComponents == 0,
         "Only one of prefix or strip_components can be set.");
     boolean wasAbsolute = createPathFragment(rawTarget).isAbsolute();
     if (wasAbsolute || forceExtractRootRelative) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPath.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPath.java
@@ -51,9 +51,9 @@ public final class StripPrefixedPath {
    *
    * Only one of <code>prefix</code> or <code>stripComponents</code> is allowed.
    */
-  public static StripPrefixedPath maybeDeprefix(byte[] entry, Optional<String> prefix, int stripComponents) {
+  public static StripPrefixedPath maybeDeprefix(byte[] entry, String prefix, int stripComponents) {
     Preconditions.checkNotNull(entry);
-    Preconditions.checkArgument(!(prefix.isPresent() && !prefix.get().isEmpty() && stripComponents != 0),
+    Preconditions.checkArgument(!(!prefix.isEmpty() && stripComponents != 0),
         "Only one of prefix or strip_components can be set.");
 
     PathFragment entryPath = relativize(entry);
@@ -64,14 +64,14 @@ public final class StripPrefixedPath {
     }
   }
 
-  private static StripPrefixedPath maybeStripPrefix(PathFragment entryPath, Optional<String> prefix) {
+  private static StripPrefixedPath maybeStripPrefix(PathFragment entryPath, String prefix) {
     if (prefix.isEmpty()) {
       return new StripPrefixedPath(entryPath, false, false);
     }
 
     // Bazel parses Starlark files, which are the ultimate source of prefixes, as Latin-1
     // (ISO-8859-1).
-    PathFragment prefixPath = relativize(prefix.get().getBytes(ISO_8859_1));
+    PathFragment prefixPath = relativize(prefix.getBytes(ISO_8859_1));
     boolean found = false;
     boolean skip = false;
     if (entryPath.startsWith(prefixPath)) {
@@ -116,7 +116,7 @@ public final class StripPrefixedPath {
   }
 
   public static PathFragment maybeDeprefixSymlink(
-      byte[] rawTarget, Optional<String> prefix, int stripComponents, Path root) {
+      byte[] rawTarget, String prefix, int stripComponents, Path root) {
     return maybeDeprefixSymlink(rawTarget, prefix, stripComponents, root, false);
   }
 
@@ -144,11 +144,11 @@ public final class StripPrefixedPath {
    */
   public static PathFragment maybeDeprefixSymlink(
       byte[] rawTarget,
-      Optional<String> prefix,
+      String prefix,
       int stripComponents,
       Path root,
       boolean forceExtractRootRelative) {
-    Preconditions.checkArgument(!(prefix.isPresent() && !prefix.get().isEmpty() && stripComponents != 0),
+    Preconditions.checkArgument(!(!prefix.isEmpty() && stripComponents != 0),
         "Only one of prefix or strip_components can be set.");
     boolean wasAbsolute = createPathFragment(rawTarget).isAbsolute();
     if (wasAbsolute || forceExtractRootRelative) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPath.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPath.java
@@ -84,15 +84,42 @@ public final class StripPrefixedPath {
 
   public static PathFragment maybeDeprefixSymlink(
       byte[] rawTarget, Optional<String> prefix, Path root) {
+    return maybeDeprefixSymlink(rawTarget, prefix, root, false);
+  }
+
+  /**
+   * Normalizes and possibly deprefixes a target link.
+   *
+   * <p>A target link will only be deprefixed and relative to the given root if any of the
+   * following:
+   *
+   * <ul>
+   *   <li>The link is absolute
+   *   <li>The link is known to be relative to the root (<code>forceExtractRootRelative</code>)
+   * </ul>
+   *
+   * Otherwise, no deprefixing will occur.
+   *
+   * @param rawTarget The target path for the link.
+   * @param prefix The prefix to remove.
+   * @param root The path for absolute or <code>forceExtractRootRelative</code> to be relative to.
+   * @param forceExtractRootRelative Forces the given <code>rawTarget</code> to be relative to the
+   *     <code>root</code>.
+   * @return The normalized and possibly deprefixed link target.
+   */
+  public static PathFragment maybeDeprefixSymlink(
+      byte[] rawTarget, Optional<String> prefix, Path root, boolean forceExtractRootRelative) {
     boolean wasAbsolute = createPathFragment(rawTarget).isAbsolute();
-    // Strip the prefix from the link path if set.
-    PathFragment linkPathFragment = maybeDeprefix(rawTarget, prefix).getPathFragment();
-    if (wasAbsolute) {
+    if (wasAbsolute || forceExtractRootRelative) {
+      // Strip the prefix from the link path if set
+      PathFragment linkPathFragment = maybeDeprefix(rawTarget, prefix).getPathFragment();
       // Recover the path to an absolute path as maybeDeprefix() relativize the path
       // even if the prefix is not set
       return root.getRelative(linkPathFragment).asFragment();
+    } else {
+      // No deprefixing needed if not relative to extraction root.
+      return relativize(rawTarget);
     }
-    return linkPathFragment;
   }
 
   public PathFragment getPathFragment() {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
@@ -79,7 +79,7 @@ public class ZipDecompressor implements Decompressor {
   public Path decompress(DecompressorDescriptor descriptor)
       throws IOException, InterruptedException {
     Path destinationDirectory = descriptor.destinationPath();
-    Optional<String> prefix = descriptor.prefix();
+    String prefix = descriptor.prefix();
     int stripComponents = descriptor.stripComponents();
     Map<String, String> renameFiles = descriptor.renameFiles();
     boolean foundPrefix = false;
@@ -92,7 +92,7 @@ public class ZipDecompressor implements Decompressor {
         String entryName = entry.getName();
         entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath =
-            StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix.orElse(""), stripComponents);
+            StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix, stripComponents);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
         if (entryPath.skip()) {
           continue;
@@ -107,7 +107,7 @@ public class ZipDecompressor implements Decompressor {
             symlinks);
       }
 
-      if (prefix.isPresent() && !foundPrefix) {
+      if (!prefix.isEmpty() && !foundPrefix) {
         Set<String> prefixes = new HashSet<>();
         for (ZipFileEntry entry : entries) {
           StripPrefixedPath entryPath =
@@ -115,7 +115,7 @@ public class ZipDecompressor implements Decompressor {
           CouldNotFindPrefixException.maybeMakePrefixSuggestion(entryPath.getPathFragment())
               .ifPresent(prefixes::add);
         }
-        throw new CouldNotFindPrefixException(prefix.get(), prefixes);
+        throw new CouldNotFindPrefixException(prefix, prefixes);
       }
     }
 
@@ -131,7 +131,7 @@ public class ZipDecompressor implements Decompressor {
       ZipFileEntry entry,
       Path destinationDirectory,
       PathFragment strippedRelativePath,
-      Optional<String> prefix,
+      String prefix,
       int stripComponents,
       Map<Path, PathFragment> symlinks)
       throws IOException, InterruptedException {
@@ -175,7 +175,7 @@ public class ZipDecompressor implements Decompressor {
       symlinks.put(
           outputPath,
           maybeDeprefixSymlink(
-              buffer, prefix.orElse(""), stripComponents, destinationDirectory, /* forceExtractRootRelative= */ false));
+              buffer, prefix, stripComponents, destinationDirectory, /* forceExtractRootRelative= */ false));
     } else {
       try (InputStream input = reader.getInputStream(entry);
           OutputStream output = outputPath.getOutputStream()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
@@ -168,7 +168,10 @@ public class ZipDecompressor implements Decompressor {
                 + new String(buffer, UTF_8));
       }
 
-      symlinks.put(outputPath, maybeDeprefixSymlink(buffer, prefix, destinationDirectory));
+      symlinks.put(
+          outputPath,
+          maybeDeprefixSymlink(
+              buffer, prefix, destinationDirectory, /* forceExtractRootRelative= */ false));
     } else {
       try (InputStream input = reader.getInputStream(entry);
           OutputStream output = outputPath.getOutputStream()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
@@ -92,7 +92,7 @@ public class ZipDecompressor implements Decompressor {
         String entryName = entry.getName();
         entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath =
-            StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix, stripComponents);
+            StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix.orElse(""), stripComponents);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
         if (entryPath.skip()) {
           continue;
@@ -111,7 +111,7 @@ public class ZipDecompressor implements Decompressor {
         Set<String> prefixes = new HashSet<>();
         for (ZipFileEntry entry : entries) {
           StripPrefixedPath entryPath =
-              StripPrefixedPath.maybeDeprefix(entry.getName().getBytes(UTF_8), Optional.empty(), 0);
+              StripPrefixedPath.maybeDeprefix(entry.getName().getBytes(UTF_8), "", 0);
           CouldNotFindPrefixException.maybeMakePrefixSuggestion(entryPath.getPathFragment())
               .ifPresent(prefixes::add);
         }
@@ -175,7 +175,7 @@ public class ZipDecompressor implements Decompressor {
       symlinks.put(
           outputPath,
           maybeDeprefixSymlink(
-              buffer, prefix, stripComponents, destinationDirectory, /* forceExtractRootRelative= */ false));
+              buffer, prefix.orElse(""), stripComponents, destinationDirectory, /* forceExtractRootRelative= */ false));
     } else {
       try (InputStream input = reader.getInputStream(entry);
           OutputStream output = outputPath.getOutputStream()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
@@ -80,6 +80,7 @@ public class ZipDecompressor implements Decompressor {
       throws IOException, InterruptedException {
     Path destinationDirectory = descriptor.destinationPath();
     Optional<String> prefix = descriptor.prefix();
+    int stripComponents = descriptor.stripComponents();
     Map<String, String> renameFiles = descriptor.renameFiles();
     boolean foundPrefix = false;
     // Store link, target info of symlinks, we create them after regular files are extracted.
@@ -91,24 +92,26 @@ public class ZipDecompressor implements Decompressor {
         String entryName = entry.getName();
         entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath =
-            StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix);
+            StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix, stripComponents);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
         if (entryPath.skip()) {
           continue;
         }
-        PathFragment pathFragment =
-            entryPath.getPathFragment().stripComponents(descriptor.stripComponents());
-        if (Objects.equals(pathFragment, PathFragment.EMPTY_FRAGMENT)) {
-          continue;
-        }
-        extractZipEntry(reader, entry, destinationDirectory, pathFragment, prefix, symlinks);
+        extractZipEntry(
+            reader,
+            entry,
+            destinationDirectory,
+            entryPath.getPathFragment(),
+            prefix,
+            stripComponents,
+            symlinks);
       }
 
       if (prefix.isPresent() && !foundPrefix) {
         Set<String> prefixes = new HashSet<>();
         for (ZipFileEntry entry : entries) {
           StripPrefixedPath entryPath =
-              StripPrefixedPath.maybeDeprefix(entry.getName().getBytes(UTF_8), Optional.empty());
+              StripPrefixedPath.maybeDeprefix(entry.getName().getBytes(UTF_8), Optional.empty(), 0);
           CouldNotFindPrefixException.maybeMakePrefixSuggestion(entryPath.getPathFragment())
               .ifPresent(prefixes::add);
         }
@@ -129,6 +132,7 @@ public class ZipDecompressor implements Decompressor {
       Path destinationDirectory,
       PathFragment strippedRelativePath,
       Optional<String> prefix,
+      int stripComponents,
       Map<Path, PathFragment> symlinks)
       throws IOException, InterruptedException {
     if (strippedRelativePath.isAbsolute()) {
@@ -171,7 +175,7 @@ public class ZipDecompressor implements Decompressor {
       symlinks.put(
           outputPath,
           maybeDeprefixSymlink(
-              buffer, prefix, destinationDirectory, /* forceExtractRootRelative= */ false));
+              buffer, prefix, stripComponents, destinationDirectory, /* forceExtractRootRelative= */ false));
     } else {
       try (InputStream input = reader.getInputStream(entry);
           OutputStream output = outputPath.getOutputStream()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -35,7 +35,6 @@ import com.google.devtools.build.lib.bazel.repository.RepositoryUtils;
 import com.google.devtools.build.lib.bazel.repository.cache.DownloadCache;
 import com.google.devtools.build.lib.bazel.repository.cache.DownloadCache.KeyType;
 import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorDescriptor;
-import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorDescriptor.Builder;
 import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorValue;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
@@ -1175,17 +1174,17 @@ Strip the given number of leading components from file paths on extraction. Only
           .post(
               new ExtractProgress(
                   outputPath.getPath().toString(), "Extracting " + downloadedPath.getBaseName()));
-      Builder ddb = DecompressorDescriptor.builder()
+      DecompressorDescriptor.Builder descriptorBuilder = DecompressorDescriptor.builder()
           .setContext(identifyingStringForLogging)
           .setArchivePath(downloadedPath)
           .setDestinationPath(outputPath.getPath())
           .setStripComponents(stripComponents)
           .setRenameFiles(renameFilesMap);
       if (!stripPrefix.isEmpty()) {
-        ddb.setPrefix(stripPrefix);
+        descriptorBuilder.setPrefix(stripPrefix);
       }
       DecompressorValue.decompress(
-          ddb.build(),
+          descriptorBuilder.build(),
           // Type does NOT need to be passed here, as the existing code renames the archive path to
           // include the type extension. The decompression code then uses the file extension to get
           // the proper decompressor.
@@ -1385,7 +1384,7 @@ Strip the given number of leading components from file paths on extraction. Only
         .post(
             new ExtractProgress(
                 outputPath.getPath().toString(), "Extracting " + archivePath.getBasename()));
-    Builder ddb =
+    DecompressorDescriptor.Builder descriptorBuilder =
         DecompressorDescriptor.builder()
             .setContext(identifyingStringForLogging)
             .setArchivePath(archivePath.getPath())
@@ -1393,9 +1392,10 @@ Strip the given number of leading components from file paths on extraction. Only
             .setStripComponents(stripComponents)
             .setRenameFiles(renameFilesMap);
     if (!stripPrefix.isEmpty()) {
-      ddb.setPrefix(stripPrefix);
+      descriptorBuilder.setPrefix(stripPrefix);
     }
-    DecompressorValue.decompress(ddb.build(), Optional.ofNullable(type).filter(s -> !s.isBlank()));
+    DecompressorValue.decompress(
+        descriptorBuilder.build(), Optional.ofNullable(type).filter(s -> !s.isBlank()));
     env.getListener().post(new ExtractProgress(outputPath.getPath().toString()));
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -35,6 +35,7 @@ import com.google.devtools.build.lib.bazel.repository.RepositoryUtils;
 import com.google.devtools.build.lib.bazel.repository.cache.DownloadCache;
 import com.google.devtools.build.lib.bazel.repository.cache.DownloadCache.KeyType;
 import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorDescriptor;
+import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorDescriptor.Builder;
 import com.google.devtools.build.lib.bazel.repository.decompressor.DecompressorValue;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
@@ -1174,15 +1175,17 @@ Strip the given number of leading components from file paths on extraction. Only
           .post(
               new ExtractProgress(
                   outputPath.getPath().toString(), "Extracting " + downloadedPath.getBaseName()));
+      Builder ddb = DecompressorDescriptor.builder()
+          .setContext(identifyingStringForLogging)
+          .setArchivePath(downloadedPath)
+          .setDestinationPath(outputPath.getPath())
+          .setStripComponents(stripComponents)
+          .setRenameFiles(renameFilesMap);
+      if (!stripPrefix.isEmpty()) {
+        ddb.setPrefix(stripPrefix);
+      }
       DecompressorValue.decompress(
-          DecompressorDescriptor.builder()
-              .setContext(identifyingStringForLogging)
-              .setArchivePath(downloadedPath)
-              .setDestinationPath(outputPath.getPath())
-              .setPrefix(stripPrefix)
-              .setStripComponents(stripComponents)
-              .setRenameFiles(renameFilesMap)
-              .build(),
+          ddb.build(),
           // Type does NOT need to be passed here, as the existing code renames the archive path to
           // include the type extension. The decompression code then uses the file extension to get
           // the proper decompressor.
@@ -1382,16 +1385,17 @@ Strip the given number of leading components from file paths on extraction. Only
         .post(
             new ExtractProgress(
                 outputPath.getPath().toString(), "Extracting " + archivePath.getBasename()));
-    DecompressorValue.decompress(
+    Builder ddb =
         DecompressorDescriptor.builder()
             .setContext(identifyingStringForLogging)
             .setArchivePath(archivePath.getPath())
             .setDestinationPath(outputPath.getPath())
-            .setPrefix(stripPrefix)
             .setStripComponents(stripComponents)
-            .setRenameFiles(renameFilesMap)
-            .build(),
-        Optional.ofNullable(type).filter(s -> !s.isBlank()));
+            .setRenameFiles(renameFilesMap);
+    if (!stripPrefix.isEmpty()) {
+      ddb.setPrefix(stripPrefix);
+    }
+    DecompressorValue.decompress(ddb.build(), Optional.ofNullable(type).filter(s -> !s.isBlank()));
     env.getListener().post(new ExtractProgress(outputPath.getPath().toString()));
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunctionTest.java
@@ -44,13 +44,14 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests decompressing archives. */
 @RunWith(JUnit4.class)
 public class CompressedTarFunctionTest {
-
+  @Rule public TestName name = new TestName();
   @Rule public TemporaryFolder folder = new TemporaryFolder();
 
   /* Tarball, created by "tar -czf <ARCHIVE_NAME> <files...>" */
@@ -58,9 +59,14 @@ public class CompressedTarFunctionTest {
 
   private TestArchiveDescriptor archiveDescriptor;
 
+  /** Provides a test filesystem descriptor for a test. NOTE: unique per individual test ONLY. */
   @Before
-  public void setUpFs() throws Exception {
-    archiveDescriptor = new TestArchiveDescriptor(ARCHIVE_NAME, "out", true);
+  public void setUpFs() {
+    archiveDescriptor =
+        new TestArchiveDescriptor(
+            ARCHIVE_NAME,
+            /* outDirName= */ this.getClass().getSimpleName() + "_" + name.getMethodName(),
+            true);
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunctionTest.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.bazel.repository.decompressor;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.devtools.build.lib.bazel.repository.decompressor.TestArchiveDescriptor.INNER_FOLDER_NAME;
 import static com.google.devtools.build.lib.bazel.repository.decompressor.TestArchiveDescriptor.ROOT_FOLDER_NAME;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -25,6 +26,7 @@ import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystem.NotASymlinkException;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.util.FileSystems;
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -32,6 +34,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.zip.GZIPInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -267,5 +270,79 @@ public class CompressedTarFunctionTest {
     // Verify that the escape link was NOT created.
     Path escapeLink = outDir.getParentDirectory().getRelative("target");
     assertThat(escapeLink.exists()).isFalse();
+  }
+
+  @Test
+  public void decompressTarWithSymlinkSharingStripPrefix() throws Exception {
+    // Creates the example archive described in https://github.com/bazelbuild/bazel/issues/30015.
+    FileSystem fs = FileSystems.getNativeFileSystem();
+    File archive = folder.newFile("symlink_with_same_strip_prefix.tar.gz");
+    try (FileOutputStream fos = new FileOutputStream(archive);
+        GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(fos);
+        TarArchiveOutputStream tos = new TarArchiveOutputStream(gzos)) {
+
+      // Create two directory entries:
+      //  - a_prefix
+      //  - a_prefix/a_prefix
+      TarArchiveEntry directory = new TarArchiveEntry("a_prefix/");
+      tos.putArchiveEntry(directory);
+      tos.closeArchiveEntry();
+      TarArchiveEntry subdirectory = new TarArchiveEntry("a_prefix/a_prefix/");
+      tos.putArchiveEntry(subdirectory);
+      tos.closeArchiveEntry();
+
+      // Create the two regular files:
+      // - a_prefix/regular_file
+      // - a_prefix/a_prefix/other_file
+      TarArchiveEntry regularFile = new TarArchiveEntry("a_prefix/regular_file");
+      byte[] regularFileContents = "hello".getBytes();
+      regularFile.setSize(regularFileContents.length);
+      tos.putArchiveEntry(regularFile);
+      tos.write(regularFileContents);
+      tos.closeArchiveEntry();
+
+      TarArchiveEntry otherFile = new TarArchiveEntry("a_prefix/a_prefix/other_file");
+      byte[] otherFileContents = "world".getBytes();
+      otherFile.setSize(otherFileContents.length);
+      tos.putArchiveEntry(otherFile);
+      tos.write(otherFileContents);
+      tos.closeArchiveEntry();
+
+      // Create the symbolic link pointing to other_file:
+      // - a_prefix/symbolic_file -> a_prefix/other_file
+      TarArchiveEntry symbolicFile =
+          new TarArchiveEntry("a_prefix/symbolic_file", TarArchiveEntry.LF_SYMLINK);
+      symbolicFile.setLinkName("a_prefix/other_file");
+      symbolicFile.setSize(0);
+      tos.putArchiveEntry(symbolicFile);
+      tos.closeArchiveEntry();
+    }
+    Path archivePath = fs.getPath(archive.getAbsolutePath());
+    Path extractPath = fs.getPath(folder.newFolder().getAbsolutePath());
+
+    DecompressorDescriptor descriptor =
+        DecompressorDescriptor.builder()
+            .setArchivePath(archivePath)
+            .setDestinationPath(extractPath)
+            .setPrefix("a_prefix")
+            .build();
+    Path outputDir = decompress(descriptor);
+
+    Path outputSymbolicFile = outputDir.getRelative("symbolic_file");
+    assertWithMessage("symbolic_file should exist")
+        .that(outputSymbolicFile.exists(Symlinks.NOFOLLOW))
+        .isTrue();
+
+    Path symlinkTarget = outputDir.getRelative(outputSymbolicFile.readSymbolicLink());
+    assertWithMessage("symbolic_file target should exist: " + symlinkTarget.toString())
+        .that(symlinkTarget.exists())
+        .isTrue();
+
+    assertWithMessage("a_prefix/other_file and symbolic_file should be the same file")
+        .that(
+            Files.isSameFile(
+                java.nio.file.Paths.get(outputDir.getRelative("a_prefix/other_file").toString()),
+                java.nio.file.Paths.get(outputDir.getRelative("symbolic_file").toString())))
+        .isTrue();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunctionTest.java
@@ -281,6 +281,7 @@ public class CompressedTarFunctionTest {
   @Test
   public void decompressTarWithSymlinkSharingStripPrefix() throws Exception {
     // Creates the example archive described in https://github.com/bazelbuild/bazel/issues/30015.
+    // Also includes an absolute symlink to show it's deprefixed correctly.
     FileSystem fs = FileSystems.getNativeFileSystem();
     File archive = folder.newFile("symlink_with_same_strip_prefix.tar.gz");
     try (FileOutputStream fos = new FileOutputStream(archive);
@@ -322,6 +323,15 @@ public class CompressedTarFunctionTest {
       symbolicFile.setSize(0);
       tos.putArchiveEntry(symbolicFile);
       tos.closeArchiveEntry();
+
+      // Create an absolute symbolic link pointing to other_file:
+      // - a_prefix/abs_symbolic_file -> /a_prefix/a_prefix/other_file
+      TarArchiveEntry absSymbolicFile =
+          new TarArchiveEntry("a_prefix/abs_symbolic_file", TarArchiveEntry.LF_SYMLINK);
+      absSymbolicFile.setLinkName("/a_prefix/a_prefix/other_file");
+      absSymbolicFile.setSize(0);
+      tos.putArchiveEntry(absSymbolicFile);
+      tos.closeArchiveEntry();
     }
     Path archivePath = fs.getPath(archive.getAbsolutePath());
     Path extractPath = fs.getPath(folder.newFolder().getAbsolutePath());
@@ -334,6 +344,7 @@ public class CompressedTarFunctionTest {
             .build();
     Path outputDir = decompress(descriptor);
 
+    // Verify the relative symbolic link.
     Path outputSymbolicFile = outputDir.getRelative("symbolic_file");
     assertWithMessage("symbolic_file should exist")
         .that(outputSymbolicFile.exists(Symlinks.NOFOLLOW))
@@ -349,6 +360,24 @@ public class CompressedTarFunctionTest {
             Files.isSameFile(
                 java.nio.file.Paths.get(outputDir.getRelative("a_prefix/other_file").toString()),
                 java.nio.file.Paths.get(outputDir.getRelative("symbolic_file").toString())))
+        .isTrue();
+
+    // Verify the absolute symbolic link.
+    Path outputAbsSymbolicFile = outputDir.getRelative("abs_symbolic_file");
+    assertWithMessage("abs_symbolic_file should exist")
+        .that(outputSymbolicFile.exists(Symlinks.NOFOLLOW))
+        .isTrue();
+
+    Path absSymlinkTarget = outputDir.getRelative(outputAbsSymbolicFile.readSymbolicLink());
+    assertWithMessage("abs_symbolic_file target should exist: " + symlinkTarget.toString())
+        .that(absSymlinkTarget.exists())
+        .isTrue();
+
+    assertWithMessage("a_prefix/other_file and abs_symbolic_file should be the same file")
+        .that(
+            Files.isSameFile(
+                java.nio.file.Paths.get(outputDir.getRelative("a_prefix/other_file").toString()),
+                java.nio.file.Paths.get(outputDir.getRelative("abs_symbolic_file").toString())))
         .isTrue();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPathTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPathTest.java
@@ -36,30 +36,30 @@ public class StripPrefixedPathTest {
   @Test
   public void testStripPrefix() {
     StripPrefixedPath result =
-        StripPrefixedPath.maybeDeprefix("foo/bar".getBytes(UTF_8), Optional.of("foo"), 0);
+        StripPrefixedPath.maybeDeprefix("foo/bar".getBytes(UTF_8), "foo", 0);
     assertThat(PathFragment.create("bar")).isEqualTo(result.getPathFragment());
     assertThat(result.foundPrefix()).isTrue();
     assertThat(result.skip()).isFalse();
 
-    result = StripPrefixedPath.maybeDeprefix("foo".getBytes(UTF_8), Optional.of("foo"), 0);
+    result = StripPrefixedPath.maybeDeprefix("foo".getBytes(UTF_8), "foo", 0);
     assertThat(result.skip()).isTrue();
 
-    result = StripPrefixedPath.maybeDeprefix("bar/baz".getBytes(UTF_8), Optional.of("foo"), 0);
+    result = StripPrefixedPath.maybeDeprefix("bar/baz".getBytes(UTF_8), "foo", 0);
     assertThat(result.foundPrefix()).isFalse();
 
-    result = StripPrefixedPath.maybeDeprefix("foof/bar".getBytes(UTF_8), Optional.of("foo"), 0);
+    result = StripPrefixedPath.maybeDeprefix("foof/bar".getBytes(UTF_8), "foo", 0);
     assertThat(result.foundPrefix()).isFalse();
   }
 
   @Test
   public void stripComponents() {
     StripPrefixedPath result =
-        StripPrefixedPath.maybeDeprefix("foo/bar".getBytes(UTF_8), Optional.empty(), 1);
+        StripPrefixedPath.maybeDeprefix("foo/bar".getBytes(UTF_8), "", 1);
     assertThat(PathFragment.create("bar")).isEqualTo(result.getPathFragment());
     assertThat(result.foundPrefix()).isFalse();
     assertThat(result.skip()).isFalse();
 
-    result = StripPrefixedPath.maybeDeprefix("foo".getBytes(UTF_8), Optional.empty(), 1);
+    result = StripPrefixedPath.maybeDeprefix("foo".getBytes(UTF_8), "", 1);
     assertThat(result.foundPrefix()).isFalse();
     assertThat(result.skip()).isTrue();
   }
@@ -68,7 +68,7 @@ public class StripPrefixedPathTest {
   public void stripPrefixAndComponents() {
     IllegalArgumentException e = assertThrows(
         IllegalArgumentException.class,
-        () -> StripPrefixedPath.maybeDeprefix("foo/bar".getBytes(UTF_8), Optional.of("foo"), 1));
+        () -> StripPrefixedPath.maybeDeprefix("foo/bar".getBytes(UTF_8), "foo", 1));
 
     assertThat(e).hasMessageThat().contains("Only one of prefix or strip_components can be set.");
   }
@@ -76,16 +76,16 @@ public class StripPrefixedPathTest {
   @Test
   public void testAbsolute() {
     StripPrefixedPath result =
-        StripPrefixedPath.maybeDeprefix("/foo/bar".getBytes(UTF_8), Optional.empty(), 0);
+        StripPrefixedPath.maybeDeprefix("/foo/bar".getBytes(UTF_8), "", 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("foo/bar"));
 
-    result = StripPrefixedPath.maybeDeprefix("///foo/bar/baz".getBytes(UTF_8), Optional.empty(), 0);
+    result = StripPrefixedPath.maybeDeprefix("///foo/bar/baz".getBytes(UTF_8), "", 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("foo/bar/baz"));
 
-    result = StripPrefixedPath.maybeDeprefix("/foo/bar/baz".getBytes(UTF_8), Optional.of("/foo"), 0);
+    result = StripPrefixedPath.maybeDeprefix("/foo/bar/baz".getBytes(UTF_8), "/foo", 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("bar/baz"));
 
-    result = StripPrefixedPath.maybeDeprefix("/foo/bar/baz".getBytes(UTF_8), Optional.empty(), 1);
+    result = StripPrefixedPath.maybeDeprefix("/foo/bar/baz".getBytes(UTF_8), "", 1);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("bar/baz"));
   }
 
@@ -95,23 +95,23 @@ public class StripPrefixedPathTest {
       return;
     }
     StripPrefixedPath result =
-        StripPrefixedPath.maybeDeprefix("c:/foo/bar".getBytes(UTF_8), Optional.empty(), 0);
+        StripPrefixedPath.maybeDeprefix("c:/foo/bar".getBytes(UTF_8), "", 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("foo/bar"));
   }
 
   @Test
   public void testNormalize() {
     StripPrefixedPath result =
-        StripPrefixedPath.maybeDeprefix("../bar".getBytes(UTF_8), Optional.empty(), 0);
+        StripPrefixedPath.maybeDeprefix("../bar".getBytes(UTF_8), "", 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("../bar"));
 
-    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), Optional.empty(), 0);
+    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), "", 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("baz"));
 
-    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), Optional.of("foo"), 0);
+    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), "foo", 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("baz"));
 
-    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), Optional.empty(), 1);
+    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), "", 1);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.EMPTY_FRAGMENT);
   }
 
@@ -122,45 +122,45 @@ public class StripPrefixedPathTest {
 
     PathFragment relativeNoPrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "a/b".getBytes(UTF_8), Optional.empty(), 0, fileSystem.getPath("/usr"));
+            "a/b".getBytes(UTF_8), "", 0, fileSystem.getPath("/usr"));
     // there is no attempt to get absolute path for the relative symlinks target path
     assertThat(relativeNoPrefix).isEqualTo(PathFragment.create("a/b"));
 
     PathFragment absoluteNoPrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "/a/b".getBytes(UTF_8), Optional.empty(), 0, fileSystem.getPath("/usr"));
+            "/a/b".getBytes(UTF_8), "", 0, fileSystem.getPath("/usr"));
     assertThat(absoluteNoPrefix).isEqualTo(PathFragment.create("/usr/a/b"));
 
     PathFragment absolutePrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "/root/a/b".getBytes(UTF_8), Optional.of("root"), 0, fileSystem.getPath("/usr"));
+            "/root/a/b".getBytes(UTF_8), "root", 0, fileSystem.getPath("/usr"));
     assertThat(absolutePrefix).isEqualTo(PathFragment.create("/usr/a/b"));
 
     PathFragment absoluteStripComponents =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "/root/a/b".getBytes(UTF_8), Optional.empty(), 1, fileSystem.getPath("/usr"));
+            "/root/a/b".getBytes(UTF_8), "", 1, fileSystem.getPath("/usr"));
     assertThat(absoluteStripComponents).isEqualTo(PathFragment.create("/usr/a/b"));
 
     PathFragment relativePrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "root/a/b".getBytes(UTF_8), Optional.of("root"), 0, fileSystem.getPath("/usr"));
+            "root/a/b".getBytes(UTF_8), "root", 0, fileSystem.getPath("/usr"));
     // Only absolute paths or paths relative to extraction root are deprefixed.
     assertThat(relativePrefix).isEqualTo(PathFragment.create("root/a/b"));
 
     PathFragment relativeStripComponents =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "root/a/b".getBytes(UTF_8), Optional.empty(), 1, fileSystem.getPath("/usr"));
+            "root/a/b".getBytes(UTF_8), "", 1, fileSystem.getPath("/usr"));
     assertThat(relativeStripComponents).isEqualTo(PathFragment.create("root/a/b"));
 
     PathFragment forceDeprefixRelativePrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "root/a/b".getBytes(UTF_8), Optional.of("root"), 0, fileSystem.getPath("/usr"), true);
+            "root/a/b".getBytes(UTF_8), "root", 0, fileSystem.getPath("/usr"), true);
     // Forced deprefixing into root relative path.
     assertThat(forceDeprefixRelativePrefix).isEqualTo(PathFragment.create("/usr/a/b"));
 
     PathFragment forceDeprefixRelativeComponents =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "root/a/b".getBytes(UTF_8), Optional.empty(), 1, fileSystem.getPath("/usr"), true);
+            "root/a/b".getBytes(UTF_8), "", 1, fileSystem.getPath("/usr"), true);
     assertThat(forceDeprefixRelativeComponents).isEqualTo(PathFragment.create("/usr/a/b"));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPathTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPathTest.java
@@ -110,7 +110,13 @@ public class StripPrefixedPathTest {
     PathFragment relativePrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
             "root/a/b".getBytes(UTF_8), Optional.of("root"), fileSystem.getPath("/usr"));
-    // there is no attempt to get absolute path for the relative symlinks target path
-    assertThat(relativePrefix).isEqualTo(PathFragment.create("a/b"));
+    // Only absolute paths or paths relative to extraction root are deprefixed.
+    assertThat(relativePrefix).isEqualTo(PathFragment.create("root/a/b"));
+
+    PathFragment forceDeprefixRelativePrefix =
+        StripPrefixedPath.maybeDeprefixSymlink(
+            "root/a/b".getBytes(UTF_8), Optional.of("root"), fileSystem.getPath("/usr"), true);
+    // Forced deprefixing into root relative path.
+    assertThat(forceDeprefixRelativePrefix).isEqualTo(PathFragment.create("/usr/a/b"));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPathTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/StripPrefixedPathTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.bazel.repository.decompressor;
 
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertThrows;
 
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.util.OS;
@@ -33,33 +34,58 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class StripPrefixedPathTest {
   @Test
-  public void testStrip() {
+  public void testStripPrefix() {
     StripPrefixedPath result =
-        StripPrefixedPath.maybeDeprefix("foo/bar".getBytes(UTF_8), Optional.of("foo"));
+        StripPrefixedPath.maybeDeprefix("foo/bar".getBytes(UTF_8), Optional.of("foo"), 0);
     assertThat(PathFragment.create("bar")).isEqualTo(result.getPathFragment());
     assertThat(result.foundPrefix()).isTrue();
     assertThat(result.skip()).isFalse();
 
-    result = StripPrefixedPath.maybeDeprefix("foo".getBytes(UTF_8), Optional.of("foo"));
+    result = StripPrefixedPath.maybeDeprefix("foo".getBytes(UTF_8), Optional.of("foo"), 0);
     assertThat(result.skip()).isTrue();
 
-    result = StripPrefixedPath.maybeDeprefix("bar/baz".getBytes(UTF_8), Optional.of("foo"));
+    result = StripPrefixedPath.maybeDeprefix("bar/baz".getBytes(UTF_8), Optional.of("foo"), 0);
     assertThat(result.foundPrefix()).isFalse();
 
-    result = StripPrefixedPath.maybeDeprefix("foof/bar".getBytes(UTF_8), Optional.of("foo"));
+    result = StripPrefixedPath.maybeDeprefix("foof/bar".getBytes(UTF_8), Optional.of("foo"), 0);
     assertThat(result.foundPrefix()).isFalse();
+  }
+
+  @Test
+  public void stripComponents() {
+    StripPrefixedPath result =
+        StripPrefixedPath.maybeDeprefix("foo/bar".getBytes(UTF_8), Optional.empty(), 1);
+    assertThat(PathFragment.create("bar")).isEqualTo(result.getPathFragment());
+    assertThat(result.foundPrefix()).isFalse();
+    assertThat(result.skip()).isFalse();
+
+    result = StripPrefixedPath.maybeDeprefix("foo".getBytes(UTF_8), Optional.empty(), 1);
+    assertThat(result.foundPrefix()).isFalse();
+    assertThat(result.skip()).isTrue();
+  }
+
+  @Test
+  public void stripPrefixAndComponents() {
+    IllegalArgumentException e = assertThrows(
+        IllegalArgumentException.class,
+        () -> StripPrefixedPath.maybeDeprefix("foo/bar".getBytes(UTF_8), Optional.of("foo"), 1));
+
+    assertThat(e).hasMessageThat().contains("Only one of prefix or strip_components can be set.");
   }
 
   @Test
   public void testAbsolute() {
     StripPrefixedPath result =
-        StripPrefixedPath.maybeDeprefix("/foo/bar".getBytes(UTF_8), Optional.empty());
+        StripPrefixedPath.maybeDeprefix("/foo/bar".getBytes(UTF_8), Optional.empty(), 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("foo/bar"));
 
-    result = StripPrefixedPath.maybeDeprefix("///foo/bar/baz".getBytes(UTF_8), Optional.empty());
+    result = StripPrefixedPath.maybeDeprefix("///foo/bar/baz".getBytes(UTF_8), Optional.empty(), 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("foo/bar/baz"));
 
-    result = StripPrefixedPath.maybeDeprefix("/foo/bar/baz".getBytes(UTF_8), Optional.of("/foo"));
+    result = StripPrefixedPath.maybeDeprefix("/foo/bar/baz".getBytes(UTF_8), Optional.of("/foo"), 0);
+    assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("bar/baz"));
+
+    result = StripPrefixedPath.maybeDeprefix("/foo/bar/baz".getBytes(UTF_8), Optional.empty(), 1);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("bar/baz"));
   }
 
@@ -69,21 +95,24 @@ public class StripPrefixedPathTest {
       return;
     }
     StripPrefixedPath result =
-        StripPrefixedPath.maybeDeprefix("c:/foo/bar".getBytes(UTF_8), Optional.empty());
+        StripPrefixedPath.maybeDeprefix("c:/foo/bar".getBytes(UTF_8), Optional.empty(), 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("foo/bar"));
   }
 
   @Test
   public void testNormalize() {
     StripPrefixedPath result =
-        StripPrefixedPath.maybeDeprefix("../bar".getBytes(UTF_8), Optional.empty());
+        StripPrefixedPath.maybeDeprefix("../bar".getBytes(UTF_8), Optional.empty(), 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("../bar"));
 
-    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), Optional.empty());
+    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), Optional.empty(), 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("baz"));
 
-    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), Optional.of("foo"));
+    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), Optional.of("foo"), 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("baz"));
+
+    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), Optional.empty(), 1);
+    assertThat(result.getPathFragment()).isEqualTo(PathFragment.EMPTY_FRAGMENT);
   }
 
   @Test
@@ -93,30 +122,45 @@ public class StripPrefixedPathTest {
 
     PathFragment relativeNoPrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "a/b".getBytes(UTF_8), Optional.empty(), fileSystem.getPath("/usr"));
+            "a/b".getBytes(UTF_8), Optional.empty(), 0, fileSystem.getPath("/usr"));
     // there is no attempt to get absolute path for the relative symlinks target path
     assertThat(relativeNoPrefix).isEqualTo(PathFragment.create("a/b"));
 
     PathFragment absoluteNoPrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "/a/b".getBytes(UTF_8), Optional.empty(), fileSystem.getPath("/usr"));
+            "/a/b".getBytes(UTF_8), Optional.empty(), 0, fileSystem.getPath("/usr"));
     assertThat(absoluteNoPrefix).isEqualTo(PathFragment.create("/usr/a/b"));
 
     PathFragment absolutePrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "/root/a/b".getBytes(UTF_8), Optional.of("root"), fileSystem.getPath("/usr"));
+            "/root/a/b".getBytes(UTF_8), Optional.of("root"), 0, fileSystem.getPath("/usr"));
     assertThat(absolutePrefix).isEqualTo(PathFragment.create("/usr/a/b"));
+
+    PathFragment absoluteStripComponents =
+        StripPrefixedPath.maybeDeprefixSymlink(
+            "/root/a/b".getBytes(UTF_8), Optional.empty(), 1, fileSystem.getPath("/usr"));
+    assertThat(absoluteStripComponents).isEqualTo(PathFragment.create("/usr/a/b"));
 
     PathFragment relativePrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "root/a/b".getBytes(UTF_8), Optional.of("root"), fileSystem.getPath("/usr"));
+            "root/a/b".getBytes(UTF_8), Optional.of("root"), 0, fileSystem.getPath("/usr"));
     // Only absolute paths or paths relative to extraction root are deprefixed.
     assertThat(relativePrefix).isEqualTo(PathFragment.create("root/a/b"));
 
+    PathFragment relativeStripComponents =
+        StripPrefixedPath.maybeDeprefixSymlink(
+            "root/a/b".getBytes(UTF_8), Optional.empty(), 1, fileSystem.getPath("/usr"));
+    assertThat(relativeStripComponents).isEqualTo(PathFragment.create("root/a/b"));
+
     PathFragment forceDeprefixRelativePrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "root/a/b".getBytes(UTF_8), Optional.of("root"), fileSystem.getPath("/usr"), true);
+            "root/a/b".getBytes(UTF_8), Optional.of("root"), 0, fileSystem.getPath("/usr"), true);
     // Forced deprefixing into root relative path.
     assertThat(forceDeprefixRelativePrefix).isEqualTo(PathFragment.create("/usr/a/b"));
+
+    PathFragment forceDeprefixRelativeComponents =
+        StripPrefixedPath.maybeDeprefixSymlink(
+            "root/a/b".getBytes(UTF_8), Optional.empty(), 1, fileSystem.getPath("/usr"), true);
+    assertThat(forceDeprefixRelativeComponents).isEqualTo(PathFragment.create("/usr/a/b"));
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
See #29999 which describes a case where using `strip_components` does not properly handle symbolic links. This change consolidates the logic for handling `strip_components` into the `StripPrefixedPath` class which already handled `strip_prefix` logic. With the consolidation, we no longer miss the handling of symbolic and hard links.

This code builds on top of the pull request in https://github.com/bazelbuild/bazel/pull/30042 - those commits are included here.  It is recommended that you review that pull request before reviewing this pull request (so you don't have to review the same commits twice and to ensure this code is still relevant, since it builds on top of the decisions there).

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->
Fixes #29999 - the code that introduced support for `strip_components` didn't handle symbolic links correctly.
Fixes #30015

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No, this is a bug fix.

### Checklist

- [X] I have added tests for the new use cases (if any).
- [N/A] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Fixes an error when using `strip_components` with archives containing symbolic//hard links.
