### PR TITLE
[8.8.0] Remote: add opt-in recovery for the failure circuit breaker

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
@@ -107,11 +107,22 @@ public class Retrier {
     /** Returns the current {@link State} of the circuit breaker. */
     State state();
 
-    /** Called after an execution failed. */
-    void recordFailure();
+    /**
+     * Called after an execution failed.
+     *
+     * @param observedState the {@link State} returned by {@link #state()} when this call was
+     *     dispatched, so the breaker can attribute the outcome (in particular, distinguish a {@link
+     *     State#TRIAL_CALL} probe from an ordinary call).
+     */
+    void recordFailure(State observedState);
 
-    /** Called after an execution succeeded. */
-    void recordSuccess();
+    /**
+     * Called after an execution succeeded.
+     *
+     * @param observedState the {@link State} returned by {@link #state()} when this call was
+     *     dispatched (see {@link #recordFailure(State)}).
+     */
+    void recordSuccess(State observedState);
 
     /**
      * Returns a human-readable description of the breaker's current failure statistics (for example
@@ -148,10 +159,10 @@ public class Retrier {
         }
 
         @Override
-        public void recordFailure() {}
+        public void recordFailure(State observedState) {}
 
         @Override
-        public void recordSuccess() {}
+        public void recordSuccess(State observedState) {}
 
         @Override
         public String failureDetails() {
@@ -294,16 +305,16 @@ public class Retrier {
           throw new InterruptedException();
         }
         T r = callWithContext(call, backoff, rpcId);
-        circuitBreaker.recordSuccess();
+        circuitBreaker.recordSuccess(circuitState);
         return r;
       } catch (Exception e) {
         Throwables.throwIfInstanceOf(e, InterruptedException.class);
         if (!shouldRetry.test(e)) {
           // A non-retriable error doesn't represent server failure.
-          circuitBreaker.recordSuccess();
+          circuitBreaker.recordSuccess(circuitState);
           throw e;
         }
-        circuitBreaker.recordFailure();
+        circuitBreaker.recordFailure(circuitState);
         if (Objects.equals(circuitState, State.TRIAL_CALL)) {
           throw e;
         }
@@ -373,7 +384,7 @@ public class Retrier {
           Futures.transformAsync(
               callWithContext(call, backoff, rpcId),
               (f) -> {
-                circuitBreaker.recordSuccess();
+                circuitBreaker.recordSuccess(circuitState);
                 return immediateFuture(f);
               },
               directExecutor());
@@ -390,7 +401,7 @@ public class Retrier {
   private <T> ListenableFuture<T> onExecuteAsyncFailure(
       Exception t, AsyncCallable<T> call, Backoff backoff, State circuitState, @Nullable String rpcId) {
     if (isRetriable(t)) {
-      circuitBreaker.recordFailure();
+      circuitBreaker.recordFailure(circuitState);
       if (circuitState.equals(State.TRIAL_CALL)) {
         return immediateFailedFuture(t);
       }
@@ -414,7 +425,7 @@ public class Retrier {
       // gRPC Errors NOT_FOUND, OUT_OF_RANGE, ALREADY_EXISTS etc. are non-retriable error, and they
       // don't represent an
       // issue in Server. So treating these errors as successful api call.
-      circuitBreaker.recordSuccess();
+      circuitBreaker.recordSuccess(circuitState);
       return immediateFailedFuture(t);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
@@ -15,6 +15,8 @@ package com.google.devtools.build.lib.remote.circuitbreaker;
 
 import com.google.devtools.build.lib.remote.Retrier;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 /** Factory for {@link Retrier.CircuitBreaker} */
 public class CircuitBreakerFactory {
@@ -32,11 +34,27 @@ public class CircuitBreakerFactory {
    */
   public static Retrier.CircuitBreaker createCircuitBreaker(final RemoteOptions remoteOptions) {
     if (remoteOptions.circuitBreakerStrategy == RemoteOptions.CircuitBreakerStrategy.FAILURE) {
+      int slidingWindowMillis = (int) remoteOptions.remoteFailureWindowInterval.toMillis();
+      int recoveryDelayMillis = (int) remoteOptions.remoteCircuitBreakerRecoveryDelay.toMillis();
+      boolean needsScheduler = slidingWindowMillis > 0 || recoveryDelayMillis > 0;
       return new FailureCircuitBreaker(
           remoteOptions.remoteFailureRateThreshold,
-          (int) remoteOptions.remoteFailureWindowInterval.toMillis(),
-          remoteOptions.remoteMinCallCountToComputeFailureRate);
+          slidingWindowMillis,
+          remoteOptions.remoteMinCallCountToComputeFailureRate,
+          recoveryDelayMillis,
+          needsScheduler ? newScheduler() : null);
     }
     return Retrier.ALLOW_ALL_CALLS;
+  }
+
+  /**
+   * Returns a single-threaded scheduler for the breaker's window-decrement and recovery-probe
+   * tasks. The worker is a daemon so a per-build breaker never keeps the server alive; it is a
+   * platform thread because these are trivial, non-blocking tasks driven by a delay queue, which
+   * virtual threads do not suit.
+   */
+  private static ScheduledExecutorService newScheduler() {
+    return Executors.newSingleThreadScheduledExecutor(
+        Thread.ofPlatform().name("remote-circuit-breaker").daemon().factory());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
@@ -15,27 +15,62 @@ package com.google.devtools.build.lib.remote.circuitbreaker;
 
 import com.google.devtools.build.lib.remote.Retrier;
 import java.util.Locale;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * The {@link FailureCircuitBreaker} implementation of the {@link Retrier.CircuitBreaker} prevents
- * further calls to a remote cache once the failures rate within a given window exceeds a specified
- * threshold for a build. In the context of Bazel, a new instance of {@link Retrier.CircuitBreaker}
- * is created for each build. Therefore, if the circuit breaker trips during a build, the remote
- * cache will be disabled for that build. However, it will be enabled again for the next build as a
- * new instance of {@link Retrier.CircuitBreaker} will be created.
+ * A {@link Retrier.CircuitBreaker} that stops calling a remote cache/executor once the failure rate
+ * within a sliding window exceeds a configured threshold. In the context of Bazel a new instance is
+ * created for each build, so a breaker that trips disables the remote cache for that build (by
+ * default for the remainder of it) and is reset for the next build.
+ *
+ * <p>Recovery within a build is opt-in via a positive recovery delay. After the breaker trips it
+ * moves through a small state machine: {@code OPEN} (all calls rejected) then, once the recovery
+ * delay elapses, {@code RECOVERING} (the next caller is handed a single {@link State#TRIAL_CALL}
+ * probe while everyone else keeps seeing {@link State#REJECT_CALLS}) then {@code PROBING} (the
+ * probe is in flight). A successful probe closes the breaker ({@link State#ACCEPT_CALLS}) and
+ * starts a fresh window; a failed probe reopens it and schedules the next probe. With a
+ * non-positive delay (the default) the breaker never leaves {@code OPEN}, preserving the previous
+ * permanent-open behaviour.
+ *
+ * <p>The outcome of a probe is attributed using the {@link State} each call observed when it was
+ * dispatched (passed to {@link #recordSuccess(State)}/{@link #recordFailure(State)}): only the call
+ * that observed {@link State#TRIAL_CALL} can resolve the probe, so a slow call that started before
+ * the breaker tripped cannot hijack it.
  */
 public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
 
-  private State state;
-  private final AtomicInteger successes;
-  private final AtomicInteger failures;
+  /**
+   * Internal health state. Maps to the interface {@link State} exposed to the {@link Retrier}:
+   * {@code CLOSED} to {@link State#ACCEPT_CALLS}, everything else to {@link State#REJECT_CALLS}
+   * except that {@code RECOVERING} hands a single {@link State#TRIAL_CALL} to one caller.
+   */
+  private enum Health {
+    /** Normal operation; calls are accepted. */
+    CLOSED,
+    /** Tripped; all calls are rejected until the recovery delay elapses. */
+    OPEN,
+    /** The recovery delay has elapsed; the next caller may be given a single trial probe. */
+    RECOVERING,
+    /** A single trial probe is in flight; other callers are still rejected. */
+    PROBING
+  }
+
+  private final AtomicReference<Health> health = new AtomicReference<>(Health.CLOSED);
+  private final AtomicInteger successes = new AtomicInteger(0);
+  private final AtomicInteger failures = new AtomicInteger(0);
+
+  // Bumped whenever the counters are reset, so window-decrement tasks scheduled before the reset
+  // become no-ops instead of decrementing the fresh counts.
+  private final AtomicLong generation = new AtomicLong(0);
+
   private final int failureRateThreshold;
   private final int slidingWindowSize;
   private final int minCallCountToComputeFailureRate;
+  private final int recoveryDelayMillis;
   private final ScheduledExecutorService scheduledExecutor;
 
   /**
@@ -45,35 +80,57 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
    *     circuit breaker in given time window.
    * @param slidingWindowSize the size of the sliding window in milliseconds to calculate the number
    *     of failures.
-   * @param minCallCountToComputeFailureRate the minimum number of calls within the window before the
-   *     failure rate is computed and the breaker may trip.
+   * @param minCallCountToComputeFailureRate the minimum number of calls within the window before
+   *     the failure rate is computed and the breaker may trip.
+   * @param recoveryDelayMillis the delay in milliseconds after the breaker trips before it issues a
+   *     trial probe. A non-positive value disables recovery, keeping a tripped breaker open for the
+   *     remainder of the build.
+   * @param scheduledExecutor executor for scheduling tasks to decrement success and failure counts
+   *     and to make trial probes available; may be {@code null} only when both the sliding window
+   *     and recovery are disabled.
    */
   public FailureCircuitBreaker(
-      int failureRateThreshold, int slidingWindowSize, int minCallCountToComputeFailureRate) {
-    this.failures = new AtomicInteger(0);
-    this.successes = new AtomicInteger(0);
+      int failureRateThreshold,
+      int slidingWindowSize,
+      int minCallCountToComputeFailureRate,
+      int recoveryDelayMillis,
+      ScheduledExecutorService scheduledExecutor) {
     this.failureRateThreshold = failureRateThreshold;
     this.slidingWindowSize = slidingWindowSize;
     this.minCallCountToComputeFailureRate = minCallCountToComputeFailureRate;
-    this.state = State.ACCEPT_CALLS;
-    this.scheduledExecutor =
-        slidingWindowSize > 0 ? Executors.newSingleThreadScheduledExecutor() : null;
+    this.recoveryDelayMillis = recoveryDelayMillis;
+    this.scheduledExecutor = scheduledExecutor;
   }
 
   @Override
   public State state() {
-    return this.state;
+    Health current = health.get();
+    if (current == Health.RECOVERING) {
+      // The recovery delay has elapsed: hand TRIAL_CALL to exactly one caller (whoever wins the
+      // CAS); every other caller keeps seeing REJECT_CALLS until the probe resolves.
+      if (health.compareAndSet(Health.RECOVERING, Health.PROBING)) {
+        return State.TRIAL_CALL;
+      }
+      // Lost the race for the probe; re-read so the returned state reflects where we ended up.
+      current = health.get();
+    }
+    return current == Health.CLOSED ? State.ACCEPT_CALLS : State.REJECT_CALLS;
   }
 
   @Override
-  public void recordFailure() {
+  public void recordFailure(State observedState) {
+    if (observedState == State.TRIAL_CALL) {
+      // The trial probe failed: reopen and schedule the next probe. Only the probe observes
+      // TRIAL_CALL, so a slow pre-trip call cannot consume the trial outcome here.
+      if (health.compareAndSet(Health.PROBING, Health.OPEN)) {
+        scheduleTrial();
+      }
+      return;
+    }
+
     int failureCount = failures.incrementAndGet();
     int totalCallCount = successes.get() + failureCount;
-    if (slidingWindowSize > 0) {
-      var unused =
-          scheduledExecutor.schedule(
-              failures::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
-    }
+    scheduleWindowDecrement(failures);
 
     if (totalCallCount < minCallCountToComputeFailureRate) {
       // The remote call count is below the threshold required to calculate the failure rate.
@@ -81,19 +138,58 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
     }
     double failureRate = (failureCount * 100.0) / totalCallCount;
 
-    // Since the state can only be changed to the open state, synchronization is not required.
-    if (failureRate > this.failureRateThreshold) {
-      this.state = State.REJECT_CALLS;
+    // Only the thread that trips the breaker (wins the CAS) schedules the single recovery probe.
+    if (failureRate > failureRateThreshold && health.compareAndSet(Health.CLOSED, Health.OPEN)) {
+      scheduleTrial();
     }
   }
 
   @Override
-  public void recordSuccess() {
+  public void recordSuccess(State observedState) {
+    if (observedState == State.TRIAL_CALL) {
+      // The trial probe succeeded: close the breaker and start a fresh window.
+      if (health.compareAndSet(Health.PROBING, Health.CLOSED)) {
+        resetCounters();
+      }
+      return;
+    }
+
     successes.incrementAndGet();
+    scheduleWindowDecrement(successes);
+  }
+
+  private void resetCounters() {
+    // Invalidate window-decrement tasks scheduled before the reset, then zero the counts, so stale
+    // decrements cannot erase failures recorded after recovery.
+    generation.incrementAndGet();
+    failures.set(0);
+    successes.set(0);
+  }
+
+  private void scheduleWindowDecrement(AtomicInteger counter) {
     if (slidingWindowSize > 0) {
+      long scheduledGeneration = generation.get();
       var unused =
           scheduledExecutor.schedule(
-              successes::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
+              () -> {
+                if (generation.get() == scheduledGeneration) {
+                  var ignored = counter.decrementAndGet();
+                }
+              },
+              slidingWindowSize,
+              TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private void scheduleTrial() {
+    if (recoveryDelayMillis > 0 && scheduledExecutor != null) {
+      var unused =
+          scheduledExecutor.schedule(
+              () -> {
+                var ignored = health.compareAndSet(Health.OPEN, Health.RECOVERING);
+              },
+              recoveryDelayMillis,
+              TimeUnit.MILLISECONDS);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -747,6 +747,23 @@ public final class RemoteOptions extends CommonRemoteOptions {
   public int remoteMinCallCountToComputeFailureRate;
 
   @Option(
+      name = "experimental_remote_circuit_breaker_recovery_delay",
+      defaultValue = "0",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.EXECUTION},
+      converter = RemoteDurationConverter.class,
+      help =
+          "The delay after the failure circuit breaker trips before it allows a single trial remote"
+              + " call to probe whether the remote cache/executor has recovered. If the trial"
+              + " succeeds the breaker closes and normal calls resume; otherwise it re-opens and"
+              + " waits again before the next trial. A zero or negative value (the default)"
+              + " disables recovery, so a tripped breaker stays open for the remainder of the"
+              + " build. Following units can be used: Days (d), hours (h), minutes (m), seconds"
+              + " (s), and milliseconds (ms). If the unit is omitted, the value is interpreted as"
+              + " seconds. Only takes effect with --experimental_circuit_breaker_strategy=failure.")
+  public Duration remoteCircuitBreakerRecoveryDelay;
+
+  @Option(
       name = "experimental_remote_cache_lease_extension",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.REMOTE,

--- a/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
@@ -100,8 +100,8 @@ public class RetrierTest {
     assertThat(e).hasMessageThat().isEqualTo("call failed");
 
     assertThat(numCalls.get()).isEqualTo(3);
-    verify(alwaysOpen, times(3)).recordFailure();
-    verify(alwaysOpen, never()).recordSuccess();
+    verify(alwaysOpen, times(3)).recordFailure(State.ACCEPT_CALLS);
+    verify(alwaysOpen, never()).recordSuccess(State.ACCEPT_CALLS);
   }
 
   @Test
@@ -124,8 +124,8 @@ public class RetrierTest {
     assertThat(e).hasMessageThat().isEqualTo("call failed");
 
     assertThat(numCalls.get()).isEqualTo(1);
-    verify(alwaysOpen, never()).recordFailure();
-    verify(alwaysOpen, times(1)).recordSuccess();
+    verify(alwaysOpen, never()).recordFailure(State.ACCEPT_CALLS);
+    verify(alwaysOpen, times(1)).recordSuccess(State.ACCEPT_CALLS);
   }
 
   @Test
@@ -145,8 +145,8 @@ public class RetrierTest {
     });
     assertThat(val).isEqualTo(1);
 
-    verify(alwaysOpen, times(2)).recordFailure();
-    verify(alwaysOpen, times(1)).recordSuccess();
+    verify(alwaysOpen, times(2)).recordFailure(State.ACCEPT_CALLS);
+    verify(alwaysOpen, times(1)).recordSuccess(State.ACCEPT_CALLS);
   }
 
   @Test
@@ -212,10 +212,10 @@ public class RetrierTest {
           }
 
           @Override
-          public void recordFailure() {}
+          public void recordFailure(State observedState) {}
 
           @Override
-          public void recordSuccess() {}
+          public void recordSuccess(State observedState) {}
 
           @Override
           public String failureDetails() {
@@ -561,7 +561,7 @@ public class RetrierTest {
     }
 
     @Override
-    public synchronized void recordFailure() {
+    public synchronized void recordFailure(State observedState) {
       consecutiveFailures++;
       if (consecutiveFailures >= maxConsecutiveFailures) {
         state = State.REJECT_CALLS;
@@ -569,7 +569,7 @@ public class RetrierTest {
     }
 
     @Override
-    public synchronized void recordSuccess() {
+    public synchronized void recordSuccess(State observedState) {
       consecutiveFailures = 0;
       state = State.ACCEPT_CALLS;
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/BUILD
@@ -26,6 +26,7 @@ java_test(
         "//src/main/java/com/google/devtools/common/options",
         "//src/test/java/com/google/devtools/build/lib:test_runner",
         "//third_party:junit4",
+        "//third_party:mockito",
         "//third_party:truth",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactoryTest.java
@@ -61,10 +61,10 @@ public class CircuitBreakerFactoryTest {
     // rate, which exceeds the 10% threshold. This would not trip under the default min call count
     // of 100, proving the flag took effect.
     for (int i = 0; i < 4; i++) {
-      circuitBreaker.recordSuccess();
+      circuitBreaker.recordSuccess(State.ACCEPT_CALLS);
     }
     assertThat(circuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
-    circuitBreaker.recordFailure();
+    circuitBreaker.recordFailure(State.ACCEPT_CALLS);
     assertThat(circuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
@@ -14,12 +14,19 @@
 package com.google.devtools.build.lib.remote.circuitbreaker;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.devtools.build.lib.remote.Retrier.CircuitBreaker.State;
+import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.common.options.Options;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.IntStream;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,66 +34,97 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class FailureCircuitBreakerTest {
 
+  private final RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+
+  /**
+   * Returns a mock scheduler that records scheduled tasks by delay: tasks scheduled at {@code
+   * recoveryDelayMillis} (the recovery probes) go into {@code trialTasks}, everything else (the
+   * sliding-window decrements) into {@code windowTasks}. A test runs them manually to simulate the
+   * recovery delay or the window elapsing. All tasks the breaker schedules are {@link Runnable}s.
+   */
+  private static ScheduledExecutorService newSchedulerCapturing(
+      long recoveryDelayMillis, List<Runnable> trialTasks, List<Runnable> windowTasks) {
+    ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
+    when(mockScheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+        .thenAnswer(
+            invocation -> {
+              Runnable task = invocation.getArgument(0);
+              long delayMillis = invocation.getArgument(1);
+              if (delayMillis == recoveryDelayMillis) {
+                trialTasks.add(task);
+              } else {
+                windowTasks.add(task);
+              }
+              return null;
+            });
+    return mockScheduler;
+  }
+
   @Test
-  public void testRecordFailure_circuitTrips() throws InterruptedException {
+  public void testRecordFailure_circuitTrips() {
     final int failureRateThreshold = 10;
     final int windowInterval = 100;
+    List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
     FailureCircuitBreaker failureCircuitBreaker =
         new FailureCircuitBreaker(
             failureRateThreshold,
             windowInterval,
-            CircuitBreakerFactory.DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE);
+            remoteOptions.remoteMinCallCountToComputeFailureRate,
+            /* recoveryDelayMillis= */ 0,
+            newSchedulerCapturing(/* recoveryDelayMillis= */ 0, new ArrayList<>(), windowTasks));
 
     List<Runnable> listOfSuccessAndFailureCalls = new ArrayList<>();
     for (int index = 0; index < failureRateThreshold; index++) {
-      listOfSuccessAndFailureCalls.add(failureCircuitBreaker::recordFailure);
+      listOfSuccessAndFailureCalls.add(
+          () -> failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS));
     }
-
     for (int index = 0; index < failureRateThreshold * 9; index++) {
-      listOfSuccessAndFailureCalls.add(failureCircuitBreaker::recordSuccess);
+      listOfSuccessAndFailureCalls.add(
+          () -> failureCircuitBreaker.recordSuccess(State.ACCEPT_CALLS));
     }
-
     Collections.shuffle(listOfSuccessAndFailureCalls);
 
-    // make calls equals to threshold number of not ignored failure calls in parallel.
+    // Make calls equal to the threshold number of not-ignored failure calls in parallel.
     listOfSuccessAndFailureCalls.stream().parallel().forEach(Runnable::run);
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
 
-    // Sleep for windowInterval + 1ms.
-    Thread.sleep(windowInterval + 1 /*to compensate any delay*/);
+    // Run all captured window-decrement tasks to simulate the window expiring.
+    int expectedCalls = failureRateThreshold * 10;
+    assertThat(windowTasks).hasSize(expectedCalls);
+    windowTasks.forEach(Runnable::run);
+    windowTasks.clear(); // Clear for the next round.
 
-    // make calls equals to threshold number of not ignored failure calls in parallel.
     listOfSuccessAndFailureCalls.stream().parallel().forEach(Runnable::run);
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
 
-    // Sleep for less than windowInterval.
-    Thread.sleep(windowInterval - 5);
-    failureCircuitBreaker.recordFailure();
+    // We don't run the new scheduled tasks, simulating being within the window.
+    failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS);
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 
   @Test
-  public void testRecordFailure_minCallCriteriaNotMet() throws InterruptedException {
-    final int failureRateThreshold = 10;
+  public void testRecordFailure_minCallCriteriaNotMet() {
+    final int failureRateThreshold = 0;
     final int windowInterval = 100;
-    final int minCallToComputeFailure =
-        CircuitBreakerFactory.DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE;
+    final int minCallToComputeFailure = remoteOptions.remoteMinCallCountToComputeFailureRate;
     FailureCircuitBreaker failureCircuitBreaker =
-        new FailureCircuitBreaker(failureRateThreshold, windowInterval, minCallToComputeFailure);
+        new FailureCircuitBreaker(
+            failureRateThreshold,
+            windowInterval,
+            remoteOptions.remoteMinCallCountToComputeFailureRate,
+            /* recoveryDelayMillis= */ 0,
+            mock(ScheduledExecutorService.class));
 
-    // make half failure call, half success call and number of total call less than
+    // Make success calls, a failure call, and a total number of calls less than
     // minCallToComputeFailure.
-    IntStream.range(0, minCallToComputeFailure >> 1)
-        .parallel()
-        .forEach(i -> failureCircuitBreaker.recordFailure());
-    IntStream.range(0, minCallToComputeFailure >> 1)
-        .parallel()
-        .forEach(i -> failureCircuitBreaker.recordSuccess());
+    for (int index = 0; index < minCallToComputeFailure - 2; index++) {
+      failureCircuitBreaker.recordSuccess(State.ACCEPT_CALLS);
+    }
+    failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS);
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
 
-    // Sleep for less than windowInterval.
-    Thread.sleep(windowInterval - 50);
-    failureCircuitBreaker.recordFailure();
+    // We don't run the scheduled tasks, simulating being within the window.
+    failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS);
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 
@@ -94,24 +132,172 @@ public class FailureCircuitBreakerTest {
   public void testFailureDetails_reportsStats() {
     final int failureRateThreshold = 10;
     final int windowInterval = 100;
-    ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
     FailureCircuitBreaker failureCircuitBreaker =
         new FailureCircuitBreaker(
             failureRateThreshold,
             windowInterval,
             /* minCallCountToComputeFailureRate= */ 0,
-            /* minFailCountToComputeFailureRate= */ 0,
-            mockScheduler);
+            /* recoveryDelayMillis= */ 0,
+            mock(ScheduledExecutorService.class));
 
-    failureCircuitBreaker.recordSuccess();
-    failureCircuitBreaker.recordFailure();
-    failureCircuitBreaker.recordFailure();
-    failureCircuitBreaker.recordFailure();
+    failureCircuitBreaker.recordSuccess(State.ACCEPT_CALLS);
+    failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS);
+    failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS);
+    failureCircuitBreaker.recordFailure(State.ACCEPT_CALLS);
 
     String details = failureCircuitBreaker.failureDetails();
     assertThat(details).contains("3 out of 4 remote calls failed");
     assertThat(details).contains("75.00%");
     assertThat(details).contains("the last 100ms");
     assertThat(details).contains("10% failure rate threshold");
+  }
+
+  @Test
+  public void testRecovery_disabledByDefault_breakerStaysOpen() {
+    List<Runnable> trialTasks = Collections.synchronizedList(new ArrayList<>());
+    List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
+    FailureCircuitBreaker breaker =
+        new FailureCircuitBreaker(
+            /* failureRateThreshold= */ 0,
+            /* slidingWindowSize= */ 100,
+            /* minCallCountToComputeFailureRate= */ 1,
+            /* recoveryDelayMillis= */ 0,
+            newSchedulerCapturing(/* recoveryDelayMillis= */ 0, trialTasks, windowTasks));
+
+    // A single failure trips the breaker (0% threshold, min call count of 1).
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
+
+    // Recovery is disabled: no probe is ever scheduled and the breaker never leaves REJECT_CALLS.
+    assertThat(trialTasks).isEmpty();
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
+  }
+
+  @Test
+  public void testRecovery_trialProbeSuccessClosesBreaker() {
+    List<Runnable> trialTasks = Collections.synchronizedList(new ArrayList<>());
+    List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
+    FailureCircuitBreaker breaker =
+        new FailureCircuitBreaker(
+            /* failureRateThreshold= */ 0,
+            /* slidingWindowSize= */ 100,
+            /* minCallCountToComputeFailureRate= */ 1,
+            /* recoveryDelayMillis= */ 1000,
+            newSchedulerCapturing(/* recoveryDelayMillis= */ 1000, trialTasks, windowTasks));
+
+    // Trip the breaker; a single recovery probe is scheduled for after the recovery delay.
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
+    assertThat(trialTasks).hasSize(1);
+
+    // Before the delay elapses the breaker is still open.
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
+
+    // Simulate the recovery delay elapsing.
+    trialTasks.get(0).run();
+
+    // Exactly one caller gets the trial probe; concurrent callers keep seeing REJECT_CALLS.
+    assertThat(breaker.state()).isEqualTo(State.TRIAL_CALL);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
+
+    // The probe succeeds: the breaker closes and normal calls resume.
+    breaker.recordSuccess(State.TRIAL_CALL);
+    assertThat(breaker.state()).isEqualTo(State.ACCEPT_CALLS);
+  }
+
+  @Test
+  public void testRecovery_trialProbeFailureReopensAndReschedules() {
+    List<Runnable> trialTasks = Collections.synchronizedList(new ArrayList<>());
+    List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
+    FailureCircuitBreaker breaker =
+        new FailureCircuitBreaker(
+            /* failureRateThreshold= */ 0,
+            /* slidingWindowSize= */ 100,
+            /* minCallCountToComputeFailureRate= */ 1,
+            /* recoveryDelayMillis= */ 1000,
+            newSchedulerCapturing(/* recoveryDelayMillis= */ 1000, trialTasks, windowTasks));
+
+    // Trip the breaker and let the first recovery delay elapse.
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(trialTasks).hasSize(1);
+    trialTasks.get(0).run();
+    assertThat(breaker.state()).isEqualTo(State.TRIAL_CALL);
+
+    // The probe fails: the breaker re-opens and schedules another probe.
+    breaker.recordFailure(State.TRIAL_CALL);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
+    assertThat(trialTasks).hasSize(2);
+
+    // The next recovery delay elapses and another single probe is offered.
+    trialTasks.get(1).run();
+    assertThat(breaker.state()).isEqualTo(State.TRIAL_CALL);
+  }
+
+  @Test
+  public void testRecovery_slowPreTripCallCannotHijackProbe() {
+    List<Runnable> trialTasks = Collections.synchronizedList(new ArrayList<>());
+    List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
+    FailureCircuitBreaker breaker =
+        new FailureCircuitBreaker(
+            /* failureRateThreshold= */ 0,
+            /* slidingWindowSize= */ 100,
+            /* minCallCountToComputeFailureRate= */ 1,
+            /* recoveryDelayMillis= */ 1000,
+            newSchedulerCapturing(/* recoveryDelayMillis= */ 1000, trialTasks, windowTasks));
+
+    // Trip, let the recovery delay elapse, and hand out the probe.
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    trialTasks.get(0).run();
+    assertThat(breaker.state()).isEqualTo(State.TRIAL_CALL);
+
+    // A call that started before the breaker tripped now completes with a failure. It observed
+    // ACCEPT_CALLS, so it must not consume the in-flight probe, reopen the breaker, or schedule a
+    // new probe.
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
+    assertThat(trialTasks).hasSize(1);
+
+    // The actual probe then succeeds and still closes the breaker.
+    breaker.recordSuccess(State.TRIAL_CALL);
+    assertThat(breaker.state()).isEqualTo(State.ACCEPT_CALLS);
+  }
+
+  @Test
+  public void testRecovery_successfulProbeInvalidatesStaleWindowDecrements() {
+    List<Runnable> trialTasks = Collections.synchronizedList(new ArrayList<>());
+    List<Runnable> windowTasks = Collections.synchronizedList(new ArrayList<>());
+    FailureCircuitBreaker breaker =
+        new FailureCircuitBreaker(
+            /* failureRateThreshold= */ 0,
+            /* slidingWindowSize= */ 100,
+            /* minCallCountToComputeFailureRate= */ 2,
+            /* recoveryDelayMillis= */ 1000,
+            newSchedulerCapturing(/* recoveryDelayMillis= */ 1000, trialTasks, windowTasks));
+
+    // Two failures trip the breaker (100% rate once the min call count of 2 is met); each schedules a
+    // window-decrement task.
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
+    assertThat(windowTasks).hasSize(2);
+
+    // A probe succeeds and closes the breaker, resetting the counters (and bumping the generation).
+    trialTasks.get(0).run();
+    assertThat(breaker.state()).isEqualTo(State.TRIAL_CALL);
+    breaker.recordSuccess(State.TRIAL_CALL);
+    assertThat(breaker.state()).isEqualTo(State.ACCEPT_CALLS);
+
+    // A fresh failure is recorded after the reset.
+    breaker.recordFailure(State.ACCEPT_CALLS);
+
+    // The two stale (pre-reset) window decrements now fire. They must not erase the fresh failure.
+    windowTasks.get(0).run();
+    windowTasks.get(1).run();
+
+    // One more failure reaches the min count of 2 at a 100% rate, so the breaker trips again --
+    // which
+    // only holds if the fresh failure survived the stale decrements.
+    breaker.recordFailure(State.ACCEPT_CALLS);
+    assertThat(breaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 }


### PR DESCRIPTION
## Requesting inclusion in 8.8.0

Please consider this for the **8.8.0** release. We depend on `--remote_download_minimal` (Build without the Bytes), where a tripped failure circuit breaker is currently unrecoverable for the rest of the invocation: a burst of *transient* remote-cache errors trips the breaker, the breaker-rejected prefetch reads become lost inputs, action rewinding re-runs the generating actions, and the still-open breaker rejects those re-executions too — failing the build. This backport makes that recoverable behind an opt-in flag, with no change to default behaviour.

## Backport of #30260 (tracking issue #30304)

Now that #30260 has landed on `master` (as `d1a022d0eb`), this is the cherry-pick of that commit onto `release-8.8.0`, with the merge conflicts resolved and adapted to the 8.8.0 baseline. It reflects the **final, reviewed** version of #30260 (the earlier revision of this PR predated the review changes).

Adaptations vs. the master commit, where 8.8.0 predates master prerequisites:

- `RemoteOptions` values are read as public `@Option` fields (8.8.0 predates master's getter refactor); the new `--experimental_remote_circuit_breaker_recovery_delay` option is added in that style.
- `--experimental_remote_min_call_count_to_compute_failure_rate` is already present on `release-8.8.0` (via #30234) and is used unchanged; the orthogonal min-fail-count half of #30178 was **not** backported, so its constructor parameter, trip-guard clause and tests are omitted.
- The `Retrier.CircuitBreaker` interface change (`recordSuccess`/`recordFailure` now take the observed `State`) is threaded through 8.8.0's existing `shouldRetry` retry flow.
- `//third_party:mockito` is added to the circuitbreaker test deps (already present on master) for the new mock-scheduler-based recovery tests. `failureDetails()` is already on `release-8.8.0` via #30384.

Otherwise it mirrors #30260's `TRIAL_CALL` half-open state machine (`CLOSED`/`OPEN`/`RECOVERING`/`PROBING`), gated behind the new `--experimental_remote_circuit_breaker_recovery_delay` (`Duration`, default `0` = today's permanent-open behaviour, so nothing changes unless it is enabled).

As on master, the end-to-end circuit-breaker × Build-without-the-Bytes recovery integration test is left to a follow-up to keep this change focused on the breaker state machine.

## Testing

Built and tested on `release-8.8.0` (base `a62d241f39`) with the branch-pinned Bazel 8.7.0 and `--lockfile_mode=error`:

- `//src/test/java/com/google/devtools/build/lib/remote/circuitbreaker:circuitbreaker` — PASSED
- `//src/test/java/com/google/devtools/build/lib/remote:RemoteTests --test_filter=RetrierTest` — PASSED

## Review

Requesting review for inclusion in the 8.8.0 release. Thanks!
