### PR TITLE
repository: register tar marker charset

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
@@ -220,9 +220,8 @@ public abstract class CompressedTarFunction implements Decompressor {
 
     @Override
     public Iterator<Charset> charsets() {
-      // This charset is only meant for internal use within CompressedTarFunction and thus should
-      // not be discoverable.
-      return Collections.emptyIterator();
+      // Native Image registers hosted charsets ahead of time by enumerating their providers.
+      return Collections.<Charset>singleton(CHARSET).iterator();
     }
 
     @Override
@@ -237,12 +236,10 @@ public abstract class CompressedTarFunction implements Decompressor {
    * charset.
    */
   private static class MarkedIso88591Charset extends Charset {
-    // The name
-    // * must not collide with the name of any other charset.
-    // * must not appear in archive entry names by chance.
-    // * is internal to CompressedTarFunction.
-    // This is best served by a cryptographically random UUID, generated at startup.
-    private static final String NAME = UUID.randomUUID().toString();
+    // Native Image needs a stable name to register this charset ahead of time. The marker is
+    // random so it cannot occur in archive entry names by chance.
+    private static final String NAME = "X-BAZEL-MARKED-ISO-8859-1";
+    private static final String MARKER = UUID.randomUUID().toString();
 
     private MarkedIso88591Charset() {
       super(NAME, new String[0]);
@@ -251,8 +248,8 @@ public abstract class CompressedTarFunction implements Decompressor {
     public static Optional<String> getRawBytesStringIfMarked(String s) {
       // Check for the marker in all positions as TarArchiveInputStream manipulates the raw name in
       // certain cases (for example, appending a '/' to directory names).
-      if (s.contains(NAME)) {
-        return Optional.of(s.replaceAll(NAME, ""));
+      if (s.contains(MARKER)) {
+        return Optional.of(s.replace(MARKER, ""));
       }
       return Optional.empty();
     }
@@ -276,13 +273,18 @@ public abstract class CompressedTarFunction implements Decompressor {
         protected CoderResult implFlush(CharBuffer out) {
           // Append the marker to the end of the buffer to indicate that it was decoded with this
           // charset.
-          if (out.remaining() < NAME.length()) {
+          if (out.remaining() < MARKER.length()) {
             return CoderResult.OVERFLOW;
           }
-          out.put(NAME);
+          out.put(MARKER);
           return CoderResult.UNDERFLOW;
         }
       };
+    }
+
+    @Override
+    public boolean canEncode() {
+      return false;
     }
 
     @Override

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -3570,6 +3570,37 @@ EOF
   assert_contains "bar" "$output_base/external/+repo+foo/out_dir/Ä_foo_∅.txt"
 }
 
+# Verifies that PAX names containing only Latin-1 code points remain distinguishable from raw
+# single-byte USTAR names.
+function test_extract_pax_tar_latin1_unicode_file_names() {
+  local archive_tar="${TEST_TMPDIR}/pax-latin1.tar"
+
+  pushd "${TEST_TMPDIR}"
+  mkdir "Ä_pax"
+  echo "bar" > "Ä_pax/Ä_foo.txt"
+  tar --format=pax -cvf pax-latin1.tar "Ä_pax"
+  popd
+
+  cat > $(setup_module_dot_bazel) <<EOF
+repo = use_repo_rule('//:test.bzl', 'repo')
+repo(name = 'foo')
+EOF
+  touch BUILD
+
+  cat >test.bzl <<EOF
+def _impl(repository_ctx):
+  repository_ctx.extract('${archive_tar}', 'out_dir', 'Ä_pax/')
+  repository_ctx.file("BUILD", "filegroup(name='bar', srcs=[])")
+
+repo = repository_rule(implementation=_impl)
+EOF
+
+  bazel build @foo//:bar >& $TEST_log || fail "Failed to build"
+
+  output_base="$(bazel info output_base)"
+  assert_contains "bar" "$output_base/external/+repo+foo/out_dir/Ä_foo.txt"
+}
+
 # Verifies that tar entries with USTAR headers, for which an encoding isn't specified, are extracted
 # correctly if that encoding happens to be UTF-8.
 function test_extract_ustar_tar_non_ascii_utf8_file_names() {


### PR DESCRIPTION
Commons Compress decodes UStar names with a caller-selected charset
but always decodes PAX paths as UTF-8. Bazel uses a private marker
charset to distinguish those sources and preserve raw UStar bytes
without corrupting PAX Unicode names.

Native Image cannot resolve that charset when its lookup name changes
at startup and its provider is hidden from enumeration. Give the
charset a stable private name, keep the collision marker random,
and expose the provider charset for ahead-of-time registration.

Add a Latin-1-only PAX regression because names outside Latin-1 masked
the lookup ambiguity in the existing test.

Extracted from #30282.
