### PR TITLE
Fix silent archive-extraction overwrites from APFS path collisions on macOS

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ArFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ArFunction.java
@@ -45,6 +45,7 @@ public class ArFunction implements Decompressor {
     }
 
     Map<String, String> renameFiles = descriptor.renameFiles();
+    HostPathCollisionChecker collisionChecker = HostPathCollisionChecker.create();
 
     try (InputStream decompressorStream =
         new BufferedInputStream(descriptor.archivePath().getInputStream(), BUFFER_SIZE)) {
@@ -70,6 +71,7 @@ public class ArFunction implements Decompressor {
           // happen
           continue;
         } else {
+          collisionChecker.checkAndRecord(entryPathRelative);
           // We do not have to worry about symlinks in .ar files - it's not supported
           // by the .ar file format.
           try (OutputStream out = filePath.getOutputStream()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/BUILD
@@ -21,6 +21,7 @@ java_library(
         "//src/java_tools/singlejar/java/com/google/devtools/build/zip",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository:exception",
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/util:pair",
         "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
@@ -77,6 +77,7 @@ public abstract class CompressedTarFunction implements Decompressor {
     Set<String> availablePrefixes = new HashSet<>();
     // Store link, target info of symlinks, we create them after regular files are extracted.
     Map<Path, PathFragment> symlinks = new LinkedHashMap<>();
+    HostPathCollisionChecker collisionChecker = HostPathCollisionChecker.create();
 
     try (InputStream compressedInputStream = descriptor.archivePath().getInputStream();
         InputStream decompressorStream =
@@ -123,6 +124,7 @@ public abstract class CompressedTarFunction implements Decompressor {
         if (entry.isDirectory()) {
           filePath.createDirectoryAndParents();
         } else {
+          collisionChecker.checkAndRecord(strippedRelativePath);
           if (entry.isSymbolicLink() || entry.isLink()) {
             PathFragment targetName =
                 maybeDeprefixSymlink(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/HostPathCollisionChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/HostPathCollisionChecker.java
@@ -1,0 +1,141 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.decompressor;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.devtools.build.lib.util.OS;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
+import java.text.Normalizer;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Rejects two archive entries whose extraction paths differ byte-for-byte but resolve to the same
+ * file on the host filesystem.
+ *
+ * <p>Bazel keeps archive entry names as raw bytes and compares them byte-for-byte, which is exact
+ * on Linux and Windows. macOS/APFS resolves names through Unicode canonical normalization (so an
+ * NFC and an NFD spelling of an accented name are one file) and, on the default case-insensitive
+ * volume, through full case folding (so {@code SECRET} and {@code secret}, the sharp s and {@code
+ * ss}, and the Latin ligatures and their component letters are one file). Two such entries would
+ * otherwise extract on top of each other, letting the second silently replace the contents written
+ * for the first under a name the byte-level code never sees as equal.
+ *
+ * <p>The containment checks in the decompressors stay byte-level: they are conservative in the
+ * escaping direction and folding them would only widen what they accept. This check instead closes
+ * the collision that the byte-level logic cannot see.
+ *
+ * <p>One instance tracks a single extraction and is not thread-safe.
+ */
+final class HostPathCollisionChecker {
+
+  private final Map<String, String> firstPathByResolvedForm = new HashMap<>();
+  private final boolean normalizeUnicode;
+  private final boolean foldCase;
+
+  @VisibleForTesting
+  HostPathCollisionChecker(boolean normalizeUnicode, boolean foldCase) {
+    this.normalizeUnicode = normalizeUnicode;
+    this.foldCase = foldCase;
+  }
+
+  /**
+   * Returns a checker configured for the host the Bazel server runs on. It is a no-op on every
+   * platform except macOS. On macOS canonical normalization always applies; case folding applies
+   * unless {@code -Dbazel.darwin.case_sensitive=true} declares the volume case-sensitive.
+   */
+  static HostPathCollisionChecker create() {
+    if (OS.getCurrent() != OS.DARWIN) {
+      return new HostPathCollisionChecker(false, false);
+    }
+    return new HostPathCollisionChecker(true, !Boolean.getBoolean("bazel.darwin.case_sensitive"));
+  }
+
+  /**
+   * Records {@code relativePath} as an extraction target and throws if a byte-distinct target that
+   * resolves to the same host file was already recorded during this extraction. Two entries that
+   * share the exact same bytes are left to the existing last-writer-wins behavior.
+   */
+  void checkAndRecord(PathFragment relativePath) throws IOException {
+    if (!normalizeUnicode && !foldCase) {
+      // No folding applies off macOS, so no two byte-distinct paths can collide; skip the map
+      // entirely to keep extraction allocation-free on Linux and Windows.
+      return;
+    }
+    String path = relativePath.getPathString();
+    String existing = firstPathByResolvedForm.putIfAbsent(resolvedForm(path), path);
+    if (existing != null && !existing.equals(path)) {
+      throw new IOException(
+          String.format(
+              "Failed to extract %s, it resolves to the same file as %s on this filesystem",
+              path, existing));
+    }
+  }
+
+  /**
+   * Maps a Bazel-internal path string to a representative that is equal for two paths iff the host
+   * filesystem resolves them to the same file.
+   */
+  @VisibleForTesting
+  String resolvedForm(String path) {
+    if (!normalizeUnicode) {
+      return path;
+    }
+    String unicode = recoverUnicode(path);
+    if (unicode == null) {
+      // Not valid UTF-8; the filesystem treats such a name as opaque bytes, so compare raw bytes.
+      return path;
+    }
+    String resolved = Normalizer.normalize(unicode, Normalizer.Form.NFC);
+    if (foldCase) {
+      // Upper- then lower-casing folds case across the whole string the way a case-insensitive
+      // volume equates names, including the sharp s (to "ss") and the Latin ligatures.
+      resolved = resolved.toUpperCase(Locale.ROOT).toLowerCase(Locale.ROOT);
+    }
+    return resolved;
+  }
+
+  /**
+   * Recovers the Unicode name from Bazel's internal path representation, in which archive entry
+   * names are the original bytes held one per char as ISO-8859-1. Returns the argument unchanged if
+   * it is pure ASCII (already valid, identical UTF-8) or already holds decoded Unicode (any char
+   * above 0xFF), or null if the bytes are not UTF-8.
+   */
+  private static String recoverUnicode(String internalPath) {
+    boolean isAscii = true;
+    for (int i = 0; i < internalPath.length(); i++) {
+      char c = internalPath.charAt(i);
+      if (c > 0xFF) {
+        return internalPath;
+      }
+      if (c >= 0x80) {
+        isAscii = false;
+      }
+    }
+    if (isAscii) {
+      // ASCII is a subset of both ISO-8859-1 and UTF-8, so the string is already its decoded form.
+      return internalPath;
+    }
+    byte[] bytes = internalPath.getBytes(ISO_8859_1);
+    String candidate = new String(bytes, UTF_8);
+    return Arrays.equals(candidate.getBytes(UTF_8), bytes) ? candidate : null;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/SevenZDecompressor.java
@@ -50,6 +50,7 @@ public class SevenZDecompressor implements Decompressor {
     int stripComponents = descriptor.stripComponents();
     ImmutableMap<String, String> renameFiles = descriptor.renameFiles();
     boolean foundPrefix = false;
+    HostPathCollisionChecker collisionChecker = HostPathCollisionChecker.create();
 
     try (SevenZFile sevenZFile =
         SevenZFile.builder().setFile(descriptor.archivePath().getPathFile()).get()) {
@@ -86,7 +87,8 @@ public class SevenZDecompressor implements Decompressor {
         if (entryPath.skip()) {
           continue;
         }
-        extract7zEntry(sevenZFile, entry, destinationDirectory, entryPath.getPathFragment());
+        extract7zEntry(
+            sevenZFile, entry, destinationDirectory, entryPath.getPathFragment(), collisionChecker);
       }
 
       if (!prefix.isEmpty() && !foundPrefix) {
@@ -107,7 +109,8 @@ public class SevenZDecompressor implements Decompressor {
       SevenZFile sevenZFile,
       SevenZArchiveEntry entry,
       Path destinationDirectory,
-      PathFragment strippedRelativePath)
+      PathFragment strippedRelativePath,
+      HostPathCollisionChecker collisionChecker)
       throws IOException, InterruptedException {
     if (strippedRelativePath.isAbsolute()) {
       throw new IOException(
@@ -126,6 +129,7 @@ public class SevenZDecompressor implements Decompressor {
     if (isDirectory) {
       outputPath.createDirectoryAndParents();
     } else {
+      collisionChecker.checkAndRecord(strippedRelativePath);
       try (InputStream input = sevenZFile.getInputStream(entry);
           OutputStream output = outputPath.getOutputStream()) {
         ByteStreams.copy(input, output);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/ZipDecompressor.java
@@ -83,6 +83,7 @@ public class ZipDecompressor implements Decompressor {
     boolean foundPrefix = false;
     // Store link, target info of symlinks, we create them after regular files are extracted.
     Map<Path, PathFragment> symlinks = new HashMap<>();
+    HostPathCollisionChecker collisionChecker = HostPathCollisionChecker.create();
 
     try (ZipReader reader = new ZipReader(descriptor.archivePath().getPathFile())) {
       Collection<ZipFileEntry> entries = reader.entries();
@@ -102,7 +103,8 @@ public class ZipDecompressor implements Decompressor {
             entryPath.getPathFragment(),
             prefix,
             stripComponents,
-            symlinks);
+            symlinks,
+            collisionChecker);
       }
 
       if (!prefix.isEmpty() && !foundPrefix) {
@@ -131,7 +133,8 @@ public class ZipDecompressor implements Decompressor {
       PathFragment strippedRelativePath,
       String prefix,
       int stripComponents,
-      Map<Path, PathFragment> symlinks)
+      Map<Path, PathFragment> symlinks,
+      HostPathCollisionChecker collisionChecker)
       throws IOException, InterruptedException {
     if (strippedRelativePath.isAbsolute()) {
       throw new IOException(
@@ -151,45 +154,48 @@ public class ZipDecompressor implements Decompressor {
     boolean isSymlink = (permissions & S_IFLNK) == S_IFLNK;
     if (isDirectory) {
       outputPath.createDirectoryAndParents();
-    } else if (isSymlink) {
-      Preconditions.checkState(entry.getSize() < MAX_PATH_LENGTH);
-      byte[] buffer = new byte[(int) entry.getSize()];
-      // For symlinks, the "compressed data" is actually the target name.
-      int read = reader.getInputStream(entry).read(buffer);
-      Preconditions.checkState(read == buffer.length);
-
-      PathFragment target = StripPrefixedPath.createPathFragment(buffer);
-      Path targetPath = outputPath.getParentDirectory().getRelative(target);
-      if (!target.isAbsolute() && !targetPath.startsWith(destinationDirectory)) {
-        throw new IOException(
-            "Zip entries cannot refer to files outside of their directory: "
-                + reader.getFilename()
-                + " has a symlink "
-                + strippedRelativePath
-                + " pointing to "
-                + new String(buffer, UTF_8));
-      }
-
-      symlinks.put(
-          outputPath,
-          maybeDeprefixSymlink(
-              buffer,
-              prefix,
-              stripComponents,
-              destinationDirectory,
-              /* forceExtractRootRelative= */ false));
     } else {
-      try (InputStream input = reader.getInputStream(entry);
-          OutputStream output = outputPath.getOutputStream()) {
-        ByteStreams.copy(input, output);
-        if (Thread.interrupted()) {
-          throw new InterruptedException();
+      collisionChecker.checkAndRecord(strippedRelativePath);
+      if (isSymlink) {
+        Preconditions.checkState(entry.getSize() < MAX_PATH_LENGTH);
+        byte[] buffer = new byte[(int) entry.getSize()];
+        // For symlinks, the "compressed data" is actually the target name.
+        int read = reader.getInputStream(entry).read(buffer);
+        Preconditions.checkState(read == buffer.length);
+
+        PathFragment target = StripPrefixedPath.createPathFragment(buffer);
+        Path targetPath = outputPath.getParentDirectory().getRelative(target);
+        if (!target.isAbsolute() && !targetPath.startsWith(destinationDirectory)) {
+          throw new IOException(
+              "Zip entries cannot refer to files outside of their directory: "
+                  + reader.getFilename()
+                  + " has a symlink "
+                  + strippedRelativePath
+                  + " pointing to "
+                  + new String(buffer, UTF_8));
         }
+
+        symlinks.put(
+            outputPath,
+            maybeDeprefixSymlink(
+                buffer,
+                prefix,
+                stripComponents,
+                destinationDirectory,
+                /* forceExtractRootRelative= */ false));
+      } else {
+        try (InputStream input = reader.getInputStream(entry);
+            OutputStream output = outputPath.getOutputStream()) {
+          ByteStreams.copy(input, output);
+          if (Thread.interrupted()) {
+            throw new InterruptedException();
+          }
+        }
+        // Ensure that all files are at least user-readable. Some archives contain files that
+        // are not, but many other tools are working around this and thus mask these issues.
+        outputPath.chmod(permissions | 0400);
+        outputPath.setLastModifiedTime(entry.getTime());
       }
-      // Ensure that all files are at least user-readable. Some archives contain files that
-      // are not, but many other tools are working around this and thus mask these issues.
-      outputPath.chmod(permissions | 0400);
-      outputPath.setLastModifiedTime(entry.getTime());
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/HostPathCollisionCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/HostPathCollisionCheckerTest.java
@@ -1,0 +1,116 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.decompressor;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertThrows;
+
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link HostPathCollisionChecker}. Non-ASCII entry names use unicode escapes. */
+@RunWith(JUnit4.class)
+public final class HostPathCollisionCheckerTest {
+
+  // Builds the internal path representation a tar/zip/7z entry name would have: the name's UTF-8
+  // bytes held one per char as ISO-8859-1.
+  private static PathFragment entry(String name) {
+    return PathFragment.create(new String(name.getBytes(UTF_8), ISO_8859_1));
+  }
+
+  private static void assertCollision(
+      boolean normalize, boolean foldCase, String first, String second) throws IOException {
+    HostPathCollisionChecker checker = new HostPathCollisionChecker(normalize, foldCase);
+    checker.checkAndRecord(entry(first));
+    assertThrows(IOException.class, () -> checker.checkAndRecord(entry(second)));
+  }
+
+  private static void assertNoCollision(boolean normalize, boolean foldCase, String... names)
+      throws IOException {
+    HostPathCollisionChecker checker = new HostPathCollisionChecker(normalize, foldCase);
+    for (String name : names) {
+      checker.checkAndRecord(entry(name));
+    }
+  }
+
+  @Test
+  public void caseInsensitive_foldsSharpSLigaturesAndCase() throws Exception {
+    assertCollision(true, true, "ss_output.txt", "\u00df_output.txt"); // ss vs sharp s
+    assertCollision(true, true, "fi_c", "\ufb01_c"); // fi ligature
+    assertCollision(true, true, "ff_d", "\ufb00_d");
+    assertCollision(true, true, "fl_l", "\ufb02_l");
+    assertCollision(true, true, "ffi_t", "\ufb03_t");
+    assertCollision(true, true, "ffl_r", "\ufb04_r");
+    assertCollision(true, true, "st_k", "\ufb05_k"); // long-s t ligature
+    assertCollision(true, true, "SECRET.env", "secret.env");
+    assertCollision(true, true, "CONFIG.json", "config.json");
+  }
+
+  @Test
+  public void caseInsensitive_foldsCanonicalNfcNfd() throws Exception {
+    assertCollision(true, true, "\u00e9_p", "e\u0301_p"); // e-acute NFC vs NFD
+    assertCollision(true, true, "\u00f1_p", "n\u0303_p"); // n-tilde NFC vs NFD
+  }
+
+  @Test
+  public void caseInsensitive_nestedFoldedDirectoryCollides() throws Exception {
+    assertCollision(true, true, "dir_\u00df/x", "dir_ss/x");
+  }
+
+  @Test
+  public void caseInsensitive_doesNotOverfoldCompatibilityForms() throws Exception {
+    // APFS keeps these distinct; NFKC would wrongly fold them, so the check must not.
+    assertNoCollision(true, true, "\uff21_x", "A_x"); // fullwidth A vs A
+    assertNoCollision(true, true, "x\u00b2", "x2"); // superscript two
+    assertNoCollision(true, true, "\u2460_w", "1_w"); // circled one
+    assertNoCollision(true, true, "\u216b_v", "XII_v"); // roman numeral twelve
+  }
+
+  @Test
+  public void caseSensitive_foldsNormalizationOnly() throws Exception {
+    assertCollision(true, false, "\u00e9_p", "e\u0301_p"); // NFC/NFD still collide
+    assertNoCollision(true, false, "ss_output.txt", "\u00df_output.txt"); // case fold off
+    assertNoCollision(true, false, "SECRET.env", "secret.env");
+    assertNoCollision(true, false, "fi_c", "\ufb01_c");
+  }
+
+  @Test
+  public void nonDarwin_identityFoldsNothing() throws Exception {
+    assertNoCollision(false, false, "ss_output.txt", "\u00df_output.txt");
+    assertNoCollision(false, false, "SECRET.env", "secret.env");
+    assertNoCollision(false, false, "\u00e9_p", "e\u0301_p");
+  }
+
+  @Test
+  public void identicalBytePathIsAllowed() throws Exception {
+    assertNoCollision(true, true, "dup.txt", "dup.txt");
+  }
+
+  @Test
+  public void distinctNamesAreAllowed() throws Exception {
+    assertNoCollision(true, true, "a.txt", "b.txt", "sub/c.txt", "\u00df_only.txt");
+  }
+
+  @Test
+  public void create_returnsUsableCheckerOnAnyHost() throws Exception {
+    HostPathCollisionChecker checker = HostPathCollisionChecker.create();
+    checker.checkAndRecord(PathFragment.create("a.txt"));
+    checker.checkAndRecord(PathFragment.create("b.txt"));
+  }
+}


### PR DESCRIPTION
### Description
On macOS the archive decompressors compare entry names as raw bytes, but APFS folds names through Unicode normalization (NFC/NFD) and, on case-insensitive volumes, case folding. Two byte-distinct entries can therefore hit the same inode, and the second silently overwrites the first: for example `pkg/ss_output.txt` and `pkg/ß_output.txt` under `strip_prefix "pkg"`, or `SECRET.env` next to `secret.env`. Both still land inside the destination, so this is a name collision (CWE-706, CWE-176), not a directory escape.

I add `HostPathCollisionChecker`. Per extraction it records each written target in the host's equivalence form and throws if a byte-distinct entry resolves to one already written. It is wired into `CompressedTarFunction`, `ZipDecompressor`, `SevenZDecompressor` and `ArFunction`; identical bytes keep the current last-writer-wins behavior. Folding is canonical NFC plus case folding, not NFKC, which over-folds compatibility forms that APFS keeps distinct. Off macOS it is a no-op, so Linux and Windows are unchanged. `-Dbazel.darwin.case_sensitive=true` drops the case-fold step for case-sensitive volumes.

### Motivation
A silent overwrite during extraction is a data integrity bug: an archive can carry two files a Linux build sees as separate, and on a Mac one clobbers the other with no warning. This turns the collision into a hard error instead.

### Build API Changes
No

### Checklist
- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes
RELNOTES: On macOS, archive extraction now errors when two byte-distinct entries resolve to the same path under APFS normalization or case folding, instead of silently overwriting.