### PR TITLE
[8.8.0] skyframe: report top-level aspect failures

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeErrorProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeErrorProcessor.java
@@ -365,6 +365,16 @@ public final class SkyframeErrorProcessor {
     }
 
     Preconditions.checkNotNull(eventBus);
+    // Top-level aspect failures may be the only processed error in nokeep_going Skymeld.
+    if (errorKey instanceof TopLevelAspectsKey topLevelAspectsKey) {
+      if (individualErrorProcessingResult.isAnalysisError()) {
+        eventBus.post(
+            AnalysisFailureEvent.whileAnalyzingTarget(
+                topLevelAspectsKey.getBaseConfiguredTargetKey(),
+                individualErrorProcessingResult.analysisRootCauses()));
+      }
+      return;
+    }
     if (!(errorKey instanceof ConfiguredTargetKey)) {
       return;
     }

--- a/src/test/java/com/google/devtools/build/lib/analysis/StubbableFSBuildViewTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/StubbableFSBuildViewTest.java
@@ -76,9 +76,18 @@ public class StubbableFSBuildViewTest extends BuildViewTestBase {
     assertThat(result.hasError()).isTrue();
     assertThat(result.getFailureDetail().getMessage())
         .contains("command succeeded, but not all targets were analyzed");
-    assertThat(recorder.events).hasSize(1);
+    // Bazel 8.x predates 97a31fd305, which removed the direct
+    // TopLevelAspectsKey -> ConfiguredTargetKey dependency. With that dependency
+    // present, this test observes both error paths: the TopLevelAspectsKey event
+    // has no root causes, while the ConfiguredTargetKey event does.
+    assertThat(recorder.events).hasSize(2);
+    ImmutableList<AnalysisFailureEvent> eventsWithRootCauses =
+        recorder.events.stream()
+            .filter(event -> !event.getRootCauses().isEmpty())
+            .collect(ImmutableList.toImmutableList());
+    assertThat(eventsWithRootCauses).hasSize(1);
     assertThat(
-            Iterables.getOnlyElement(recorder.events)
+            Iterables.getOnlyElement(eventsWithRootCauses)
                 .getRootCauses()
                 .getSingleton()
                 .getDetailedExitCode()

--- a/src/test/shell/integration/build_event_stream_test.sh
+++ b/src/test/shell/integration/build_event_stream_test.sh
@@ -837,9 +837,9 @@ function test_aspect_analysis_failure_no_target_summary() {
   expect_log 'last_message: true'
   expect_log_once '^build_tool_logs'
   expect_log_once '^completed '  # target completes due to -k
-  # One "aborted" for failed aspect analysis, another for target_summary_id
-  # announced by "completed" event asserted above
-  expect_log_n 'aborted' 2
+  # One "aborted" for failed aspect analysis, one for the target_configured
+  # event, and one for the target_summary_id announced by "completed" above.
+  expect_log_n '^aborted' 3
   expect_not_log '^target_summary '  # no summary due to analysis failure
 }
 


### PR DESCRIPTION
Replaces #29952.

skyframe: report top-level aspect failures

OutputArtifactConflictTest flakes under Skymeld + nokeep_going because
evaluation can abort with a TopLevelAspectsKey as the only processed
analysis error. A local stress run on origin/master reproduced it as:

  FAIL: ...OutputArtifactConflictTest (shard 3 of 3, run 32 of 50)
  testConflictErrorAndUnfinishedAspectAnalysis_mergedAnalysisExecution
  [skymeld=true,minimizeMemory=true,keepGoing=false]
  expected to contain any of:
    [//x:y, //x/y:y, //x:fail_analysis]
  but was                   : []

The existing error processor skipped non-configured-target keys there.
BEP consumers could miss the AnalysisFailureEvent even though the
analysis error was reported to the event handler.

Report failures against the top-level aspect's base configured target so
the failure is emitted on the same path used for configured target keys.
Update the BEP integration test expectation for the additional aborted
event that is now reported.

Release-8.8 replacement note: the production change and BEP shell-test expectation match the original cherry-pick. This branch also needs one test-only AnalysisTests adaptation because the release branch observes the additional top-level aspect failure event in StubbableFSBuildViewTest.