### PR TITLE
Avoid fetching yanked metadata in error mode

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -642,6 +642,11 @@ public class IndexRegistry implements Registry {
           YankedVersionsValue.create(
               Optional.of(ImmutableMap.of(selectedModuleKey.version(), yankedInfo))));
     }
+    if (knownFileHashesMode == KnownFileHashesMode.ENFORCE) {
+      // metadata.json is mutable and can't be fetched in error mode. If source.json is missing
+      // from the lockfile, its later fetch will report the actionable missing-checksum error.
+      return Optional.of(YankedVersionsValue.NONE_YANKED);
+    }
     if (knownFileHashes.containsKey(getSourceJsonUrl(selectedModuleKey))) {
       // If the source.json hash is recorded in the lockfile, we know that the module was selected
       // when the lockfile was created. Since it does not appear in the list of selected yanked
@@ -656,9 +661,6 @@ public class IndexRegistry implements Registry {
     }
     // The lockfile does not contain sufficient information to determine the "yanked" status of the
     // module - network access to the registry is required.
-    // Note that this point can't (and must not) be reached with --lockfile_mode=error: The lockfile
-    // records the source.json hashes of all selected modules and the result of selection is fully
-    // determined by the lockfile.
     return Optional.empty();
   }
 

--- a/src/test/py/bazel/bzlmod/bazel_yanked_versions_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_yanked_versions_test.py
@@ -277,6 +277,44 @@ class BazelYankedVersionsTest(test_base.TestBase):
         env_add={'BZLMOD_ALLOW_YANKED_VERSIONS': 'yanked2@1.0'},
     )
 
+  def testDowngradedDepWithStaleLockfileReportsMissingChecksum(self):
+    self.writeBazelrcFile(allow_yanked_versions=False)
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'bazel_dep(name = "aaa", version = "1.1")',
+            # Keep aaa@1.0's MODULE.bazel in the lockfile without selecting it.
+            'bazel_dep(name = "bbb", version = "1.0")',
+        ],
+    )
+    self.ScratchFile('BUILD', ['filegroup(name="hello")'])
+    self.RunBazel(['build', '--nobuild', '//:all'])
+
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'bazel_dep(name = "aaa", version = "1.0")',
+            'bazel_dep(name = "bbb", version = "1.0")',
+        ],
+    )
+    exit_code, _, stderr = self.RunBazel(
+        ['build', '--nobuild', '--lockfile_mode=error', '//:all'],
+        allow_failure=True,
+    )
+    self.AssertExitCode(exit_code, 32, stderr)
+    self.assertIn(
+        'Missing checksum for registry file '
+        + self.main_registry.getURL()
+        + '/modules/aaa/1.0/source.json not permitted with'
+        ' --lockfile_mode=error. Please run'
+        ' `bazel mod deps --lockfile_mode=update` to update your lockfile.',
+        ''.join(stderr),
+    )
+    self.assertNotIn(
+        'Cannot fetch a file without a checksum in ENFORCE mode.',
+        ''.join(stderr),
+    )
+
   def testYankedVersionsFetchedIncrementally(self):
     self.writeBazelrcFile(allow_yanked_versions=False)
     self.ScratchFile(


### PR DESCRIPTION
When a stale lockfile selects a downgraded module whose source.json is
not recorded, yanked-version resolution tries to fetch mutable
metadata.json in ENFORCE mode. The downloader then trips an internal
check and crashes instead of reporting the missing lockfile checksum.

Skip the mutable lookup in error mode so the later source.json check
produces the actionable lockfile error, and cover the downgrade case.

Fixes #29497.