### PR TITLE
Validate that --test_output=streamed does not conflict with user options

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -35,7 +35,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.10.0/MODULE.bazel": "f75e8807570484a99be90abcd52b5e1f390362c258bcb73106f4544957a48101",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
-    "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
     "https://bcr.bazel.build/modules/bazel_features/1.20.0/MODULE.bazel": "8b85300b9c8594752e0721a37210e34879d23adc219ed9dc8f4104a4a1750920",

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/FetchCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/FetchCommand.java
@@ -50,6 +50,7 @@ import com.google.devtools.build.skyframe.EvaluationContext;
 import com.google.devtools.build.skyframe.EvaluationResult;
 import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.common.options.OptionsParser;
+import com.google.devtools.common.options.OptionsParsingException;
 import com.google.devtools.common.options.OptionsParsingResult;
 import java.util.List;
 import java.util.stream.Stream;
@@ -76,7 +77,7 @@ public final class FetchCommand implements BlazeCommand {
   public static final String NAME = "fetch";
 
   @Override
-  public void editOptions(OptionsParser optionsParser) {
+  public void editOptions(OptionsParser optionsParser) throws OptionsParsingException {
     TargetFetcher.injectNoBuildOption(optionsParser);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/TargetFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/TargetFetcher.java
@@ -62,15 +62,11 @@ public class TargetFetcher {
     return result;
   }
 
-  static void injectNoBuildOption(OptionsParser optionsParser) {
-    try {
-      optionsParser.parse(
-          PriorityCategory.COMPUTED_DEFAULT,
-          "Options required to fetch target",
-          ImmutableList.of("--nobuild"));
-    } catch (OptionsParsingException e) {
-      throw new IllegalStateException("Fetch target needed option failed to parse", e);
-    }
+  static void injectNoBuildOption(OptionsParser optionsParser) throws OptionsParsingException {
+    optionsParser.parse(
+        PriorityCategory.COMPUTED_DEFAULT,
+        "Options required to fetch target",
+        ImmutableList.of("--nobuild"));
   }
 
   static class TargetFetcherException extends Exception {

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
@@ -64,6 +64,7 @@ import com.google.devtools.build.skyframe.QueryableGraph.Reason;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.common.options.OptionsParser;
+import com.google.devtools.common.options.OptionsParsingException;
 import com.google.devtools.common.options.OptionsParsingResult;
 import java.io.IOException;
 import java.net.URI;
@@ -123,7 +124,7 @@ public final class VendorCommand implements BlazeCommand {
   }
 
   @Override
-  public void editOptions(OptionsParser optionsParser) {
+  public void editOptions(OptionsParser optionsParser) throws OptionsParsingException {
     TargetFetcher.injectNoBuildOption(optionsParser);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommand.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.runtime;
 
 import com.google.devtools.common.options.OptionsParser;
+import com.google.devtools.common.options.OptionsParsingException;
 import com.google.devtools.common.options.OptionsParsingResult;
 
 /**
@@ -45,5 +46,5 @@ public interface BlazeCommand {
    *
    * @param optionsParser the options parser for the current command
    */
-  default void editOptions(OptionsParser optionsParser) {}
+  default void editOptions(OptionsParser optionsParser) throws OptionsParsingException {}
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/AqueryCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/AqueryCommand.java
@@ -66,15 +66,11 @@ import com.google.devtools.common.options.OptionsParsingResult;
 public final class AqueryCommand implements BlazeCommand {
 
   @Override
-  public void editOptions(OptionsParser optionsParser) {
-    try {
-      optionsParser.parse(
-          PriorityCategory.COMPUTED_DEFAULT,
-          "Option required by aquery",
-          ImmutableList.of("--nobuild"));
-    } catch (OptionsParsingException e) {
-      throw new IllegalStateException("Aquery's known options failed to parse", e);
-    }
+  public void editOptions(OptionsParser optionsParser) throws OptionsParsingException {
+    optionsParser.parse(
+        PriorityCategory.COMPUTED_DEFAULT,
+        "Option required by aquery",
+        ImmutableList.of("--nobuild"));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CoverageCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CoverageCommand.java
@@ -117,20 +117,15 @@ public class CoverageCommand extends TestCommand {
   }
 
   @Override
-  public void editOptions(OptionsParser optionsParser) {
+  public void editOptions(OptionsParser optionsParser) throws OptionsParsingException {
     super.editOptions(optionsParser);
-    try {
-      optionsParser.parse(
-          PriorityCategory.SOFTWARE_REQUIREMENT,
-          "Options required by the coverage command",
-          ImmutableList.of("--collect_code_coverage"));
-      optionsParser.parse(
-          PriorityCategory.COMPUTED_DEFAULT,
-          "Options suggested for the coverage command",
-          ImmutableList.of(TestTimeout.COVERAGE_CMD_TIMEOUT));
-    } catch (OptionsParsingException e) {
-      // Should never happen.
-      throw new IllegalStateException("Unexpected exception", e);
-    }
+    optionsParser.parse(
+        PriorityCategory.SOFTWARE_REQUIREMENT,
+        "Options required by the coverage command",
+        ImmutableList.of("--collect_code_coverage"));
+    optionsParser.parse(
+        PriorityCategory.COMPUTED_DEFAULT,
+        "Options suggested for the coverage command",
+        ImmutableList.of(TestTimeout.COVERAGE_CMD_TIMEOUT));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CqueryCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CqueryCommand.java
@@ -77,43 +77,39 @@ import java.util.List;
 public final class CqueryCommand implements BlazeCommand {
 
   @Override
-  public void editOptions(OptionsParser optionsParser) {
+  public void editOptions(OptionsParser optionsParser) throws OptionsParsingException {
     CqueryOptions cqueryOptions = optionsParser.getOptions(CqueryOptions.class);
-    try {
-      if (!cqueryOptions.getTransitions().equals(CqueryOptions.Transitions.NONE)) {
-        optionsParser.parse(
-            PriorityCategory.COMPUTED_DEFAULT,
-            "Option required by setting the --transitions flag",
-            ImmutableList.of("--output=transitions"));
-      }
+    if (!cqueryOptions.getTransitions().equals(CqueryOptions.Transitions.NONE)) {
       optionsParser.parse(
           PriorityCategory.COMPUTED_DEFAULT,
-          "Options required by cquery",
-          ImmutableList.of("--nobuild"));
-      optionsParser.parse(
-          PriorityCategory.COMPUTED_DEFAULT,
-          "cquery should include 'tags = [\"manual\"]' targets by default",
-          ImmutableList.of("--build_manual_tests"));
-      optionsParser.parse(
-          PriorityCategory.SOFTWARE_REQUIREMENT,
-          // https://github.com/bazelbuild/bazel/issues/11078
-          "cquery should not exclude test_suite rules",
-          ImmutableList.of("--noexpand_test_suites"));
-      if (cqueryOptions.getShowRequiredConfigFragments() != IncludeConfigFragmentsEnum.OFF) {
-        optionsParser.parse(
-            PriorityCategory.COMPUTED_DEFAULT,
-            "Options required by cquery's --show_config_fragments flag",
-            ImmutableList.of(
-                "--include_config_fragments_provider="
-                    + cqueryOptions.getShowRequiredConfigFragments()));
-      }
-      optionsParser.parse(
-          PriorityCategory.SOFTWARE_REQUIREMENT,
-          "cquery should not exclude tests",
-          ImmutableList.of("--nobuild_tests_only"));
-    } catch (OptionsParsingException e) {
-      throw new IllegalStateException("Cquery's known options failed to parse", e);
+          "Option required by setting the --transitions flag",
+          ImmutableList.of("--output=transitions"));
     }
+    optionsParser.parse(
+        PriorityCategory.COMPUTED_DEFAULT,
+        "Options required by cquery",
+        ImmutableList.of("--nobuild"));
+    optionsParser.parse(
+        PriorityCategory.COMPUTED_DEFAULT,
+        "cquery should include 'tags = [\"manual\"]' targets by default",
+        ImmutableList.of("--build_manual_tests"));
+    optionsParser.parse(
+        PriorityCategory.SOFTWARE_REQUIREMENT,
+        // https://github.com/bazelbuild/bazel/issues/11078
+        "cquery should not exclude test_suite rules",
+        ImmutableList.of("--noexpand_test_suites"));
+    if (cqueryOptions.getShowRequiredConfigFragments() != IncludeConfigFragmentsEnum.OFF) {
+      optionsParser.parse(
+          PriorityCategory.COMPUTED_DEFAULT,
+          "Options required by cquery's --show_config_fragments flag",
+          ImmutableList.of(
+              "--include_config_fragments_provider="
+                  + cqueryOptions.getShowRequiredConfigFragments()));
+    }
+    optionsParser.parse(
+        PriorityCategory.SOFTWARE_REQUIREMENT,
+        "cquery should not exclude tests",
+        ImmutableList.of("--nobuild_tests_only"));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -232,8 +232,7 @@ public class RunCommand implements BlazeCommand {
     this.testPolicy = testPolicy;
   }
 
-  @Override
-  public void editOptions(OptionsParser optionsParser) {}
+
 
   /** Returns the arguments in a {@link ConfiguredTarget}'s {@code args} attribute. */
   private static ImmutableList<String> getBinaryArgs(ConfiguredTarget targetToRun) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/ShutdownCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/ShutdownCommand.java
@@ -54,8 +54,7 @@ public final class ShutdownCommand implements BlazeCommand {
     public abstract int getHeapSizeLimit();
   }
 
-  @Override
-  public void editOptions(OptionsParser optionsParser) {}
+
 
   @Override
   public BlazeCommandResult exec(CommandEnvironment env, OptionsParsingResult options) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/TestCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/TestCommand.java
@@ -80,17 +80,31 @@ public class TestCommand implements BlazeCommand {
   }
 
   @Override
-  public void editOptions(OptionsParser optionsParser) {
+  public void editOptions(OptionsParser optionsParser) throws OptionsParsingException {
     TestOutputFormat testOutput = optionsParser.getOptions(ExecutionOptions.class).getTestOutput();
-    try {
-      if (testOutput == TestOutputFormat.STREAMED) {
-        optionsParser.parse(
-            PriorityCategory.SOFTWARE_REQUIREMENT,
-            "streamed output requires locally run tests, without sharding",
-            ImmutableList.of("--test_sharding_strategy=disabled", "--test_strategy=exclusive"));
+    if (testOutput == TestOutputFormat.STREAMED) {
+      for (com.google.devtools.common.options.ParsedOptionDescription option :
+          optionsParser.asListOfExplicitOptions()) {
+        String optionName = option.getOptionDefinition().getOptionName();
+        if (optionName.equals("test_strategy")) {
+          String value = option.getUnconvertedValue();
+          if (value != null && !value.equals("exclusive") && !value.isEmpty()) {
+            throw new OptionsParsingException(
+                "test_strategy=" + value + " is not allowed when --test_output=streamed is set");
+          }
+        }
+        if (optionName.equals("test_sharding_strategy")) {
+          String value = option.getUnconvertedValue();
+          if (value != null && !value.equals("disabled") && !value.isEmpty()) {
+            throw new OptionsParsingException(
+                "test_sharding_strategy=" + value + " is not allowed when --test_output=streamed is set");
+          }
+        }
       }
-    } catch (OptionsParsingException e) {
-      throw new IllegalStateException("Known options failed to parse", e);
+      optionsParser.parse(
+          PriorityCategory.SOFTWARE_REQUIREMENT,
+          "streamed output requires locally run tests, without sharding",
+          ImmutableList.of("--test_sharding_strategy=disabled", "--test_strategy=exclusive"));
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/VersionCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/VersionCommand.java
@@ -59,8 +59,7 @@ public final class VersionCommand implements BlazeCommand {
     public abstract boolean getGnuFormat();
   }
 
-  @Override
-  public void editOptions(OptionsParser optionsParser) {}
+
 
   @Override
   public BlazeCommandResult exec(CommandEnvironment env, OptionsParsingResult options) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/mobileinstall/MobileInstallCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/mobileinstall/MobileInstallCommand.java
@@ -372,19 +372,15 @@ public class MobileInstallCommand implements BlazeCommand {
   }
 
   @Override
-  public void editOptions(OptionsParser optionsParser) {
+  public void editOptions(OptionsParser optionsParser) throws OptionsParsingException {
     Options options = optionsParser.getOptions(Options.class);
-    try {
-      optionsParser.parse(
-          PriorityCategory.COMMAND_LINE,
-          "Options required by the Starlark implementation of mobile-install command",
-          ImmutableList.of(
-              "--aspects=" + options.getMobileInstallAspect() + "%MIASPECT",
-              "--output_groups=mobile_install" + INTERNAL_SUFFIX,
-              "--output_groups=mobile_install_launcher" + INTERNAL_SUFFIX));
-    } catch (OptionsParsingException e) {
-      throw new IllegalStateException(e);
-    }
+    optionsParser.parse(
+        PriorityCategory.COMMAND_LINE,
+        "Options required by the Starlark implementation of mobile-install command",
+        ImmutableList.of(
+            "--aspects=" + options.getMobileInstallAspect() + "%MIASPECT",
+            "--output_groups=mobile_install" + INTERNAL_SUFFIX,
+            "--output_groups=mobile_install_launcher" + INTERNAL_SUFFIX));
   }
 
   @Nullable

--- a/src/test/shell/integration/test_test.sh
+++ b/src/test/shell/integration/test_test.sh
@@ -585,4 +585,20 @@ EOF
       || fail "expected build to succeed"
 }
 
+function test_streamed_output_validation_errors() {
+  local -r pkg=$FUNCNAME
+  mkdir -p $pkg || fail "mkdir -p $pkg failed"
+  touch $pkg/BUILD
+
+  # 1. Combining --test_output=streamed and --test_strategy=remote should fail
+  bazel test --test_output=streamed --test_strategy=remote //$pkg:all &> $TEST_log \
+      && fail "expected test to fail due to options conflict"
+  expect_log "test_strategy=remote is not allowed when --test_output=streamed is set"
+
+  # 2. Combining --test_output=streamed and --test_sharding_strategy=forced=2 should fail
+  bazel test --test_output=streamed --test_sharding_strategy=forced=2 //$pkg:all &> $TEST_log \
+      && fail "expected test to fail due to options conflict"
+  expect_log "test_sharding_strategy=forced=2 is not allowed when --test_output=streamed is set"
+}
+
 run_suite "test tests"


### PR DESCRIPTION
Previously, setting --test_output=streamed would silently override --test_strategy and --test_sharding_strategy options specified by the user (by forcing them to 'exclusive' and 'disabled' respectively).

This change checks if the user has explicitly set conflicting values for these options when --test_output=streamed is enabled, and throws an OptionsParsingException if they did.

To support throwing OptionsParsingException from editOptions, updated the editOptions signature in the BlazeCommand interface.

Fixes #4178