### PR TITLE
Support per-mnemonic worker sandboxing

### DIFF
--- a/site/en/docs/sandboxing.md
+++ b/site/en/docs/sandboxing.md
@@ -58,8 +58,9 @@ preferring an OS-specific sandbox to the less hermetic generic one.
 the `--worker_sandboxing` flag. In addition to the plain boolean form, the flag
 can be scoped to a specific worker-key mnemonic with
 `--worker_sandboxing=<mnemonic>=<boolean>` (for example
-`--worker_sandboxing --worker_sandboxing=Javac=no` to sandbox all workers except
-`Javac`; a later plain boolean value applies to all mnemonics again).
+`--worker_sandboxing --worker_sandboxing=Javac=no` to sandbox all singleplex
+workers except `Javac`; a later plain boolean value applies to all mnemonics
+again).
 
 The `local` (a.k.a. `standalone`) strategy does not do any kind of sandboxing.
 It simply executes the action's command line with the working directory set to

--- a/site/en/docs/sandboxing.md
+++ b/site/en/docs/sandboxing.md
@@ -59,7 +59,7 @@ the `--worker_sandboxing` flag. In addition to the plain boolean form, the flag
 can be scoped to a specific worker-key mnemonic with
 `--worker_sandboxing=<mnemonic>=<boolean>` (for example
 `--worker_sandboxing --worker_sandboxing=Javac=no` to sandbox all workers except
-`Javac`).
+`Javac`; a later plain boolean value applies to all mnemonics again).
 
 The `local` (a.k.a. `standalone`) strategy does not do any kind of sandboxing.
 It simply executes the action's command line with the working directory set to

--- a/site/en/docs/sandboxing.md
+++ b/site/en/docs/sandboxing.md
@@ -55,7 +55,11 @@ You can choose which kind of sandboxing to use, if any, with the
 strategy makes Bazel pick one of the sandbox implementations listed below,
 preferring an OS-specific sandbox to the less hermetic generic one.
 [Persistent workers](/remote/persistent) run in a generic sandbox if you pass
-the `--worker_sandboxing` flag.
+the `--worker_sandboxing` flag. In addition to the plain boolean form, the flag
+can be scoped to a specific worker-key mnemonic with
+`--worker_sandboxing=<mnemonic>=<boolean>` (for example
+`--worker_sandboxing --worker_sandboxing=Javac=no` to sandbox all workers except
+`Javac`).
 
 The `local` (a.k.a. `standalone`) strategy does not do any kind of sandboxing.
 It simply executes the action's command line with the working directory set to

--- a/site/en/remote/persistent.md
+++ b/site/en/remote/persistent.md
@@ -135,7 +135,8 @@ the plain boolean form, the flag may be scoped to a worker-key mnemonic as
 `--worker_sandboxing=<mnemonic>=<boolean>`, allowing sandboxing to be enabled or
 disabled per mnemonic (for example
 `--worker_sandboxing --worker_sandboxing=Javac=no`). Later values override
