### PR TITLE
Reject sibling paths in git_repository add_prefix

### DIFF
--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -159,16 +159,21 @@ function test_git_repository_add_prefix() {
 }
 
 function test_git_repository_add_prefix_prevent_uproot() {
-      cat >> MODULE.bazel <<EOF
+  local victim_dir="$(bazel info output_base)/external/+git_repository+pluto-victim"
+  mkdir -p "$victim_dir"
+  touch "$victim_dir/sentinel"
+
+  cat >> MODULE.bazel <<EOF
 git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
 git_repository(
     name = "pluto",
     remote = "does-not-matter",
     tag = "1-build",
-    add_prefix = "../uplevel/attempt",
+    add_prefix = "../+git_repository+pluto-victim",
 )
 EOF
   bazel build @pluto >& $TEST_log && fail "Build succeeded"
+  assert_exists "$victim_dir/sentinel"
   expect_log "escaped the base directory"
 }
 

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -71,7 +71,7 @@ def _checkout_path(ctx):
     root = ctx.path(".")
     if ctx.attr.add_prefix:
         add_prefix_root = root.get_child(ctx.attr.add_prefix)
-        if not str(add_prefix_root).startswith(str(root)):
+        if add_prefix_root != root and not str(add_prefix_root).startswith(str(root) + "/"):
             fail(
                 "add_prefix '%s' escaped the base directory of '%s': '%s'" %
                 (ctx.attr.add_prefix, str(root), str(add_prefix_root)),


### PR DESCRIPTION
git_repository checks add_prefix containment with a raw string prefix.
A normalized path can therefore select a sibling whose name shares the
checkout-root prefix, and the worker deletes that sibling before
fetching.

Require a path-component boundary (or the root itself) and cover the
destructive sibling case with a sentinel regression.

Follow-up to #29453.