### PR TITLE
Run rules_jvm_external jar tools with exec Java

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -70,7 +70,11 @@ single_version_override(
 single_version_override(
     module_name = "rules_jvm_external",
     patch_strip = 1,
-    patches = ["//third_party:rules_jvm_external_6.8_bazel_vendor.patch"],
+    patches = [
+        "//third_party:rules_jvm_external_6.8_bazel_vendor.patch",
+        # TODO: Remove this patch once a new version of rules_jvm_external is released and adopted by Bazel.
+        "//third_party:rules_jvm_external_6.8_exec_jar_tools.patch",
+    ],
     version = "6.8",
 )
 

--- a/third_party/rules_jvm_external_6.8_exec_jar_tools.patch
+++ b/third_party/rules_jvm_external_6.8_exec_jar_tools.patch
@@ -1,0 +1,78 @@
+diff --git a/private/rules/jvm_import.bzl b/private/rules/jvm_import.bzl
+index 0fbbd10..de36b90 100644
+--- a/private/rules/jvm_import.bzl
++++ b/private/rules/jvm_import.bzl
+@@ -7,7 +7,7 @@
+ # [0]: https://github.com/square/bazel_maven_repository/pull/48
+ # [1]: https://github.com/bazelbuild/bazel/issues/4549
+
+-load("@rules_java//java:defs.bzl", "JavaInfo")
++load("@rules_java//java:defs.bzl", "JavaInfo", "java_common")
+ load("@rules_license//rules:providers.bzl", "PackageInfo")
+ load("//private/lib:coordinates.bzl", "to_external_form", "to_purl", "unpack_coordinates")
+ load("//private/lib:urls.bzl", "scheme_and_host")
+@@ -26,6 +26,8 @@ def _jvm_import_impl(ctx):
+     if not ctx.attr.jar:
+         print(ctx.attr.name, "The `jars` attribute is deprecated and will be removed in `rules_jvm_external` 7.0. Please use the `jar` attribute instead.")
+
++    java_runtime = ctx.attr._java_runtime[java_common.JavaRuntimeInfo]
++    add_jar_manifest_entry = ctx.file._add_jar_manifest_entry
+     injar = ctx.file.jar if ctx.attr.jar else ctx.files.jars[0]
+
+     if ctx.attr._stamp_manifest[StampManifestProvider].stamp_enabled:
+@@ -33,11 +35,15 @@ def _jvm_import_impl(ctx):
+         args = ctx.actions.args()
+         args.add_all(["--source", injar, "--output", outjar])
+         args.add("--manifest-entry", ctx.label, format = "Target-Label:%s")
++        java_args = ctx.actions.args()
++        java_args.add_all(["-jar", add_jar_manifest_entry])
+         ctx.actions.run(
+-            executable = ctx.executable._add_jar_manifest_entry,
+-            arguments = [args],
++            executable = java_runtime.java_executable_exec_path,
++            arguments = [java_args, args],
+             inputs = [injar],
+             outputs = [outjar],
++            env = {"LC_CTYPE": "C.UTF-8"},
++            tools = [add_jar_manifest_entry, java_runtime.files],
+             mnemonic = "StampJarManifest",
+             progress_message = "Stamping the manifest of %{label}",
+         )
+@@ -59,13 +65,17 @@ def _jvm_import_impl(ctx):
+     # Make sure the compile jar is safe to compile with
+     args.add("--make-safe")
+
++    java_args = ctx.actions.args()
++    java_args.add_all(["-jar", add_jar_manifest_entry])
+     ctx.actions.run(
+-        executable = ctx.executable._add_jar_manifest_entry,
+-        arguments = [args],
++        executable = java_runtime.java_executable_exec_path,
++        arguments = [java_args, args],
+         inputs = [outjar],
+         outputs = [compilejar],
++        env = {"LC_CTYPE": "C.UTF-8"},
++        tools = [add_jar_manifest_entry, java_runtime.files],
+         mnemonic = "CreateCompileJar",
+-        progress_message = "Creating compile jar for %s" % ctx.label,
++        progress_message = "Creating compile jar for %{label}",
+     )
+
+     additional_providers = []
+@@ -129,9 +139,14 @@ jvm_import = rule(
+             doc = "URL from where `jar` will be downloaded from.",
+         ),
+         "_add_jar_manifest_entry": attr.label(
+-            executable = True,
++            allow_single_file = True,
++            cfg = "exec",
++            default = "//private/tools/java/com/github/bazelbuild/rules_jvm_external/jar:AddJarManifestEntry_deploy.jar",
++        ),
++        "_java_runtime": attr.label(
++            default = "@rules_java//toolchains:current_java_runtime",
++            providers = [java_common.JavaRuntimeInfo],
+             cfg = "exec",
+-            default = "//private/tools/java/com/github/bazelbuild/rules_jvm_external/jar:AddJarManifestEntry",
+         ),
+         "_stamp_manifest": attr.label(
+             default = "@rules_jvm_external//settings:stamp_manifest",


### PR DESCRIPTION
## Summary

By Codex

- patch `rules_jvm_external` 6.8 so `jvm_import` runs `AddJarManifestEntry_deploy.jar` with `current_java_runtime` in the exec configuration
- set `LC_CTYPE=C.UTF-8` for `StampJarManifest` and `CreateCompileJar` so Java can open `AddJarManifestEntry_deploy.jar` from a non-ASCII output base on Linux
- keep the `java -jar` invocation aligned with `rules_jvm_external` master and omit the launcher-only `-XX:-UsePerfData` flag

## Motivation

This replaces #29764, which was erased from `master` after an accidental GitHub merge. Invoking `AddJarManifestEntry_deploy.jar` through `current_java_runtime` avoids executing the generated Bash launcher on a Windows host with Linux remote execution.

Bazel does not inherit a UTF-8 locale into `jvm_import` actions. `//src/test/shell/bazel:bazel_determinism_test` uses an output base containing `äöü€`; without `LC_CTYPE=C.UTF-8`, both `java -jar` and `java -cp` fail to open `AddJarManifestEntry_deploy.jar` on Linux.

The corresponding upstream changes are bazel-contrib/rules_jvm_external#1583 and bazel-contrib/rules_jvm_external#1610.

## Validation

- `patch --dry-run --forward -p1 ...` against `rules_jvm_external` 6.8
- `bash -n scripts/bootstrap/bootstrap.sh`
- earlier validation: built `@maven//:org_brotli_dec` with a non-ASCII output base and `LC_ALL`, `LANG`, and `LC_CTYPE` cleared from the action environment
- earlier validation: confirmed with `aquery` that `StampJarManifest` and `CreateCompileJar` use the exec Java runtime, `-jar AddJarManifestEntry_deploy.jar`, and `LC_CTYPE=C.UTF-8`
