### PR TITLE
Move --incompatible_disable_native_apple_binary_rule to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -591,6 +591,16 @@ public final class BazelRulesModule extends BlazeModule {
   public abstract static class BazelBuildGraveyardOptions extends BuildGraveyardOptions {
     @Deprecated
     @Option(
+        name = "incompatible_disable_native_apple_binary_rule",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getDisableNativeAppleBinaryRule();
+
+    @Deprecated
+    @Option(
         name = "incompatible_disable_legacy_cc_provider",
         defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
@@ -56,21 +56,6 @@ public abstract class ObjcCommandLineOptions extends FragmentOptions {
               + " objc_import.")
   public abstract boolean getIncompatibleObjcAlwayslinkByDefault();
 
-  /**
-   * @deprecated delete when we are sure it's not used anywhere.
-   */
-  @Deprecated
-  @Option(
-      name = "incompatible_disable_native_apple_binary_rule",
-      defaultValue = "false",
-      documentationCategory = OptionDocumentationCategory.INPUT_STRICTNESS,
-      effectTags = {
-        OptionEffectTag.EAGERNESS_TO_EXIT,
-      },
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
-      help = "No-op. Kept here for backwards compatibility.")
-  public abstract boolean getIncompatibleDisableNativeAppleBinaryRule();
-
   @Option(
       name = "incompatible_strip_executable_safely",
       defaultValue = "false",


### PR DESCRIPTION
## History

`--incompatible_disable_native_apple_binary_rule` was introduced disabled on December 2, 2020 by [`65e9732c7d`](https://github.com/bazelbuild/bazel/commit/65e9732c7d2a791ed2d6f9e90c8279acdbf1096f) to reject uses of the native `apple_binary` rule and direct users to `rules_apple`. The test suite was updated for the incompatible-change flip in July 2021 by [`cc6c1678a4`](https://github.com/bazelbuild/bazel/commit/cc6c1678a4bdfe9cb078ae72b58ae222139b3ea7). [`0535477eab`](https://github.com/bazelbuild/bazel/commit/0535477eabfbafb9665cc5a191b677077496751c) removed the native `apple_binary` rule, the `ObjcConfiguration` field, and the flag check on January 12, 2022. [`2172c545c7`](https://github.com/bazelbuild/bazel/commit/2172c545c78410fe111ea2e8f8429d7efda98fd2) then marked the flag deprecated and removed remaining test uses in February 2022.

The option itself was removed from `ObjcCommandLineOptions` in January 2026 by [`cb541be1ee`](https://github.com/bazelbuild/bazel/commit/cb541be1eea5aafcce370ef8078b2e03537c0233). The broad option-metadata cleanup in [`b677ed0db0`](https://github.com/bazelbuild/bazel/commit/b677ed0db0d0e404d07d38438ab373068b8cec81) reintroduced the declaration in April 2026 without reintroducing any consumer.

## Summary

Moves `--incompatible_disable_native_apple_binary_rule` from `ObjcCommandLineOptions` to `BazelBuildGraveyardOptions`. A deprecated graveyard no-op keeps existing command lines accepted.

## Why this is safe

The native `apple_binary` rule and the flag's only behavior were deleted in January 2022. The current repository has no reference to `getIncompatibleDisableNativeAppleBinaryRule()` and no reference to the flag outside its option declaration. The April 2026 change restored only the declaration, so removing it from `ObjcCommandLineOptions` cannot change Apple rule behavior. Existing positive and negative command-line spellings remain accepted and receive the standard deprecation warning.

## Impact

The flag no longer contributes Objective-C native configuration state. Apple rules continue to use the Starlark implementations from `rules_apple`.

## Validation

- `bazel --output_base=/private/tmp/bazel-remove-disable-native-apple-binary-rule-ob test --jobs=2 --remote_cache= --disk_cache=/private/tmp/bazel-pr-disk-cache //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest //src/test/java/com/google/devtools/build/lib/analysis/starlark:StarlarkAttrTransitionProviderTest //src/test/java/com/google/devtools/build/lib/starlark:StarlarkIntegrationTest`
