### PR TITLE
Provide a means to record remote spawn memory usage

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -318,6 +318,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util:exit_code",
         "//src/main/java/com/google/devtools/build/lib/util/io",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/protobuf:execution_statistics_java_proto",
         "//src/main/protobuf:failure_details_java_proto",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -34,6 +34,7 @@ import build.bazel.remote.execution.v2.ExecutionStage.Value;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -68,11 +69,16 @@ import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.remote.util.Utils.InMemoryOutput;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
+import com.google.devtools.build.lib.shell.Protos.ExecutionStatistics;
+import com.google.devtools.build.lib.shell.Protos.ResourceUsage;
 import com.google.devtools.build.lib.util.ExitCode;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
@@ -322,7 +328,10 @@ public class RemoteSpawnRunner implements SpawnRunner {
             maybePrintExecutionMessages(context, result.getMessage(), result.success());
 
             profileAccounting(clampTimeNanos, result.getExecutionMetadata());
-            spawnMetricsAccounting(spawnMetrics, result.getExecutionMetadata());
+            spawnMetricsAccounting(
+                spawnMetrics,
+                result.getExecutionMetadata(),
+                remoteOptions.getRemoteMeasuredMemorySource());
 
             try (SilentCloseable c = prof.profile(REMOTE_DOWNLOAD, "download server logs")) {
               maybeDownloadServerLogs(action, result.getResponse());
@@ -437,7 +446,9 @@ public class RemoteSpawnRunner implements SpawnRunner {
 
   @VisibleForTesting
   static void spawnMetricsAccounting(
-      SpawnMetrics.Builder spawnMetrics, ExecutedActionMetadata executionMetadata) {
+      SpawnMetrics.Builder spawnMetrics,
+      ExecutedActionMetadata executionMetadata,
+      @Nullable RemoteOptions.MeasuredMemorySource measuredMemorySource) {
     // Expect that a non-empty worker indicates that all fields are populated.
     // If the bounded sides of these checkpoints are default timestamps, i.e. unset,
     // the phase durations can be extremely large. Unset pairs, or a fully unset
@@ -468,6 +479,114 @@ public class RemoteSpawnRunner implements SpawnRunner {
               executionMetadata.getOutputUploadCompletedTimestamp());
       spawnMetrics.setProcessOutputsTime(remoteProcessOutputsTime);
     }
+
+    // Measured peak memory usage is carried in the worker-specific auxiliary metadata (e.g. a
+    // getrusage(2) message on POSIX-like systems), independently of the timestamp-based accounting
+    // above. This mirrors the local execution path, which derives the measured peak memory from the
+    // parsed execution statistics.
+    spawnMetricsMemoryAccounting(spawnMetrics, executionMetadata, measuredMemorySource);
+  }
+
+  /**
+   * Populates the measured peak memory from the auxiliary metadata, if present.
+   *
+   * <p>If a {@link RemoteOptions.MeasuredMemorySource} is configured (via
+   * {@code --experimental_remote_measured_memory_source}), the entry matching its type URL is read
+   * by walking to the configured field number path. This lets Bazel read peak memory from an
+   * arbitrary backend's proto without compiling it in. Otherwise, Bazel falls back to its own
+   * {@link ExecutionStatistics} message. Its {@code maxrss} is in kilobytes per the getrusage(2)
+   * convention (e.g. as produced by Bazel's {@code linux-sandbox}).
+   */
+  private static void spawnMetricsMemoryAccounting(
+      SpawnMetrics.Builder spawnMetrics,
+      ExecutedActionMetadata executionMetadata,
+      @Nullable RemoteOptions.MeasuredMemorySource measuredMemorySource) {
+    // A user-configured source takes precedence over the built-in default.
+    if (measuredMemorySource != null) {
+      for (Any auxiliaryMetadata : executionMetadata.getAuxiliaryMetadataList()) {
+        if (!auxiliaryMetadata.getTypeUrl().equals(measuredMemorySource.typeUrl())) {
+          continue;
+        }
+        long rawValue =
+            readInt64AtFieldPath(auxiliaryMetadata.getValue(), measuredMemorySource.fieldPath());
+        long measuredMemoryPeakBytes = rawValue * measuredMemorySource.bytesPerUnit();
+        if (measuredMemoryPeakBytes > 0) {
+          spawnMetrics.setMeasuredMemoryPeakBytes(measuredMemoryPeakBytes);
+        }
+        return;
+      }
+    }
+
+    for (Any auxiliaryMetadata : executionMetadata.getAuxiliaryMetadataList()) {
+      if (!auxiliaryMetadata.is(ExecutionStatistics.class)) {
+        continue;
+      }
+      try {
+        ResourceUsage resourceUsage =
+            auxiliaryMetadata.unpack(ExecutionStatistics.class).getResourceUsage();
+        long measuredMemoryPeakBytes = resourceUsage.getMaxrss() * 1024;
+        if (measuredMemoryPeakBytes > 0) {
+          spawnMetrics.setMeasuredMemoryPeakBytes(measuredMemoryPeakBytes);
+        }
+      } catch (InvalidProtocolBufferException e) {
+        // Ignore malformed auxiliary metadata rather than failing the spawn over a metric.
+      }
+      return;
+    }
+  }
+
+  // Protocol buffer wire types (see https://protobuf.dev/programming-guides/encoding/).
+  private static final int WIRETYPE_VARINT = 0;
+  private static final int WIRETYPE_FIXED64 = 1;
+  private static final int WIRETYPE_LENGTH_DELIMITED = 2;
+  private static final int WIRETYPE_FIXED32 = 5;
+
+  /**
+   * Reads an integer field from a serialized protocol buffer message by walking the given path of
+   * field numbers, descending into submessages for every path element but the last. Returns 0 if
+   * the path cannot be resolved or the bytes are malformed; this is best-effort metric extraction
+   * that must never fail the spawn.
+   */
+  private static long readInt64AtFieldPath(
+      ByteString serialized, ImmutableList<Integer> fieldPath) {
+    try {
+      return readInt64AtFieldPath(serialized.newCodedInput(), fieldPath, 0);
+    } catch (IOException e) {
+      return 0;
+    }
+  }
+
+  private static long readInt64AtFieldPath(
+      CodedInputStream input, ImmutableList<Integer> fieldPath, int depth) throws IOException {
+    int targetField = fieldPath.get(depth);
+    boolean leaf = depth == fieldPath.size() - 1;
+    for (int tag = input.readTag(); tag != 0; tag = input.readTag()) {
+      int fieldNumber = tag >>> 3;
+      int wireType = tag & 0x7;
+      if (fieldNumber != targetField) {
+        input.skipField(tag);
+        continue;
+      }
+      if (leaf) {
+        switch (wireType) {
+          case WIRETYPE_VARINT:
+            return input.readInt64();
+          case WIRETYPE_FIXED64:
+            return input.readFixed64();
+          case WIRETYPE_FIXED32:
+            return Integer.toUnsignedLong(input.readFixed32());
+          default:
+            input.skipField(tag);
+            return 0;
+        }
+      }
+      if (wireType != WIRETYPE_LENGTH_DELIMITED) {
+        input.skipField(tag);
+        continue;
+      }
+      return readInt64AtFieldPath(input.readBytes().newCodedInput(), fieldPath, depth + 1);
+    }
+    return 0;
   }
 
   private SpawnResult downloadAndFinalizeSpawnResult(

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -14,7 +14,10 @@
 
 package com.google.devtools.build.lib.remote.options;
 
+import com.google.common.base.Ascii;
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.devtools.build.lib.remote.Scrubber;
 import com.google.devtools.build.lib.util.OptionsUtils;
@@ -861,6 +864,31 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
   public abstract void setScrubber(Scrubber value);
 
   @Option(
+      name = "experimental_remote_measured_memory_source",
+      converter = MeasuredMemorySourceConverter.class,
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      metadataTags = OptionMetadataTag.EXPERIMENTAL,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "Configures where Bazel reads the measured peak memory of remotely executed actions from"
+              + " the worker-provided auxiliary metadata"
+              + " (ExecutedActionMetadata.auxiliary_metadata), so it can be recorded as"
+              + " measured_memory_peak_bytes in the execution log.\n\n"
+              + "The value has the form <type_url>:<field_path>[:<unit>], where:\n"
+              + " - <type_url> is the type URL of the auxiliary metadata entry, e.g."
+              + " type.googleapis.com/tools.protos.ExecutionStatistics;\n"
+              + " - <field_path> is a dot-separated path of protocol buffer field numbers locating"
+              + " the integer field holding the peak memory, e.g. 1.5 for field 5 nested inside"
+              + " submessage field 1;\n"
+              + " - <unit> is an optional multiplier to bytes: bytes (default), kb, mb, gb, or a"
+              + " positive integer.\n\n"
+              + "This does not require the backend's proto to be compiled into Bazel; only the"
+              + " field numbers are needed. If unset, Bazel still recognizes its own"
+              + " tools.protos.ExecutionStatistics auxiliary metadata by default.")
+  public abstract MeasuredMemorySource getRemoteMeasuredMemorySource();
+
+  @Option(
       name = "experimental_remote_cache_chunking",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.REMOTE,
@@ -926,6 +954,129 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
     @Override
     public String getTypeDescription() {
       return "Converts to a Scrubber";
+    }
+  }
+
+  /**
+   * Describes where to find the measured peak memory of a remotely executed action within the
+   * worker-provided {@code ExecutedActionMetadata.auxiliary_metadata}.
+   *
+   * <p>Because auxiliary metadata entries are opaque {@code Any} messages whose concrete type is
+   * backend-specific, this identifies the entry by its type URL and the (possibly nested) protocol
+   * buffer field number path of the integer holding the peak memory, plus a multiplier converting
+   * that value to bytes. This avoids compiling the backend's proto into Bazel.
+   */
+  public static final class MeasuredMemorySource {
+    private final String typeUrl;
+    private final ImmutableList<Integer> fieldPath;
+    private final long bytesPerUnit;
+    private final String rawValue;
+
+    MeasuredMemorySource(
+        String typeUrl, ImmutableList<Integer> fieldPath, long bytesPerUnit, String rawValue) {
+      this.typeUrl = typeUrl;
+      this.fieldPath = fieldPath;
+      this.bytesPerUnit = bytesPerUnit;
+      this.rawValue = rawValue;
+    }
+
+    /** The type URL of the auxiliary metadata {@code Any} entry to read from. */
+    public String typeUrl() {
+      return typeUrl;
+    }
+
+    /** The dot-path of protocol buffer field numbers locating the peak memory integer. */
+    public ImmutableList<Integer> fieldPath() {
+      return fieldPath;
+    }
+
+    /** The multiplier converting the raw field value to bytes. */
+    public long bytesPerUnit() {
+      return bytesPerUnit;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof MeasuredMemorySource other && rawValue.equals(other.rawValue);
+    }
+
+    @Override
+    public int hashCode() {
+      return rawValue.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return rawValue;
+    }
+  }
+
+  /** Converts {@code <type_url>:<field_path>[:<unit>]} to a {@link MeasuredMemorySource}. */
+  public static final class MeasuredMemorySourceConverter
+      extends Converter.Contextless<MeasuredMemorySource> {
+
+    @Override
+    public MeasuredMemorySource convert(String input) throws OptionsParsingException {
+      List<String> parts = Splitter.on(':').splitToList(input);
+      if (parts.size() < 2 || parts.size() > 3) {
+        throw new OptionsParsingException(
+            "Expected <type_url>:<field_path>[:<unit>], got: " + input);
+      }
+      String typeUrl = parts.get(0);
+      if (typeUrl.isEmpty()) {
+        throw new OptionsParsingException("Empty type URL in: " + input);
+      }
+      ImmutableList.Builder<Integer> fieldPath = ImmutableList.builder();
+      for (String field : Splitter.on('.').split(parts.get(1))) {
+        int fieldNumber;
+        try {
+          fieldNumber = Integer.parseInt(field);
+        } catch (NumberFormatException e) {
+          throw new OptionsParsingException(
+              "Field path must be dot-separated positive integers, got: " + parts.get(1), e);
+        }
+        if (fieldNumber <= 0) {
+          throw new OptionsParsingException("Field numbers must be positive, got: " + fieldNumber);
+        }
+        fieldPath.add(fieldNumber);
+      }
+      long bytesPerUnit = parts.size() == 3 ? parseUnit(parts.get(2)) : 1;
+      return new MeasuredMemorySource(typeUrl, fieldPath.build(), bytesPerUnit, input);
+    }
+
+    private static long parseUnit(String unit) throws OptionsParsingException {
+      switch (Ascii.toLowerCase(unit)) {
+        case "b":
+        case "bytes":
+          return 1;
+        case "kb":
+        case "kib":
+          return 1024;
+        case "mb":
+        case "mib":
+          return 1024L * 1024;
+        case "gb":
+        case "gib":
+          return 1024L * 1024 * 1024;
+        default:
+          long scale;
+          try {
+            scale = Long.parseLong(unit);
+          } catch (NumberFormatException e) {
+            throw new OptionsParsingException(
+                "Unit must be one of bytes/kb/mb/gb or a positive integer multiplier, got: " + unit,
+                e);
+          }
+          if (scale <= 0) {
+            throw new OptionsParsingException("Unit multiplier must be positive, got: " + scale);
+          }
+          return scale;
+      }
+    }
+
+    @Override
+    public String getTypeDescription() {
+      return "a peak-memory source of the form <type_url>:<field_path>[:<unit>]";
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -189,6 +189,7 @@ java_library(
         "//src/main/protobuf:bazel_output_service_java_grpc",
         "//src/main/protobuf:bazel_output_service_java_proto",
         "//src/main/protobuf:cache_salt_java_proto",
+        "//src/main/protobuf:execution_statistics_java_proto",
         "//src/main/protobuf:failure_details_java_proto",
         "//src/main/protobuf:invocation_policy_java_proto",
         "//src/main/protobuf:remote_execution_log_java_proto",

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -100,6 +100,8 @@ import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOutputsMode;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.FakeSpawnExecutionContext;
+import com.google.devtools.build.lib.shell.Protos.ExecutionStatistics;
+import com.google.devtools.build.lib.shell.Protos.ResourceUsage;
 import com.google.devtools.build.lib.testutil.TestConstants;
 import com.google.devtools.build.lib.testutil.TestUtils;
 import com.google.devtools.build.lib.util.ExitCode;
@@ -1499,7 +1501,9 @@ public class RemoteSpawnRunnerTest {
   public void accountingDisabledWithoutWorker() {
     SpawnMetrics.Builder spawnMetrics = Mockito.mock(SpawnMetrics.Builder.class);
     RemoteSpawnRunner.spawnMetricsAccounting(
-        spawnMetrics, ExecutedActionMetadata.getDefaultInstance());
+        spawnMetrics,
+        ExecutedActionMetadata.getDefaultInstance(),
+        /* measuredMemorySource= */ null);
     verifyNoMoreInteractions(spawnMetrics);
   }
 
@@ -1528,7 +1532,8 @@ public class RemoteSpawnRunnerTest {
             .setOutputUploadStartTimestamp(outputUploadStart)
             .setOutputUploadCompletedTimestamp(outputUploadComplete)
             .build();
-    RemoteSpawnRunner.spawnMetricsAccounting(builder, executedMetadata);
+    RemoteSpawnRunner.spawnMetricsAccounting(
+        builder, executedMetadata, /* measuredMemorySource= */ null);
     SpawnMetrics spawnMetrics = builder.build();
     // remote queue time is accumulated
     assertThat(spawnMetrics.queueTimeInMs()).isEqualTo(2 * 1000L);
@@ -1538,6 +1543,100 @@ public class RemoteSpawnRunnerTest {
     assertThat(spawnMetrics.executionWallTimeInMs()).isEqualTo(1 * 1000L);
     // ProcessOutputs time is unspecified, assume substituted
     assertThat(spawnMetrics.processOutputsTimeInMs()).isEqualTo(1 * 1000L);
+  }
+
+  @Test
+  public void accountingReadsMeasuredMemoryFromAuxiliaryMetadata() {
+    SpawnMetrics.Builder builder = SpawnMetrics.Builder.forRemoteExec();
+    // maxrss follows the getrusage(2) convention of being reported in kilobytes.
+    long maxRssKb = 12345;
+    ExecutedActionMetadata executedMetadata =
+        ExecutedActionMetadata.newBuilder()
+            .setWorker("test worker")
+            .addAuxiliaryMetadata(
+                Any.pack(
+                    ExecutionStatistics.newBuilder()
+                        .setResourceUsage(ResourceUsage.newBuilder().setMaxrss(maxRssKb))
+                        .build()))
+            .build();
+
+    RemoteSpawnRunner.spawnMetricsAccounting(
+        builder, executedMetadata, /* measuredMemorySource= */ null);
+
+    assertThat(builder.build().measuredMemoryPeak()).isEqualTo(maxRssKb * 1024);
+  }
+
+  @Test
+  public void accountingIgnoresUnrelatedAuxiliaryMetadata() {
+    SpawnMetrics.Builder builder = SpawnMetrics.Builder.forRemoteExec();
+    ExecutedActionMetadata executedMetadata =
+        ExecutedActionMetadata.newBuilder()
+            .setWorker("test worker")
+            .addAuxiliaryMetadata(Any.pack(Timestamp.getDefaultInstance()))
+            .build();
+
+    RemoteSpawnRunner.spawnMetricsAccounting(
+        builder, executedMetadata, /* measuredMemorySource= */ null);
+
+    assertThat(builder.build().measuredMemoryPeak()).isEqualTo(0L);
+  }
+
+  @Test
+  public void accountingReadsMeasuredMemoryFromConfiguredSource() throws Exception {
+    SpawnMetrics.Builder builder = SpawnMetrics.Builder.forRemoteExec();
+    // Simulate an arbitrary backend that reports peak memory (in KiB) at field 5 nested inside
+    // submessage field 1 of a message Bazel doesn't have compiled in. We reuse ExecutionStatistics
+    // purely as a stand-in with that exact field layout (resource_usage=1, maxrss=5).
+    long peakMemoryKb = 4096;
+    Any backendMetadata =
+        Any.pack(
+            ExecutionStatistics.newBuilder()
+                .setResourceUsage(ResourceUsage.newBuilder().setMaxrss(peakMemoryKb))
+                .build());
+    // Rewrite the type URL so it doesn't match Bazel's built-in ExecutionStatistics recognition.
+    Any backendMetadataWithCustomType =
+        backendMetadata.toBuilder()
+            .setTypeUrl("type.googleapis.com/example.backend.ResourceUsage")
+            .build();
+    ExecutedActionMetadata executedMetadata =
+        ExecutedActionMetadata.newBuilder()
+            .setWorker("test worker")
+            .addAuxiliaryMetadata(backendMetadataWithCustomType)
+            .build();
+    RemoteOptions.MeasuredMemorySource source =
+        new RemoteOptions.MeasuredMemorySourceConverter()
+            .convert("type.googleapis.com/example.backend.ResourceUsage:1.5:kb");
+
+    RemoteSpawnRunner.spawnMetricsAccounting(builder, executedMetadata, source);
+
+    assertThat(builder.build().measuredMemoryPeak()).isEqualTo(peakMemoryKb * 1024);
+  }
+
+  @Test
+  public void accountingConfiguredSourceTakesPrecedenceOverBuiltin() throws Exception {
+    SpawnMetrics.Builder builder = SpawnMetrics.Builder.forRemoteExec();
+    // A built-in ExecutionStatistics entry (maxrss field 5) read by default otherwise.
+    Any builtin =
+        Any.pack(
+            ExecutionStatistics.newBuilder()
+                .setResourceUsage(ResourceUsage.newBuilder().setMaxrss(1))
+                .build());
+    ExecutedActionMetadata executedMetadata =
+        ExecutedActionMetadata.newBuilder()
+            .setWorker("test worker")
+            .addAuxiliaryMetadata(builtin)
+            .build();
+    // Point the configured source at the same entry but a different field (utime_sec=1), so we can
+    // prove the configured source, not the built-in maxrss, is what gets read.
+    RemoteOptions.MeasuredMemorySource source =
+        new RemoteOptions.MeasuredMemorySourceConverter()
+            .convert(builtin.getTypeUrl() + ":1.1:kb");
+
+    RemoteSpawnRunner.spawnMetricsAccounting(builder, executedMetadata, source);
+
+    // utime_sec is 0 in the built-in entry, so the configured (precedence) read yields 0, not the
+    // maxrss-derived 1 * 1024 the built-in path would have produced.
+    assertThat(builder.build().measuredMemoryPeak()).isEqualTo(0L);
   }
 
   @Test

--- a/src/test/shell/bazel/remote/remote_execution_sandboxing_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_sandboxing_test.sh
@@ -101,6 +101,40 @@ function test_genrule() {
     || fail "Hermetic genrule failed: examples/genrule:simple"
 }
 
+function test_genrule_reports_measured_memory() {
+  bazel build \
+      --spawn_strategy=remote \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_cache=grpc://localhost:${worker_port} \
+      --execution_log_json_file=output.json \
+      examples/genrule:simple &> $TEST_log \
+    || fail "Hermetic genrule failed: examples/genrule:simple"
+
+  # The sandbox measures peak memory and the remote worker propagates it to the client through the
+  # action's auxiliary metadata, so the execution log should record a non-zero measured peak memory
+  # for the remotely executed spawn. Proto3 JSON omits zero-valued fields, so the presence of the
+  # field confirms a non-zero value was recorded.
+  grep '"measuredMemoryPeakBytes"' output.json \
+    || fail "execution log does not contain measured peak memory for remotely executed spawn"
+}
+
+function test_genrule_reports_measured_memory_via_configured_source() {
+  # Read peak memory through the generic, field-number-based source instead of the built-in
+  # recognition. The worker emits tools.protos.ExecutionStatistics, whose resource_usage is field 1
+  # and maxrss (kilobytes) is field 5.
+  bazel build \
+      --spawn_strategy=remote \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_cache=grpc://localhost:${worker_port} \
+      --experimental_remote_measured_memory_source=type.googleapis.com/tools.protos.ExecutionStatistics:1.5:kb \
+      --execution_log_json_file=output.json \
+      examples/genrule:simple &> $TEST_log \
+    || fail "Hermetic genrule failed: examples/genrule:simple"
+
+  grep '"measuredMemoryPeakBytes"' output.json \
+    || fail "configured measured-memory source did not record peak memory for remote spawn"
+}
+
 function test_genrule_can_write_to_path() {
   bazel build \
       --spawn_strategy=remote \

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/BUILD
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/BUILD
@@ -65,6 +65,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/lib/windows",
         "//src/main/java/com/google/devtools/common/options",
+        "//src/main/protobuf:execution_statistics_java_proto",
         "//src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http",
         "//third_party:flogger",
         "//third_party:guava",

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
@@ -54,6 +54,7 @@ import com.google.devtools.build.lib.shell.AbnormalTerminationException;
 import com.google.devtools.build.lib.shell.CommandException;
 import com.google.devtools.build.lib.shell.CommandResult;
 import com.google.devtools.build.lib.shell.FutureCommandResult;
+import com.google.devtools.build.lib.shell.Protos.ExecutionStatistics;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -72,6 +73,7 @@ import io.grpc.stub.StreamObserver;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.time.Duration;
 import java.time.Instant;
@@ -352,12 +354,15 @@ final class ExecutionServer extends ExecutionImplBase {
 
     // TODO(ulfjack): This is basically a copy of LocalSpawnRunner. Ideally, we'd use that
     // implementation instead of copying it.
+    String uuid = UUID.randomUUID().toString();
+    // When running under the sandbox, ask it to write execution statistics (e.g. peak memory) so we
+    // can surface them to the client via the action's auxiliary metadata.
+    Path statisticsPath = execRoot.getChild("stats-" + uuid);
     com.google.devtools.build.lib.shell.Command cmd =
-        getCommand(command, workingDirectory.asFragment());
+        getCommand(command, workingDirectory.asFragment(), statisticsPath);
     Instant startTime = Instant.now();
     CommandResult cmdResult = null;
 
-    String uuid = UUID.randomUUID().toString();
     Path stdout = execRoot.getChild("stdout-" + uuid);
     Path stderr = execRoot.getChild("stderr-" + uuid);
     try (FileOutErr outErr = new FileOutErr(stdout, stderr)) {
@@ -454,6 +459,11 @@ final class ExecutionServer extends ExecutionImplBase {
         }
       }
 
+      // Surface any measured execution statistics (e.g. peak memory) to the client through the
+      // execution metadata's auxiliary metadata, following the convention documented for
+      // ExecutedActionMetadata.auxiliary_metadata.
+      result = maybeAddExecutionStatistics(result, statisticsPath);
+
       resp.setResult(result);
 
       if (errStatus != null) {
@@ -472,6 +482,33 @@ final class ExecutionServer extends ExecutionImplBase {
 
   private static boolean wasTimeout(long timeoutMillis, long wallTimeMillis) {
     return timeoutMillis > 0 && wallTimeMillis > timeoutMillis;
+  }
+
+  // Reads the execution statistics written by the sandbox (if any) and attaches them to the
+  // action's execution metadata as auxiliary metadata. This lets clients record measured resource
+  // usage (e.g. peak memory) for remotely executed actions, just as they do for local ones.
+  private static ActionResult maybeAddExecutionStatistics(
+      ActionResult result, Path statisticsPath) {
+    if (!statisticsPath.exists()) {
+      return result;
+    }
+    try (InputStream in = statisticsPath.getInputStream()) {
+      ExecutionStatistics executionStatistics =
+          ExecutionStatistics.parseFrom(in, ExtensionRegistry.getEmptyRegistry());
+      if (!executionStatistics.hasResourceUsage()) {
+        return result;
+      }
+      return result.toBuilder()
+          .setExecutionMetadata(
+              result.getExecutionMetadata().toBuilder()
+                  .addAuxiliaryMetadata(Any.pack(executionStatistics)))
+          .build();
+    } catch (IOException e) {
+      // Best-effort: if we can't read the stats, just don't attach them.
+      logger.atWarning().withCause(e).log(
+          "Failed to read execution statistics from %s", statisticsPath);
+      return result;
+    }
   }
 
   private static ImmutableList<String> getArguments(Command command) {
@@ -568,7 +605,7 @@ final class ExecutionServer extends ExecutionImplBase {
   // arguments. Otherwise, returns a Command that would run the specified command inside the
   // specified docker container.
   private com.google.devtools.build.lib.shell.Command getCommand(
-      Command cmd, PathFragment workingDirectory)
+      Command cmd, PathFragment workingDirectory, Path statisticsPath)
       throws StatusException, InterruptedException, IOException {
     ImmutableList<String> arguments = getArguments(cmd);
     Map<String, String> environmentVariables = getEnvironmentVariables(cmd);
@@ -619,6 +656,9 @@ final class ExecutionServer extends ExecutionImplBase {
       // Run command with sandboxing.
       ArrayList<String> newCommandLineElements = new ArrayList<>(arguments.size());
       newCommandLineElements.add(sandboxPath.getPathString());
+      // Have the sandbox write execution statistics (e.g. peak memory) to a file.
+      newCommandLineElements.add("-S");
+      newCommandLineElements.add(statisticsPath.getPathString());
       if (workerOptions.getSandboxingBlockNetwork()) {
         newCommandLineElements.add("-N");
       }


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
