### PR TITLE
Fix SimpleLogHandler log rotation/size-cap property names

### DIFF
--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -647,8 +647,9 @@ static std::string GetSimpleLogHandlerProps(
          "com.google.devtools.build.lib.util.SimpleLogHandler.prefix=" +
          java_log.AsJvmArgument() +
          "\n"
-         "com.google.devtools.build.lib.util.SimpleLogHandler.limit=1024000\n"
-         "com.google.devtools.build.lib.util.SimpleLogHandler.total_limit="
+         "com.google.devtools.build.lib.util.SimpleLogHandler.rotate_limit_bytes"
+         "=1024000\n"
+         "com.google.devtools.build.lib.util.SimpleLogHandler.total_limit_bytes="
          "20971520\n"  // 20 MB.
          "com.google.devtools.build.lib.util.SimpleLogHandler.formatter=" +
          java_logging_formatter + "\n";


### PR DESCRIPTION
The server JVM logging config passed 'limit' and 'total_limit' keys, which are FileHandler property names left over from before the switch to SimpleLogHandler (commit 8b99432877). SimpleLogHandler (commit 172d36dfe19) reads 'rotate_limit_bytes' and 'total_limit_bytes', so both values fell back to 0 (unlimited): java.log never rotated and the 20 MB total cap was never enforced. The dead rotate branch also disabled the only per-record flush, leaving the log tail buffered in memory.

### Description

this rewires properties that got lost in commit 8b99432877.

### Motivation

this leaves log records in memory for longer, which makes debugging crashes harder.  

### Build API Changes

n/a

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
