### PR TITLE
Update Starlark language docs to remove set from unsupported features…

### DIFF
--- a/site/en/rules/language.md
+++ b/site/en/rules/language.md
@@ -159,7 +159,7 @@ The following Python features are not supported:
 * `class` (see [`struct`](lib/struct#struct) function).
 * `import` (see [`load`](/extending/concepts#loading-an-extension) statement).
 * `while`, `yield`.
-* float and set types.
+* float types.
 * generators and generator expressions.
 * `is` (use `==` instead).
 * `try`, `raise`, `except`, `finally` (see [`fail`](lib/globals#fail) for fatal errors).


### PR DESCRIPTION
… list

Since Starlark now supports the built-in `set` type, this change updates the language documentation (`site/en/rules/language.md`) to remove sets from the list of unsupported Python features.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description

Since Starlark [now supports the built-in `set` type](https://bazel.build/rules/lib/core/set), this change updates the language documentation (`site/en/rules/language.md`) to remove sets from the list of unsupported Python features.

### Motivation

Fix inconsistency in docs.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
