### PR TITLE
Reject uplevel paths in root-package outputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -153,7 +153,8 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       fragment = original.replaceName(filename);
     }
 
-    if (!fragment.startsWith(ruleContext.getPackageDirectory())) {
+    if (fragment.containsUplevelReferences()
+        || !fragment.startsWith(ruleContext.getPackageDirectory())) {
       throw Starlark.errorf(
           "the output artifact '%s' is not under package directory '%s' for target '%s'",
           fragment, ruleContext.getPackageDirectory(), ruleContext.getLabel());
@@ -177,7 +178,8 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       fragment = original.replaceName(filename);
     }
 
-    if (!fragment.startsWith(ruleContext.getPackageDirectory())) {
+    if (fragment.containsUplevelReferences()
+        || !fragment.startsWith(ruleContext.getPackageDirectory())) {
       throw Starlark.errorf(
           "the output directory '%s' is not under package directory '%s' for target '%s'",
           fragment, ruleContext.getPackageDirectory(), ruleContext.getLabel());
@@ -212,6 +214,12 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
               .getOutputDirRelativePath(
                   getSemantics().getBool(EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT));
       rootRelativePath = original.replaceName(filename);
+    }
+
+    if (rootRelativePath.containsUplevelReferences()) {
+      throw Starlark.errorf(
+          "the output symlink '%s' contains uplevel references for target '%s'",
+          rootRelativePath, ruleContext.getLabel());
     }
 
     result =

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkIntegrationTest.java
@@ -4031,6 +4031,28 @@ public class StarlarkIntegrationTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testDeclareFileUplevelReferenceInRootPackage() throws Exception {
+    scratch.file(
+        "test_rule.bzl",
+        """
+        def _my_rule_impl(ctx):
+          ctx.actions.declare_file('../f')
+        my_rule = rule(implementation = _my_rule_impl)
+        """);
+    scratch.file(
+        "BUILD",
+        """
+        load(':test_rule.bzl', 'my_rule')
+        my_rule(name = 'target')
+        """);
+
+    reporter.removeHandler(failFastHandler);
+    assertThat(getConfiguredTarget("//:target")).isNull();
+    assertContainsEvent(
+        "the output artifact '../f' is not under package directory '' for target '//:target'");
+  }
+
+  @Test
   public void testDeclareDirectoryInvalidParent_withSibling() throws Exception {
     scratch.file("test/dep/test_file.txt", "Test file");
 
@@ -4088,6 +4110,51 @@ public class StarlarkIntegrationTest extends BuildViewTestCase {
     assertContainsEvent(
         "the output directory '/foo/exe' is not under package directory "
             + "'test/starlark' for target '//test/starlark:target'");
+  }
+
+  @Test
+  public void testDeclareDirectoryUplevelReferenceInRootPackage() throws Exception {
+    scratch.file(
+        "test_rule.bzl",
+        """
+        def _my_rule_impl(ctx):
+          ctx.actions.declare_directory('../f')
+        my_rule = rule(implementation = _my_rule_impl)
+        """);
+    scratch.file(
+        "BUILD",
+        """
+        load(':test_rule.bzl', 'my_rule')
+        my_rule(name = 'target')
+        """);
+
+    reporter.removeHandler(failFastHandler);
+    assertThat(getConfiguredTarget("//:target")).isNull();
+    assertContainsEvent(
+        "the output directory '../f' is not under package directory '' for target '//:target'");
+  }
+
+  @Test
+  public void testDeclareSymlinkUplevelReferenceInRootPackage() throws Exception {
+    scratch.file(
+        "test_rule.bzl",
+        """
+        def _my_rule_impl(ctx):
+          ctx.actions.declare_symlink('../f')
+        my_rule = rule(implementation = _my_rule_impl)
+        """);
+    scratch.file(
+        "BUILD",
+        """
+        load(':test_rule.bzl', 'my_rule')
+        my_rule(name = 'target')
+        """);
+    useConfiguration("--allow_unresolved_symlinks");
+
+    reporter.removeHandler(failFastHandler);
+    assertThat(getConfiguredTarget("//:target")).isNull();
+    assertContainsEvent(
+        "the output symlink '../f' contains uplevel references for target '//:target'");
   }
 
   @Test


### PR DESCRIPTION
The empty package path lets ../f pass the file and directory prefix
checks, while declare_symlink performs no package check. Artifact
creation then throws an unchecked IllegalArgumentException and crashes
analysis instead of reporting an actionable Starlark error.

Reject uplevel references at the Starlark boundary without tightening
the existing symlink-sibling contract, and cover all three output kinds
in the root package.

Fixes #22362.