### PR TITLE
[9.3.0] Parse latest Bazel 10 syntax for tuple and struct type annotations

### DIFF
--- a/src/main/java/net/starlark/java/syntax/Parser.java
+++ b/src/main/java/net/starlark/java/syntax/Parser.java
@@ -1125,13 +1125,20 @@ final class Parser {
     return expr;
   }
 
-  // TypeArgument = TypeExpr | ListOfTypes | DictOfTypes | string | ellipsis
+  // TypeArgument = TypeExpr | ListOfTypes | DictOfTypes | '(' ')' | string | ellipsis
   private Expression parseTypeArgument() {
     switch (token.kind) {
       case LBRACKET: // [...]
         return parseTypeList();
       case LBRACE: // {...}
         return parseTypeDict();
+      case LPAREN: // the empty tuple ()
+        {
+          int lparenOffset = expect(TokenKind.LPAREN);
+          int rparenOffset = expect(TokenKind.RPAREN);
+          return new ListExpression(
+              locs, /* isTuple= */ true, lparenOffset, ImmutableList.of(), rparenOffset);
+        }
       case STRING:
         return parseStringLiteral();
       case ELLIPSIS:
@@ -1198,9 +1205,7 @@ final class Parser {
   private Expression parseTypeApplication(Identifier constructor) {
     expect(TokenKind.LBRACKET);
     ImmutableList.Builder<Expression> args = ImmutableList.builder();
-    if (token.kind != TokenKind.RBRACKET) {
-      args.add(parseTypeArgument());
-    }
+    args.add(parseTypeArgument());
     while (token.kind != TokenKind.RBRACKET && token.kind != TokenKind.EOF) {
       expect(TokenKind.COMMA);
       args.add(parseTypeArgument());

--- a/src/main/java/net/starlark/java/syntax/Parser.java
+++ b/src/main/java/net/starlark/java/syntax/Parser.java
@@ -1125,7 +1125,7 @@ final class Parser {
     return expr;
   }
 
-  // TypeArgument = TypeExpr | ListOfTypes | DictOfTypes | string
+  // TypeArgument = TypeExpr | ListOfTypes | DictOfTypes | string | ellipsis
   private Expression parseTypeArgument() {
     switch (token.kind) {
       case LBRACKET: // [...]
@@ -1134,6 +1134,8 @@ final class Parser {
         return parseTypeDict();
       case STRING:
         return parseStringLiteral();
+      case ELLIPSIS:
+        return parsePrimary();
       default:
     }
     if (token.kind != TokenKind.IDENTIFIER) {

--- a/src/main/java/net/starlark/java/syntax/Parser.java
+++ b/src/main/java/net/starlark/java/syntax/Parser.java
@@ -1175,7 +1175,15 @@ final class Parser {
 
   // TypeEntry = string ':' TypeArgument .
   private DictExpression.Entry parseTypeDictEntry() {
-    Expression key = parseStringLiteral();
+    Expression key;
+    if (token.kind == TokenKind.STRING) {
+      key = parseStringLiteral();
+    } else {
+      int start = token.start;
+      syntaxError(String.format("expected %s", TokenKind.STRING));
+      int end = syncTo(EXPR_TERMINATOR_SET);
+      key = makeErrorExpression(start, end);
+    }
     int colonOffset = expect(TokenKind.COLON);
     Expression value = parseTypeArgument();
     return new DictExpression.Entry(locs, key, colonOffset, value);

--- a/src/test/java/net/starlark/java/eval/DynamicTypeCheckTest.java
+++ b/src/test/java/net/starlark/java/eval/DynamicTypeCheckTest.java
@@ -143,7 +143,6 @@ public class DynamicTypeCheckTest {
 
   @Test
   public void runtimeTypecheck_tuple() throws Exception {
-    ev.exec("def f(a: tuple[]): pass", "f(())");
     ev.exec("def f(a: tuple[int, str]): pass", "f((1, 'a'))");
     ev.exec("def f(a: tuple[int, str, bool]): pass", "f((1, 'a', True))");
     assertExecThrows(EvalException.class, "def f(a: tuple[int, str]): pass", "f((1, 2))")

--- a/src/test/java/net/starlark/java/syntax/ParserTest.java
+++ b/src/test/java/net/starlark/java/syntax/ParserTest.java
@@ -1465,15 +1465,26 @@ public final class ParserTest {
     setFileOptions(FileOptions.builder().allowTypeSyntax(true).build());
     // basic examples
     assertThat(parseTypeExpression("int")).isInstanceOf(Identifier.class);
-    assertThat(parseTypeExpression("tuple[]")).isInstanceOf(TypeApplication.class);
     assertThat(parseTypeExpression("list[str]")).isInstanceOf(TypeApplication.class);
     assertThat(parseTypeExpression("dict[str, int]")).isInstanceOf(TypeApplication.class);
+    // type applications must have at least one argument
+    assertThat(assertThrows(SyntaxError.Exception.class, () -> parseTypeExpression("tuple[]")))
+        .hasMessageThat()
+        .contains("syntax error at ']': expected a type argument");
     // type expressions can use list literals
     assertThat(parseTypeExpression("Callable[[int, str], int]"))
         .isInstanceOf(TypeApplication.class);
     // type expressions can use dict literals
     assertThat(parseTypeExpression("TypedDict[{'a': int, 'b': bool}]"))
         .isInstanceOf(TypeApplication.class);
+    // type expressions can use empty tuple literals
+    assertThat(parseTypeExpression("tuple[()]")).isInstanceOf(TypeApplication.class);
+    // ...but not non-empty tuples
+    assertThat(
+            assertThrows(
+                SyntaxError.Exception.class, () -> parseTypeExpression("tuple[(int, str)]")))
+        .hasMessageThat()
+        .contains("syntax error at 'int': expected )");
     // type expressions can use string literals
     assertThat(parseTypeExpression("Literal['abc']")).isInstanceOf(TypeApplication.class);
     // composition
@@ -1519,7 +1530,7 @@ public final class ParserTest {
   public void testDefWithTypeAnnotations() throws Exception {
     setFileOptions(FileOptions.builder().allowTypeSyntax(true).build());
     parseStatement("def f(a: int): pass");
-    parseStatement("def f(a: tuple[]): pass");
+    parseStatement("def f(a: tuple[()]): pass");
     parseStatement("def f(a: list[str]): pass");
     parseStatement("def f(a: dict[str, int]): pass");
 

--- a/src/test/java/net/starlark/java/syntax/ParserTest.java
+++ b/src/test/java/net/starlark/java/syntax/ParserTest.java
@@ -1474,9 +1474,20 @@ public final class ParserTest {
     // type expressions can use list literals
     assertThat(parseTypeExpression("Callable[[int, str], int]"))
         .isInstanceOf(TypeApplication.class);
-    // type expressions can use dict literals
+    // type expressions can use dict literals with string keys and type expression values
     assertThat(parseTypeExpression("TypedDict[{'a': int, 'b': bool}]"))
         .isInstanceOf(TypeApplication.class);
+    // (non-string keys, or non-type-expression values, are a parse-time error)
+    assertThat(
+            assertThrows(
+                SyntaxError.Exception.class, () -> parseTypeExpression("TypedDict[{x: y}]")))
+        .hasMessageThat()
+        .contains("syntax error at 'x': expected string literal");
+    assertThat(
+            assertThrows(
+                SyntaxError.Exception.class, () -> parseTypeExpression("TypedDict[{'x': foo()}]")))
+        .hasMessageThat()
+        .contains("syntax error at '(': expected ,");
     // type expressions can use empty tuple literals
     assertThat(parseTypeExpression("tuple[()]")).isInstanceOf(TypeApplication.class);
     // ...but not non-empty tuples

--- a/src/test/java/net/starlark/java/syntax/ParserTest.java
+++ b/src/test/java/net/starlark/java/syntax/ParserTest.java
@@ -1739,10 +1739,15 @@ public final class ParserTest {
   }
 
   @Test
-  public void testEllipsisAllowedInTypeExpressions() throws Exception {
+  public void testEllipsisAllowedInTypeExpressionArgumentsOnly() throws Exception {
     setFileOptions(
-        FileOptions.builder().allowTypeSyntax(true).tolerateInvalidTypeExpressions(true).build());
-    parseStatement("x : Tuple[int, ...]");
+        FileOptions.builder().allowTypeSyntax(true).tolerateInvalidTypeExpressions(false).build());
+    parseStatement("x : tuple[int, ...]");
+    assertThat(parseStatementError("x : ...")).contains("syntax error at '...': expected a type");
+    assertThat(parseStatementError("x : int | ..."))
+        .contains("syntax error at '...': expected identifier");
+    assertThat(parseStatementError("x : tuple[int | ...]"))
+        .contains("syntax error at '...': expected identifier");
   }
 
   @Test


### PR DESCRIPTION
This PR cherry-picks only the changes to Parser.java and ParserTest.java from the following commits:

* "Add a homogeneous unsized tuple type, i.e. `tuple[T, ...]`"
  https://github.com/bazelbuild/bazel/commit/f1b3273f9fc7220ba16fe84ca570f18
  PiperOrigin-RevId: 874720099
  Change-Id: I483d9fcfb42706a2bf57aaf23b25e9b29e23ed1a

* "Type tagger: Use `tuple[()]` for an empty tuple, and `tuple` for an arbitrary one"
  https://github.com/bazelbuild/bazel/commit/2004bad12fd4f72c2436520846e0dcf162a0232a
  PiperOrigin-RevId: 876242226
  Change-Id: Iab359664be5e05c883cc5d859fd5f1ca432877d6

* "Add struct type""
  https://github.com/bazelbuild/bazel/commit/f0011d8f293380532a26713ea739928f2b65c0a3
  PiperOrigin-RevId: 888239789
  Change-Id: Iac10979a0f20e9d16f0c4bafa5b3af6a37598307

RELNOTES: None
