### PR TITLE
Fix `ResourceSet` `equals`/`hashCode` by making it a record

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -526,6 +526,7 @@ java_library(
         ":exec_exception",
         ":localhost_compute_resources",
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
+        "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/worker:worker_key",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceSet.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceSet.java
@@ -16,8 +16,8 @@ package com.google.devtools.build.lib.actions;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.primitives.Doubles;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
+import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.worker.WorkerKey;
 import com.google.devtools.common.options.Converter;
@@ -31,33 +31,22 @@ import javax.annotation.Nullable;
  * Action, or the total available resources. We plan to use this to do smarter scheduling of
  * actions, for example making sure that we don't schedule jobs concurrently if they would use so
  * much memory as to cause the machine to thrash.
+ *
+ * @param resources Map of extra resources (for example: GPUs, embedded boards, ...) mapping name of
+ *     the resource to a value.
+ * @param localTestCount The number of local tests.
+ * @param workerKey The workerKey of used worker. Null if no worker is used.
  */
+@AutoCodec
 @Immutable
-public class ResourceSet implements ResourceSetOrBuilder {
+public record ResourceSet(
+    ImmutableMap<String, Double> resources, int localTestCount, @Nullable WorkerKey workerKey)
+    implements ResourceSetOrBuilder {
   public static final String CPU = "cpu";
   public static final String MEMORY = "memory";
 
   /** For actions that consume negligible resources. */
   public static final ResourceSet ZERO = new ResourceSet(ImmutableMap.of(), 0, null);
-
-  /**
-   * Map of extra resources (for example: GPUs, embedded boards, ...) mapping name of the resource
-   * to a value.
-   */
-  private final ImmutableMap<String, Double> resources;
-
-  /** The number of local tests. */
-  private final int localTestCount;
-
-  /** The workerKey of used worker. Null if no worker is used. */
-  @Nullable private final WorkerKey workerKey;
-
-  private ResourceSet(
-      ImmutableMap<String, Double> resources, int localTestCount, @Nullable WorkerKey workerKey) {
-    this.resources = resources;
-    this.localTestCount = localTestCount;
-    this.workerKey = workerKey;
-  }
 
   public static ResourceSet createWithRamCpu(double memoryMb, double cpu) {
     return create(ImmutableMap.of(MEMORY, memoryMb, CPU, cpu));
@@ -160,29 +149,6 @@ public class ResourceSet implements ResourceSetOrBuilder {
         + "\n";
   }
 
-  @Override
-  public boolean equals(Object that) {
-    if (that == null) {
-      return false;
-    }
-
-    if (!(that instanceof ResourceSet thatResourceSet)) {
-      return false;
-    }
-
-    return thatResourceSet.getMemoryMb() == getMemoryMb()
-        && thatResourceSet.getCpuUsage() == getCpuUsage()
-        && thatResourceSet.localTestCount == getLocalTestCount();
-  }
-
-  @Override
-  public int hashCode() {
-    int p = 239;
-    return Doubles.hashCode(getMemoryMb())
-        + Doubles.hashCode(getCpuUsage()) * p
-        + getLocalTestCount() * p * p;
-  }
-
   /** Converter for {@link ResourceSet}. */
   public static class ResourceSetConverter extends Converter.Contextless<ResourceSet> {
     private static final Splitter SPLITTER = Splitter.on(',');
@@ -217,7 +183,7 @@ public class ResourceSet implements ResourceSetOrBuilder {
   }
 
   @Override
-  public ResourceSet buildResourceSet(OS os, int inputsSize) throws ExecException {
+  public ResourceSet buildResourceSet(OS os, int inputsSize) {
     return this;
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/actions/ResourceSetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ResourceSetTest.java
@@ -17,6 +17,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.actions.ResourceSet.ResourceSetConverter;
 import com.google.devtools.common.options.OptionsParsingException;
 import org.junit.Before;
@@ -31,7 +32,7 @@ public class ResourceSetTest {
   private ResourceSetConverter converter;
 
   @Before
-  public final void createConverter() throws Exception  {
+  public final void createConverter() throws Exception {
     converter = new ResourceSetConverter();
   }
 
@@ -56,6 +57,23 @@ public class ResourceSetTest {
   @Test
   public void testConverterThrowsWhenGivenNegativeInputs() throws Exception {
     assertThrows(OptionsParsingException.class, () -> converter.convert("-1,0,0"));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            ResourceSet.createWithRamCpu(100, 1),
+            ResourceSet.createWithRamCpu(100, 1),
+            ResourceSet.create(ImmutableMap.of("memory", 100.0, "cpu", 1.0)))
+        .addEqualityGroup(ResourceSet.createWithRamCpu(200, 1))
+        .addEqualityGroup(ResourceSet.createWithRamCpu(100, 2))
+        .addEqualityGroup(ResourceSet.create(ImmutableMap.of("memory", 100.0, "cpu", 1.0), 5))
+        .addEqualityGroup(
+            ResourceSet.create(ImmutableMap.of("memory", 100.0, "cpu", 1.0, "my_resource", 1.0), 5))
+        .addEqualityGroup(
+            ResourceSet.create(ImmutableMap.of("memory", 100.0, "cpu", 1.0, "my_resource", 2.0), 5))
+        .testEquals();
   }
 
   @Test


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
