### PR TITLE
Update `//third_party:fastutil-stripped.jar` to use the new `proguard…

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -62,13 +62,11 @@ display "."
 log "Building output/bazel"
 # We set host and target platform directly because we are building for the local
 # host.
-set -x
 bazel_build "src:bazel_nojdk${EXE_EXT}" \
   --action_env=PATH \
   --host_platform=@platforms//host \
   --platforms=@platforms//host \
   || fail "Could not build Bazel"
-set +x
 bazel_bin_path="$(get_bazel_bin_path)/src/bazel_nojdk${EXE_EXT}"
 [ -e "$bazel_bin_path" ] \
   || fail "Could not find freshly built Bazel binary at '$bazel_bin_path'"

--- a/compile.sh
+++ b/compile.sh
@@ -67,7 +67,6 @@ bazel_build "src:bazel_nojdk${EXE_EXT}" \
   --action_env=PATH \
   --host_platform=@platforms//host \
   --platforms=@platforms//host \
-  "${EXTRA_BAZEL_BOOTSTRAP_ARGS[@]}" \
   || fail "Could not build Bazel"
 set +x
 bazel_bin_path="$(get_bazel_bin_path)/src/bazel_nojdk${EXE_EXT}"

--- a/compile.sh
+++ b/compile.sh
@@ -62,11 +62,14 @@ display "."
 log "Building output/bazel"
 # We set host and target platform directly because we are building for the local
 # host.
+set -x
 bazel_build "src:bazel_nojdk${EXE_EXT}" \
   --action_env=PATH \
   --host_platform=@platforms//host \
   --platforms=@platforms//host \
+  "${EXTRA_BAZEL_BOOTSTRAP_ARGS[@]}" \
   || fail "Could not build Bazel"
+set +x
 bazel_bin_path="$(get_bazel_bin_path)/src/bazel_nojdk${EXE_EXT}"
 [ -e "$bazel_bin_path" ] \
   || fail "Could not find freshly built Bazel binary at '$bazel_bin_path'"

--- a/scripts/bootstrap/buildenv.sh
+++ b/scripts/bootstrap/buildenv.sh
@@ -18,6 +18,9 @@
 
 set -o errexit
 
+# Extra args to pass to the bootstrapped bazel.
+EXTRA_BAZEL_BOOTSTRAP_ARGS=()
+
 # Check if all necessary tools are available.
 # List: https://github.com/bazelbuild/bazel/issues/7641#issuecomment-472344261
 for tool in basename cat chmod comm cp dirname find grep ln ls mkdir mktemp \
@@ -46,6 +49,10 @@ msys*|mingw*|cygwin*)
   # This is necessary to avoid overly longs paths during bootstrapping, see for
   # example https://github.com/bazelbuild/bazel/issues/4536
   export TMPDIR="${TMPDIR:-${TMP:-${TEMP:-}}}"
+
+  # Set the pythonpath: without this, the bootstrapped bazel tries to execute
+  # bare "python.exe" and cannot find it.
+  EXTRA_BAZEL_BOOTSTRAP_ARGS+=("--python_path=/c/python3/python.exe")
 esac
 
 # If BAZEL_WRKDIR is set, default all variables to point into

--- a/scripts/bootstrap/buildenv.sh
+++ b/scripts/bootstrap/buildenv.sh
@@ -18,9 +18,6 @@
 
 set -o errexit
 
-# Extra args to pass to the bootstrapped bazel.
-EXTRA_BAZEL_BOOTSTRAP_ARGS=()
-
 # Check if all necessary tools are available.
 # List: https://github.com/bazelbuild/bazel/issues/7641#issuecomment-472344261
 for tool in basename cat chmod comm cp dirname find grep ln ls mkdir mktemp \
@@ -52,7 +49,7 @@ msys*|mingw*|cygwin*)
 
   # Set the pythonpath: without this, the bootstrapped bazel tries to execute
   # bare "python.exe" and cannot find it.
-  EXTRA_BAZEL_BOOTSTRAP_ARGS+=("--python_path=/c/python3/python.exe")
+  DIST_BOOTSTRAP_ARGS="${DIST_BOOTSTRAP_ARGS} --python_path=$(which python.exe)"
 esac
 
 # If BAZEL_WRKDIR is set, default all variables to point into

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,6 +1,7 @@
-load("@rules_java//java:defs.bzl", "java_binary", "java_import", "java_library", "java_plugin")
+load("@rules_java//java:defs.bzl", "java_import", "java_library", "java_plugin")
 load("@rules_license//rules:license.bzl", "license")
 load("//src/tools/bzlmod:utils.bzl", "get_repo_root")
+load("//tools/build_defs/proguard:proguard.bzl", "proguard_jar")
 load("//tools/distributions:distribution_rules.bzl", "distrib_jar_filegroup", "distrib_java_import")
 
 package(default_visibility = ["//visibility:public"])
@@ -317,50 +318,19 @@ alias(
 # When using new classes from this dependency, make sure to update fastutil.proguard.
 java_import(
     name = "fastutil",
-    jars = [":fastutil_stripped_jar"],
+    jars = [":fastutil-stripped.jar"],
 )
 
-genrule(
-    name = "fastutil_stripped_jar",
+proguard_jar(
+    name = "fastutil_proguard",
     srcs = [
         "@maven//:it_unimi_dsi_fastutil_file",
+    ],
+    out = "fastutil-stripped.jar",
+    proguard_spec = "fastutil.proguard",
+    deps = [
         "@rules_java//toolchains:platformclasspath_nostrip",
     ],
-    outs = ["fastutil-stripped.jar"],
-    # ProGuard output is silenced below because it prints
-    # ...
-    # Caused by: java.net.UnknownHostException: bk-docker-3gmr: Temporary failure in name resolution
-    # ...
-    # when running in the Bazel sandbox, which throws off bazel_determinism_test.
-    cmd = """
-    $(location :proguard_bin) \
-        -injars $(execpath @maven//:it_unimi_dsi_fastutil_file) \
-        -outjars $@ \
-        -libraryjars $(execpath @rules_java//toolchains:platformclasspath_nostrip) \
-        @$(location //tools:fastutil.proguard) > /dev/null
-    # Null out the file times stored in the jar to make the output reproducible.
-    TMPDIR=$$(mktemp -d)
-    trap 'rm -rf $$TMPDIR' EXIT
-    unzip -q $@ -d $$TMPDIR
-    rm $@
-    find $$TMPDIR -type f -print0 | xargs -0 touch -t 198001010000.00
-    OUTPUT="$$(pwd)/$@"
-    (cd $$TMPDIR && find . -type f | LC_ALL=C sort | zip -qDX0r@ "$$OUTPUT")
-    """,
-    tools = [
-        ":proguard_bin",
-        "//tools:fastutil.proguard",
-    ],
-)
-
-java_binary(
-    name = "proguard_bin",
-    jvm_flags = [
-        # Prevent ProGuard from calling out to the internet through log4j.
-        "-Dlog4j.rootLogger=OFF",
-    ],
-    main_class = "proguard.ProGuard",
-    runtime_deps = ["@maven//:com_guardsquare_proguard_base"],
 )
 
 java_library(

--- a/third_party/fastutil.proguard
+++ b/third_party/fastutil.proguard
@@ -1,0 +1,10 @@
+-dontobfuscate
+-dontoptimize
+-keep ,includedescriptorclasses class it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap { *; }
+-keep ,includedescriptorclasses class it.unimi.dsi.fastutil.ints.IntArrayList { *; }
+-keep ,includedescriptorclasses class it.unimi.dsi.fastutil.ints.IntArrays { *; }
+-keep ,includedescriptorclasses class it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap { *; }
+-keep ,includedescriptorclasses class it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap { *; }
+# These classes access a `getChannel()` on InputStream subclasses via reflection.
+-dontnote it.unimi.dsi.fastutil.io.FastBufferedInputStream
+-dontnote it.unimi.dsi.fastutil.io.FastBufferedOutputStream


### PR DESCRIPTION
…_jar` rule.

Revert "Automated rollback of commit 2db79959524720ae5b173231f29a64e87ca6354d." This reverts commit a2aea7bb0eab85b6b102c6947b181393984ff948.

Part 2 of removing the dependence on a non-hermetic `unzip` binary.

The last step will remove the now-unused `//tools:fastutil.proguard` file.

RELNOTES: None.

Tested:
This fixes [the previous failure](https://buildkite.com/bazel/bazel-bazel/builds/36084/list?sid=019f5c1e-e082-41d6-9950-0e1a8a808d1f&tab=artifacts) by explicitly adding the `--python_path` flag for bootstrap builds on Windows: without the flag any python scripts in the bootstrapped build will fail to find the `python.exe` executable (even though `/c/python3` is in `PATH`).

I ran the test suite after enabling `//src/test/shell/bazel:bazel_bootstrap_distfile_test` to run in presubmit and verified: https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/35275/list (the interesting part is [Windows Shard 10](https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/35275/list?jid=019fb49a-9400-4fec-9b01-a4910ad567f5&tab=output), line 792).