### PR TITLE
[8.8.0] Use valid digests in rewinding tests (https://github.com/bazelbuild/b…

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
@@ -758,15 +758,12 @@ public class RewindingTestsHelper {
       addSpawnShim(
           "Executing genrule //test:consume_" + target,
           (spawn, context) -> {
-            ImmutableMap.Builder<String, ActionInput> inputMapBuilder = ImmutableMap.builder();
+            ImmutableList.Builder<ActionInput> lostInputs = ImmutableList.builder();
             for (int e = 1; e <= target; e++) {
-              ActionInput input = SpawnInputUtils.getInputWithName(spawn, "out_" + e + ".txt");
-              inputMapBuilder.put("fake_digest_" + target + "_" + e, input);
+              lostInputs.add(SpawnInputUtils.getInputWithName(spawn, "out_" + e + ".txt"));
             }
             ImmutableMap<String, ActionInput> inputMap = inputMapBuilder.buildOrThrow();
-            return ExecResult.ofException(
-                new LostInputsExecException(
-                    inputMap, new ActionInputDepOwnerMap(inputMap.values())));
+            return createLostInputsExecException(context, lostInputs.build());
           });
     }
     List<SkyKey> rewoundKeys = collectOrderedRewoundKeys();


### PR DESCRIPTION
…azel/pull/30185)

This simplifies future work in this area.

Closes #30185.

PiperOrigin-RevId: 947060913
Change-Id: Ib23a536d410d126b19948257b402ce9767d504bf

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/317d98e214b5c4b30f959dd8f79daf187d1b79b4