### PR TITLE
Add --experimental_max_repeated_lost_inputs to make the action-rewinding lost-input limit configurable

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
@@ -393,6 +393,19 @@ public abstract class BuildRequestOptions extends OptionsBase {
   public abstract boolean getExperimentalPreciseRewinding();
 
   @Option(
+      name = "experimental_max_repeated_lost_inputs",
+      defaultValue = "20",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.EXECUTION},
+      help =
+          "The maximum number of times action rewinding will try to recover the same lost input (or"
+              + " top-level output) for the same action before giving up and failing the build. Set"
+              + " this lower to fail fast on an unstable remote cache instead of repeatedly"
+              + " rewinding a single lost input; 0 fails on the first lost input. Only takes effect"
+              + " when --rewind_lost_inputs is enabled.")
+  public abstract int getMaxRepeatedLostInputs();
+
+  @Option(
       name = "incompatible_skip_genfiles_symlink",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -245,6 +245,7 @@ public final class SkyframeActionExecutor {
   private boolean finalizeActions;
   private boolean rewindingEnabled;
   private boolean preciseRewindingEnabled;
+  private int maxRepeatedLostInputs;
   private boolean invocationRetriesEnabled;
   private final Supplier<ImmutableList<Root>> sourceRootSupplier;
 
@@ -346,6 +347,7 @@ public final class SkyframeActionExecutor {
     this.finalizeActions = buildRequestOptions.getFinalizeActions();
     this.rewindingEnabled = buildRequestOptions.getRewindLostInputs();
     this.preciseRewindingEnabled = buildRequestOptions.getExperimentalPreciseRewinding();
+    this.maxRepeatedLostInputs = buildRequestOptions.getMaxRepeatedLostInputs();
     this.invocationRetriesEnabled =
         options.getOptions(ExecutionOptions.class).getRemoteRetryOnTransientCacheError() > 0;
     this.outputService = checkNotNull(outputService);
@@ -440,6 +442,15 @@ public final class SkyframeActionExecutor {
 
   public boolean preciseRewindingEnabled() {
     return preciseRewindingEnabled;
+  }
+
+  /**
+   * Returns the maximum number of times the same input (or top-level output) may be lost by the
+   * same action before rewinding gives up and fails the build. Configured by {@code
+   * --experimental_max_repeated_lost_inputs}.
+   */
+  public int maxRepeatedLostInputs() {
+    return maxRepeatedLostInputs;
   }
 
   public boolean invocationRetriesEnabled() {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/rewinding/ActionRewindStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/rewinding/ActionRewindStrategy.java
@@ -91,7 +91,6 @@ import javax.annotation.Nullable;
 public final class ActionRewindStrategy {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
-  @VisibleForTesting static final int MAX_REPEATED_LOST_INPUTS = 20;
   @VisibleForTesting static final int MAX_ACTION_REWIND_EVENTS = 5;
   private static final int MAX_LOST_INPUTS_RECORDED = 5;
 
@@ -515,7 +514,7 @@ public final class ActionRewindStrategy {
     for (LostInputRecord lostInputRecord : currentAttemptLostOutputRecords) {
       String digest = lostInputRecord.lostInputDigest();
       int losses = historyForThisTopLevelKey.add(lostInputRecord, /* occurrences= */ 1) + 1;
-      if (losses > MAX_REPEATED_LOST_INPUTS) {
+      if (losses > skyframeActionExecutor.maxRepeatedLostInputs()) {
         ActionInput lostOutput =
             Iterables.find(
                 lostOutputsByDigest.get(digest),
@@ -524,7 +523,9 @@ public final class ActionRewindStrategy {
             new GenericActionRewindException(
                 String.format(
                     "Lost output %s (digest %s), and rewinding was ineffective after %d attempts.",
-                    prettyPrint(lostOutput), digest, MAX_REPEATED_LOST_INPUTS),
+                    prettyPrint(lostOutput),
+                    digest,
+                    skyframeActionExecutor.maxRepeatedLostInputs()),
                 ActionRewinding.Code.LOST_OUTPUT_TOO_MANY_TIMES);
         bugReporter.sendBugReport(e);
         throw e;
@@ -582,7 +583,7 @@ public final class ActionRewindStrategy {
       // the same input is repeatedly lost.
       String digest = lostInputRecord.lostInputDigest();
       int losses = historyForThisAction.add(lostInputRecord, /* occurrences= */ 1) + 1;
-      if (losses > MAX_REPEATED_LOST_INPUTS) {
+      if (losses > skyframeActionExecutor.maxRepeatedLostInputs()) {
         // This ensures coalesced shared actions aren't orphaned.
         skyframeActionExecutor.prepareForRewinding(
             failedKey, failedAction, /* depsToRewind= */ ImmutableList.of());

--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/BUILD
@@ -42,6 +42,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/skyframe",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
+        "//src/main/java/com/google/devtools/common/options",
         "//src/main/protobuf:failure_details_java_proto",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
         "//src/test/java/com/google/devtools/build/lib/buildtool/util",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTest.java
@@ -199,14 +199,9 @@ public final class RewindingTest extends BuildIntegrationTestCase {
   }
 
   @Test
-  public void ineffectiveRewindingResultsInLostInputTooManyTimes() throws Exception {
-    helper.runIneffectiveRewindingResultsInLostInputTooManyTimes();
-    assertOutputForRule2NotCreated();
-  }
-
-  @Test
-  public void lostInputTooManyTimesLimitIsConfigurable() throws Exception {
-    helper.runLostInputTooManyTimesLimitIsConfigurable();
+  public void ineffectiveRewindingResultsInLostInputTooManyTimes(
+      @TestParameter({"2", "20"}) int maxRepeatedLostInputs) throws Exception {
+    helper.runIneffectiveRewindingResultsInLostInputTooManyTimes(maxRepeatedLostInputs);
     assertOutputForRule2NotCreated();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTest.java
@@ -205,6 +205,12 @@ public final class RewindingTest extends BuildIntegrationTestCase {
   }
 
   @Test
+  public void lostInputTooManyTimesLimitIsConfigurable() throws Exception {
+    helper.runLostInputTooManyTimesLimitIsConfigurable();
+    assertOutputForRule2NotCreated();
+  }
+
+  @Test
   public void interruptedDuringRewindStopsNormally() throws Exception {
     helper.runInterruptedDuringRewindStopsNormally();
     assertOutputForRule2NotCreated();

--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
@@ -632,13 +632,14 @@ public class RewindingTestsHelper {
     assertThat(rewoundArtifactOwnerLabels(rewoundKeys)).containsExactly("//test:rule1");
   }
 
-  public final void runIneffectiveRewindingResultsInLostInputTooManyTimes() throws Exception {
+  public final void runIneffectiveRewindingResultsInLostInputTooManyTimes(int maxRepeatedLostInputs)
+      throws Exception {
     // This test sets up two genrules, and makes the several execution attempts of rule2 fail,
     // saying that the file produced by rule1 is missing. The last time rule2 fails because of the
     // same lost input, rewinding is not attempted, and the build fails with a
-    // LOST_INPUT_TOO_MANY_TIMES detailed exit code.
-    int maxRepeatedLostInputs =
-        Options.getDefaults(BuildRequestOptions.class).getMaxRepeatedLostInputs();
+    // LOST_INPUT_TOO_MANY_TIMES detailed exit code. The repeated-loss limit is set via
+    // --experimental_max_repeated_lost_inputs so this exercises both the default and a lower limit.
+    testCase.addOptions("--experimental_max_repeated_lost_inputs=" + maxRepeatedLostInputs);
     writeTwoGenrulePackage(testCase);
 
     // Store a reference to the input so that we can match the exception message. The output
@@ -692,56 +693,6 @@ public class RewindingTestsHelper {
     assertOnlyActionsRewound(rewoundKeys);
     assertThat(Iterables.frequency(rewoundArtifactOwnerLabels(rewoundKeys), "//test:rule1"))
         .isEqualTo(maxRepeatedLostInputs);
-  }
-
-  /**
-   * Like {@link #runIneffectiveRewindingResultsInLostInputTooManyTimes}, but verifies that {@code
-   * --experimental_max_repeated_lost_inputs} overrides the default repeated-loss limit: rewinding
-   * gives up, and the build fails with {@link ActionRewinding.Code#LOST_INPUT_TOO_MANY_TIMES},
-   * after the configured number of repeated losses rather than the default.
-   */
-  public final void runLostInputTooManyTimesLimitIsConfigurable() throws Exception {
-    int maxRepeatedLostInputs = 2;
-    testCase.addOptions("--experimental_max_repeated_lost_inputs=" + maxRepeatedLostInputs);
-    writeTwoGenrulePackage(testCase);
-
-    // Fail rule2 with the same lost input one more time than the configured limit allows.
-    AtomicReference<ActionInput> intermediate = new AtomicReference<>();
-    for (int i = 0; i <= maxRepeatedLostInputs; i++) {
-      addSpawnShim(
-          "Executing genrule //test:rule2",
-          (spawn, context) -> {
-            intermediate.set(SpawnInputUtils.getInputWithName(spawn, "intermediate.txt"));
-            return ExecResult.ofException(
-                new LostInputsExecException(
-                    ImmutableSetMultimap.of("fakedigest/10", intermediate.get())));
-          });
-    }
-
-    RecordingBugReporter bugReporter = testCase.recordBugReportsAndReinitialize();
-    BuildFailedException e =
-        assertThrows(BuildFailedException.class, () -> testCase.buildTarget("//test:rule2"));
-    assertThat(e.getDetailedExitCode().getFailureDetail().getActionRewinding().getCode())
-        .isEqualTo(ActionRewinding.Code.LOST_INPUT_TOO_MANY_TIMES);
-
-    // The give-up (and bug report) happens at the configured limit + 1, not the default 20 + 1.
-    String errorDetail =
-        String.format(
-            "lost input too many times (#%s) for the same action. lostInput: %s, "
-                + "lostInput digest: fakedigest/10, "
-                + "failedAction: action 'Executing genrule //test:rule2'",
-            maxRepeatedLostInputs + 1, intermediate.get());
-    assertThat(e.getDetailedExitCode().getFailureDetail().getMessage()).contains(errorDetail);
-    assertThat(Iterables.getOnlyElement(bugReporter.getExceptions()))
-        .hasMessageThat()
-        .contains(errorDetail);
-
-    // rule2 executed once per loss: the configured rewinds plus the final give-up attempt.
-    // With the default limit this would be 21; the configured limit of 2 makes it 3.
-    assertThat(
-            Iterables.frequency(
-                getExecutedSpawnDescriptions(), "Executing genrule //test:rule2"))
-        .isEqualTo(maxRepeatedLostInputs + 1);
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
@@ -89,6 +89,7 @@ import com.google.devtools.build.skyframe.QueryableGraph.Reason;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.build.skyframe.ValueWithMetadata;
+import com.google.devtools.common.options.Options;
 import com.google.errorprone.annotations.ForOverride;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -636,12 +637,14 @@ public class RewindingTestsHelper {
     // saying that the file produced by rule1 is missing. The last time rule2 fails because of the
     // same lost input, rewinding is not attempted, and the build fails with a
     // LOST_INPUT_TOO_MANY_TIMES detailed exit code.
+    int maxRepeatedLostInputs =
+        Options.getDefaults(BuildRequestOptions.class).getMaxRepeatedLostInputs();
     writeTwoGenrulePackage(testCase);
 
     // Store a reference to the input so that we can match the exception message. The output
     // directory name (and hence the string representation) varies by platform.
     AtomicReference<ActionInput> intermediate = new AtomicReference<>();
-    for (int i = 0; i <= ActionRewindStrategy.MAX_REPEATED_LOST_INPUTS; i++) {
+    for (int i = 0; i <= maxRepeatedLostInputs; i++) {
       addSpawnShim(
           "Executing genrule //test:rule2",
           (spawn, context) -> {
@@ -664,7 +667,7 @@ public class RewindingTestsHelper {
             "lost input too many times (#%s) for the same action. lostInput: %s, "
                 + "lostInput digest: fakedigest/10, "
                 + "failedAction: action 'Executing genrule //test:rule2'",
-            ActionRewindStrategy.MAX_REPEATED_LOST_INPUTS + 1, intermediate.get());
+            maxRepeatedLostInputs + 1, intermediate.get());
     assertThat(e.getDetailedExitCode().getFailureDetail().getMessage()).contains(errorDetail);
     assertThat(Iterables.getOnlyElement(bugReporter.getExceptions()))
         .hasMessageThat()
@@ -674,7 +677,7 @@ public class RewindingTestsHelper {
         .containsExactlyElementsIn(
             Iterables.concat(
                 Collections.nCopies(
-                    ActionRewindStrategy.MAX_REPEATED_LOST_INPUTS + 1,
+                    maxRepeatedLostInputs + 1,
                     ImmutableList.of(
                         "Executing genrule //test:rule1", "Executing genrule //test:rule2"))))
         .inOrder();
@@ -684,12 +687,61 @@ public class RewindingTestsHelper {
         /* completedRewound= */ ImmutableList.of("Executing genrule //test:rule1"),
         /* failedRewound= */ ImmutableList.of(),
         /* expectResultReceivedForFailedRewound= */ false,
-        /* actionRewindingPostLostInputCounts= */ ImmutableList.of(
-            ActionRewindStrategy.MAX_REPEATED_LOST_INPUTS + 1));
+        /* actionRewindingPostLostInputCounts= */ ImmutableList.of(maxRepeatedLostInputs + 1));
 
     assertOnlyActionsRewound(rewoundKeys);
     assertThat(Iterables.frequency(rewoundArtifactOwnerLabels(rewoundKeys), "//test:rule1"))
-        .isEqualTo(ActionRewindStrategy.MAX_REPEATED_LOST_INPUTS);
+        .isEqualTo(maxRepeatedLostInputs);
+  }
+
+  /**
+   * Like {@link #runIneffectiveRewindingResultsInLostInputTooManyTimes}, but verifies that {@code
+   * --experimental_max_repeated_lost_inputs} overrides the default repeated-loss limit: rewinding
+   * gives up, and the build fails with {@link ActionRewinding.Code#LOST_INPUT_TOO_MANY_TIMES},
+   * after the configured number of repeated losses rather than the default.
+   */
+  public final void runLostInputTooManyTimesLimitIsConfigurable() throws Exception {
+    int maxRepeatedLostInputs = 2;
+    testCase.addOptions("--experimental_max_repeated_lost_inputs=" + maxRepeatedLostInputs);
+    writeTwoGenrulePackage(testCase);
+
+    // Fail rule2 with the same lost input one more time than the configured limit allows.
+    AtomicReference<ActionInput> intermediate = new AtomicReference<>();
+    for (int i = 0; i <= maxRepeatedLostInputs; i++) {
+      addSpawnShim(
+          "Executing genrule //test:rule2",
+          (spawn, context) -> {
+            intermediate.set(SpawnInputUtils.getInputWithName(spawn, "intermediate.txt"));
+            return ExecResult.ofException(
+                new LostInputsExecException(
+                    ImmutableSetMultimap.of("fakedigest/10", intermediate.get())));
+          });
+    }
+
+    RecordingBugReporter bugReporter = testCase.recordBugReportsAndReinitialize();
+    BuildFailedException e =
+        assertThrows(BuildFailedException.class, () -> testCase.buildTarget("//test:rule2"));
+    assertThat(e.getDetailedExitCode().getFailureDetail().getActionRewinding().getCode())
+        .isEqualTo(ActionRewinding.Code.LOST_INPUT_TOO_MANY_TIMES);
+
+    // The give-up (and bug report) happens at the configured limit + 1, not the default 20 + 1.
+    String errorDetail =
+        String.format(
+            "lost input too many times (#%s) for the same action. lostInput: %s, "
+                + "lostInput digest: fakedigest/10, "
+                + "failedAction: action 'Executing genrule //test:rule2'",
+            maxRepeatedLostInputs + 1, intermediate.get());
+    assertThat(e.getDetailedExitCode().getFailureDetail().getMessage()).contains(errorDetail);
+    assertThat(Iterables.getOnlyElement(bugReporter.getExceptions()))
+        .hasMessageThat()
+        .contains(errorDetail);
+
+    // rule2 executed once per loss: the configured rewinds plus the final give-up attempt.
+    // With the default limit this would be 21; the configured limit of 2 makes it 3.
+    assertThat(
+            Iterables.frequency(
+                getExecutedSpawnDescriptions(), "Executing genrule //test:rule2"))
+        .isEqualTo(maxRepeatedLostInputs + 1);
   }
 
   /**
@@ -3182,6 +3234,8 @@ public class RewindingTestsHelper {
   }
 
   public final void runTopLevelOutputRewound_ineffectiveRewinding() throws Exception {
+    int maxRepeatedLostInputs =
+        Options.getDefaults(BuildRequestOptions.class).getMaxRepeatedLostInputs();
     testCase.write(
         "foo/defs.bzl",
         """
@@ -3208,7 +3262,7 @@ public class RewindingTestsHelper {
     Map<Label, TargetCompleteEvent> targetCompleteEvents = recordTargetCompleteEvents();
     listenForNoCompletionEventsBeforeRewinding(fooLostAndFound, targetCompleteEvents);
 
-    for (int i = 0; i <= ActionRewindStrategy.MAX_REPEATED_LOST_INPUTS; i++) {
+    for (int i = 0; i <= maxRepeatedLostInputs; i++) {
       addSpawnShim(
           "Action foo/lost.out",
           (spawn, context) -> {
@@ -3226,10 +3280,9 @@ public class RewindingTestsHelper {
     assertOnlyActionsRewound(rewoundKeys);
     assertThat(rewoundArtifactOwnerLabels(rewoundKeys))
         .containsExactlyElementsIn(
-            Collections.nCopies(
-                ActionRewindStrategy.MAX_REPEATED_LOST_INPUTS, "//foo:lost_and_found"));
+            Collections.nCopies(maxRepeatedLostInputs, "//foo:lost_and_found"));
     assertThat(ImmutableMultiset.copyOf(getExecutedSpawnDescriptions()))
-        .hasCount("Action foo/lost.out", ActionRewindStrategy.MAX_REPEATED_LOST_INPUTS + 1);
+        .hasCount("Action foo/lost.out", maxRepeatedLostInputs + 1);
 
     ActionExecutionValue actionExecutionValue =
         (ActionExecutionValue)
@@ -3243,8 +3296,7 @@ public class RewindingTestsHelper {
         String.format(
             "Lost output foo/lost.out (digest %s), and rewinding was ineffective after %d"
                 + " attempts.",
-            toHex(lostInput.getDigest(), lostInput.getSize()),
-            ActionRewindStrategy.MAX_REPEATED_LOST_INPUTS);
+            toHex(lostInput.getDigest(), lostInput.getSize()), maxRepeatedLostInputs);
     testCase.assertContainsError(expectedError);
     assertThat(e.getDetailedExitCode().getFailureDetail().getMessage()).contains(expectedError);
     assertThat(Iterables.getOnlyElement(bugReporter.getExceptions()))
@@ -3257,8 +3309,7 @@ public class RewindingTestsHelper {
     assertThat(event.failed()).isTrue();
     assertOutputsReported(event, "bin/foo/found.out");
 
-    recorder.assertTotalLostOutputCountsFromStats(
-        ImmutableList.of(ActionRewindStrategy.MAX_REPEATED_LOST_INPUTS + 1));
+    recorder.assertTotalLostOutputCountsFromStats(ImmutableList.of(maxRepeatedLostInputs + 1));
   }
 
   final void listenForNoCompletionEventsBeforeRewinding(


### PR DESCRIPTION
## Problem

Action rewinding gives up — failing the build with `LOST_INPUT_TOO_MANY_TIMES` /
`LOST_OUTPUT_TOO_MANY_TIMES` — once the same action loses the same input/output more than a
hardcoded `MAX_REPEATED_LOST_INPUTS = 20` times (`ActionRewindStrategy`).

We're rolling out `--rewind_lost_inputs`, and when the remote cache is unstable, spending up to
20 rewind cycles per lost input is the wrong tradeoff: we'd rather **give up early and re-run the
build without the cache** than grind against a cache that keeps evicting intermediate blobs (the
"20× slower" path). Today the give-up threshold is hardcoded, so there is no way to fail fast
short of patching Bazel.

## Change

Adds `--experimental_max_repeated_lost_inputs` (default `20`, behavior-preserving), threaded
through `BuildRequestOptions` → `SkyframeActionExecutor` (cached per build in
`prepareForExecution`, exposed via `maxRepeatedLostInputs()`) → `ActionRewindStrategy`, mirroring
the existing `--rewind_lost_inputs` wiring. Lower it to give up sooner — `0` fails on the first
lost input. It governs both the lost-input and lost-top-level-output give-up checks. The
`MAX_REPEATED_LOST_INPUTS` constant is retained as the default and test anchor.

## Test

The existing `ineffectiveRewindingResultsInLostInputTooManyTimes` `RewindingTest` case is now
parameterized with `@TestParameter({"2", "20"})`: it sets `--experimental_max_repeated_lost_inputs`
to each value and asserts the same repeatedly-lost input causes give-up on attempt N+1, covering
both a lowered limit and the default.
