### PR TITLE
Fix stale CODEOWNERS handles for apple shell tests (@reinhillman typo, drop non-existent @kelvinchan-google)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,7 +33,7 @@ android/ @ahumesky @ted-xie
 
 /src/main/java/com/google/devtools/build/lib/rules/apple @bazelbuild/rules_apple-team
 /src/test/java/com/google/devtools/build/lib/rules/apple @bazelbuild/rules_apple-team
-/src/test/shell/bazel/apple @allevato @davidgoldman @dmaclach @kelvinchan-google @reinhillman @thomasvl @bazelbuild/rules_apple-team
+/src/test/shell/bazel/apple @allevato @davidgoldman @dmaclach @reinhillmann @thomasvl @bazelbuild/rules_apple-team
 /tools/osx @bazelbuild/rules_apple-team
 
 # Bzlmod


### PR DESCRIPTION
Hi, and thank you for Bazel.

Small CODEOWNERS fix. Line 36 (the `src/test/shell/bazel/apple` owners) lists two handles that don't resolve to GitHub accounts:

- `@reinhillman` → 404, but `@reinhillmann` (double-n) is an active account ("Rein Hillmann… Google, Apple dev tooling") — this looks like a one-character typo.
- `@kelvinchan-google` → 404 with no redirect and no rename found via user search — appears to be a departed/renamed account (similar to `@comius`, removed in the 2025-11-18 CODEOWNERS update).

GitHub silently drops review-request routing for invalid CODEOWNERS entries, so PRs under that path currently under-notify their intended reviewers. This PR fixes the `@reinhillman`→`@reinhillmann` typo and drops `@kelvinchan-google`. If you know Kelvin's current handle, happy to re-point instead of removing.

(I understand CODEOWNERS here may flow through your internal tooling — feel free to apply this internally and close the PR if that's the process.)

For transparency: I used AI assistance to spot and draft this; I verified the 404s and the active `@reinhillmann` account myself.
