### PR TITLE
[8.8.0] Clear in-memory repos in commands without a remote cache (https://git…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -26,6 +26,7 @@ import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.Tree;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher;
@@ -168,23 +169,33 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
                     || reposWithLostFiles.contains(repoName)
                 ? repoName
                 : null,
-        repoName -> {
-          try {
-            externalFs.getPath(externalDirectory.getChild(repoName)).deleteTree();
-          } catch (IOException e) {
-            throw new IllegalStateException("In-memory file system is not expected to throw", e);
-          }
-          materializations.remove(repoName);
-          markerFileContents.remove(repoName);
-        });
-    if (!reposWithLostFiles.isEmpty()) {
-      evaluator.delete(
-          k ->
-              k.functionName().equals(SkyFunctions.REPOSITORY_DIRECTORY)
-                  && reposWithLostFiles.contains(((RepositoryName) k.argument()).getName()));
-    }
+        this::evictInMemoryRepo);
+    invalidateRepoDirectories(evaluator, reposWithLostFiles);
     reposWithLostFiles.clear();
     this.evaluator = null;
+  }
+
+  /** Removes the contents of the given repo from the in-memory overlay file system. */
+  private void evictInMemoryRepo(String repoName) {
+    try {
+      externalFs.deleteTree(externalDirectory.getChild(repoName));
+    } catch (IOException e) {
+      throw new IllegalStateException("In-memory file system is not expected to throw", e);
+    }
+    materializations.remove(repoName);
+    markerFileContents.remove(repoName);
+  }
+
+  /** Invalidates the {@link SkyFunctions#REPOSITORY_DIRECTORY} nodes of the given repos. */
+  private static void invalidateRepoDirectories(
+      MemoizingEvaluator evaluator, Set<String> repoNames) {
+    if (repoNames.isEmpty()) {
+      return;
+    }
+    evaluator.delete(
+        k ->
+            k.functionName().equals(SkyFunctions.REPOSITORY_DIRECTORY)
+                && repoNames.contains(((RepositoryName) k.argument()).getName()));
   }
 
   /**
@@ -339,6 +350,18 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
                 actionInput -> externalFs.getMetadata(actionInput.getExecPath()),
                 ActionInputPrefetcher.Priority.CRITICAL,
                 ActionInputPrefetcher.Reason.INPUTS));
+  }
+
+  /**
+   * Informs the FS that no cache is available and in-memory repos can no longer be used.
+   *
+   * <p>Must not be called while accessing external repos.
+   */
+  public void notifyNoCacheAvailable(MemoizingEvaluator evaluator) {
+    checkState(materializationExecutor == null, "must not be called when active");
+    var reposToDiscard = ImmutableSet.copyOf(markerFileContents.keySet());
+    reposToDiscard.forEach(this::evictInMemoryRepo);
+    invalidateRepoDirectories(evaluator, reposToDiscard);
   }
 
   private record WalkResult(

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -347,10 +347,24 @@ public final class RemoteModule extends BlazeModule {
       knownMissingCasDigests.clear();
     }
 
+    var cacheAvailable = setup(env);
+    if (!cacheAvailable) {
+      if (env.getDirectories().getOutputBase().getFileSystem()
+          instanceof RemoteExternalOverlayFileSystem remoteFs) {
+        remoteFs.notifyNoCacheAvailable(env.getSkyframeExecutor().getEvaluator());
+      }
+    }
+  }
+
+  /**
+   * Sets up all requested remote functionality (caching, execution, downloader, ...) and returns
+   * whether any cache (disk or remote) is enabled.
+   */
+  private boolean setup(CommandEnvironment env) throws AbruptExitException {
     RemoteOptions remoteOptions = env.getOptions().getOptions(RemoteOptions.class);
     if (remoteOptions == null) {
       // Quit if no supported command is being used. See getCommandOptions for details.
-      return;
+      return false;
     }
 
     this.remoteOptions = remoteOptions;
@@ -416,7 +430,7 @@ public final class RemoteModule extends BlazeModule {
       actionContextProvider =
           RemoteActionContextProvider.createForPlaceholder(
               env, retryScheduler, digestUtil, knownMissingCasDigests);
-      return;
+      return false;
     }
 
     if (enableHttpCache && enableRemoteExecution) {
@@ -511,7 +525,7 @@ public final class RemoteModule extends BlazeModule {
               remoteOptions);
     } catch (IOException e) {
       handleInitFailure(env, e, Code.CREDENTIALS_INIT_FAILURE);
-      return;
+      return false;
     }
 
     int maxConcurrencyPerConnection = 0;
@@ -571,7 +585,7 @@ public final class RemoteModule extends BlazeModule {
 
     if ((enableHttpCache || enableDiskCache) && !enableGrpcCache) {
       initHttpAndDiskCache(env, credentials, authAndTlsOptions, remoteOptions, digestUtil);
-      return;
+      return true;
     }
 
     ClientInterceptor loggingInterceptor = null;
@@ -582,7 +596,7 @@ public final class RemoteModule extends BlazeModule {
                 env.getWorkingDirectory().getRelative(remoteOptions.remoteGrpcLog));
       } catch (IOException e) {
         handleInitFailure(env, e, Code.RPC_LOG_FAILURE);
-        return;
+        return false;
       }
       loggingInterceptor = new LoggingInterceptor(rpcLogFile, env.getRuntime().getClock());
     }
