### PR TITLE
Validate downloader config rewrite replacements, and fail loudly on malformed configs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
@@ -93,6 +93,30 @@ public class UrlRewriter {
     return !stripped.contains("urlencode(");
   }
 
+  static void validateReplacement(Pattern pattern, String replacement) {
+    int groupCount = pattern.matcher("").groupCount();
+    Matcher tokenMatcher = REPLACEMENT_TOKEN_PATTERN.matcher(replacement);
+    while (tokenMatcher.find()) {
+      String token = tokenMatcher.group();
+      if (token.startsWith("\\")) {
+        continue;
+      }
+      int groupIndex = getGroupIndex(token);
+      if (groupIndex > groupCount) {
+        throw new IndexOutOfBoundsException("No group " + groupIndex);
+      }
+    }
+
+    String stripped = REPLACEMENT_TOKEN_PATTERN.matcher(replacement).replaceAll("");
+    if (stripped.contains("$")) {
+      throw new IllegalArgumentException("Illegal group reference");
+    }
+  }
+
+  private static int getGroupIndex(String token) {
+    return Integer.parseInt(token.replaceAll("\\D+", ""));
+  }
+
   private final UrlRewriterConfig config;
 
   @VisibleForTesting
@@ -317,11 +341,11 @@ public class UrlRewriter {
     while (m.find()) {
       String token = m.group();
       if (token.contains("urlencode")) {
-        int groupIndex = Integer.parseInt(token.replaceAll("\\D+", ""));
+        int groupIndex = getGroupIndex(token);
         String val = Strings.nullToEmpty(matcher.group(groupIndex));
         m.appendReplacement(sb, Matcher.quoteReplacement(escapeUrlPath(val)));
       } else if (token.startsWith("$")) {
-        int groupIndex = Integer.parseInt(token.replaceAll("\\D+", ""));
+        int groupIndex = getGroupIndex(token);
         String val = Strings.nullToEmpty(matcher.group(groupIndex));
         m.appendReplacement(sb, Matcher.quoteReplacement(val));
       } else if (token.startsWith("\\")) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java
@@ -84,8 +84,7 @@ class UrlRewriterConfig {
   /**
    * Constructor for a single file. The {@code config} will be read to completion.
    *
-   * @throws UrlRewriterParseException If the file contents was invalid.
-   * @throws UncheckedIOException If any processing problems occur.
+   * @throws UrlRewriterParseException If the file contents was invalid, or could not be read.
    */
   public UrlRewriterConfig(String filePathForErrorReporting, Reader config)
       throws UrlRewriterParseException {
@@ -95,8 +94,7 @@ class UrlRewriterConfig {
   /**
    * Constructor for multiple files. The {@code configs} will be read to completion.
    *
-   * @throws UrlRewriterParseException If the file(s) contents was invalid.
-   * @throws UncheckedIOException If any processing problems occur.
+   * @throws UrlRewriterParseException If the file(s) contents was invalid, or could not be read.
    */
   public UrlRewriterConfig(List<String> filePathsForErrorReporting, List<Reader> configs)
       throws UrlRewriterParseException {
@@ -112,8 +110,19 @@ class UrlRewriterConfig {
     for (int i = 0; i < filePathsForErrorReporting.size(); i++) {
       String filePathForErrorReporting = filePathsForErrorReporting.get(i);
       Reader config = configs.get(i);
-      parseConfig(
-          config, filePathForErrorReporting, allowList, blockList, rewrites, allBlockedMessage);
+      try {
+        parseConfig(
+            config, filePathForErrorReporting, allowList, blockList, rewrites, allBlockedMessage);
+      } catch (RuntimeException e) {
+        // Defense in depth: parseConfig reports the malformed inputs it recognizes as a
+        // UrlRewriterParseException (a checked exception, not caught here). Anything else, such as
+        // an I/O error surfaced as an UncheckedIOException or a future parsing gap, must still be
+        // reported as a downloader-config error. Otherwise it escapes as an uncaught exception and
+        // terminates Bazel with an internal error (exit code 37) and no error message, the same
+        // silent failure mode as the invalid regex in issue #20832.
+        throw new UrlRewriterParseException(
+            "Failed to parse downloader config file `" + filePathForErrorReporting + "`", e);
+      }
     }
 
     this.allowList = allowList.build();

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java
@@ -168,8 +168,11 @@ class UrlRewriterConfig {
                       + line,
                   location);
             }
+            String matchPattern = parts.get(1);
+            String rewritePattern = parts.get(2);
+            Pattern pattern;
             try {
-              rewrites.put(Pattern.compile(parts.get(1)), parts.get(2));
+              pattern = Pattern.compile(matchPattern);
             } catch (PatternSyntaxException e) {
               throw new UrlRewriterParseException(
                   "Invalid regex in `rewrite`: "
@@ -177,10 +180,31 @@ class UrlRewriterConfig {
                       + " at index "
                       + e.getIndex()
                       + " in `"
-                      + parts.get(1)
+                      + matchPattern
                       + "`",
                   location);
             }
+            // The replacement string is expanded lazily by java.util.regex.Matcher, only when a URL
+            // is actually rewritten during a download. Validate it eagerly here so that a malformed
+            // replacement (e.g. `$3` when the pattern has two groups, or a trailing `$`) surfaces
+            // as a config parse error, rather than silently aborting a later download with an
+            // uncaught exception and no error message. Wrapping the (already valid) pattern so that
+            // it always matches lets Matcher's replacement parser flag the exact same error and we
+            // surface it here at parse time.
+            try {
+              var unused =
+                  Pattern.compile("(?:" + matchPattern + ")|.*")
+                      .matcher("")
+                      .replaceFirst(rewritePattern);
+            } catch (IndexOutOfBoundsException | IllegalArgumentException e) {
+              throw new UrlRewriterParseException(
+                  "Invalid rewrite pattern `"
+                      + rewritePattern
+                      + "` in `rewrite`: "
+                      + e.getMessage(),
+                  location);
+            }
+            rewrites.put(pattern, rewritePattern);
           }
           case ALL_BLOCKED_MESSAGE_DIRECTIVE -> {
             if (parts.size() == 1) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java
@@ -168,12 +168,15 @@ class UrlRewriterConfig {
                       + line,
                   location);
             }
-            if (!UrlRewriter.isValidUrlEncodeSyntax(parts.get(2))) {
+            String matchPattern = parts.get(1);
+            String rewritePattern = parts.get(2);
+            if (!UrlRewriter.isValidUrlEncodeSyntax(rewritePattern)) {
               throw new UrlRewriterParseException(
-                  "Invalid urlencode syntax in `rewrite` replacement: " + parts.get(2), location);
+                  "Invalid urlencode syntax in `rewrite` replacement: " + rewritePattern, location);
             }
+            Pattern pattern;
             try {
-              rewrites.put(Pattern.compile(parts.get(1)), parts.get(2));
+              pattern = Pattern.compile(matchPattern);
             } catch (PatternSyntaxException e) {
               throw new UrlRewriterParseException(
                   "Invalid regex in `rewrite`: "
@@ -181,10 +184,21 @@ class UrlRewriterConfig {
                       + " at index "
                       + e.getIndex()
                       + " in `"
-                      + parts.get(1)
+                      + matchPattern
                       + "`",
                   location);
             }
+            try {
+              UrlRewriter.validateReplacement(pattern, rewritePattern);
+            } catch (IndexOutOfBoundsException | IllegalArgumentException e) {
+              throw new UrlRewriterParseException(
+                  "Invalid rewrite pattern `"
+                      + rewritePattern
+                      + "` in `rewrite`: "
+                      + e.getMessage(),
+                  location);
+            }
+            rewrites.put(pattern, rewritePattern);
           }
           case ALL_BLOCKED_MESSAGE_DIRECTIVE -> {
             if (parts.size() == 1) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterParseException.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterParseException.java
@@ -22,12 +22,17 @@ public class UrlRewriterParseException extends Exception {
   @Nullable private final Location location;
 
   public UrlRewriterParseException(String message) {
-    this(message, /* location= */ null);
+    this(message, /* location= */ (Location) null);
   }
 
   public UrlRewriterParseException(String message, @Nullable Location location) {
     super(message);
     this.location = location;
+  }
+
+  public UrlRewriterParseException(String message, Throwable cause) {
+    super(message, cause);
+    this.location = null;
   }
 
   @Nullable

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
@@ -274,6 +274,38 @@ public class UrlRewriterTest {
   }
 
   @Test
+  public void rewriteWithBackReferenceToMissingGroupFailsToParse() throws Exception {
+    // The matching pattern has two capturing groups, but the rewrite pattern references a third
+    // (`$3`). This parses fine, but `$3` is only expanded lazily by java.util.regex.Matcher when a
+    // URL is actually rewritten during a download, at which point it throws an uncaught
+    // IndexOutOfBoundsException and terminates Bazel with no diagnostic (exit code 37). A malformed
+    // config must instead be reported eagerly, at parse time.
+    String config = "rewrite (github.com)/(.*) https://mirror.example.com/$1/$2/$3\n";
+    try {
+      new UrlRewriterConfig("/some/file", new StringReader(config));
+      fail("expected a UrlRewriterParseException for the invalid rewrite pattern");
+    } catch (UrlRewriterParseException e) {
+      assertThat(e.getLocation()).isEqualTo(Location.fromFileLineColumn("/some/file", 1, 0));
+      assertThat(e.getMessage()).contains("https://mirror.example.com/$1/$2/$3");
+      assertThat(e.getMessage()).contains("No group 3");
+    }
+  }
+
+  @Test
+  public void rewriteWithDanglingDollarInReplacementFailsToParse() throws Exception {
+    // A rewrite pattern that ends with a bare `$` is an illegal replacement string that likewise
+    // only fails when a URL is rewritten. It too must be rejected at parse time.
+    String config = "rewrite (github.com)/(.*) https://mirror.example.com/$1/$\n";
+    try {
+      new UrlRewriterConfig("/some/file", new StringReader(config));
+      fail("expected a UrlRewriterParseException for the invalid rewrite pattern");
+    } catch (UrlRewriterParseException e) {
+      assertThat(e.getLocation()).isEqualTo(Location.fromFileLineColumn("/some/file", 1, 0));
+      assertThat(e.getMessage()).contains("https://mirror.example.com/$1/$");
+    }
+  }
+
+  @Test
   public void noAllBlockedMessage() throws Exception {
     String config = "";
     UrlRewriterConfig munger = new UrlRewriterConfig("/some/file", new StringReader(config));

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
@@ -306,6 +306,30 @@ public class UrlRewriterTest {
   }
 
   @Test
+  public void ioErrorReadingConfigIsReportedAsParseError() throws Exception {
+    // Defense in depth: a failure that is not one of the malformed inputs parseConfig recognizes
+    // (here, an I/O error, which it wraps in an UncheckedIOException) must still surface as a
+    // UrlRewriterParseException rather than escaping as an uncaught exception and terminating Bazel
+    // with an internal error and no diagnostic.
+    Reader throwsOnRead =
+        new Reader() {
+          @Override
+          public int read(char[] cbuf, int off, int len) throws IOException {
+            throw new IOException("simulated read failure");
+          }
+
+          @Override
+          public void close() {}
+        };
+    UrlRewriterParseException e =
+        assertThrows(
+            UrlRewriterParseException.class,
+            () -> new UrlRewriterConfig("/some/file", throwsOnRead));
+    assertThat(e.getMessage()).contains("Failed to parse downloader config file `/some/file`");
+    assertThat(e).hasCauseThat().hasMessageThat().contains("simulated read failure");
+  }
+
+  @Test
   public void noAllBlockedMessage() throws Exception {
     String config = "";
     UrlRewriterConfig munger = new UrlRewriterConfig("/some/file", new StringReader(config));

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
@@ -274,6 +274,33 @@ public class UrlRewriterTest {
   }
 
   @Test
+  public void rewriteWithBackReferenceToMissingGroupFailsToParse() throws Exception {
+    // Replacement group references must name a capturing group in the matching pattern.
+    String config = "rewrite (github.com)/(.*) https://mirror.example.com/$1/$2/$3\n";
+    try {
+      new UrlRewriterConfig("/some/file", new StringReader(config));
+      fail("expected a UrlRewriterParseException for the invalid rewrite pattern");
+    } catch (UrlRewriterParseException e) {
+      assertThat(e.getLocation()).isEqualTo(Location.fromFileLineColumn("/some/file", 1, 0));
+      assertThat(e.getMessage()).contains("https://mirror.example.com/$1/$2/$3");
+      assertThat(e.getMessage()).contains("No group 3");
+    }
+  }
+
+  @Test
+  public void rewriteWithDanglingDollarInReplacementFailsToParse() throws Exception {
+    // An unescaped dollar must introduce a supported replacement token.
+    String config = "rewrite (github.com)/(.*) https://mirror.example.com/$1/$\n";
+    try {
+      new UrlRewriterConfig("/some/file", new StringReader(config));
+      fail("expected a UrlRewriterParseException for the invalid rewrite pattern");
+    } catch (UrlRewriterParseException e) {
+      assertThat(e.getLocation()).isEqualTo(Location.fromFileLineColumn("/some/file", 1, 0));
+      assertThat(e.getMessage()).contains("https://mirror.example.com/$1/$");
+    }
+  }
+
+  @Test
   public void noAllBlockedMessage() throws Exception {
     String config = "";
     UrlRewriterConfig munger = new UrlRewriterConfig("/some/file", new StringReader(config));
@@ -531,6 +558,19 @@ public class UrlRewriterTest {
         munger.amend(urls).stream().map(UrlRewriter.RewrittenURL::url).collect(toImmutableList());
 
     assertThat(amended).containsExactly(URI.create("https://mirror.com/foo/bar-baz%3Fqux=1"));
+  }
+
+  @Test
+  public void rewriteWithUrlEncodeBackReferenceToMissingGroupFailsToParse() throws Exception {
+    String config = "rewrite (github.com)/(.*) https://mirror.example.com/${urlencode($3)}\n";
+    try {
+      new UrlRewriterConfig("/some/file", new StringReader(config));
+      fail("expected a UrlRewriterParseException for the invalid rewrite pattern");
+    } catch (UrlRewriterParseException e) {
+      assertThat(e.getLocation()).isEqualTo(Location.fromFileLineColumn("/some/file", 1, 0));
+      assertThat(e.getMessage()).contains("https://mirror.example.com/${urlencode($3)}");
+      assertThat(e.getMessage()).contains("No group 3");
+    }
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
@@ -301,6 +301,30 @@ public class UrlRewriterTest {
   }
 
   @Test
+  public void ioErrorReadingConfigIsReportedAsParseError() throws Exception {
+    // Defense in depth: a failure that is not one of the malformed inputs parseConfig recognizes
+    // (here, an I/O error, which it wraps in an UncheckedIOException) must still surface as a
+    // UrlRewriterParseException rather than escaping as an uncaught exception and terminating Bazel
+    // with an internal error and no diagnostic.
+    Reader throwsOnRead =
+        new Reader() {
+          @Override
+          public int read(char[] cbuf, int off, int len) throws IOException {
+            throw new IOException("simulated read failure");
+          }
+
+          @Override
+          public void close() {}
+        };
+    UrlRewriterParseException e =
+        assertThrows(
+            UrlRewriterParseException.class,
+            () -> new UrlRewriterConfig("/some/file", throwsOnRead));
+    assertThat(e.getMessage()).contains("Failed to parse downloader config file `/some/file`");
+    assertThat(e).hasCauseThat().hasMessageThat().contains("simulated read failure");
+  }
+
+  @Test
   public void noAllBlockedMessage() throws Exception {
     String config = "";
     UrlRewriterConfig munger = new UrlRewriterConfig("/some/file", new StringReader(config));


### PR DESCRIPTION
## Description

Validate a `rewrite` directive's replacement string while parsing `--downloader_config`, so a malformed replacement, for example a back-reference to a group that does not exist (`$3` when the pattern has two groups) or a trailing `$`, is reported as a config parse error instead of terminating Bazel with an uncaught internal error (exit code 37) on the first matching download.

As defense in depth, the parse loop also converts any other unexpected `RuntimeException` (such as an I/O error surfaced as an `UncheckedIOException`) into a `UrlRewriterParseException` that names the config file and keeps the original exception as its cause, so no parsing failure can escape as an uncaught internal error (exit code 37).

**Fixes:** #30215

## Motivation

A URL rewriter can rewrite download URLs via `rewrite` rules whose replacement strings use back-references into the matching pattern's capturing groups. The matching pattern is validated at parse time, but the replacement is not: it is expanded only when a URL is rewritten during a download. A replacement with a back-reference to a group that does not exist, or that is otherwise malformed, therefore reaches the download path and throws an uncaught exception, and Bazel exits with an internal error (exit code 37) and no diagnostic.

This is the same silent-termination failure mode as earlier downloader-config bugs (#20832 for an invalid regex, #28305 / #30204 for an unparseable line whose exception was wrapped in a `RuntimeException`).

## Build API Changes

No

## Checklist

- [x] I have added tests for the new use cases.
- [ ] I have updated the documentation (not applicable).

## Release Notes

RELNOTES: None