### PR TITLE
Shut down worker pool during integration test cleanup

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerModule.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerModule.java
@@ -270,7 +270,7 @@ public class WorkerModule extends BlazeModule {
     Preconditions.checkArgument(!reason.isEmpty());
 
     if (workerPool != null) {
-      if (workerVerbose || alwaysLog) {
+      if ((workerVerbose || alwaysLog) && env != null) {
         env.getReporter().handle(Event.info(reason));
       }
       workerPool.close();
@@ -286,6 +286,14 @@ public class WorkerModule extends BlazeModule {
       this.workerFactory.setReporter(null);
     }
     WorkerMultiplexerManager.afterCommand();
+  }
+
+  @Override
+  public void blazeShutdown() {
+    shutdownPool(
+        "Blaze server shutting down, shutting down worker pool...",
+        /* alwaysLog= */ false,
+        /* workerVerbose= */ false);
   }
 
   public WorkerPoolConfig getWorkerPoolConfig() {

--- a/src/test/java/com/google/devtools/build/lib/buildtool/util/BuildIntegrationTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/util/BuildIntegrationTestCase.java
@@ -432,9 +432,9 @@ public abstract class BuildIntegrationTestCase {
   @After
   public final void cleanUp() throws Exception {
     try {
-      doCleanup();
-    } finally {
       getRuntime().getBlazeModules().forEach(BlazeModule::blazeShutdown);
+    } finally {
+      doCleanup();
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugIntegrationTest.java
@@ -51,6 +51,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import org.junit.Before;
@@ -82,20 +83,42 @@ public class StarlarkDebugIntegrationTest extends BuildIntegrationTestCase {
     addOptions("--experimental_skylark_debug_reset_analysis");
     write("foo/BUILD", "genrule(name = 'foo', outs = ['foo.out'], cmd = 'touch $@')");
 
+    AtomicReference<MockDebugClient> clientRef = new AtomicReference<>();
+
     // run async, otherwise this will just block on the result indefinitely
     CompletableFuture<BuildResult> resultCf =
         CompletableFuture.supplyAsync(
             () -> {
               try {
-                return buildTarget(StarlarkDebugIntegrationTest::createClient, "//foo");
+                return buildTarget(
+                    port -> {
+                      MockDebugClient client = createClient(port);
+                      clientRef.set(client);
+                    },
+                    "//foo");
               } catch (Exception e) {
                 throw new RuntimeException(e);
               }
             },
             Executors.newSingleThreadExecutor());
 
-    TimeoutException unusedError =
-        assertThrows(TimeoutException.class, () -> resultCf.get(10, SECONDS));
+    try {
+      assertThrows(TimeoutException.class, () -> resultCf.get(10, SECONDS));
+    } finally {
+      MockDebugClient client = clientRef.get();
+      if (client != null) {
+        try {
+          client.close();
+        } catch (IOException e) {
+          // ignore
+        }
+      }
+      try {
+        resultCf.get(5, SECONDS);
+      } catch (Exception e) {
+        // ignore failure, we just want to ensure the thread finished
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
This implements blazeShutdown in WorkerModule and updates BuildIntegrationTestCase to call blazeShutdown on all modules before running doCleanup(). This ensures that worker processes are killed before their log directories (which are in the tmp/workspace directories being cleaned up) are deleted, avoiding resource leaks and IOExceptions in workers.
