### PR TITLE
Attempt to fix Windows breakage, plan B

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -354,7 +354,7 @@ genrule(
     # In msys, a file path without .exe suffix(say foo), refers to a file with .exe
     # suffix(say foo.exe), if foo.exe exists and foo doesn't. So, on windows, we
     # need to remove bazel.exe first, so that cat to bazel won't fail.
-    cmd = "rm -f $@; cat $(location //src/main/cpp:client) $(location :package-zip" + jdk + ") > $@ && zip -qA $@ && chmod a+x $@",
+    cmd = "set -euo pipefail && rm -f $@ && cat $(location //src/main/cpp:client) $(location :package-zip" + jdk + ") > $@ && zip -qA $@ && chmod a+x $@",
     executable = 1,
     output_to_bindir = 1,
     visibility = [


### PR DESCRIPTION
Set pipefail and add `&&` between each step in the zip creation.
