### PR TITLE
[9.2.0] Redo logic for bfs of VendorCommand.java (https://github.com/bazelbuild/bazel/pull/30088)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
@@ -304,17 +304,17 @@ public final class VendorCommand implements BlazeCommand {
       InMemoryGraph inMemoryGraph, ImmutableList<SkyKey> targetKeys) throws InterruptedException {
     ImmutableSet.Builder<RepositoryName> repos = ImmutableSet.builder();
     Queue<SkyKey> nodes = new ArrayDeque<>(targetKeys);
-    Set<SkyKey> visited = new HashSet<>();
+    // Mark nodes as visited when they are enqueued.
+    Set<SkyKey> visited = new HashSet<>(targetKeys);
     while (!nodes.isEmpty()) {
       SkyKey key = nodes.remove();
-      visited.add(key);
       NodeEntry nodeEntry = inMemoryGraph.get(null, Reason.VENDOR_EXTERNAL_REPOS, key);
       if (nodeEntry.getValue() instanceof RepositoryDirectoryValue.Success repoDirValue
           && !repoDirValue.excludeFromVendoring()) {
         repos.add((RepositoryName) key.argument());
       }
       for (SkyKey depKey : nodeEntry.getDirectDeps()) {
-        if (!visited.contains(depKey)) {
+        if (visited.add(depKey)) {
           nodes.add(depKey);
         }
       }


### PR DESCRIPTION
Redo logic for bfs of VendorCommand.java
### Description
Adding the nodes of the graph into visited when we're dequeing while checking if they exist while enqueing means that we might accidentally add the same nodes multiple time, leading to OOM on big production graphs.

Example:
```
target keys = [A, B]
nodes = [A, B]

A -> C
B -> C
```

We visit A, then add C to nodes.
Then we visit B, also adding C to nodes under the old logic (duplicated).

This patch changes the logic so that we add a node to visited whenever we enqueue so this doesn't happen. See
https://en.wikipedia.org/wiki/Breadth-first_search#Pseudocode for pseudocode.

### Motivation

Fix oom bug

### Build API Changes

No

### Checklist

- [NA] I have added tests for the new use cases (if any).
- [NA] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #30088.

PiperOrigin-RevId: 943722164
Change-Id: I153afd4281a3c138fe401a145b0d6465fa198e50

Commit https://github.com/bazelbuild/bazel/commit/01407e480d94f23b058c941d9c9e58f64839bdd7