### PR TITLE
Retry HTTP 408 and 429 in HTTP_RESULT_CLASSIFIER

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -244,7 +244,9 @@ public final class RemoteModule extends BlazeModule {
             return Result.SUCCESS;
           }
           retry =
-              status == HttpResponseStatus.INTERNAL_SERVER_ERROR.code()
+              status == HttpResponseStatus.REQUEST_TIMEOUT.code()
+                  || status == HttpResponseStatus.TOO_MANY_REQUESTS.code()
+                  || status == HttpResponseStatus.INTERNAL_SERVER_ERROR.code()
                   || status == HttpResponseStatus.BAD_GATEWAY.code()
                   || status == HttpResponseStatus.SERVICE_UNAVAILABLE.code()
                   || status == HttpResponseStatus.GATEWAY_TIMEOUT.code();


### PR DESCRIPTION
### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

Add REQUEST_TIMEOUT (408) and TOO_MANY_REQUESTS (429) to the retryable status set for the HTTP remote cache client, alongside the existing 500/502/503/504.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

With --experimental_remote_repo_contents_cache pointed at an HTTP backend like GCS, a burst of concurrent CI jobs against a cold repo-contents object can trip GCS's per-object ramp-up throttling. GCS surfaces the throttle as HTTP 429 SlowDown. The current classifier does not treat 429 as retryable, so a single throttled lookup propagates as an IOException and aborts the load phase with:

> ERROR: error loading package '@@repo//pkg': 429 Too Many Requests <?xml ...><Error><Code>SlowDown</Code>...

Precedent: HttpConnector is used for http_archive/go_repository fetches and has always retried 408/429 with exponential backoff and jitter. The remote-cache HTTP client is the only HTTP path in Bazel that treats them as terminal.

Related #29744.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->



### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Retry 408 and 429 status codes with HTTP remote caching.
