### PR TITLE
[9.2.0] Recover lost inputs from deduplicated Merkle subtrees under path mapping

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
@@ -234,9 +234,16 @@ public final class MerkleTreeComputer {
    * @param metadata the metadata of the aggregate {@link ActionInput} that forms the subtree
    * @param isTool whether the subtree consists of tool inputs
    * @param uploadBlobs whether the blobs in this tree will be uploaded
+   * @param unmappedExecPath the exec path of the aggregate input, included only when path mapping
+   *     is used and reusing an ongoing computation for an identical mapped subtree with a different
+   *     unmapped exec path would be incorrect (currently only because the failure case of a lost
+   *     input depends on the unmapped path)
    */
   private record InFlightCacheKey(
-      FileArtifactValue metadata, boolean isTool, boolean uploadBlobs) {}
+      FileArtifactValue metadata,
+      boolean isTool,
+      boolean uploadBlobs,
+      @Nullable PathFragment unmappedExecPath) {}
 
   /**
    * Builds a Merkle tree for the inputs of a {@link Spawn}.
@@ -751,6 +758,7 @@ public final class MerkleTreeComputer {
     return switch (input) {
       case Artifact artifact when artifact.isTreeArtifact() ->
           computeForTreeArtifactIfAbsent(
+              artifact.getExecPath(),
               metadataProvider.getTreeMetadata(artifact),
               mappedExecPath,
               isToolInput,
@@ -778,6 +786,8 @@ public final class MerkleTreeComputer {
         }
         yield computeIfAbsent(
             metadata,
+            // Source artifacts are not path mapped.
+            /* unmappedExecPath= */ null,
             () -> explodeDirectory(artifact, artifactPathResolver).entrySet(),
             isToolInput.test(mappedExecPath),
             metadataProvider,
