### PR TITLE
tests: require mount-capable runners

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -274,10 +274,20 @@ constraint_value(
     visibility = ["//visibility:public"],
 )
 
+constraint_setting(name = "mount_support")
+
+# A machine that permits privileged mount operations.
+constraint_value(
+    name = "mount_capable",
+    constraint_setting = ":mount_support",
+    visibility = ["//visibility:public"],
+)
+
 platform(
     name = "default_host_platform",
     constraint_values = [
         ":highcpu_machine",
+        ":mount_capable",
     ],
     parents = ["@platforms//host"],
 )
@@ -295,6 +305,9 @@ REMOTE_PLATFORMS = ("rbe_ubuntu2404",)
 [
     platform(
         name = platform_name + "_platform",
+        constraint_values = [
+            "//:mount_capable",
+        ],
         exec_properties = {
             "dockerNetwork": "standard",
             "dockerPrivileged": "true",

--- a/src/test/java/com/google/devtools/build/lib/sandbox/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/BUILD
@@ -97,6 +97,9 @@ java_test(
         "ProcessWrapperSandboxedSpawnRunnerTest.java",
     ],
     data = ["//src/test/java/com/google/devtools/build/lib:embedded_scripts"],
+    exec_group_compatible_with = {
+        "test": ["//:mount_capable"],
+    },
     tags = ["no_windows"],
     test_class = "com.google.devtools.build.lib.AllTests",
     runtime_deps = [

--- a/src/test/java/com/google/devtools/build/lib/shell/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/shell/BUILD
@@ -255,6 +255,9 @@ java_test(
         "//src/main/tools:linux-sandbox",
         "//src/test/shell/integration:spend_cpu_time",
     ],
+    exec_group_compatible_with = {
+        "test": ["//:mount_capable"],
+    },
     tags = [
         "no_windows",
         "shell",

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -460,6 +460,9 @@ sh_test(
     name = "bazel_spawnstats_test",
     srcs = ["bazel_spawnstats_test.sh"],
     data = [":test-deps"],
+    exec_group_compatible_with = {
+        "test": ["//:mount_capable"],
+    },
     tags = ["no_windows"],
 )
 

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -118,6 +118,9 @@ sh_test(
         ":test-deps",
         "//src/test/java/com/google/devtools/build/lib/worker:ExampleWorker_deploy.jar",
     ],
+    exec_group_compatible_with = {
+        "test": ["//:mount_capable"],
+    },
     shard_count = 10,
     tags = [
         # MacOS does not have cgroups so it can't support hardened sandbox
@@ -562,6 +565,9 @@ sh_test(
         "//src/main/tools:linux-sandbox",
         "//src/test/shell:sandboxing_test_utils",
     ],
+    exec_group_compatible_with = {
+        "test": ["//:mount_capable"],
+    },
     shard_count = 2,
     tags = [
         "no_macos",
@@ -796,6 +802,9 @@ sh_test(
         ":test-deps",
         "//src/test/shell:sandboxing_test_utils",
     ],
+    exec_group_compatible_with = {
+        "test": ["//:mount_capable"],
+    },
     shard_count = 4,
     tags = ["no_windows"],
 )

--- a/src/test/tools/BUILD
+++ b/src/test/tools/BUILD
@@ -42,6 +42,9 @@ sh_test(
     data = [
         "//src/main/tools:linux-sandbox",
     ],
+    exec_group_compatible_with = {
+        "test": ["//:mount_capable"],
+    },
     tags = [
         "no_macos",
         "no_windows",


### PR DESCRIPTION
Sandbox tests that mount /proc fail on container-only remote workers
because those workers cannot perform the privileged mount operation.
RBE vendors need a portable way to identify suitable workers without
embedding scheduler-specific properties in upstream BUILD files.

Add public mount_support and mount_capable constraints, advertise the
capability on the local and privileged Ubuntu RBE platforms, and require
it on the affected test execution groups. This limits the constraint to
TestRunner actions while leaving compilation and other execution groups
eligible for ordinary workers.
