### PR TITLE
Silence duplicate option warnings from lower priority expansion

### DIFF
--- a/src/main/java/com/google/devtools/common/options/OptionValueDescription.java
+++ b/src/main/java/com/google/devtools/common/options/OptionValueDescription.java
@@ -268,11 +268,11 @@ public abstract class OptionValueDescription {
                     parsedOption.getCommandLineForm()));
           } else if ((optionThatExpandedToEffectiveValue != null)
               && (expandedFrom != null)
-              && !(samePriorityCategory
-                  && parsedOption
-                      .getPriority()
-                      .getPriorityCategory()
-                      .equals(PriorityCategory.RC_FILE))) {
+              && samePriorityCategory
+              && !parsedOption
+                  .getPriority()
+                  .getPriorityCategory()
+                  .equals(PriorityCategory.RC_FILE)) {
             warnings.add(
                 String.format(
                     "%s was expanded from both %s and %s",

--- a/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
+++ b/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
@@ -1581,6 +1581,19 @@ public final class OptionsParserTest {
   }
 
   @Test
+  public void noWarningForTwoConflictingExpansionOptionsFromDifferentPriorities()
+      throws Exception {
+    OptionsParser parser =
+        OptionsParser.builder().optionsClasses(ExpansionWarningOptions.class).build();
+    parser.parse(OptionPriority.PriorityCategory.RC_FILE, null, ImmutableList.of("--first"));
+    parser.parse(OptionPriority.PriorityCategory.COMMAND_LINE, null, ImmutableList.of("--second"));
+
+    assertThat(parser.getOptions(ExpansionWarningOptions.class).getUnderlying())
+        .isEqualTo("expandedFromSecond");
+    assertThat(parser.getWarnings()).isEmpty();
+  }
+
+  @Test
   public void noWarningForTwoConflictingExpansionOptionsFromRcFile() throws Exception {
     OptionsParser parser =
         OptionsParser.builder().optionsClasses(ExpansionWarningOptions.class).build();


### PR DESCRIPTION
Previously this config:

```
common:default --bes_results_url=remote.buildbuddy.io
common --config=default

common:override --bes_results_url=buildbuddy.buildbuddy.io
```

With `bazel build --config=override ...` would result in:

```
WARNING: option '--bes_results_url' was expanded from both option '--config=default' (source /.../.bazelrc) and option '--config=override' (source command line options)
```

Now we correctly treat the default config as coming from the lower
priority RC file
