### PR TITLE
Materialize overlay-only symlinks to local files for local actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -542,8 +542,10 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       }
       return getSymlinks(treeArtifact, treeArtifact.getPath(), treeMetadata, metadataSupplier);
     }
-    if ((metadata.isRemote() || metadata.getType() == FileStateType.SYMLINK)
-        && !inputPath.startsWith(execRoot)) {
+    if (!inputPath.startsWith(execRoot)
+        && (metadata.isRemote()
+            || metadata.getType() == FileStateType.SYMLINK
+            || isOverlayOnlySymlink(inputPath))) {
       // A path in an external repo, e.g. a source artifact consumed by an action or a file
       // prefetched during the materialization of an external repo. It may be (part of) a chain of
       // symlinks created by the repo rule, which has to be reproduced verbatim on disk.
@@ -567,6 +569,27 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       return ImmutableList.of();
     }
     return ImmutableList.of(new Symlink(inputPath, resolvedPath));
+  }
+
+  /**
+   * Returns whether the given path is a symlink in an overlay file system that isn't present on
+   * the host file system.
+   *
+   * <p>A symlink in a repo backed by the remote repo contents cache can resolve to a file in a
+   * repo that has been materialized on disk. Its metadata then describes a local regular file,
+   * but the symlink itself only exists in the in-memory overlay and still has to be planted on
+   * disk for local actions to consume it.
+   */
+  private static boolean isOverlayOnlySymlink(Path path) throws IOException {
+    var fs = path.getFileSystem();
+    if (fs == fs.getHostFileSystem()) {
+      // The path is on the host file system, so any symlink already exists on disk.
+      return false;
+    }
+    var stat = path.statIfFound(Symlinks.NOFOLLOW);
+    return stat != null
+        && stat.isSymbolicLink()
+        && path.forHostFileSystem().statIfFound(Symlinks.NOFOLLOW) == null;
   }
 
   private static Path resolveOneSymlink(Path path, @Nullable PathFragment targetPathFragment)

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -348,6 +348,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote/util:rx_futures",
         "//src/main/java/com/google/devtools/build/lib/remote/util:rx_utils",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:flogger",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
@@ -50,6 +50,7 @@ import com.google.devtools.build.lib.remote.util.AsyncTaskCache;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.RxUtils.TransferResult;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.protobuf.Message;
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.Completable;
@@ -120,7 +121,19 @@ public class RemoteExecutionCache extends CombinedCache implements MerkleTreeUpl
           }
           return Futures.transform(
               downloadFromDiskCache,
-              unused -> remoteActionFileSystem.getHostFileSystem().exists(path.asFragment()),
+              unused -> {
+                // A source file in an external repo may be a symlink that only exists in an
+                // in-memory file system, but points to a file that is available on the host file
+                // system (see RemoteExternalOverlayFileSystem). Since the upload reads through
+                // the symlink, check availability at the resolved path.
+                PathFragment pathToCheck;
+                try {
+                  pathToCheck = path.resolveSymbolicLinks().asFragment();
+                } catch (IOException e) {
+                  pathToCheck = path.asFragment();
+                }
+                return remoteActionFileSystem.getHostFileSystem().exists(pathToCheck);
+              },
               directExecutor());
         }
       };

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -56,6 +56,7 @@ import com.google.devtools.build.skyframe.MemoizingEvaluator;
 import com.google.devtools.build.skyframe.SkyFunctionException;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
@@ -419,6 +420,14 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
   // All other methods delegate to the file system given by this method. It is important to override
   // each non-final FileSystem method to benefit from optimizations implemented in the respective
   // underlying file systems.
