### PR TITLE
singlejar: bound the ZIP64 central-directory size against the mapped file

### DIFF
--- a/src/tools/singlejar/input_jar.cc
+++ b/src/tools/singlejar/input_jar.cc
@@ -124,12 +124,17 @@ bool InputJar::LocateCentralDirectory(const std::string& path) {
     cdh_ = reinterpret_cast<const CDH*>(ecd);
     preamble_size_ = mapped_file_.offset(cdh_) - cen_position;
   } else {
-    auto ecd64loc = reinterpret_cast<const ECD64Locator*>(ziph::byte_ptr(ecd) -
-                                                          sizeof(ECD64Locator));
-    if (ecd64loc->is()) {
-      auto ecd64 = reinterpret_cast<const ECD64*>(ziph::byte_ptr(ecd64loc) -
-                                                  sizeof(ECD64));
-      if (!ecd64->is()) {
+    // The optional ECD64 locator and ECD64 records precede the ECD. Their
+    // locations are derived from an untrusted archive, so verify that each
+    // probed record lies within the mapped file before dereferencing it.
+    const unsigned char* ecd64loc_start =
+        ziph::byte_ptr(ecd) - sizeof(ECD64Locator);
+    auto ecd64loc = reinterpret_cast<const ECD64Locator*>(ecd64loc_start);
+    if (ecd64loc_start >= mapped_file_.start() && ecd64loc->is()) {
+      const unsigned char* ecd64_start =
+          ziph::byte_ptr(ecd64loc) - sizeof(ECD64);
+      auto ecd64 = reinterpret_cast<const ECD64*>(ecd64_start);
+      if (ecd64_start < mapped_file_.start() || !ecd64->is()) {
         diag_warnx(
             "%s:%d: %s is corrupt, expected ECD64 record at offset 0x%" PRIx64
             " is missing",
@@ -137,8 +142,18 @@ bool InputJar::LocateCentralDirectory(const std::string& path) {
         mapped_file_.Close();
         return false;
       }
-      cdh_ = reinterpret_cast<const CDH*>(ziph::byte_ptr(ecd64) -
-                                          ecd64->cen_size());
+      // The Central Directory precedes the ECD64 record by cen_size bytes.
+      // Reject a size that would place it before the start of the mapping, as
+      // that would make cdh_ point outside the mapped file.
+      uint64_t ecd64_cen_size = ecd64->cen_size();
+      if (ecd64_cen_size > static_cast<uint64_t>(mapped_file_.offset(ecd64))) {
+        diag_warnx("%s:%d: %s is corrupt: Central Directory size 0x%" PRIx64
+                   " is too large",
+                   __FILE__, __LINE__, path.c_str(), ecd64_cen_size);
+        mapped_file_.Close();
+        return false;
+      }
+      cdh_ = reinterpret_cast<const CDH*>(ziph::byte_ptr(ecd64) - ecd64_cen_size);
       preamble_size_ = mapped_file_.offset(cdh_) - ecd64->cen_offset();
       // Find CEN and preamble size.
     } else {

--- a/src/tools/singlejar/input_jar_bad_jar_test.cc
+++ b/src/tools/singlejar/input_jar_bad_jar_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
+#include <cstdio>
 #include <string>
 
 #include "src/tools/singlejar/input_jar.h"
@@ -19,6 +21,17 @@
 #include "googletest/include/gtest/gtest.h"
 
 static const char kJar[] = "jar.jar";
+
+namespace {
+bool WriteBytes(const std::string &path, const uint8_t *data, size_t size) {
+  FILE *fp = fopen(path.c_str(), "wb");
+  if (fp == nullptr) {
+    return false;
+  }
+  bool ok = fwrite(data, 1, size, fp) == size;
+  return fclose(fp) == 0 && ok;
+}
+}  // namespace
 
 TEST(InputJarBadJarTest, NotAJar) {
   std::string out_path = singlejar_test_util::OutputFilePath(kJar);
@@ -31,6 +44,37 @@ TEST(InputJarBadJarTest, NotAJar) {
 TEST(InputJarBadJarTest, EmptyFile) {
   std::string out_path = singlejar_test_util::OutputFilePath(kJar);
   ASSERT_TRUE(singlejar_test_util::AllocateFile(out_path, 0));
+  InputJar input_jar;
+  ASSERT_FALSE(input_jar.Open(out_path));
+}
+
+// A crafted archive that presents a valid ECD, ECD64 Locator and ECD64 record,
+// but whose ECD64 Central Directory size is far larger than the file. The
+// Central Directory header pointer is computed as `ecd64 - cen_size`, so an
+// unchecked size makes it point outside the mapped file. `Open()` must reject
+// the archive instead of dereferencing an out-of-bounds pointer.
+TEST(InputJarBadJarTest, Zip64CentralDirectorySizeOutOfBounds) {
+  // Layout: [ECD64 (56 bytes)][ECD64Locator (20 bytes)][ECD (22 bytes)].
+  static const uint8_t kArchive[] = {
+      // ECD64: signature, remaining_size, version/version_to_extract,
+      // this_disk_nr, cen_disk_nr, this_disk_entries, total_entries,
+      // cen_size (0x0000000000100000), cen_offset.
+      0x50, 0x4b, 0x06, 0x06, 0x2c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      // ECD64Locator: signature, ecd64_disk_nr, ecd64_offset, total_disks.
+      0x50, 0x4b, 0x06, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+      // ECD: signature, disk numbers/entry counts, cen_size32 (0xFFFFFFFF),
+      // cen_offset32 (0xFFFFFFFF), comment_length. The 0xFFFFFFFF markers force
+      // the ZIP64 code path.
+      0x50, 0x4b, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+  };
+  std::string out_path = singlejar_test_util::OutputFilePath(kJar);
+  ASSERT_TRUE(WriteBytes(out_path, kArchive, sizeof(kArchive)));
   InputJar input_jar;
   ASSERT_FALSE(input_jar.Open(out_path));
 }


### PR DESCRIPTION
## Summary

`InputJar::LocateCentralDirectory` (`src/tools/singlejar/input_jar.cc`) locates the
central directory of a ZIP64 archive by walking backwards from the End of Central
Directory (ECD) record through the ZIP64 EOCD Locator and ZIP64 EOCD records. Two
values derived from the untrusted archive are used without a bounds check:

1. The ZIP64 EOCD Locator and ZIP64 EOCD records are dereferenced (`->is()`) without
   verifying that they lie within the mapped file.
2. The central-directory header pointer is computed as `ecd64 - ecd64->cen_size()`,
   where `cen_size` is a 64-bit field read straight from the archive. The 32-bit path
   already rejects a `cen_size32` larger than the ECD offset, but the ZIP64 path had no
   equivalent check, so `cdh_` could point outside the mapping and the following
   `cdh_->is()` read out of bounds.

`singlejar` merges `.jar`/`.zip` inputs while building, so the archive bytes are
untrusted (for example, a dependency-supplied jar).

## Reproduction

A 98-byte crafted archive — a valid ECD, a valid ZIP64 EOCD Locator, a valid ZIP64 EOCD
whose `cen_size` is `0x100000`, and `cen_size32`/`cen_offset32` set to the `0xFFFFFFFF`
ZIP64 markers to force the ZIP64 code path — makes `cdh_` point ~1 MiB before the start
of the mapping. Built with AddressSanitizer, `InputJar::Open()` on this input reports:

```
AddressSanitizer: SEGV on unknown address ... READ
    #0 CDH::is() const src/tools/singlejar/zip_headers.h:376
    #1 InputJar::LocateCentralDirectory(...) src/tools/singlejar/input_jar.cc:156
```

With this change the same input is rejected cleanly ("Central Directory size ... is too
large"), and a valid archive (including a real ZIP64 archive) still opens.

## Fix

- Verify the probed ZIP64 EOCD Locator and ZIP64 EOCD records lie within the mapped file
  before dereferencing them.
- Reject a ZIP64 `cen_size` that would place the central directory before the start of
  the mapping, mirroring the existing 32-bit guard.

Adds a regression test: `InputJarBadJarTest.Zip64CentralDirectorySizeOutOfBounds`.
