### PR TITLE
[9.2.0] Prevent UrlRewriterParseException from being wrapped in RuntimeException (https://github.com/bazelbuild/bazel/pull/28305)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
@@ -129,7 +129,7 @@ public class UrlRewriter {
         return new UrlRewriter(
             configPaths.stream().map(PathFragment::getPathString).toList(), readers);
       } catch (Throwable e) {
-        throw closer.rethrow(e);
+        throw closer.rethrow(e, UrlRewriterParseException.class);
       } finally {
         closer.close();
       }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
@@ -261,11 +261,15 @@ public class UrlRewriterTest {
   @Test
   public void parseError() throws Exception {
     String config = "#comment\nhello";
+    assertThrows(
+        UrlRewriterParseException.class,
+        () -> testUrlRewriter("/some/file", new StringReader(config)));
     try {
       new UrlRewriterConfig("/some/file", new StringReader(config));
       fail();
     } catch (UrlRewriterParseException e) {
       assertThat(e.getLocation()).isEqualTo(Location.fromFileLineColumn("/some/file", 2, 0));
+      assertThat(e.getMessage()).contains("Unable to parse: hello");
     }
   }
 


### PR DESCRIPTION
When attempting to run a Bazel command, Bazel server will shutdown and exit with an unexpected error when the [downloader config](https://bazel.build/reference/command-line-reference#common_options-flag--downloader_config) is invalid:

```
$ echo "#test\nfoo" > bazel_downloader.cfg
$ cat bazel_downloader.cfg
#test
foo
$ bazel-dev build //... --downloader_config=bazel_downloader.cfg
< exits immediately with the Bazel server killed >
$ echo $?
37
```

`37` corresponds to `Unhandled Exception / Internal Bazel Error` as per the [docs](https://bazel.build/run/scripts#exit-codes).

This PR introduces changes that will let catch and rethrow `UrlRewriterParseException` before `Closer.rethrow()` to prevent it from being wrapped in `RuntimeException`.

```
$ bazel-dev-fixed query //... --downloader_config=bazel_downloader.cfg
...
ERROR: Failed to parse downloader config at bazel_downloader.cfg:2: Unable to parse: foo
$ echo $?
2
```

Closes #28305.

PiperOrigin-RevId: 891501161
Change-Id: I3cbfe2e2cdcad14c6b5e8210e2e1b8e999eba0ae

Commit https://github.com/bazelbuild/bazel/commit/45ea1f009a76996b32d8eda0bd5f43f958a68293