### PR TITLE
Retry timed-out HTTP cache uploads

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -62,16 +62,13 @@ import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.remote.CombinedCacheClientFactory.CombinedCacheClient;
 import com.google.devtools.build.lib.remote.LeaseService.LeaseExtension;
 import com.google.devtools.build.lib.remote.RemoteServerCapabilities.ServerCapabilitiesRequirement;
-import com.google.devtools.build.lib.remote.Retrier.ResultClassifier;
-import com.google.devtools.build.lib.remote.Retrier.ResultClassifier.Result;
 import com.google.devtools.build.lib.remote.circuitbreaker.CircuitBreakerFactory;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.disk.DiskCacheClient;
 import com.google.devtools.build.lib.remote.disk.DiskCacheGarbageCollectorIdleTask;
 import com.google.devtools.build.lib.remote.downloader.GrpcRemoteDownloader;
-import com.google.devtools.build.lib.remote.http.DownloadTimeoutException;
-import com.google.devtools.build.lib.remote.http.HttpException;
+import com.google.devtools.build.lib.remote.http.HttpCacheClient;
 import com.google.devtools.build.lib.remote.logging.LoggingInterceptor;
 import com.google.devtools.build.lib.remote.logging.RemoteExecutionLog.LogEntry;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -117,14 +114,11 @@ import com.google.devtools.common.options.RegexPatternOption;
 import io.grpc.CallCredentials;
 import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
-import io.netty.handler.codec.DecoderException;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.channels.ClosedChannelException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -234,43 +228,6 @@ public final class RemoteModule extends BlazeModule {
     return !Strings.isNullOrEmpty(options.getRemoteOutputService());
   }
 
