### PR TITLE
Move --host_compiler to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -591,6 +591,16 @@ public final class BazelRulesModule extends BlazeModule {
   public abstract static class BazelBuildGraveyardOptions extends BuildGraveyardOptions {
     @Deprecated
     @Option(
+        name = "host_compiler",
+        defaultValue = "null",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract String getHostCompiler();
+
+    @Deprecated
+    @Option(
         name = "incompatible_disable_legacy_cc_provider",
         defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -160,14 +160,6 @@ public abstract class CppOptions extends FragmentOptions {
       help = "The C++ compiler to use for compiling the target.")
   public abstract String getCppCompiler();
 
-  @Option(
-      name = "host_compiler",
-      defaultValue = "null",
-      documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS, OptionEffectTag.EXECUTION},
-      help = "No-op flag. Will be removed in a future release.")
-  public abstract String getHostCppCompiler();
-
   // This is different from --platform_suffix in that that one is designed to facilitate the
   // migration to toolchains and this one is designed to eliminate the C++ toolchain identifier
   // from the output directory path.

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -251,7 +251,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:objc_use_dotd_pruning",
         "//command_line_option:host_copt",
         "//command_line_option:host_conlyopt",
-        "//command_line_option:host_compiler",
         "//command_line_option:host_cxxopt",
         "//command_line_option:host_per_file_copt",
         "//command_line_option:host_grte_top",
@@ -277,7 +276,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:experimental_use_llvm_covmap",
     ],
     outputs = [
-        "//command_line_option:compiler",
         "//command_line_option:grte_top",
         "//command_line_option:copt",
         "//command_line_option:cxxopt",
@@ -287,7 +285,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:strip",
     ],
     func = lambda settings: {
-        "//command_line_option:compiler": settings["//command_line_option:host_compiler"],
         "//command_line_option:grte_top": settings["//command_line_option:host_grte_top"],
         # TODO: Properly fix https://github.com/bazelbuild/bazel/issues/24545 with features.
         "//command_line_option:copt": settings["//command_line_option:host_copt"] + ([] if py_internal.get_current_os_name() == "windows" else ["-g0"]),


### PR DESCRIPTION
## History

`--host_compiler` was introduced on January 22, 2019 by [`47cca2ed7d`](https://github.com/bazelbuild/bazel/commit/47cca2ed7d2058dba3a36e3bebb677976686ec0f) to select the host compiler when `--host_crosstool_top` was set. C++ toolchain resolution removed the `--host_crosstool_top` selection mechanism and made `--host_compiler` a no-op on December 6, 2023 in [`e116bae821`](https://github.com/bazelbuild/bazel/commit/e116bae8213ca31ae590a60748c1b6d505a4f819).

## Summary

Moves `--host_compiler` from `CppOptions` to `BazelBuildGraveyardOptions`. This also removes `host_compiler` from the builtin exec transition and removes the now-unused mapping from `host_compiler` to `compiler`. A deprecated graveyard no-op keeps existing command lines accepted.

## Why this is safe

`CppOptions.getHostCppCompiler()` has no Java consumer. Its only remaining reference is the builtin exec-transition input that rewrites `--host_compiler` to `--compiler`; `CppOptions.getCppCompiler()` is no longer consumed by C++ toolchain selection either. Removing these fields therefore cannot change compiler or toolchain selection. Existing command lines remain accepted and receive the standard deprecation warning.

## Validation

- `bazel test --jobs=2 --remote_cache= --disk_cache=/private/tmp/bazel-pr-disk-cache //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest //src/test/java/com/google/devtools/build/lib/analysis/starlark:StarlarkAttrTransitionProviderTest //src/test/java/com/google/devtools/build/lib/starlark:StarlarkIntegrationTest`
