### PR TITLE
Remote: preserve the gRPC log across cache-eviction retries

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -382,6 +382,26 @@ public final class RemoteModule extends BlazeModule {
     credentialModule = Preconditions.checkNotNull(runtime.getBlazeModule(CredentialModule.class));
   }
 
+  /**
+   * Opens the gRPC log at {@code path} for writing.
+   *
+   * <p>When the command is retried in-process after a transient remote cache error (see {@code
+   * --experimental_remote_cache_eviction_retries}), {@code attemptNumber} is greater than 1 and the
+   * log written by the previous attempt is still at {@code path}. Truncating it would discard the
+   * log of the very attempt that hit the cache eviction, which is exactly the one worth debugging.
+   * Instead, rename the existing file to {@code <path>.<previous attempt number>} so every
+   * attempt's log is preserved. See https://github.com/bazelbuild/bazel/issues/18695.
+   */
+  @VisibleForTesting
+  static AsynchronousMessageOutputStream<LogEntry> openRpcLogFile(Path path, int attemptNumber)
+      throws IOException {
+    if (attemptNumber > 1 && path.exists()) {
+      path.renameTo(
+          path.getParentDirectory().getChild(path.getBaseName() + "." + (attemptNumber - 1)));
+    }
+    return new AsynchronousMessageOutputStream<>(path);
+  }
+
   @Override
   public void beforeCommand(CommandEnvironment env) throws AbruptExitException {
     Preconditions.checkState(actionContextProvider == null, "actionContextProvider must be null");
@@ -686,8 +706,9 @@ public final class RemoteModule extends BlazeModule {
     if (remoteOptions.getRemoteGrpcLog() != null) {
       try {
         rpcLogFile =
-            new AsynchronousMessageOutputStream<>(
-                env.getWorkingDirectory().getRelative(remoteOptions.getRemoteGrpcLog()));
+            openRpcLogFile(
+                env.getWorkingDirectory().getRelative(remoteOptions.getRemoteGrpcLog()),
+                env.getAttemptNumber());
       } catch (IOException e) {
         handleInitFailure(env, e, Code.RPC_LOG_FAILURE);
         return false;

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -709,4 +709,31 @@ public final class RemoteModuleTest {
       assertThat(circuitBreaker).isEqualTo(Retrier.ALLOW_ALL_CALLS);
     }
   }
+
+  @Test
+  public void openRpcLogFile_firstAttempt_doesNotRenameExistingFile() throws Exception {
+    Scratch scratch = new Scratch(new InMemoryFileSystem(DigestHashFunction.SHA256));
+    Path log = scratch.file("/workspace/grpc.log", "stale contents");
+
+    RemoteModule.openRpcLogFile(log, /* attemptNumber= */ 1).close();
+
+    // Attempt 1 is a fresh build: the log is (re)created at the base path and nothing is preserved.
+    assertThat(log.exists()).isTrue();
+    assertThat(scratch.resolve("/workspace/grpc.log.1").exists()).isFalse();
+  }
+
+  @Test
+  public void openRpcLogFile_retry_preservesPreviousAttemptLog() throws Exception {
+    Scratch scratch = new Scratch(new InMemoryFileSystem(DigestHashFunction.SHA256));
+    Path log = scratch.file("/workspace/grpc.log", "attempt 1 contents");
+
+    RemoteModule.openRpcLogFile(log, /* attemptNumber= */ 2).close();
+
+    // The retry must not clobber the previous attempt's log: it is renamed aside, and a fresh log
+    // is opened at the base path for the new attempt.
+    Path preserved = scratch.resolve("/workspace/grpc.log.1");
+    assertThat(preserved.exists()).isTrue();
+    assertThat(preserved.getFileSize()).isGreaterThan(0L);
+    assertThat(log.exists()).isTrue();
+  }
 }

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -2685,6 +2685,71 @@ EOF
   expect_log "uuid: \"${second_id#INFO: Invocation ID: }\""
 }
 
+function test_remote_cache_eviction_retries_preserve_grpc_log() {
+  mkdir -p a
+
+  cat > a/BUILD <<'EOF'
+genrule(
+  name = 'foo',
+  srcs = ['foo.in'],
+  outs = ['foo.out'],
+  cmd = 'cat $(SRCS) > $@',
+)
+
+genrule(
+  name = 'bar',
+  srcs = ['foo.out', 'bar.in'],
+  outs = ['bar.out'],
+  cmd = 'cat $(SRCS) > $@',
+  tags = ['no-remote-exec'],
+)
+EOF
+
+  echo foo > a/foo.in
+  echo bar > a/bar.in
+
+  # Populate remote cache
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_download_minimal \
+      //a:bar >& $TEST_log || fail "Failed to build"
+
+  bazel clean
+
+  # Clean build, foo.out isn't downloaded
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_download_minimal \
+      //a:bar >& $TEST_log || fail "Failed to build"
+
+  # Evict blobs from remote cache
+  stop_worker
+  start_worker
+
+  echo "updated bar" > a/bar.in
+
+  # Incremental build triggers remote cache eviction error and Bazel retries the
+  # build in-process. The gRPC log of the attempt that hit the eviction must be
+  # preserved rather than truncated when the retry reopens the log.
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_download_minimal \
+      --experimental_remote_cache_eviction_retries=1 \
+      --remote_grpc_log=grpc.log \
+      //a:bar >& $TEST_log || fail "Failed to build"
+
+  expect_log "Found transient remote cache error, retrying the build..."
+
+  # The retry renames the first attempt's log to grpc.log.1 and writes the second
+  # attempt's log at the base path, so both attempts are available for debugging.
+  [[ -f grpc.log.1 ]] \
+      || fail "Expected first attempt's gRPC log to be preserved as grpc.log.1"
+  [[ -s grpc.log.1 ]] \
+      || fail "Expected preserved gRPC log grpc.log.1 to be non-empty"
+  [[ -f grpc.log ]] \
+      || fail "Expected second attempt's gRPC log to be written to grpc.log"
+}
+
 function test_download_toplevel_symlinks_runfiles() {
     cat > rules.bzl <<EOF
 def _symlink_rule_impl(ctx):


### PR DESCRIPTION
### Problem

When a build is retried in-process after a transient remote cache error
(`--experimental_remote_cache_eviction_retries`), each attempt re-runs
`RemoteModule#beforeCommand`, which reopens `--remote_grpc_log` at a fixed path in
truncate mode (`AsynchronousMessageOutputStream` → `Path#getOutputStream()`).

The ordering makes the loss deterministic: the failing attempt's `afterCommand`
flushes and closes its log, then the next attempt's `beforeCommand` truncates that
same path. So the attempt that actually hit the cache eviction — the one worth
debugging — is exactly the one whose gRPC log is discarded, leaving only the final
attempt's log behind.

This is the `--remote_grpc_log` facet of #18695.

### Fix

When `attemptNumber > 1` and a log already exists at the target path, rename it to
`<path>.<previous attempt number>` before opening a fresh log for the current
attempt. Every attempt's log is preserved, and the base path keeps pointing at the
latest attempt (so existing tooling that reads the fixed path is unaffected).

