### PR TITLE
Move --crosstool_top to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -635,6 +635,16 @@ public final class BazelRulesModule extends BlazeModule {
   public abstract static class BazelBuildGraveyardOptions extends BuildGraveyardOptions {
     @Deprecated
     @Option(
+        name = "crosstool_top",
+        defaultValue = "@bazel_tools//tools/cpp:toolchain",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract String getCrosstoolTop();
+
+    @Deprecated
+    @Option(
         name = "host_compiler",
         defaultValue = "null",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -625,6 +625,16 @@ public final class BazelRulesModule extends BlazeModule {
   public abstract static class BazelBuildGraveyardOptions extends BuildGraveyardOptions {
     @Deprecated
     @Option(
+        name = "crosstool_top",
+        defaultValue = "@bazel_tools//tools/cpp:toolchain",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract String getCrosstoolTop();
+
+    @Deprecated
+    @Option(
         name = "host_compiler",
         defaultValue = "null",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
@@ -94,7 +94,7 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
 
   /** Flags we'd like to remove once there are no more repo references. */
   private static final ImmutableSet<String> DEPRECATED_PRE_PLATFORMS_FLAGS =
-      ImmutableSet.of("cpu", "host_cpu", "crosstool_top");
+      ImmutableSet.of("cpu", "host_cpu");
 
   /**
    * The settings this {@code config_setting} expects.

--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
@@ -94,7 +94,7 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
 
   /** Flags we'd like to remove once there are no more repo references. */
   private static final ImmutableSet<String> DEPRECATED_PRE_PLATFORMS_FLAGS =
-      ImmutableSet.of("cpu", "host_cpu", "crosstool_top");
+      ImmutableSet.of("cpu", "host_cpu");
 
   /**
    * The settings this {@code config_setting} expects.
@@ -459,6 +459,14 @@ Either remove one of these settings or ensure they match the same value.
     String canonicalOptionName = options.getCanonicalName(optionName);
     Class<? extends FragmentOptions> optionClass = options.getOptionClass(canonicalOptionName);
     if (optionClass == null) {
+      // Protobuf still defines config_settings for the retired --crosstool_top flag.
+      if (canonicalOptionName.equals("crosstool_top")) {
+        return new NoMatch(
+            NoMatch.Diff.what(toOptionLabel(optionName))
+                .want(expectedRawValue)
+                .got("<option removed>")
+                .build());
+      }
       if (isTestOption(canonicalOptionName)) {
         // If TestOptions isn't present then they were trimmed, so any test options set are
         // considered unset by default.

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -137,21 +137,6 @@ public abstract class CppOptions extends FragmentOptions {
     }
   }
 
-  // @Deprecated
-  // TODO(https://github.com/bazelbuild/bazel/pull/26854): figure out how to deprecate
-  // this without warning spam because of a globally set bazelrc.
-  @Option(
-      name = "crosstool_top",
-      defaultValue = "@bazel_tools//tools/cpp:toolchain",
-      converter = LabelConverter.class,
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {
-        OptionEffectTag.NO_OP,
-      },
-      metadataTags = {OptionMetadataTag.HIDDEN},
-      help = "No-op flag. Will be removed in a future release.")
-  public abstract Label getCrosstoolTop();
-
   @Option(
       name = "compiler",
       defaultValue = "null",

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrTransitionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrTransitionProviderTest.java
@@ -3085,11 +3085,6 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
     // TODO(waltl): check that dynamic_mode is parsed properly.
   }
 
-  @Test
-  public void testOptionConversionCrosstoolTop() throws Exception {
-    // TODO(waltl): check that crosstool_top is parsed properly.
-  }
-
   /**
    * Changing --cpu implicitly changes the target platform. Test that the old value of --platforms
    * gets cleared out (platform mappings can then kick in to set --platforms correctly).

--- a/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
@@ -3066,7 +3066,7 @@ public final class ConfigSettingTest extends BuildViewTestCase {
   }
 
   @Test
-  @TestParameters({"{flag: cpu}", "{flag: host_cpu}", "{flag: crosstool_top}"})
+  @TestParameters({"{flag: cpu}", "{flag: host_cpu}"})
   public void selectOnDeprecatedFlagEmitsWarning(String flag) throws Exception {
     scratch.file(
         "test/BUILD",
@@ -3087,7 +3087,7 @@ public final class ConfigSettingTest extends BuildViewTestCase {
   }
 
   @Test
-  @TestParameters({"{flag: cpu}", "{flag: host_cpu}", "{flag: crosstool_top}"})
+  @TestParameters({"{flag: cpu}", "{flag: host_cpu}"})
   public void selectOnDisabledFlagFails(String flag) throws Exception {
     scratch.file(
         "test/BUILD",

--- a/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
@@ -223,6 +223,22 @@ public final class ConfigSettingTest extends BuildViewTestCase {
         "    values = {'not_an_option': 'bar'})");
   }
 
+  @Test
+  public void retiredCrosstoolTopDoesNotMatch() throws Exception {
+    scratch.file(
+        "test/BUILD",
+        """
+        config_setting(
+            name = "legacy_android_crosstool",
+            values = {"crosstool_top": "@androidndk//:toolchain-libcpp"},
+        )
+        """);
+
+    assertThat(getConfigMatchingProviderResultAsBoolean("//test:legacy_android_crosstool"))
+        .isFalse();
+    assertNoEvents();
+  }
+
   /**
    * Tests that rule analysis fails on internal options.
    */
@@ -3066,7 +3082,7 @@ public final class ConfigSettingTest extends BuildViewTestCase {
   }
 
   @Test
-  @TestParameters({"{flag: cpu}", "{flag: host_cpu}", "{flag: crosstool_top}"})
+  @TestParameters({"{flag: cpu}", "{flag: host_cpu}"})
   public void selectOnDeprecatedFlagEmitsWarning(String flag) throws Exception {
     scratch.file(
         "test/BUILD",
@@ -3087,7 +3103,7 @@ public final class ConfigSettingTest extends BuildViewTestCase {
   }
 
   @Test
-  @TestParameters({"{flag: cpu}", "{flag: host_cpu}", "{flag: crosstool_top}"})
+  @TestParameters({"{flag: cpu}", "{flag: host_cpu}"})
   public void selectOnDisabledFlagFails(String flag) throws Exception {
     scratch.file(
         "test/BUILD",

--- a/src/test/java/com/google/devtools/build/lib/testutil/TestConstants.java
+++ b/src/test/java/com/google/devtools/build/lib/testutil/TestConstants.java
@@ -156,7 +156,7 @@ public class TestConstants {
           "--host_platform=@platforms//host",
           // TODO(#7849): Remove after flag flip.
           "--incompatible_use_toolchain_resolution_for_java_rules",
-          "--incompatible_disable_select_on=cpu,crosstool_top,host_cpu");
+          "--incompatible_disable_select_on=cpu,host_cpu");
 
   public static final ImmutableList<String> PRODUCT_SPECIFIC_BUILD_LANG_OPTIONS =
       ImmutableList.of();

--- a/tools/cpp/BUILD.tools
+++ b/tools/cpp/BUILD.tools
@@ -108,14 +108,7 @@ config_setting(
     },
 )
 
-# This is the entry point for --crosstool_top.  Toolchains are found
-# by lopping off the name of --crosstool_top and searching for
-# "cc-compiler-${CPU}" in this BUILD file, where CPU is the target CPU
-# specified in --cpu.
-#
-# This file group should include
-#   * all cc_toolchain targets supported
-#   * all file groups that said cc_toolchain might refer to
+# The default C++ toolchain target.
 alias(
     name = "toolchain",
     actual = "@local_config_cc//:toolchain",


### PR DESCRIPTION
## Summary

C++ toolchain resolution stopped using `--crosstool_top` in [e116bae821](https://github.com/bazelbuild/bazel/commit/e116bae8213ca31ae590a60748c1b6d505a4f819). This PR moves the flag from `CppOptions` to `BazelBuildGraveyardOptions` as a deprecated no-op. Existing command lines and bazelrc files can still set it, but it no longer has a configuration value used for C++ toolchain selection.

## Legacy `config_setting` references

Bazel's pinned protobuf `36.0.bcr.1` still defines `config_setting(values = {"crosstool_top": ...})` targets. When `crosstool_top` is absent from `BuildOptions`, `ConfigSetting` now treats these settings as nonmatching instead of failing analysis with `unknown option: 'crosstool_top'`. A `select()` using them takes `//conditions:default` when present, regardless of the supplied `--crosstool_top` value. `ConfigSettingTest.retiredCrosstoolTopDoesNotMatch` covers this behavior.

The PR also removes the obsolete deprecated-select handling and tests for `crosstool_top`, a placeholder transition test, and a stale `tools/cpp` comment.

## Validation

[Full presubmit](https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/36555) passed on commit `6fbe32e9cd` across Linux, macOS, Windows, and RBE.

RELNOTES: --crosstool_top is now a deprecated no-op; config_setting values for it no longer match.
