### PR TITLE
Update rules-tutorial.md

### DIFF
--- a/site/en/rules/rules-tutorial.md
+++ b/site/en/rules/rules-tutorial.md
@@ -149,7 +149,7 @@ bin2
 ```
 
 Whenever you declare a file, you have to tell Bazel how to generate it by
-creating an action. Use [`ctx.actions.write`](lib/actions#write),
+creating an [action](https://bazel.build/extending/rules#actions). Use [`ctx.actions.write`](lib/actions#write),
 to create a file with the given content.
 
 ```python


### PR DESCRIPTION
Update `rules-tutorial.md`, specifically the "Create a File" section. It turns "action" into a link (to the "actions" documentation), to clarify that the word "action" refers to the Bazel-specific concept of "build actions", rather than the generic English concept of "a thing that is done."

It was an embarrassingly long time from when I started reading about Bazel before I realized the "action graph" existed, and that the purpose of build rules is to generate nodes in the action graph that run build-related commands, rather than to run build commands themselves. I think making this a link would've helped me notice sooner that "actions" are a Bazel concept and led me in the direction of reading about them.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
Update the Bazel rules tutorial to clarify the use of the word "action". On first reading, I didn't yet know about the Bazel "actions graph" or understand that, in Bazel's model, "action" refers to a specific data structure that serves a specific role. I interpreted the word in its generic english sense and initially found the tutorial very confusing.

### Motivation
Hopefully avoids the specific point of confusion that I experienced reading the tutorial.

### Build API Changes
No changes

### Checklist
- ~~I have added tests for the new use cases (if any).~~ N/A
- [x] I have updated the documentation (if applicable).

### Release Notes
None, docs only.
