### PR TITLE
Remote: make the failure circuit breaker's minimum call/fail counts configurable

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
@@ -19,8 +19,6 @@ import java.util.concurrent.Executors;
 
 /** Factory for {@link Retrier.CircuitBreaker} */
 public class CircuitBreakerFactory {
-  public static final int DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE = 100;
-  public static final int DEFAULT_MIN_FAIL_COUNT_TO_COMPUTE_FAILURE_RATE = 12;
 
   private CircuitBreakerFactory() {}
 
@@ -38,6 +36,8 @@ public class CircuitBreakerFactory {
       return new FailureCircuitBreaker(
           remoteOptions.getRemoteFailureRateThreshold(),
           slidingWindowMillis,
+          remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
+          remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
           slidingWindowMillis > 0 ? Executors.newSingleThreadScheduledExecutor() : null);
     }
     return Retrier.ALLOW_ALL_CALLS;

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
@@ -44,18 +44,24 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
    *     circuit breaker in given time window.
    * @param slidingWindowSize the size of the sliding window in milliseconds to calculate the number
    *     of failures.
+   * @param minCallCountToComputeFailureRate the minimum number of calls within the window before
+   *     the failure rate is computed and the breaker may trip.
+   * @param minFailCountToComputeFailureRate the minimum number of failures within the window before
+   *     the failure rate is computed and the breaker may trip.
    * @param scheduledExecutor executor for scheduling tasks to decrement success and failure counts.
    */
   public FailureCircuitBreaker(
-      int failureRateThreshold, int slidingWindowSize, ScheduledExecutorService scheduledExecutor) {
+      int failureRateThreshold,
+      int slidingWindowSize,
+      int minCallCountToComputeFailureRate,
+      int minFailCountToComputeFailureRate,
+      ScheduledExecutorService scheduledExecutor) {
     this.failures = new AtomicInteger(0);
     this.successes = new AtomicInteger(0);
     this.failureRateThreshold = failureRateThreshold;
     this.slidingWindowSize = slidingWindowSize;
-    this.minCallCountToComputeFailureRate =
-        CircuitBreakerFactory.DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE;
-    this.minFailCountToComputeFailureRate =
-        CircuitBreakerFactory.DEFAULT_MIN_FAIL_COUNT_TO_COMPUTE_FAILURE_RATE;
+    this.minCallCountToComputeFailureRate = minCallCountToComputeFailureRate;
+    this.minFailCountToComputeFailureRate = minFailCountToComputeFailureRate;
     this.state = State.ACCEPT_CALLS;
     this.scheduledExecutor = scheduledExecutor;
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -794,6 +794,34 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
   public abstract Duration getRemoteFailureWindowInterval();
 
   @Option(
+      name = "experimental_remote_min_call_count_to_compute_failure_rate",
+      defaultValue = "100",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.EXECUTION},
+      help =
+          "The minimum number of remote calls that must be observed within the failure window"
+              + " before the circuit breaker computes the failure rate. The rate is computed (and"
+              + " the breaker may trip) once either this many total calls or"
+              + " --experimental_remote_min_fail_count_to_compute_failure_rate failures are"
+              + " observed. Only takes effect with"
+              + " --experimental_circuit_breaker_strategy=failure.")
+  public abstract int getRemoteMinCallCountToComputeFailureRate();
+
+  @Option(
+      name = "experimental_remote_min_fail_count_to_compute_failure_rate",
+      defaultValue = "12",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.EXECUTION},
+      help =
+          "The minimum number of failed remote calls that must be observed within the failure"
+              + " window before the circuit breaker computes the failure rate. The rate is computed"
+              + " (and the breaker may trip) once either this many failures or"
+              + " --experimental_remote_min_call_count_to_compute_failure_rate total calls are"
+              + " observed. Only takes effect with"
+              + " --experimental_circuit_breaker_strategy=failure.")
+  public abstract int getRemoteMinFailCountToComputeFailureRate();
+
+  @Option(
       name = "experimental_remote_cache_lease_extension",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.REMOTE,

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactoryTest.java
@@ -16,9 +16,11 @@ package com.google.devtools.build.lib.remote.circuitbreaker;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.devtools.build.lib.remote.Retrier;
+import com.google.devtools.build.lib.remote.Retrier.CircuitBreaker.State;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOptions.CircuitBreakerStrategy;
 import com.google.devtools.common.options.Options;
+import com.google.devtools.common.options.OptionsParsingException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -40,5 +42,56 @@ public class CircuitBreakerFactoryTest {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     assertThat(CircuitBreakerFactory.createCircuitBreaker(remoteOptions))
         .isEqualTo(Retrier.ALLOW_ALL_CALLS);
+  }
+
+  @Test
+  public void testCreateCircuitBreaker_minCallCountFromOptions() throws OptionsParsingException {
+    RemoteOptions remoteOptions =
+        Options.parse(
+                RemoteOptions.class,
+                "--experimental_circuit_breaker_strategy=failure",
+                "--experimental_remote_failure_rate_threshold=10",
+                "--experimental_remote_failure_window_interval=0",
+                "--experimental_remote_min_call_count_to_compute_failure_rate=5",
+                "--experimental_remote_min_fail_count_to_compute_failure_rate=1000")
+            .getOptions();
+    FailureCircuitBreaker circuitBreaker =
+        (FailureCircuitBreaker) CircuitBreakerFactory.createCircuitBreaker(remoteOptions);
+
+    // Four successes and one failure reach the configured min call count (5) with a 20% failure
+    // rate, which exceeds the 10% threshold. This would not trip under the default min call count
+    // of 100, proving the flag took effect. The high min fail count keeps the failure gate out of
+    // the way, so tripping here also proves the two counts are not wired in the wrong order.
+    for (int i = 0; i < 4; i++) {
+      circuitBreaker.recordSuccess();
+    }
+    assertThat(circuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
+    circuitBreaker.recordFailure();
+    assertThat(circuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+  }
+
+  @Test
+  public void testCreateCircuitBreaker_minFailCountFromOptions() throws OptionsParsingException {
+    RemoteOptions remoteOptions =
+        Options.parse(
+                RemoteOptions.class,
+                "--experimental_circuit_breaker_strategy=failure",
+                "--experimental_remote_failure_rate_threshold=10",
+                "--experimental_remote_failure_window_interval=0",
+                "--experimental_remote_min_call_count_to_compute_failure_rate=1000",
+                "--experimental_remote_min_fail_count_to_compute_failure_rate=3")
+            .getOptions();
+    FailureCircuitBreaker circuitBreaker =
+        (FailureCircuitBreaker) CircuitBreakerFactory.createCircuitBreaker(remoteOptions);
+
+    // The failure rate is computed once the configured min fail count (3) is reached, even though
+    // the total call count is far below the configured min call count (1000). Under the default min
+    // fail count of 12 the breaker would still be accepting calls here, proving the flag took
+    // effect.
+    circuitBreaker.recordFailure();
+    circuitBreaker.recordFailure();
+    assertThat(circuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
+    circuitBreaker.recordFailure();
+    assertThat(circuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.devtools.build.lib.remote.Retrier.CircuitBreaker.State;
+import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.common.options.Options;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -32,6 +34,8 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class FailureCircuitBreakerTest {
+
+  private final RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
 
   @Test
   // Suppress unchecked warnings because any(Callable.class) uses a raw type,
@@ -68,7 +72,12 @@ public class FailureCircuitBreakerTest {
               return null;
             });
     FailureCircuitBreaker failureCircuitBreaker =
-        new FailureCircuitBreaker(failureRateThreshold, windowInterval, mockScheduler);
+        new FailureCircuitBreaker(
+            failureRateThreshold,
+            windowInterval,
+            remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
+            remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
+            mockScheduler);
 
     List<Runnable> listOfSuccessAndFailureCalls = new ArrayList<>();
     for (int index = 0; index < failureRateThreshold; index++) {
@@ -104,11 +113,15 @@ public class FailureCircuitBreakerTest {
   public void testRecordFailure_minCallCriteriaNotMet() throws InterruptedException {
     final int failureRateThreshold = 0;
     final int windowInterval = 100;
-    final int minCallToComputeFailure =
-        CircuitBreakerFactory.DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE;
+    final int minCallToComputeFailure = remoteOptions.getRemoteMinCallCountToComputeFailureRate();
     ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
     FailureCircuitBreaker failureCircuitBreaker =
-        new FailureCircuitBreaker(failureRateThreshold, windowInterval, mockScheduler);
+        new FailureCircuitBreaker(
+            failureRateThreshold,
+            windowInterval,
+            remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
+            remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
+            mockScheduler);
 
     // make success calls, failure call and number of total calls less than
     // minCallToComputeFailure.
@@ -127,11 +140,15 @@ public class FailureCircuitBreakerTest {
   public void testRecordFailure_minFailCriteriaNotMet() throws InterruptedException {
     final int failureRateThreshold = 10;
     final int windowInterval = 100;
-    final int minFailToComputeFailure =
-        CircuitBreakerFactory.DEFAULT_MIN_FAIL_COUNT_TO_COMPUTE_FAILURE_RATE;
+    final int minFailToComputeFailure = remoteOptions.getRemoteMinFailCountToComputeFailureRate();
     ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
     FailureCircuitBreaker failureCircuitBreaker =
-        new FailureCircuitBreaker(failureRateThreshold, windowInterval, mockScheduler);
+        new FailureCircuitBreaker(
+            failureRateThreshold,
+            windowInterval,
+            remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
+            remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
+            mockScheduler);
 
     // make number of failure calls less than minFailToComputeFailure.
     for (int index = 0; index < minFailToComputeFailure - 1; index++) {


### PR DESCRIPTION
## Summary

The failure circuit breaker (`--experimental_circuit_breaker_strategy=failure`) only starts computing the failure rate — and therefore can only trip — after it has observed a minimum number of remote calls or failures within the failure window. Today those two thresholds are hardcoded in `CircuitBreakerFactory`:

- `DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE = 100`
- `DEFAULT_MIN_FAIL_COUNT_TO_COMPUTE_FAILURE_RATE = 12`

## Motivation

On large builds using Build without the Bytes, a burst of transient remote-cache errors (for example `ByteStream.Read` deadlines while blobs are being evicted) can cross these fixed thresholds and trip the breaker. Once tripped, the breaker rejects further remote calls for the rest of the build (a new breaker is created per build) and short-circuits the per-call gRPC retries — turning a transient hiccup into a fully local, and much slower, build.

The right thresholds depend on build size and the remote cache's characteristics, so they should be tunable rather than fixed.

## Change

Adds two options that default to the existing constants, so behavior is unchanged unless they are set:

| Flag | Default |
| --- | --- |
| `--experimental_remote_min_call_count_to_compute_failure_rate` | 100 |
| `--experimental_remote_min_fail_count_to_compute_failure_rate` | 12 |

Both counts are exposed together on purpose: they form an OR trigger (the failure rate is computed once *either* threshold is reached), so exposing only the call count would be ineffective once the still-hardcoded fail count of 12 was hit.

`FailureCircuitBreaker` now receives both values via its constructor; `CircuitBreakerFactory` reads them from `RemoteOptions`. The constants are retained as the flag defaults (and referenced by existing tests).

