### PR TITLE
Preserve execroot headers during discovery

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
@@ -31,7 +31,6 @@ import com.google.devtools.build.lib.collect.compacthashset.CompactHashSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.util.OS;
-import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.Collection;
@@ -163,17 +162,36 @@ final class HeaderDiscovery {
     for (Path execPath : dependencies) {
       PathFragment execPathFragment = execPath.asFragment();
       if (execPathFragment.isAbsolute()) {
-        if (possiblyCaseInsensitiveFileSystem) {
-          // Absolute includes from system paths are ignored. With a case-insensitive file system,
-          // the paths as reported by the compiler may differ in casing from those listed by the
-          // toolchain.
-          if (FileSystemUtils.startsWithAnyIgnoringCase(execPath, permittedSystemIncludePrefixes)) {
+        // Built-in include directories may contain vendored SDKs below the execroot, but a broad
+        // ancestor of the execroot must not hide actual inputs reported by the compiler.
+        boolean potentiallyUnderWorkspace =
+            possiblyCaseInsensitiveFileSystem
+                ? execPath.startsWithIgnoringCase(execRoot)
+                    || (siblingRepositoryLayout
+                        && execPath.startsWithIgnoringCase(execRoot.getParentDirectory()))
+                : execPath.startsWith(execRoot)
+                    || (siblingRepositoryLayout
+                        && execPath.startsWith(execRoot.getParentDirectory()));
+        boolean systemInclude = false;
+        for (Path prefix : permittedSystemIncludePrefixes) {
+          boolean matches =
+              possiblyCaseInsensitiveFileSystem
+                  ? execPath.startsWithIgnoringCase(prefix)
+                  : execPath.startsWith(prefix);
+          if (!matches) {
             continue;
           }
-        } else {
-          if (FileSystemUtils.startsWithAny(execPath, permittedSystemIncludePrefixes)) {
-            continue;
+          boolean broad =
+              possiblyCaseInsensitiveFileSystem
+                  ? execRoot.startsWithIgnoringCase(prefix)
+                  : execRoot.startsWith(prefix);
+          if (!potentiallyUnderWorkspace || !broad) {
+            systemInclude = true;
+            break;
           }
+        }
+        if (systemInclude) {
+          continue;
         }
         if (execPath.startsWith(execRoot)
             && (!ignoreMainRepository

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
@@ -30,7 +30,6 @@ import com.google.devtools.build.lib.collect.compacthashset.CompactHashSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.util.OS;
-import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.Collection;
@@ -135,17 +134,32 @@ final class HeaderDiscovery {
     for (Path execPath : dependencies) {
       PathFragment execPathFragment = execPath.asFragment();
       if (execPathFragment.isAbsolute()) {
-        if (possiblyCaseInsensitiveFileSystem) {
-          // Absolute includes from system paths are ignored. With a case-insensitive file system,
-          // the paths as reported by the compiler may differ in casing from those listed by the
-          // toolchain.
-          if (FileSystemUtils.startsWithAnyIgnoringCase(execPath, permittedSystemIncludePrefixes)) {
+        // Built-in include directories may contain vendored SDKs below the execroot, but a broad
+        // ancestor of the execroot must not hide actual inputs reported by the compiler.
+        boolean potentiallyUnderExecRoot =
+            possiblyCaseInsensitiveFileSystem
+                ? execPath.startsWithIgnoringCase(execRoot)
+                : execPath.startsWith(execRoot);
+        boolean systemInclude = false;
+        for (Path prefix : permittedSystemIncludePrefixes) {
+          boolean matches =
+              possiblyCaseInsensitiveFileSystem
+                  ? execPath.startsWithIgnoringCase(prefix)
+                  : execPath.startsWith(prefix);
+          if (!matches) {
             continue;
           }
-        } else {
-          if (FileSystemUtils.startsWithAny(execPath, permittedSystemIncludePrefixes)) {
-            continue;
+          boolean broad =
+              possiblyCaseInsensitiveFileSystem
+                  ? execRoot.startsWithIgnoringCase(prefix)
+                  : execRoot.startsWith(prefix);
+          if (!potentiallyUnderExecRoot || !broad) {
+            systemInclude = true;
+            break;
           }
+        }
+        if (systemInclude) {
+          continue;
         }
         if (execPath.startsWith(execRoot)) {
           execPathFragment = execPath.relativeTo(execRoot); // funky but tolerable path

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscoveryTest.java
@@ -240,6 +240,107 @@ public final class HeaderDiscoveryTest {
   }
 
   @Test
+  public void builtinIncludePrefix_doesNotHideExecRootInput() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    SourceArtifact resolvedArtifact = sourceArtifact("pkg/header.h");
+    PathFragment depPath = PathFragment.create("pkg/header.h");
+    when(artifactResolver.resolveSourceArtifact(eq(depPath), eq(RepositoryName.MAIN)))
+        .thenReturn(resolvedArtifact);
+
+    NestedSet<Artifact> result =
+        HeaderDiscovery.discoverInputsFromDependencies(
+            nonWindowsAction(),
+            ActionsTestUtil.createArtifact(derivedArtifactRoot, derivedRoot.getRelative("foo.cc")),
+            /* shouldValidateInclusions= */ true,
+            ImmutableList.of(execRoot.getRelative("pkg/header.h")),
+            /* permittedSystemIncludePrefixes= */ ImmutableList.of(fs.getPath("/")),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            execRoot,
+            artifactResolver,
+            /* siblingRepositoryLayout= */ false,
+            PathMapper.NOOP);
+
+    assertThat(result.toList()).containsExactly(resolvedArtifact);
+  }
+
+  @Test
+  public void narrowBuiltinIncludePrefix_hidesVendoredSdkInput() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    Path sdk = execRoot.getRelative("external/xcode/SDK");
+
+    NestedSet<Artifact> result =
+        HeaderDiscovery.discoverInputsFromDependencies(
+            nonWindowsAction(),
+            ActionsTestUtil.createArtifact(derivedArtifactRoot, derivedRoot.getRelative("foo.cc")),
+            /* shouldValidateInclusions= */ true,
+            ImmutableList.of(sdk.getRelative("usr/include/header.h")),
+            /* permittedSystemIncludePrefixes= */ ImmutableList.of(fs.getPath("/"), sdk),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            execRoot,
+            artifactResolver,
+            /* siblingRepositoryLayout= */ false,
+            PathMapper.NOOP);
+
+    assertThat(result.toList()).isEmpty();
+    verify(artifactResolver, never()).resolveSourceArtifact(any(), any());
+  }
+
+  @Test
+  public void builtinIncludePrefix_doesNotHideSiblingRepositoryInput() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    PathFragment depPath = PathFragment.create("../sibling/pkg/header.h");
+    SourceArtifact resolvedArtifact =
+        new SourceArtifact(
+            ArtifactRoot.asExternalSourceRoot(
+                Root.fromPath(fs.getPath("/output-base/external/sibling"))),
+            depPath,
+            ArtifactOwner.NULL_OWNER);
+    when(artifactResolver.resolveSourceArtifact(
+            eq(depPath), eq(RepositoryName.createUnvalidated("sibling"))))
+        .thenReturn(resolvedArtifact);
+
+    NestedSet<Artifact> result =
+        HeaderDiscovery.discoverInputsFromDependencies(
+            nonWindowsAction(),
+            ActionsTestUtil.createArtifact(derivedArtifactRoot, derivedRoot.getRelative("foo.cc")),
+            /* shouldValidateInclusions= */ true,
+            ImmutableList.of(fs.getPath("/sibling/pkg/header.h")),
+            /* permittedSystemIncludePrefixes= */ ImmutableList.of(fs.getPath("/")),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            execRoot,
+            artifactResolver,
+            /* siblingRepositoryLayout= */ true,
+            PathMapper.NOOP);
+
+    assertThat(result.toList()).containsExactly(resolvedArtifact);
+  }
+
+  @Test
+  public void windowsPlatform_casedExecRootInputIsNotHiddenByBuiltinIncludePrefix() {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+
+    ActionExecutionException thrown =
+        assertThrows(
+            ActionExecutionException.class,
+            () ->
+                HeaderDiscovery.discoverInputsFromDependencies(
+                    windowsAction(),
+                    ActionsTestUtil.createArtifact(
+                        derivedArtifactRoot, derivedRoot.getRelative("foo.cc")),
+                    /* shouldValidateInclusions= */ true,
+                    ImmutableList.of(fs.getPath("/EXECROOT/pkg/header.h")),
+                    /* permittedSystemIncludePrefixes= */ ImmutableList.of(fs.getPath("/")),
+                    NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+                    execRoot,
+                    artifactResolver,
+                    /* siblingRepositoryLayout= */ false,
+                    PathMapper.NOOP));
+
+    assertThat(thrown).hasMessageThat().contains("/EXECROOT/pkg/header.h");
+    verify(artifactResolver, never()).resolveSourceArtifactsAsciiCaseInsensitively(any(), any());
+  }
+
+  @Test
   public void windowsPlatform_sourceFileFilteredOut() throws Exception {
     ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
     SourceArtifact sourceFile = sourceArtifact("pkg/foo.cc");

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscoveryTest.java
@@ -238,6 +238,74 @@ public final class HeaderDiscoveryTest {
   }
 
   @Test
+  public void builtinIncludePrefix_doesNotHideExecRootInput() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    SourceArtifact resolvedArtifact = sourceArtifact("pkg/header.h");
+    PathFragment depPath = PathFragment.create("pkg/header.h");
+    when(artifactResolver.resolveSourceArtifact(eq(depPath), eq(RepositoryName.MAIN)))
+        .thenReturn(resolvedArtifact);
+
+    NestedSet<Artifact> result =
+        HeaderDiscovery.discoverInputsFromDependencies(
+            nonWindowsAction(),
+            ActionsTestUtil.createArtifact(derivedArtifactRoot, derivedRoot.getRelative("foo.cc")),
+            /* shouldValidateInclusions= */ true,
+            ImmutableList.of(execRoot.getRelative("pkg/header.h")),
+            /* permittedSystemIncludePrefixes= */ ImmutableList.of(fs.getPath("/")),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            execRoot,
+            artifactResolver,
+            PathMapper.NOOP);
+
+    assertThat(result.toList()).containsExactly(resolvedArtifact);
+  }
+
+  @Test
+  public void narrowBuiltinIncludePrefix_hidesVendoredSdkInput() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    Path sdk = execRoot.getRelative("external/xcode/SDK");
+
+    NestedSet<Artifact> result =
+        HeaderDiscovery.discoverInputsFromDependencies(
+            nonWindowsAction(),
+            ActionsTestUtil.createArtifact(derivedArtifactRoot, derivedRoot.getRelative("foo.cc")),
+            /* shouldValidateInclusions= */ true,
+            ImmutableList.of(sdk.getRelative("usr/include/header.h")),
+            /* permittedSystemIncludePrefixes= */ ImmutableList.of(fs.getPath("/"), sdk),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            execRoot,
+            artifactResolver,
+            PathMapper.NOOP);
+
+    assertThat(result.toList()).isEmpty();
+    verify(artifactResolver, never()).resolveSourceArtifact(any(), any());
+  }
+
+  @Test
+  public void windowsPlatform_casedExecRootInputIsNotHiddenByBuiltinIncludePrefix() {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+
+    ActionExecutionException thrown =
+        assertThrows(
+            ActionExecutionException.class,
+            () ->
+                HeaderDiscovery.discoverInputsFromDependencies(
+                    windowsAction(),
+                    ActionsTestUtil.createArtifact(
+                        derivedArtifactRoot, derivedRoot.getRelative("foo.cc")),
+                    /* shouldValidateInclusions= */ true,
+                    ImmutableList.of(fs.getPath("/EXECROOT/pkg/header.h")),
+                    /* permittedSystemIncludePrefixes= */ ImmutableList.of(fs.getPath("/")),
+                    NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+                    execRoot,
+                    artifactResolver,
+                    PathMapper.NOOP));
+
+    assertThat(thrown).hasMessageThat().contains("/EXECROOT/pkg/header.h");
+    verify(artifactResolver, never()).resolveSourceArtifactsAsciiCaseInsensitively(any(), any());
+  }
+
+  @Test
   public void windowsPlatform_sourceFileFilteredOut() throws Exception {
     ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
     SourceArtifact sourceFile = sourceArtifact("pkg/foo.cc");


### PR DESCRIPTION
Header discovery treats an absolute dependency below a built-in include
prefix as a system header. If that prefix covers the execroot, real
inputs are pruned from the dependency set and incremental C++ builds
can remain stale after a header changes.

Ignore broad built-in prefixes for execroot inputs while continuing to
honor narrow prefixes used by vendored SDKs. Focused tests cover both
cases and confirm that differently cased Windows paths are not silently
pruned.

Fixes #29613.