-earlier ones for the same mnemonic.
+earlier ones for the mnemonics they affect, so a later plain
+`--worker_sandboxing` re-enables sandboxing for all mnemonics.
 
 The
 [`--worker_quit_after_build`](/reference/command-line-reference#flag--worker_quit_after_build)

--- a/site/en/remote/persistent.md
+++ b/site/en/remote/persistent.md
@@ -130,7 +130,12 @@ Passing the
 [`--worker_sandboxing`](/reference/command-line-reference#flag--worker_sandboxing)
 flag makes each worker request use a separate sandbox directory for all its
 inputs. Setting up the [sandbox](/docs/sandboxing) takes some extra time,
-especially on macOS, but gives a better correctness guarantee.
+especially on macOS, but gives a better correctness guarantee. In addition to
+the plain boolean form, the flag may be scoped to a worker-key mnemonic as
+`--worker_sandboxing=<mnemonic>=<boolean>`, allowing sandboxing to be enabled or
+disabled per mnemonic (for example
+`--worker_sandboxing --worker_sandboxing=Javac=no`). Later values override
+earlier ones for the same mnemonic.
 
 The
 [`--worker_quit_after_build`](/reference/command-line-reference#flag--worker_quit_after_build)
@@ -238,7 +243,8 @@ might be helpful.
 Using the `worker` strategy by default does not run the action in a
 [sandbox](/docs/sandboxing), similar to the `local` strategy. You can set the
 `--worker_sandboxing` flag to run all workers inside sandboxes, making sure each
-execution of the tool only sees the input files it's supposed to have. The tool
+execution of the tool only sees the input files it's supposed to have, or scope
+it per mnemonic with `--worker_sandboxing=<mnemonic>=<boolean>`. The tool
 may still leak information between requests internally, for instance through a
 cache. Using `dynamic` strategy
 [requires workers to be sandboxed](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistry.java){: .external}.

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java
@@ -31,6 +31,7 @@ import com.google.devtools.common.options.OptionsBase;
 import com.google.devtools.common.options.OptionsClass;
 import com.google.devtools.common.options.OptionsParsingException;
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -80,7 +81,7 @@ public abstract class WorkerOptions extends OptionsBase {
 
   /**
    * Parses a "[mnemonic=]bool" assignment. An input with no '=' (a bare boolean) uses the empty
-   * string as the key, which sets the default for all mnemonics. See {@link
+   * string as the key, which sets the value for all mnemonics. See {@link
    * WorkerOptions#getWorkerSandboxingMap}.
    *
    * <p>Implements {@link BooleanStyleOption} so that the legacy boolean-only forms remain valid:
@@ -195,25 +196,28 @@ public abstract class WorkerOptions extends OptionsBase {
           "If enabled, singleplex workers will run in a sandboxed environment. This may be set as"
               + " a plain boolean (the traditional --worker_sandboxing / --noworker_sandboxing"
               + " forms still work), or as [mnemonic=]value to enable or disable sandboxing per"
-              + " worker-key mnemonic; a value with no mnemonic sets the default for all mnemonics."
-              + " Later values override earlier ones for the same mnemonic. Singleplex workers are"
-              + " always sandboxed when running under the dynamic execution strategy or with path"
-              + " mapping, irrespective of this flag.")
+              + " worker-key mnemonic; a value with no mnemonic applies to all mnemonics. Later"
+              + " values override earlier ones for the mnemonics they affect. Singleplex workers"
+              + " are always sandboxed when running under the dynamic execution strategy or with"
+              + " path mapping, irrespective of this flag.")
   public abstract List<Map.Entry<String, Boolean>> getWorkerSandboxing();
 
   public abstract void setWorkerSandboxing(List<Map.Entry<String, Boolean>> value);
 
   /**
    * Resolves {@link #getWorkerSandboxing} into a map from mnemonic to whether sandboxing is
-   * enabled, with later values overriding earlier ones for the same key. The empty-string key holds
-   * the default for mnemonics without an explicit entry.
+   * enabled, with later values overriding earlier ones for the mnemonics they affect. The
+   * empty-string key holds the current value for mnemonics without a later explicit entry.
    */
   public ImmutableMap<String, Boolean> getWorkerSandboxingMap() {
-    ImmutableMap.Builder<String, Boolean> builder = ImmutableMap.builder();
+    Map<String, Boolean> map = new LinkedHashMap<>();
     for (Map.Entry<String, Boolean> entry : getWorkerSandboxing()) {
-      builder.put(entry.getKey(), entry.getValue());
+      if (entry.getKey().isEmpty()) {
+        map.clear();
+      }
+      map.put(entry.getKey(), entry.getValue());
     }
-    return builder.buildKeepingLast();
+    return ImmutableMap.copyOf(map);
   }
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java
@@ -14,9 +14,11 @@
 package com.google.devtools.build.lib.worker;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.util.RamResourceConverter;
 import com.google.devtools.build.lib.util.ResourceConverter;
+import com.google.devtools.common.options.BooleanStyleOption;
 import com.google.devtools.common.options.Converter;
 import com.google.devtools.common.options.Converters;
 import com.google.devtools.common.options.Converters.CommaSeparatedOptionSetConverter;
@@ -73,6 +75,37 @@ public abstract class WorkerOptions extends OptionsBase {
     @Override
     public String getTypeDescription() {
       return "[name=]value, where value is " + ResourceConverter.FLAG_SYNTAX;
+    }
+  }
+
+  /**
+   * Parses a "[mnemonic=]bool" assignment. An input with no '=' (a bare boolean) uses the empty
+   * string as the key, which sets the default for all mnemonics. See {@link
+   * WorkerOptions#getWorkerSandboxingMap}.
+   *
+   * <p>Implements {@link BooleanStyleOption} so that the legacy boolean-only forms remain valid:
+   * bare {@code --worker_sandboxing} (parsed as {@code "1"}) and {@code --noworker_sandboxing}
+   * (parsed as {@code "0"}) both resolve to the empty-mnemonic default.
+   */
+  public static class MnemonicBooleanConverter
+      extends Converter.Contextless<Map.Entry<String, Boolean>> implements BooleanStyleOption {
+
+    private static final Converters.BooleanConverter VALUE_CONVERTER =
+        new Converters.BooleanConverter();
+
+    @Override
+    public Map.Entry<String, Boolean> convert(String input) throws OptionsParsingException {
+      int pos = input.indexOf('=');
+      if (pos < 0) {
+        return Maps.immutableEntry("", VALUE_CONVERTER.convert(input));
+      }
+      return Maps.immutableEntry(
+          input.substring(0, pos), VALUE_CONVERTER.convert(input.substring(pos + 1)));
+    }
+
+    @Override
+    public String getTypeDescription() {
+      return "[mnemonic=]value, where value is a boolean";
     }
   }
 
@@ -153,16 +186,35 @@ public abstract class WorkerOptions extends OptionsBase {
 
   @Option(
       name = "worker_sandboxing",
-      defaultValue = "false",
+      converter = MnemonicBooleanConverter.class,
+      allowMultiple = true,
+      defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "If enabled, singleplex workers will run in a sandboxed environment. Singleplex workers"
-              + " are always sandboxed when running under the dynamic execution strategy,"
-              + " irrespective of this flag.")
-  public abstract boolean getWorkerSandboxing();
+          "If enabled, singleplex workers will run in a sandboxed environment. This may be set as"
+              + " a plain boolean (the traditional --worker_sandboxing / --noworker_sandboxing"
+              + " forms still work), or as [mnemonic=]value to enable or disable sandboxing per"
+              + " worker-key mnemonic; a value with no mnemonic sets the default for all mnemonics."
+              + " Later values override earlier ones for the same mnemonic. Singleplex workers are"
+              + " always sandboxed when running under the dynamic execution strategy or with path"
+              + " mapping, irrespective of this flag.")
+  public abstract List<Map.Entry<String, Boolean>> getWorkerSandboxing();
 
-  public abstract void setWorkerSandboxing(boolean value);
+  public abstract void setWorkerSandboxing(List<Map.Entry<String, Boolean>> value);
+
+  /**
+   * Resolves {@link #getWorkerSandboxing} into a map from mnemonic to whether sandboxing is
+   * enabled, with later values overriding earlier ones for the same key. The empty-string key holds
+   * the default for mnemonics without an explicit entry.
+   */
+  public ImmutableMap<String, Boolean> getWorkerSandboxingMap() {
+    ImmutableMap.Builder<String, Boolean> builder = ImmutableMap.builder();
+    for (Map.Entry<String, Boolean> entry : getWorkerSandboxing()) {
+      builder.put(entry.getKey(), entry.getValue());
+    }
+    return builder.buildKeepingLast();
+  }
 
   @Option(
       name = "worker_multiplex",

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -66,6 +66,7 @@ public class WorkerParser {
   private final Path execRoot;
 
   private final WorkerOptions workerOptions;
+  private final ImmutableMap<String, Boolean> workerSandboxingMap;
   private final LocalEnvProvider localEnvProvider;
   private final BinTools binTools;
 
@@ -76,6 +77,7 @@ public class WorkerParser {
       BinTools binTools) {
     this.execRoot = execRoot;
     this.workerOptions = workerOptions;
+    this.workerSandboxingMap = workerOptions.getWorkerSandboxingMap();
     this.localEnvProvider = localEnvProvider;
     this.binTools = binTools;
   }
@@ -110,6 +112,7 @@ public class WorkerParser {
             workerFilesCombinedHash,
             workerFiles,
             workerOptions,
+            workerSandboxingMap,
             context.speculating(),
             Spawns.getWorkerProtocolFormat(spawn));
     return new WorkerConfig(key, flagFiles);
@@ -130,6 +133,30 @@ public class WorkerParser {
       WorkerOptions options,
       boolean dynamic,
       WorkerProtocolFormat protocolFormat) {
+    return createWorkerKey(
+        spawn,
+        workerArgs,
+        env,
+        execRoot,
+        workerFilesCombinedHash,
+        workerFiles,
+        options,
+        options.getWorkerSandboxingMap(),
+        dynamic,
+        protocolFormat);
+  }
+
+  private static WorkerKey createWorkerKey(
+      Spawn spawn,
+      ImmutableList<String> workerArgs,
+      ImmutableMap<String, String> env,
+      Path execRoot,
+      HashCode workerFilesCombinedHash,
+      SortedMap<PathFragment, byte[]> workerFiles,
+      WorkerOptions options,
+      ImmutableMap<String, Boolean> workerSandboxingMap,
+      boolean dynamic,
+      WorkerProtocolFormat protocolFormat) {
     String workerKeyMnemonic = Spawns.getWorkerKeyMnemonic(spawn);
     boolean mustSandbox = dynamic || Spawns.usesPathMapping(spawn);
     boolean shouldMultiplex =
@@ -145,9 +172,9 @@ public class WorkerParser {
       sandboxed = canSandboxMultiplex;
       multiplex = true;
     } else {
-      ImmutableMap<String, Boolean> sandboxingMap = options.getWorkerSandboxingMap();
-      Boolean perMnemonic = sandboxingMap.get(workerKeyMnemonic);
-      sandboxed = perMnemonic != null ? perMnemonic : sandboxingMap.getOrDefault("", false);
+      Boolean perMnemonic = workerSandboxingMap.get(workerKeyMnemonic);
+      sandboxed =
+          perMnemonic != null ? perMnemonic : workerSandboxingMap.getOrDefault("", false);
       multiplex = false;
     }
     boolean useInMemoryTracking = false;

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -145,7 +145,9 @@ public class WorkerParser {
       sandboxed = canSandboxMultiplex;
       multiplex = true;
     } else {
-      sandboxed = options.getWorkerSandboxing();
+      ImmutableMap<String, Boolean> sandboxingMap = options.getWorkerSandboxingMap();
+      Boolean perMnemonic = sandboxingMap.get(workerKeyMnemonic);
+      sandboxed = perMnemonic != null ? perMnemonic : sandboxingMap.getOrDefault("", false);
       multiplex = false;
     }
     boolean useInMemoryTracking = false;

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerModuleTest.java
@@ -105,7 +105,7 @@ public class WorkerModuleTest {
     workerDir.createDirectoryAndParents();
     aLog.createSymbolicLink(PathFragment.EMPTY_FRAGMENT);
     WorkerPool oldPool = module.workerPool;
-    options.setWorkerSandboxing(!options.getWorkerSandboxing());
+    options.setWorkerSandboxing(ImmutableList.of(Maps.immutableEntry("", true)));
     module.beforeCommand(env);
     module.buildStarting(buildStartingEvent(request));
     assertThat(storedEventHandler.getEvents()).isEmpty();

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerParserTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerParserTest.java
@@ -27,6 +27,8 @@ import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.common.options.Options;
+import com.google.devtools.common.options.OptionsParser;
+import com.google.devtools.common.options.OptionsParsingException;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
@@ -135,6 +137,107 @@ public class WorkerParserTest {
     assertThat(keyDynamicMultiplexSandboxing.isMultiplex()).isTrue();
     assertThat(keyDynamicMultiplexSandboxing.isSandboxed()).isTrue();
     assertThat(keyDynamicMultiplexSandboxing.getWorkerTypeName()).isEqualTo("multiplex-worker");
+  }
+
+  private static WorkerOptions parseWorkerOptions(String... args) throws OptionsParsingException {
+    OptionsParser parser = OptionsParser.builder().optionsClasses(WorkerOptions.class).build();
+    parser.parse(args);
+    return parser.getOptions(WorkerOptions.class);
+  }
+
+  @Test
+  public void workerSandboxing_legacyBooleanFormsStillParse() throws Exception {
+    // Bare flag and --no prefix keep working (backwards compatible with the old boolean option).
+    assertThat(parseWorkerOptions("--worker_sandboxing").getWorkerSandboxingMap())
+        .containsExactly("", true);
+    assertThat(parseWorkerOptions("--noworker_sandboxing").getWorkerSandboxingMap())
+        .containsExactly("", false);
+    assertThat(parseWorkerOptions("--worker_sandboxing=yes").getWorkerSandboxingMap())
+        .containsExactly("", true);
+    assertThat(parseWorkerOptions("--worker_sandboxing=no").getWorkerSandboxingMap())
+        .containsExactly("", false);
+  }
+
+  @Test
+  public void workerSandboxing_perMnemonicFormsParse() throws Exception {
+    assertThat(
+            parseWorkerOptions("--worker_sandboxing", "--worker_sandboxing=Javac=no")
+                .getWorkerSandboxingMap())
+        .containsExactly("", true, "Javac", false);
+    // Later values override earlier ones for the same mnemonic.
+    assertThat(
+            parseWorkerOptions("--worker_sandboxing=Javac=yes", "--worker_sandboxing=Javac=no")
+                .getWorkerSandboxingMap())
+        .containsExactly("Javac", false);
+  }
+
+  @Test
+  public void workerSandboxing_defaultsToEmptyMap() throws Exception {
+    assertThat(parseWorkerOptions().getWorkerSandboxingMap()).isEmpty();
+  }
+
+  @Test
+  public void createWorkerKey_perMnemonicSandboxingOverridesGlobalDefault() {
+    WorkerOptions options = Options.getDefaults(WorkerOptions.class);
+    options.setWorkerMultiplex(false);
+    // Global default sandboxed, but disabled for the "Foo" mnemonic.
+    options.setWorkerSandboxing(
+        ImmutableList.of(Maps.immutableEntry("", true), Maps.immutableEntry("Foo", false)));
+
+    WorkerKey fooKey =
+        WorkerTestUtils.createWorkerKeyWithRequirements(
+            fs.getPath("/outputbase"), options, "Foo", /* dynamic= */ false);
+    assertThat(fooKey.isSandboxed()).isFalse();
+
+    WorkerKey barKey =
+        WorkerTestUtils.createWorkerKeyWithRequirements(
+            fs.getPath("/outputbase"), options, "Bar", /* dynamic= */ false);
+    assertThat(barKey.isSandboxed()).isTrue();
+  }
+
+  @Test
+  public void createWorkerKey_perMnemonicSandboxingEnablesForSingleMnemonic() {
+    WorkerOptions options = Options.getDefaults(WorkerOptions.class);
+    options.setWorkerMultiplex(false);
+    // Global default unsandboxed, but enabled for the "Foo" mnemonic.
+    options.setWorkerSandboxing(
+        ImmutableList.of(Maps.immutableEntry("", false), Maps.immutableEntry("Foo", true)));
+
+    WorkerKey fooKey =
+        WorkerTestUtils.createWorkerKeyWithRequirements(
+            fs.getPath("/outputbase"), options, "Foo", /* dynamic= */ false);
+    assertThat(fooKey.isSandboxed()).isTrue();
+
+    WorkerKey barKey =
+        WorkerTestUtils.createWorkerKeyWithRequirements(
+            fs.getPath("/outputbase"), options, "Bar", /* dynamic= */ false);
+    assertThat(barKey.isSandboxed()).isFalse();
+  }
+
+  @Test
+  public void createWorkerKey_perMnemonicSandboxingLastValueWins() {
+    WorkerOptions options = Options.getDefaults(WorkerOptions.class);
+    options.setWorkerMultiplex(false);
+    options.setWorkerSandboxing(
+        ImmutableList.of(Maps.immutableEntry("Foo", true), Maps.immutableEntry("Foo", false)));
+
+    WorkerKey fooKey =
+        WorkerTestUtils.createWorkerKeyWithRequirements(
+            fs.getPath("/outputbase"), options, "Foo", /* dynamic= */ false);
+    assertThat(fooKey.isSandboxed()).isFalse();
+  }
+
+  @Test
+  public void createWorkerKey_perMnemonicSandboxingDoesNotOverrideDynamic() {
+    WorkerOptions options = Options.getDefaults(WorkerOptions.class);
+    options.setWorkerMultiplex(false);
+    // Even when sandboxing is disabled for the mnemonic, dynamic execution forces sandboxing.
+    options.setWorkerSandboxing(ImmutableList.of(Maps.immutableEntry("Foo", false)));
+
+    WorkerKey fooKey =
+        WorkerTestUtils.createWorkerKeyWithRequirements(
+            fs.getPath("/outputbase"), options, "Foo", /* dynamic= */ true);
+    assertThat(fooKey.isSandboxed()).isTrue();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerParserTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerParserTest.java
@@ -17,9 +17,9 @@ package com.google.devtools.build.lib.worker;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.actions.ExecutionRequirements.SUPPORTS_MULTIPLEX_SANDBOXING;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -296,10 +296,12 @@ public class WorkerParserTest {
 
   @Test
   public void compute_cachesWorkerSandboxingMapAcrossWorkerKeys() throws Exception {
-    WorkerOptions options = spy(Options.getDefaults(WorkerOptions.class));
-    options.setWorkerMultiplex(false);
-    options.setWorkerSandboxing(
-        ImmutableList.of(Maps.immutableEntry("Foo", true), Maps.immutableEntry("Bar", false)));
+    WorkerOptions options = mock(WorkerOptions.class, CALLS_REAL_METHODS);
+    when(options.getWorkerMultiplex()).thenReturn(false);
+    when(options.getWorkerExtraFlags()).thenReturn(ImmutableList.of());
+    when(options.getWorkerSandboxing())
+        .thenReturn(
+            ImmutableList.of(Maps.immutableEntry("Foo", true), Maps.immutableEntry("Bar", false)));
 
     AtomicInteger sandboxingMapCalls = new AtomicInteger();
     doAnswer(

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerParserTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerParserTest.java
@@ -177,6 +177,15 @@ public class WorkerParserTest {
   }
 
   @Test
+  public void workerSandboxing_invalidAssignmentsThrow() {
+    assertThrows(
+        OptionsParsingException.class, () -> parseWorkerOptions("--worker_sandboxing=Javac"));
+    assertThrows(
+        OptionsParsingException.class,
+        () -> parseWorkerOptions("--worker_sandboxing=Javac=foo=bar"));
+  }
+
+  @Test
   public void workerSandboxing_defaultsToEmptyMap() throws Exception {
     assertThat(parseWorkerOptions().getWorkerSandboxingMap()).isEmpty();
   }
@@ -262,6 +271,19 @@ public class WorkerParserTest {
         WorkerTestUtils.createWorkerKeyWithRequirements(
             fs.getPath("/outputbase"), options, "Foo", /* dynamic= */ true);
     assertThat(fooKey.isSandboxed()).isTrue();
+  }
+
+  @Test
+  public void createWorkerKey_perMnemonicSandboxingDoesNotAffectMultiplexWorkers() {
+    WorkerOptions options = Options.getDefaults(WorkerOptions.class);
+    options.setWorkerMultiplex(true);
+    options.setWorkerSandboxing(ImmutableList.of(Maps.immutableEntry("Foo", true)));
+
+    WorkerKey fooKey =
+        WorkerTestUtils.createWorkerKeyWithRequirements(
+            fs.getPath("/outputbase"), options, "Foo", /* dynamic= */ false);
+    assertThat(fooKey.isMultiplex()).isTrue();
+    assertThat(fooKey.isSandboxed()).isFalse();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerParserTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerParserTest.java
@@ -164,7 +164,12 @@ public class WorkerParserTest {
             parseWorkerOptions("--worker_sandboxing", "--worker_sandboxing=Javac=no")
                 .getWorkerSandboxingMap())
         .containsExactly("", true, "Javac", false);
-    // Later values override earlier ones for the same mnemonic.
+    assertThat(
+            parseWorkerOptions(
+                    "--worker_sandboxing", "--worker_sandboxing=Javac=no", "--worker_sandboxing")
+                .getWorkerSandboxingMap())
+        .containsExactly("", true);
+    // Later mnemonic-specific values override earlier ones for that mnemonic.
     assertThat(
             parseWorkerOptions("--worker_sandboxing=Javac=yes", "--worker_sandboxing=Javac=no")
                 .getWorkerSandboxingMap())
@@ -193,6 +198,25 @@ public class WorkerParserTest {
         WorkerTestUtils.createWorkerKeyWithRequirements(
             fs.getPath("/outputbase"), options, "Bar", /* dynamic= */ false);
     assertThat(barKey.isSandboxed()).isTrue();
+  }
+
+  @Test
+  public void createWorkerKey_laterGlobalSandboxingOverridesEarlierPerMnemonicValue()
+      throws Exception {
+    WorkerOptions options =
+        parseWorkerOptions(
+            "--worker_sandboxing", "--worker_sandboxing=Javac=no", "--worker_sandboxing");
+    options.setWorkerMultiplex(false);
+
+    WorkerKey javacKey =
+        WorkerTestUtils.createWorkerKeyWithRequirements(
+            fs.getPath("/outputbase"), options, "Javac", /* dynamic= */ false);
+    assertThat(javacKey.isSandboxed()).isTrue();
+
+    WorkerKey otherKey =
+        WorkerTestUtils.createWorkerKeyWithRequirements(
+            fs.getPath("/outputbase"), options, "Other", /* dynamic= */ false);
+    assertThat(otherKey.isSandboxed()).isTrue();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerParserTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerParserTest.java
@@ -17,12 +17,19 @@ package com.google.devtools.build.lib.worker;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.actions.ExecutionRequirements.SUPPORTS_MULTIPLEX_SANDBOXING;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.UserExecException;
+import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
+import com.google.devtools.build.lib.exec.local.LocalEnvProvider;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
@@ -31,6 +38,7 @@ import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.OptionsParsingException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -284,6 +292,46 @@ public class WorkerParserTest {
             fs.getPath("/outputbase"), options, "Foo", /* dynamic= */ false);
     assertThat(fooKey.isMultiplex()).isTrue();
     assertThat(fooKey.isSandboxed()).isFalse();
+  }
+
+  @Test
+  public void compute_cachesWorkerSandboxingMapAcrossWorkerKeys() throws Exception {
+    WorkerOptions options = spy(Options.getDefaults(WorkerOptions.class));
+    options.setWorkerMultiplex(false);
+    options.setWorkerSandboxing(
+        ImmutableList.of(Maps.immutableEntry("Foo", true), Maps.immutableEntry("Bar", false)));
+
+    AtomicInteger sandboxingMapCalls = new AtomicInteger();
+    doAnswer(
+            invocation -> {
+              sandboxingMapCalls.incrementAndGet();
+              return invocation.callRealMethod();
+            })
+        .when(options)
+        .getWorkerSandboxingMap();
+
+    WorkerParser parser =
+        new WorkerParser(
+            fs.getPath("/outputbase/execroot"),
+            options,
+            LocalEnvProvider.NOOP,
+            /* binTools= */ null);
+    SpawnExecutionContext context = mock(SpawnExecutionContext.class);
+    when(context.getInputMetadataProvider()).thenReturn(mock(InputMetadataProvider.class));
+    when(context.speculating()).thenReturn(false);
+
+    WorkerKey fooKey = parser.compute(createWorkerSpawn("Foo"), context).getWorkerKey();
+    WorkerKey barKey = parser.compute(createWorkerSpawn("Bar"), context).getWorkerKey();
+
+    assertThat(fooKey.isSandboxed()).isTrue();
+    assertThat(barKey.isSandboxed()).isFalse();
+    assertThat(sandboxingMapCalls.get()).isEqualTo(1);
+  }
+
+  private static Spawn createWorkerSpawn(String mnemonic) {
+    return WorkerTestUtils.createSpawn(
+        ImmutableList.of("--foo", "@bar"),
+        WorkerTestUtils.execRequirementsBuilder(mnemonic).buildOrThrow());
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnRunnerTest.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
@@ -230,7 +231,7 @@ public class WorkerSpawnRunnerTest {
   public void testExecInWorker_sendsCancelMessageOnInterrupt() throws Exception {
     WorkerOptions workerOptions = Options.getDefaults(WorkerOptions.class);
     workerOptions.setWorkerCancellation(true);
-    workerOptions.setWorkerSandboxing(true);
+    workerOptions.setWorkerSandboxing(ImmutableList.of(Maps.immutableEntry("", true)));
     when(spawn.getExecutionInfo())
         .thenReturn(ImmutableMap.of(ExecutionRequirements.SUPPORTS_WORKER_CANCELLATION, "1"));
     when(worker.isSandboxed()).thenReturn(true);
@@ -281,7 +282,7 @@ public class WorkerSpawnRunnerTest {
   public void testExecInWorker_unsandboxedDiesOnInterrupt() throws Exception {
     WorkerOptions workerOptions = Options.getDefaults(WorkerOptions.class);
     workerOptions.setWorkerCancellation(true);
-    workerOptions.setWorkerSandboxing(false);
+    workerOptions.setWorkerSandboxing(ImmutableList.of(Maps.immutableEntry("", false)));
     when(spawn.getExecutionInfo())
         .thenReturn(ImmutableMap.of(ExecutionRequirements.SUPPORTS_WORKER_CANCELLATION, "1"));
     WorkerSpawnRunner runner = createWorkerSpawnRunner(workerOptions);

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerTestUtils.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerTestUtils.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Maps;
 import com.google.common.hash.HashCode;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ExecutionRequirements.WorkerProtocolFormat;
@@ -71,7 +72,7 @@ public class WorkerTestUtils {
       String... args) {
     WorkerOptions workerOptions = Options.getDefaults(WorkerOptions.class);
     workerOptions.setWorkerMultiplex(multiplex);
-    workerOptions.setWorkerSandboxing(sandboxed);
+    workerOptions.setWorkerSandboxing(ImmutableList.of(Maps.immutableEntry("", sandboxed)));
 
     return createWorkerKeyFromOptions(
         protocolFormat,


### PR DESCRIPTION
### Description

Adds per-mnemonic control for `--worker_sandboxing`.

The flag continues to support the existing boolean forms, including
`--worker_sandboxing`, `--noworker_sandboxing`, `--worker_sandboxing=yes`, and
`--worker_sandboxing=no`. It can now also be specified as
`--worker_sandboxing=<mnemonic>=<boolean>` and repeated, with later values taking
precedence for the same mnemonic.

### Motivation

Worker sandboxing is currently all-or-nothing for eligible singleplex workers. In
practice, users may need to enable sandboxing broadly while excluding a specific
worker mnemonic.

Per-mnemonic control provides that flexibility without breaking existing
`--worker_sandboxing` usage.

### Build API Changes

Yes. This extends the accepted syntax of the existing `--worker_sandboxing`
command-line flag.

1. No design doc or issue.
2. The change is backward compatible. Existing boolean forms of
   `--worker_sandboxing` continue to parse and behave as before.
3. No migration needed.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES[NEW]: `--worker_sandboxing` can now be scoped per worker-key mnemonic with `--worker_sandboxing=<mnemonic>=<boolean>`.