@@ -819,6 +829,8 @@ public final class MerkleTreeComputer {
     // use isTool instead.
     return computeIfAbsent(
         runfilesArtifactValue.getMetadata(),
+        // Runfiles metadata already encodes the exec path of the root.
+        /* unmappedExecPath= */ null,
         () ->
             ImmutableList.sortedCopyOf(
                 Map.Entry.comparingByKey(HIERARCHICAL_COMPARATOR),
@@ -833,6 +845,7 @@ public final class MerkleTreeComputer {
   }
 
   private ListenableFuture<MerkleTree.RootOnly> computeForTreeArtifactIfAbsent(
+      PathFragment unmappedExecPath,
       TreeArtifactValue treeArtifactValue,
       PathFragment mappedExecPath,
       Predicate<PathFragment> isToolInput,
@@ -851,6 +864,7 @@ public final class MerkleTreeComputer {
     // use isTool instead.
     return computeIfAbsent(
         treeArtifactValue.getMetadata(),
+        unmappedExecPath,
         () ->
             Lists.transform(
                 ImmutableList.sortedCopyOf(
@@ -871,8 +885,16 @@ public final class MerkleTreeComputer {
         throws IOException, InterruptedException;
   }
 
+  /**
+   * Performs a cached computation of the sub-Merkle tree for the given aggregate input.
+   *
+   * @param unmappedExecPath the exec path of the aggregate input before path mapping to be added to
+   *     the cache key, null if this aggregate input is not subject to path mapping or the metadata
+   *     already includes the path
+   */
   private ListenableFuture<MerkleTree.RootOnly> computeIfAbsent(
       FileArtifactValue metadata,
+      @Nullable PathFragment unmappedExecPath,
       SortedInputsSupplier sortedInputsSupplier,
       boolean isTool,
       InputMetadataProvider metadataProvider,
@@ -891,7 +913,16 @@ public final class MerkleTreeComputer {
         return immediateFuture(cachedRoot);
       }
     }
-    var key = new InFlightCacheKey(metadata, isTool, blobPolicy != BlobPolicy.DISCARD);
+    var uploadBlobs = blobPolicy != BlobPolicy.DISCARD;
+    // When the upload of a path mapped tree artifact is shared between two actions that each have
+    // that tree artifact as an input under a different unmmapped exec path, CacheNotFoundExceptions
+    // triggered by evicted remote cache entries could be reported with the wrong unmapped exec
+    // path. We currently avoid this by including the unmapped exec path in the cache key for this
+    // case. Surfacing the mapped path in CNFEs and unmapping when calling
+    // BulkTransferException.getLostArtifacts has been considered, but is far more complex and only
+    // relevant for the uncommon no-DISCARD case.
+    var key =
+        new InFlightCacheKey(metadata, isTool, uploadBlobs, uploadBlobs ? unmappedExecPath : null);
     AsyncCallable<MerkleTree.RootOnly> buildMerkleTreeTask =
         () -> {
           // There is a window in which a concurrent call may have removed the in-flight cache entry
@@ -907,7 +938,8 @@ public final class MerkleTreeComputer {
           if (blobPolicy == BlobPolicy.DISCARD) {
             var inFlightComputation =
                 inFlightComputations.maybeJoinExecution(
-                    new InFlightCacheKey(metadata, isTool, /* uploadBlobs= */ true));
+                    new InFlightCacheKey(
+                        metadata, isTool, /* uploadBlobs= */ true, unmappedExecPath));
             if (inFlightComputation != null) {
               return inFlightComputation;
             }

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -2897,4 +2897,302 @@ EOF
       || fail "Failed second build after moving sh_binary to a subpackage"
 }
 
+function test_path_stripping_remote_lost_tree_inputs_stress() {
+  mkdir rules pkg
+  cat > rules/defs.bzl <<'EOF'
+def _variant_setting_impl(ctx):
+    return []
+
+variant_setting = rule(
+    implementation = _variant_setting_impl,
+    build_setting = config.string(),
+)
+
+def _variant_transition_impl(settings, attr):
+    return {"//rules:variant": attr.variant}
+
+_variant_transition = transition(
+    implementation = _variant_transition_impl,
+    inputs = [],
+    outputs = ["//rules:variant"],
+)
+
+def _tree_impl(ctx):
+    out = ctx.actions.declare_directory("tree_dir")
+    args = ctx.actions.args()
+    args.add_all([out], expand_directories = False)
+    ctx.actions.run_shell(
+        outputs = [out],
+        arguments = [args],
+        command = """
+        mkdir -p "$1/pkg"
+        dd if=/dev/zero of="$1/pkg/blob" bs=1024 count=2300 2>/dev/null
+        """,
+        execution_requirements = {"supports-path-mapping": ""},
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+tree = rule(_tree_impl)
+
+def _configured_consumer_impl(ctx):
+    tree = ctx.files.tree[0]
+    out = ctx.actions.declare_file(ctx.label.name + ".out")
+    args = ctx.actions.args()
+    args.add(out)
+    args.add_all([tree], expand_directories = False)
+    args.add(ctx.file.stamp)
+    args.add(ctx.attr.nonce)
+    ctx.actions.run_shell(
+        inputs = [tree, ctx.file.stamp],
+        outputs = [out],
+        arguments = [args],
+        command = """
+        set -e
+        wc -c "$2/pkg/blob" > "$1"
+        cat "$3" >> "$1"
+        printf '%s\n' "$4" >> "$1"
+        """,
+        execution_requirements = {"supports-path-mapping": ""},
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+configured_consumer = rule(
+    implementation = _configured_consumer_impl,
+    cfg = _variant_transition,
+    attrs = {
+        "nonce": attr.string(),
+        "stamp": attr.label(allow_single_file = True),
+        "tree": attr.label(allow_files = True),
+        "variant": attr.string(),
+    },
+)
+EOF
+  cat > rules/BUILD <<'EOF'
+load("//rules:defs.bzl", "variant_setting")
+
+variant_setting(
+    name = "variant",
+    build_setting_default = "",
+)
+EOF
+  cat > pkg/nonce.bzl <<'EOF'
+NONCE = "0"
+EOF
+  cat > pkg/BUILD <<'EOF'
+load("//pkg:nonce.bzl", "NONCE")
+load("//rules:defs.bzl", "configured_consumer", "tree")
+
+tree(name = "tree")
+EOF
+  local consumer
+  for consumer in $(seq -f "%02g" 0 15); do
+    cat >> pkg/BUILD <<EOF
+
+configured_consumer(
+    name = "consume_${consumer}",
+    nonce = NONCE,
+    stamp = "stamp.txt",
+    tree = ":tree",
+    variant = "variant_${consumer}",
+)
+EOF
+  done
+  cat >> pkg/BUILD <<'EOF'
+
+filegroup(
+    name = "all_outputs",
+    srcs = [
+EOF
+  for consumer in $(seq -f "%02g" 0 15); do
+    echo "        \":consume_${consumer}\"," >> pkg/BUILD
+  done
+  cat >> pkg/BUILD <<'EOF'
+    ],
+)
+EOF
+  echo "stamp 0" > pkg/stamp.txt
+
+  # Each consumer applies a distinct Starlark transition to the tree artifact, so the physical
+  # output paths differ. With output path stripping, all of those tree artifacts map to the same
+  # logical path in the remote action input tree.
+  local common_flags=(
+    --experimental_output_paths=strip
+    --remote_executor=grpc://localhost:${worker_port}
+    --remote_download_minimal
+    --rewind_lost_inputs
+    --experimental_remote_cache_eviction_retries=0
+    --experimental_remote_cache_chunking
+    --remote_timeout=5s
+    --jobs=64
+  )
+
+  bazel build "${common_flags[@]}" //pkg:all_outputs &> $TEST_log || fail "initial build failed"
+
+  bazel clean &> $TEST_log || fail "clean failed"
+
+  bazel build "${common_flags[@]}" //pkg:all_outputs &> $TEST_log \
+    || fail "remote-only seed build failed"
+  local execroot
+  execroot="$(bazel info execution_root 2>> $TEST_log)"
+  if find "${execroot}/bazel-out" -path "*/bin/pkg/tree_dir/pkg/blob" -print | grep -q .; then
+    find "${execroot}/bazel-out" -path "*/bin/pkg/tree_dir/pkg/blob" -print > $TEST_log
+    fail "tree outputs were downloaded during remote-only seed build"
+  fi
+
+  local attempt
+  for attempt in $(seq 1 6); do
+    delete_remote_cas_files
+    if [[ "$(count_remote_cas_files)" != "0" ]]; then
+      find "${cas_path}" -type f > $TEST_log
+      fail "remote CAS was not empty after deletion"
+    fi
+    echo "stamp ${attempt}" >> pkg/stamp.txt
+    cat > pkg/nonce.bzl <<EOF
+NONCE = "attempt_${attempt}"
+EOF
+
+    bazel build "${common_flags[@]}" //pkg:all_outputs &> $TEST_log \
+      || fail "build after remote CAS reset failed on attempt ${attempt}"
+
+    expect_not_log "Exec failed due to IOException"
+    expect_not_log "Missing digest"
+  done
+}
+
+function test_path_stripping_remote_lost_runfiles_member() {
+  add_rules_shell "MODULE.bazel"
+  mkdir pkg
+  cat > pkg/defs.bzl <<'EOF'
+def _data_impl(ctx):
+    out = ctx.actions.declare_file("data.bin")
+    args = ctx.actions.args()
+    args.add(out)
+    ctx.actions.run_shell(
+        outputs = [out],
+        arguments = [args],
+        command = 'dd if=/dev/zero of="$1" bs=1024 count=2300 2>/dev/null',
+        execution_requirements = {"supports-path-mapping": ""},
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+data = rule(_data_impl)
+
+def _consumer_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name + ".out")
+    args = ctx.actions.args()
+    args.add(out)
+    args.add(ctx.file.stamp)
+    args.add(ctx.attr.nonce)
+    # The data file lives in the tool's runfiles, so it is an input to this action even though the
+    # command below doesn't read it. With output path stripping, the runfiles member is referenced
+    # at a path-mapped location in the remote action input tree.
+    ctx.actions.run(
+        executable = ctx.executable.tool,
+        inputs = [ctx.file.stamp],
+        outputs = [out],
+        arguments = [args],
+        execution_requirements = {"supports-path-mapping": ""},
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+consumer = rule(
+    implementation = _consumer_impl,
+    attrs = {
+        "nonce": attr.string(),
+        "stamp": attr.label(allow_single_file = True),
+        "tool": attr.label(executable = True, cfg = "exec"),
+    },
+)
+EOF
+  cat > pkg/tool.sh <<'EOF'
+#!/bin/bash
+set -e
+cat "$2" > "$1"
+printf '%s\n' "$3" >> "$1"
+EOF
+  chmod +x pkg/tool.sh
+  cat > pkg/nonce.bzl <<'EOF'
+NONCE = "0"
+EOF
+  cat > pkg/BUILD <<'EOF'
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("//pkg:nonce.bzl", "NONCE")
+load("//pkg:defs.bzl", "consumer", "data")
+
+data(name = "data")
+
+sh_binary(
+    name = "tool",
+    srcs = ["tool.sh"],
+    data = [":data"],
+)
+EOF
+  local n
+  for n in $(seq -f "%02g" 0 7); do
+    cat >> pkg/BUILD <<EOF
+
+consumer(
+    name = "consume_${n}",
+    nonce = NONCE,
+    stamp = "stamp.txt",
+    tool = ":tool",
+)
+EOF
+  done
+  cat >> pkg/BUILD <<'EOF'
+
+filegroup(
+    name = "all_outputs",
+    srcs = [
+EOF
+  for n in $(seq -f "%02g" 0 7); do
+    echo "        \":consume_${n}\"," >> pkg/BUILD
+  done
+  cat >> pkg/BUILD <<'EOF'
+    ],
+)
+EOF
+  echo "stamp 0" > pkg/stamp.txt
+
+  # The data file is reachable only through the tool's runfiles tree, not as a top-level input of
+  # the consuming action. With output path stripping, the lost-input recovery path must still be
+  # able to map the (path-mapped) runfiles member back to the artifact so that rewinding can
+  # regenerate it.
+  local common_flags=(
+    --experimental_output_paths=strip
+    --remote_executor=grpc://localhost:${worker_port}
+    --remote_download_minimal
+    --rewind_lost_inputs
+    --experimental_remote_cache_eviction_retries=0
+    --experimental_remote_cache_chunking
+    --remote_timeout=5s
+    --jobs=64
+  )
+
+  bazel build "${common_flags[@]}" //pkg:all_outputs &> $TEST_log || fail "initial build failed"
+
+  bazel clean &> $TEST_log || fail "clean failed"
+
+  bazel build "${common_flags[@]}" //pkg:all_outputs &> $TEST_log \
+    || fail "remote-only seed build failed"
+
+  local attempt
+  for attempt in $(seq 1 6); do
+    delete_remote_cas_files
+    if [[ "$(count_remote_cas_files)" != "0" ]]; then
+      find "${cas_path}" -type f > $TEST_log
+      fail "remote CAS was not empty after deletion"
+    fi
+    cat > pkg/nonce.bzl <<EOF
+NONCE = "attempt_${attempt}"
+EOF
+
+    bazel build "${common_flags[@]}" //pkg:all_outputs &> $TEST_log \
+      || fail "build after remote CAS reset failed on attempt ${attempt}"
+
+    expect_not_log "Exec failed due to IOException"
+    expect_not_log "Missing digest"
+  done
+}
+
 run_suite "Build without the Bytes tests"


### PR DESCRIPTION
Merkle subtrees for tree artifacts are deduplicated across actions by content. When such a shared subtree is uploaded for remote execution and one of its blobs is missing from the CAS, the resulting `CacheNotFoundException` is annotated with the exec path of whichever action happened to compute the shared subtree. With path mapping, other actions that join the deduplicated computation can then no longer map the lost input back to their own inputs, so the `BulkTransferException` surfaces as a fatal `EXEC_IO_EXCEPTION` instead of a `LostInputsExecException` and action rewinding never runs.

This change adds the unmapped exec path to the cache key of a tree artifact to avoid a shared upload in this case. Other artifact types are not affected and the fast path of a remote cache check without uploads is unaffected.

Fixes #30065.

RELNOTES: Fixed a spurious remote-execution failure with `--experimental_output_paths=strip` where a lost input in a tree artifact shared between actions could not be recovered by action rewinding.

Closes #30085.

PiperOrigin-RevId: 944321975
Change-Id: If36408a56ab8137b915970827ebbd7a91d9ad9c1 
(cherry picked from commit 412de867485e1d5a60329265e361b4e14b087c39)

Closes #30103