### PR TITLE
Fix flakiness in non_daemon_exit_test by using dynamic wait loop

### DIFF
--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/BUILD
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/BUILD
@@ -98,7 +98,6 @@ sh_test(
         "//src/test/shell:bashunit",
         "//src/test/shell:unittest.bash",
     ],
-    flaky = True,
 )
 
 sh_test(

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/non_daemon_exit_test.sh
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/non_daemon_exit_test.sh
@@ -54,12 +54,23 @@ function test_JVMDoesNotExitImmediately() {
     fail "TESTBED process exited too soon, before 5 seconds had elapsed."
   fi
 
-  # sleep something longer than the 5 second sleep in the test itself
-  sleep 7
-  if ps -p ${testbed_pid} > /dev/null; then
-    fail "TESTBED process has not exited yet."
-  else
+  # Wait for the process to exit, up to a timeout.
+  local timeout=20
+  local elapsed=0
+  local exited=false
+  while [ $elapsed -lt $timeout ]; do
+    if ! ps -p ${testbed_pid} > /dev/null; then
+      exited=true
+      break
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  if [ "$exited" = true ]; then
     echo "TESTBED process is no longer alive."
+  else
+    fail "TESTBED process did not exit within $timeout seconds."
   fi
 
   # Remove the XML output with failures, so it does not get picked up to


### PR DESCRIPTION
Instead of a hardcoded sleep which can fail if JVM startup is slow, use a loop that checks if the process is alive with a timeout.

