### PR TITLE
docs: recommend wolfd_bazel_compile_commands for IDE integration

### DIFF
--- a/docs/install/ide.mdx
+++ b/docs/install/ide.mdx
@@ -106,7 +106,11 @@ The `compile_commands.json` file enables tools like `clang-tidy`, `clangd` (LSP)
 provide autocomplete, smart navigation, quick fixes, and more. The tool is written in C++ and
 consumes the Protobuf output of Bazel to extract the compile commands.
 
-[`hedronvision/bazel-compile-commands-extractor`](https://github.com/hedronvision/bazel-compile-commands-extractor) enables autocomplete, smart navigation, quick fixes, and more in a wide variety of extensible editors, including VSCode, Vim, Emacs, Atom, and Sublime. It lets language servers, like clangd and ccls, and other types of tooling, draw upon Bazel's understanding of how `cc` and `objc` code will be compiled, including how it configures cross-compilation for other platforms.
+[`wolfd_bazel_compile_commands`](https://registry.bazel.build/modules/wolfd_bazel_compile_commands)
+is a module in the Bazel Central Registry module that generates `compile_commands.json`
+for Bazel workspaces. It enables tools such as `clangd`, `clang-tidy`,
+and other IDE integrations to provide autocomplete, smart navigation,
+quick fixes, and other language-server features for C and C++ projects.
 
 ### Java
 


### PR DESCRIPTION
### Description

Replace the outdated `hedronvision/bazel-compile-commands-extractor`
recommendation in the IDE documentation with
`wolfd_bazel_compile_commands`.

### Motivation

Fixes #4546.

The previously recommended project appears to be unmaintained and is
not compatible with recent Bazel versions. `wolfd_bazel_compile_commands`
is available through the Bazel Central Registry and provides the same
`compile_commands.json` generation workflow for IDE integrations.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
