### PR TITLE
remote: rewind missing tree uploads

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -2039,7 +2039,12 @@ public class RemoteExecutionService {
   @Subscribe
   public void onLostInputs(LostInputsEvent event) {
     for (String digest : event.missingDigests()) {
-      knownMissingCasDigests.add(DigestUtil.fromString(digest));
+      try {
+        knownMissingCasDigests.add(DigestUtil.fromString(digest));
+      } catch (IllegalArgumentException ignored) {
+        // Some non-remote tests use synthetic lost-input digests. Only valid REAPI digests can
+        // participate in stale ActionResult suppression.
+      }
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/BUILD
@@ -29,6 +29,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote:scrubber",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
         "//src/main/java/com/google/devtools/build/lib/remote/common:bulk_transfer_exception",
+        "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/util:digest_util",
         "//src/main/java/com/google/devtools/build/lib/remote/util:tracing_metadata_utils",
         "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
@@ -39,6 +39,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
@@ -69,6 +70,7 @@ import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.remote.Scrubber;
 import com.google.devtools.build.lib.remote.Scrubber.SpawnScrubber;
 import com.google.devtools.build.lib.remote.common.BulkTransferException;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext.CachePolicy;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
@@ -87,6 +89,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -349,9 +352,65 @@ public final class MerkleTreeComputer {
               remotePathResolver,
               blobPolicy));
     } catch (BulkTransferException e) {
-      e.getLostArtifacts(spawnExecutionContext.getInputMetadataProvider()::getInput)
-          .throwIfNotEmpty();
+      var inputMetadataProvider = spawnExecutionContext.getInputMetadataProvider();
+      e.getLostArtifacts(inputMetadataProvider::getInput).throwIfNotEmpty();
+      throwLostInputsByDigestIfNotEmpty(e, allInputs, inputMetadataProvider);
       throw e;
+    }
+  }
+
+  private static void throwLostInputsByDigestIfNotEmpty(
+      BulkTransferException e,
+      Collection<? extends ActionInput> inputs,
+      InputMetadataProvider metadataProvider)
+      throws IOException, LostInputsExecException {
+    if (!e.allCausedByCacheNotFoundException()) {
+      return;
+    }
+
+    var missingDigests = new HashSet<String>();
+    for (var suppressed : e.getSuppressed()) {
+      var cacheNotFoundException = (CacheNotFoundException) suppressed;
+      missingDigests.add(DigestUtil.toString(cacheNotFoundException.getMissingDigest()));
+    }
+
+    var byDigestBuilder = ImmutableSetMultimap.<String, ActionInput>builder();
+    for (ActionInput input : inputs) {
+      if (input instanceof Artifact.SpecialArtifact specialArtifact
+          && specialArtifact.isTreeArtifact()) {
+        var treeArtifactValue = metadataProvider.getTreeMetadata(specialArtifact);
+        if (treeArtifactValue != null) {
+          for (var childEntry : treeArtifactValue.getChildValues().entrySet()) {
+            addLostInputIfMissing(
+                childEntry.getKey(), childEntry.getValue(), missingDigests, byDigestBuilder);
+          }
+        }
+        continue;
+      }
+
+      var metadata = metadataProvider.getInputMetadata(input);
+      if (metadata != null) {
+        addLostInputIfMissing(input, metadata, missingDigests, byDigestBuilder);
+      }
+    }
+    var lostInputs = byDigestBuilder.build();
+    if (!lostInputs.isEmpty()) {
+      throw new LostInputsExecException(lostInputs, e);
+    }
+  }
+
+  private static void addLostInputIfMissing(
+      ActionInput input,
+      FileArtifactValue metadata,
+      Set<String> missingDigests,
+      ImmutableSetMultimap.Builder<String, ActionInput> byDigestBuilder) {
+    if (!metadata.getType().isFile() || metadata.getDigest() == null) {
+      return;
+    }
+    var digest =
+        DigestUtil.toString(DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize()));
+    if (missingDigests.contains(digest)) {
+      byDigestBuilder.put(digest, input);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/rewinding/ActionRewindStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/rewinding/ActionRewindStrategy.java
@@ -293,6 +293,9 @@ public final class ActionRewindStrategy {
       ExtendedEventHandler listener)
       throws ActionRewindException {
     if (skyframeActionExecutor.rewindingEnabled()) {
+      // Inform remote caching that these digests are missing before rewinding their producers. This
+      // avoids accepting stale ActionResults that still reference the missing CAS objects.
+      listener.post(new LostInputsEvent(lostArtifacts.keySet()));
       return;
     }
     if (skyframeActionExecutor.invocationRetriesEnabled()) {

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/BUILD
@@ -28,6 +28,8 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/actions:virtual_action_input",
         "//src/main/java/com/google/devtools/build/lib/clock",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/remote/common:bulk_transfer_exception",
+        "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/merkletree",
         "//src/main/java/com/google/devtools/build/lib/remote/util:digest_util",
         "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputerTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.remote.merkletree;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static org.junit.Assert.assertThrows;
 
 import build.bazel.remote.execution.v2.Digest;
 import com.google.common.collect.ImmutableClassToInstanceMap;
@@ -38,6 +39,8 @@ import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.exec.util.FakeActionInputFileCache;
 import com.google.devtools.build.lib.exec.util.SpawnBuilder;
+import com.google.devtools.build.lib.remote.common.BulkTransferException;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
@@ -375,6 +378,41 @@ public class MerkleTreeComputerTest {
     assertThat(ensureInputsPresentCount.get()).isEqualTo(1);
   }
 
+  @Test
+  public void buildForSpawn_missingUploadedTreeFile_rethrowsBulkTransferException()
+      throws Exception {
+    var fakeFileCache = new FakeActionInputFileCache();
+    var treeArtifactInput =
+        ActionsTestUtil.createTreeArtifactWithGeneratingAction(artifactRoot, "dir/tree_artifact");
+    treeArtifactInput.getPath().createDirectoryAndParents();
+    var treeFileArtifact = Artifact.TreeFileArtifact.createTreeOutput(treeArtifactInput, "file");
+    FileSystemUtils.writeContentAsLatin1(treeFileArtifact.getPath(), "file content");
+    var treeFileMetadata = FileArtifactValue.createForTesting(treeFileArtifact);
+    var treeArtifactBuilder = TreeArtifactValue.newBuilder(treeArtifactInput);
+    treeArtifactBuilder.putChild(treeFileArtifact, treeFileMetadata);
+    fakeFileCache.putTreeArtifact(treeArtifactInput, treeArtifactBuilder.build());
+
+    var missingDigest =
+        DigestUtil.buildDigest(treeFileMetadata.getDigest(), treeFileMetadata.getSize());
+    var bulkTransferException = new BulkTransferException();
+    bulkTransferException.add(
+        new CacheNotFoundException(missingDigest, treeFileArtifact.getExecPathString()));
+    var spawn = new SpawnBuilder().withInputs(treeArtifactInput).build();
+    var merkleTreeComputer =
+        createMerkleTreeComputer(createUploaderThrowingOnEnsureInputsPresent(bulkTransferException));
+
+    assertThrows(
+        BulkTransferException.class,
+        () ->
+            merkleTreeComputer.buildForSpawn(
+                spawn,
+                ImmutableSet.of(),
+                /* scrubber= */ null,
+                createSpawnExecutionContext(spawn, fakeFileCache),
+                RemotePathResolver.createDefault(execRoot),
+                MerkleTreeComputer.BlobPolicy.KEEP_AND_REUPLOAD));
+  }
+
   private MerkleTreeComputer createMerkleTreeComputer(MerkleTreeUploader uploader) {
     return new MerkleTreeComputer(
         new DigestUtil(SyscallCache.NO_CACHE, DigestHashFunction.SHA256),
@@ -393,5 +431,45 @@ public class MerkleTreeComputerTest {
         new FileOutErr(),
         ImmutableClassToInstanceMap.of(),
         /* actionFileSystem= */ null);
+  }
+
+  private static MerkleTreeUploader createUploaderThrowingOnEnsureInputsPresent(
+      IOException exception) {
+    return new MerkleTreeUploader() {
+      @Override
+      public ListenableFuture<Void> uploadBlob(
+          RemoteActionExecutionContext context, Digest digest, byte[] data, boolean force) {
+        return immediateVoidFuture();
+      }
+
+      @Override
+      public ListenableFuture<Void> uploadFile(
+          RemoteActionExecutionContext context,
+          RemotePathResolver remotePathResolver,
+          Digest digest,
+          Path path,
+          boolean force) {
+        return immediateVoidFuture();
+      }
+
+      @Override
+      public ListenableFuture<Void> uploadVirtualActionInput(
+          RemoteActionExecutionContext context,
+          Digest digest,
+          VirtualActionInput virtualActionInput,
+          boolean force) {
+        return immediateVoidFuture();
+      }
+
+      @Override
+      public void ensureInputsPresent(
+          RemoteActionExecutionContext context,
+          MerkleTree.Uploadable merkleTree,
+          boolean force,
+          RemotePathResolver remotePathResolver)
+          throws IOException {
+        throw exception;
+      }
+    };
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputerTest.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.actions.DelegatingPairInputMetadataProvider
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FilesetOutputTree;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
+import com.google.devtools.build.lib.actions.LostInputsExecException;
 import com.google.devtools.build.lib.actions.RunfilesArtifactValue;
 import com.google.devtools.build.lib.actions.RunfilesTree;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -379,7 +380,7 @@ public class MerkleTreeComputerTest {
   }
 
   @Test
-  public void buildForSpawn_missingUploadedTreeFile_rethrowsBulkTransferException()
+  public void buildForSpawn_missingUploadedTreeFile_reportedAsLostInputByDigest()
       throws Exception {
     var fakeFileCache = new FakeActionInputFileCache();
     var treeArtifactInput =
@@ -394,6 +395,7 @@ public class MerkleTreeComputerTest {
 
     var missingDigest =
         DigestUtil.buildDigest(treeFileMetadata.getDigest(), treeFileMetadata.getSize());
+    var digestString = DigestUtil.toString(missingDigest);
     var bulkTransferException = new BulkTransferException();
     bulkTransferException.add(
         new CacheNotFoundException(missingDigest, treeFileArtifact.getExecPathString()));
@@ -401,16 +403,19 @@ public class MerkleTreeComputerTest {
     var merkleTreeComputer =
         createMerkleTreeComputer(createUploaderThrowingOnEnsureInputsPresent(bulkTransferException));
 
-    assertThrows(
-        BulkTransferException.class,
-        () ->
-            merkleTreeComputer.buildForSpawn(
-                spawn,
-                ImmutableSet.of(),
-                /* scrubber= */ null,
-                createSpawnExecutionContext(spawn, fakeFileCache),
-                RemotePathResolver.createDefault(execRoot),
-                MerkleTreeComputer.BlobPolicy.KEEP_AND_REUPLOAD));
+    var exception =
+        assertThrows(
+            LostInputsExecException.class,
+            () ->
+                merkleTreeComputer.buildForSpawn(
+                    spawn,
+                    ImmutableSet.of(),
+                    /* scrubber= */ null,
+                    createSpawnExecutionContext(spawn, fakeFileCache),
+                    RemotePathResolver.createDefault(execRoot),
+                    MerkleTreeComputer.BlobPolicy.KEEP_AND_REUPLOAD));
+
+    assertThat(exception.getLostInputs().get(digestString)).containsExactly(treeFileArtifact);
   }
 
   private MerkleTreeComputer createMerkleTreeComputer(MerkleTreeUploader uploader) {


### PR DESCRIPTION
Remote execution can fail while preparing inputs when a tree-artifact child that was previously considered uploaded is missing from the remote CAS. In #30065 this surfaced as an unrecoverable bulk-transfer IOException instead of action rewinding.

This PR keeps the change split into two commits:

- `remote: expose tree upload cache misses` adds a focused MerkleTreeComputer regression test for a filename-only `CacheNotFoundException` during subtree upload.
- `remote: rewind missing tree uploads` maps filename-only missing tree children back to spawn inputs by digest, posts `LostInputsEvent` while rewinding so stale producer `ActionResult`s are invalidated, and ignores synthetic non-REAPI test digests in that invalidation path.

Refs #30065.