+  //
+  // A repo backed by one of the two file systems can contain a symlink pointing into a repo backed
+  // by the other one (e.g. an in-memory repo can have been created with a symlink into a repo that
+  // has only been materialized on disk). Neither backing file system can follow such a symlink on
+  // its own as the target repo doesn't exist in it. Since this situation is rare, operations
+  // delegate to a single backing file system first and only fall back to resolving symlinks
+  // segment by segment at the overlay level if that fails (see followingSymlinks and
+  // followingParentSymlinks).
   private FileSystem fsForPath(PathFragment path) {
     if (path.startsWith(externalDirectory) && !path.equals(externalDirectory)) {
       String repoName = path.getSegment(externalDirectorySegmentCount);
@@ -441,20 +450,91 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
     return nativeFs;
   }
 
+  @FunctionalInterface
+  private interface FileSystemOp<T> {
+    T apply(FileSystem fs, PathFragment path) throws IOException;
+  }
+
+  /**
+   * Applies an operation that follows symlinks in the last path segment to the backing file system
+   * responsible for the given path, retrying it on the overlay-level canonical path if it fails
+   * because a symlink crosses between the two backing file systems.
+   */
+  private <T> T followingSymlinks(PathFragment path, FileSystemOp<T> op) throws IOException {
+    try {
+      return op.apply(fsForPath(path), path);
+    } catch (FileNotFoundException e) {
+      PathFragment resolved = resolveCrossFileSystemSymlinks(path, /* resolveLastSegment= */ true);
+      if (resolved == null) {
+        throw e;
+      }
+      return op.apply(fsForPath(resolved), resolved);
+    }
+  }
+
+  /**
+   * Applies an operation that does not follow symlinks in the last path segment to the backing
+   * file system responsible for the given path, retrying it on the overlay-level canonical path if
+   * it fails because a symlink crosses between the two backing file systems.
+   */
+  private <T> T followingParentSymlinks(PathFragment path, FileSystemOp<T> op) throws IOException {
+    try {
+      return op.apply(fsForPath(path), path);
+    } catch (FileNotFoundException e) {
+      PathFragment resolved = resolveCrossFileSystemSymlinks(path, /* resolveLastSegment= */ false);
+      if (resolved == null) {
+        throw e;
+      }
+      return op.apply(fsForPath(resolved), resolved);
+    }
+  }
+
+  /**
+   * Returns the canonical form of the given path with symlinks resolved segment by segment at the
+   * overlay level, with each segment routed to the backing file system that contains it.
+   *
+   * <p>Returns {@code null} if the path does not lie in an external repo, cannot be resolved, or
+   * resolves to itself, in which case retrying an operation on it cannot change the outcome.
+   */
+  @Nullable
+  private PathFragment resolveCrossFileSystemSymlinks(
+      PathFragment path, boolean resolveLastSegment) {
+    if (!path.startsWith(externalDirectory) || path.equals(externalDirectory)) {
+      // Only paths in external repos can contain symlinks that cross between the two backing file
+      // systems.
+      return null;
+    }
+    int segmentsToResolve = path.segmentCount() - (resolveLastSegment ? 0 : 1);
+    try {
+      // The external directory itself always exists in both backing file systems and is never a
+      // symlink, so resolution can start below it instead of at the file system root.
+      PathFragment resolved = externalDirectory;
+      for (int i = externalDirectorySegmentCount; i < segmentsToResolve; i++) {
+        resolved = appendSegment(resolved, path.getSegment(i), MAX_SYMLINKS);
+      }
+      if (!resolveLastSegment) {
+        resolved = resolved.getChild(path.getBaseName());
+      }
+      return resolved.equals(path) ? null : resolved;
+    } catch (IOException e) {
+      return null;
+    }
+  }
+
   @Override
   public boolean delete(PathFragment path) throws IOException {
-    return fsForPath(path).delete(path);
+    return followingParentSymlinks(path, FileSystem::delete);
   }
 
   @Override
   public byte[] getDigest(PathFragment path) throws IOException {
-    return fsForPath(path).getDigest(path);
+    return followingSymlinks(path, FileSystem::getDigest);
   }
 
   @Nullable
   @Override
   public byte[] getFastDigest(PathFragment path) throws IOException {
-    return fsForPath(path).getFastDigest(path);
+    return followingSymlinks(path, FileSystem::getFastDigest);
   }
 
   @Override
@@ -479,7 +559,7 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
 
   @Override
   public boolean createDirectory(PathFragment path) throws IOException {
-    return fsForPath(path).createDirectory(path);
+    return followingParentSymlinks(path, FileSystem::createDirectory);
   }
 
   @Override
@@ -489,95 +569,121 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
 
   @Override
   public long getFileSize(PathFragment path, boolean followSymlinks) throws IOException {
-    return fsForPath(path).getFileSize(path, followSymlinks);
+    return followSymlinks
+        ? followingSymlinks(path, (fs, p) -> fs.getFileSize(p, true))
+        : followingParentSymlinks(path, (fs, p) -> fs.getFileSize(p, false));
   }
 
   @Override
   public long getLastModifiedTime(PathFragment path, boolean followSymlinks) throws IOException {
-    return fsForPath(path).getLastModifiedTime(path, followSymlinks);
+    return followSymlinks
+        ? followingSymlinks(path, (fs, p) -> fs.getLastModifiedTime(p, true))
+        : followingParentSymlinks(path, (fs, p) -> fs.getLastModifiedTime(p, false));
   }
 
   @Override
   public void setLastModifiedTime(PathFragment path, long newTime) throws IOException {
-    fsForPath(path).setLastModifiedTime(path, newTime);
+    followingSymlinks(
+        path,
+        (fs, p) -> {
+          fs.setLastModifiedTime(p, newTime);
+          return null;
+        });
   }
 
   @Override
   public FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
-    return fsForPath(path).stat(path, followSymlinks);
+    return followSymlinks
+        ? followingSymlinks(path, (fs, p) -> fs.stat(p, true))
+        : followingParentSymlinks(path, (fs, p) -> fs.stat(p, false));
   }
 
   @Override
   public void createSymbolicLink(
       PathFragment linkPath, PathFragment targetFragment, SymlinkTargetType hint)
       throws IOException {
-    fsForPath(linkPath).createSymbolicLink(linkPath, targetFragment, hint);
+    followingParentSymlinks(
+        linkPath,
+        (fs, p) -> {
+          fs.createSymbolicLink(p, targetFragment, hint);
+          return null;
+        });
   }
 
   @Override
   public PathFragment readSymbolicLink(PathFragment path) throws IOException {
-    return fsForPath(path).readSymbolicLink(path);
+    return followingParentSymlinks(path, FileSystem::readSymbolicLink);
   }
 
   @Override
   public boolean exists(PathFragment path, boolean followSymlinks) {
-    return fsForPath(path).exists(path, followSymlinks);
-  }
-
-  @Override
-  public boolean exists(PathFragment path) {
-    return fsForPath(path).exists(path);
+    return statNullable(path, followSymlinks) != null;
   }
 
   @Override
   public Collection<String> getDirectoryEntries(PathFragment path) throws IOException {
-    return fsForPath(path).getDirectoryEntries(path);
+    return followingSymlinks(path, FileSystem::getDirectoryEntries);
   }
 
   @Override
   public boolean isReadable(PathFragment path) throws IOException {
-    return fsForPath(path).isReadable(path);
+    return followingSymlinks(path, FileSystem::isReadable);
   }
 
   @Override
   public void setReadable(PathFragment path, boolean readable) throws IOException {
-    fsForPath(path).setReadable(path, readable);
+    followingSymlinks(
+        path,
+        (fs, p) -> {
+          fs.setReadable(p, readable);
+          return null;
+        });
   }
 
   @Override
   public boolean isWritable(PathFragment path) throws IOException {
-    return fsForPath(path).isWritable(path);
+    return followingSymlinks(path, FileSystem::isWritable);
   }
 
   @Override
   public void setWritable(PathFragment path, boolean writable) throws IOException {
-    fsForPath(path).setWritable(path, writable);
+    followingSymlinks(
+        path,
+        (fs, p) -> {
+          fs.setWritable(p, writable);
+          return null;
+        });
   }
 
   @Override
   public boolean isExecutable(PathFragment path) throws IOException {
-    return fsForPath(path).isExecutable(path);
+    return followingSymlinks(path, FileSystem::isExecutable);
   }
 
   @Override
   public void setExecutable(PathFragment path, boolean executable) throws IOException {
-    fsForPath(path).setExecutable(path, executable);
+    followingSymlinks(
+        path,
+        (fs, p) -> {
+          fs.setExecutable(p, executable);
+          return null;
+        });
   }
 
   @Override
   public InputStream getInputStream(PathFragment path) throws IOException {
-    return fsForPath(path).getInputStream(path);
+    return followingSymlinks(path, FileSystem::getInputStream);
   }
 
   @Override
   public SeekableByteChannel createReadWriteByteChannel(PathFragment path) throws IOException {
-    return fsForPath(path).createReadWriteByteChannel(path);
+    return followingSymlinks(path, FileSystem::createReadWriteByteChannel);
   }
 
   @Override
   public OutputStream getOutputStream(PathFragment path, boolean append, boolean internal)
       throws IOException {
-    return fsForPath(path).getOutputStream(path, append, internal);
+    return followingSymlinks(path, (fs, p) -> fs.getOutputStream(p, append, internal));
   }
 
   @Override
