### PR TITLE
Move bazel binary rollup into its own rule

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -35,7 +35,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.10.0/MODULE.bazel": "f75e8807570484a99be90abcd52b5e1f390362c258bcb73106f4544957a48101",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
-    "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
     "https://bcr.bazel.build/modules/bazel_features/1.20.0/MODULE.bazel": "8b85300b9c8594752e0721a37210e34879d23adc219ed9dc8f4104a4a1750920",

--- a/src/BUILD
+++ b/src/BUILD
@@ -6,6 +6,7 @@ load("@rules_java//java:java_binary.bzl", "java_binary")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//src:release_archive.bzl", "minimum_java_compilation_runtime_filegroup", "minimum_java_runtime_filegroup", "release_archive")
+load(":bazel_binary.bzl", "bazel_binary")
 load(":embedded_tools.bzl", "srcsfile")
 load(":rule_size_test.bzl", "rule_size_test")
 
@@ -344,19 +345,10 @@ genrule(
     }),
 )
 
-[genrule(
+[bazel_binary(
     name = "bazel-bin" + suffix,
-    srcs = [
-        "//src/main/cpp:client",
-        "package-zip" + jdk,
-    ],
-    outs = ["bazel" + suffix],
-    # In msys, a file path without .exe suffix(say foo), refers to a file with .exe
-    # suffix(say foo.exe), if foo.exe exists and foo doesn't. So, on windows, we
-    # need to remove bazel.exe first, so that cat to bazel won't fail.
-    cmd = "rm -f $@; cat $(location //src/main/cpp:client) $(location :package-zip" + jdk + ") > $@ && zip -qA $@ && chmod a+x $@",
-    executable = 1,
-    output_to_bindir = 1,
+    out = "bazel" + suffix,
+    client = "//src/main/cpp:client",
     visibility = [
         "//:__pkg__",  # For distribution archive lockfile generation
         "//scripts:__pkg__",  # For bash completion generation
@@ -365,6 +357,7 @@ genrule(
         "//src/test:__subpackages__",  # For integration tests
         "//tools/compliance:__pkg__",  # For license gathering
     ],
+    workspace_zip = ":package-zip" + jdk,
 ) for suffix, jdk in [
     ("-dev", "_jdk_allmodules"),
     ("", "_jdk_minimal"),
@@ -377,13 +370,11 @@ genrule(
 # Build an executable named `bazel.exe`.
 # Works on all platforms but only makes sense on Windows.
 # Workaround for non-configurability of genrule's `outs` attribute.
-[genrule(
+[copy_file(
     name = "bazel-bin" + suffix + ".exe",
-    srcs = [":bazel-bin" + suffix],
-    outs = ["bazel" + suffix + ".exe"],
-    cmd = "cp $(location :bazel-bin" + suffix + ") $@",
-    executable = 1,
-    output_to_bindir = 1,
+    src = ":bazel-bin" + suffix,
+    out = "bazel" + suffix + ".exe",
+    is_executable = True,
     visibility = [
         "//scripts:__pkg__",  # For bash completion generation
         "//scripts/packages:__pkg__",  # For installer generation

--- a/src/bazel_binary.bzl
+++ b/src/bazel_binary.bzl
@@ -1,0 +1,66 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rule for building the Bazel binary."""
+
+def _bazel_binary_impl(ctx):
+    client = ctx.file.client
+    workspace_zip = ctx.file.workspace_zip
+    out = ctx.outputs.out
+
+    # Intermediate file for concatenation.
+    # This prevents modifying the final output in-place across multiple actions.
+    concat_out = ctx.actions.declare_file(ctx.label.name + ".concat")
+
+    # Step 1: Concatenate client binary and workspace zip.
+    ctx.actions.run_shell(
+        inputs = [client, workspace_zip],
+        outputs = [concat_out],
+        command = "cat {client} {workspace_zip} > {out}".format(
+            client = client.path,
+            workspace_zip = workspace_zip.path,
+            out = concat_out.path,
+        ),
+        mnemonic = "BazelConcat",
+        progress_message = "Concatenating client and zip for %s" % ctx.label.name,
+    )
+
+    # Step 2: Copy to final destination, adjust zip offsets, and make executable.
+    # We must copy first because zip -qA modifies the file in-place.
+    ctx.actions.run_shell(
+        inputs = [concat_out],
+        outputs = [out],
+        command = "cp {input} {out} && zip -qA {out} && chmod a+x {out}".format(
+            input = concat_out.path,
+            out = out.path,
+        ),
+        use_default_shell_env = True,
+        mnemonic = "BazelZipAdjust",
+        progress_message = "Adjusting zip offsets for %s" % ctx.label.name,
+    )
+
+    return [DefaultInfo(
+        executable = out,
+        files = depset([out]),
+    )]
+
+bazel_binary = rule(
+    implementation = _bazel_binary_impl,
+    attrs = {
+        "client": attr.label(allow_single_file = True, mandatory = True),
+        "workspace_zip": attr.label(allow_single_file = True, mandatory = True),
+        "out": attr.output(mandatory = True),
+    },
+    executable = True,
+)

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -452,5 +452,6 @@
       }
     }
   },
-  "facts": {}
+  "facts": {},
+  "factsVersions": {}
 }


### PR DESCRIPTION
Avoids using the overloaded genrule.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
