### PR TITLE
Improve error message outside of workspace

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1699,8 +1699,10 @@ int Main(int argc, const char *const *argv, WorkspaceLayout *workspace_layout,
   }
 
   if (!workspace_layout->InWorkspace(workspace)) {
-    if (!CanRunOutsideWorkspace(option_processor->GetCommand())) {
+    const string command = option_processor->GetCommand();
+    if (!CanRunOutsideWorkspace(command)) {
       BAZEL_LOG(ERROR) << startup_options->product_name
+                       << (command.empty() ? "" : " '" + command + "'")
                        << " must be invoked from within a workspace (below a"
                        << " directory having a MODULE.bazel file).\n"
                        << "See documentation at"

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -712,6 +712,14 @@ static bool IsServerMode(const string &command) {
   return "exec-server" == command;
 }
 
+// Keep this in sync with built-in commands annotated with
+// @Command(mustRunInWorkspace = false).
+static bool CanRunOutsideWorkspace(const string &command) {
+  return command == "canonicalize-flags" || command == "dump" ||
+         command == "help" || command == "license" || command == "shutdown" ||
+         command == "version";
+}
+
 // Replace this process with the blaze server. Does not exit.
 static void RunServerMode(
     const blaze_util::Path &server_exe, const vector<string> &server_exe_args,
@@ -1690,14 +1698,16 @@ int Main(int argc, const char *const *argv, WorkspaceLayout *workspace_layout,
     UnlimitCoredumps();
   }
 
-  // Only start a server when in a workspace because otherwise we won't do more
-  // than emit a help message.
   if (!workspace_layout->InWorkspace(workspace)) {
+    if (!CanRunOutsideWorkspace(option_processor->GetCommand())) {
+      BAZEL_LOG(ERROR) << startup_options->product_name
+                       << " must be invoked from within a workspace (below a"
+                       << " directory having a MODULE.bazel file).\n"
+                       << "See documentation at"
+                       << " https://bazel.build/concepts/build-ref#workspace";
+      return blaze_exit_code::BAD_ARGV;
+    }
     startup_options->batch = true;
-    BAZEL_LOG(WARNING) << "Invoking " << startup_options->product_name
-                       << " in batch mode since it is not invoked from within"
-                       << " a workspace (below a directory having a"
-                       << " MODULE.bazel file).";
   }
 
   vector<string> archive_contents;

--- a/src/test/shell/bazel/client_test.sh
+++ b/src/test/shell/bazel/client_test.sh
@@ -23,6 +23,32 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
 
 LOCK_HELPER="$(rlocation io_bazel/src/test/java/com/google/devtools/build/lib/testutil/external_file_system_lock_helper)"
 
+function test_fails_before_starting_java_outside_workspace() {
+  mkdir -p "${TEST_TMPDIR}/outside_workspace"
+  local -r install_base="${TEST_TMPDIR}/outside_install_base"
+
+  (cd "${TEST_TMPDIR}/outside_workspace" && \
+    bazel --install_base="${install_base}" build) &> "$TEST_log" \
+      && fail "Expected failure outside a workspace"
+
+  assert_equals 2 "$?"
+  [[ ! -e "${install_base}" ]] || fail "Bazel initialized its install base"
+  expect_log "^ERROR: Bazel must be invoked from within a workspace (below a directory having a MODULE\\.bazel file)\\.$"
+  expect_log "^See documentation at https://bazel\\.build/concepts/build-ref#workspace$"
+  expect_not_log "batch mode"
+  expect_not_log "OpenJDK"
+}
+
+function test_workspace_independent_command_outside_workspace() {
+  mkdir -p "${TEST_TMPDIR}/outside_workspace"
+
+  (cd "${TEST_TMPDIR}/outside_workspace" && bazel version) &> "$TEST_log" \
+    || fail "Expected version to work outside a workspace"
+
+  expect_log "Build target:"
+  expect_not_log "batch mode"
+}
+
 function test_product_name_with_bazel_info() {
   touch MODULE.bazel
 

--- a/src/test/shell/bazel/client_test.sh
+++ b/src/test/shell/bazel/client_test.sh
@@ -33,7 +33,7 @@ function test_fails_before_starting_java_outside_workspace() {
 
   assert_equals 2 "$?"
   [[ ! -e "${install_base}" ]] || fail "Bazel initialized its install base"
-  expect_log "^ERROR: Bazel must be invoked from within a workspace (below a directory having a MODULE\\.bazel file)\\.$"
+  expect_log "^ERROR: Bazel 'build' must be invoked from within a workspace (below a directory having a MODULE\\.bazel file)\\.$"
   expect_log "^See documentation at https://bazel\\.build/concepts/build-ref#workspace$"
   expect_not_log "batch mode"
   expect_not_log "OpenJDK"


### PR DESCRIPTION
Before:

```
WARNING: Invoking Bazel in batch mode since it is not invoked from within a workspace (below a directory having a MODULE.bazel file).
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
ERROR: The 'build' command is only supported from within a workspace (below a directory having a MODULE.bazel file).
See documentation at https://bazel.build/concepts/build-ref#workspace
```

After:

```
ERROR: Bazel must be invoked from within a workspace (below a directory having a MODULE.bazel file).
See documentation at https://bazel.build/concepts/build-ref#workspace
```
