### PR TITLE
Remote: include failure statistics in circuit breaker rejection message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
@@ -112,12 +112,10 @@ public class Retrier {
     /**
      * Returns a human-readable description of the breaker's current failure statistics (for example
      * the observed failure rate and the configured threshold), for appending to the {@link
-     * CircuitBreakerException} message when a call is rejected. Returns an empty string when no
-     * details are available.
+     * CircuitBreakerException} message when a call is rejected. Implementations that have no details
+     * to report should return an empty string.
      */
-    default String failureDetails() {
-      return "";
-    }
+    String failureDetails();
   }
 
   /** Thrown if the call was stopped by a circuit breaker. */
@@ -170,6 +168,11 @@ public class Retrier {
 
         @Override
         public void recordSuccess() {}
+
+        @Override
+        public String failureDetails() {
+          return "";
+        }
       };
 
   /** Disables retries. */

--- a/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
@@ -108,12 +108,24 @@ public class Retrier {
 
     /** Called after an execution succeeded. */
     void recordSuccess();
+
+    /**
+     * Returns a human-readable description of the breaker's current failure statistics (for example
+     * the observed failure rate and the configured threshold), for appending to the {@link
+     * CircuitBreakerException} message when a call is rejected. Returns an empty string when no
+     * details are available.
+     */
+    default String failureDetails() {
+      return "";
+    }
   }
 
   /** Thrown if the call was stopped by a circuit breaker. */
   public static class CircuitBreakerException extends IOException {
-    private CircuitBreakerException() {
-      super("Call not executed due to a high failure rate.");
+    private CircuitBreakerException(String failureDetails) {
+      super(
+          "Call not executed due to a high failure rate."
+              + (failureDetails == null || failureDetails.isEmpty() ? "" : " " + failureDetails));
     }
   }
 
@@ -293,7 +305,7 @@ public class Retrier {
     while (true) {
       State circuitState = circuitBreaker.state();
       if (State.REJECT_CALLS.equals(circuitState)) {
-        throw new CircuitBreakerException();
+        throw new CircuitBreakerException(circuitBreaker.failureDetails());
       }
       try {
         if (Thread.interrupted()) {
@@ -374,7 +386,8 @@ public class Retrier {
       AsyncCallable<T> call, Backoff backoff, @Nullable String rpcId) {
     final State circuitState = circuitBreaker.state();
     if (State.REJECT_CALLS.equals(circuitState)) {
-      return Futures.immediateFailedFuture(new CircuitBreakerException());
+      return Futures.immediateFailedFuture(
+          new CircuitBreakerException(circuitBreaker.failureDetails()));
     }
     try {
       ListenableFuture<T> future =

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.remote.circuitbreaker;
 
 import com.google.devtools.build.lib.remote.Retrier;
+import java.util.Locale;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -96,5 +97,21 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
           scheduledExecutor.schedule(
               successes::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
     }
+  }
+
+  @Override
+  public String failureDetails() {
+    int failureCount = failures.get();
+    int totalCallCount = successes.get() + failureCount;
+    double failureRate = totalCallCount == 0 ? 0.0 : (failureCount * 100.0) / totalCallCount;
+    String window =
+        slidingWindowSize > 0
+            ? String.format(Locale.US, "the last %dms", slidingWindowSize)
+            : "the whole build";
+    return String.format(
+        Locale.US,
+        "%d out of %d remote calls failed (%.2f%%) within %s, exceeding the %d%% failure rate"
+            + " threshold.",
+        failureCount, totalCallCount, failureRate, window, failureRateThreshold);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
@@ -203,6 +203,37 @@ public class RetrierTest {
   }
 
   @Test
+  public void circuitBreakerExceptionIncludesFailureDetails() throws Exception {
+    // The details reported by the circuit breaker are appended to the exception message.
+    CircuitBreaker cb =
+        new CircuitBreaker() {
+          @Override
+          public State state() {
+            return State.REJECT_CALLS;
+          }
+
+          @Override
+          public void recordFailure() {}
+
+          @Override
+          public void recordSuccess() {}
+
+          @Override
+          public String failureDetails() {
+            return "42 out of 50 remote calls failed";
+          }
+        };
+    Retrier r = new Retrier(() -> new ZeroBackoff(3), RETRY_ALL, retryService, cb);
+
+    CircuitBreakerException e =
+        assertThrows(CircuitBreakerException.class, () -> r.execute(() -> 10));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Call not executed due to a high failure rate. 42 out of 50 remote calls failed");
+  }
+
+  @Test
   public void circuitBreakerCanRecover() throws Exception {
     // Test that a circuit breaker can recover from REJECT_CALLS to ACCEPT_CALLS by
     // utilizing the TRIAL_CALL state.

--- a/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
@@ -614,6 +614,11 @@ public class RetrierTest {
       state = State.ACCEPT_CALLS;
     }
 
+    @Override
+    public String failureDetails() {
+      return "";
+    }
+
     void trialCall() {
       state = State.TRIAL_CALL;
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
@@ -143,4 +143,24 @@ public class FailureCircuitBreakerTest {
     failureCircuitBreaker.recordFailure();
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
   }
+
+  @Test
+  public void testFailureDetails_reportsStats() {
+    final int failureRateThreshold = 10;
+    final int windowInterval = 100;
+    ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
+    FailureCircuitBreaker failureCircuitBreaker =
+        new FailureCircuitBreaker(failureRateThreshold, windowInterval, mockScheduler);
+
+    failureCircuitBreaker.recordSuccess();
+    failureCircuitBreaker.recordFailure();
+    failureCircuitBreaker.recordFailure();
+    failureCircuitBreaker.recordFailure();
+
+    String details = failureCircuitBreaker.failureDetails();
+    assertThat(details).contains("3 out of 4 remote calls failed");
+    assertThat(details).contains("75.00%");
+    assertThat(details).contains("the last 100ms");
+    assertThat(details).contains("10% failure rate threshold");
+  }
 }


### PR DESCRIPTION
## Motivation

When the remote failure circuit breaker (`--experimental_circuit_breaker_strategy=failure`) trips, every subsequent remote call is rejected immediately with:

> Call not executed due to a high failure rate.

This message is user-visible — during build-without-the-bytes it is wrapped in a `BulkTransferException` and shown in the build error — but it gives no indication of *why* the breaker tripped. `FailureCircuitBreaker` also logs nothing on the state transition and exposes no metric, so today there is no built-in way to tell:

- what failure rate was observed,
- what threshold was configured, or
- how many calls failed in the window.

This makes a tripped breaker hard to diagnose in practice: the gRPC log (`--remote_grpc_log`) can't show it either, because rejected calls never become RPCs.

## Change

Append the breaker's current statistics to the `CircuitBreakerException` message, so the reason is visible at the exact point of failure:

> Call not executed due to a high failure rate. 104 out of 104 remote calls failed (100.00%) within the last 80000ms, exceeding the 15% failure rate threshold.

Implementation:

- Add a `CircuitBreaker.failureDetails()` interface method with a default that returns an empty string, so `ALLOW_ALL_CALLS` and any other implementation are unaffected.
- Implement it in `FailureCircuitBreaker` to report failures/total, the observed failure rate, the window, and the configured threshold.
- Append the details to the `CircuitBreakerException` message at both the synchronous (`execute`) and asynchronous (`executeAsync`) rejection sites. The existing sentence is kept as a stable prefix, so anything matching the old string still works.

