### PR TITLE
Update the embedded JDK to 26

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -382,7 +382,7 @@ use_repo(
     "openjdk_linux_vanilla",
     "openjdk_macos_aarch64_vanilla",
     "openjdk_macos_x86_64_vanilla",
-    "openjdk_win_arm64_jmods",
+    "openjdk_win_arm64_jlink_tool",
     "openjdk_win_arm64_vanilla",
     "openjdk_win_vanilla",
 )

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -370,7 +370,7 @@
   "moduleExtensions": {
     "//:repositories.bzl%async_profiler_repos": {
       "general": {
-        "bzlTransitiveDigest": "ls6m1Kowdl+1j4w7pskwwhAhBgIfX4bNj6W1FDg78P4=",
+        "bzlTransitiveDigest": "NULKS7rZgHu4Y/uYq40RSEEnrgQLRyupLBq5Z9DJx1o=",
         "usagesDigest": "7jreou9WV8qOgoUM+8bYvk7WC5dIlxvYXDi24CckXQQ=",
         "recordedInputs": [
           "REPO_MAPPING:,async_profiler +async_profiler_repos+async_profiler",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -81,71 +81,73 @@ def embedded_jdk_repositories():
     """OpenJDK distributions used to create a version of Bazel bundled with the OpenJDK."""
     http_file(
         name = "openjdk_linux_vanilla",
-        integrity = "sha256-8XUtAFG2yiM2Jd2ywYyRcO2+VcXuZRW/79jqAZfuHCA=",
+        integrity = "sha256-fWZj6o1CmN9l3gZeMvn0SXRf9gfTC6XRN3fLkunUYT0=",
         downloaded_file_path = "zulu-linux-vanilla.tar.gz",
-        url = "https://cdn.azul.com/zulu/bin/zulu25.32.17-ca-jdk25.0.2-linux_x64.tar.gz",
+        url = "https://cdn.azul.com/zulu/bin/zulu26.30.11-ca-jdk26.0.1-linux_x64.tar.gz",
     )
     http_file(
         name = "openjdk_linux_aarch64_vanilla",
-        integrity = "sha256-9ylaux3ssvbg6p92CnCRfy1HNW20Nm1hXHq5sBw8aGY=",
+        integrity = "sha256-zBtFncRC10IrRqO1/lKsrqVIefp5E+KaBWUM71Rof18=",
         downloaded_file_path = "zulu-linux-aarch64-vanilla.tar.gz",
-        url = "https://cdn.azul.com/zulu/bin/zulu25.32.17-ca-jdk25.0.2-linux_aarch64.tar.gz",
+        url = "https://cdn.azul.com/zulu/bin/zulu26.30.11-ca-jdk26.0.1-linux_aarch64.tar.gz",
     )
     http_file(
         name = "openjdk_linux_ppc64le_vanilla",
-        integrity = "sha256-smK3NbIVFzADdm2jZYjV9xfc6toChttBtDn5P7KtpGg=",
+        integrity = "sha256-YOAW+vQXeEBDADXZSPg/KIfVVv5RK3jB1DsyAyL+ZoU=",
         downloaded_file_path = "adoptopenjdk-ppc64le-vanilla.tar.gz",
-        url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_ppc64le_linux_hotspot_25.0.2_10.tar.gz",
+        url = "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_ppc64le_linux_hotspot_26.0.1_8.tar.gz",
     )
     http_file(
         name = "openjdk_linux_riscv64_vanilla",
-        integrity = "sha256-FoEZ5PujUPTms8qSRQorkKhQK4miNaBEFemt+fXTFk4=",
+        integrity = "sha256-8bdi1thlmWJ5g98gDyFbyXBESmlxWco/rpMgh1a0RxU=",
         downloaded_file_path = "adoptopenjdk-riscv64-vanilla.tar.gz",
-        url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_riscv64_linux_hotspot_25.0.2_10.tar.gz",
+        url = "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_riscv64_linux_hotspot_26.0.1_8.tar.gz",
     )
     http_file(
         name = "openjdk_linux_s390x_vanilla",
-        integrity = "sha256-FeXLytzz1DYjwxuCUGPNwoF7nxuoQLUdxu9w5dM8hOM=",
+        integrity = "sha256-lC3n3tFCdZKipLbb6kCDstCJHeJibHhj6XDePigZqT8=",
         downloaded_file_path = "adoptopenjdk-s390x-vanilla.tar.gz",
-        url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_s390x_linux_hotspot_25.0.2_10.tar.gz",
+        url = "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_s390x_linux_hotspot_26.0.1_8.tar.gz",
     )
     http_file(
         name = "openjdk_macos_x86_64_vanilla",
-        integrity = "sha256-/iI0bBkpIMW4SyP0qiTj3rsLuU/EKAFvfCssd5DIJ4A=",
+        integrity = "sha256-GSYQQQ3N+27cokKbDV0rHN8yL1MiGKwAMn4bz43+KbM=",
         downloaded_file_path = "zulu-macos-vanilla.tar.gz",
-        url = "https://cdn.azul.com/zulu/bin/zulu25.32.17-ca-jdk25.0.2-macosx_x64.tar.gz",
+        url = "https://cdn.azul.com/zulu/bin/zulu26.30.11-ca-jdk26.0.1-macosx_x64.tar.gz",
     )
     http_file(
         name = "openjdk_macos_aarch64_vanilla",
-        integrity = "sha256-U3rHT6HKLE3Y9gY93t4BOK5KiW8Si/4QtCin3MSqkp8=",
+        integrity = "sha256-fxsSMjJTejCm7UqofWqE1Ca3Wr81Dr4jVnhKJh6dYHY=",
         downloaded_file_path = "zulu-macos-aarch64-vanilla.tar.gz",
-        url = "https://cdn.azul.com/zulu/bin/zulu25.32.17-ca-jdk25.0.2-macosx_aarch64.tar.gz",
+        url = "https://cdn.azul.com/zulu/bin/zulu26.30.11-ca-jdk26.0.1-macosx_aarch64.tar.gz",
     )
     http_file(
         name = "openjdk_win_vanilla",
-        integrity = "sha256-kLy7y+L7euxDzo/S76Ak/MSPALvc16drWPkS1rl+bVY=",
+        integrity = "sha256-j3b0CLDiKJdLDJV4qSdZGJu13Pp/elIVgnd+QEoyRKA=",
         downloaded_file_path = "zulu-win-vanilla.zip",
-        url = "https://cdn.azul.com/zulu/bin/zulu25.32.17-ca-jdk25.0.2-win_x64.zip",
+        url = "https://cdn.azul.com/zulu/bin/zulu26.30.11-ca-jdk26.0.1-win_x64.zip",
     )
     http_file(
         name = "openjdk_win_arm64_vanilla",
-        integrity = "sha256-zhWbTuPBCc1RNXrPhCZBQsHdsOGHjSBGbqxQsBU0cVQ=",
-        downloaded_file_path = "zulu-win-arm64.zip",
-        # Use an EA release of 25.0.3 here since versions <= 25.0.2 are affected by a severe JDK bug
-        # that causes virtual threads (and thus repo rules) to hang indefinitely on Windows ARM64.
-        # https://github.com/bazelbuild/bazel/issues/28520
-        # https://mail.openjdk.org/pipermail/loom-dev/2026-February/008286.html
-        url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B1-ea-beta/OpenJDK25U-jdk_aarch64_windows_hotspot_25.0.3_1-ea.zip",
+        integrity = "sha256-JMBoQdovyQStuciKVAawKJZmXkxqKpGYFyO0jiVUzPM=",
+        downloaded_file_path = "bellsoft-win-arm64.zip",
+        # BellSoft Liberica is currently the only vendor with a GA JDK 26 build
+        # for Windows ARM64. It ships with jmods, which are required for
+        # cross-jlinking the minimized JDK.
+        url = "https://github.com/bell-sw/Liberica/releases/download/26.0.1%2B10/bellsoft-jdk26.0.1%2B10-windows-aarch64.zip",
     )
 
-    # The Adoptium Temurin JDK above has JEP 493 enabled, which means it does not ship with jmods.
-    # These are needed for cross-jlinking (minimizing the JDK on a different platform).
-    # https://adoptium.net/news/2025/08/eclipse-temurin-jdk24-JEP493-enabled
+    # The Windows arm64 runtime above is cross-jlinked on a Windows x64 host. Since
+    # JDK 26, jlink requires the tool JDK and the target java.base to be the exact
+    # same build (both vendor and build number are compared), so the jlink tool has
+    # to be a Windows x64 build of the same BellSoft Liberica release as
+    # openjdk_win_arm64_vanilla. It is used only as the jlink tool; the embedded
+    # Windows x64 runtime itself is still Azul Zulu (openjdk_win_vanilla).
     http_file(
-        name = "openjdk_win_arm64_jmods",
-        integrity = "sha256-2rjwZCoUIYD7L9nLwLJindsYPkDMvpI4km5a9UlxFtg=",
-        downloaded_file_path = "temurin-win-arm64-jmods.zip",
-        url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B1-ea-beta/OpenJDK25U-jmods_aarch64_windows_hotspot_25.0.3_1-ea.zip",
+        name = "openjdk_win_arm64_jlink_tool",
+        integrity = "sha256-En7H6N+8rEOUfa+NziEm1slGG92cG10N9V9aoW1v48s=",
+        downloaded_file_path = "bellsoft-win-x64-jlink-tool.zip",
+        url = "https://github.com/bell-sw/Liberica/releases/download/26.0.1%2B10/bellsoft-jdk26.0.1%2B10-windows-amd64.zip",
     )
 
 def _async_profiler_repos(ctx):

--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -48,10 +48,12 @@ _BAZEL_ARGS="--spawn_strategy=standalone \
       --lockfile_mode=update \
       --deleted_packages=third_party/remoteapis \
       --override_repository=$(cat derived/maven/MAVEN_CANONICAL_REPO_NAME)=derived/maven \
-      --java_runtime_version=${JAVA_VERSION} \
+      --java_runtime_version=local_jdk \
       --java_language_version=${JAVA_VERSION} \
-      --tool_java_runtime_version=${JAVA_VERSION} \
+      --tool_java_runtime_version=local_jdk \
       --tool_java_language_version=${JAVA_VERSION} \
+      --javacopt=-proc:full \
+      --host_javacopt=-proc:full \
       --define=protobuf_allow_msvc=true \
       ${DIST_BOOTSTRAP_ARGS:-} \
       ${EXTRA_BAZEL_ARGS:-}"

--- a/src/BUILD
+++ b/src/BUILD
@@ -222,24 +222,32 @@ sh_binary(
     ],
 )
 
+# The jlink tool must have the same build as the target JDK. When cross-jlinking
+# the Windows arm64 runtime on a Windows x64 host, jdk_for_jlink (the host's
+# embedded JDK) is Azul Zulu and would not match the BellSoft target, so a
+# matching BellSoft Windows x64 build is used as the jlink tool instead. These
+# selects are resolved in the target configuration, so they key on the target
+# platform even though the selected tool is built for (and runs on) the exec
+# platform.
+_JLINK_TOOL = select({
+    "//src/conditions:windows_arm64": ["@openjdk_win_arm64_jlink_tool//file"],
+    "//conditions:default": [":jdk_for_jlink"],
+})
+
+_JLINK_TOOL_LOCATION = select({
+    "//src/conditions:windows_arm64": "$(location @openjdk_win_arm64_jlink_tool//file)",
+    "//conditions:default": "$(location :jdk_for_jlink)",
+})
+
 genrule(
     name = "embedded_jdk_minimal",
     srcs = [
         ":embedded_jdk_vanilla",
         ":jdeps_modules.golden",
-    ] + select({
-        "//src/conditions:windows_arm64": ["@openjdk_win_arm64_jmods//file"],
-        "//conditions:default": [],
-    }),
-    outs = ["minimal_jdk.zip"],
-    cmd = "$(location :minimize_jdk) $(location :jdk_for_jlink) $(location :embedded_jdk_vanilla) $(location :jdeps_modules.golden) $@" + select({
-        "//src/conditions:windows_arm64": " $(location @openjdk_win_arm64_jmods//file)",
-        "//conditions:default": "",
-    }),
-    tools = [
-        ":jdk_for_jlink",
-        ":minimize_jdk",
     ],
+    outs = ["minimal_jdk.zip"],
+    cmd = "$(location :minimize_jdk) " + _JLINK_TOOL_LOCATION + " $(location :embedded_jdk_vanilla) $(location :jdeps_modules.golden) $@",
+    tools = [":minimize_jdk"] + _JLINK_TOOL,
     visibility = ["//src/test/shell/bazel:__pkg__"],
 )
 
@@ -248,19 +256,10 @@ genrule(
     srcs = [
         ":embedded_jdk_vanilla",
         ":jdeps_modules.golden",
-    ] + select({
-        "//src/conditions:windows_arm64": ["@openjdk_win_arm64_jmods//file"],
-        "//conditions:default": [],
-    }),
-    outs = ["allmodules_jdk.zip"],
-    cmd = "$(location :minimize_jdk) --allmodules $(location :jdk_for_jlink) $(location :embedded_jdk_vanilla) $(location :jdeps_modules.golden) $@" + select({
-        "//src/conditions:windows_arm64": " $(location @openjdk_win_arm64_jmods//file)",
-        "//conditions:default": "",
-    }),
-    tools = [
-        ":jdk_for_jlink",
-        ":minimize_jdk",
     ],
+    outs = ["allmodules_jdk.zip"],
+    cmd = "$(location :minimize_jdk) --allmodules " + _JLINK_TOOL_LOCATION + " $(location :embedded_jdk_vanilla) $(location :jdeps_modules.golden) $@",
+    tools = [":minimize_jdk"] + _JLINK_TOOL,
     visibility = ["//src/test/shell/bazel:__pkg__"],
 )
 


### PR DESCRIPTION
### Description

Bumps the OpenJDK distributions bundled with Bazel (the "embedded JDK" used to run Bazel) from 25 to 26.0.1 on all platforms:

| Platform | Vendor / version |
|---|---|
| Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64 | Azul Zulu 26.0.1 |
| Linux ppc64le, riscv64, s390x | Adoptium Temurin 26.0.1+8 |
| Windows arm64 | BellSoft Liberica 26.0.1+10 |

BellSoft Liberica is currently the only vendor shipping a GA JDK 26 build for Windows arm64 (Azul Zulu and Adoptium Temurin do not).

The Windows arm64 runtime is cross-jlinked on a Windows x86_64 host. As of JDK 26 (https://bugs.openjdk.org/browse/JDK-8347831), `jlink` requires the tool JDK and the target `java.base` to be the exact same build, so the Azul Zulu Windows x86_64 JDK cannot be used to cross-jlink the BellSoft Windows arm64 target.

To keep the embedded Windows x86_64 runtime on Azul Zulu, a Windows x86_64 build of the same BellSoft release is added as a dedicated jlink tool (`openjdk_win_arm64_jlink_tool`) and selected only for the `windows_arm64` target.

BellSoft ships with jmods, so the separate `openjdk_win_arm64_jmods` archive (previously needed only because the Temurin build has JEP 493 enabled) is removed together with its wiring in the `embedded_jdk_minimal`/`embedded_jdk_allmodules` genrules.

### Motivation

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any). — N/A.
- [ ] I have updated the documentation (if applicable). — N/A.

### Release Notes

RELNOTES: The JDK bundled with Bazel has been updated to 26.