@@ -609,7 +715,9 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
   @Override
   public byte[] getxattr(PathFragment path, String name, boolean followSymlinks)
       throws IOException {
-    return fsForPath(path).getxattr(path, name, followSymlinks);
+    return followSymlinks
+        ? followingSymlinks(path, (fs, p) -> fs.getxattr(p, name, true))
+        : followingParentSymlinks(path, (fs, p) -> fs.getxattr(p, name, false));
   }
 
   @Nullable
@@ -620,55 +728,72 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
 
   @Override
   public Path resolveSymbolicLinks(PathFragment path) throws IOException {
-    // Ensure that the return value doesn't leave the overlay file system.
-    return getPath(fsForPath(path).resolveSymbolicLinks(path).asFragment());
+    try {
+      // Ensure that the return value doesn't leave the overlay file system.
+      return getPath(fsForPath(path).resolveSymbolicLinks(path).asFragment());
+    } catch (FileNotFoundException e) {
+      PathFragment resolved = resolveCrossFileSystemSymlinks(path, /* resolveLastSegment= */ true);
+      if (resolved == null) {
+        throw e;
+      }
+      return getPath(resolved);
+    }
   }
 
   @Nullable
   @Override
   public FileStatus statNullable(PathFragment path, boolean followSymlinks) {
-    return fsForPath(path).statNullable(path, followSymlinks);
+    var fs = fsForPath(path);
+    var status = fs.statNullable(path, followSymlinks);
+    if (status == null && fs == externalFs) {
+      // The in-memory file system may have failed to fully resolve the path due to a symlink
+      // pointing out of it. Only retry in this direction as retrying failed native operations
+      // would noticeably slow down existence checks for paths that legitimately don't exist.
+      PathFragment resolved = resolveCrossFileSystemSymlinks(path, followSymlinks);
+      if (resolved != null) {
+        return fsForPath(resolved).statNullable(resolved, followSymlinks);
+      }
+    }
+    return status;
   }
 
   @Nullable
   @Override
   public FileStatus statIfFound(PathFragment path, boolean followSymlinks) throws IOException {
-    return fsForPath(path).statIfFound(path, followSymlinks);
-  }
-
-  @Override
-  public boolean isFile(PathFragment path, boolean followSymlinks) {
-    return fsForPath(path).isFile(path, followSymlinks);
-  }
-
-  @Override
-  public boolean isSpecialFile(PathFragment path, boolean followSymlinks) {
-    return fsForPath(path).isSpecialFile(path, followSymlinks);
-  }
-
-  @Override
-  public boolean isSymbolicLink(PathFragment path) {
-    return fsForPath(path).isSymbolicLink(path);
-  }
-
-  @Override
-  public boolean isDirectory(PathFragment path, boolean followSymlinks) {
-    return fsForPath(path).isDirectory(path, followSymlinks);
+    var fs = fsForPath(path);
+    var status = fs.statIfFound(path, followSymlinks);
+    if (status == null && fs == externalFs) {
+      // The in-memory file system may have failed to fully resolve the path due to a symlink
+      // pointing out of it. Only retry in this direction as retrying failed native operations
+      // would noticeably slow down existence checks for paths that legitimately don't exist.
+      PathFragment resolved = resolveCrossFileSystemSymlinks(path, followSymlinks);
+      if (resolved != null) {
+        return fsForPath(resolved).statIfFound(resolved, followSymlinks);
+      }
+    }
+    return status;
   }
 
   @Override
   public PathFragment readSymbolicLinkUnchecked(PathFragment path) throws IOException {
-    return fsForPath(path).readSymbolicLinkUnchecked(path);
+    return followingParentSymlinks(path, FileSystem::readSymbolicLinkUnchecked);
   }
 
   @Override
   public Collection<Dirent> readdir(PathFragment path, boolean followSymlinks) throws IOException {
-    return fsForPath(path).readdir(path, followSymlinks);
+    // The path itself must be a directory, so symlinks in its last segment are always followed;
+    // followSymlinks only applies to the types reported for the entries.
+    return followingSymlinks(path, (fs, p) -> fs.readdir(p, followSymlinks));
   }
 
   @Override
   public void chmod(PathFragment path, int mode) throws IOException {
-    fsForPath(path).chmod(path, mode);
+    followingSymlinks(
+        path,
+        (fs, p) -> {
+          fs.chmod(p, mode);
+          return null;
+        });
   }
 
   @Override

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -1529,6 +1529,24 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     self.assertFalse(os.path.exists(os.path.join(my_repo_dir, 'BUILD')))
     self.assertFalse(os.path.lexists(external_link))
 
