### PR TITLE
Fix race condition in worker death detection

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
@@ -181,10 +181,6 @@ public class WorkerFactory {
   }
 
   public boolean validateWorker(WorkerKey key, Worker worker) {
-    // Status is invalid if the status is either killed or pending killed.
-    if (!worker.getStatus().isValid()) {
-      return false;
-    }
     Optional<Integer> exitValue = worker.getExitValue();
     if (exitValue.isPresent()) {
       // At this point, the worker factory has no idea what caused the process to be killed - so we
@@ -204,6 +200,10 @@ public class WorkerFactory {
         WorkerLoggingHelper.logMessage(
             reporter, WorkerLoggingHelper.LogLevel.WARNING, errorMessage.toString());
       }
+      return false;
+    }
+    // Status is invalid if the status is either killed or pending killed.
+    if (!worker.getStatus().isValid()) {
       return false;
     }
     boolean filesChanged =

--- a/src/test/shell/integration/bazel_worker_test.sh
+++ b/src/test/shell/integration/bazel_worker_test.sh
@@ -393,7 +393,7 @@ EOF
 }
 
 # Disabled for being flaky, see b/182373389
-function DISABLED_test_build_succeeds_even_if_worker_exits() {
+function test_build_succeeds_even_if_worker_exits() {
   prepare_example_worker
   cat >>BUILD <<EOF
 [work(
@@ -407,11 +407,21 @@ EOF
   bazel build --worker_verbose :hello_world_1 &> "$TEST_log" \
     || fail "build failed"
 
+  # Wait for worker process to fully exit.
+  local count=0
+  while pgrep -f "ExampleWorker.*${OUTPUT_BASE}" > /dev/null; do
+    if [ $count -gt 100 ]; then
+      fail "Worker did not exit in time"
+    fi
+    sleep 0.1
+    count=$((count + 1))
+  done
+
   # This time, the worker is dead before the build starts, so a new one is made.
-  bazel build --worker_verbose :hello_world_2 &> "$TEST_log" \
+  bazel build --worker_verbose :hello_world_2 &>> "$TEST_log" \
     || fail "build failed"
 
-  expect_log "Work worker (id [0-9]\+, key hash -\?[0-9]\+) has unexpectedly died with exit code 0."
+  expect_log "Work worker (id [0-9]\+) has unexpectedly died with exit code 0."
 }
 
 function test_build_fails_if_worker_dies_during_action() {


### PR DESCRIPTION
When a worker exits voluntarily (e.g. due to exit-after-build or limit reached), the background metrics collector (profiler) might detect its death before the build thread does during validation. This transitions the worker status to KILLED_UNKNOWN.

When the build thread later validates the worker, it saw the invalid status and returned early, skipping the exit value check and thus failing to log the "unexpectedly died" warning.

This CL swaps the checks in WorkerFactory.validateWorker so that we always check if the process has exited first, ensuring we log the warning even if the status was already updated by the background collector.

Also, re-enable the test_build_succeeds_even_if_worker_exits test with a dynamic wait loop to ensure the worker has exited.
