### PR TITLE
Move --experimental_enable_jspecify to the graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -591,6 +591,16 @@ public final class BazelRulesModule extends BlazeModule {
   public abstract static class BazelBuildGraveyardOptions extends BuildGraveyardOptions {
     @Deprecated
     @Option(
+        name = "experimental_enable_jspecify",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.EXPERIMENTAL, OptionMetadataTag.DEPRECATED},
+        help = "Deprecated no-op.")
+    public abstract boolean getEnableJspecify();
+
+    @Deprecated
+    @Option(
         name = "incompatible_disable_legacy_cc_provider",
         defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
@@ -146,7 +146,6 @@ public final class JavaCompilationHelper {
     JspecifyInfo jspecifyInfo = javaToolchain.jspecifyInfo();
     boolean jspecify =
         enableJspecify
-            && getJavaConfiguration().experimentalEnableJspecify()
             && jspecifyInfo != null
             && jspecifyInfo.matches(ruleContext.getLabel());
     if (jspecify) {

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
@@ -96,7 +96,6 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
   private final ImmutableList<Label> pluginList;
   private final boolean experimentalTurbineAnnotationProcessing;
   private final int experimentalTurbineCpuReservation;
-  private final boolean experimentalEnableJspecify;
   private final boolean multiReleaseDeployJars;
   private final boolean disallowJavaImportExports;
 
@@ -152,7 +151,6 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
     this.experimentalTurbineAnnotationProcessing =
         javaOptions.getExperimentalTurbineAnnotationProcessing();
     this.experimentalTurbineCpuReservation = javaOptions.getTurbineCpuReservation();
-    this.experimentalEnableJspecify = javaOptions.getExperimentalEnableJspecify();
   }
 
   @Override
@@ -393,10 +391,6 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
 
   public int experimentalTurbineCpuReservation() {
     return experimentalTurbineCpuReservation;
-  }
-
-  public boolean experimentalEnableJspecify() {
-    return experimentalEnableJspecify;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -423,12 +423,4 @@ public abstract class JavaOptions extends FragmentOptions {
       help = "When enabled, java_import.exports is not supported.")
   public abstract boolean getDisallowJavaImportExports();
 
-  @Option(
-      name = "experimental_enable_jspecify",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
-      help = "Enable experimental jspecify integration.")
-  public abstract boolean getExperimentalEnableJspecify();
 }

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -338,7 +338,6 @@ bazel_fragments["JavaOptions"] = fragment(
         "//command_line_option:experimental_turbine_cpu_reservation",
         "//command_line_option:incompatible_multi_release_deploy_jars",
         "//command_line_option:incompatible_disallow_java_import_exports",
-        "//command_line_option:experimental_enable_jspecify",
         "//command_line_option:experimental_run_android_lint_on_java_rules",
     ],
     outputs = [


### PR DESCRIPTION
## History

`--experimental_enable_jspecify` was introduced enabled by default on May 7, 2021 by [`41a0c35ee6`](https://github.com/bazelbuild/bazel/commit/41a0c35ee6fe9655a8398ca3cbbaa90600e869b2) as the global gate for the JSpecify integration. [`88499f615b`](https://github.com/bazelbuild/bazel/commit/88499f615bc03d1b6a3e4e38f2890a4e987a954d) added the separate `java_common.compile(enable_jspecify=...)` gate in February 2022 so individual Java rule implementations could opt out, initially for `java_lite_proto_library`. [`31efa5c903`](https://github.com/bazelbuild/bazel/commit/31efa5c903b51bbc38825f1e9d45fecc878643ec) made that per-compilation argument named and defaulted it to `True` in September 2023. The global flag has remained enabled by default since its introduction.

## Summary

Moves `--experimental_enable_jspecify` from `JavaOptions` to `BazelBuildGraveyardOptions`, removes its `JavaConfiguration` field, removes the global condition from `JavaCompilationHelper`, and removes exec-transition propagation. A deprecated graveyard no-op keeps existing command lines accepted.

## Why this is safe

The removed global gate has always defaulted to enabled, so removing it preserves Bazel's default behavior. JSpecify activation still requires the Java toolchain to provide `_jspecify_info` and its package matcher to select the target. The independent per-compilation `enable_jspecify` argument also remains and continues to let Java rule implementations opt out. No Bazel test or command line sets the global flag. Existing positive and negative command-line spellings remain accepted and receive the standard deprecation warning.

## Impact

JSpecify remains enabled by default and remains subject to the Java toolchain package matcher and the per-compilation gate. `--noexperimental_enable_jspecify` no longer disables JSpecify globally, and the removed option no longer contributes Java native configuration or exec-transition state.

## Validation

- `bazel --output_base=/private/tmp/bazel-remove-experimental-enable-jspecify-ob test --bes_backend= --jobs=2 --remote_cache= --disk_cache=/private/tmp/bazel-pr-disk-cache //src/test/java/com/google/devtools/build/lib/packages/semantics:ConsistencyTest //src/test/java/com/google/devtools/build/lib/analysis/starlark:StarlarkAttrTransitionProviderTest //src/test/java/com/google/devtools/build/lib/starlark:StarlarkIntegrationTest //src/test/java/com/google/devtools/build/lib/rules/java:JavaConfigurationTest //src/test/java/com/google/devtools/build/lib/rules/java:JavaStarlarkApiTest`
