### PR TITLE
Remote: add opt-in recovery for the failure circuit breaker

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
@@ -106,11 +106,22 @@ public class Retrier {
     /** Returns the current {@link State} of the circuit breaker. */
     State state();
 
-    /** Called after an execution failed. */
-    void recordFailure();
+    /**
+     * Called after an execution failed.
+     *
+     * @param observedState the {@link State} returned by {@link #state()} when this call was
+     *     dispatched, so the breaker can attribute the outcome (in particular, distinguish a {@link
+     *     State#TRIAL_CALL} probe from an ordinary call).
+     */
+    void recordFailure(State observedState);
 
-    /** Called after an execution succeeded. */
-    void recordSuccess();
+    /**
+     * Called after an execution succeeded.
+     *
+     * @param observedState the {@link State} returned by {@link #state()} when this call was
+     *     dispatched (see {@link #recordFailure(State)}).
+     */
+    void recordSuccess(State observedState);
 
     /**
      * Returns a human-readable description of the breaker's current failure statistics (for example
@@ -167,10 +178,10 @@ public class Retrier {
         }
 
         @Override
-        public void recordFailure() {}
+        public void recordFailure(State observedState) {}
 
         @Override
-        public void recordSuccess() {}
+        public void recordSuccess(State observedState) {}
 
         @Override
         public String failureDetails() {
@@ -318,16 +329,16 @@ public class Retrier {
           throw new InterruptedException();
         }
         T r = callWithContext(call, backoff, rpcId);
-        circuitBreaker.recordSuccess();
+        circuitBreaker.recordSuccess(circuitState);
         return r;
       } catch (InterruptedException e) {
         throw e;
       } catch (Exception e) {
         Result r = resultClassifier.test(e);
         if (r.equals(Result.SUCCESS)) {
-          circuitBreaker.recordSuccess();
+          circuitBreaker.recordSuccess(circuitState);
         } else {
-          circuitBreaker.recordFailure();
+          circuitBreaker.recordFailure(circuitState);
         }
         if (!r.equals(Result.TRANSIENT_FAILURE) || Objects.equals(circuitState, State.TRIAL_CALL)) {
           throw e;
@@ -399,7 +410,7 @@ public class Retrier {
           Futures.transformAsync(
               callWithContext(call, backoff, rpcId),
               (f) -> {
-                circuitBreaker.recordSuccess();
+                circuitBreaker.recordSuccess(circuitState);
                 return immediateFuture(f);
               },
               directExecutor());
@@ -421,7 +432,7 @@ public class Retrier {
       @Nullable String rpcId) {
     Result r = resultClassifier.test(t);
     if (r.equals(Result.TRANSIENT_FAILURE)) {
-      circuitBreaker.recordFailure();
+      circuitBreaker.recordFailure(circuitState);
       if (circuitState.equals(State.TRIAL_CALL)) {
         return immediateFailedFuture(t);
       }
@@ -440,9 +451,9 @@ public class Retrier {
       }
     } else {
       if (r.equals(Result.SUCCESS)) {
-        circuitBreaker.recordSuccess();
+        circuitBreaker.recordSuccess(circuitState);
       } else {
-        circuitBreaker.recordFailure();
+        circuitBreaker.recordFailure(circuitState);
       }
       return immediateFailedFuture(t);
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.remote.circuitbreaker;
 import com.google.devtools.build.lib.remote.Retrier;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 /** Factory for {@link Retrier.CircuitBreaker} */
 public class CircuitBreakerFactory {
@@ -42,8 +43,23 @@ public class CircuitBreakerFactory {
           remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
           remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
           recoveryDelayMillis,
-          needsScheduler ? Executors.newSingleThreadScheduledExecutor() : null);
+          needsScheduler ? newScheduler() : null);
     }
     return Retrier.ALLOW_ALL_CALLS;
