### PR TITLE
runtime: tolerate missing GC beans

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BUILD
@@ -261,6 +261,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
         "//src/main/java/com/google/devtools/build/lib/metrics:garbage-collection-metrics-util",
         "//src/main/protobuf:memory_pressure_java_proto",
+        "//third_party:flogger",
         "//third_party:guava",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/runtime/MemoryPressureListener.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/MemoryPressureListener.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.eventbus.EventBus;
+import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.metrics.GarbageCollectionMetricsUtils;
@@ -41,6 +42,7 @@ import javax.management.openmbean.CompositeData;
 
 @ThreadSafe
 final class MemoryPressureListener implements NotificationListener {
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   private final AtomicReference<EventBus> eventBus = new AtomicReference<>();
   private final AtomicReference<GcThrashingDetector> gcThrashingDetector = new AtomicReference<>();
@@ -66,6 +68,13 @@ final class MemoryPressureListener implements NotificationListener {
       List<GarbageCollectorMXBean> gcBeans, Executor executor) {
     ImmutableList<NotificationEmitter> tenuredGcEmitters = findTenuredCollectorBeans(gcBeans);
     if (tenuredGcEmitters.isEmpty()) {
+      if (gcBeans.isEmpty()) {
+        logger.atWarning().log(
+            "No garbage collector MXBeans are available. Memory-pressure notifications are "
+                + "disabled, so optional caches cannot be limited based on heap usage and peak "
+                + "memory may be higher.");
+        return new MemoryPressureListener(executor);
+      }
       var names =
           gcBeans.stream()
               .map(GarbageCollectorMXBean::getMemoryPoolNames)

--- a/src/test/java/com/google/devtools/build/lib/runtime/MemoryPressureListenerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/MemoryPressureListenerTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import com.google.common.testing.TestLogHandler;
 import com.sun.management.GarbageCollectionNotificationInfo;
 import com.sun.management.GcInfo;
 import java.lang.management.GarbageCollectorMXBean;
@@ -35,6 +36,9 @@ import java.lang.management.MemoryUsage;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import javax.management.Notification;
 import javax.management.NotificationEmitter;
 import org.junit.Before;
@@ -86,6 +90,29 @@ public final class MemoryPressureListenerTest {
         () ->
             MemoryPressureListener.createFromBeans(
                 ImmutableList.of(mockUselessBean), directExecutor()));
+  }
+
+  @Test
+  public void createFromBeans_noGcBeansCreatesNoopListenerAndWarns() {
+    TestLogHandler handler = new TestLogHandler();
+    Logger logger = Logger.getLogger(MemoryPressureListener.class.getName());
+    logger.addHandler(handler);
+    try {
+      MemoryPressureListener underTest =
+          MemoryPressureListener.createFromBeans(ImmutableList.of(), directExecutor());
+
+      underTest.initForInvocation(
+          eventBus, mock(GcThrashingDetector.class), mock(GcChurningDetector.class));
+      underTest.reset();
+
+      assertThat(handler.getStoredLogRecords()).hasSize(1);
+      LogRecord warning = handler.getStoredLogRecords().get(0);
+      assertThat(warning.getLevel()).isEqualTo(Level.WARNING);
+      assertThat(warning.getMessage())
+          .contains("optional caches cannot be limited based on heap usage");
+    } finally {
+      logger.removeHandler(handler);
+    }
   }
 
   @Test


### PR DESCRIPTION
This change is needed because some Java runtimes expose no garbage
collector MXBeans. Bazel treats an empty list as an unsupported
collector and aborts server startup before it can run a command.

Treat an empty bean list as an environment without memory-pressure
notifications. Log a warning when the listener is created because
optional caches cannot be limited based on heap usage and peak memory
may be higher. Preserve the existing error for a non-empty list of
unknown collectors, so ordinary HotSpot diagnostics remain unchanged.

Cover listener initialization, reset, and warning output with no
collector beans.

Extracted from #30282.
