### PR TITLE
Exclude repos with cross-repo symlinks from the remote repo contents cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryUtils.java
@@ -81,7 +81,7 @@ public class RepositoryUtils {
    * @param safeForLocalCache whether the repo is safe to cache in the local repo contents cache
    *     after replanting
    * @param safeForRemoteCache whether the repo is safe to cache in the remote repo contents cache
-   *     after replanting
+   *     after replanting.
    */
   public record ReplantSymlinksResult(boolean safeForLocalCache, boolean safeForRemoteCache) {}
 
@@ -114,7 +114,9 @@ public class RepositoryUtils {
       boolean replantSymlinksIntoMainRepo)
       throws IOException {
     boolean portableSymlinksOnly = true;
-    boolean hasSymlinkIntoMainRepo = false;
+    // TODO(#30160): Repos with symlinks pointing out of the repo are currently excluded from the
+    // remote repo contents cache since cross-FS resolution of symlinks proved tricky to get right.
+    boolean symlinksResolveWithinRepo = true;
     try {
       Collection<Path> symlinks = FileSystemUtils.traverseTree(repoDir, Path::isSymbolicLink);
       Path workspaceSymlinkUnderExternal = externalRepoRoot.getChild(WORKSPACE_SYMLINK_NAME);
@@ -125,7 +127,7 @@ public class RepositoryUtils {
         PathFragment target = symlink.readSymbolicLink();
         PathFragment originalTarget = target;
         if (target.startsWith(workspace.asFragment())) {
-          hasSymlinkIntoMainRepo = true;
+          symlinksResolveWithinRepo = false;
           if (!replantSymlinksIntoMainRepo) {
             // Symlinks pointing into the main repo can't be replanted to a relative path that
             // stays under the external root. They make the repo unsafe to cache.
@@ -137,10 +139,20 @@ public class RepositoryUtils {
                   .asFragment()
                   .getRelative(target.relativeTo(workspace.asFragment()));
         }
+        if (!target.isAbsolute()) {
+          // A symlink that was created with a relative target by the repo rule. Resolve it
+          // against the symlink's parent directory to determine whether it stays within the repo.
+          if (!symlink.getParentDirectory().getRelative(target).startsWith(repoDir)) {
+            portableSymlinksOnly = false;
+            symlinksResolveWithinRepo = false;
+          }
+          continue;
+        }
         if (!target.startsWith(externalRepoRoot.asFragment())) {
           // This symlink doesn't point into any Bazel repo, including the main repo, and thus its
           // target isn't managed by Bazel. We assume such symlinks are portable across machines
-          // on which the repo is relevant (e.g. /lib/ld-linux.so* or /usr/bin/ld).
+          // on which the repo is relevant (e.g. /lib/ld-linux.so* or /usr/bin/ld)
+          symlinksResolveWithinRepo = false;
           continue;
         }
         PathFragment newTarget;
@@ -158,6 +170,7 @@ public class RepositoryUtils {
           // be possible to use these symlinks portably, but this would likely require changes to
           // FileFunction to mimic this resolution behavior.
           portableSymlinksOnly = false;
+          symlinksResolveWithinRepo = false;
           // Rewrite for consistency even if not portable. A mix of absolute and relative symlinks
           // would result in less predictable behavior and reduced test coverage.
           newTarget =
@@ -175,6 +188,7 @@ public class RepositoryUtils {
           var newTargetNioPath = symlink.getFileSystem().getNioPath(newTarget);
           if (symlinkNioPath == null || newTargetNioPath == null) {
             portableSymlinksOnly = false;
+            symlinksResolveWithinRepo = false;
             continue;
           }
           symlink.delete();
@@ -182,9 +196,11 @@ public class RepositoryUtils {
             Files.createSymbolicLink(symlinkNioPath, newTargetNioPath);
           } catch (IOException e) {
             // Creating a real symlink failed (likely no Developer Mode or symlink privilege).
-            // Restore the original symlink/junction and mark as non-portable.
+            // Restore the original symlink/junction and mark as non-portable. The absolute target
+            // also doesn't resolve within the repo when restored elsewhere.
             FileSystemUtils.ensureSymbolicLink(symlink, originalTarget);
             portableSymlinksOnly = false;
+            symlinksResolveWithinRepo = false;
           }
         } else {
           FileSystemUtils.ensureSymbolicLink(symlink, newTarget);
@@ -194,6 +210,6 @@ public class RepositoryUtils {
       throw new IOException(
           String.format("Failed to rewrite symlinks under %s: %s", repoDir, e.getMessage()), e);
     }
-    return new ReplantSymlinksResult(portableSymlinksOnly, !hasSymlinkIntoMainRepo);
+    return new ReplantSymlinksResult(portableSymlinksOnly, symlinksResolveWithinRepo);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
@@ -105,7 +105,8 @@ import javax.annotation.Nullable;
  * "least recently added" eviction when the size of action result exceeds a certain threshold.
  */
 public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCache {
-  private static final UUID GUID = UUID.fromString("f4a165a9-5557-45a7-bf25-230b6d42393a");
+  // Salts all cache keys; change it whenever previously cached entries may no longer be valid.
+  private static final UUID GUID = UUID.fromString("0336b325-9db8-4592-a5eb-79b4970bc4ce");
   private static final String MARKER_FILE_PATH = ".recorded_inputs";
   private static final String REPO_DIRECTORY_PATH = "repo_contents";
   private static final Splitter SPLIT_ON_SPACE = Splitter.on(' ');

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -22,19 +22,26 @@ import tempfile
 from absl.testing import absltest
 from src.test.py.bazel import test_base
 
+# Whether repos containing symlinks that point out of the repo can be added to
+# the remote repo contents cache. If False, such repos are refetched instead of
+# being restored from the cache.
+# TODO(#30160): Flip to True once the overlay file system supports resolving
+# symlinks across its backing file systems.
+CROSS_REPO_SYMLINKS_CACHEABLE = False
+
 
 class RemoteRepoContentsCacheTest(test_base.TestBase):
 
   def setUp(self):
     test_base.TestBase.setUp(self)
-    worker_port = self.StartRemoteWorker()
+    self._worker_port = self.StartRemoteWorker()
     self.ScratchFile(
         '.bazelrc',
         [
             'startup --experimental_remote_repo_contents_cache',
             # Only use the remote repo contents cache.
             'common --repo_contents_cache=',
-            'common --remote_cache=grpc://localhost:' + str(worker_port),
+            'common --remote_cache=grpc://localhost:' + str(self._worker_port),
             'common --auth_enabled=false',
             'common --remote_timeout=3600s',
             'common --verbose_failures',
@@ -1345,14 +1352,20 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     # and fully materialized (along with dep_repo) because other accesses it.
     self.RunBazel(['clean', '--expunge'])
     _, _, stderr = self.RunBazel(['build', '@other//:haha'])
-    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    if CROSS_REPO_SYMLINKS_CACHEABLE:
+      self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    else:
+      self.assertIn('JUST FETCHED', '\n'.join(stderr))
     full_layout = snapshot()
 
     # Lazy action-input materialization: only external_link.txt and its resolved
     # target in dep_repo are materialized.
     self.RunBazel(['clean', '--expunge'])
     _, _, stderr = self.RunBazel(['build', '//main:use_link'])
-    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    if CROSS_REPO_SYMLINKS_CACHEABLE:
+      self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    else:
+      self.assertIn('JUST FETCHED', '\n'.join(stderr))
     action_layout = snapshot()
 
     # The cross-repo symlink must be reproduced (as an absolute symlink into the
@@ -1360,6 +1373,202 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     self.assertEqual(action_layout, full_layout)
     self.assertEqual(action_layout['type'], 'symlink')
     self.assertEqual(action_layout['resolves_to'], 'dep_hello')
+
+  def setUpExternalSymlinkWithNativeTargetRepo(self):
+    """Creates a repo with a symlink into another, remotely cached repo.
+
+    The target repo is materialized on disk, while the repo containing the
+    symlink is restored into the in-memory overlay if
+    CROSS_REPO_SYMLINKS_CACHEABLE and refetched otherwise.
+
+    Returns a tuple of the paths of the repo containing the symlink, the repo
+    containing its target and the symlink.
+    """
+    if self.IsWindows():
+      self.ScratchFile(
+          '.bazelrc',
+          ['startup --windows_enable_symlinks'],
+          mode='a',
+      )
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'dep_repo_rule = use_repo_rule("//:dep_repo.bzl", "dep_repo_rule")',
+            'dep_repo_rule(name = "dep_repo")',
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            (
+                'repo(name = "my_repo", external_file ='
+                ' "@dep_repo//:dep_data.txt")'
+            ),
+            (
+                'materializer_rule ='
+                ' use_repo_rule("//:materializer.bzl", "materializer_rule")'
+            ),
+            (
+                'materializer_rule(name = "materializer", dep_file ='
+                ' "@dep_repo//:dep_data.txt")'
+            ),
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'dep_repo.bzl',
+        [
+            'def _dep_repo_impl(rctx):',
+            '  rctx.file("BUILD", "exports_files([\'dep_data.txt\'])")',
+            '  rctx.file("dep_data.txt", "dep_hello")',
+            '  print("JUST FETCHED DEP_REPO")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'dep_repo_rule = repository_rule(_dep_repo_impl)',
+        ],
+    )
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            (
+                '  rctx.file("BUILD", "filegroup(name=\'haha\')\\n'
+                "exports_files(['external_link.txt'])\")"
+            ),
+            '  rctx.symlink(rctx.attr.external_file, "external_link.txt")',
+            '  print("JUST FETCHED MY_REPO")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            (
+                'repo = repository_rule(_repo_impl,'
+                ' attrs={"external_file": attr.label()})'
+            ),
+        ],
+    )
+    self.ScratchFile(
+        'materializer.bzl',
+        [
+            'def _materializer_impl(rctx):',
+            '  rctx.file("BUILD", "filegroup(name=\'haha\')")',
+            '  rctx.read(rctx.attr.dep_file)',
+            '  return rctx.repo_metadata()',
+            (
+                'materializer_rule = repository_rule(_materializer_impl,'
+                ' attrs={"dep_file": attr.label()})'
+            ),
+        ],
+    )
+    self.ScratchFile(
+        'main/BUILD.bazel',
+        [
+            'genrule(',
+            '  name = "remote",',
+            '  srcs = ["@my_repo//:external_link.txt"],',
+            '  outs = ["remote.txt"],',
+            '  cmd = "cat $< > $@",',
+            '  tags = ["no-cache"],',
+            ')',
+            'genrule(',
+            '  name = "local",',
+            '  srcs = ["@my_repo//:external_link.txt"],',
+            '  outs = ["local.txt"],',
+            '  cmd = "cat $< > $@",',
+            '  tags = ["no-cache"],',
+            ')',
+        ],
+    )
+
+    # Populate the remote repo contents cache without creating an action-cache
+    # entry for either genrule.
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    stderr_text = '\n'.join(stderr)
+    self.assertIn('JUST FETCHED DEP_REPO', stderr_text)
+    self.assertIn('JUST FETCHED MY_REPO', stderr_text)
+
+    my_repo_dir = self.RepoDir('my_repo')
+    dep_repo_dir = self.RepoDir('dep_repo')
+    external_link = os.path.join(my_repo_dir, 'external_link.txt')
+
+    # Materialize only dep_repo in a fresh output base.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '@materializer//:haha'])
+    self.assertNotIn('JUST FETCHED DEP_REPO', '\n'.join(stderr))
+    self.assertTrue(os.path.exists(os.path.join(dep_repo_dir, 'dep_data.txt')))
+    self.assertFalse(os.path.lexists(external_link))
+
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    if CROSS_REPO_SYMLINKS_CACHEABLE:
+      # Restore my_repo into the in-memory overlay while leaving dep_repo on
+      # the native file system.
+      self.assertNotIn('JUST FETCHED MY_REPO', '\n'.join(stderr))
+      self.assertFalse(os.path.exists(os.path.join(my_repo_dir, 'BUILD')))
+      self.assertFalse(os.path.lexists(external_link))
+    else:
+      # my_repo is refetched rather than restored from the cache as its symlink
+      # points out of the repo.
+      self.assertIn('JUST FETCHED MY_REPO', '\n'.join(stderr))
+      self.assertTrue(os.path.exists(os.path.join(my_repo_dir, 'BUILD')))
+      self.assertTrue(os.path.islink(external_link))
+
+    return my_repo_dir, dep_repo_dir, external_link
+
+  def testRepoExternalSymlinkWithNativeTargetRepo(self):
+    my_repo_dir, _, external_link = (
+        self.setUpExternalSymlinkWithNativeTargetRepo()
+    )
+
+    # A remote action must be able to consume the symlink as an action input
+    # without materializing or refetching its repo.
+    _, _, stderr = self.RunBazel([
+        'build',
+        '//main:remote',
+        '--spawn_strategy=remote',
+        '--remote_executor=grpc://localhost:' + str(self._worker_port),
+    ])
+    self.assertNotIn('JUST FETCHED MY_REPO', '\n'.join(stderr))
+    with open(self.Path('bazel-bin/main/remote.txt')) as f:
+      self.assertEqual(f.read(), 'dep_hello')
+    if CROSS_REPO_SYMLINKS_CACHEABLE:
+      self.assertFalse(os.path.exists(os.path.join(my_repo_dir, 'BUILD')))
+      self.assertFalse(os.path.lexists(external_link))
+
+  def testRepoExternalSymlinkWithNativeTargetRepoUpload(self):
+    my_repo_dir, _, external_link = (
+        self.setUpExternalSymlinkWithNativeTargetRepo()
+    )
+
+    # Remove the target contents from the CAS so remote input upload has to
+    # read through the symlink instead of reusing the repository blob.
+    dep_blob = self.DeleteCasEntry(b'dep_hello')
+
+    # A remote action must be able to upload the native target through the
+    # symlink path.
+    _, _, stderr = self.RunBazel([
+        'build',
+        '//main:remote',
+        '--spawn_strategy=remote',
+        '--remote_executor=grpc://localhost:' + str(self._worker_port),
+    ])
+    self.assertNotIn('JUST FETCHED MY_REPO', '\n'.join(stderr))
+    self.assertTrue(os.path.exists(dep_blob))
+    with open(self.Path('bazel-bin/main/remote.txt')) as f:
+      self.assertEqual(f.read(), 'dep_hello')
+    if CROSS_REPO_SYMLINKS_CACHEABLE:
+      self.assertFalse(os.path.exists(os.path.join(my_repo_dir, 'BUILD')))
+      self.assertFalse(os.path.lexists(external_link))
+
+  def testRepoExternalSymlinkWithNativeTargetRepoLocalAction(self):
+    my_repo_dir, _, external_link = (
+        self.setUpExternalSymlinkWithNativeTargetRepo()
+    )
+
+    # A local action needs the symlink on the host file system.
+    self.RunBazel([
+        'build',
+        '//main:local',
+        '--spawn_strategy=local',
+    ])
+    with open(self.Path('bazel-bin/main/local.txt')) as f:
+      self.assertEqual(f.read(), 'dep_hello')
+    self.assertTrue(os.path.islink(external_link))
+    with open(external_link) as f:
+      self.assertEqual(f.read(), 'dep_hello')
+    if CROSS_REPO_SYMLINKS_CACHEABLE:
+      self.assertFalse(os.path.exists(os.path.join(my_repo_dir, 'BUILD')))
 
   def testLostRemoteFile_build(self):
     # Create a repo with two BUILD files (one in a subpackage), build a target
@@ -1543,8 +1752,18 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     # After expunging: my_repo cached, not materialized
     self.RunBazel(['clean', '--expunge'])
     _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
-    self.assertNotIn('JUST FETCHED MY_REPO', '\n'.join(stderr))
-    self.assertFalse(os.path.exists(os.path.join(repo_dir, 'BUILD')))
+    if CROSS_REPO_SYMLINKS_CACHEABLE or not expect_symlinks:
+      # Without symlink support, rctx.symlink falls back to copying the target
+      # file, so the repo doesn't contain any symlinks pointing out of it and
+      # is cached even when repos with cross-repo symlinks aren't.
+      self.assertNotIn('JUST FETCHED MY_REPO', '\n'.join(stderr))
+      self.assertFalse(os.path.exists(os.path.join(repo_dir, 'BUILD')))
+    else:
+      # my_repo is refetched, which also materializes dep_repo as its file is
+      # referenced by label.
+      self.assertIn('JUST FETCHED MY_REPO', '\n'.join(stderr))
+      self.assertNotIn('JUST FETCHED DEP_REPO', '\n'.join(stderr))
+      self.assertTrue(os.path.exists(os.path.join(repo_dir, 'BUILD')))
 
     # Fetch other: my_repo materialized; dep_repo only if watch_dep_file.
     _, _, stderr = self.RunBazel(['build', '@other//:haha'])
@@ -1558,7 +1777,7 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
       self.assertTrue(os.path.islink(external_link))
     with open(internal_link) as f:
       self.assertEqual(f.read(), 'hello')
-    if watch_dep_file:
+    if watch_dep_file or not CROSS_REPO_SYMLINKS_CACHEABLE:
       with open(external_link) as f:
         self.assertEqual(f.read(), 'dep_hello')
     else:
@@ -1787,8 +2006,15 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     # cross-repo symlinked .bzl loaded by the BUILD file must still be readable.
     self.RunBazel(['clean', '--expunge'])
     _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
-    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
-    self.assertFalse(os.path.exists(os.path.join(repo_dir, 'helper.bzl')))
+    if CROSS_REPO_SYMLINKS_CACHEABLE:
+      self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+      self.assertFalse(os.path.exists(os.path.join(repo_dir, 'helper.bzl')))
+    else:
+      # my_repo is refetched, which also materializes helper_repo as its file
+      # is referenced by label.
+      self.assertIn('JUST FETCHED', '\n'.join(stderr))
+      self.assertNotIn('JUST FETCHED HELPER', '\n'.join(stderr))
+      self.assertTrue(os.path.islink(os.path.join(repo_dir, 'helper.bzl')))
 
   def testRun(self):
     self.ScratchFile(

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -16,6 +16,7 @@
 
 """Bazel Python integration test framework."""
 
+import hashlib
 import os
 import re
 import shutil
@@ -520,6 +521,21 @@ class TestBase(absltest.TestCase):
     shutil.rmtree(self._cas_path)
     # The worker needs the CAS path as well as the tmp dir to exist.
     os.makedirs(os.path.join(self._cas_path, 'tmp'))
+
+  def DeleteCasEntry(self, content):
+    """Deletes the CAS entry of the "local remote worker" with the given content.
+
+    Args:
+      content: bytes; the contents of the CAS entry to delete.
+
+    Returns:
+      str: the path of the deleted CAS entry.
+    """
+    digest = hashlib.sha256(content).hexdigest()
+    blob_path = os.path.join(self._cas_path, 'cas', digest[:2], digest)
+    self.assertTrue(os.path.exists(blob_path))
+    os.remove(blob_path)
+    return blob_path
 
   def RunProgram(
       self,


### PR DESCRIPTION
### Description
This is meant as a temporary stopgap for the many symlink-related issues found with the remote repo contents cache and includes tests found while debugging #30149.

The new and old tests are parameterized in a test suite variable to keep the diff small and enable future experimentation with improved symlink support. As part of #30160, I'll investigate a more conceptual approach to symlink resolution that unifies the logic with that in RemoteActionFileSystem.

### Motivation

Fixes #30149

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: The remote repo contents cache no longer caches or restores repos with cross-repo symlinks, thus avoiding a large surface area for bugs. The effort to reenable this support is tracked by https://github.com/bazelbuild/bazel/issues/30160. 