@@ -691,7 +705,7 @@ public final class RemoteModule extends BlazeModule {
                   remoteOptions.remoteVerifyDownloads);
         } catch (Exception e) {
           handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
-          return;
+          return false;
         }
       }
 
@@ -741,7 +755,7 @@ public final class RemoteModule extends BlazeModule {
                   remoteOptions.remoteVerifyDownloads);
         } catch (Exception e) {
           handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
-          return;
+          return false;
         }
       }
 
@@ -836,6 +850,8 @@ public final class RemoteModule extends BlazeModule {
       downloaderChannel.release();
       env.getDownloaderDelegate().setDelegate(remoteDownloader);
     }
+
+    return true;
   }
 
   private static ReferenceCountedChannel createChannel(

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -433,6 +433,121 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     self.assertTrue(os.path.exists(os.path.join(repo_dir, 'BUILD')))
     self.assertTrue(os.path.exists(os.path.join(other_repo_dir, 'BUILD')))
 
+  def testAccessFromOtherRepo_withoutRemoteCache(self):
+    # Regression test for a crash when a command that doesn't configure a remote
+    # cache accesses a repo that a previous cached build injected into the
+    # in-memory overlay file system but didn't materialize to disk: the
+    # in-memory contents can't be served, so such repos must be re-fetched
+    # from scratch.
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo")',
+            'other_repo = use_repo_rule("//:other_repo.bzl", "other_repo")',
+            'other_repo(name = "other", build_file = "@my_repo//:BUILD")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            '  rctx.file("BUILD", "filegroup(name=\'haha\')")',
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(_repo_impl)',
+        ],
+    )
+    self.ScratchFile(
+        'other_repo.bzl',
+        [
+            'def _other_repo_impl(rctx):',
+            '  rctx.file("BUILD", rctx.read(rctx.path(rctx.attr.build_file)))',
+            '  return rctx.repo_metadata()',
+            (
+                'other_repo = repository_rule(_other_repo_impl,'
+                ' attrs={"build_file": attr.label()})'
+            ),
+        ],
+    )
+
+    repo_dir = self.RepoDir('my_repo')
+
+    # Populate the cache: my_repo is materialized as a side effect of fetching
+    # other, which reads my_repo's BUILD file.
+    self.RunBazel(['build', '@other//:haha'])
+
+    # After expunging, fetch my_repo only: it is injected from the cache but not
+    # materialized to disk and kept in memory for subsequent commands.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertFalse(os.path.exists(os.path.join(repo_dir, 'BUILD')))
+
+    # Access my_repo from a command without a remote cache (same server). Its
+    # in-memory contents can't be served, so it must be re-fetched from scratch.
+    _, _, stderr = self.RunBazel(['build', '@other//:haha', '--remote_cache='])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertTrue(os.path.exists(os.path.join(repo_dir, 'BUILD')))
+
+  def testActionInput_withoutRemoteCache(self):
+    # Like testAccessFromOtherRepo_withoutRemoteCache, but the in-memory repo is
+    # accessed as a source file consumed by an action (which goes through the
+    # file system's getInputStream) rather than via ctx.path()/materialization.
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo")',
+        ],
+    )
+    self.ScratchFile(
+        'BUILD.bazel',
+        [
+            'genrule(',
+            '    name = "gen",',
+            '    srcs = ["@my_repo//:data.txt"],',
+            '    outs = ["out.txt"],',
+            '    cmd = "cp $< $@",',
+            ')',
+        ],
+    )
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            '  rctx.file("data.txt", "from my_repo")',
+            (
+                '  rctx.file("BUILD", "exports_files([\'data.txt\'])\\n'
+                "filegroup(name='haha')\")"
+            ),
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(_repo_impl)',
+        ],
+    )
+
+    repo_dir = self.RepoDir('my_repo')
+
+    # Populate the cache by building the genrule, which reads my_repo's
+    # data.txt.
+    self.RunBazel(['build', '//:gen'])
+
+    # After expunging, fetch my_repo without reading data.txt: it is injected
+    # from the cache but not materialized to disk and kept in memory.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertFalse(os.path.exists(os.path.join(repo_dir, 'data.txt')))
+
+    # Build the genrule from a command without a remote cache (same server). The
+    # action input lives only in memory and can't be served, so my_repo must be
+    # re-fetched from scratch.
+    _, _, stderr = self.RunBazel(['build', '//:gen', '--remote_cache='])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertTrue(os.path.exists(os.path.join(repo_dir, 'data.txt')))
+
   def testAccessFromOtherRepo_symlink(self):
     self.ScratchFile(
         'MODULE.bazel',


### PR DESCRIPTION
…hub.com/bazelbuild/bazel/pull/30045)

