### PR TITLE
Fail Bazel's native C++ coverage collector on tool errors

### DIFF
--- a/src/test/shell/bazel/bazel_cc_code_coverage_test.sh
+++ b/src/test/shell/bazel/bazel_cc_code_coverage_test.sh
@@ -564,4 +564,51 @@ function test_cc_test_coverage_gcov() {
     fi
 }
 
+function test_cc_coverage_tool_failures_fail_collection() {
+    local failing_tool="$PWD/failing_coverage_tool"
+    cat > "$failing_tool" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then
+  echo "gcov (GCC) 8.0.0"
+  exit 0
+fi
+echo "fake coverage tool failed: $1" >&2
+exit 1
+EOF
+    chmod +x "$failing_tool"
+
+    touch "$COVERAGE_DIR_VAR/test.profraw"
+    if (COVERAGE_DIR="$COVERAGE_DIR_VAR" \
+        COVERAGE_MANIFEST="$COVERAGE_MANIFEST_VAR" \
+        GENERATE_LLVM_LCOV="1" \
+        LLVM_PROFDATA="$failing_tool" \
+        LLVM_COV="true" \
+        "$COLLECT_CC_COVERAGE_SCRIPT") >& "$TEST_log"; then
+      fail "Expected llvm-profdata failure to fail coverage collection"
+    fi
+    expect_log "fake coverage tool failed: merge"
+
+    if (COVERAGE_DIR="$COVERAGE_DIR_VAR" \
+        COVERAGE_MANIFEST="$COVERAGE_MANIFEST_VAR" \
+        GENERATE_LLVM_LCOV="1" \
+        LLVM_PROFDATA="true" \
+        LLVM_COV="$failing_tool" \
+        "$COLLECT_CC_COVERAGE_SCRIPT") >& "$TEST_log"; then
+      fail "Expected llvm-cov failure to fail coverage collection"
+    fi
+    expect_log "fake coverage tool failed: export"
+
+    rm "$COVERAGE_DIR_VAR/test.profraw"
+    if (COVERAGE_DIR="$COVERAGE_DIR_VAR" \
+        COVERAGE_GCOV_PATH="$failing_tool" \
+        ROOT="$ROOT_VAR" \
+        COVERAGE_MANIFEST="$COVERAGE_MANIFEST_VAR" \
+        BAZEL_CC_COVERAGE_TOOL="GCOV" \
+        "$COLLECT_CC_COVERAGE_SCRIPT") >& "$TEST_log"; then
+      fail "Expected gcov failure to fail coverage collection"
+    fi
+    expect_log "fake coverage tool failed: -i"
+    [[ ! -L "$COVERAGE_DIR_VAR/gcov" ]] || fail "Expected gcov symlink to be removed"
+}
+
 run_suite "Testing tools/test/collect_cc_coverage.sh"

--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -37,7 +37,7 @@
 # gcda or profraw) and uses either lcov or gcov to get the coverage data.
 # The coverage data is placed in $COVERAGE_OUTPUT_FILE.
 
-set -u
+set -euo pipefail
 
 if [[ -n "${VERBOSE_COVERAGE:-}" ]]; then
   set -x
@@ -66,6 +66,8 @@ function init_gcov() {
   # convert the path to an absolute one.
   COVERAGE_GCOV_PATH_ABS="$(cd "${COVERAGE_GCOV_PATH%/*}" && pwd)/${COVERAGE_GCOV_PATH##*/}"
   ln -s "${COVERAGE_GCOV_PATH_ABS}" "${GCOV}"
+  # Do not leave a toolchain symlink in the coverage tree artifact on failure.
+  trap 'rm -f "${GCOV}"' EXIT
 }
 
 # Computes code coverage data using the clang generated metadata found under
@@ -179,8 +181,6 @@ function gcov_coverage() {
       fi
     fi
   done < "${COVERAGE_MANIFEST}"
-
-  rm -f "${GCOV}"
 }
 
 function main() {


### PR DESCRIPTION
Bazel's bundled native C++ coverage collector (`tools/test/collect_cc_coverage.sh`)
can mask failed llvm-profdata, llvm-cov, and gcov commands and report
successful collection with missing or partial data. Fail-fast and pipeline
failure propagation now pass those errors to the test runner.

The temporary gcov symlink is removed on exit, including after a failure.
A fake-tool test covers all three previously masked failure paths.

This change applies to Bazel's bundled native collector. The default
`rules_cc` coverage script is a separate implementation and is unchanged here.
