### PR TITLE
fix(auth): re-apply netrc credentials on same-host HTTP redirects

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/StaticCredentials.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/StaticCredentials.java
@@ -42,7 +42,28 @@ public final class StaticCredentials extends Credentials {
   public Map<String, List<String>> getRequestMetadata(URI uri) {
     Preconditions.checkNotNull(uri);
 
-    return credentials.getOrDefault(uri, ImmutableMap.of());
+    // First try exact URI match.
+    Map<String, List<String>> result = credentials.get(uri);
+    if (result != null) {
+      return result;
+    }
+
+    // Fall back to matching by host (and port) for same-host redirects.
+    // This matches the behavior of curl --netrc and wget, which re-derive
+    // credentials from netrc per host on every redirect hop.
+    String host = uri.getHost();
+    if (host == null) {
+      return ImmutableMap.of();
+    }
+    int port = uri.getPort();
+    for (Map.Entry<URI, Map<String, List<String>>> entry : credentials.entrySet()) {
+      URI credUri = entry.getKey();
+      if (host.equals(credUri.getHost()) && port == credUri.getPort()) {
+        return entry.getValue();
+      }
+    }
+
+    return ImmutableMap.of();
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/authandtls/StaticCredentialsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/StaticCredentialsTest.java
@@ -1,0 +1,99 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.authandtls;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.net.URI;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link StaticCredentials}. */
+@RunWith(JUnit4.class)
+public class StaticCredentialsTest {
+
+  @Test
+  public void exactUriMatch() throws Exception {
+    URI uri = URI.create("https://example.com/path/to/file");
+    Map<String, ImmutableList<String>> headers =
+        ImmutableMap.of("Authorization", ImmutableList.of("Bearer token123"));
+    StaticCredentials credentials =
+        new StaticCredentials(ImmutableMap.of(uri, headers));
+
+    assertThat(credentials.getRequestMetadata(uri)).isEqualTo(headers);
+  }
+
+  @Test
+  public void sameHostDifferentPath_fallback() throws Exception {
+    URI originalUri = URI.create("https://example.com/old/path");
+    URI redirectUri = URI.create("https://example.com/new/path");
+    Map<String, ImmutableList<String>> headers =
+        ImmutableMap.of("Authorization", ImmutableList.of("Bearer token123"));
+    StaticCredentials credentials =
+        new StaticCredentials(ImmutableMap.of(originalUri, headers));
+
+    // Exact match fails, but host-based fallback should succeed.
+    assertThat(credentials.getRequestMetadata(redirectUri)).isEqualTo(headers);
+  }
+
+  @Test
+  public void sameHostDifferentPort_noFallback() throws Exception {
+    URI originalUri = URI.create("https://example.com:8080/path");
+    URI differentPortUri = URI.create("https://example.com:9090/path");
+    Map<String, ImmutableList<String>> headers =
+        ImmutableMap.of("Authorization", ImmutableList.of("Bearer token123"));
+    StaticCredentials credentials =
+        new StaticCredentials(ImmutableMap.of(originalUri, headers));
+
+    // Different port should not match.
+    assertThat(credentials.getRequestMetadata(differentPortUri)).isEmpty();
+  }
+
+  @Test
+  public void differentHost_noFallback() throws Exception {
+    URI originalUri = URI.create("https://example.com/path");
+    URI differentHostUri = URI.create("https://other.com/path");
+    Map<String, ImmutableList<String>> headers =
+        ImmutableMap.of("Authorization", ImmutableList.of("Bearer token123"));
+    StaticCredentials credentials =
+        new StaticCredentials(ImmutableMap.of(originalUri, headers));
+
+    // Different host should not match.
+    assertThat(credentials.getRequestMetadata(differentHostUri)).isEmpty();
+  }
+
+  @Test
+  public void sameHostNoPort_matchesHostWithNoPort() throws Exception {
+    URI originalUri = URI.create("https://example.com/path");
+    URI redirectUri = URI.create("https://example.com/other");
+    Map<String, ImmutableList<String>> headers =
+        ImmutableMap.of("Authorization", ImmutableList.of("Bearer token123"));
+    StaticCredentials credentials =
+        new StaticCredentials(ImmutableMap.of(originalUri, headers));
+
+    assertThat(credentials.getRequestMetadata(redirectUri)).isEqualTo(headers);
+  }
+
+  @Test
+  public void emptyCredentials_returnsEmpty() throws Exception {
+    StaticCredentials credentials = StaticCredentials.EMPTY;
+    URI uri = URI.create("https://example.com/path");
+
+    assertThat(credentials.getRequestMetadata(uri)).isEmpty();
+  }
+}


### PR DESCRIPTION
## Problem

When `http_archive`/`http_file` follows a redirect to a different path on the **same host**, Bazel drops the netrc/auth credentials. This causes 401 Unauthorized errors when downloading from servers that redirect to a canonical path.

**Example:**
- Request `GET /start` with `Authorization: Basic ...` header
- Server responds with `307 Redirect` to `/protected`
- Bazel follows redirect but sends `GET /protected` **without** credentials → 401

## Root Cause

`StaticCredentials.getRequestMetadata(uri)` performs an **exact-URI lookup** only. When the redirect target has a different path, the URI key doesn't match, so no credentials are returned.

## Fix

Add a **host-based fallback** in `StaticCredentials.getRequestMetadata()`: if no exact URI match is found, fall back to matching by host (and port). This matches the behavior of `curl --netrc` and `wget`, which re-derive credentials from netrc per host on every redirect hop.

## Testing

Added `StaticCredentialsTest` with test cases for:
- Exact URI match
- Same host, different path (fallback)
- Same host, different port (no fallback)
- Different host (no fallback)

Fixes #30013