### PR TITLE
[9.2.0] Do not cache CommandContext in BES client

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModule.java
@@ -142,9 +142,7 @@ public class BazelBuildEventServiceModule
           new BuildEventServiceGrpcClient(
               newGrpcChannel(config),
               credentials != null ? MoreCallCredentials.from(credentials) : null,
-              makeGrpcInterceptor(config),
-              env.getBuildRequestId(),
-              env.getCommandId());
+              makeGrpcInterceptor(config));
     }
     return client;
   }

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BuildEventServiceProtoUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BuildEventServiceProtoUtil.java
@@ -51,21 +51,15 @@ public final class BuildEventServiceProtoUtil {
 
   /** Creates a {@link PublishLifecycleEventRequest} from a {@link LifecycleEvent}. */
   public static PublishLifecycleEventRequest publishLifecycleEventRequest(
-      LifecycleEvent lifecycleEvent) {
+      CommandContext commandContext, LifecycleEvent lifecycleEvent) {
     return switch (lifecycleEvent) {
-      case LifecycleEvent.BuildEnqueued(CommandContext commandContext, Instant eventTime) ->
+      case LifecycleEvent.BuildEnqueued(Instant eventTime) ->
           buildEnqueued(commandContext, eventTime);
-      case LifecycleEvent.InvocationStarted(CommandContext commandContext, Instant eventTime) ->
+      case LifecycleEvent.InvocationStarted(Instant eventTime) ->
           invocationStarted(commandContext, eventTime);
-      case LifecycleEvent.InvocationFinished(
-              CommandContext commandContext,
-              Instant eventTime,
-              InvocationStatus status) ->
+      case LifecycleEvent.InvocationFinished(Instant eventTime, InvocationStatus status) ->
           invocationFinished(commandContext, eventTime, status);
-      case LifecycleEvent.BuildFinished(
-              CommandContext commandContext,
-              Instant eventTime,
-              InvocationStatus status) ->
+      case LifecycleEvent.BuildFinished(Instant eventTime, InvocationStatus status) ->
           buildFinished(commandContext, eventTime, status);
     };
   }
@@ -128,18 +122,11 @@ public final class BuildEventServiceProtoUtil {
 
   /** Creates a {@link PublishBuildToolEventStreamRequest} from a {@link StreamEvent}. */
   public static PublishBuildToolEventStreamRequest publishBuildToolEventStreamRequest(
-      StreamEvent streamEvent) {
+      CommandContext commandContext, StreamEvent streamEvent) {
     return switch (streamEvent) {
-      case StreamEvent.BazelEvent(
-              CommandContext commandContext,
-              Instant eventTime,
-              long sequenceNumber,
-              ByteString payload) ->
+      case StreamEvent.BazelEvent(Instant eventTime, long sequenceNumber, ByteString payload) ->
           bazelEvent(commandContext, eventTime, sequenceNumber, payload);
-      case StreamEvent.StreamFinished(
-              CommandContext commandContext,
-              Instant eventTime,
-              long sequenceNumber) ->
+      case StreamEvent.StreamFinished(Instant eventTime, long sequenceNumber) ->
           streamFinished(commandContext, eventTime, sequenceNumber);
     };
   }

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceTransportGrpcTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceTransportGrpcTest.java
@@ -32,7 +32,6 @@ import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.UUID;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -63,9 +62,7 @@ public class BuildEventServiceTransportGrpcTest extends AbstractBuildEventServic
     return new BuildEventServiceGrpcClient(
         ManagedChannelBuilder.forTarget("localhost:" + serverPort).usePlaintext().build(),
         /* callCredentials= */ null,
-        /* interceptor= */ null,
-        "testing/" + UUID.randomUUID(),
-        UUID.randomUUID());
+        /* interceptor= */ null);
   }
 
   @Override


### PR DESCRIPTION
Cherry-picks fbbdfad763472928b6c32babe3308c9506f13ec1 onto
release-9.2.0.

Do not cache (parts of) the CommandContext in BuildEventServiceGrpcClient.

The client may outlive the command that started it.

Caching it in a StreamContext, on the other hand, is fine because these are command-scoped.

PiperOrigin-RevId: 836649514
Change-Id: Id21577f480597dc085fdc73aa102870fdfabd268
