### PR TITLE
Avoid min/max crashes from mutating key functions

### DIFF
--- a/src/main/java/net/starlark/java/eval/MethodLibrary.java
+++ b/src/main/java/net/starlark/java/eval/MethodLibrary.java
@@ -14,10 +14,7 @@
 
 package net.starlark.java.eval;
 
-import static java.util.Comparator.comparing;
-
 import com.google.common.base.Ascii;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Ordering;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -115,19 +112,24 @@ class MethodLibrary {
     Object items = (args.size() == 1) ? args.get(0) : args;
     try {
       if (keyFn.isPresent()) {
-        try {
-          // Snapshot before calling user Starlark code so key functions can mutate the original
-          // iterable without invalidating Java's iterator.
-          return Arrays.stream(Starlark.toArray(items))
-              .map(value -> ValueWithComparisonKey.make(value, keyFn.get(), thread))
-              .max(comparing(ValueWithComparisonKey::getComparisonKey, maxOrdering))
-              .get()
-              .getValue();
-        } catch (ValueWithComparisonKey.KeyCallException ex) {
-          Throwables.throwIfInstanceOf(ex.getCause(), EvalException.class);
-          Throwables.throwIfInstanceOf(ex.getCause(), InterruptedException.class);
-          throw new AssertionError("Got invalid ValueWithComparisonKey.KeyCallException", ex);
+        // Snapshot before calling user Starlark code so key functions can mutate the original
+        // iterable without invalidating Java's iterator.
+        Object[] array = Starlark.toArray(items);
+        if (array.length == 0) {
+          throw new NoSuchElementException();
         }
+        StarlarkCallable key = keyFn.get();
+        Object bestValue = array[0];
+        Object bestKey = Starlark.positionalOnlyCall(thread, key, bestValue);
+        for (int i = 1; i < array.length; i++) {
+          Object value = array[i];
+          Object comparisonKey = Starlark.positionalOnlyCall(thread, key, value);
+          if (maxOrdering.compare(comparisonKey, bestKey) > 0) {
+            bestValue = value;
+            bestKey = comparisonKey;
+          }
+        }
+        return bestValue;
       } else {
         return maxOrdering.max(Starlark.toIterable(items));
       }
@@ -135,51 +137,6 @@ class MethodLibrary {
       throw new EvalException(ex.getMessage()); // e.g. unsupported comparison: int <=> string
     } catch (NoSuchElementException ex) {
       throw new EvalException("expected at least one item", ex);
-    }
-  }
-
-  /**
-   * Original value decorated with its comparison key; storing the comparison key alongside the
-   * value ensures that we call the comparison key computation function only once per original value
-   * (which is important in case the function has side effects).
-   */
-  private static final class ValueWithComparisonKey {
-    private final Object value;
-    private final Object comparisonKey;
-
-    private ValueWithComparisonKey(Object value, Object comparisonKey) {
-      this.value = value;
-      this.comparisonKey = comparisonKey;
-    }
-
-    /**
-     * @throws KeyCallException wrapping the exception thrown by the underlying {@link
-     *     Starlark#positionalOnlyCall} call if it threw.
-     */
-    static ValueWithComparisonKey make(
-        Object value, StarlarkCallable keyFn, StarlarkThread thread) {
-      try {
-        return new ValueWithComparisonKey(value, Starlark.positionalOnlyCall(thread, keyFn, value));
-      } catch (EvalException | InterruptedException ex) {
-        throw new KeyCallException(ex);
-      }
-    }
-
-    Object getValue() {
-      return value;
-    }
-
-    Object getComparisonKey() {
-      return comparisonKey;
-    }
-
-    /**
-     * An unchecked exception wrapping an exception thrown by {@link Starlark#positionalOnlyCall}.
-     */
-    private static final class KeyCallException extends RuntimeException {
-      KeyCallException(Exception cause) {
-        super(cause);
-      }
     }
   }
 

--- a/src/main/java/net/starlark/java/eval/MethodLibrary.java
+++ b/src/main/java/net/starlark/java/eval/MethodLibrary.java
@@ -14,7 +14,6 @@
 
 package net.starlark.java.eval;
 
-import static com.google.common.collect.Streams.stream;
 import static java.util.Comparator.comparing;
 
 import com.google.common.base.Ascii;
@@ -113,11 +112,13 @@ class MethodLibrary {
       throws EvalException, InterruptedException {
     // Args can either be a list of items to compare, or a singleton list whose element is an
     // iterable of items to compare. In either case, there must be at least one item to compare.
-    Iterable<?> items = (args.size() == 1) ? Starlark.toIterable(args.get(0)) : args;
+    Object items = (args.size() == 1) ? args.get(0) : args;
     try {
       if (keyFn.isPresent()) {
         try {
-          return stream(items)
+          // Snapshot before calling user Starlark code so key functions can mutate the original
+          // iterable without invalidating Java's iterator.
+          return Arrays.stream(Starlark.toArray(items))
               .map(value -> ValueWithComparisonKey.make(value, keyFn.get(), thread))
               .max(comparing(ValueWithComparisonKey::getComparisonKey, maxOrdering))
               .get()
@@ -128,7 +129,7 @@ class MethodLibrary {
           throw new AssertionError("Got invalid ValueWithComparisonKey.KeyCallException", ex);
         }
       } else {
-        return maxOrdering.max(items);
+        return maxOrdering.max(Starlark.toIterable(items));
       }
     } catch (ClassCastException ex) {
       throw new EvalException(ex.getMessage()); // e.g. unsupported comparison: int <=> string

--- a/src/test/java/net/starlark/java/eval/MethodLibraryTest.java
+++ b/src/test/java/net/starlark/java/eval/MethodLibraryTest.java
@@ -312,6 +312,19 @@ public final class MethodLibraryTest {
   }
 
   @Test
+  public void testKeyFunctionMayMutateInputList() throws Exception {
+    ev.new Scenario()
+        .setUp(
+            "a = list(range(10))",
+            "def mutating_key(x):",
+            "  a.pop()",
+            "  return x")
+        .testEval("min(a, key = mutating_key)", "0")
+        .testEval("max(a, key = mutating_key)", "9")
+        .testEval("sorted(a, key = mutating_key)", "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]");
+  }
+
+  @Test
   public void testDictionaryCopy() throws Exception {
     ev.new Scenario()
         .setUp("x = {1 : 2}", "y = dict(x)")


### PR DESCRIPTION
## Summary
- Snapshot `min`/`max` inputs before invoking user-provided `key` functions, matching the safe behavior `sorted` already gets from copying its iterable first.
- Add regression coverage for `min`, `max`, and `sorted` when the key function mutates the original list.
- Keep key comparison as a straight-line loop so checked Starlark exceptions propagate normally and no stream wrapper allocation is needed.

Fixes #30201

## Test plan
- `git diff --check`
- Islo Linux x86_64 sandbox: `bazelisk test --test_output=errors --test_filter=net.starlark.java.eval.MethodLibraryTest //src/test/java/net/starlark/java/eval:EvalTests`