### PR TITLE
Fix ExampleWorker to wait for active requests before exiting

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/worker/ExampleWorker.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/ExampleWorker.java
@@ -109,8 +109,17 @@ public final class ExampleWorker {
         } else {
           startResponseThread(workerIO, request);
         }
-        if (workerOptions.getExitAfter() > 0 && workUnitCounter > workerOptions.getExitAfter()) {
-          System.exit(0);
+        if (workerOptions.getExitAfter() > 0) {
+          try {
+            while (!activeRequests.isEmpty()) {
+              Thread.sleep(1);
+            }
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+          if (workUnitCounter > workerOptions.getExitAfter()) {
+            System.exit(0);
+          }
         }
       }
 


### PR DESCRIPTION
When `--exit_after` is used, the worker should not exit immediately if there are still active requests being processed. Wait for them to finish before calling `System.exit(0)`.

This is one source of flakiness in our tests.