### PR TITLE
[8.8.0] Cherry-pick commit 47b0fd6 and 46c5e78.

### DIFF
--- a/src/jdeps_modules.golden
+++ b/src/jdeps_modules.golden
@@ -7,4 +7,5 @@ java.naming
 java.sql
 java.xml
 jdk.management
+jdk.net
 jdk.unsupported

--- a/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
@@ -141,6 +141,61 @@ public class AuthAndTLSOptions extends OptionsBase {
   public Duration grpcKeepaliveTimeout;
 
   @Option(
+      name = "grpc_tcp_keepalive",
+      defaultValue = "true",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          """
+          Whether to enable TCP keep-alive (the SO_KEEPALIVE socket option) for outgoing gRPC
+          connections. This operates at the transport layer and is independent of the
+          application-level keep-alive pings configured with `--grpc_keepalive_time`. When enabled,
+          the keep-alive behavior is controlled by `--grpc_tcp_keepalive_time`,
+          `--grpc_tcp_keepalive_interval` and `--grpc_tcp_keepalive_count`.
+          """)
+  public boolean grpcTcpKeepalive;
+
+  @Option(
+      name = "grpc_tcp_keepalive_time",
+      defaultValue = "60s",
+      converter = DurationConverter.class,
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          """
+          When `--grpc_tcp_keepalive` is enabled, the amount of idle time on a gRPC connection
+          before the first TCP keep-alive probe is sent (TCP_KEEPIDLE). Has no effect if TCP
+          keep-alive is disabled.
+          """)
+  public Duration grpcTcpKeepaliveTime;
+
+  @Option(
+      name = "grpc_tcp_keepalive_interval",
+      defaultValue = "10s",
+      converter = DurationConverter.class,
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          """
+          When `--grpc_tcp_keepalive` is enabled, the amount of time between successive TCP
+          keep-alive probes (TCP_KEEPINTVL). Has no effect if TCP keep-alive is disabled.
+          """)
+  public Duration grpcTcpKeepaliveInterval;
+
+  @Option(
+      name = "grpc_tcp_keepalive_count",
+      defaultValue = "3",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          """
+          When `--grpc_tcp_keepalive` is enabled, the number of unacknowledged TCP keep-alive probes
+          to send before considering the connection dead (TCP_KEEPCNT). Has no effect if TCP
+          keep-alive is disabled.
+          """)
+  public int grpcTcpKeepaliveCount;
+
+  @Option(
       name = "credential_helper",
       oldName = "experimental_credential_helper",
       defaultValue = "null",

--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -35,13 +35,16 @@ import io.grpc.auth.MoreCallCredentials;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.epoll.EpollDomainSocketChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.kqueue.KQueue;
 import io.netty.channel.kqueue.KQueueDomainSocketChannel;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.socket.nio.NioChannelOption;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -57,6 +60,7 @@ import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import jdk.net.ExtendedSocketOptions;
 
 /** Utility methods for using {@link AuthAndTLSOptions} with Google Cloud. */
 public final class GoogleAuthUtils {
@@ -96,6 +100,34 @@ public final class GoogleAuthUtils {
       if (options.grpcKeepaliveTime != null) {
         builder.keepAliveTime(options.grpcKeepaliveTime.getSeconds(), TimeUnit.SECONDS);
         builder.keepAliveTimeout(options.grpcKeepaliveTimeout.getSeconds(), TimeUnit.SECONDS);
+      }
+      boolean isUnixSocketChannel = targetUrl.startsWith("unix:") || !Strings.isNullOrEmpty(proxy);
+      if (options.grpcTcpKeepalive && !isUnixSocketChannel) {
+        builder.withOption(ChannelOption.SO_KEEPALIVE, true);
+        boolean epoll = Epoll.isAvailable();
+        long idleSeconds = options.grpcTcpKeepaliveTime.toSeconds();
+        if (idleSeconds > 0) {
+          builder.withOption(
+              epoll
+                  ? EpollChannelOption.TCP_KEEPIDLE
+                  : NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPIDLE),
+              Math.toIntExact(idleSeconds));
+        }
+        long intervalSeconds = options.grpcTcpKeepaliveInterval.toSeconds();
+        if (intervalSeconds > 0) {
+          builder.withOption(
+              epoll
+                  ? EpollChannelOption.TCP_KEEPINTVL
+                  : NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPINTERVAL),
+              Math.toIntExact(intervalSeconds));
+        }
+        if (options.grpcTcpKeepaliveCount > 0) {
+          builder.withOption(
+              epoll
+                  ? EpollChannelOption.TCP_KEEPCNT
+                  : NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPCOUNT),
+              options.grpcTcpKeepaliveCount);
+        }
       }
       if (interceptors != null) {
         builder.intercept(interceptors);


### PR DESCRIPTION
Cherry-pick commit https://github.com/bazelbuild/bazel/commit/47b0fd692e632ec401327498b6d0e7bbc46353df and https://github.com/bazelbuild/bazel/commit/46c5e789f84c7bf4ba1edb105eefa7bc4ebc841b.

Closes https://github.com/bazelbuild/bazel/issues/29883.
Closes https://github.com/bazelbuild/bazel/issues/29904.

---

Enable TCP keepalive by default for gRPC connections. (https://github.com/bazelbuild/bazel/pull/29879)

### Description

We (BuildBuddy) see a fair amount of support issues where connections are killed due to idle flow timeouts (e.g. NAT gateways) and the usual advice is for the customer to configure TCP keepalive on their client host.

Instead of playing whackamole, I'd like to make TCP keepalive on by default for Bazel with reasonable defaults rather than relying on client hosts having appropriate settings configured.

I've kept the settings as flags in case there are users that have more esoteric needs that require adjusting these settings since the explicit settings in this PR override the OS settings.

### Build API Changes

No

### Release Notes

RELNOTES: Enable TCP keepalive by default for gRPC connections with reasonable defaults

Closes #29879.

PiperOrigin-RevId: 934460935
Change-Id: I81fa4443e4da8a626cd62a30524470c6d4fd84ef

---

Fix enabling TCP keepalive on Linux. (https://github.com/bazelbuild/bazel/pull/29902)

On Linux, gRPC defaults to epoll which uses a different set of options.

https://github.com/bazelbuild/bazel/pull/29879 worked on Mac but was a no-op on Linux.

Closes #29902.

PiperOrigin-RevId: 936173912
Change-Id: I3796427c6f9fe887b0557bb56466e176af25f160