### PR TITLE
Prevent clients from depending on the wrong autocodec target

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec/BUILD
@@ -93,10 +93,12 @@ java_library(
     ],
 )
 
-# @AutoCodec annotation only. Used by clients and the processor.
+# @AutoCodec annotation only. Clients should not depend on this directly as it doesn't include the processor.
+# Depend on :autocodec instead.
 java_library(
     name = "autocodec-annotation",
     srcs = ["AutoCodec.java"],
+    visibility = ["//visibility:private"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization",
     ],


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
The `autocodec-annotation` target is suggested by `buildozer` fixups, but isn't what clients should use as it doesn't include the processor.


### Motivation
https://github.com/bazelbuild/bazel/pull/30257#issuecomment-4969731583

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
