### PR TITLE
Fix Bzlmod registry downloads to try all rewritten URLs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -460,8 +460,8 @@ public class DownloadManager {
     for (int attempt = 0; ; ++attempt) {
       try {
         content =
-            bzlmodHttpDownloader.downloadAndReadOneUrl(
-                rewrittenUrls.get(0),
+            bzlmodHttpDownloader.downloadAndRead(
+                rewrittenUrls,
                 credentialFactory.create(authHeaders),
                 checksum,
                 eventHandler,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
@@ -20,7 +20,6 @@ import com.google.auth.Credentials;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId.FetchId;
 import com.google.devtools.build.lib.buildeventstream.FetchEvent;
 import com.google.devtools.build.lib.clock.Clock;
@@ -43,6 +42,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Semaphore;
+import java.util.function.Function;
 
 /**
  * HTTP implementation of {@link Downloader}.
@@ -87,62 +87,26 @@ public class HttpDownloader implements Downloader {
       Optional<String> type,
       String context)
       throws IOException, InterruptedException {
-    HttpConnectorMultiplexer multiplexer = setUpConnectorMultiplexer(eventHandler, clientEnv);
-
-    // Iterate over urls and download the file falling back to the next url if previous failed,
-    // while reporting progress to the CLI.
-    boolean success = false;
-
-    List<IOException> ioExceptions = ImmutableList.of();
-
-    for (URI url : urls) {
-      semaphore.acquire();
-
-      try (HttpStream payload = multiplexer.connect(url, checksum, headers, credentials, type);
-          OutputStream out = destination.getOutputStream()) {
-        try {
-          ByteStreams.copy(payload, out);
-        } catch (SocketTimeoutException e) {
-          // SocketTimeoutExceptions are InterruptedIOExceptions; however they do not signify
-          // an external interruption, but simply a failed download due to some server timing
-          // out. So rethrow them as ordinary IOExceptions.
-          throw new IOException(e);
-        }
-        success = true;
-        break;
-      } catch (InterruptedIOException e) {
-        throw new InterruptedException(e.getMessage());
-      } catch (IOException e) {
-        if (ioExceptions.isEmpty()) {
-          ioExceptions = new ArrayList<>(1);
-        }
-        ioExceptions.add(e);
-        eventHandler.handle(
-            Event.warn("Download from " + url + " failed: " + e.getClass() + " " + e.getMessage()));
-        continue;
-      } finally {
-        semaphore.release();
-        eventHandler.post(new FetchEvent(url.toString(), FetchId.Downloader.HTTP, success));
-      }
-    }
-
-    if (!success) {
-      final IOException exception =
-          new IOException(
-              "Error downloading "
-                  + urls
-                  + " to "
-                  + destination
-                  + (ioExceptions.isEmpty()
-                      ? ""
-                      : ": " + Iterables.getLast(ioExceptions).getMessage()));
-
-      for (IOException cause : ioExceptions) {
-        exception.addSuppressed(cause);
-      }
-
-      throw exception;
-    }
+    // Stream the payload straight to the destination file (without buffering a potentially large
+    // archive in memory) and report progress to the CLI. On total failure, wrap every per-URL
+    // failure in a single new IOException naming the URLs and the destination.
+    var unused =
+        this.<Void>downloadFromUrls(
+            urls,
+            headers,
+            credentials,
+            checksum,
+            type,
+            eventHandler,
+            clientEnv,
+            /* reportProgressEvents= */ true,
+            payload -> {
+              try (OutputStream out = destination.getOutputStream()) {
+                payload.transferTo(out);
+              }
+              return null;
+            },
+            ioExceptions -> aggregatedDownloadException(urls, destination, ioExceptions));
   }
 
   /**
@@ -163,44 +127,153 @@ public class HttpDownloader implements Downloader {
       Map<String, String> clientEnv)
       throws IOException, InterruptedException {
     checkArgument(!urls.isEmpty(), "Cannot download from an empty list of URLs");
+    // Buffer the (small) registry file in memory and return the bytes. Unlike download(), this
+    // posts no progress events and preserves the type of the failing exception for the caller.
+    return downloadFromUrls(
+        urls,
+        ImmutableMap.of(),
+        credentials,
+        checksum,
+        Optional.empty(),
+        eventHandler,
+        clientEnv,
+        /* reportProgressEvents= */ false, // TODO(wyv): Do we need to report any event here?
+        payload -> {
+          ByteArrayOutputStream out = new ByteArrayOutputStream();
+          payload.transferTo(out);
+          return out.toByteArray();
+        },
+        HttpDownloader::lastDownloadException);
+  }
+
+  /** Consumes a successfully connected {@link HttpStream}, producing the download's result. */
+  @FunctionalInterface
+  private interface StreamProcessor<T> {
+    T process(HttpStream payload) throws IOException;
+  }
+
+  /**
+   * Connects to each of {@code urls} in order and hands the first one that succeeds to {@code
+   * processor}, returning its result. On failure it falls back to the next URL; if every URL fails,
+   * it throws the exception that {@code onAllUrlsFailed} builds from the collected per-URL
+   * failures.
+   *
+   * <p>This is the shared engine behind {@link #download} (which streams the payload to a file) and
+   * {@link #downloadAndRead} (which reads it into memory). They differ only in how the payload is
+   * consumed ({@code processor}), what is thrown when every URL fails ({@code onAllUrlsFailed}),
+   * and whether per-URL progress is reported ({@code reportProgressEvents}).
+   */
+  private <T> T downloadFromUrls(
+      List<URI> urls,
+      Map<String, List<String>> headers,
+      Credentials credentials,
+      Optional<Checksum> checksum,
+      Optional<String> type,
+      ExtendedEventHandler eventHandler,
+      Map<String, String> clientEnv,
+      boolean reportProgressEvents,
+      StreamProcessor<T> processor,
+      Function<List<IOException>, IOException> onAllUrlsFailed)
+      throws IOException, InterruptedException {
     HttpConnectorMultiplexer multiplexer = setUpConnectorMultiplexer(eventHandler, clientEnv);
 
+    // Iterate over the URLs, attempting each in turn and falling back to the next one if the
+    // previous one failed, until one succeeds.
     List<IOException> ioExceptions = ImmutableList.of();
 
     for (URI url : urls) {
       semaphore.acquire();
-      ByteArrayOutputStream out = new ByteArrayOutputStream();
-      try (HttpStream payload =
-          multiplexer.connect(url, checksum, ImmutableMap.of(), credentials, Optional.empty())) {
-        ByteStreams.copy(payload, out);
-        return out.toByteArray();
+      boolean success = false;
+
+      try (HttpStream payload = multiplexer.connect(url, checksum, headers, credentials, type)) {
+        T result = processor.process(payload);
+        success = true;
+        return result;
       } catch (SocketTimeoutException e) {
-        // SocketTimeoutExceptions are InterruptedIOExceptions; however they do not signify
-        // an external interruption, but simply a failed download due to some server timing
-        // out. So treat them as ordinary IOExceptions and fall back to the next URL.
-        if (ioExceptions.isEmpty()) {
-          ioExceptions = new ArrayList<>(1);
-        }
-        ioExceptions.add(new IOException(e));
+        // SocketTimeoutExceptions are InterruptedIOExceptions; however they do not signify an
+        // external interruption, but simply a failed download due to some server timing out. So
+        // treat them as ordinary IOExceptions and fall back to the next URL.
+        ioExceptions =
+            recordFailure(
+                ioExceptions, new IOException(e), url, eventHandler, reportProgressEvents);
       } catch (InterruptedIOException e) {
         throw new InterruptedException(e.getMessage());
       } catch (IOException e) {
-        if (ioExceptions.isEmpty()) {
-          ioExceptions = new ArrayList<>(1);
-        }
-        ioExceptions.add(e);
+        ioExceptions = recordFailure(ioExceptions, e, url, eventHandler, reportProgressEvents);
       } finally {
         semaphore.release();
-        // TODO(wyv): Do we need to report any event here?
+        if (reportProgressEvents) {
+          eventHandler.post(new FetchEvent(url.toString(), FetchId.Downloader.HTTP, success));
+        }
       }
     }
 
-    // Rethrow the last failure (preserving its type), attaching the earlier ones as suppressed.
+    throw onAllUrlsFailed.apply(ioExceptions);
+  }
+
+  /**
+   * Records a failed download attempt for {@code url}, lazily allocating the (initially empty and
+   * immutable) {@code ioExceptions} list on first use and returning it for the caller to reassign.
+   * When {@code reportProgressEvents} is set, the failure is also surfaced to the CLI as a warning.
+   */
+  private static List<IOException> recordFailure(
+      List<IOException> ioExceptions,
+      IOException failure,
+      URI url,
+      ExtendedEventHandler eventHandler,
+      boolean reportProgressEvents) {
+    if (ioExceptions.isEmpty()) {
+      ioExceptions = new ArrayList<>(1);
+    }
+    ioExceptions.add(failure);
+    if (reportProgressEvents) {
+      eventHandler.handle(
+          Event.warn(
+              "Download from "
+                  + url
+                  + " failed: "
+                  + failure.getClass()
+                  + " "
+                  + failure.getMessage()));
+    }
+    return ioExceptions;
+  }
+
+  /**
+   * Builds the exception thrown by {@link #download} when every URL failed: a new {@link
+   * IOException} naming the URLs and destination, with each per-URL failure attached as a
+   * suppressed exception.
+   */
+  private static IOException aggregatedDownloadException(
+      List<URI> urls, Path destination, List<IOException> ioExceptions) {
+    IOException exception =
+        new IOException(
+            "Error downloading "
+                + urls
+                + " to "
+                + destination
+                + (ioExceptions.isEmpty()
+                    ? ""
+                    : ": " + Iterables.getLast(ioExceptions).getMessage()));
+    for (IOException cause : ioExceptions) {
+      exception.addSuppressed(cause);
+    }
+    return exception;
+  }
+
+  /**
+   * Builds the exception thrown by {@link #downloadAndRead} when every URL failed: the last failure
+   * itself, so its original type is preserved (letting callers distinguish e.g. {@link
+   * java.io.FileNotFoundException}), with the earlier failures attached as suppressed exceptions.
+   * The list is non-empty: {@link #downloadAndRead} rejects an empty URL list, and the loop records
+   * a failure for every URL it attempts.
+   */
+  private static IOException lastDownloadException(List<IOException> ioExceptions) {
     IOException last = Iterables.getLast(ioExceptions);
     for (IOException e : ioExceptions.subList(0, ioExceptions.size() - 1)) {
       last.addSuppressed(e);
     }
-    throw last;
+    return last;
   }
 
   private HttpConnectorMultiplexer setUpConnectorMultiplexer(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.auth.Credentials;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -143,33 +145,62 @@ public class HttpDownloader implements Downloader {
     }
   }
 
-  /** Downloads the contents of one URL and reads it into a byte array. */
-  public byte[] downloadAndReadOneUrl(
-      URI url,
+  /**
+   * Downloads the contents of the first of the given URLs that succeeds.
+   *
+   * <p>As with {@link #download}, the URLs are tried in order, falling back to the next one if the
+   * previous one fails; callers typically pass the rewritten URLs of a single logical resource
+   * (e.g. a mirror/proxy URL followed by the direct URL as a fallback). If all of them fail, the
+   * last failure is rethrown with its original type preserved (so callers can still distinguish
+   * e.g. {@link java.io.FileNotFoundException}), and the earlier failures are attached to it as
+   * suppressed exceptions.
+   */
+  public byte[] downloadAndRead(
+      List<URI> urls,
       Credentials credentials,
       Optional<Checksum> checksum,
       ExtendedEventHandler eventHandler,
       Map<String, String> clientEnv)
       throws IOException, InterruptedException {
+    checkArgument(!urls.isEmpty(), "Cannot download from an empty list of URLs");
     HttpConnectorMultiplexer multiplexer = setUpConnectorMultiplexer(eventHandler, clientEnv);
 
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    semaphore.acquire();
-    try (HttpStream payload =
-        multiplexer.connect(url, checksum, ImmutableMap.of(), credentials, Optional.empty())) {
-      ByteStreams.copy(payload, out);
-    } catch (SocketTimeoutException e) {
-      // SocketTimeoutExceptions are InterruptedIOExceptions; however they do not signify
-      // an external interruption, but simply a failed download due to some server timing
-      // out. So rethrow them as ordinary IOExceptions.
-      throw new IOException(e);
-    } catch (InterruptedIOException e) {
-      throw new InterruptedException(e.getMessage());
-    } finally {
-      semaphore.release();
-      // TODO(wyv): Do we need to report any event here?
+    List<IOException> ioExceptions = ImmutableList.of();
+
+    for (URI url : urls) {
+      semaphore.acquire();
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      try (HttpStream payload =
+          multiplexer.connect(url, checksum, ImmutableMap.of(), credentials, Optional.empty())) {
+        ByteStreams.copy(payload, out);
+        return out.toByteArray();
+      } catch (SocketTimeoutException e) {
+        // SocketTimeoutExceptions are InterruptedIOExceptions; however they do not signify
+        // an external interruption, but simply a failed download due to some server timing
+        // out. So treat them as ordinary IOExceptions and fall back to the next URL.
+        if (ioExceptions.isEmpty()) {
+          ioExceptions = new ArrayList<>(1);
+        }
+        ioExceptions.add(new IOException(e));
+      } catch (InterruptedIOException e) {
+        throw new InterruptedException(e.getMessage());
+      } catch (IOException e) {
+        if (ioExceptions.isEmpty()) {
+          ioExceptions = new ArrayList<>(1);
+        }
+        ioExceptions.add(e);
+      } finally {
+        semaphore.release();
+        // TODO(wyv): Do we need to report any event here?
+      }
     }
-    return out.toByteArray();
+
+    // Rethrow the last failure (preserving its type), attaching the earlier ones as suppressed.
+    IOException last = Iterables.getLast(ioExceptions);
+    for (IOException e : ioExceptions.subList(0, ioExceptions.size() - 1)) {
+      last.addSuppressed(e);
+    }
+    throw last;
   }
 
   private HttpConnectorMultiplexer setUpConnectorMultiplexer(

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -710,7 +711,7 @@ public class HttpDownloaderTest {
   }
 
   @Test
-  public void downloadAndReadOneUrl_ok() throws IOException, InterruptedException {
+  public void downloadAndRead_ok() throws IOException, InterruptedException {
     try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName(null))) {
       @SuppressWarnings("unused")
       Future<?> possiblyIgnoredError =
@@ -733,8 +734,10 @@ public class HttpDownloaderTest {
 
       assertThat(
               new String(
-                  httpDownloader.downloadAndReadOneUrl(
-                      URI.create(String.format("http://localhost:%d/foo", server.getLocalPort())),
+                  httpDownloader.downloadAndRead(
+                      ImmutableList.of(
+                          URI.create(
+                              String.format("http://localhost:%d/foo", server.getLocalPort()))),
                       StaticCredentials.EMPTY,
                       Optional.empty(),
                       eventHandler,
@@ -745,7 +748,7 @@ public class HttpDownloaderTest {
   }
 
   @Test
-  public void downloadAndReadOneUrl_notFound() throws IOException, InterruptedException {
+  public void downloadAndRead_notFound() throws IOException, InterruptedException {
     try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName(null))) {
       @SuppressWarnings("unused")
       Future<?> possiblyIgnoredError =
@@ -769,8 +772,9 @@ public class HttpDownloaderTest {
       assertThrows(
           IOException.class,
           () ->
-              httpDownloader.downloadAndReadOneUrl(
-                  URI.create(String.format("http://localhost:%d/foo", server.getLocalPort())),
+              httpDownloader.downloadAndRead(
+                  ImmutableList.of(
+                      URI.create(String.format("http://localhost:%d/foo", server.getLocalPort()))),
                   StaticCredentials.EMPTY,
                   Optional.empty(),
                   eventHandler,
@@ -779,7 +783,7 @@ public class HttpDownloaderTest {
   }
 
   @Test
-  public void downloadAndReadOneUrl_checksumProvided()
+  public void downloadAndRead_checksumProvided()
       throws IOException, Checksum.InvalidChecksumException, InterruptedException {
     try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName(null))) {
       @SuppressWarnings("unused")
@@ -803,8 +807,10 @@ public class HttpDownloaderTest {
 
       assertThat(
               new String(
-                  httpDownloader.downloadAndReadOneUrl(
-                      URI.create(String.format("http://localhost:%d/foo", server.getLocalPort())),
+                  httpDownloader.downloadAndRead(
+                      ImmutableList.of(
+                          URI.create(
+                              String.format("http://localhost:%d/foo", server.getLocalPort()))),
                       StaticCredentials.EMPTY,
                       Optional.of(
                           Checksum.fromString(
@@ -818,7 +824,7 @@ public class HttpDownloaderTest {
   }
 
   @Test
-  public void downloadAndReadOneUrl_checksumMismatch() throws IOException {
+  public void downloadAndRead_checksumMismatch() throws IOException {
     try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName(null))) {
       @SuppressWarnings("unused")
       Future<?> possiblyIgnoredError =
@@ -843,8 +849,10 @@ public class HttpDownloaderTest {
           assertThrows(
               UnrecoverableHttpException.class,
               () ->
-                  httpDownloader.downloadAndReadOneUrl(
-                      URI.create(String.format("http://localhost:%d/foo", server.getLocalPort())),
+                  httpDownloader.downloadAndRead(
+                      ImmutableList.of(
+                          URI.create(
+                              String.format("http://localhost:%d/foo", server.getLocalPort()))),
                       StaticCredentials.EMPTY,
                       Optional.of(
                           Checksum.fromString(
@@ -853,6 +861,137 @@ public class HttpDownloaderTest {
                       eventHandler,
                       ImmutableMap.of()));
       assertThat(e).hasMessageThat().contains("Checksum was");
+    }
+  }
+
+  @Test
+  public void downloadAndRead_twoUrlsFirstNotFoundAndSecondOk()
+      throws IOException, InterruptedException {
+    try (ServerSocket server1 = new ServerSocket(0, 1, InetAddress.getByName(null));
+        ServerSocket server2 = new ServerSocket(0, 1, InetAddress.getByName(null))) {
+      @SuppressWarnings("unused")
+      Future<?> possiblyIgnoredError =
+          executor.submit(
+              () -> {
+                try (Socket socket = server1.accept()) {
+                  readHttpRequest(socket.getInputStream());
+                  sendLines(
+                      socket,
+                      "HTTP/1.1 404 Not Found",
+                      "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                      "Connection: close",
+                      "Content-Type: text/plain",
+                      "Content-Length: 0",
+                      "",
+                      "");
+                }
+                return null;
+              });
+
+      @SuppressWarnings("unused")
+      Future<?> possiblyIgnoredError2 =
+          executor.submit(
+              () -> {
+                while (!executor.isShutdown()) {
+                  try (Socket socket = server2.accept()) {
+                    readHttpRequest(socket.getInputStream());
+                    sendLines(
+                        socket,
+                        "HTTP/1.1 200 OK",
+                        "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                        "Connection: close",
+                        "Content-Type: text/plain",
+                        "",
+                        "content2");
+                  }
+                }
+                return null;
+              });
+
+      ImmutableList<URI> urls =
+          ImmutableList.of(
+              URI.create(String.format("http://localhost:%d/foo", server1.getLocalPort())),
+              URI.create(String.format("http://localhost:%d/foo", server2.getLocalPort())));
+
+      byte[] content =
+          httpDownloader.downloadAndRead(
+              urls,
+              StaticCredentials.EMPTY,
+              Optional.empty(),
+              eventHandler,
+              Collections.emptyMap());
+
+      assertThat(new String(content, UTF_8)).isEqualTo("content2");
+    }
+  }
+
+  @Test
+  public void downloadAndReadOneUrlForBzlmod_fallsBackToNextRewrittenUrl()
+      throws IOException, InterruptedException {
+    try (ServerSocket primary = new ServerSocket(0, 1, InetAddress.getByName(null));
+        ServerSocket fallback = new ServerSocket(0, 1, InetAddress.getByName(null))) {
+      // The first (e.g. proxy/mirror) URL fails ...
+      @SuppressWarnings("unused")
+      Future<?> possiblyIgnoredError =
+          executor.submit(
+              () -> {
+                try (Socket socket = primary.accept()) {
+                  readHttpRequest(socket.getInputStream());
+                  sendLines(
+                      socket,
+                      "HTTP/1.1 404 Not Found",
+                      "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                      "Connection: close",
+                      "Content-Type: text/plain",
+                      "Content-Length: 0",
+                      "",
+                      "");
+                }
+                return null;
+              });
+
+      // ... so the read must fall back to the second (e.g. direct) URL.
+      @SuppressWarnings("unused")
+      Future<?> possiblyIgnoredError2 =
+          executor.submit(
+              () -> {
+                while (!executor.isShutdown()) {
+                  try (Socket socket = fallback.accept()) {
+                    readHttpRequest(socket.getInputStream());
+                    sendLines(
+                        socket,
+                        "HTTP/1.1 200 OK",
+                        "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                        "Connection: close",
+                        "Content-Type: text/plain",
+                        "",
+                        "content2");
+                  }
+                }
+                return null;
+              });
+
+      URI originalUrl = URI.create("https://example.com/foo");
+      URI primaryUrl = URI.create(String.format("http://localhost:%d/foo", primary.getLocalPort()));
+      URI fallbackUrl =
+          URI.create(String.format("http://localhost:%d/foo", fallback.getLocalPort()));
+
+      // A rewriter that expands the single registry URL into an ordered [primary, fallback] list,
+      // like e.g. a proxy/mirror rewrite with a direct-URL fallback.
+      UrlRewriter rewriter = mock(UrlRewriter.class);
+      when(rewriter.amend(any()))
+          .thenReturn(
+              ImmutableList.of(
+                  UrlRewriter.RewrittenURL.create(primaryUrl, true),
+                  UrlRewriter.RewrittenURL.create(fallbackUrl, true)));
+      when(rewriter.updateAuthHeaders(any(), any(), any())).thenReturn(ImmutableMap.of());
+      downloadManager.setUrlRewriter(rewriter);
+
+      byte[] content =
+          downloadManager.downloadAndReadOneUrlForBzlmod(
+              originalUrl, Collections.emptyMap(), Optional.empty());
+
+      assertThat(new String(content, UTF_8)).isEqualTo("content2");
     }
   }
 


### PR DESCRIPTION
### Description

Convert HttpDownloader#downloadAndReadOneUrl to downloadAndRead, which now takes the full list of rewritten URLs, not just the first, so Bzlmod registry downloads fall back too.

A regression test drives the full Bzlmod path with a rewriter that yields a failing URL followed by a working one and asserts the content is read from the fallback.

Also, refactor HttpDownloader to share a single URL-fallback loop. `download()` writes to a file and `downloadAndRead()` reads into memory. Each had their own copy of the same loop: try each URL in order, fall back to the next on failure, and report the failures when none succeed. Extract that loop into a single `downloadFromUrls()` helper so the two can no longer drift apart.

Fixes: #30086

### Motivation

A URL rewriter can expand a single registry URL into an ordered list of candidates (e.g. a mirror followed by the upstream URL as a fallback). Repository-rule downloads honor the whole list: HttpDownloader#download tries the URLs in order and falls back to the next one when a download fails. Without the fix, Bzlmod registry downloads read from only the first rewritten URL, so a fetch fails on a bad first candidate instead of falling back, even though an http_archive with the same URLs succeeds.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [X] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None