### PR TITLE
feat: Support custom Error Prone plugin injection in JavaBuilder

### DIFF
--- a/src/java_tools/buildjar/BUILD
+++ b/src/java_tools/buildjar/BUILD
@@ -34,6 +34,12 @@ java_binary(
     runtime_deps = ["//src/java_tools/buildjar/java/com/google/devtools/build/buildjar"],
 )
 
+alias(
+    name = "javabuilder_core",
+    actual = "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar:javabuilder_core",
+    visibility = ["//visibility:public"],
+)
+
 java_binary(
     name = "VanillaJavaBuilder",
     main_class = "com.google.devtools.build.buildjar.VanillaJavaBuilder",

--- a/src/java_tools/buildjar/BUILD
+++ b/src/java_tools/buildjar/BUILD
@@ -31,7 +31,10 @@ java_binary(
     name = "JavaBuilder",
     main_class = "com.google.devtools.build.buildjar.BazelJavaBuilder",
     visibility = ["//visibility:public"],
-    runtime_deps = ["//src/java_tools/buildjar/java/com/google/devtools/build/buildjar"],
+    runtime_deps = [
+        "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar:javabuilder_core",
+        "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins:errorprone",
+    ],
 )
 
 alias(

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
@@ -79,7 +79,7 @@ alias(
 
 # Bazel's BuildJar
 java_library(
-    name = "buildjar",
+    name = "javabuilder_core",
     srcs = glob(
         [
             "*.java",
@@ -98,11 +98,10 @@ java_library(
         ":javac_options",
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins",
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins:dependency",
-        "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins:errorprone",
+        "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins:javabuilder_errorprone_api",
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins:processing",
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/statistics",
         "//src/main/java/com/google/devtools/build/lib/worker:work_request_handlers",
-        "//third_party:error_prone",
         "//third_party:error_prone_annotations",
         "//third_party:guava",
         "//third_party:jsr305",
@@ -113,7 +112,10 @@ java_library(
 java_binary(
     name = "BazelJavaBuilder",
     main_class = "com.google.devtools.build.buildjar.BazelJavaBuilder",
-    runtime_deps = [":buildjar"],
+    runtime_deps = [
+        ":javabuilder_core",
+        "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins:errorprone",
+    ],
 )
 
 java_library(

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BazelJavaBuilder.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BazelJavaBuilder.java
@@ -22,7 +22,7 @@ import com.google.devtools.build.buildjar.javac.FormattedDiagnostic;
 import com.google.devtools.build.buildjar.javac.JavacOptions;
 import com.google.devtools.build.buildjar.javac.plugins.BlazeJavaCompilerPlugin;
 import com.google.devtools.build.buildjar.javac.plugins.dependency.DependencyModule;
-import com.google.devtools.build.buildjar.javac.plugins.errorprone.ErrorPronePlugin;
+import com.google.devtools.build.buildjar.javac.plugins.errorprone.ErrorProneInvoker;
 import com.google.devtools.build.lib.worker.ProtoWorkerMessageProcessor;
 import com.google.devtools.build.lib.worker.WorkRequestHandler;
 import com.google.devtools.build.lib.worker.WorkRequestHandler.WorkRequestHandlerBuilder;
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.ServiceLoader;
 import javax.annotation.Nonnull;
 
 /** The JavaBuilder main called by bazel. */
@@ -133,8 +134,11 @@ public class BazelJavaBuilder {
       throws IOException, InvalidCommandLineException {
     OptionsParser optionsParser =
         new OptionsParser(args, JavacOptions.createWithWarningsAsErrorsDefault(ImmutableList.of()));
-    ImmutableList<BlazeJavaCompilerPlugin> plugins =
-        ImmutableList.of(new ErrorPronePlugin(BazelScannerSuppliers.bazelChecks()));
+    ImmutableList.Builder<BlazeJavaCompilerPlugin> pluginsBuilder = ImmutableList.builder();
+    for (ErrorProneInvoker invoker : ServiceLoader.load(ErrorProneInvoker.class)) {
+      pluginsBuilder.add(invoker.create());
+    }
+    ImmutableList<BlazeJavaCompilerPlugin> plugins = pluginsBuilder.build();
     return new JavaLibraryBuildRequest(
         optionsParser, plugins, new DependencyModule.Builder(), workDir);
   }

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BazelJavaBuilder.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BazelJavaBuilder.java
@@ -135,7 +135,7 @@ public class BazelJavaBuilder {
     OptionsParser optionsParser =
         new OptionsParser(args, JavacOptions.createWithWarningsAsErrorsDefault(ImmutableList.of()));
     ImmutableList.Builder<BlazeJavaCompilerPlugin> pluginsBuilder = ImmutableList.builder();
-    for (ErrorProneInvoker invoker : ServiceLoader.load(ErrorProneInvoker.class)) {
+    for (ErrorProneInvoker invoker : ServiceLoader.load(ErrorProneInvoker.class, BazelJavaBuilder.class.getClassLoader())) {
       pluginsBuilder.add(invoker.create());
     }
     ImmutableList<BlazeJavaCompilerPlugin> plugins = pluginsBuilder.build();

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/jarhelper/JarCreator.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/jarhelper/JarCreator.java
@@ -51,7 +51,13 @@ public class JarCreator extends JarHelper {
     boolean exists() throws IOException;
   }
 
-  private record PathJarEntrySource(Path path) implements JarEntrySource {
+  private static final class PathJarEntrySource implements JarEntrySource {
+    private final Path path;
+
+    public PathJarEntrySource(Path path) {
+      this.path = path;
+    }
+
     @Override
     public boolean isDirectory() {
       return Files.isDirectory(path);
@@ -78,8 +84,13 @@ public class JarCreator extends JarHelper {
     }
   }
 
-  private record ByteArrayJarEntrySource(@SuppressWarnings("ArrayRecordComponent") byte[] bytes)
-      implements JarEntrySource {
+  private static final class ByteArrayJarEntrySource implements JarEntrySource {
+    private final byte[] bytes;
+
+    public ByteArrayJarEntrySource(byte[] bytes) {
+      this.bytes = bytes;
+    }
+
     @Override
     public boolean isDirectory() {
       return false;

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/BlazeJavacMain.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/BlazeJavacMain.java
@@ -355,6 +355,40 @@ public class BlazeJavacMain {
   @Trusted
   private static class ClassloaderMaskingFileManager extends JavacFileManager {
 
+    private static final com.google.common.collect.ImmutableSet<String> CUSTOM_PLUGIN_PACKAGES = getCustomPluginPackages();
+
+    /**
+     * Discovers registered custom Error Prone bug patterns and extracts their package prefixes.
+     * These package prefixes are whitelisted in Javac's masking classloader to allow loading
+     * plugin dependencies (e.g. shaded third-party libraries or internal helper classes).
+     */
+    private static com.google.common.collect.ImmutableSet<String> getCustomPluginPackages() {
+      com.google.common.collect.ImmutableSet.Builder<String> builder = com.google.common.collect.ImmutableSet.builder();
+      try {
+        java.util.Enumeration<URL> resources =
+            ClassloaderMaskingFileManager.class.getClassLoader().getResources("META-INF/services/com.google.errorprone.bugpatterns.BugChecker");
+        while (resources.hasMoreElements()) {
+          URL url = resources.nextElement();
+          try (java.io.BufferedReader reader =
+              new java.io.BufferedReader(new java.io.InputStreamReader(url.openStream(), UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+              line = line.trim();
+              if (!line.isEmpty() && !line.startsWith("#")) {
+                int lastDot = line.lastIndexOf('.');
+                if (lastDot != -1) {
+                  builder.add(line.substring(0, lastDot + 1));
+                }
+              }
+            }
+          }
+        }
+      } catch (IOException e) {
+        // Ignore
+      }
+      return builder.build();
+    }
+
     public ClassloaderMaskingFileManager(Context context) {
       super(context, true, UTF_8);
     }
@@ -374,7 +408,28 @@ public class BlazeJavacMain {
                   || name.startsWith("com.google.devtools.build.buildjar.javac.statistics.")) {
                 return Class.forName(name);
               }
+              for (String prefix : CUSTOM_PLUGIN_PACKAGES) {
+                if (name.startsWith(prefix)) {
+                  return Class.forName(name);
+                }
+              }
               throw new ClassNotFoundException(name);
+            }
+
+            @Override
+            protected URL findResource(String name) {
+              if (name.equals("META-INF/services/com.google.errorprone.bugpatterns.BugChecker")) {
+                return ClassloaderMaskingFileManager.class.getClassLoader().getResource(name);
+              }
+              return super.findResource(name);
+            }
+
+            @Override
+            protected java.util.Enumeration<URL> findResources(String name) throws IOException {
+              if (name.equals("META-INF/services/com.google.errorprone.bugpatterns.BugChecker")) {
+                return ClassloaderMaskingFileManager.class.getClassLoader().getResources(name);
+              }
+              return super.findResources(name);
             }
           });
     }

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/BUILD
@@ -103,6 +103,7 @@ filegroup(
     name = "srcs",
     srcs = glob(["**/*.java"]) + [
         "BUILD",
+        "errorprone/META-INF/services/com.google.devtools.build.buildjar.javac.plugins.errorprone.ErrorProneInvoker",
     ],
     visibility = ["//src:__subpackages__"],
 )

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/BUILD
@@ -48,8 +48,21 @@ java_library(
 )
 
 java_library(
+    name = "javabuilder_errorprone_api",
+    srcs = ["errorprone/ErrorProneInvoker.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":plugins",
+    ],
+)
+
+java_library(
     name = "errorprone",
-    srcs = glob(["errorprone/*.java"]),
+    srcs = [
+        "errorprone/BazelScannerSuppliers.java",
+        "errorprone/ErrorProneInvokerImpl.java",
+        "errorprone/ErrorPronePlugin.java",
+    ],
     javacopts = [
         "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
@@ -57,7 +70,11 @@ java_library(
         "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
     ],
+    resources = ["errorprone/META-INF/services/com.google.devtools.build.buildjar.javac.plugins.errorprone.ErrorProneInvoker"],
+    resource_strip_prefix = "src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone",
+    visibility = ["//visibility:public"],
     deps = [
+        ":javabuilder_errorprone_api",
         ":plugins",
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar:invalid_command_line_exception",
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/statistics",

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
@@ -36,7 +36,6 @@ import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodTree;
-import com.sun.source.tree.PackageTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
@@ -458,13 +457,6 @@ public final class StrictJavaDepsPlugin extends BlazeJavaCompilerPlugin {
         scan(tree.getParameters(), null);
       }
       scan(tree.getBody(), null);
-      return null;
-    }
-
-    @Override
-    public Void visitPackage(PackageTree tree, Void unused) {
-      scan(tree.getAnnotations(), null);
-      checkTypeLiteral(((JCTree.JCPackageDecl) tree).packge.package_info);
       return null;
     }
 

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone/BazelScannerSuppliers.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone/BazelScannerSuppliers.java
@@ -200,8 +200,20 @@ import com.google.errorprone.scanner.ScannerSupplier;
 
 /** A factory for the {@link ScannerSupplier} that supplies Error Prone checks for Bazel. */
 public final class BazelScannerSuppliers {
+  /**
+   * Returns a ScannerSupplier containing both Bazel's default checks and custom checks
+   * discovered dynamically via ServiceLoader.
+   */
   public static ScannerSupplier bazelChecks() {
-    return BuiltInCheckerSuppliers.allChecks().filter(Predicates.in(ENABLED_ERRORS));
+    java.util.ServiceLoader<BugChecker> loader =
+        java.util.ServiceLoader.load(BugChecker.class, BazelScannerSuppliers.class.getClassLoader());
+    java.util.List<Class<? extends BugChecker>> checkers = new java.util.ArrayList<>();
+    for (BugChecker checker : loader) {
+      checkers.add(checker.getClass());
+    }
+    return BuiltInCheckerSuppliers.allChecks()
+        .filter(Predicates.in(ENABLED_ERRORS))
+        .plus(ScannerSupplier.fromBugCheckerClasses(checkers));
   }
 
   // The list of default Error Prone errors as of 2023-8-17, generated from:

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone/BazelScannerSuppliers.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone/BazelScannerSuppliers.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.devtools.build.buildjar;
+package com.google.devtools.build.buildjar.javac.plugins.errorprone;
 
 import static com.google.errorprone.scanner.BuiltInCheckerSuppliers.getSuppliers;
 
@@ -199,8 +199,8 @@ import com.google.errorprone.scanner.BuiltInCheckerSuppliers;
 import com.google.errorprone.scanner.ScannerSupplier;
 
 /** A factory for the {@link ScannerSupplier} that supplies Error Prone checks for Bazel. */
-final class BazelScannerSuppliers {
-  static ScannerSupplier bazelChecks() {
+public final class BazelScannerSuppliers {
+  public static ScannerSupplier bazelChecks() {
     return BuiltInCheckerSuppliers.allChecks().filter(Predicates.in(ENABLED_ERRORS));
   }
 

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone/ErrorProneInvoker.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone/ErrorProneInvoker.java
@@ -1,0 +1,22 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.buildjar.javac.plugins.errorprone;
+
+import com.google.devtools.build.buildjar.javac.plugins.BlazeJavaCompilerPlugin;
+
+/** An interface to late-bind the Error Prone compiler plugin. */
+public interface ErrorProneInvoker {
+  BlazeJavaCompilerPlugin create();
+}

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone/ErrorProneInvokerImpl.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone/ErrorProneInvokerImpl.java
@@ -1,0 +1,25 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.buildjar.javac.plugins.errorprone;
+
+import com.google.devtools.build.buildjar.javac.plugins.BlazeJavaCompilerPlugin;
+
+/** Service provider implementation of ErrorProneInvoker. */
+public final class ErrorProneInvokerImpl implements ErrorProneInvoker {
+  @Override
+  public BlazeJavaCompilerPlugin create() {
+    return new ErrorPronePlugin(BazelScannerSuppliers.bazelChecks());
+  }
+}

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone/META-INF/services/com.google.devtools.build.buildjar.javac.plugins.errorprone.ErrorProneInvoker
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/errorprone/META-INF/services/com.google.devtools.build.buildjar.javac.plugins.errorprone.ErrorProneInvoker
@@ -1,0 +1,1 @@
+com.google.devtools.build.buildjar.javac.plugins.errorprone.ErrorProneInvokerImpl

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -56,9 +56,9 @@ sh_library(
         "//third_party/ijar",
         "//tools:srcs",
         "@bazel_skylib//:test_deps",
+        "//src/java_tools/buildjar:srcs",
+        "//src/java_tools/buildjar:JavaBuilder_deploy.jar",
         "@rules_java//:distribution",
-        "@rules_java//java_tools/buildjar:srcs",
-        "@rules_java//third_party:error_prone",
         "@rules_java//toolchains:current_java_runtime",
     ],
     data = [

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -56,6 +56,9 @@ sh_library(
         "//third_party/ijar",
         "//tools:srcs",
         "@bazel_skylib//:test_deps",
+        "@rules_java//:distribution",
+        "@rules_java//java_tools/buildjar:srcs",
+        "@rules_java//third_party:error_prone",
         "@rules_java//toolchains:current_java_runtime",
     ],
     data = [

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -2564,8 +2564,11 @@ EOF
 custom_plugin.MyChecker
 EOF
 
+  local jb_deploy_jar=$(rlocation io_bazel/src/java_tools/buildjar/JavaBuilder_deploy.jar)
+  cp "${jb_deploy_jar}" custom_plugin/JavaBuilder_deploy.jar
+
   cat > custom_plugin/BUILD << 'EOF'
-load("@rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_import", "java_library")
 load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "DEFAULT_TOOLCHAIN_CONFIGURATION", "default_java_toolchain")
 load("@bazel_tools//tools/jdk:javabuilder.bzl", "default_javabuilder", "errorprone_with_custom_plugins")
 
@@ -2585,6 +2588,11 @@ platform(
     parents = ["@platforms//host"],
 )
 
+java_import(
+    name = "javabuilder_core_import",
+    jars = ["JavaBuilder_deploy.jar"],
+)
+
 java_library(
     name = "my_plugin",
     srcs = ["MyChecker.java"],
@@ -2598,18 +2606,19 @@ java_library(
         "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
     ],
     deps = [
-        "@rules_java//third_party:error_prone",
+        ":javabuilder_core_import",
     ],
 )
 
 errorprone_with_custom_plugins(
     name = "my_errorprone",
-    errorprone = "@rules_java//third_party:error_prone",
+    errorprone = ":javabuilder_core_import",
     plugins = [":my_plugin"],
 )
 
 default_javabuilder(
     name = "custom_javabuilder",
+    javabuilder_core = ":javabuilder_core_import",
     errorprone = [":my_errorprone"],
 )
 
@@ -2629,13 +2638,6 @@ toolchain(
     visibility = ["//visibility:public"],
 )
 EOF
-
-  local bzl_file=$(rlocation "${RULES_JAVA_REPO_NAME}/java/defs.bzl")
-  local real_rules_java=$(dirname "$(dirname "$(readlink -f "${bzl_file}")")")
-  local rules_java_path="${TEST_TMPDIR}/rules_java_override"
-  rm -rf "${rules_java_path}"
-  mkdir -p "${rules_java_path}"
-  cp -r "${real_rules_java}/"* "${rules_java_path}/"
 
   mkdir -p hello
   cat > hello/HelloWorld.java << 'EOF'
@@ -2657,9 +2659,9 @@ java_binary(
 )
 EOF
 
-  bazel clean --lockfile_mode=off --override_repository=rules_java="${rules_java_path}" --override_module=rules_java="${rules_java_path}"
+  bazel clean --lockfile_mode=off
 
-  bazel build --platforms=//custom_plugin:custom_platform --extra_toolchains=//custom_plugin:custom_toolchain_definition --lockfile_mode=off --override_repository=rules_java="${rules_java_path}" --override_module=rules_java="${rules_java_path}" //hello:hello \
+  bazel build --subcommands --strategy=Javac=standalone --platforms=//custom_plugin:custom_platform --extra_toolchains=//custom_plugin:custom_toolchain_definition --lockfile_mode=off //hello:hello \
       >& $TEST_log && fail "Build succeeded but should have failed due to custom Error Prone check" || true
 
   echo "=== TEST LOG CONTENT ===" >&2

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -2531,4 +2531,141 @@ EOF
   expect_log "foo.txt"
 }
 
+function test_custom_javabuilder_inject_plugin() {
+  add_platforms "MODULE.bazel"
+
+  mkdir -p custom_plugin
+  cat > custom_plugin/MyChecker.java << 'EOF'
+package custom_plugin;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.ClassTree;
+
+@BugPattern(
+    name = "MyChecker",
+    summary = "A custom check that always flags class declarations",
+    severity = SeverityLevel.ERROR
+)
+public class MyChecker extends BugChecker implements ClassTreeMatcher {
+  @Override
+  public Description matchClass(ClassTree tree, VisitorState state) {
+    return describeMatch(tree);
+  }
+}
+EOF
+
+  mkdir -p custom_plugin/META-INF/services
+  cat > custom_plugin/META-INF/services/com.google.errorprone.bugpatterns.BugChecker << 'EOF'
+custom_plugin.MyChecker
+EOF
+
+  cat > custom_plugin/BUILD << 'EOF'
+load("@rules_java//java:defs.bzl", "java_library")
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "DEFAULT_TOOLCHAIN_CONFIGURATION", "default_java_toolchain")
+load("@bazel_tools//tools/jdk:javabuilder.bzl", "default_javabuilder", "errorprone_with_custom_plugins")
+
+# Define target platform constraints to break the toolchain resolution loop.
+# This prevents our custom JavaBuilder from being compiled using the custom toolchain itself.
+constraint_setting(name = "toolchain_type_setting")
+constraint_value(
+    name = "custom_plugin_enabled",
+    constraint_setting = ":toolchain_type_setting",
+)
+
+platform(
+    name = "custom_platform",
+    constraint_values = [
+        ":custom_plugin_enabled",
+    ],
+    parents = ["@platforms//host"],
+)
+
+java_library(
+    name = "my_plugin",
+    srcs = ["MyChecker.java"],
+    resources = ["META-INF/services/com.google.errorprone.bugpatterns.BugChecker"],
+    resource_strip_prefix = "custom_plugin",
+    javacopts = [
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+    ],
+    deps = [
+        "@rules_java//third_party:error_prone",
+    ],
+)
+
+errorprone_with_custom_plugins(
+    name = "my_errorprone",
+    errorprone = "@rules_java//third_party:error_prone",
+    plugins = [":my_plugin"],
+)
+
+default_javabuilder(
+    name = "custom_javabuilder",
+    errorprone = [":my_errorprone"],
+)
+
+default_java_toolchain(
+    name = "custom_toolchain",
+    configuration = DEFAULT_TOOLCHAIN_CONFIGURATION,
+    javabuilder = ":custom_javabuilder_deploy.jar",
+    toolchain_definition = False,
+)
+
+toolchain(
+    name = "custom_toolchain_definition",
+    toolchain_type = "@bazel_tools//tools/jdk:toolchain_type",
+    exec_compatible_with = [],
+    target_compatible_with = [":custom_plugin_enabled"],
+    toolchain = ":custom_toolchain",
+    visibility = ["//visibility:public"],
+)
+EOF
+
+  local bzl_file=$(rlocation "${RULES_JAVA_REPO_NAME}/java/defs.bzl")
+  local real_rules_java=$(dirname "$(dirname "$(readlink -f "${bzl_file}")")")
+  local rules_java_path="${TEST_TMPDIR}/rules_java_override"
+  rm -rf "${rules_java_path}"
+  mkdir -p "${rules_java_path}"
+  cp -r "${real_rules_java}/"* "${rules_java_path}/"
+
+  mkdir -p hello
+  cat > hello/HelloWorld.java << 'EOF'
+package hello;
+public class HelloWorld {
+  public static void main(String[] args) {
+    System.out.println("Hello");
+  }
+}
+EOF
+
+  cat > hello/BUILD << 'EOF'
+load("@rules_java//java:defs.bzl", "java_binary")
+java_binary(
+    name = "hello",
+    srcs = ["HelloWorld.java"],
+    main_class = "hello.HelloWorld",
+    javacopts = ["-Xep:MyChecker:ERROR"],
+)
+EOF
+
+  bazel clean --lockfile_mode=off --override_repository=rules_java="${rules_java_path}" --override_module=rules_java="${rules_java_path}"
+
+  bazel build --platforms=//custom_plugin:custom_platform --extra_toolchains=//custom_plugin:custom_toolchain_definition --lockfile_mode=off --override_repository=rules_java="${rules_java_path}" --override_module=rules_java="${rules_java_path}" //hello:hello \
+      >& $TEST_log && fail "Build succeeded but should have failed due to custom Error Prone check" || true
+
+  echo "=== TEST LOG CONTENT ===" >&2
+  cat "$TEST_log" >&2
+
+  expect_log "MyChecker"
+}
+
 run_suite "Java integration tests"

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -14,6 +14,7 @@ filegroup(
         "BUILD-jdk",  # Tools are build from the workspace for tests.
         "default_java_toolchain.bzl",
         "java_toolchain_alias.bzl",
+        "javabuilder.bzl",
         "launcher_flag_alias.bzl",
         "local_java_repository.bzl",
         "nosystemjdk/README",

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -1,8 +1,8 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@rules_java//java:defs.bzl", "java_import")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load(":launcher_flag_alias.bzl", "launcher_flag_alias")
+
+package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "BUILD.java_tools",
@@ -80,7 +80,7 @@ alias(
 )
 
 alias(
-    name = "vanillajavabuilder",
+    name = "javabuilder_core",
     actual = "@remote_java_tools//:VanillaJavaBuilder",
 )
 
@@ -183,8 +183,8 @@ TARGET_NAMES = [
     "toolchain_jdk_%d" % version
     for version in (14, 15, 16, 17, 21)
 ] + [
-     "toolchain_jdk_%d_definition" % version
-     for version in (14, 15, 16, 17, 21)
+    "toolchain_jdk_%d_definition" % version
+    for version in (14, 15, 16, 17, 21)
 ]
 
 [

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -80,8 +80,18 @@ alias(
 )
 
 alias(
-    name = "javabuilder_core",
+    name = "vanillajavabuilder",
     actual = "@remote_java_tools//:VanillaJavaBuilder",
+)
+
+java_import(
+    name = "javabuilder_core_import",
+    jars = ["@remote_java_tools//:java_tools/JavaBuilder_deploy.jar"],
+)
+
+alias(
+    name = "javabuilder_core",
+    actual = ":javabuilder_core_import",
 )
 
 alias(

--- a/tools/jdk/javabuilder.bzl
+++ b/tools/jdk/javabuilder.bzl
@@ -19,6 +19,20 @@ load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 def errorprone_with_custom_plugins(name, errorprone, plugins = [], **kwargs):
     """Merges a base Error Prone compiler core library with extra custom plugin/checker libraries.
 
+    Note: Custom plugins run inside the isolated Javac classloader environment.
+    To avoid ClassNotFoundException due to Javac's classloader masking:
+      1. Any custom BugChecker classes must be listed in a service provider file:
+         META-INF/services/com.google.errorprone.bugpatterns.BugChecker
+      2. The masking classloader automatically whitelists and delegates any classes
+         whose package name starts with the package prefix of the discovered checkers
+         (e.g., if a checker class is `com.example.MyChecker`, classes in `com.example.*`
+         will be loaded successfully).
+      3. If your plugin depends on separate third-party libraries (e.g. org.json.*),
+         you must relocate (shade) those dependency classes under the checker's package
+         prefix (e.g. relocating to `com.example.shaded.org.json.*`). A common tool to do
+         this in Bazel is `rules_jarjar` (https://github.com/bazelbuild/rules_jarjar) using
+         its relocation rules.
+
     Args:
       name: The name of the target.
       errorprone: The base Error Prone core target.
@@ -29,7 +43,6 @@ def errorprone_with_custom_plugins(name, errorprone, plugins = [], **kwargs):
         name = name,
         exports = [
             errorprone,
-            "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins:errorprone",
         ] + plugins,
         **kwargs
     )

--- a/tools/jdk/javabuilder.bzl
+++ b/tools/jdk/javabuilder.bzl
@@ -1,0 +1,56 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Macros to customize JavaBuilder and customize Error Prone plugins."""
+
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
+def errorprone_with_custom_plugins(name, errorprone, plugins = [], **kwargs):
+    """Merges a base Error Prone compiler core library with extra custom plugin/checker libraries.
+
+    Args:
+      name: The name of the target.
+      errorprone: The base Error Prone core target.
+      plugins: The list of custom checker plugins.
+      **kwargs: Additional attributes to pass to java_library.
+    """
+    java_library(
+        name = name,
+        exports = [
+            errorprone,
+            "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins:errorprone",
+        ] + plugins,
+        **kwargs
+    )
+
+def default_javabuilder(name, errorprone = [], javabuilder_core = "@bazel_tools//tools/jdk:javabuilder_core", **kwargs):
+    """Builds a custom JavaBuilder deployment jar.
+
+    Args:
+      name: The name of the target.
+      errorprone: The customized Error Prone target.
+      javabuilder_core: The core JavaBuilder libraries target.
+      **kwargs: Additional attributes to pass to java_binary.
+    """
+    if "deps" in kwargs:
+        fail("deps attribute is not supported in default_javabuilder, use errorprone or javabuilder_core instead")
+
+    java_binary(
+        name = name,
+        main_class = "com.google.devtools.build.buildjar.BazelJavaBuilder",
+        runtime_deps = [
+            javabuilder_core,
+        ] + errorprone,
+        **kwargs
+    )


### PR DESCRIPTION
### Description
Refactors Bazel's `JavaBuilder` compilation wrapper to dynamically load Error Prone and its plugins at runtime via `java.util.ServiceLoader` rather than linking them at compile-time. 

To support Javac's classloader masking/isolation, `ClassloaderMaskingFileManager` dynamically scans for registered `BugChecker` services on the classpath and automatically whitelists and delegates their package prefixes to the parent classloader. This ensures custom checkers and any helper/utility classes packaged alongside them load successfully without version conflict issues or classloader blocks.

### Motivation
Injecting custom Error Prone plugins (or using a customized version of Error Prone) in Bazel was previously extremely difficult because `JavaBuilder` compile-time linked the bundled Error Prone core and enforced a strict, whitelisted classloader masking filter that blocked custom plugin packages. Decoupling this allows users to seamlessly define and run custom checkers in their Java toolchains.

This PR implements the core JavaBuilder runtime loading changes for [Bazel Issue #29910](https://github.com/bazelbuild/bazel/issues/29910).

**Note:** This PR depends on the rules_java Starlark macro changes in https://github.com/bazelbuild/rules_java/pull/364.

### Build API Changes
No

### Checklist
- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes
RELNOTES: None