### PR TITLE
Allow passing empty value to `--experimental_remote_scrubbing_config`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -855,7 +855,7 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
               + " affected actions.\n\n"
               + "In order to successfully use this feature, you likely want to set a custom"
               + " --host_platform together with --experimental_platform_in_output_dir (to normalize"
-              + " output prefixes).")
+              + " output prefixes). An empty value disables scrubbing.")
   public abstract Scrubber getScrubber();
 
   public abstract void setScrubber(Scrubber value);
@@ -915,7 +915,11 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
   private static final class ScrubberConverter extends Converter.Contextless<Scrubber> {
 
     @Override
+    @Nullable
     public Scrubber convert(String path) throws OptionsParsingException {
+      if (path.isEmpty()) {
+        return null;
+      }
       try {
         return Scrubber.parse(path);
       } catch (Scrubber.ConfigParseException e) {

--- a/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
@@ -127,6 +127,14 @@ public class RemoteOptionsTest {
   }
 
   @Test
+  public void scrubbingConfig_emptyValue_disables() throws Exception {
+    OptionsParser parser = OptionsParser.builder().optionsClasses(RemoteOptions.class).build();
+    parser.parse("--experimental_remote_scrubbing_config=");
+    RemoteOptions options = parser.getOptions(RemoteOptions.class);
+    assertThat(options.getScrubber()).isNull();
+  }
+
+  @Test
   public void diskCache_trueValue_usesDefaultLocation(
       @TestParameter({"true", "1", "yes", "t", "y"}) String arg) throws Exception {
     OptionsParser parser = OptionsParser.builder().optionsClasses(RemoteOptions.class).build();


### PR DESCRIPTION
### Description

This change allows disabling remote scrubbing config by setting `--experimental_remote_scrubbing_config` to empty value e.g. `--experimental_remote_scrubbing_config=`.

### Motivation

Remote scrubbing config is incompatible with RBE and forces the user to pass empty file to `--experimental_remote_scrubbing_config` to disable it. That works but is not aligned with the rest of the Bazel flags which breaks the user expectations.

### Build API Changes

Yes

1. This has not been discussed in design doc or issue.
2. This change is backward compatible.
3. It is not a breaking change.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: `--experimental_remote_scrubbing_config=` now disables remote cache key scrubbing, allowing command-line overrides of scrubbing configs set in .bazelrc.
