### PR TITLE
[9.2.0] Handle mapped paths in C++20 module input discovery (https://github.com/bazelbuild/bazel/pull/30047)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -1661,10 +1661,14 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
       DetailedExitCode code = createDetailedExitCode(message, Code.MODMAP_INPUT_FILE_READ_FAILURE);
       throw new ActionExecutionException(message, this, /* catastrophe= */ false, code);
     }
+    var pathMapper =
+        PathMappers.create(
+            this, PathMappers.getOutputPathsMode(configuration), /* isStarlarkAction= */ false);
     // All module files referenced in the modmap input file are expected to be known modules. We
     // delegate error reporting to the compiler by silently skipping over unknown files.
     return moduleFiles.toList().stream()
-        .filter(moduleFile -> usedModulePaths.contains(moduleFile.getExecPathString()))
+        .filter(
+            moduleFile -> usedModulePaths.contains(pathMapper.getMappedExecPathString(moduleFile)))
         .collect(toImmutableSet());
   }
 


### PR DESCRIPTION
### Description

### Motivation
This is necessary to support C++20 modules with path mapping enabled. Further rules_cc fixes are necessary before this can be tested end-to-end.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #30047.

PiperOrigin-RevId: 944024894
Change-Id: I4e2c41b74fbce5157463a6710a6ea9846e4f0766

Commit https://github.com/bazelbuild/bazel/commit/416e9b3f8798614e2aa923a74032f0acd6a6e8d3