### PR TITLE
Attempt to fix windows presubmit, plan C

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -345,7 +345,7 @@ genrule(
 )
 
 [genrule(
-    name = "bazel-bin" + suffix,
+    name = "bazel-bin-src" + suffix,
     srcs = [
         "//src/main/cpp:client",
         "package-zip" + jdk,
@@ -379,9 +379,9 @@ genrule(
 # Workaround for non-configurability of genrule's `outs` attribute.
 [genrule(
     name = "bazel-bin" + suffix + ".exe",
-    srcs = [":bazel-bin" + suffix],
+    srcs = [":bazel-bin-src" + suffix],
     outs = ["bazel" + suffix + ".exe"],
-    cmd = "cp $(location :bazel-bin" + suffix + ") $@",
+    cmd = "cp $(location :bazel-bin-src" + suffix + ") $@",
     executable = 1,
     output_to_bindir = 1,
     visibility = [


### PR DESCRIPTION
Rename bazel-bin to bazel-bin-src.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