-  public static final ResultClassifier HTTP_RESULT_CLASSIFIER =
-      e -> {
-        boolean retry = false;
-        if (e instanceof ClosedChannelException) {
-          retry = true;
-        } else if (e instanceof DownloadTimeoutException) {
-          retry = true;
-        } else if (e instanceof HttpException httpException) {
-          int status = httpException.response().status().code();
-          if (status == HttpResponseStatus.NOT_FOUND.code()) {
-            return Result.SUCCESS;
-          }
-          retry =
-              status == HttpResponseStatus.REQUEST_TIMEOUT.code()
-                  || status == HttpResponseStatus.TOO_MANY_REQUESTS.code()
-                  || status == HttpResponseStatus.INTERNAL_SERVER_ERROR.code()
-                  || status == HttpResponseStatus.BAD_GATEWAY.code()
-                  || status == HttpResponseStatus.SERVICE_UNAVAILABLE.code()
-                  || status == HttpResponseStatus.GATEWAY_TIMEOUT.code();
-        } else if (e instanceof IOException) {
-          String msg = Ascii.toLowerCase(e.getMessage());
-          if (msg.contains("connection reset")) {
-            retry = true;
-          } else if (msg.contains("operation timed out")) {
-            retry = true;
-          }
-        } else {
-          // Workaround for a netty bug: https://github.com/netty/netty/issues/11815. Remove this
-          // once it is fixed in the upstream.
-          if (e instanceof DecoderException
-              && e.getMessage().endsWith("functions:OPENSSL_internal:BAD_DECRYPT")) {
-            retry = true;
-          }
-        }
-        return retry ? Result.TRANSIENT_FAILURE : Result.PERMANENT_FAILURE;
-      };
-
   private void initHttpAndDiskCache(
       CommandEnvironment env,
       Credentials credentials,
@@ -291,7 +248,10 @@ public final class RemoteModule extends BlazeModule {
               Preconditions.checkNotNull(env.getWorkingDirectory(), "workingDirectory"),
               digestUtil,
               new RemoteRetrier(
-                  remoteOptions, HTTP_RESULT_CLASSIFIER, retryScheduler, circuitBreaker));
+                  remoteOptions,
+                  HttpCacheClient.HTTP_RESULT_CLASSIFIER,
+                  retryScheduler,
+                  circuitBreaker));
     } catch (IOException e) {
       handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
       return;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -62,16 +62,13 @@ import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.remote.CombinedCacheClientFactory.CombinedCacheClient;
 import com.google.devtools.build.lib.remote.LeaseService.LeaseExtension;
 import com.google.devtools.build.lib.remote.RemoteServerCapabilities.ServerCapabilitiesRequirement;
-import com.google.devtools.build.lib.remote.Retrier.ResultClassifier;
-import com.google.devtools.build.lib.remote.Retrier.ResultClassifier.Result;
 import com.google.devtools.build.lib.remote.circuitbreaker.CircuitBreakerFactory;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.disk.DiskCacheClient;
 import com.google.devtools.build.lib.remote.disk.DiskCacheGarbageCollectorIdleTask;
 import com.google.devtools.build.lib.remote.downloader.GrpcRemoteDownloader;
-import com.google.devtools.build.lib.remote.http.DownloadTimeoutException;
-import com.google.devtools.build.lib.remote.http.HttpException;
+import com.google.devtools.build.lib.remote.http.HttpCacheClient;
 import com.google.devtools.build.lib.remote.logging.LoggingInterceptor;
 import com.google.devtools.build.lib.remote.logging.RemoteExecutionLog.LogEntry;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -117,14 +114,11 @@ import com.google.devtools.common.options.RegexPatternOption;
 import io.grpc.CallCredentials;
 import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
-import io.netty.handler.codec.DecoderException;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.channels.ClosedChannelException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -235,43 +229,6 @@ public final class RemoteModule extends BlazeModule {
     return !Strings.isNullOrEmpty(options.getRemoteOutputService());
   }
 
-  public static final ResultClassifier HTTP_RESULT_CLASSIFIER =
-      e -> {
-        boolean retry = false;
-        if (e instanceof ClosedChannelException) {
-          retry = true;
-        } else if (e instanceof DownloadTimeoutException) {
-          retry = true;
-        } else if (e instanceof HttpException httpException) {
-          int status = httpException.response().status().code();
-          if (status == HttpResponseStatus.NOT_FOUND.code()) {
-            return Result.SUCCESS;
-          }
-          retry =
-              status == HttpResponseStatus.REQUEST_TIMEOUT.code()
-                  || status == HttpResponseStatus.TOO_MANY_REQUESTS.code()
-                  || status == HttpResponseStatus.INTERNAL_SERVER_ERROR.code()
-                  || status == HttpResponseStatus.BAD_GATEWAY.code()
-                  || status == HttpResponseStatus.SERVICE_UNAVAILABLE.code()
-                  || status == HttpResponseStatus.GATEWAY_TIMEOUT.code();
-        } else if (e instanceof IOException) {
-          String msg = Ascii.toLowerCase(e.getMessage());
-          if (msg.contains("connection reset")) {
-            retry = true;
-          } else if (msg.contains("operation timed out")) {
-            retry = true;
-          }
-        } else {
-          // Workaround for a netty bug: https://github.com/netty/netty/issues/11815. Remove this
-          // once it is fixed in the upstream.
-          if (e instanceof DecoderException
-              && e.getMessage().endsWith("functions:OPENSSL_internal:BAD_DECRYPT")) {
-            retry = true;
-          }
-        }
-        return retry ? Result.TRANSIENT_FAILURE : Result.PERMANENT_FAILURE;
-      };
-
   private void initHttpAndDiskCache(
       CommandEnvironment env,
       Credentials credentials,
@@ -293,7 +250,10 @@ public final class RemoteModule extends BlazeModule {
               Preconditions.checkNotNull(env.getWorkingDirectory(), "workingDirectory"),
               digestUtil,
               new RemoteRetrier(
-                  remoteOptions, HTTP_RESULT_CLASSIFIER, retryScheduler, circuitBreaker),
+                  remoteOptions,
+                  HttpCacheClient.HTTP_RESULT_CLASSIFIER,
+                  retryScheduler,
+                  circuitBreaker),
               checkDiskCacheActionResultIntegrity);
     } catch (IOException e) {
       handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -20,6 +20,7 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.ServerCapabilities;
 import build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy;
 import com.google.auth.Credentials;
+import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.GoogleLogger;
@@ -30,6 +31,8 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
 import com.google.devtools.build.lib.remote.RemoteRetrier;
+import com.google.devtools.build.lib.remote.Retrier.ResultClassifier;
+import com.google.devtools.build.lib.remote.Retrier.ResultClassifier.Result;
 import com.google.devtools.build.lib.remote.common.ActionKey;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
@@ -57,6 +60,7 @@ import io.netty.channel.pool.FixedChannelPool;
 import io.netty.channel.pool.SimpleChannelPool;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -84,6 +88,7 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
+import java.nio.channels.ClosedChannelException;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
@@ -129,6 +134,40 @@ public final class HttpCacheClient extends RemoteCacheClient {
 
   public static final String AC_PREFIX = "ac/";
   public static final String CAS_PREFIX = "cas/";
+  public static final ResultClassifier HTTP_RESULT_CLASSIFIER =
+      e ->
+          switch (e) {
+            case ClosedChannelException ignored -> Result.TRANSIENT_FAILURE;
+            case DownloadTimeoutException ignored -> Result.TRANSIENT_FAILURE;
+            case UploadTimeoutException ignored -> Result.TRANSIENT_FAILURE;
+            case HttpException httpException -> {
+              int status = httpException.response().status().code();
+              if (status == HttpResponseStatus.NOT_FOUND.code()) {
+                yield Result.SUCCESS;
+              }
+              yield status == HttpResponseStatus.REQUEST_TIMEOUT.code()
+                      || status == HttpResponseStatus.TOO_MANY_REQUESTS.code()
+                      || status == HttpResponseStatus.INTERNAL_SERVER_ERROR.code()
+                      || status == HttpResponseStatus.BAD_GATEWAY.code()
+                      || status == HttpResponseStatus.SERVICE_UNAVAILABLE.code()
+                      || status == HttpResponseStatus.GATEWAY_TIMEOUT.code()
+                  ? Result.TRANSIENT_FAILURE
+                  : Result.PERMANENT_FAILURE;
+            }
+            case IOException ioException -> {
+              String msg = Ascii.toLowerCase(ioException.getMessage());
+              yield msg.contains("connection reset") || msg.contains("operation timed out")
+                  ? Result.TRANSIENT_FAILURE
+                  : Result.PERMANENT_FAILURE;
+            }
+            // Workaround for a netty bug: https://github.com/netty/netty/issues/11815. Remove this
+            // once it is fixed in the upstream.
+            case DecoderException decoder
+                when decoder.getMessage().endsWith("functions:OPENSSL_internal:BAD_DECRYPT") ->
+                Result.TRANSIENT_FAILURE;
+            case null, default -> Result.PERMANENT_FAILURE;
+          };
+
   private static final Pattern INVALID_TOKEN_ERROR =
       Pattern.compile("\\s*error\\s*=\\s*\"?invalid_token\"?");
 
@@ -751,11 +790,13 @@ public final class HttpCacheClient extends RemoteCacheClient {
   public ListenableFuture<Void> uploadActionResult(
       RemoteActionExecutionContext context, ActionKey actionKey, ActionResult actionResult) {
     ByteString serialized = actionResult.toByteString();
-    return uploadAsync(
-        actionKey.digest().getHash(),
-        serialized.size(),
-        serialized.newInput(),
-        /* casUpload= */ false);
+    return retrier.executeAsync(
+        () ->
+            uploadAsync(
+                actionKey.digest().getHash(),
+                serialized.size(),
+                serialized.newInput(),
+                /* casUpload= */ false));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -20,6 +20,7 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.ServerCapabilities;
 import build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy;
 import com.google.auth.Credentials;
+import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.GoogleLogger;
@@ -30,6 +31,8 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
 import com.google.devtools.build.lib.remote.RemoteRetrier;
+import com.google.devtools.build.lib.remote.Retrier.ResultClassifier;
+import com.google.devtools.build.lib.remote.Retrier.ResultClassifier.Result;
 import com.google.devtools.build.lib.remote.common.ActionKey;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
@@ -56,6 +59,7 @@ import io.netty.channel.pool.FixedChannelPool;
 import io.netty.channel.pool.SimpleChannelPool;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -83,6 +87,7 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
+import java.nio.channels.ClosedChannelException;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
@@ -127,6 +132,40 @@ public final class HttpCacheClient extends RemoteCacheClient {
 
   public static final String AC_PREFIX = "ac/";
   public static final String CAS_PREFIX = "cas/";
+  public static final ResultClassifier HTTP_RESULT_CLASSIFIER =
+      e ->
+          switch (e) {
+            case ClosedChannelException ignored -> Result.TRANSIENT_FAILURE;
+            case DownloadTimeoutException ignored -> Result.TRANSIENT_FAILURE;
+            case UploadTimeoutException ignored -> Result.TRANSIENT_FAILURE;
+            case HttpException httpException -> {
+              int status = httpException.response().status().code();
+              if (status == HttpResponseStatus.NOT_FOUND.code()) {
+                yield Result.SUCCESS;
+              }
+              yield status == HttpResponseStatus.REQUEST_TIMEOUT.code()
+                      || status == HttpResponseStatus.TOO_MANY_REQUESTS.code()
+                      || status == HttpResponseStatus.INTERNAL_SERVER_ERROR.code()
+                      || status == HttpResponseStatus.BAD_GATEWAY.code()
+                      || status == HttpResponseStatus.SERVICE_UNAVAILABLE.code()
+                      || status == HttpResponseStatus.GATEWAY_TIMEOUT.code()
+                  ? Result.TRANSIENT_FAILURE
+                  : Result.PERMANENT_FAILURE;
+            }
+            case IOException ioException -> {
+              String msg = Ascii.toLowerCase(ioException.getMessage());
+              yield msg.contains("connection reset") || msg.contains("operation timed out")
+                  ? Result.TRANSIENT_FAILURE
+                  : Result.PERMANENT_FAILURE;
+            }
+            // Workaround for a netty bug: https://github.com/netty/netty/issues/11815. Remove this
+            // once it is fixed in the upstream.
+            case DecoderException decoder
+                when decoder.getMessage().endsWith("functions:OPENSSL_internal:BAD_DECRYPT") ->
+                Result.TRANSIENT_FAILURE;
+            case null, default -> Result.PERMANENT_FAILURE;
+          };
+
   private static final Pattern INVALID_TOKEN_ERROR =
       Pattern.compile("\\s*error\\s*=\\s*\"?invalid_token\"?");
 
@@ -746,11 +785,13 @@ public final class HttpCacheClient extends RemoteCacheClient {
   public ListenableFuture<Void> uploadActionResult(
       RemoteActionExecutionContext context, ActionKey actionKey, ActionResult actionResult) {
     ByteString serialized = actionResult.toByteString();
-    return uploadAsync(
-        actionKey.digest().getHash(),
-        serialized.size(),
-        serialized.newInput(),
-        /* casUpload= */ false);
+    return retrier.executeAsync(
+        () ->
+            uploadAsync(
+                actionKey.digest().getHash(),
+                serialized.size(),
+                serialized.newInput(),
+                /* casUpload= */ false));
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -110,6 +110,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntFunction;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
@@ -452,6 +453,68 @@ public class HttpCacheClientTest {
                       /* force= */ false)));
     } finally {
       testServer.stop(server);
+    }
+  }
+
+  @Test(timeout = 30000)
+  public void uploadsRetryAfterTimeout() throws Exception {
+    ServerChannel server = null;
+    HttpCacheClient blobStore = null;
+    ListeningScheduledExecutorService retryScheduler =
+        MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1));
+    try {
+      UploadRetryHandler handler = new UploadRetryHandler();
+      server = testServer.start(handler);
+
+      RemoteRetrier retrier =
+          new RemoteRetrier(
+              () -> new Retrier.ZeroBackoff(1),
+              HttpCacheClient.HTTP_RESULT_CLASSIFIER,
+              retryScheduler,
+              Retrier.ALLOW_ALL_CALLS);
+      blobStore =
+          createHttpBlobStore(
+              server,
+              /* timeoutSeconds= */ 1,
+              /* remoteVerifyDownloads= */ true,
+              /* creds= */ null,
+              Options.getDefaults(AuthAndTLSOptions.class),
+              Optional.of(retrier));
+      ByteString data = ByteString.copyFromUtf8("File Contents");
+      Digest digest = DIGEST_UTIL.compute(data.toByteArray());
+
+      getFromFuture(
+          blobStore.uploadBlob(remoteActionExecutionContext, digest, data, /* force= */ false));
+      getFromFuture(
+          blobStore.uploadActionResult(
+              remoteActionExecutionContext,
+              new ActionKey(digest),
+              ActionResult.newBuilder().setExitCode(1).build()));
+
+      assertThat(handler.requests.get()).isEqualTo(4);
+    } finally {
+      if (blobStore != null) {
+        blobStore.close();
+      }
+      retryScheduler.shutdownNow();
+      testServer.stop(server);
+    }
+  }
+
+  @Sharable
+  private static final class UploadRetryHandler
+      extends SimpleChannelInboundHandler<FullHttpRequest> {
+    private final AtomicInteger requests = new AtomicInteger();
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {
+      if (requests.incrementAndGet() % 2 == 1) {
+        return;
+      }
+      FullHttpResponse response =
+          new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+      HttpUtil.setContentLength(response, 0);
+      ctx.writeAndFlush(response);
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -111,6 +111,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntFunction;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
@@ -453,6 +454,68 @@ public class HttpCacheClientTest {
                       /* force= */ false)));
     } finally {
       testServer.stop(server);
+    }
+  }
+
+  @Test(timeout = 30000)
+  public void uploadsRetryAfterTimeout() throws Exception {
+    ServerChannel server = null;
+    HttpCacheClient blobStore = null;
+    ListeningScheduledExecutorService retryScheduler =
+        MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1));
+    try {
+      UploadRetryHandler handler = new UploadRetryHandler();
+      server = testServer.start(handler);
+
+      RemoteRetrier retrier =
+          new RemoteRetrier(
+              () -> new Retrier.ZeroBackoff(1),
+              HttpCacheClient.HTTP_RESULT_CLASSIFIER,
+              retryScheduler,
+              Retrier.ALLOW_ALL_CALLS);
+      blobStore =
+          createHttpBlobStore(
+              server,
+              /* timeoutSeconds= */ 1,
+              /* remoteVerifyDownloads= */ true,
+              /* creds= */ null,
+              Options.getDefaults(AuthAndTLSOptions.class),
+              Optional.of(retrier));
+      ByteString data = ByteString.copyFromUtf8("File Contents");
+      Digest digest = DIGEST_UTIL.compute(data.toByteArray());
+
+      getFromFuture(
+          blobStore.uploadBlob(remoteActionExecutionContext, digest, data, /* force= */ false));
+      getFromFuture(
+          blobStore.uploadActionResult(
+              remoteActionExecutionContext,
+              new ActionKey(digest),
+              ActionResult.newBuilder().setExitCode(1).build()));
+
+      assertThat(handler.requests.get()).isEqualTo(4);
+    } finally {
+      if (blobStore != null) {
+        blobStore.close();
+      }
+      retryScheduler.shutdownNow();
+      testServer.stop(server);
+    }
+  }
+
+  @Sharable
+  private static final class UploadRetryHandler
+      extends SimpleChannelInboundHandler<FullHttpRequest> {
+    private final AtomicInteger requests = new AtomicInteger();
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {
+      if (requests.incrementAndGet() % 2 == 1) {
+        return;
+      }
+      FullHttpResponse response =
+          new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+      HttpUtil.setContentLength(response, 0);
+      ctx.writeAndFlush(response);
     }
   }
 


### PR DESCRIPTION
HTTP upload timeouts are recoverable, but the HTTP classifier marks
download timeouts, not upload timeouts, transient. ActionResult uploads
also bypass the retrier, so a stalled CAS or AC PUT can drop an
otherwise successful result.

Classify upload timeouts as transient, retry ActionResult PUTs with a
fresh stream per attempt, and cover both cache endpoints and transports.

Addresses #30205.