### PR TITLE
Fix action rewinding with a non-verifying AC

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -1213,28 +1213,49 @@ public final class RemoteModule extends BlazeModule {
       builder.setActionInputPrefetcher(actionInputFetcher);
       actionContextProvider.setActionInputFetcher(actionInputFetcher);
 
-      LeaseExtension leaseExtension = null;
-      if (remoteOptions.getRemoteCacheLeaseExtension()) {
-        leaseExtension =
-            new RemoteLeaseExtension(
+      BuildRequestOptions buildRequestOptions =
+          env.getOptions().getOptions(BuildRequestOptions.class);
+      boolean rewindLostInputs =
+          buildRequestOptions != null && buildRequestOptions.getRewindLostInputs();
+      LeaseService leaseService = null;
+      if (rewindLostInputs) {
+        // Action rewinding regenerates lost inputs within the build, so there is no need for the
+        // lease service to extend leases or to discard all remote metadata after a build that
+        // encountered lost inputs.
+        if (remoteOptions.getRemoteCacheLeaseExtension()) {
+          env.getReporter()
+              .handle(
+                  Event.warn(
+                      "--experimental_remote_cache_lease_extension has no effect since"
+                          + " --rewind_lost_inputs is enabled, which recovers from lost remote"
+                          + " cache entries as they are encountered."));
+        }
+      } else {
+        LeaseExtension leaseExtension = null;
+        if (remoteOptions.getRemoteCacheLeaseExtension()) {
+          leaseExtension =
+              new RemoteLeaseExtension(
+                  env.getSkyframeExecutor().getEvaluator(),
+                  env.getBlazeWorkspace().getPersistentActionCache(),
+                  env.getBuildRequestId(),
+                  env.getCommandId().toString(),
+                  actionContextProvider.getCombinedCache(),
+                  remoteOptions.getRemoteCacheTtl());
+        }
+        leaseService =
+            new LeaseService(
                 env.getSkyframeExecutor().getEvaluator(),
-                env.getBlazeWorkspace().getPersistentActionCache(),
-                env.getBuildRequestId(),
-                env.getCommandId().toString(),
-                actionContextProvider.getCombinedCache(),
-                remoteOptions.getRemoteCacheTtl());
+                () -> env.getBlazeWorkspace().getPersistentActionCache(),
+                leaseExtension);
+        env.getEventBus().register(leaseService);
       }
-      var leaseService =
-          new LeaseService(
-              env.getSkyframeExecutor().getEvaluator(),
-              () -> env.getBlazeWorkspace().getPersistentActionCache(),
-              leaseExtension);
-      env.getEventBus().register(leaseService);
 
       if (outputService instanceof RemoteOutputService remoteOutputService) {
         remoteOutputService.setRemoteOutputChecker(remoteOutputChecker);
         remoteOutputService.setActionInputFetcher(actionInputFetcher);
-        remoteOutputService.setLeaseService(leaseService);
+        if (leaseService != null) {
+          remoteOutputService.setLeaseService(leaseService);
+        }
         env.getEventBus().register(outputService);
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/rewinding/ActionRewindStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/rewinding/ActionRewindStrategy.java
@@ -292,14 +292,15 @@ public final class ActionRewindStrategy {
       LostType lostType,
       ExtendedEventHandler listener)
       throws ActionRewindException {
+    // Bazel's (but not Blaze's) remote implementation needs to learn about lost digests to
+    // invalidate caches, both for rewinding and for invocation retries in BlazeCommandDispatcher.
+    listener.post(new LostInputsEvent(lostArtifacts.keySet()));
     if (skyframeActionExecutor.rewindingEnabled()) {
       return;
     }
     if (skyframeActionExecutor.invocationRetriesEnabled()) {
       // If rewinding failed, Bazel may still be able to recover by retrying the invocation in
-      // BlazeCommandDispatcher if retries are enabled. This requires emitting an event to inform
-      // Bazel's remote module of the lost inputs.
-      listener.post(new LostInputsEvent(lostArtifacts.keySet()));
+      // BlazeCommandDispatcher if retries are enabled.
       throw new FallbackToBuildRewindingException(
           lostArtifacts.entries().stream()
               .limit(MAX_LOST_INPUTS_RECORDED)

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
@@ -26,7 +26,6 @@ import com.google.devtools.build.lib.actions.BuildFailedException;
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialModule;
 import com.google.devtools.build.lib.dynamic.DynamicExecutionModule;
 import com.google.devtools.build.lib.remote.options.RemoteStartupOptions;
-import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.IntegrationTestUtils;
 import com.google.devtools.build.lib.remote.util.IntegrationTestUtils.WorkerInstance;
 import com.google.devtools.build.lib.runtime.BlazeModule;
@@ -1082,17 +1081,7 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
         "  cmd = 'sleep 2 && cat $(location :foo) > $@ && echo bar >> $@',",
         ")");
     addOptions("--experimental_remote_cache_ttl=1s", "--experimental_remote_cache_lease_extension");
-    var content = "foo".getBytes(UTF_8);
-    var hashCode = getFileSystem().getDigestFunction().getHashFunction().hashBytes(content);
-    var digest = DigestUtil.buildDigest(hashCode.asBytes(), content.length).getHash();
-    // Calculate the blob path in CAS. This is specific to the remote worker. See
-    // {@link DiskCacheClient#getPath()}.
-    var blobPath =
-        getFileSystem()
-            .getPath(worker.getCasPath())
-            .getChild("cas")
-            .getChild(digest.substring(0, 2))
-            .getChild(digest);
+    var blobPath = getFileSystem().getPath(worker.getCasBlobPath("foo".getBytes(UTF_8)));
     var mtimes = Sets.newConcurrentHashSet();
     // Observe the mtime of the blob in background.
     var thread =
@@ -1115,6 +1104,56 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
     thread.join();
     // We should be able to observe more than 1 mtime if the server extends the lease.
     assertThat(mtimes.size()).isGreaterThan(1);
+  }
+
+  @Test
+  public void actionRewinding_lostInputWithStaleActionCacheEntry_recovers() throws Exception {
+    // The unverified worker serves cached action results even if the blobs they reference are
+    // missing from the CAS, emulating a remote cache without integrity checks. Rewinding must not
+    // accept such an action result for a rewound action, as it would reinstate the stale metadata
+    // of the lost blob instead of regenerating it.
+    var unverifiedWorker = IntegrationTestUtils.createWorker("--noaction_cache_integrity_check");
+    try (var ignored = unverifiedWorker.start()) {
+      addOptions("--remote_executor=grpc://localhost:" + unverifiedWorker.getPort());
+      enableActionRewinding();
+      write(
+          "a/BUILD",
+          """
+        genrule(
+            name = "foo",
+            srcs = [],
+            outs = ["foo.out"],
+            cmd = "echo -n foo > $@",
+        )
+
+        genrule(
+            name = "bar",
+            srcs = [
+                ":foo",
+                "bar.in",
+            ],
+            outs = ["bar.out"],
+            cmd = "cat $(location :foo) $(location bar.in) > $@",
+        )
+        """);
+      write("a/bar.in", "bar");
+
+      buildTarget("//a:bar");
+
+      // Delete the blob backing foo.out from the CAS while keeping all action cache entries.
+      unverifiedWorker.evictBlob("foo".getBytes(UTF_8));
+      if (useDiskCache) {
+        // Prevent the disk cache from restoring the deleted blob.
+        addOptions("--disk_cache=" + UUID.randomUUID());
+      }
+
+      // Invalidate only //a:bar so that its execution discovers the lost input and rewinds //a:foo.
+      write("a/bar.in", "bar2");
+      setDownloadToplevel();
+      buildTarget("//a:bar");
+
+      assertValidOutputFile("a/bar.out", "foobar2\n");
+    }
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/DiskCacheIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/DiskCacheIntegrationTest.java
@@ -398,13 +398,6 @@ public class DiskCacheIntegrationTest extends BuildIntegrationTestCase {
   }
 
   private boolean remoteCacheEntryExists(Digest digest) {
-    return fileSystem
-        .getPath(
-            worker
-                .getCasPath()
-                .getRelative("cas")
-                .getRelative(digest.getHash().substring(0, 2))
-                .getRelative(digest.getHash()))
-        .exists();
+    return fileSystem.getPath(worker.getCasBlobPath(digest)).exists();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/util/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/BUILD
@@ -71,10 +71,12 @@ java_library(
         ":free_port_finder",
         "//src/main/java/com/google/devtools/build/lib/shell",
         "//src/main/java/com/google/devtools/build/lib/util:os",
+        "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party:junit4",
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
         "@rules_java//java/runfiles",
     ],
 )

--- a/src/test/java/com/google/devtools/build/lib/remote/util/IntegrationTestUtils.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/IntegrationTestUtils.java
@@ -15,9 +15,11 @@ package com.google.devtools.build.lib.remote.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import build.bazel.remote.execution.v2.Digest;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.Hashing;
 import com.google.devtools.build.lib.shell.Subprocess;
 import com.google.devtools.build.lib.shell.SubprocessBuilder;
 import com.google.devtools.build.lib.util.OS;
@@ -41,8 +43,7 @@ public final class IntegrationTestUtils {
   private IntegrationTestUtils() {}
 
   private static final String WORKER_RLOCATIONPATH =
-      "io_bazel/src/tools/remote/worker"
-          + (OS.getCurrent() == OS.WINDOWS ? ".exe" : "");
+      "io_bazel/src/tools/remote/worker" + (OS.getCurrent() == OS.WINDOWS ? ".exe" : "");
 
   /**
    * Manages a remote worker instance as a {@link TestRule}.
@@ -50,8 +51,8 @@ public final class IntegrationTestUtils {
    * <p>Should be kept in a static variable annotated with both {@link org.junit.ClassRule} and
    * {@link org.junit.Rule}.
    */
-  public static WorkerInstance createWorker() {
-    return createWorker(/* useHttp= */ false);
+  public static WorkerInstance createWorker(String... extraArgs) {
+    return createWorker(/* useHttp= */ false, extraArgs);
   }
 
   /**
@@ -60,7 +61,7 @@ public final class IntegrationTestUtils {
    * <p>Should be kept in a static variable annotated with both {@link org.junit.ClassRule} and
    * {@link org.junit.Rule}.
    */
-  public static WorkerInstance createWorker(boolean useHttp) {
+  public static WorkerInstance createWorker(boolean useHttp, String... extraArgs) {
     // The worker directory must not be a subdirectory of the test temporary directory for two
     // reasons:
     // 1. It should be preserved between individual tests so that the worker can be kept running.
@@ -73,7 +74,7 @@ public final class IntegrationTestUtils {
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
-    return new WorkerInstance(useHttp, workerTmpDir);
+    return new WorkerInstance(useHttp, workerTmpDir, ImmutableList.copyOf(extraArgs));
   }
 
   private static Path systemTmpDir() {
@@ -101,17 +102,19 @@ public final class IntegrationTestUtils {
     private final Path stderrPath;
     private final Path workPath;
     private final Path casPath;
+    private final ImmutableList<String> extraArgs;
 
     @Nullable private Integer port;
     @Nullable private Subprocess process;
 
-    private WorkerInstance(boolean useHttp, Path dir) {
+    private WorkerInstance(boolean useHttp, Path dir, ImmutableList<String> extraArgs) {
       this.useHttp = useHttp;
       this.stdPath = dir.resolve("std");
       this.stdoutPath = stdPath.resolve("stdout");
       this.stderrPath = stdPath.resolve("stderr");
       this.workPath = dir.resolve("work_path");
       this.casPath = dir.resolve("cas_path");
+      this.extraArgs = extraArgs;
     }
 
     @Override
@@ -120,11 +123,8 @@ public final class IntegrationTestUtils {
         return new Statement() {
           @Override
           public void evaluate() throws Throwable {
-            start();
-            try {
+            try (var ignored = start()) {
               base.evaluate();
-            } finally {
-              stop();
             }
           }
         };
@@ -144,7 +144,7 @@ public final class IntegrationTestUtils {
       }
     }
 
-    private void start() throws IOException, InterruptedException {
+    public AutoCloseable start() throws IOException, InterruptedException {
       Preconditions.checkState(process == null);
       Preconditions.checkState(port == null);
 
@@ -165,13 +165,18 @@ public final class IntegrationTestUtils {
               .setStdout(stdoutPath.toFile())
               .setStderr(stderrPath.toFile())
               .setArgv(
-                  ImmutableList.of(
-                      workerPath,
-                      "--work_path=" + workPath,
-                      "--cas_path=" + casPath,
-                      (useHttp ? "--http_listen_port=" : "--listen_port=") + port))
+                  ImmutableList.<String>builder()
+                      .add(
+                          workerPath,
+                          "--work_path=" + workPath,
+                          "--cas_path=" + casPath,
+                          (useHttp ? "--http_listen_port=" : "--listen_port=") + port)
+                      .addAll(extraArgs)
+                      .build())
               .start();
       waitForPortOpen(process, port);
+
+      return this::stop;
     }
 
     private void waitForPortOpen(Subprocess process, int port)
@@ -258,6 +263,34 @@ public final class IntegrationTestUtils {
 
     public PathFragment getCasPath() {
       return PathFragment.create(casPath.toString());
+    }
+
+    /** Returns the path of the blob with the given contents in the worker's CAS. */
+    public PathFragment getCasBlobPath(byte[] contents) {
+      return getCasBlobPath(
+          Digest.newBuilder()
+              .setHash(Hashing.sha256().hashBytes(contents).toString())
+              .setSizeBytes(contents.length)
+              .build());
+    }
+
+    /** Returns the path of the blob with the given digest in the worker's CAS. */
+    public PathFragment getCasBlobPath(Digest digest) {
+      return PathFragment.create(casBlobPath(digest).toString());
+    }
+
+    /**
+     * Deletes the blob with the given contents from the worker's CAS, leaving all other state (in
+     * particular action cache entries referencing the blob) intact.
+     */
+    public void evictBlob(byte[] contents) throws IOException {
+      Files.delete(Path.of(getCasBlobPath(contents).getPathString()));
+    }
+
+    // Mirrors the on-disk layout of DiskCacheClient.
+    private Path casBlobPath(Digest digest) {
+      String hash = digest.getHash();
+      return casPath.resolve("cas").resolve(hash.substring(0, 2)).resolve(hash);
     }
   }
 }

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
@@ -18,6 +18,7 @@ import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 import static com.google.devtools.build.lib.util.StringEncoding.unicodeToInternal;
 
 import build.bazel.remote.execution.v2.ActionCacheUpdateCapabilities;
+import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
@@ -29,13 +30,17 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.remote.CombinedCache;
 import com.google.devtools.build.lib.remote.Store;
+import com.google.devtools.build.lib.remote.common.ActionKey;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.disk.DiskCacheClient;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.protobuf.ExtensionRegistry;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** A {@link CombinedCache} backed by an {@link DiskCacheClient}. */
@@ -71,6 +76,28 @@ class OnDiskBlobStoreCache extends CombinedCache {
   /** If the given blob exists, updates its mtime and returns true. Otherwise, returns false. */
   boolean refresh(Digest digest) throws IOException {
     return diskCacheClient.refresh(diskCacheClient.toPath(digest, Store.CAS));
+  }
+
+  @Override
+  public CachedActionResult downloadActionResult(
+      RemoteActionExecutionContext context,
+      ActionKey actionKey,
+      boolean inlineOutErr,
+      Set<String> inlineOutputFiles)
+      throws IOException, InterruptedException {
+    if (remoteWorkerOptions.getActionCacheIntegrityCheck()) {
+      return super.downloadActionResult(context, actionKey, inlineOutErr, inlineOutputFiles);
+    }
+    // Serve the action result without checking that the blobs it references are present in the
+    // CAS, emulating a remote cache without integrity checks.
+    Path path = diskCacheClient.toPath(actionKey.digest(), Store.AC);
+    if (!path.exists()) {
+      return null;
+    }
+    try (InputStream in = path.getInputStream()) {
+      return CachedActionResult.disk(
+          ActionResult.parseFrom(in, ExtensionRegistry.getEmptyRegistry()));
+    }
   }
 
   @SuppressWarnings("ProtoParseWithRegistry")

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorkerOptions.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorkerOptions.java
@@ -234,6 +234,17 @@ public abstract class RemoteWorkerOptions extends OptionsBase {
               + " invocation id. This is useful for testing only.")
   public abstract boolean getErrorOnDuplicateDownloads();
 
+  @Option(
+      name = "action_cache_integrity_check",
+      defaultValue = "true",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "If false, action results are served without checking that the blobs they reference"
+              + " are present in the CAS. This emulates remote caches that do not perform"
+              + " integrity checks and is useful for testing only.")
+  public abstract boolean getActionCacheIntegrityCheck();
+
   private static final int MAX_JOBS = 16384;
 
   /**


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
When an input is discovered to be lost, its digest has to be registered as missing so that a rewound action doesn't use an AC hit that references the missing CAS entry. This can only happen when the remote AC does not verify that the CAS references are live, which is a recommendation but not a requirement in the spec.

### Motivation
Before this change, a non-verifying remote AC would cause any attempt to rewind an action to run into the max rewinding limit per input and fail.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Action rewinding (`--rewind_lost_inputs`) can now succeed even if the remote cache doesn't verify that AC entries aren't stale.
