### PR TITLE
info: handle missing java.home

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/info/JavaHomeInfoItem.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/info/JavaHomeInfoItem.java
@@ -30,7 +30,11 @@ public final class JavaHomeInfoItem extends InfoItem {
   @Override
   public byte[] get(
       Supplier<BuildConfigurationValue> configurationSupplier, CommandEnvironment env) {
-    String javaHome = StringEncoding.platformToInternal(System.getProperty("java.home"));
+    String javaHomeProperty = System.getProperty("java.home");
+    if (javaHomeProperty == null) {
+      return print("unknown");
+    }
+    String javaHome = StringEncoding.platformToInternal(javaHomeProperty);
     if (javaHome == null) {
       return print("unknown");
     }

--- a/src/test/java/com/google/devtools/build/lib/runtime/commands/info/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/runtime/commands/info/BUILD
@@ -28,6 +28,17 @@ java_test(
 )
 
 java_test(
+    name = "JavaHomeInfoItemTest",
+    size = "small",
+    srcs = ["JavaHomeInfoItemTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/runtime/commands/info",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
+java_test(
     name = "RemoteRequestedInfoItemHandlerTest",
     size = "small",
     srcs = ["RemoteRequestedInfoItemHandlerTest.java"],

--- a/src/test/java/com/google/devtools/build/lib/runtime/commands/info/JavaHomeInfoItemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/commands/info/JavaHomeInfoItemTest.java
@@ -1,0 +1,38 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.runtime.commands.info;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class JavaHomeInfoItemTest {
+  @Test
+  public void missingJavaHomeReportsUnknown() throws Exception {
+    String javaHome = System.clearProperty("java.home");
+    try {
+      assertThat(new JavaHomeInfoItem().get(/* configurationSupplier= */ null, /* env= */ null))
+          .isEqualTo("unknown\n".getBytes(ISO_8859_1));
+    } finally {
+      if (javaHome != null) {
+        System.setProperty("java.home", javaHome);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change is needed because some Java runtimes omit the java.home
system property. Passing that null value into Bazel path encoding makes
bazel info fail instead of reporting the available runtime metadata.

Return unknown when the property is absent, matching the existing
fallback for an unencodable value. Cover the exact output while leaving
normal JVM path normalization unchanged.

Extracted from #30282.