+  def testRepoExternalSymlinkWithNativeTargetRepoLocalAction(self):
+    my_repo_dir, _, external_link = (
+        self.setUpExternalSymlinkWithNativeTargetRepo()
+    )
+
+    # A local action needs the original symlink on the host file system.
+    self.RunBazel([
+        'build',
+        '//main:local',
+        '--spawn_strategy=local',
+    ])
+    with open(self.Path('bazel-bin/main/local.txt')) as f:
+      self.assertEqual(f.read(), 'dep_hello')
+    self.assertFalse(os.path.exists(os.path.join(my_repo_dir, 'BUILD')))
+    self.assertTrue(os.path.islink(external_link))
+    with open(external_link) as f:
+      self.assertEqual(f.read(), 'dep_hello')
+
   def testLostRemoteFile_build(self):
     # Create a repo with two BUILD files (one in a subpackage), build a target
     # from one to cause it to be cached, then build that target again after

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -27,14 +27,14 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
 
   def setUp(self):
     test_base.TestBase.setUp(self)
-    worker_port = self.StartRemoteWorker()
+    self._worker_port = self.StartRemoteWorker()
     self.ScratchFile(
         '.bazelrc',
         [
             'startup --experimental_remote_repo_contents_cache',
             # Only use the remote repo contents cache.
             'common --repo_contents_cache=',
-            'common --remote_cache=grpc://localhost:' + str(worker_port),
+            'common --remote_cache=grpc://localhost:' + str(self._worker_port),
             'common --auth_enabled=false',
             'common --remote_timeout=3600s',
             'common --verbose_failures',
@@ -1360,6 +1360,146 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     self.assertEqual(action_layout, full_layout)
     self.assertEqual(action_layout['type'], 'symlink')
     self.assertEqual(action_layout['resolves_to'], 'dep_hello')
+
+  def setUpExternalSymlinkWithNativeTargetRepo(self):
+    """Creates an in-memory repo with a symlink into a materialized repo.
+
+    Returns a tuple of the paths of the in-memory repo, the materialized repo
+    and the symlink.
+    """
+    if self.IsWindows():
+      self.ScratchFile(
+          '.bazelrc',
+          ['startup --windows_enable_symlinks'],
+          mode='a',
+      )
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'dep_repo_rule = use_repo_rule("//:dep_repo.bzl", "dep_repo_rule")',
+            'dep_repo_rule(name = "dep_repo")',
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            (
+                'repo(name = "my_repo", external_file ='
+                ' "@dep_repo//:dep_data.txt")'
+            ),
+            (
+                'materializer_rule ='
+                ' use_repo_rule("//:materializer.bzl", "materializer_rule")'
+            ),
+            (
+                'materializer_rule(name = "materializer", dep_file ='
+                ' "@dep_repo//:dep_data.txt")'
+            ),
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'dep_repo.bzl',
+        [
+            'def _dep_repo_impl(rctx):',
+            '  rctx.file("BUILD", "exports_files([\'dep_data.txt\'])")',
+            '  rctx.file("dep_data.txt", "dep_hello")',
+            '  print("JUST FETCHED DEP_REPO")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'dep_repo_rule = repository_rule(_dep_repo_impl)',
+        ],
+    )
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            (
+                '  rctx.file("BUILD", "filegroup(name=\'haha\')\\n'
+                "exports_files(['external_link.txt'])\")"
+            ),
+            '  rctx.symlink(rctx.attr.external_file, "external_link.txt")',
+            '  print("JUST FETCHED MY_REPO")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            (
+                'repo = repository_rule(_repo_impl,'
+                ' attrs={"external_file": attr.label()})'
+            ),
+        ],
+    )
+    self.ScratchFile(
+        'materializer.bzl',
+        [
+            'def _materializer_impl(rctx):',
+            '  rctx.file("BUILD", "filegroup(name=\'haha\')")',
+            '  rctx.read(rctx.attr.dep_file)',
+            '  return rctx.repo_metadata()',
+            (
+                'materializer_rule = repository_rule(_materializer_impl,'
+                ' attrs={"dep_file": attr.label()})'
+            ),
+        ],
+    )
+    self.ScratchFile(
+        'main/BUILD.bazel',
+        [
+            'genrule(',
+            '  name = "remote",',
+            '  srcs = ["@my_repo//:external_link.txt"],',
+            '  outs = ["remote.txt"],',
+            '  cmd = "cat $< > $@",',
+            '  tags = ["no-cache"],',
+            ')',
+            'genrule(',
+            '  name = "local",',
+            '  srcs = ["@my_repo//:external_link.txt"],',
+            '  outs = ["local.txt"],',
+            '  cmd = "cat $< > $@",',
+            '  tags = ["no-cache"],',
+            ')',
+        ],
+    )
+
+    # Populate the remote repo contents cache without creating an action-cache
+    # entry for either genrule.
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    stderr_text = '\n'.join(stderr)
+    self.assertIn('JUST FETCHED DEP_REPO', stderr_text)
+    self.assertIn('JUST FETCHED MY_REPO', stderr_text)
+
+    my_repo_dir = self.RepoDir('my_repo')
+    dep_repo_dir = self.RepoDir('dep_repo')
+    external_link = os.path.join(my_repo_dir, 'external_link.txt')
+
+    # Materialize only dep_repo in a fresh output base.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '@materializer//:haha'])
+    self.assertNotIn('JUST FETCHED DEP_REPO', '\n'.join(stderr))
+    self.assertTrue(os.path.exists(os.path.join(dep_repo_dir, 'dep_data.txt')))
+    self.assertFalse(os.path.lexists(external_link))
+
+    # Restore my_repo into the in-memory overlay while leaving dep_repo on the
+    # native file system.
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertNotIn('JUST FETCHED MY_REPO', '\n'.join(stderr))
+    self.assertFalse(os.path.exists(os.path.join(my_repo_dir, 'BUILD')))
+    self.assertFalse(os.path.lexists(external_link))
+
+    return my_repo_dir, dep_repo_dir, external_link
+
+  def testRepoExternalSymlinkWithNativeTargetRepo(self):
+    my_repo_dir, _, external_link = (
+        self.setUpExternalSymlinkWithNativeTargetRepo()
+    )
+
+    # A remote action must be able to consume the in-memory symlink pointing at
+    # the native target without materializing or refetching its repo.
+    _, _, stderr = self.RunBazel([
+        'build',
+        '//main:remote',
+        '--spawn_strategy=remote',
+        '--remote_executor=grpc://localhost:' + str(self._worker_port),
+    ])
+    self.assertNotIn('JUST FETCHED MY_REPO', '\n'.join(stderr))
+    with open(self.Path('bazel-bin/main/remote.txt')) as f:
+      self.assertEqual(f.read(), 'dep_hello')
+    self.assertFalse(os.path.exists(os.path.join(my_repo_dir, 'BUILD')))
+    self.assertFalse(os.path.lexists(external_link))
 
   def testLostRemoteFile_build(self):
     # Create a repo with two BUILD files (one in a subpackage), build a target

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -15,6 +15,7 @@
 # pylint: disable=g-long-ternary
 # pylint: disable=g-bad-todo
 
