### PR TITLE
[8.8.0] Bump SourceDirectoryIntegrationTest timeout

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -2015,7 +2015,6 @@ java_test(
 
 java_test(
     name = "SourceDirectoryIntegrationTest",
-    timeout = "short",
     srcs = ["SourceDirectoryIntegrationTest.java"],
     jvm_flags = [
         "-DBAZEL_TRACK_SOURCE_DIRECTORIES=1",


### PR DESCRIPTION
Address https://buildkite.com/bazel/bazel-bazel/builds/32076

PiperOrigin-RevId: 758612011
Change-Id: I4d5daef744d4118eddf8ac4a4ca0d4f74bbe648e

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/dd6b9b5c2e6e7357327a605ab9b9f20f724edf0e