### PR TITLE
Add experimental lazy location expansion for Args

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -178,6 +178,7 @@ java_library(
         ":rule_error_consumer",
         ":run_environment_info",
         ":starlark/args",
+        ":starlark/starlark_custom_command_line",
         ":starlark/bazel_build_api_globals",
         ":starlark/function_transition_util",
         ":starlark/starlark_api_provider",
@@ -1781,11 +1782,16 @@ java_library(
 
 java_library(
     name = "starlark/starlark_custom_command_line",
-    srcs = ["starlark/StarlarkCustomCommandLine.java"],
+    srcs = [
+        "starlark/LazyLocationExpansion.java",
+        "starlark/StarlarkCustomCommandLine.java",
+    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:commandline_item",
+        "//src/main/java/net/starlark/java/annot",
+        "//src/main/java/com/google/devtools/build/lib/util:shell_escaper",
         "//src/main/java/com/google/devtools/build/lib/actions:fileset_output_symlink",
         "//src/main/java/com/google/devtools/build/lib/actions:fileset_output_tree",
         "//src/main/java/com/google/devtools/build/lib/actions:param_file_action_input",

--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.analysis.RuleContext.PrerequisiteValidator;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
+import com.google.devtools.build.lib.analysis.starlark.LazyLocationExpansion;
 import com.google.devtools.build.lib.analysis.config.Fragment;
 import com.google.devtools.build.lib.analysis.config.FragmentClassSet;
 import com.google.devtools.build.lib.analysis.config.FragmentOptions;
@@ -690,6 +691,9 @@ public /*final*/ class ConfiguredRuleClassProvider
       @Nullable Label networkAllowlistForTests) {
     this.preludeLabel = preludeLabel;
     this.runfilesPrefix = runfilesPrefix;
+    // The main repository runfiles directory name is a product-level constant; record it for
+    // lazily rendered location expansions instead of storing it in every expansion.
+    LazyLocationExpansion.setWorkspaceRunfilesDirectory(runfilesPrefix);
     this.toolsRepository = toolsRepository;
     this.bundledBuiltinsRoot = bundledBuiltinsRoot;
     this.builtinsBzlPackagePathInSource = builtinsBzlPackagePathInSource;

--- a/src/main/java/com/google/devtools/build/lib/analysis/LocationExpander.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/LocationExpander.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.LocationExpander.LocationFunction.PathType;
+import com.google.devtools.build.lib.analysis.starlark.LazyLocationExpansion;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.Label.PackageContext;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
@@ -237,6 +238,58 @@ public final class LocationExpander {
     return expand(attrValue, new AttributeErrorReporter(ruleErrorConsumer, attrName));
   }
 
+  /**
+   * Expands the location expressions in the given value into a lazily rendered {@link
+   * LazyLocationExpansion} instead of an eagerly expanded string. Literal segments and unknown
+   * functions are rendered directly from the original string; only the resolved artifacts and a
+   * compact site layout are retained.
+   *
+   * @throws IllegalStateException if a location expression is invalid, with the same message that
+   *     {@link #expand} would report
+   */
+  public LazyLocationExpansion expandLazily(String value) {
+    List<Integer> layout = new ArrayList<>();
+    List<Object> values = new ArrayList<>();
+    int restart = 0;
+    while (true) {
+      int start = value.indexOf("$(", restart);
+      if (start == -1) {
+        break;
+      }
+      int nextWhitespace = value.indexOf(' ', start);
+      if (nextWhitespace == -1) {
+        break;
+      }
+      String fname = value.substring(start + 2, nextWhitespace);
+      LocationFunction function = functions.get(fname);
+      if (function == null) {
+        restart = start + 2;
+        continue;
+      }
+
+      int end = value.indexOf(')', nextWhitespace);
+      if (end == -1) {
+        throw new IllegalStateException(
+            String.format("unterminated $(%s) expression", fname));
+      }
+
+      String functionValue = value.substring(nextWhitespace + 1, end).trim();
+      Collection<Artifact> artifacts =
+          function.resolveLazily(functionValue, repositoryMapping, workspaceRunfilesDirectory);
+      layout.add(start);
+      layout.add(end + 1);
+      layout.add(function.pathTypeMode());
+      values.add(
+          artifacts.size() == 1
+              ? artifacts.iterator().next()
+              : ImmutableList.copyOf(artifacts));
+
+      restart = end + 1;
+    }
+    return new LazyLocationExpansion(
+        value, layout.stream().mapToInt(Integer::intValue).toArray(), values.toArray());
+  }
+
   @VisibleForTesting
   static final class LocationFunction {
     enum PathType {
@@ -276,18 +329,49 @@ public final class LocationExpander {
      */
     public String apply(
         String arg, RepositoryMapping repositoryMapping, String workspaceRunfilesDirectory) {
-      Label label;
+      Set<String> paths =
+          resolveLabel(parseLabel(arg, repositoryMapping), workspaceRunfilesDirectory);
+      return joinPaths(paths);
+    }
+
+    /**
+     * Resolves the label-like string to the artifacts it expands to, applying the same validation
+     * (and throwing the same exceptions) as {@link #apply}, but without retaining any rendered
+     * paths.
+     */
+    Collection<Artifact> resolveLazily(
+        String arg, RepositoryMapping repositoryMapping, String workspaceRunfilesDirectory) {
+      Label label = parseLabel(arg, repositoryMapping);
+      Collection<Artifact> artifacts = locationMapSupplier.get().get(label);
+      if (artifacts == null) {
+        throw new IllegalStateException(
+            String.format(
+                "label '%s' in %s expression is not a declared prerequisite of this rule",
+                label, functionName()));
+      }
+      // Rendered only for validation; the strings are not retained.
+      var unused = resolveLabel(label, workspaceRunfilesDirectory);
+      return artifacts;
+    }
+
+    /** Returns the {@link LazyLocationExpansion} mode corresponding to this function. */
+    int pathTypeMode() {
+      return switch (pathType) {
+        case LOCATION -> LazyLocationExpansion.MODE_LOCATION;
+        case EXEC -> LazyLocationExpansion.MODE_EXEC;
+        case RLOCATION -> LazyLocationExpansion.MODE_RLOCATION;
+      };
+    }
+
+    private Label parseLabel(String arg, RepositoryMapping repositoryMapping) {
       try {
-        label =
-            Label.parseWithPackageContext(
-                arg, PackageContext.of(root.getPackageIdentifier(), repositoryMapping));
+        return Label.parseWithPackageContext(
+            arg, PackageContext.of(root.getPackageIdentifier(), repositoryMapping));
       } catch (LabelSyntaxException e) {
         throw new IllegalStateException(
             String.format(
                 "invalid label in %s expression: %s", functionName(), e.getMessage()), e);
       }
-      Set<String> paths = resolveLabel(label, workspaceRunfilesDirectory);
-      return joinPaths(paths);
     }
 
     /** Returns all target location(s) of the given label. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/Args.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/Args.java
@@ -527,6 +527,13 @@ public abstract class Args implements CommandLineArgsApi {
     }
 
     private void addSingleArg(Object value, @Nullable String format) throws EvalException {
+      if (value instanceof LazyLocationExpansion expansion) {
+        if (format != null) {
+          throw Starlark.errorf("format is not supported for lazily expanded locations");
+        }
+        commandLine.addExpandedLocation(expansion);
+        return;
+      }
       if (value instanceof String s) {
         value = s.intern();
       }

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/LazyLocationExpansion.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/LazyLocationExpansion.java
@@ -1,0 +1,156 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.analysis.starlark;
+
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.PathMapper;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
+import com.google.devtools.build.lib.util.ShellEscaper;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.util.List;
+import java.util.TreeSet;
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.StarlarkSemantics;
+import net.starlark.java.eval.StarlarkValue;
+
+/**
+ * The result of {@code ctx.expand_location(..., lazy = True)}: a compact recipe for the expanded
+ * string that can be added to {@code ctx.actions.args()} in place of the eagerly expanded string.
+ *
+ * <p>Unlike eager expansion, no string containing artifact paths is created during analysis: the
+ * recipe only references the original input string (which is typically an attribute value that is
+ * retained by the rule anyway), a small {@code int[]} describing the location expression sites,
+ * and the resolved artifacts. Paths are rendered only when the consuming action's command line is
+ * expanded, at which point they are subject to path mapping.
+ */
+@StarlarkBuiltin(
+    name = "lazy_location_expansion",
+    documented = false,
+    doc = "An opaque, lazily rendered location expansion that can be added to Args.")
+public final class LazyLocationExpansion implements StarlarkValue {
+
+  // Path rendering modes, mirroring LocationExpander.LocationFunction.PathType.
+  public static final int MODE_LOCATION = 0;
+  public static final int MODE_EXEC = 1;
+  public static final int MODE_RLOCATION = 2;
+
+  // The name of the runfiles directory of the main repository ("_main" for Bazel). This is a
+  // constant that only depends on the product, so the choice is recorded once when the product's
+  // ConfiguredRuleClassProvider is constructed rather than stored per expansion, which keeps both
+  // the instance layout and the retained encoding in Args free of it.
+  private static volatile String workspaceRunfilesDirectory;
+
+  /** Records the product's main repository runfiles directory name. */
+  public static void setWorkspaceRunfilesDirectory(String directory) {
+    workspaceRunfilesDirectory = directory;
+  }
+
+  private final String original;
+  // Triples of (site start offset, site end offset, mode), one per location expression in
+  // original. The literal segments between sites are rendered directly from original.
+  private final int[] layout;
+  // One element per site: an Artifact or an ImmutableList<Artifact>.
+  private final Object[] values;
+
+  public LazyLocationExpansion(String original, int[] layout, Object[] values) {
+    this.original = original;
+    this.layout = layout;
+    this.values = values;
+  }
+
+  String original() {
+    return original;
+  }
+
+  int[] layout() {
+    return layout;
+  }
+
+  Object[] values() {
+    return values;
+  }
+
+  @Override
+  public boolean isImmutable() {
+    return true;
+  }
+
+  @Override
+  public void repr(Printer printer, StarlarkSemantics semantics) {
+    printer.append("lazy_location_expansion(").repr(original, semantics).append(")");
+  }
+
+  /**
+   * Renders the expansion, reading the per-site values from {@code values} starting at {@code
+   * valuesStart}. Exec paths are subject to {@code pathMapper}.
+   */
+  static String render(
+      String original, int[] layout, List<Object> values, int valuesStart, PathMapper pathMapper) {
+    StringBuilder result = new StringBuilder(original.length());
+    int numSites = layout.length / 3;
+    int previousEnd = 0;
+    for (int i = 0; i < numSites; i++) {
+      result.append(original, previousEnd, layout[3 * i]);
+      renderSite(result, values.get(valuesStart + i), layout[3 * i + 2], pathMapper);
+      previousEnd = layout[3 * i + 1];
+    }
+    result.append(original, previousEnd, original.length());
+    return result.toString();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void renderSite(
+      StringBuilder result, Object value, int mode, PathMapper pathMapper) {
+    // Mirrors LocationExpander.LocationFunction#getPaths and #joinPaths: paths are deduplicated
+    // and sorted after rendering and joined with spaces after shell escaping.
+    TreeSet<String> paths = new TreeSet<>();
+    if (value instanceof Artifact artifact) {
+      paths.add(renderPath(artifact, mode, pathMapper));
+    } else {
+      for (Artifact artifact : (ImmutableList<Artifact>) value) {
+        paths.add(renderPath(artifact, mode, pathMapper));
+      }
+    }
+    boolean first = true;
+    for (String path : paths) {
+      if (!first) {
+        result.append(' ');
+      }
+      result.append(ShellEscaper.escapeString(path));
+      first = false;
+    }
+  }
+
+  private static String renderPath(Artifact artifact, int mode, PathMapper pathMapper) {
+    // Mirrors LocationExpander.LocationFunction#getPath. Only exec paths are subject to path
+    // mapping: runfiles and rlocation paths do not contain a configuration prefix.
+    PathFragment path =
+        switch (mode) {
+          case MODE_LOCATION -> artifact.getRunfilesPath();
+          case MODE_EXEC -> pathMapper.map(artifact.getExecPath());
+          case MODE_RLOCATION -> {
+            PathFragment runfilesPath = artifact.getRunfilesPath();
+            if (runfilesPath.startsWith(LabelConstants.EXTERNAL_RUNFILES_PATH_PREFIX)) {
+              yield runfilesPath.relativeTo(LabelConstants.EXTERNAL_RUNFILES_PATH_PREFIX);
+            } else {
+              yield PathFragment.create(workspaceRunfilesDirectory).getRelative(runfilesPath);
+            }
+          }
+          default -> throw new IllegalStateException("unknown mode: " + mode);
+        };
+    return path.getCallablePathString();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
@@ -775,6 +775,82 @@ public class StarlarkCustomCommandLine extends CommandLine {
     }
   }
 
+  /**
+   * Denotes a lazily rendered location expansion: followed by the original string, the site
+   * layout, the workspace runfiles directory and one value per site.
+   */
+  @SerializationConstant @VisibleForSerialization
+  public static final Object EXPANDED_LOCATION_ARG_MARKER =
+      new Object() {
+        @Override
+        public String toString() {
+          return "EXPANDED_LOCATION_ARG_MARKER";
+        }
+      };
+
+  /**
+   * Representation of a lazily rendered location expansion originating from {@code
+   * ctx.expand_location(..., lazy = True)} being passed to {@code Args.add}.
+   *
+   * <p>Unlike an eagerly expanded string, this retains no artifact paths during analysis: it
+   * references the original input string, a small {@code int[]} and the resolved artifacts, which
+   * are all retained elsewhere anyway. Paths are rendered during preprocessing and are thus
+   * subject to path mapping.
+   */
+  private static final class ExpandedLocationArg {
+
+    private static final UUID EXPANDED_LOCATION_ARG_UUID =
+        UUID.fromString("d5f4a692-3b1c-4d8e-9a07-6e21f9c64b58");
+
+    static void push(List<Object> arguments, LazyLocationExpansion expansion) {
+      arguments.add(EXPANDED_LOCATION_ARG_MARKER);
+      arguments.add(expansion.original());
+      arguments.add(expansion.layout());
+      Collections.addAll(arguments, expansion.values());
+    }
+
+    static int preprocess(
+        List<Object> arguments,
+        int argi,
+        PreprocessedCommandLine.Builder builder,
+        PathMapper pathMapper) {
+      String original = (String) arguments.get(argi++);
+      int[] layout = (int[]) arguments.get(argi++);
+      builder.addArg(LazyLocationExpansion.render(original, layout, arguments, argi, pathMapper));
+      return argi + layout.length / 3;
+    }
+
+    static int addToFingerprint(List<Object> arguments, int argi, Fingerprint fingerprint) {
+      String original = (String) arguments.get(argi++);
+      int[] layout = (int[]) arguments.get(argi++);
+      fingerprint.addUUID(EXPANDED_LOCATION_ARG_UUID);
+      fingerprint.addString(original);
+      for (int i : layout) {
+        fingerprint.addInt(i);
+      }
+      // Path mapping may affect the rendering of exec paths at execution time, but its effect is a
+      // pure function of the artifacts' exec paths, the modes in the layout (both fingerprinted
+      // here) and the path mapping mode, which is fingerprinted by the consuming action. It is
+      // thus safe to fingerprint the unmapped exec paths.
+      int numSites = layout.length / 3;
+      for (int i = 0; i < numSites; i++) {
+        Object value = arguments.get(argi++);
+        if (value instanceof Artifact artifact) {
+          fingerprint.addInt(1);
+          fingerprint.addPath(artifact.getExecPath());
+        } else {
+          @SuppressWarnings("unchecked")
+          var artifacts = (ImmutableList<Artifact>) value;
+          fingerprint.addInt(artifacts.size());
+          for (Artifact artifact : artifacts) {
+            fingerprint.addPath(artifact.getExecPath());
+          }
+        }
+      }
+      return argi;
+    }
+  }
+
   /** Denotes that the following two elements are an object and format string. */
   @SerializationConstant @VisibleForSerialization
   public static final Object SINGLE_FORMATTED_ARG_MARKER =
@@ -879,6 +955,12 @@ public class StarlarkCustomCommandLine extends CommandLine {
       return this;
     }
 
+    @CanIgnoreReturnValue
+    Builder addExpandedLocation(LazyLocationExpansion expansion) {
+      ExpandedLocationArg.push(arguments, expansion);
+      return this;
+    }
+
     CommandLine build(boolean flagPerLine, @Nullable RepositoryMapping mainRepoMapping) {
       if (arguments.isEmpty()) {
         return CommandLine.empty();
@@ -944,6 +1026,8 @@ public class StarlarkCustomCommandLine extends CommandLine {
                     arguments, argi, builder, inputMetadataProvider, pathMapper, mainRepoMapping);
       } else if (arg == SINGLE_FORMATTED_ARG_MARKER) {
         argi = SingleFormattedArg.preprocess(arguments, argi, builder, mainRepoMapping);
+      } else if (arg == EXPANDED_LOCATION_ARG_MARKER) {
+        argi = ExpandedLocationArg.preprocess(arguments, argi, builder, pathMapper);
       } else {
         builder.addArg(expandToCommandLine(arg, mainRepoMapping));
       }
@@ -1080,6 +1164,8 @@ public class StarlarkCustomCommandLine extends CommandLine {
                     mainRepoMapping);
       } else if (arg == SINGLE_FORMATTED_ARG_MARKER) {
         argi = SingleFormattedArg.addToFingerprint(arguments, argi, fingerprint, mainRepoMapping);
+      } else if (arg == EXPANDED_LOCATION_ARG_MARKER) {
+        argi = ExpandedLocationArg.addToFingerprint(arguments, argi, fingerprint);
       } else {
         addSingleObjectToFingerprint(fingerprint, arg, mainRepoMapping);
       }

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
@@ -1030,8 +1030,8 @@ public final class StarlarkRuleContext
   }
 
   @Override
-  public String expandLocation(
-      String input, Sequence<?> targets, boolean shortPaths, StarlarkThread thread)
+  public Object expandLocation(
+      String input, Sequence<?> targets, boolean shortPaths, boolean lazy, StarlarkThread thread)
       throws EvalException {
     checkMutable("expand_location");
     try {
@@ -1047,6 +1047,9 @@ public final class StarlarkRuleContext
       } else {
         checkPrivateAccess(thread);
         expander = LocationExpander.withRunfilesPaths(ruleContext, labelMap);
+      }
+      if (lazy) {
+        return expander.expandLazily(input);
       }
       return expander.expand(input);
     } catch (IllegalStateException ise) {

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -663,6 +663,18 @@ public abstract class BuildLanguageOptions extends OptionsBase {
 
   // TODO: b/350661266 - Delete this flag.
   @Option(
+      name = "experimental_lazy_location_expansion",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+      help =
+          "If set to true, ctx.expand_location accepts a lazy parameter that makes it return an"
+              + " opaque value for use with ctx.actions.args() instead of an eagerly expanded"
+              + " string.")
+  public abstract boolean getExperimentalLazyLocationExpansion();
+
+  @Option(
       name = "experimental_starlark_types",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
@@ -959,6 +971,8 @@ public abstract class BuildLanguageOptions extends OptionsBase {
                 INCOMPATIBLE_LOCATIONS_PREFERS_EXECUTABLE,
                 getIncompatibleLocationsPrefersExecutable())
             .setBool(
+                EXPERIMENTAL_LAZY_LOCATION_EXPANSION, getExperimentalLazyLocationExpansion())
+            .setBool(
                 INCOMPATIBLE_RESOLVE_SELECT_KEYS_EAGERLY, getIncompatibleResolveSelectKeysEagerly())
             .setBool(
                 StarlarkSemantics.EXPERIMENTAL_ENABLE_STARLARK_SET,
@@ -1134,6 +1148,8 @@ public abstract class BuildLanguageOptions extends OptionsBase {
       "+incompatible_simplify_unconditional_selects_in_rule_attrs";
   public static final String INCOMPATIBLE_LOCATIONS_PREFERS_EXECUTABLE =
       "+incompatible_locations_prefers_executable";
+  public static final String EXPERIMENTAL_LAZY_LOCATION_EXPANSION =
+      "-experimental_lazy_location_expansion";
   public static final String EXPERIMENTAL_REPOSITORY_CTX_EXECUTE_WASM =
       "-experimental_repository_ctx_execute_wasm";
   public static final String EXPERIMENTAL_REPOSITORY_CTX_WASM_COMPILATION =

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleContextApi.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.starlarkbuildapi;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.docgen.annot.DocCategory;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.collect.nestedset.Depset.TypeException;
 import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
@@ -459,12 +460,24 @@ public interface StarlarkRuleContextApi<ConstraintValueT extends ConstraintValue
             positional = false,
             defaultValue = "False",
             documented = false),
+        @Param(
+            name = "lazy",
+            named = true,
+            positional = false,
+            defaultValue = "False",
+            enableOnlyWithFlag = BuildLanguageOptions.EXPERIMENTAL_LAZY_LOCATION_EXPANSION,
+            doc =
+                "Experimental: if true, returns an opaque value that can be passed to"
+                    + " <code>Args.add</code> in place of the eagerly expanded string. Location"
+                    + " paths are only rendered when the consuming action's command line is"
+                    + " expanded, which retains less memory during analysis and makes the paths"
+                    + " subject to path mapping."),
       },
       allowReturnNones = true,
       useStarlarkThread = true)
   @Nullable
-  String expandLocation(
-      String input, Sequence<?> targets, boolean shortPaths, StarlarkThread thread)
+  Object expandLocation(
+      String input, Sequence<?> targets, boolean shortPaths, boolean lazy, StarlarkThread thread)
       throws EvalException;
 
   @StarlarkMethod(

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
@@ -693,6 +693,65 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
   }
 
   @Test
+  public void testExpandLocationLazy_rendersSameAsEager() throws Exception {
+    setBuildLanguageOptions("--experimental_lazy_location_expansion");
+    ev.setSemantics("--experimental_lazy_location_expansion");
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:bar");
+    setRuleContext(ruleContext);
+
+    String input =
+        "before $(location :jl) $(rootpath :jl) $(rlocationpath :jl) middle $(locations :gl)"
+            + " $(unknown) end";
+    String eager = (String) ev.eval("ruleContext.expand_location('" + input + "')");
+    CommandLine commandLine =
+        getCommandLine(
+            "args = ruleContext.actions.args()",
+            "args.add(ruleContext.expand_location('" + input + "', lazy = True))");
+
+    assertThat(commandLine.arguments()).containsExactly(eager);
+  }
+
+  @Test
+  public void testExpandLocationLazy_isNotAString() throws Exception {
+    setBuildLanguageOptions("--experimental_lazy_location_expansion");
+    ev.setSemantics("--experimental_lazy_location_expansion");
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:bar");
+    setRuleContext(ruleContext);
+
+    Object lazy = ev.eval("ruleContext.expand_location('$(location :jl)', lazy = True)");
+
+    assertThat(lazy).isNotInstanceOf(String.class);
+  }
+
+  @Test
+  public void testExpandLocationLazy_fingerprint() throws Exception {
+    setBuildLanguageOptions("--experimental_lazy_location_expansion");
+    ev.setSemantics("--experimental_lazy_location_expansion");
+    setRuleContext(createRuleContext("//foo:bar"));
+
+    CommandLine commandLine1 =
+        getCommandLine(
+            "args = ruleContext.actions.args()",
+            "args.add(ruleContext.expand_location('a $(location :jl)', lazy = True))");
+    CommandLine commandLine1Again =
+        getCommandLine(
+            "args = ruleContext.actions.args()",
+            "args.add(ruleContext.expand_location('a $(location :jl)', lazy = True))");
+    CommandLine commandLine2 =
+        getCommandLine(
+            "args = ruleContext.actions.args()",
+            "args.add(ruleContext.expand_location('b $(location :jl)', lazy = True))");
+    CommandLine commandLine3 =
+        getCommandLine(
+            "args = ruleContext.actions.args()",
+            "args.add(ruleContext.expand_location('a $(rootpath :jl)', lazy = True))");
+
+    assertThat(getDigest(commandLine1)).isEqualTo(getDigest(commandLine1Again));
+    assertThat(getDigest(commandLine1)).isNotEqualTo(getDigest(commandLine2));
+    assertThat(getDigest(commandLine1)).isNotEqualTo(getDigest(commandLine3));
+  }
+
+  @Test
   public void testExpandLocationWithShortPathsIsPrivateAPI() throws Exception {
     scratch.file(
         "abc/rule.bzl",


### PR DESCRIPTION
Adds `ctx.expand_location(input, targets, lazy = True)`, gated behind the new `--experimental_lazy_location_expansion` flag. Instead of an eagerly expanded string, it returns an opaque `LazyLocationExpansion` that can be passed to `Args.add` in place of the string.

### Motivation

Eagerly expanded location strings bake artifact paths into strings that are retained in the analysis cache for the lifetime of the server (roughly 36 + length bytes per argument per action), and such strings can never be path mapped. The lazy form stores a compact recipe instead: a reference to the original input string (typically an attribute value retained by the rule anyway), an `int[]` of (start, end, mode) triples for the location expression sites, and the resolved artifacts — no string containing artifact paths is created during analysis at all, and no substrings of the input are retained either. That's ~36 bytes plus 12 bytes per expression site, independent of path lengths.

### Design

* `LocationExpander#expandLazily` scans exactly like `#expand`, but records site spans and resolved artifacts instead of appending rendered paths. Validation (unknown labels, empty or multiple expansions for singular functions) still happens during analysis with the same error messages, by rendering paths transiently.
* `StarlarkCustomCommandLine` gains an `EXPANDED_LOCATION_ARG_MARKER` encoding. Rendering happens at preprocess time and mirrors `LocationFunction` (callable paths, sorted and deduplicated plural expansions, shell escaping), with exec paths going through the `PathMapper` — lazily expanded locations are thus compatible with `--experimental_output_paths=strip`.
* Literal segments and unknown functions render directly from the original string.
* The main repository's runfiles directory name (needed by `$(rlocationpath)` rendering) is a constant that only depends on the product, so it is recorded once when the `ConfiguredRuleClassProvider` is constructed rather than stored per expansion — it appears in neither the instance layout nor the retained encoding.
* Fingerprinting covers the original string, the site layout and the artifacts' unmapped exec paths; the effect of path mapping on the rendering is a pure function of these plus the output paths mode, which the consuming action fingerprints.

### Notes for review

* Sending this as a draft to collect feedback on the API shape (`lazy` parameter on `expand_location` vs. a separate method) and on recording the runfiles directory in `ConfiguredRuleClassProvider`'s constructor.
* Motivated by a Starlark library that implements the same idea with `Args.add_joined`/`map_each` tokens; the native form retains less (no literal substrings, no per-token tuples) and needs no library. Happy to share the detailed memory model and benchmark numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hbS4fiUT83VKyVTvxJkjf
