### PR TITLE
[9.2.0] Temporarily disable //src/test/py/bazel:launcher_test on Windows

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -276,6 +276,9 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/4292
       - "-//src/test/shell/bazel/remote/..."
       - "-//tools/python:pywrapper_test"
+      # Temporarily disable this test which is failing on Windows due to a clang update.
+      # TODO(b/530925565): Re-enable.
+      - "-//src/test/py/bazel:launcher_test"
     include_json_profile:
       - build
       - test

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -284,6 +284,9 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/4292
       - "-//src/test/shell/bazel/remote/..."
       - "-//tools/python:pywrapper_test"
+      # Temporarily disable this test which is failing on Windows due to a clang update.
+      # TODO(b/530925565): Re-enable.
+      - "-//src/test/py/bazel:launcher_test"
     include_json_profile:
       - build
       - test


### PR DESCRIPTION
This test is failing due to a clang update.

PiperOrigin-RevId: 943497618
Change-Id: Ib2993df0e60e39c7563280c3393ce69f0c3f0dcf
(Original commit 7460f6d09dbd1ad6bf6e81e64342bd02df59b3e3)