### PR TITLE
Redo logic for bfs of VendorCommand.java

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
@@ -305,17 +305,17 @@ public final class VendorCommand implements BlazeCommand {
       InMemoryGraph inMemoryGraph, ImmutableList<SkyKey> targetKeys) throws InterruptedException {
     ImmutableSet.Builder<RepositoryName> repos = ImmutableSet.builder();
     Queue<SkyKey> nodes = new ArrayDeque<>(targetKeys);
-    Set<SkyKey> visited = new HashSet<>();
+    // Mark nodes as visited when they are enqueued.
+    Set<SkyKey> visited = new HashSet<>(targetKeys);
     while (!nodes.isEmpty()) {
       SkyKey key = nodes.remove();
-      visited.add(key);
       NodeEntry nodeEntry = inMemoryGraph.get(null, Reason.VENDOR_EXTERNAL_REPOS, key);
       if (nodeEntry.getValue() instanceof RepositoryDirectoryValue.Success repoDirValue
           && !repoDirValue.excludeFromVendoring()) {
         repos.add((RepositoryName) key.argument());
       }
       for (SkyKey depKey : nodeEntry.getDirectDeps()) {
-        if (!visited.contains(depKey)) {
+        if (visited.add(depKey)) {
           nodes.add(depKey);
         }
       }


### PR DESCRIPTION
Redo logic for bfs of VendorCommand.java
### Description
<!--
Please provide a brief summary of the changes in this PR.
-->
Adding the nodes of the graph into visited when we're dequeing while checking if they exist while enqueing means that we might accidentally add the same nodes multiple time, leading to OOM on big production graphs.

Example:
```
target keys = [A, B]
nodes = [A, B]

A -> C
B -> C
```

We visit A, then add C to nodes.
Then we visit B, also adding C to nodes under the old logic (duplicated).


This patch changes the logic so that we add a node to visited whenever we enqueue so this doesn't happen. See
https://en.wikipedia.org/wiki/Breadth-first_search#Pseudocode for pseudocode.


### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

Fix oom bug

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [NA] I have added tests for the new use cases (if any).
- [NA] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
