### PR TITLE
tools/jdk: disable implicit __init__.py creation for proguard_allowlister

### DIFF
--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -141,12 +141,16 @@ py_binary(
     srcs = [
         "proguard_allowlister.py",
     ],
+    # See https://github.com/bazel-contrib/rules_python/issues/2945
+    legacy_create_init = 0,
 )
 
 py_test(
     name = "proguard_allowlister_test",
     srcs = ["proguard_allowlister_test.py"],
     data = ["proguard_allowlister_test_input.pgcfg"],
+    # See https://github.com/bazel-contrib/rules_python/issues/2945
+    legacy_create_init = 0,
     deps = [
         ":proguard_allowlister",
     ],


### PR DESCRIPTION
Set `legacy_create_init = 0` on the proguard_allowlister py_binary and
py_test to silence the deprecation warning about implicit `__init__.py`
creation. These targets do not rely on implicitly created `__init__.py`
files.

See https://github.com/bazel-contrib/rules_python/issues/2945

```
======================================================================
WARNING: Target @@bazel_tools//tools/jdk:proguard_allowlister is using implicit __init__.py creation.
  This diabolic behavior is deprecated and will be disabled by default in a
  future release.
  See https://github.com/bazel-contrib/rules_python/issues/2945

  Ensure all __init__.py files are explicitly created and
  added to the srcs or deps of your targets.

  Disable implicit creation by setting:
    legacy_create_init = 0
  on the target, or globally by setting:
    --incompatible_default_to_explicit_init_py
======================================================================
```