+  }
+
+  /**
+   * Returns a single-threaded scheduler for the breaker's window-decrement and recovery-probe tasks.
+   * The worker is a daemon so a per-build breaker never keeps the server alive; it is a platform
+   * thread because these are trivial, non-blocking tasks driven by a delay queue, which virtual
+   * threads do not suit.
+   */
+  private static ScheduledExecutorService newScheduler() {
+    return Executors.newSingleThreadScheduledExecutor(
+        runnable -> {
+          Thread thread = new Thread(runnable, "remote-circuit-breaker");
+          thread.setDaemon(true);
+          return thread;
+        });
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
@@ -33,12 +33,16 @@ public class CircuitBreakerFactory {
   public static Retrier.CircuitBreaker createCircuitBreaker(final RemoteOptions remoteOptions) {
     if (remoteOptions.getCircuitBreakerStrategy() == RemoteOptions.CircuitBreakerStrategy.FAILURE) {
       int slidingWindowMillis = (int) remoteOptions.getRemoteFailureWindowInterval().toMillis();
+      int recoveryDelayMillis =
+          (int) remoteOptions.getRemoteCircuitBreakerRecoveryDelay().toMillis();
+      boolean needsScheduler = slidingWindowMillis > 0 || recoveryDelayMillis > 0;
       return new FailureCircuitBreaker(
           remoteOptions.getRemoteFailureRateThreshold(),
           slidingWindowMillis,
           remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
           remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
-          slidingWindowMillis > 0 ? Executors.newSingleThreadScheduledExecutor() : null);
+          recoveryDelayMillis,
+          needsScheduler ? Executors.newSingleThreadScheduledExecutor() : null);
     }
     return Retrier.ALLOW_ALL_CALLS;
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
@@ -17,48 +17,62 @@ import com.google.devtools.build.lib.remote.Retrier;
 import java.util.Locale;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * The {@link FailureCircuitBreaker} implementation of the {@link Retrier.CircuitBreaker} prevents
- * further calls to a remote cache once the failures rate within a given window exceeds a specified
- * threshold for a build. In the context of Bazel, a new instance of {@link Retrier.CircuitBreaker}
- * is created for each build. Therefore, if the circuit breaker trips during a build, the remote
- * cache will by default be disabled for the remainder of that build. However, it will be enabled
- * again for the next build as a new instance of {@link Retrier.CircuitBreaker} will be created.
+ * A {@link Retrier.CircuitBreaker} that stops calling a remote cache/executor once the failure rate
+ * within a sliding window exceeds a configured threshold. In the context of Bazel a new instance is
+ * created for each build, so a breaker that trips disables the remote cache for that build (by
+ * default for the remainder of it) and is reset for the next build.
  *
- * <p>If a positive recovery delay is configured, a tripped breaker does not stay open for the whole
- * build: after the delay elapses it hands a single {@link State#TRIAL_CALL} probe to one in-flight
- * call. If that probe succeeds the breaker closes ({@link State#ACCEPT_CALLS}) and normal calls
- * resume; if it fails the breaker re-opens and schedules another probe. With a non-positive delay
- * (the default) recovery is disabled and the breaker stays open for the remainder of the build.
+ * <p>Recovery within a build is opt-in via a positive recovery delay. After the breaker trips it
+ * moves through a small state machine: {@code OPEN} (all calls rejected) then, once the recovery
+ * delay elapses, {@code RECOVERING} (the next caller is handed a single {@link State#TRIAL_CALL}
+ * probe while everyone else keeps seeing {@link State#REJECT_CALLS}) then {@code PROBING} (the probe
+ * is in flight). A successful probe closes the breaker ({@link State#ACCEPT_CALLS}) and starts a
+ * fresh window; a failed probe reopens it and schedules the next probe. With a non-positive delay
+ * (the default) the breaker never leaves {@code OPEN}, preserving the previous permanent-open
+ * behaviour.
+ *
+ * <p>The outcome of a probe is attributed using the {@link State} each call observed when it was
+ * dispatched (passed to {@link #recordSuccess(State)}/{@link #recordFailure(State)}): only the call
+ * that observed {@link State#TRIAL_CALL} can resolve the probe, so a slow call that started before
+ * the breaker tripped cannot hijack it.
  */
 public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
 
-  private final AtomicReference<State> state;
-  private final AtomicInteger successes;
-  private final AtomicInteger failures;
+  /**
+   * Internal health state. Maps to the interface {@link State} exposed to the {@link Retrier}:
+   * {@code CLOSED} to {@link State#ACCEPT_CALLS}, everything else to {@link State#REJECT_CALLS}
+   * except that {@code RECOVERING} hands a single {@link State#TRIAL_CALL} to one caller.
+   */
+  private enum Health {
+    /** Normal operation; calls are accepted. */
+    CLOSED,
+    /** Tripped; all calls are rejected until the recovery delay elapses. */
+    OPEN,
+    /** The recovery delay has elapsed; the next caller may be given a single trial probe. */
+    RECOVERING,
+    /** A single trial probe is in flight; other callers are still rejected. */
+    PROBING
+  }
+
+  private final AtomicReference<Health> health = new AtomicReference<>(Health.CLOSED);
+  private final AtomicInteger successes = new AtomicInteger(0);
+  private final AtomicInteger failures = new AtomicInteger(0);
+
+  // Bumped whenever the counters are reset, so window-decrement tasks scheduled before the reset
+  // become no-ops instead of decrementing the fresh counts.
+  private final AtomicLong generation = new AtomicLong(0);
+
   private final int failureRateThreshold;
   private final int slidingWindowSize;
   private final int minCallCountToComputeFailureRate;
   private final int minFailCountToComputeFailureRate;
   private final int recoveryDelayMillis;
   private final ScheduledExecutorService scheduledExecutor;
-
-  // Set true by the scheduled recovery task once the recovery delay has elapsed, signalling that a
-  // single trial probe may be issued. Consumed by state() when it hands out a TRIAL_CALL.
-  private volatile boolean trialEligible;
-
-  // True while exactly one trial probe is outstanding, so concurrent callers keep seeing
-  // REJECT_CALLS (avoiding a thundering herd) until the probe resolves. Because the CircuitBreaker
-  // interface's record* methods carry no per-call identity, the probe's outcome is attributed via
-  // this flag: whichever in-flight call resolves first wins. If an ACCEPT-era call is still running
-  // when the probe is issued it may resolve the probe instead; this is self-correcting (a concurrent
-  // success is a valid "remote recovered" signal, and a spurious re-open only costs one more
-  // recovery delay), so we accept it rather than widen the interface.
-  private final AtomicBoolean trialInFlight = new AtomicBoolean(false);
 
   /**
    * Creates a {@link FailureCircuitBreaker}.
@@ -75,7 +89,8 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
    *     trial probe. A non-positive value disables recovery, keeping a tripped breaker open for the
    *     remainder of the build.
    * @param scheduledExecutor executor for scheduling tasks to decrement success and failure counts
-   *     and to re-enable trial probes.
+   *     and to make trial probes available; may be {@code null} only when both the sliding window
+   *     and recovery are disabled.
    */
   public FailureCircuitBreaker(
       int failureRateThreshold,
@@ -84,39 +99,37 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
       int minFailCountToComputeFailureRate,
       int recoveryDelayMillis,
       ScheduledExecutorService scheduledExecutor) {
-    this.failures = new AtomicInteger(0);
-    this.successes = new AtomicInteger(0);
     this.failureRateThreshold = failureRateThreshold;
     this.slidingWindowSize = slidingWindowSize;
     this.minCallCountToComputeFailureRate = minCallCountToComputeFailureRate;
     this.minFailCountToComputeFailureRate = minFailCountToComputeFailureRate;
     this.recoveryDelayMillis = recoveryDelayMillis;
-    this.state = new AtomicReference<>(State.ACCEPT_CALLS);
     this.scheduledExecutor = scheduledExecutor;
   }
 
   @Override
   public State state() {
-    State current = this.state.get();
-    // When recovery is enabled and a probe is due, hand TRIAL_CALL to exactly one caller; everyone
-    // else continues to see REJECT_CALLS until the probe resolves via recordSuccess/recordFailure.
-    if (current == State.REJECT_CALLS
-        && recoveryDelayMillis > 0
-        && trialEligible
-        && trialInFlight.compareAndSet(false, true)) {
-      trialEligible = false;
-      return State.TRIAL_CALL;
+    Health current = health.get();
+    if (current == Health.RECOVERING) {
+      // The recovery delay has elapsed: hand TRIAL_CALL to exactly one caller (whoever wins the
+      // CAS); every other caller keeps seeing REJECT_CALLS until the probe resolves.
+      if (health.compareAndSet(Health.RECOVERING, Health.PROBING)) {
+        return State.TRIAL_CALL;
+      }
+      // Lost the race for the probe; re-read so the returned state reflects where we ended up.
+      current = health.get();
     }
-    return current;
+    return current == Health.CLOSED ? State.ACCEPT_CALLS : State.REJECT_CALLS;
   }
 
   @Override
-  public void recordFailure() {
-    if (trialInFlight.get()) {
-      // The trial probe failed: stay open and schedule another probe after the recovery delay.
-      this.state.set(State.REJECT_CALLS);
-      trialInFlight.set(false);
-      scheduleTrial();
+  public void recordFailure(State observedState) {
+    if (observedState == State.TRIAL_CALL) {
+      // The trial probe failed: reopen and schedule the next probe. Only the probe observes
+      // TRIAL_CALL, so a slow pre-trip call cannot consume the trial outcome here.
+      if (health.compareAndSet(Health.PROBING, Health.OPEN)) {
+        scheduleTrial();
+      }
       return;
     }
 
@@ -131,22 +144,20 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
     }
     double failureRate = (failureCount * 100.0) / totalCallCount;
 
-    // Only the thread that flips the state to REJECT_CALLS schedules the (single) recovery probe.
-    if (failureRate > this.failureRateThreshold
-        && this.state.compareAndSet(State.ACCEPT_CALLS, State.REJECT_CALLS)) {
+    // Only the thread that trips the breaker (wins the CAS) schedules the single recovery probe.
+    if (failureRate > failureRateThreshold
+        && health.compareAndSet(Health.CLOSED, Health.OPEN)) {
       scheduleTrial();
     }
   }
 
   @Override
-  public void recordSuccess() {
-    if (trialInFlight.get()) {
-      // The trial probe succeeded: reset the counters (window decrements scheduled before the reset
-      // are floored at zero, see decrementToFloor) and close the breaker to resume normal calls.
-      failures.set(0);
-      successes.set(0);
-      this.state.set(State.ACCEPT_CALLS);
-      trialInFlight.set(false);
+  public void recordSuccess(State observedState) {
+    if (observedState == State.TRIAL_CALL) {
+      // The trial probe succeeded: close the breaker and start a fresh window.
+      if (health.compareAndSet(Health.PROBING, Health.CLOSED)) {
+        resetCounters();
+      }
       return;
     }
 
@@ -154,22 +165,27 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
     scheduleWindowDecrement(successes);
   }
 
-  private void scheduleWindowDecrement(AtomicInteger counter) {
-    if (slidingWindowSize > 0) {
-      var unused =
-          scheduledExecutor.schedule(
-              () -> decrementToFloor(counter), slidingWindowSize, TimeUnit.MILLISECONDS);
-    }
+  private void resetCounters() {
+    // Invalidate window-decrement tasks scheduled before the reset, then zero the counts, so stale
+    // decrements cannot erase failures recorded after recovery.
+    generation.incrementAndGet();
+    failures.set(0);
+    successes.set(0);
   }
 
-  /**
-   * Decrements {@code counter} as its sliding window slides, flooring at zero. Flooring matters
-   * after a successful trial probe resets the counters to zero: decrement tasks scheduled before the
-   * reset would otherwise drive the counts negative and leave the breaker unable to trip again for a
-   * long time.
-   */
-  private static void decrementToFloor(AtomicInteger counter) {
-    counter.updateAndGet(value -> value > 0 ? value - 1 : 0);
+  private void scheduleWindowDecrement(AtomicInteger counter) {
+    if (slidingWindowSize > 0) {
+      long scheduledGeneration = generation.get();
+      var unused =
+          scheduledExecutor.schedule(
+              () -> {
+                if (generation.get() == scheduledGeneration) {
+                  var ignored = counter.decrementAndGet();
+                }
+              },
+              slidingWindowSize,
+              TimeUnit.MILLISECONDS);
+    }
   }
 
   private void scheduleTrial() {
@@ -177,7 +193,7 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
       var unused =
           scheduledExecutor.schedule(
               () -> {
-                trialEligible = true;
+                var ignored = health.compareAndSet(Health.OPEN, Health.RECOVERING);
               },
               recoveryDelayMillis,
               TimeUnit.MILLISECONDS);

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
@@ -17,26 +17,48 @@ import com.google.devtools.build.lib.remote.Retrier;
 import java.util.Locale;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * The {@link FailureCircuitBreaker} implementation of the {@link Retrier.CircuitBreaker} prevents
  * further calls to a remote cache once the failures rate within a given window exceeds a specified
  * threshold for a build. In the context of Bazel, a new instance of {@link Retrier.CircuitBreaker}
  * is created for each build. Therefore, if the circuit breaker trips during a build, the remote
- * cache will be disabled for that build. However, it will be enabled again for the next build as a
- * new instance of {@link Retrier.CircuitBreaker} will be created.
+ * cache will by default be disabled for the remainder of that build. However, it will be enabled
+ * again for the next build as a new instance of {@link Retrier.CircuitBreaker} will be created.
+ *
+ * <p>If a positive recovery delay is configured, a tripped breaker does not stay open for the whole
+ * build: after the delay elapses it hands a single {@link State#TRIAL_CALL} probe to one in-flight
+ * call. If that probe succeeds the breaker closes ({@link State#ACCEPT_CALLS}) and normal calls
+ * resume; if it fails the breaker re-opens and schedules another probe. With a non-positive delay
+ * (the default) recovery is disabled and the breaker stays open for the remainder of the build.
  */
 public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
 
-  private State state;
+  private final AtomicReference<State> state;
   private final AtomicInteger successes;
   private final AtomicInteger failures;
   private final int failureRateThreshold;
   private final int slidingWindowSize;
   private final int minCallCountToComputeFailureRate;
   private final int minFailCountToComputeFailureRate;
+  private final int recoveryDelayMillis;
   private final ScheduledExecutorService scheduledExecutor;
+
+  // Set true by the scheduled recovery task once the recovery delay has elapsed, signalling that a
+  // single trial probe may be issued. Consumed by state() when it hands out a TRIAL_CALL.
+  private volatile boolean trialEligible;
+
+  // True while exactly one trial probe is outstanding, so concurrent callers keep seeing
+  // REJECT_CALLS (avoiding a thundering herd) until the probe resolves. Because the CircuitBreaker
+  // interface's record* methods carry no per-call identity, the probe's outcome is attributed via
+  // this flag: whichever in-flight call resolves first wins. If an ACCEPT-era call is still running
+  // when the probe is issued it may resolve the probe instead; this is self-correcting (a concurrent
+  // success is a valid "remote recovered" signal, and a spurious re-open only costs one more
+  // recovery delay), so we accept it rather than widen the interface.
+  private final AtomicBoolean trialInFlight = new AtomicBoolean(false);
 
   /**
    * Creates a {@link FailureCircuitBreaker}.
@@ -45,17 +67,22 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
    *     circuit breaker in given time window.
    * @param slidingWindowSize the size of the sliding window in milliseconds to calculate the number
    *     of failures.
-   * @param minCallCountToComputeFailureRate the minimum number of calls within the window before
-   *     the failure rate is computed and the breaker may trip.
+   * @param minCallCountToComputeFailureRate the minimum number of calls within the window before the
+   *     failure rate is computed and the breaker may trip.
    * @param minFailCountToComputeFailureRate the minimum number of failures within the window before
    *     the failure rate is computed and the breaker may trip.
-   * @param scheduledExecutor executor for scheduling tasks to decrement success and failure counts.
+   * @param recoveryDelayMillis the delay in milliseconds after the breaker trips before it issues a
+   *     trial probe. A non-positive value disables recovery, keeping a tripped breaker open for the
+   *     remainder of the build.
+   * @param scheduledExecutor executor for scheduling tasks to decrement success and failure counts
+   *     and to re-enable trial probes.
    */
   public FailureCircuitBreaker(
       int failureRateThreshold,
       int slidingWindowSize,
       int minCallCountToComputeFailureRate,
       int minFailCountToComputeFailureRate,
+      int recoveryDelayMillis,
       ScheduledExecutorService scheduledExecutor) {
     this.failures = new AtomicInteger(0);
     this.successes = new AtomicInteger(0);
@@ -63,24 +90,39 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
     this.slidingWindowSize = slidingWindowSize;
     this.minCallCountToComputeFailureRate = minCallCountToComputeFailureRate;
     this.minFailCountToComputeFailureRate = minFailCountToComputeFailureRate;
-    this.state = State.ACCEPT_CALLS;
+    this.recoveryDelayMillis = recoveryDelayMillis;
+    this.state = new AtomicReference<>(State.ACCEPT_CALLS);
     this.scheduledExecutor = scheduledExecutor;
   }
 
   @Override
   public State state() {
-    return this.state;
+    State current = this.state.get();
+    // When recovery is enabled and a probe is due, hand TRIAL_CALL to exactly one caller; everyone
+    // else continues to see REJECT_CALLS until the probe resolves via recordSuccess/recordFailure.
+    if (current == State.REJECT_CALLS
+        && recoveryDelayMillis > 0
+        && trialEligible
+        && trialInFlight.compareAndSet(false, true)) {
+      trialEligible = false;
+      return State.TRIAL_CALL;
+    }
+    return current;
   }
 
   @Override
   public void recordFailure() {
+    if (trialInFlight.get()) {
+      // The trial probe failed: stay open and schedule another probe after the recovery delay.
+      this.state.set(State.REJECT_CALLS);
+      trialInFlight.set(false);
+      scheduleTrial();
+      return;
+    }
+
     int failureCount = failures.incrementAndGet();
     int totalCallCount = successes.get() + failureCount;
-    if (slidingWindowSize > 0) {
-      var unused =
-          scheduledExecutor.schedule(
-              failures::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
-    }
+    scheduleWindowDecrement(failures);
 
     if (totalCallCount < minCallCountToComputeFailureRate
         && failureCount < minFailCountToComputeFailureRate) {
@@ -89,19 +131,56 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
     }
     double failureRate = (failureCount * 100.0) / totalCallCount;
 
-    // Since the state can only be changed to the open state, synchronization is not required.
-    if (failureRate > this.failureRateThreshold) {
-      this.state = State.REJECT_CALLS;
+    // Only the thread that flips the state to REJECT_CALLS schedules the (single) recovery probe.
+    if (failureRate > this.failureRateThreshold
+        && this.state.compareAndSet(State.ACCEPT_CALLS, State.REJECT_CALLS)) {
+      scheduleTrial();
     }
   }
 
   @Override
   public void recordSuccess() {
+    if (trialInFlight.get()) {
+      // The trial probe succeeded: reset the counters (window decrements scheduled before the reset
+      // are floored at zero, see decrementToFloor) and close the breaker to resume normal calls.
+      failures.set(0);
+      successes.set(0);
+      this.state.set(State.ACCEPT_CALLS);
+      trialInFlight.set(false);
+      return;
+    }
+
     successes.incrementAndGet();
+    scheduleWindowDecrement(successes);
+  }
+
+  private void scheduleWindowDecrement(AtomicInteger counter) {
     if (slidingWindowSize > 0) {
       var unused =
           scheduledExecutor.schedule(
-              successes::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
+              () -> decrementToFloor(counter), slidingWindowSize, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  /**
+   * Decrements {@code counter} as its sliding window slides, flooring at zero. Flooring matters
+   * after a successful trial probe resets the counters to zero: decrement tasks scheduled before the
+   * reset would otherwise drive the counts negative and leave the breaker unable to trip again for a
+   * long time.
+   */
+  private static void decrementToFloor(AtomicInteger counter) {
+    counter.updateAndGet(value -> value > 0 ? value - 1 : 0);
+  }
+
+  private void scheduleTrial() {
+    if (recoveryDelayMillis > 0 && scheduledExecutor != null) {
+      var unused =
+          scheduledExecutor.schedule(
+              () -> {
+                trialEligible = true;
+              },
+              recoveryDelayMillis,
+              TimeUnit.MILLISECONDS);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -822,6 +822,23 @@ public abstract class RemoteOptions extends CommonRemoteOptions {
   public abstract int getRemoteMinFailCountToComputeFailureRate();
 
   @Option(
+      name = "experimental_remote_circuit_breaker_recovery_delay",
+      defaultValue = "0",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.EXECUTION},
+      converter = RemoteDurationConverter.class,
+      help =
+          "The delay after the failure circuit breaker trips before it allows a single trial remote"
+              + " call to probe whether the remote cache/executor has recovered. If the trial"
+              + " succeeds the breaker closes and normal calls resume; otherwise it re-opens and"
+              + " waits again before the next trial. A zero or negative value (the default) disables"
+              + " recovery, so a tripped breaker stays open for the remainder of the build. Following"
+              + " units can be used: Days (d), hours (h), minutes (m), seconds (s), and milliseconds"
+              + " (ms). If the unit is omitted, the value is interpreted as seconds. Only takes"
+              + " effect with --experimental_circuit_breaker_strategy=failure.")
+  public abstract Duration getRemoteCircuitBreakerRecoveryDelay();
+
+  @Option(
       name = "experimental_remote_cache_lease_extension",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.REMOTE,

--- a/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
@@ -98,8 +98,8 @@ public class RetrierTest {
     assertThat(e).hasMessageThat().isEqualTo("call failed");
 
     assertThat(numCalls.get()).isEqualTo(3);
-    verify(alwaysOpen, times(3)).recordFailure();
-    verify(alwaysOpen, never()).recordSuccess();
+    verify(alwaysOpen, times(3)).recordFailure(State.ACCEPT_CALLS);
+    verify(alwaysOpen, never()).recordSuccess(State.ACCEPT_CALLS);
   }
 
   @Test
@@ -122,8 +122,8 @@ public class RetrierTest {
     assertThat(e).hasMessageThat().isEqualTo("call failed");
 
     assertThat(numCalls.get()).isEqualTo(1);
-    verify(alwaysOpen, never()).recordFailure();
-    verify(alwaysOpen, times(1)).recordSuccess();
+    verify(alwaysOpen, never()).recordFailure(State.ACCEPT_CALLS);
+    verify(alwaysOpen, times(1)).recordSuccess(State.ACCEPT_CALLS);
   }
 
   @Test
@@ -145,8 +145,8 @@ public class RetrierTest {
             });
     assertThat(val).isEqualTo(1);
 
-    verify(alwaysOpen, times(2)).recordFailure();
-    verify(alwaysOpen, times(1)).recordSuccess();
+    verify(alwaysOpen, times(2)).recordFailure(State.ACCEPT_CALLS);
+    verify(alwaysOpen, times(1)).recordSuccess(State.ACCEPT_CALLS);
   }
 
   @Test
@@ -213,10 +213,10 @@ public class RetrierTest {
           }
 
           @Override
-          public void recordFailure() {}
+          public void recordFailure(State observedState) {}
 
           @Override
-          public void recordSuccess() {}
+          public void recordSuccess(State observedState) {}
 
           @Override
           public String failureDetails() {
@@ -601,7 +601,7 @@ public class RetrierTest {
     }
 
     @Override
-    public synchronized void recordFailure() {
+    public synchronized void recordFailure(State observedState) {
       consecutiveFailures++;
       if (consecutiveFailures >= maxConsecutiveFailures) {
         state = State.REJECT_CALLS;
@@ -609,7 +609,7 @@ public class RetrierTest {
     }
 
     @Override
-    public synchronized void recordSuccess() {
+    public synchronized void recordSuccess(State observedState) {
       consecutiveFailures = 0;
       state = State.ACCEPT_CALLS;
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactoryTest.java
@@ -63,10 +63,10 @@ public class CircuitBreakerFactoryTest {
     // of 100, proving the flag took effect. The high min fail count keeps the failure gate out of
     // the way, so tripping here also proves the two counts are not wired in the wrong order.
     for (int i = 0; i < 4; i++) {
-      circuitBreaker.recordSuccess();
+      circuitBreaker.recordSuccess(State.ACCEPT_CALLS);
     }
     assertThat(circuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
-    circuitBreaker.recordFailure();
+    circuitBreaker.recordFailure(State.ACCEPT_CALLS);
     assertThat(circuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 
@@ -88,10 +88,10 @@ public class CircuitBreakerFactoryTest {
     // the total call count is far below the configured min call count (1000). Under the default min
     // fail count of 12 the breaker would still be accepting calls here, proving the flag took
     // effect.
-    circuitBreaker.recordFailure();
-    circuitBreaker.recordFailure();
+    circuitBreaker.recordFailure(State.ACCEPT_CALLS);
+    circuitBreaker.recordFailure(State.ACCEPT_CALLS);
     assertThat(circuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
-    circuitBreaker.recordFailure();
+    circuitBreaker.recordFailure(State.ACCEPT_CALLS);
     assertThat(circuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
@@ -77,6 +77,7 @@ public class FailureCircuitBreakerTest {
             windowInterval,
             remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
             remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
+            /* recoveryDelayMillis= */ 0,
             mockScheduler);
 
     List<Runnable> listOfSuccessAndFailureCalls = new ArrayList<>();
@@ -121,6 +122,7 @@ public class FailureCircuitBreakerTest {
             windowInterval,
             remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
             remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
+            /* recoveryDelayMillis= */ 0,
             mockScheduler);
 
     // make success calls, failure call and number of total calls less than
@@ -148,6 +150,7 @@ public class FailureCircuitBreakerTest {
             windowInterval,
             remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
             remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
+            /* recoveryDelayMillis= */ 0,
             mockScheduler);
 
     // make number of failure calls less than minFailToComputeFailure.
@@ -172,6 +175,7 @@ public class FailureCircuitBreakerTest {
             windowInterval,
             /* minCallCountToComputeFailureRate= */ 0,
             /* minFailCountToComputeFailureRate= */ 0,
+            /* recoveryDelayMillis= */ 0,
             mockScheduler);
 
     failureCircuitBreaker.recordSuccess();
@@ -184,5 +188,149 @@ public class FailureCircuitBreakerTest {
     assertThat(details).contains("75.00%");
     assertThat(details).contains("the last 100ms");
     assertThat(details).contains("10% failure rate threshold");
+  }
+
+  /**
+   * Returns a mock scheduler that records the tasks the breaker schedules, splitting them by delay:
+   * recovery-probe tasks (scheduled at {@code recoveryDelayMillis}) go into {@code trialTasks} and
+   * sliding-window decrement tasks (scheduled at the window size) go into {@code windowTasks}. A test
+   * can then run them manually to simulate the recovery delay or the window elapsing.
+   */
+  private static ScheduledExecutorService newRecoveryScheduler(
+      long recoveryDelayMillis, List<Runnable> trialTasks, List<Runnable> windowTasks) {
+    ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
+    when(mockScheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+        .thenAnswer(
+            invocation -> {
+              Runnable task = invocation.getArgument(0);
+              long delayMillis = invocation.getArgument(1);
+              if (delayMillis == recoveryDelayMillis) {
+                trialTasks.add(task);
+              } else {
+                windowTasks.add(task);
+              }
+              return null;
+            });
+    return mockScheduler;
+  }
+
+  @Test
+  public void testRecovery_disabledByDefault_breakerStaysOpen() {
+    List<Runnable> trialTasks = Collections.synchronizedList(new ArrayList<>());
+    List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
+    FailureCircuitBreaker failureCircuitBreaker =
+        new FailureCircuitBreaker(
+            /* failureRateThreshold= */ 0,
+            /* slidingWindowSize= */ 100,
+            /* minCallCountToComputeFailureRate= */ 1,
+            /* minFailCountToComputeFailureRate= */ 1,
+            /* recoveryDelayMillis= */ 0,
+            newRecoveryScheduler(/* recoveryDelayMillis= */ 0, trialTasks, windowTasks));
+
+    // A single failure trips the breaker (0% threshold, min counts of 1).
+    failureCircuitBreaker.recordFailure();
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+
+    // With recovery disabled, no trial probe is ever scheduled and the breaker stays open.
+    assertThat(trialTasks).isEmpty();
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+  }
+
+  @Test
+  public void testRecovery_trialProbeSuccessClosesBreaker() {
+    List<Runnable> trialTasks = Collections.synchronizedList(new ArrayList<>());
+    List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
+    FailureCircuitBreaker failureCircuitBreaker =
+        new FailureCircuitBreaker(
+            /* failureRateThreshold= */ 0,
+            /* slidingWindowSize= */ 100,
+            /* minCallCountToComputeFailureRate= */ 1,
+            /* minFailCountToComputeFailureRate= */ 1,
+            /* recoveryDelayMillis= */ 1000,
+            newRecoveryScheduler(/* recoveryDelayMillis= */ 1000, trialTasks, windowTasks));
+
+    // Trip the breaker; a single recovery probe is scheduled for after the recovery delay.
+    failureCircuitBreaker.recordFailure();
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+    assertThat(trialTasks).hasSize(1);
+
+    // Before the delay elapses the breaker is still open.
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+
+    // Simulate the recovery delay elapsing.
+    trialTasks.get(0).run();
+
+    // Exactly one caller gets the trial probe; concurrent callers keep seeing REJECT_CALLS.
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.TRIAL_CALL);
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+
+    // The probe succeeds: the breaker closes and normal calls resume.
+    failureCircuitBreaker.recordSuccess();
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
+  }
+
+  @Test
+  public void testRecovery_trialProbeFailureReopensAndReschedules() {
+    List<Runnable> trialTasks = Collections.synchronizedList(new ArrayList<>());
+    List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
+    FailureCircuitBreaker failureCircuitBreaker =
+        new FailureCircuitBreaker(
+            /* failureRateThreshold= */ 0,
+            /* slidingWindowSize= */ 100,
+            /* minCallCountToComputeFailureRate= */ 1,
+            /* minFailCountToComputeFailureRate= */ 1,
+            /* recoveryDelayMillis= */ 1000,
+            newRecoveryScheduler(/* recoveryDelayMillis= */ 1000, trialTasks, windowTasks));
+
+    // Trip the breaker and let the first recovery delay elapse.
+    failureCircuitBreaker.recordFailure();
+    assertThat(trialTasks).hasSize(1);
+    trialTasks.get(0).run();
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.TRIAL_CALL);
+
+    // The probe fails: the breaker re-opens and schedules another probe.
+    failureCircuitBreaker.recordFailure();
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+    assertThat(trialTasks).hasSize(2);
+
+    // The next recovery delay elapses and another single probe is offered.
+    trialTasks.get(1).run();
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.TRIAL_CALL);
+  }
+
+  @Test
+  public void testRecovery_successfulProbeFloorsStaleWindowDecrements() {
+    List<Runnable> trialTasks = Collections.synchronizedList(new ArrayList<>());
+    List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
+    FailureCircuitBreaker failureCircuitBreaker =
+        new FailureCircuitBreaker(
+            /* failureRateThreshold= */ 0,
+            /* slidingWindowSize= */ 100,
+            /* minCallCountToComputeFailureRate= */ 1,
+            /* minFailCountToComputeFailureRate= */ 1,
+            /* recoveryDelayMillis= */ 1000,
+            newRecoveryScheduler(/* recoveryDelayMillis= */ 1000, trialTasks, windowTasks));
+
+    // Accumulate several failures; the first trips the breaker and each schedules a window decrement.
+    for (int index = 0; index < 5; index++) {
+      failureCircuitBreaker.recordFailure();
+    }
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+    assertThat(windowTasks).hasSize(5);
+    assertThat(trialTasks).hasSize(1);
+
+    // A probe succeeds and closes the breaker, resetting the failure/success counters to zero.
+    trialTasks.get(0).run();
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.TRIAL_CALL);
+    failureCircuitBreaker.recordSuccess();
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
+
+    // The window decrements scheduled before the reset now fire; flooring keeps the counts at zero
+    // instead of driving them negative...
+    windowTasks.forEach(Runnable::run);
+
+    // ...so a single fresh failure can still trip the breaker again.
+    failureCircuitBreaker.recordFailure();
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
@@ -25,7 +25,6 @@ import com.google.devtools.common.options.Options;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
@@ -37,166 +36,13 @@ public class FailureCircuitBreakerTest {
 
   private final RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
 
-  @Test
-  // Suppress unchecked warnings because any(Callable.class) uses a raw type,
-  // which causes Javac to fail with -Werror.
-  @SuppressWarnings("unchecked")
-  public void testRecordFailure_circuitTrips() throws InterruptedException {
-    final int failureRateThreshold = 10;
-    final int windowInterval = 100;
-    ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
-    List<Runnable> capturedRunnables = Collections.synchronizedList(new ArrayList<>());
-
-    // Stub both schedule overloads to capture the scheduled tasks.
-    // This allows us to simulate window expiration by running them manually.
-    // We need to stub Callable because method references like failures::decrementAndGet
-    // return a value and can be matched to Callable by the compiler.
-    when(mockScheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
-        .thenAnswer(
-            invocation -> {
-              capturedRunnables.add(invocation.getArgument(0));
-              return null;
-            });
-    when(mockScheduler.schedule(any(Callable.class), anyLong(), any(TimeUnit.class)))
-        .thenAnswer(
-            invocation -> {
-              Callable<?> callable = invocation.getArgument(0);
-              capturedRunnables.add(
-                  () -> {
-                    try {
-                      callable.call();
-                    } catch (Exception e) {
-                      throw new RuntimeException(e);
-                    }
-                  });
-              return null;
-            });
-    FailureCircuitBreaker failureCircuitBreaker =
-        new FailureCircuitBreaker(
-            failureRateThreshold,
-            windowInterval,
-            remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
-            remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
-            /* recoveryDelayMillis= */ 0,
-            mockScheduler);
-
-    List<Runnable> listOfSuccessAndFailureCalls = new ArrayList<>();
-    for (int index = 0; index < failureRateThreshold; index++) {
-      listOfSuccessAndFailureCalls.add(failureCircuitBreaker::recordFailure);
-    }
-
-    for (int index = 0; index < failureRateThreshold * 9; index++) {
-      listOfSuccessAndFailureCalls.add(failureCircuitBreaker::recordSuccess);
-    }
-
-    Collections.shuffle(listOfSuccessAndFailureCalls);
-
-    // make calls equals to threshold number of not ignored failure calls in parallel.
-    listOfSuccessAndFailureCalls.stream().parallel().forEach(Runnable::run);
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
-
-    int expectedCalls = failureRateThreshold * 10;
-    // Run all captured runnables to simulate window expiration.
-    assertThat(capturedRunnables).hasSize(expectedCalls);
-    capturedRunnables.forEach(Runnable::run);
-    capturedRunnables.clear(); // Clear for the next round
-
-    // make calls equals to threshold number of not ignored failure calls in parallel.
-    listOfSuccessAndFailureCalls.stream().parallel().forEach(Runnable::run);
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
-
-    // We don't run the new scheduled tasks, simulating being within the window.
-    failureCircuitBreaker.recordFailure();
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
-  }
-
-  @Test
-  public void testRecordFailure_minCallCriteriaNotMet() throws InterruptedException {
-    final int failureRateThreshold = 0;
-    final int windowInterval = 100;
-    final int minCallToComputeFailure = remoteOptions.getRemoteMinCallCountToComputeFailureRate();
-    ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
-    FailureCircuitBreaker failureCircuitBreaker =
-        new FailureCircuitBreaker(
-            failureRateThreshold,
-            windowInterval,
-            remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
-            remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
-            /* recoveryDelayMillis= */ 0,
-            mockScheduler);
-
-    // make success calls, failure call and number of total calls less than
-    // minCallToComputeFailure.
-    for (int index = 0; index < minCallToComputeFailure - 2; index++) {
-      failureCircuitBreaker.recordSuccess();
-    }
-    failureCircuitBreaker.recordFailure();
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
-
-    // We don't run the scheduled tasks, simulating being within the window.
-    failureCircuitBreaker.recordFailure();
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
-  }
-
-  @Test
-  public void testRecordFailure_minFailCriteriaNotMet() throws InterruptedException {
-    final int failureRateThreshold = 10;
-    final int windowInterval = 100;
-    final int minFailToComputeFailure = remoteOptions.getRemoteMinFailCountToComputeFailureRate();
-    ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
-    FailureCircuitBreaker failureCircuitBreaker =
-        new FailureCircuitBreaker(
-            failureRateThreshold,
-            windowInterval,
-            remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
-            remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
-            /* recoveryDelayMillis= */ 0,
-            mockScheduler);
-
-    // make number of failure calls less than minFailToComputeFailure.
-    for (int index = 0; index < minFailToComputeFailure - 1; index++) {
-      failureCircuitBreaker.recordFailure();
-    }
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
-
-    // We don't run the scheduled tasks, simulating being within the window.
-    failureCircuitBreaker.recordFailure();
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
-  }
-
-  @Test
-  public void testFailureDetails_reportsStats() {
-    final int failureRateThreshold = 10;
-    final int windowInterval = 100;
-    ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
-    FailureCircuitBreaker failureCircuitBreaker =
-        new FailureCircuitBreaker(
-            failureRateThreshold,
-            windowInterval,
-            /* minCallCountToComputeFailureRate= */ 0,
-            /* minFailCountToComputeFailureRate= */ 0,
-            /* recoveryDelayMillis= */ 0,
-            mockScheduler);
-
-    failureCircuitBreaker.recordSuccess();
-    failureCircuitBreaker.recordFailure();
-    failureCircuitBreaker.recordFailure();
-    failureCircuitBreaker.recordFailure();
-
-    String details = failureCircuitBreaker.failureDetails();
-    assertThat(details).contains("3 out of 4 remote calls failed");
-    assertThat(details).contains("75.00%");
-    assertThat(details).contains("the last 100ms");
-    assertThat(details).contains("10% failure rate threshold");
-  }
-
   /**
-   * Returns a mock scheduler that records the tasks the breaker schedules, splitting them by delay:
-   * recovery-probe tasks (scheduled at {@code recoveryDelayMillis}) go into {@code trialTasks} and
-   * sliding-window decrement tasks (scheduled at the window size) go into {@code windowTasks}. A test
-   * can then run them manually to simulate the recovery delay or the window elapsing.
+   * Returns a mock scheduler that records scheduled tasks by delay: tasks scheduled at {@code
+   * recoveryDelayMillis} (the recovery probes) go into {@code trialTasks}, everything else (the
+   * sliding-window decrements) into {@code windowTasks}. A test runs them manually to simulate the
+   * recovery delay or the window elapsing. All tasks the breaker schedules are {@link Runnable}s.
    */
-  private static ScheduledExecutorService newRecoveryScheduler(
+  private static ScheduledExecutorService newSchedulerCapturing(
       long recoveryDelayMillis, List<Runnable> trialTasks, List<Runnable> windowTasks) {
     ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
     when(mockScheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
@@ -215,122 +61,275 @@ public class FailureCircuitBreakerTest {
   }
 
   @Test
+  public void testRecordFailure_circuitTrips() {
+    final int failureRateThreshold = 10;
+    final int windowInterval = 100;
+    List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
+    FailureCircuitBreaker failureCircuitBreaker =
+        new FailureCircuitBreaker(
+            failureRateThreshold,
+            windowInterval,
+            remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
+            remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
+            /* recoveryDelayMillis= */ 0,
+            newSchedulerCapturing(/* recoveryDelayMillis= */ 0, new ArrayList<>(), windowTasks));
+
+    List<Runnable> listOfSuccessAndFailureCalls = new ArrayList<>();
+    for (int index = 0; index < failureRateThreshold; index++) {
+      listOfSuccessAndFailureCalls.add(
+          () -> failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS));
+    }
+    for (int index = 0; index < failureRateThreshold * 9; index++) {
+      listOfSuccessAndFailureCalls.add(
+          () -> failureCircuitBreaker.recordSuccess(State.ACCEPT_CALLS));
+    }
+    Collections.shuffle(listOfSuccessAndFailureCalls);
+
+    // Make calls equal to the threshold number of not-ignored failure calls in parallel.
+    listOfSuccessAndFailureCalls.stream().parallel().forEach(Runnable::run);
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
+
+    // Run all captured window-decrement tasks to simulate the window expiring.
+    int expectedCalls = failureRateThreshold * 10;
+    assertThat(windowTasks).hasSize(expectedCalls);
+    windowTasks.forEach(Runnable::run);
+    windowTasks.clear(); // Clear for the next round.
+
+    listOfSuccessAndFailureCalls.stream().parallel().forEach(Runnable::run);
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
+
+    // We don't run the new scheduled tasks, simulating being within the window.
+    failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+  }
+
+  @Test
+  public void testRecordFailure_minCallCriteriaNotMet() {
+    final int failureRateThreshold = 0;
+    final int windowInterval = 100;
+    final int minCallToComputeFailure = remoteOptions.getRemoteMinCallCountToComputeFailureRate();
+    FailureCircuitBreaker failureCircuitBreaker =
+        new FailureCircuitBreaker(
+            failureRateThreshold,
+            windowInterval,
+            remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
+            remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
+            /* recoveryDelayMillis= */ 0,
+            mock(ScheduledExecutorService.class));
+
+    // Make success calls, a failure call, and a total number of calls less than
+    // minCallToComputeFailure.
+    for (int index = 0; index < minCallToComputeFailure - 2; index++) {
+      failureCircuitBreaker.recordSuccess(State.ACCEPT_CALLS);
+    }
+    failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
+
+    // We don't run the scheduled tasks, simulating being within the window.
+    failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+  }
+
+  @Test
+  public void testRecordFailure_minFailCriteriaNotMet() {
+    final int failureRateThreshold = 10;
+    final int windowInterval = 100;
+    final int minFailToComputeFailure = remoteOptions.getRemoteMinFailCountToComputeFailureRate();
+    FailureCircuitBreaker failureCircuitBreaker =
+        new FailureCircuitBreaker(
+            failureRateThreshold,
+            windowInterval,
+            remoteOptions.getRemoteMinCallCountToComputeFailureRate(),
+            remoteOptions.getRemoteMinFailCountToComputeFailureRate(),
+            /* recoveryDelayMillis= */ 0,
+            mock(ScheduledExecutorService.class));
+
+    // Make a number of failure calls less than minFailToComputeFailure.
+    for (int index = 0; index < minFailToComputeFailure - 1; index++) {
+      failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS);
+    }
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
+
+    // We don't run the scheduled tasks, simulating being within the window.
+    failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+  }
+
+  @Test
+  public void testFailureDetails_reportsStats() {
+    final int failureRateThreshold = 10;
+    final int windowInterval = 100;
+    FailureCircuitBreaker failureCircuitBreaker =
+        new FailureCircuitBreaker(
+            failureRateThreshold,
+            windowInterval,
+            /* minCallCountToComputeFailureRate= */ 0,
+            /* minFailCountToComputeFailureRate= */ 0,
+            /* recoveryDelayMillis= */ 0,
+            mock(ScheduledExecutorService.class));
+
+    failureCircuitBreaker.recordSuccess(State.ACCEPT_CALLS);
+    failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS);
+    failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS);
+    failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS);
+
+    String details = failureCircuitBreaker.failureDetails();
+    assertThat(details).contains("3 out of 4 remote calls failed");
+    assertThat(details).contains("75.00%");
+    assertThat(details).contains("the last 100ms");
+    assertThat(details).contains("10% failure rate threshold");
+  }
+
+  @Test
   public void testRecovery_disabledByDefault_breakerStaysOpen() {
     List<Runnable> trialTasks = Collections.synchronizedList(new ArrayList<>());
     List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
-    FailureCircuitBreaker failureCircuitBreaker =
+    FailureCircuitBreaker breaker =
         new FailureCircuitBreaker(
             /* failureRateThreshold= */ 0,
             /* slidingWindowSize= */ 100,
             /* minCallCountToComputeFailureRate= */ 1,
             /* minFailCountToComputeFailureRate= */ 1,
             /* recoveryDelayMillis= */ 0,
-            newRecoveryScheduler(/* recoveryDelayMillis= */ 0, trialTasks, windowTasks));
+            newSchedulerCapturing(/* recoveryDelayMillis= */ 0, trialTasks, windowTasks));
 
     // A single failure trips the breaker (0% threshold, min counts of 1).
-    failureCircuitBreaker.recordFailure();
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
 
-    // With recovery disabled, no trial probe is ever scheduled and the breaker stays open.
+    // Recovery is disabled: no probe is ever scheduled and the breaker never leaves REJECT_CALLS.
     assertThat(trialTasks).isEmpty();
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 
   @Test
   public void testRecovery_trialProbeSuccessClosesBreaker() {
     List<Runnable> trialTasks = Collections.synchronizedList(new ArrayList<>());
     List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
-    FailureCircuitBreaker failureCircuitBreaker =
+    FailureCircuitBreaker breaker =
         new FailureCircuitBreaker(
             /* failureRateThreshold= */ 0,
             /* slidingWindowSize= */ 100,
             /* minCallCountToComputeFailureRate= */ 1,
             /* minFailCountToComputeFailureRate= */ 1,
             /* recoveryDelayMillis= */ 1000,
-            newRecoveryScheduler(/* recoveryDelayMillis= */ 1000, trialTasks, windowTasks));
+            newSchedulerCapturing(/* recoveryDelayMillis= */ 1000, trialTasks, windowTasks));
 
     // Trip the breaker; a single recovery probe is scheduled for after the recovery delay.
-    failureCircuitBreaker.recordFailure();
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
     assertThat(trialTasks).hasSize(1);
 
     // Before the delay elapses the breaker is still open.
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
 
     // Simulate the recovery delay elapsing.
     trialTasks.get(0).run();
 
     // Exactly one caller gets the trial probe; concurrent callers keep seeing REJECT_CALLS.
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.TRIAL_CALL);
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+    assertThat(breaker.state()).isEqualTo(State.TRIAL_CALL);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
 
     // The probe succeeds: the breaker closes and normal calls resume.
-    failureCircuitBreaker.recordSuccess();
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
+    breaker.recordSuccess(State.TRIAL_CALL);
+    assertThat(breaker.state()).isEqualTo(State.ACCEPT_CALLS);
   }
 
   @Test
   public void testRecovery_trialProbeFailureReopensAndReschedules() {
     List<Runnable> trialTasks = Collections.synchronizedList(new ArrayList<>());
     List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
-    FailureCircuitBreaker failureCircuitBreaker =
+    FailureCircuitBreaker breaker =
         new FailureCircuitBreaker(
             /* failureRateThreshold= */ 0,
             /* slidingWindowSize= */ 100,
             /* minCallCountToComputeFailureRate= */ 1,
             /* minFailCountToComputeFailureRate= */ 1,
             /* recoveryDelayMillis= */ 1000,
-            newRecoveryScheduler(/* recoveryDelayMillis= */ 1000, trialTasks, windowTasks));
+            newSchedulerCapturing(/* recoveryDelayMillis= */ 1000, trialTasks, windowTasks));
 
     // Trip the breaker and let the first recovery delay elapse.
-    failureCircuitBreaker.recordFailure();
+    breaker.recordFailure(State.ACCEPT_CALLS);
     assertThat(trialTasks).hasSize(1);
     trialTasks.get(0).run();
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.TRIAL_CALL);
+    assertThat(breaker.state()).isEqualTo(State.TRIAL_CALL);
 
     // The probe fails: the breaker re-opens and schedules another probe.
-    failureCircuitBreaker.recordFailure();
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+    breaker.recordFailure(State.TRIAL_CALL);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
     assertThat(trialTasks).hasSize(2);
 
     // The next recovery delay elapses and another single probe is offered.
     trialTasks.get(1).run();
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.TRIAL_CALL);
+    assertThat(breaker.state()).isEqualTo(State.TRIAL_CALL);
   }
 
   @Test
-  public void testRecovery_successfulProbeFloorsStaleWindowDecrements() {
+  public void testRecovery_slowPreTripCallCannotHijackProbe() {
     List<Runnable> trialTasks = Collections.synchronizedList(new ArrayList<>());
     List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
-    FailureCircuitBreaker failureCircuitBreaker =
+    FailureCircuitBreaker breaker =
         new FailureCircuitBreaker(
             /* failureRateThreshold= */ 0,
             /* slidingWindowSize= */ 100,
             /* minCallCountToComputeFailureRate= */ 1,
             /* minFailCountToComputeFailureRate= */ 1,
             /* recoveryDelayMillis= */ 1000,
-            newRecoveryScheduler(/* recoveryDelayMillis= */ 1000, trialTasks, windowTasks));
+            newSchedulerCapturing(/* recoveryDelayMillis= */ 1000, trialTasks, windowTasks));
 
-    // Accumulate several failures; the first trips the breaker and each schedules a window decrement.
-    for (int index = 0; index < 5; index++) {
-      failureCircuitBreaker.recordFailure();
-    }
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
-    assertThat(windowTasks).hasSize(5);
+    // Trip, let the recovery delay elapse, and hand out the probe.
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    trialTasks.get(0).run();
+    assertThat(breaker.state()).isEqualTo(State.TRIAL_CALL);
+
+    // A call that started before the breaker tripped now completes with a failure. It observed
+    // ACCEPT_CALLS, so it must not consume the in-flight probe, reopen the breaker, or schedule a
+    // new probe.
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
     assertThat(trialTasks).hasSize(1);
 
-    // A probe succeeds and closes the breaker, resetting the failure/success counters to zero.
+    // The actual probe then succeeds and still closes the breaker.
+    breaker.recordSuccess(State.TRIAL_CALL);
+    assertThat(breaker.state()).isEqualTo(State.ACCEPT_CALLS);
+  }
+
+  @Test
+  public void testRecovery_successfulProbeInvalidatesStaleWindowDecrements() {
+    List<Runnable> trialTasks = Collections.synchronizedList(new ArrayList<>());
+    List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
+    FailureCircuitBreaker breaker =
+        new FailureCircuitBreaker(
+            /* failureRateThreshold= */ 0,
+            /* slidingWindowSize= */ 100,
+            /* minCallCountToComputeFailureRate= */ 2,
+            /* minFailCountToComputeFailureRate= */ 2,
+            /* recoveryDelayMillis= */ 1000,
+            newSchedulerCapturing(/* recoveryDelayMillis= */ 1000, trialTasks, windowTasks));
+
+    // Two failures trip the breaker (100% rate once the min counts of 2 are met); each schedules a
+    // window-decrement task.
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
+    assertThat(windowTasks).hasSize(2);
+
+    // A probe succeeds and closes the breaker, resetting the counters (and bumping the generation).
     trialTasks.get(0).run();
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.TRIAL_CALL);
-    failureCircuitBreaker.recordSuccess();
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
+    assertThat(breaker.state()).isEqualTo(State.TRIAL_CALL);
+    breaker.recordSuccess(State.TRIAL_CALL);
+    assertThat(breaker.state()).isEqualTo(State.ACCEPT_CALLS);
 
-    // The window decrements scheduled before the reset now fire; flooring keeps the counts at zero
-    // instead of driving them negative...
-    windowTasks.forEach(Runnable::run);
+    // A fresh failure is recorded after the reset.
+    breaker.recordFailure(State.ACCEPT_CALLS);
 
-    // ...so a single fresh failure can still trip the breaker again.
-    failureCircuitBreaker.recordFailure();
-    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+    // The two stale (pre-reset) window decrements now fire. They must not erase the fresh failure.
+    windowTasks.get(0).run();
+    windowTasks.get(1).run();
+
+    // One more failure reaches the min count of 2 at a 100% rate, so the breaker trips again -- which
+    // only holds if the fresh failure survived the stale decrements.
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 }


### PR DESCRIPTION
The failure circuit breaker (`--experimental_circuit_breaker_strategy=failure`) only transitions `ACCEPT_CALLS → REJECT_CALLS`; it never uses the half-open `TRIAL_CALL` state that `Retrier.CircuitBreaker` defines and `Retrier` already handles. Once tripped it rejects every remaining remote call for the build, so a burst of *transient* cache errors disables the remote cache for the rest of the invocation.

Under `--remote_download_minimal` (Build without the Bytes) this is unrecoverable: the breaker-rejected prefetch reads are converted to `CacheNotFoundException` and treated as lost inputs, action rewinding re-runs the generating actions, and the still-open breaker rejects those re-executions too. The breaker trips only on transient failures (`RemoteRetrier.EXPERIMENTAL_GRPC_RESULT_CLASSIFIER` maps `NOT_FOUND`/`ALREADY_EXISTS` to `SUCCESS`), so an ordinary cache miss does not trip it.

## What this change does

Implements `TRIAL_CALL` half-open recovery in `FailureCircuitBreaker`, gated behind a new `--experimental_remote_circuit_breaker_recovery_delay` (`Duration`, default `0` = today's permanent-open behaviour, so nothing changes unless it is enabled). The breaker is a small CAS-driven state machine (`CLOSED`/`OPEN`/`RECOVERING`/`PROBING`):

- After tripping, a single-probe transition is scheduled for after the recovery delay.
- `state()` hands `TRIAL_CALL` to exactly one in-flight call; concurrent callers keep seeing `REJECT_CALLS`, avoiding a thundering herd.
- A successful probe closes the breaker (`ACCEPT_CALLS`) and starts a fresh window; a failed probe re-opens it and reschedules the next probe.
- The `State` each call observed is passed into `recordSuccess`/`recordFailure`, so only the call that observed `TRIAL_CALL` can resolve the probe — a slow call that started before the breaker tripped cannot hijack it.
- Window-decrement tasks scheduled before a counter reset are invalidated via a generation counter, so stale decrements cannot erase failures recorded after recovery.

## Testing

`FailureCircuitBreakerTest` covers: recovery disabled (default — the breaker stays open), a successful probe closing the breaker, a failed probe re-opening and rescheduling, a slow pre-trip call being unable to hijack the probe, and stale window decrements being invalidated after a reset. `RetrierTest` and `CircuitBreakerFactoryTest` continue to pass.

```
bazel test //src/test/java/com/google/devtools/build/lib/remote/circuitbreaker:circuitbreaker
bazel test //src/test/java/com/google/devtools/build/lib/remote:RemoteTests --test_filter=RetrierTest
```

## Follow-up

Integration coverage for the circuit breaker × Build-without-the-Bytes prefetch/rewinding interaction — an end-to-end test that a tripped breaker recovers mid-build and the invocation succeeds — will be added in a follow-up PR. It is kept separate to keep this change focused on the breaker state machine and to avoid introducing a test-only seam into production code here.

Fixes #30259
