### PR TITLE
[8.8.0] Remote: make the failure circuit breaker's minimum call count configurable

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
@@ -34,7 +34,8 @@ public class CircuitBreakerFactory {
     if (remoteOptions.circuitBreakerStrategy == RemoteOptions.CircuitBreakerStrategy.FAILURE) {
       return new FailureCircuitBreaker(
           remoteOptions.remoteFailureRateThreshold,
-          (int) remoteOptions.remoteFailureWindowInterval.toMillis());
+          (int) remoteOptions.remoteFailureWindowInterval.toMillis(),
+          remoteOptions.remoteMinCallCountToComputeFailureRate);
     }
     return Retrier.ALLOW_ALL_CALLS;
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
@@ -44,14 +44,16 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
    *     circuit breaker in given time window.
    * @param slidingWindowSize the size of the sliding window in milliseconds to calculate the number
    *     of failures.
+   * @param minCallCountToComputeFailureRate the minimum number of calls within the window before the
+   *     failure rate is computed and the breaker may trip.
    */
-  public FailureCircuitBreaker(int failureRateThreshold, int slidingWindowSize) {
+  public FailureCircuitBreaker(
+      int failureRateThreshold, int slidingWindowSize, int minCallCountToComputeFailureRate) {
     this.failures = new AtomicInteger(0);
     this.successes = new AtomicInteger(0);
     this.failureRateThreshold = failureRateThreshold;
     this.slidingWindowSize = slidingWindowSize;
-    this.minCallCountToComputeFailureRate =
-        CircuitBreakerFactory.DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE;
+    this.minCallCountToComputeFailureRate = minCallCountToComputeFailureRate;
     this.state = State.ACCEPT_CALLS;
     this.scheduledExecutor =
         slidingWindowSize > 0 ? Executors.newSingleThreadScheduledExecutor() : null;

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -736,6 +736,17 @@ public final class RemoteOptions extends CommonRemoteOptions {
   public Duration remoteFailureWindowInterval;
 
   @Option(
+      name = "experimental_remote_min_call_count_to_compute_failure_rate",
+      defaultValue = "100",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.EXECUTION},
+      help =
+          "The minimum number of remote calls that must be observed within the failure window"
+              + " before the circuit breaker computes the failure rate and may trip. Only takes"
+              + " effect with --experimental_circuit_breaker_strategy=failure.")
+  public int remoteMinCallCountToComputeFailureRate;
+
+  @Option(
       name = "experimental_remote_cache_lease_extension",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.REMOTE,

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactoryTest.java
@@ -16,9 +16,11 @@ package com.google.devtools.build.lib.remote.circuitbreaker;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.devtools.build.lib.remote.Retrier;
+import com.google.devtools.build.lib.remote.Retrier.CircuitBreaker.State;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOptions.CircuitBreakerStrategy;
 import com.google.devtools.common.options.Options;
+import com.google.devtools.common.options.OptionsParsingException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -40,5 +42,29 @@ public class CircuitBreakerFactoryTest {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     assertThat(CircuitBreakerFactory.createCircuitBreaker(remoteOptions))
         .isEqualTo(Retrier.ALLOW_ALL_CALLS);
+  }
+
+  @Test
+  public void testCreateCircuitBreaker_minCallCountFromOptions() throws OptionsParsingException {
+    RemoteOptions remoteOptions =
+        Options.parse(
+                RemoteOptions.class,
+                "--experimental_circuit_breaker_strategy=failure",
+                "--experimental_remote_failure_rate_threshold=10",
+                "--experimental_remote_failure_window_interval=0",
+                "--experimental_remote_min_call_count_to_compute_failure_rate=5")
+            .getOptions();
+    FailureCircuitBreaker circuitBreaker =
+        (FailureCircuitBreaker) CircuitBreakerFactory.createCircuitBreaker(remoteOptions);
+
+    // Four successes and one failure reach the configured min call count (5) with a 20% failure
+    // rate, which exceeds the 10% threshold. This would not trip under the default min call count
+    // of 100, proving the flag took effect.
+    for (int i = 0; i < 4; i++) {
+      circuitBreaker.recordSuccess();
+    }
+    assertThat(circuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
+    circuitBreaker.recordFailure();
+    assertThat(circuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
@@ -32,7 +32,10 @@ public class FailureCircuitBreakerTest {
     final int failureRateThreshold = 10;
     final int windowInterval = 100;
     FailureCircuitBreaker failureCircuitBreaker =
-        new FailureCircuitBreaker(failureRateThreshold, windowInterval);
+        new FailureCircuitBreaker(
+            failureRateThreshold,
+            windowInterval,
+            CircuitBreakerFactory.DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE);
 
     List<Runnable> listOfSuccessAndFailureCalls = new ArrayList<>();
     for (int index = 0; index < failureRateThreshold; index++) {
@@ -69,7 +72,7 @@ public class FailureCircuitBreakerTest {
     final int minCallToComputeFailure =
         CircuitBreakerFactory.DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE;
     FailureCircuitBreaker failureCircuitBreaker =
-        new FailureCircuitBreaker(failureRateThreshold, windowInterval);
+        new FailureCircuitBreaker(failureRateThreshold, windowInterval, minCallToComputeFailure);
 
     // make half failure call, half success call and number of total call less than
     // minCallToComputeFailure.


### PR DESCRIPTION
Manual cherry-pick of #30178 (commit 23c25a2f6436d4450e2ca5c657bd989dfe7b3386) to `release-8.8.0`, addressing #30203. The automated cherry-pick hit merge conflicts, so this resolves them by hand.

### Why it isn't a clean cherry-pick

`release-8.8.0` predates a later refactor on master that introduced the failure-count "OR trigger" (`minFailCountToComputeFailureRate`), the injected `ScheduledExecutorService`, and the `DEFAULT_MIN_FAIL_COUNT_TO_COMPUTE_FAILURE_RATE` constant. On `release-8.8.0` the failure circuit breaker gates the failure-rate computation solely on a minimum **call** count.

This backport therefore exposes only the flag that applies to `release-8.8.0`:

- `--experimental_remote_min_call_count_to_compute_failure_rate` (default `100`)

The default equals the previously hardcoded `DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE`, so behavior is unchanged unless the flag is set. The companion `--experimental_remote_min_fail_count_to_compute_failure_rate` flag from #30178 is intentionally omitted, because the failure-count trigger it controls does not exist on this branch. Introducing it would also change the breaker's default trip behavior on a patch release.

### Motivation

On large builds using Build without the Bytes, a burst of transient remote-cache errors (for example `ByteStream.Read` deadlines while blobs are being evicted) can cross the fixed threshold and trip the breaker. Once tripped, the breaker rejects further remote calls for the rest of the build and short-circuits the per-call gRPC retries, turning a transient hiccup into a fully local (and much slower) build. The appropriate threshold depends on build size and the remote cache's behavior, so it should be tunable.

### Test plan

- `bazel test //src/test/java/com/google/devtools/build/lib/remote/circuitbreaker:circuitbreaker`
- Added `CircuitBreakerFactoryTest.testCreateCircuitBreaker_minCallCountFromOptions`, which parses the new flag and verifies the breaker trips at the configured minimum call count (and would not under the default of 100).
- Existing `FailureCircuitBreakerTest` cases were updated to pass the threshold through the constructor.

(`FailureCircuitBreakerTest.testRecordFailure_circuitTrips` is a pre-existing timing-sensitive flaky test, tracked in b/287004093 and tagged `manual`; this change does not alter its behavior.)
