### PR TITLE
[8.8.0] Remove the client gRPC message size limit

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -87,6 +87,10 @@ public final class GoogleAuthUtils {
       NettyChannelBuilder builder =
           newNettyChannelBuilder(targetUrl, proxy)
               .executor(executor)
+              // The server is trusted, so the default limit of 4 MiB on inbound messages only
+              // breaks legitimately large messages such as the ActionResult of an action with
+              // many output files (https://github.com/bazelbuild/bazel/issues/29821).
+              .maxInboundMessageSize(Integer.MAX_VALUE)
               .negotiationType(
                   isTlsEnabled(target) ? NegotiationType.TLS : NegotiationType.PLAINTEXT);
       if (options.grpcKeepaliveTime != null) {

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -697,6 +697,44 @@ EOF
       || fail "Remote execution generated different result"
 }
 
+# Tests an action with so many output files that the serialized ActionResult
+# proto exceeds the default gRPC maximum message size of 4 MiB.
+# Regression test for https://github.com/bazelbuild/bazel/issues/29821.
+function test_action_result_exceeding_grpc_max_message_size() {
+  mkdir -p a
+  # 15000 outputs with ~290 character paths serialize to an ActionResult of
+  # more than 5 MB.
+  cat > a/BUILD <<'EOF'
+DIR = "x" * 250
+
+N = 15000
+
+genrule(
+    name = "many_outputs",
+    outs = ["%s/%s.txt" % (DIR, i) for i in range(N)],
+    cmd = ("mkdir -p $(RULEDIR)/{dir} && cd $(RULEDIR)/{dir} && " +
+           "seq 0 {max} | sed 's/$$/.txt/' | xargs touch").format(
+        dir = DIR,
+        max = N - 1,
+    ),
+)
+EOF
+
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      //a:many_outputs >& $TEST_log \
+      || fail "Failed to build //a:many_outputs with remote execution"
+
+  # Also exercise the remote cache hit path, which fetches the same
+  # ActionResult via GetActionResult.
+  bazel clean >& $TEST_log
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      //a:many_outputs >& $TEST_log \
+      || fail "Failed to build //a:many_outputs from the remote cache"
+  expect_log "1 remote cache hit"
+}
+
 function test_py_test() {
   mkdir -p a
   cat > a/BUILD <<EOF

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
@@ -216,6 +216,9 @@ public final class RemoteWorker {
 
     NettyServerBuilder b =
         NettyServerBuilder.forPort(workerOptions.listenPort)
+            // Support large messages such as the ActionResult of an action with many
+            // output files (https://github.com/bazelbuild/bazel/issues/29821).
+            .maxInboundMessageSize(Integer.MAX_VALUE)
             .addService(ServerInterceptors.intercept(actionCacheServer, interceptors))
             .addService(ServerInterceptors.intercept(bsServer, interceptors))
             .addService(ServerInterceptors.intercept(casServer, interceptors))


### PR DESCRIPTION
…ild/bazel/pull/29823)

Actions can have large `ActionResult`s due to their number of output files. Since the remote server is trusted anyway and the max message size is not a sizing hint, there is no point in limiting it.

Fixes #29821

No

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES: Bazel no longer limits the size of gRPC messages received from the remote executor or cache.

Closes #29823.

PiperOrigin-RevId: 933723049
Change-Id: I97ca2177fc6e8c3edc179257449e7892a7932929

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/5b92d9b186e9b3b6f6161ec26bacb3d08ceabd0c