`RemoteExternalOverlayFileSystem` now drops all in-memory repo state when running a command without a cache configured.

Fixes a crash in the remote repo contents cache (`--experimental_remote_repo_contents_cache`) when a repo injected by a cachedbuild is accessed by a later command that runs without a remote cache:

```
java.lang.RuntimeException: Unrecoverable error while evaluating node 'SINGLE_EXTENSION_EVAL:@@gazelle+//:extensions.bzl%go_deps' (requested by nodes 'SINGLE_EXTENSION:@@gazelle+//:extensions.bzl%go_deps')
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:552)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:435)
	at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: net.starlark.java.eval.Starlark$UncheckedEvalException: NullPointerException thrown during Starlark evaluation (module extension @@gazelle+//:extensions.bzl%go_deps)
	at <starlark>.path(<builtin>:0)
	at <starlark>.deps_from_go_mod(/root/.cache/bazel/_bazel_root/f3c1d9cbc2a31229f3cc0e3922038c0e/external/gazelle+/internal/bzlmod/go_mod.bzl:179)
	at <starlark>._go_deps_impl(/root/.cache/bazel/_bazel_root/f3c1d9cbc2a31229f3cc0e3922038c0e/external/gazelle+/internal/bzlmod/go_deps.bzl:448)
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.concurrent.ExecutorService.submit(java.util.concurrent.Callable)" because "this.materializationExecutor" is null
	at com.google.devtools.build.lib.remote.RemoteExternalOverlayFileSystem.lambda$ensureMaterialized$0(RemoteExternalOverlayFileSystem.java:301)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(Unknown Source)
	at com.google.devtools.build.lib.remote.RemoteExternalOverlayFileSystem.ensureMaterialized(RemoteExternalOverlayFileSystem.java:298)
	at com.google.devtools.build.lib.bazel.repository.starlark.StarlarkBaseExternalContext.getPathFromLabel(StarlarkBaseExternalContext.java:2363)
	at com.google.devtools.build.lib.bazel.repository.starlark.StarlarkBaseExternalContext.getPath(StarlarkBaseExternalContext.java:1573)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at net.starlark.java.eval.MethodDescriptor.call(MethodDescriptor.java:261)
	at net.starlark.java.eval.BuiltinFunction.positionalOnlyCall(BuiltinFunction.java:74)
	at net.starlark.java.eval.Starlark.positionalOnlyCall(Starlark.java:878)
	at net.starlark.java.eval.Eval.evalPositionalOnlyCall(Eval.java:789)
	at net.starlark.java.eval.Eval.evalCall(Eval.java:706)
	at net.starlark.java.eval.Eval.eval(Eval.java:566)
	at net.starlark.java.eval.Eval.execAssignment(Eval.java:120)
	at net.starlark.java.eval.Eval.exec(Eval.java:300)
	at net.starlark.java.eval.Eval.execStatements(Eval.java:82)
	at net.starlark.java.eval.Eval.execFunctionBody(Eval.java:66)
	at net.starlark.java.eval.StarlarkFunction$ArgumentProcessor.call(StarlarkFunction.java:577)
	at net.starlark.java.eval.StarlarkCallable.positionalOnlyCall(StarlarkCallable.java:112)
	at net.starlark.java.eval.Starlark.positionalOnlyCall(Starlark.java:878)
	at net.starlark.java.eval.Eval.evalPositionalOnlyCall(Eval.java:789)
	at net.starlark.java.eval.Eval.evalCall(Eval.java:706)
	at net.starlark.java.eval.Eval.eval(Eval.java:566)
	at net.starlark.java.eval.Eval.execAssignment(Eval.java:120)
	at net.starlark.java.eval.Eval.exec(Eval.java:300)
	at net.starlark.java.eval.Eval.execStatements(Eval.java:82)
	at net.starlark.java.eval.Eval.execFor(Eval.java:137)
	at net.starlark.java.eval.Eval.exec(Eval.java:308)
	at net.starlark.java.eval.Eval.execStatements(Eval.java:82)
	at net.starlark.java.eval.Eval.execFor(Eval.java:137)
	at net.starlark.java.eval.Eval.exec(Eval.java:308)
	at net.starlark.java.eval.Eval.execStatements(Eval.java:82)
	at net.starlark.java.eval.Eval.execFunctionBody(Eval.java:66)
	at net.starlark.java.eval.StarlarkFunction$ArgumentProcessor.call(StarlarkFunction.java:577)
	at net.starlark.java.eval.StarlarkCallable.positionalOnlyCall(StarlarkCallable.java:112)
	at net.starlark.java.eval.Starlark.positionalOnlyCall(Starlark.java:878)
	at com.google.devtools.build.lib.bazel.bzlmod.RegularRunnableExtension.runInternal(RegularRunnableExtension.java:293)
	at com.google.devtools.build.lib.bazel.bzlmod.RegularRunnableExtension.lambda$run$0(RegularRunnableExtension.java:236)
	at com.google.devtools.build.skyframe.WorkerSkyKeyComputeState.lambda$getOrStartWorker$0(WorkerSkyKeyComputeState.java:172)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
	at java.base/java.util.concurrent.ThreadPerTaskExecutor$TaskRunner.run(Unknown Source)
	at java.base/java.lang.VirtualThread.run(Unknown Source)
```

No

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES: Fixed a crash with `--experimental_remote_repo_contents_cache` when running without a remote or disk cache.

Closes #30045.

PiperOrigin-RevId: 939694605
Change-Id: Ie6fa660d0d623e586abd5016a0aa3d0b66c64136

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/0464e54ecc187bcd18c99348cf1c24a78e8e15f1