+import hashlib
 import json
 import os
 import re
@@ -1496,6 +1497,33 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
         '--remote_executor=grpc://localhost:' + str(self._worker_port),
     ])
     self.assertNotIn('JUST FETCHED MY_REPO', '\n'.join(stderr))
+    with open(self.Path('bazel-bin/main/remote.txt')) as f:
+      self.assertEqual(f.read(), 'dep_hello')
+    self.assertFalse(os.path.exists(os.path.join(my_repo_dir, 'BUILD')))
+    self.assertFalse(os.path.lexists(external_link))
+
+  def testRepoExternalSymlinkWithNativeTargetRepoUpload(self):
+    my_repo_dir, _, external_link = (
+        self.setUpExternalSymlinkWithNativeTargetRepo()
+    )
+
+    # Remove the target contents from the CAS so remote input upload has to
+    # read through the overlay symlink instead of reusing the repository blob.
+    dep_digest = hashlib.sha256(b'dep_hello').hexdigest()
+    dep_blob = os.path.join(self._cas_path, 'cas', dep_digest[:2], dep_digest)
+    self.assertTrue(os.path.exists(dep_blob))
+    os.remove(dep_blob)
+
+    # A remote action must be able to upload the native target through the
+    # symlink path stored in the overlay.
+    _, _, stderr = self.RunBazel([
+        'build',
+        '//main:remote',
+        '--spawn_strategy=remote',
+        '--remote_executor=grpc://localhost:' + str(self._worker_port),
+    ])
+    self.assertNotIn('JUST FETCHED MY_REPO', '\n'.join(stderr))
+    self.assertTrue(os.path.exists(dep_blob))
     with open(self.Path('bazel-bin/main/remote.txt')) as f:
       self.assertEqual(f.read(), 'dep_hello')
     self.assertFalse(os.path.exists(os.path.join(my_repo_dir, 'BUILD')))


### PR DESCRIPTION
### Description

With `--experimental_remote_repo_contents_cache`, a source file in an external repo can be a symlink that only exists in the in-memory file system while pointing at a file in a repo that has been materialized on disk. Since the resolved target's metadata describes a local regular file, `AbstractActionInputPrefetcher` didn't recognize the input as a repo symlink chain that has to be reproduced on disk and skipped it entirely. Local actions consuming the symlink then failed with `No such file or directory`.

The prefetcher now also reproduces the symlink chain on disk when the input path is a symlink in an overlay file system that isn't present on the host file system, even if its metadata describes a local file. As the target file is already available locally, only the symlinks are planted, without downloading anything. The check is expressed in terms of `FileSystem#getHostFileSystem` since referencing `RemoteExternalOverlayFileSystem` directly would create a build dependency cycle, and builds without an overlay file system don't pay for the extra stat.

Stacked on #30154 and #30155, only the last commit is new. The new integration test runs a local action consuming the in-memory symlink and asserts that the symlink is planted on disk. Together, the tests of the three PRs cover the full reproducer from #30149, which passes on this PR.

### Motivation

Fixes #30149.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
