### PR TITLE
Apply arg_replacements scrubbing to params file cache key hashing

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ParamFileActionInput.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ParamFileActionInput.java
@@ -95,4 +95,8 @@ public final class ParamFileActionInput extends VirtualActionInput {
   public Iterable<String> getArguments() {
     return arguments;
   }
+
+  public ParameterFileType getType() {
+    return type;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -247,7 +247,11 @@ public class RemoteExecutionService {
             commandId,
             workspaceName);
 
-    this.scrubber = remoteOptions.getScrubber();
+    Scrubber configuredScrubber = remoteOptions.getScrubber();
+    this.scrubber =
+        configuredScrubber != null && remoteOptions.getScrubParamFilesArgReplacements()
+            ? configuredScrubber.withParamFileScrubbing()
+            : configuredScrubber;
 
     this.tempPathGenerator = tempPathGenerator;
     this.captureCorruptedOutputsDir = captureCorruptedOutputsDir;

--- a/src/main/java/com/google/devtools/build/lib/remote/Scrubber.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Scrubber.java
@@ -54,9 +54,14 @@ public final class Scrubber {
   }
 
   private final ImmutableList<SpawnScrubber> spawnScrubbers;
+  private final boolean scrubParamFiles;
 
   @VisibleForTesting
   Scrubber(Config configProto) {
+    this(configProto, /* scrubParamFiles= */ false);
+  }
+
+  private Scrubber(Config configProto, boolean scrubParamFiles) {
     ArrayList<SpawnScrubber> spawnScrubbers = new ArrayList<>();
     for (Config.Rule ruleProto : configProto.getRulesList()) {
       spawnScrubbers.add(new SpawnScrubber(ruleProto));
@@ -64,6 +69,21 @@ public final class Scrubber {
     // Reverse the order so that later rules supersede earlier ones.
     Collections.reverse(spawnScrubbers);
     this.spawnScrubbers = ImmutableList.copyOf(spawnScrubbers);
+    this.scrubParamFiles = scrubParamFiles;
+  }
+
+  private Scrubber(ImmutableList<SpawnScrubber> spawnScrubbers, boolean scrubParamFiles) {
+    this.spawnScrubbers = spawnScrubbers;
+    this.scrubParamFiles = scrubParamFiles;
+  }
+
+  /**
+   * Returns a {@link Scrubber} identical to this one but where every resolved {@link
+   * SpawnScrubber} also applies {@code arg_replacements} scrubbing to params file content when
+   * computing cache keys.
+   */
+  public Scrubber withParamFileScrubbing() {
+    return new Scrubber(spawnScrubbers, /* scrubParamFiles= */ true);
   }
 
   /**
@@ -91,7 +111,7 @@ public final class Scrubber {
   public SpawnScrubber forSpawn(Spawn spawn) {
     for (SpawnScrubber spawnScrubber : spawnScrubbers) {
       if (spawnScrubber.matches(spawn)) {
-        return spawnScrubber;
+        return scrubParamFiles ? spawnScrubber.withParamFileScrubbing() : spawnScrubber;
       }
     }
     return null;
@@ -102,12 +122,14 @@ public final class Scrubber {
     if (this == o) {
       return true;
     }
-    return o instanceof Scrubber that && spawnScrubbers.equals(that.spawnScrubbers);
+    return o instanceof Scrubber that
+        && scrubParamFiles == that.scrubParamFiles
+        && spawnScrubbers.equals(that.spawnScrubbers);
   }
 
   @Override
   public int hashCode() {
-    return spawnScrubbers.hashCode();
+    return Objects.hash(spawnScrubbers, scrubParamFiles);
   }
 
   /**
@@ -124,6 +146,7 @@ public final class Scrubber {
     private final ImmutableList<Pattern> omittedInputPatterns;
     private final ImmutableMap<Pattern, String> argReplacements;
     private final String salt;
+    private final boolean scrubParamFiles;
 
     private SpawnScrubber(Config.Rule ruleProto) {
       Config.Matcher matcherProto = ruleProto.getMatcher();
@@ -141,6 +164,28 @@ public final class Scrubber {
           transformProto.getArgReplacementsList().stream()
               .collect(toImmutableMap(r -> Pattern.compile(r.getSource()), r -> r.getTarget()));
       this.salt = ruleProto.getTransform().getSalt();
+      this.scrubParamFiles = false;
+    }
+
+    private SpawnScrubber(SpawnScrubber base, boolean scrubParamFiles) {
+      this.mnemonicPattern = base.mnemonicPattern;
+      this.labelPattern = base.labelPattern;
+      this.kindPattern = base.kindPattern;
+      this.matchTools = base.matchTools;
+      this.omittedInputPatterns = base.omittedInputPatterns;
+      this.argReplacements = base.argReplacements;
+      this.salt = base.salt;
+      this.scrubParamFiles = scrubParamFiles;
+    }
+
+    /** Returns a new SpawnScrubber identical to this one but with param file scrubbing enabled. */
+    public SpawnScrubber withParamFileScrubbing() {
+      return new SpawnScrubber(this, /* scrubParamFiles= */ true);
+    }
+
+    /** Whether arg_replacements should be applied to params file content when hashing. */
+    public boolean shouldScrubParamFiles() {
+      return scrubParamFiles;
     }
 
     private String emptyToAll(String s) {

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/BUILD
@@ -20,6 +20,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:action_input_helper",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
+        "//src/main/java/com/google/devtools/build/lib/actions:param_file_action_input",
         "//src/main/java/com/google/devtools/build/lib/actions:runfiles_metadata",
         "//src/main/java/com/google/devtools/build/lib/actions:virtual_action_input",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
@@ -55,6 +55,7 @@ import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FileStateType;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.LostInputsExecException;
+import com.google.devtools.build.lib.actions.ParamFileActionInput;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.RunfilesArtifactValue;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -682,6 +683,20 @@ public final class MerkleTreeComputer {
           }
         }
         case VirtualActionInput virtualActionInput -> {
+          if (spawnScrubber != null
+              && spawnScrubber.shouldScrubParamFiles()
+              && virtualActionInput instanceof ParamFileActionInput paramFile) {
+            ImmutableList<String> scrubbedArgs =
+                ImmutableList.copyOf(paramFile.getArguments()).stream()
+                    .map(spawnScrubber::transformArgument)
+                    .collect(toImmutableList());
+            virtualActionInput =
+                new ParamFileActionInput(
+                    paramFile.getExecPath(),
+                    paramFile.getParamFileArg(),
+                    scrubbedArgs,
+                    paramFile.getType());
+          }
           var digest = digestUtil.compute(virtualActionInput);
           addFile(currentDirectory, name, digest, nodeProperties);
           if (blobPolicy != BlobPolicy.DISCARD && digest.getSizeBytes() != 0) {

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -846,6 +846,18 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
   public abstract boolean getExperimentalRemoteCacheChunking();
 
   @Option(
+      name = "experimental_remote_scrubbing_param_files_arg_replacements_enabled",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "If enabled, arg_replacements rules from the remote scrubbing config are also applied"
+              + " to params file content when computing the Merkle tree hash. This ensures that"
+              + " two actions whose params files differ only in scrubbed strings (e.g. absolute"
+              + " workspace paths) produce the same remote cache key.")
+  public abstract boolean getScrubParamFilesArgReplacements();
+
+  @Option(
       name = "experimental_throttle_remote_action_building",
       defaultValue = "true",
       converter = BooleanConverter.class,


### PR DESCRIPTION
Behavior is conditional to --experimental_remote_scrubbing_param_files_arg_replacements_enabled param

Summary:
  Intent:
    - The xplat scrubber's `arg_replacements` rules normalize command-line arguments before they enter the remote cache key, allowing machines with different paths/workspace roots to share cache hits.
    - Params files (virtual action inputs written as `@params` files) were previously hashed using their raw byte content, bypassing the `arg_replacements` logic entirely.
    - This change extends the same normalization to params file content so that the hash used in the Merkle tree reflects the scrubbed arguments, not the raw ones.

  Changes:
    - `CommandLines.ParamFileActionInput`: added `getType()` and `getCharset()` getters so callers can reconstruct a params file with different arguments.
    - `DirectoryTreeBuilder.buildFromActionInputs()`: when a `VirtualActionInput` is a `ParamFileActionInput` and a `SpawnScrubber` is active, each argument is passed through `spawnScrubber.transformArgument()` before the digest is computed. The resulting Merkle tree node (both hash and byte content) reflects the scrubbed args, consistent with how regular command-line args are already handled in `buildCommand()`.

Tags: #has_java

Differential Revision: https://code.uberinternal.com/D25337121

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
