### PR TITLE
Allow passing strings as executable in `template_ctx.run()`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTemplateContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTemplateContext.java
@@ -115,6 +115,9 @@ public final class StarlarkTemplateContext implements StarlarkTemplateContextApi
     switch (executableUnchecked) {
       case Artifact executable -> builder.setExecutable(executable);
       case FilesToRunProvider filesToRun -> builder.setExecutable(filesToRun);
+      // Normalise if needed and then pass as a String; this keeps the reference when PathFragment
+      // is passed from native to Starlark.
+      case String executablePath -> builder.setExecutableAsString(PathFragment.create(executablePath).getPathString());
       default -> {
         throw Starlark.errorf(
             "Expected a File or FilesToRunProvider but got %s", Starlark.type(executableUnchecked));


### PR DESCRIPTION
This updates the implementation of `template_ctx.run()` to match its [documentation](https://bazel.build/rules/lib/builtins/template_ctx#run) and `actions.run()`.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
