### PR TITLE
tests: route heavy tests to high-CPU workers

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/sandbox/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/BUILD
@@ -97,6 +97,9 @@ java_test(
         "ProcessWrapperSandboxedSpawnRunnerTest.java",
     ],
     data = ["//src/test/java/com/google/devtools/build/lib:embedded_scripts"],
+    exec_group_compatible_with = {
+        "test": ["//:highcpu_machine"],
+    },
     tags = ["no_windows"],
     test_class = "com.google.devtools.build.lib.AllTests",
     runtime_deps = [

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -460,6 +460,9 @@ sh_test(
     name = "bazel_spawnstats_test",
     srcs = ["bazel_spawnstats_test.sh"],
     data = [":test-deps"],
+    exec_group_compatible_with = {
+        "test": ["//:highcpu_machine"],
+    },
     tags = ["no_windows"],
 )
 

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -118,6 +118,9 @@ sh_test(
         ":test-deps",
         "//src/test/java/com/google/devtools/build/lib/worker:ExampleWorker_deploy.jar",
     ],
+    exec_group_compatible_with = {
+        "test": ["//:highcpu_machine"],
+    },
     shard_count = 10,
     tags = [
         # MacOS does not have cgroups so it can't support hardened sandbox
@@ -796,6 +799,9 @@ sh_test(
         ":test-deps",
         "//src/test/shell:sandboxing_test_utils",
     ],
+    exec_group_compatible_with = {
+        "test": ["//:highcpu_machine"],
+    },
     shard_count = 4,
     tags = ["no_windows"],
 )


### PR DESCRIPTION
Sandbox and spawn-related tests need more CPU capacity than default RBE
workers provide. Route the test actions for SpawnRunnerTests,
bazel_spawnstats_test, bazel_hardened_sandboxed_worker_test, and
sandboxing_test to the existing highcpu_machine platform so that RBE
places them in the highcpu pool.

Apply the constraint to the test execution group only, leaving build
actions unconstrained. The default host platform already advertises
highcpu_machine, so local test execution remains eligible.
