### PR TITLE
Skip executable checks for remote symlink inputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkAction.java
@@ -307,6 +307,19 @@ public final class SymlinkAction extends AbstractAction implements RichDataProdu
             ? actionExecutionContext.getSyscallCache()
             : SyscallCache.NO_CACHE;
     try {
+      // Unmaterialized remote outputs have no permissions and are made executable on download.
+      FileArtifactValue metadata =
+          actionExecutionContext.getInputMetadataProvider().getInputMetadata(primaryInput);
+      if (!primaryInput.isSourceArtifact()
+          && metadata != null
+          && metadata.isRemote()
+          && metadata.getContentsProxy() == null) {
+        // An action filesystem needs the parent to resolve the output symlink during validation.
+        if (actionExecutionContext.getActionFileSystem() != null) {
+          inputPath.getParentDirectory().createDirectoryAndParents();
+        }
+        return;
+      }
       FileStatus stat = syscallCache.statIfFound(inputPath, Symlinks.FOLLOW);
       if (stat == null || !stat.isFile()) {
         String message = String.format("'%s' is not a file", primaryInput.getExecPathString());

--- a/src/test/java/com/google/devtools/build/lib/actions/ExecutableSymlinkActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ExecutableSymlinkActionTest.java
@@ -111,7 +111,6 @@ public class ExecutableSymlinkActionTest {
         ActionsTestUtil.createArtifact(outputRoot, outputRoot.getRoot().getRelative("some-output"));
     SymlinkAction action = SymlinkAction.toExecutable(NULL_ACTION_OWNER, input, output, "progress");
     FakeActionInputFileCache inputMetadataProvider = new FakeActionInputFileCache();
-    inputMetadataProvider.put(input, FileArtifactValue.createForTesting(input));
     ActionExecutionException e =
         assertThrows(
             ActionExecutionException.class,
@@ -137,6 +136,61 @@ public class ExecutableSymlinkActionTest {
     String want = "'in/some-file' is not executable";
       String got = e.getMessage();
     assertWithMessage("got %s, want %s", got, want).that(got.contains(want)).isTrue();
+  }
+
+  @Test
+  public void testFailIfMaterializedRemoteInputIsNotExecutable() throws Exception {
+    Path file = inputRoot.getRoot().getRelative("some-file");
+    FileSystemUtils.createEmptyFile(file);
+    file.setExecutable(/*executable=*/false);
+    Artifact input = ActionsTestUtil.createArtifact(inputRoot, file);
+    Artifact output =
+        ActionsTestUtil.createArtifact(outputRoot, outputRoot.getRoot().getRelative("some-output"));
+    SymlinkAction action = SymlinkAction.toExecutable(NULL_ACTION_OWNER, input, output, "progress");
+    FileArtifactValue metadata =
+        FileArtifactValue.createForRemoteFileWithMaterializationData(
+            new byte[] {1},
+            /* size= */ 0,
+            /* locationIndex= */ 1,
+            /* expirationTime= */ null,
+            /* inMemoryOutput= */ false);
+    metadata.setContentsProxy(FileContentsProxy.create(file.stat()));
+    FakeActionInputFileCache inputMetadataProvider = new FakeActionInputFileCache();
+    inputMetadataProvider.put(input, metadata);
+
+    ActionExecutionException e =
+        assertThrows(
+            ActionExecutionException.class,
+            () -> action.execute(createContext(inputMetadataProvider)));
+    assertThat(e).hasMessageThat().contains("'in/some-file' is not executable");
+  }
+
+  @Test
+  public void testFailIfRemoteSourceInputIsNotExecutable() throws Exception {
+    Path sourceDir = scratch.dir("/source");
+    ArtifactRoot sourceRoot = ArtifactRoot.asSourceRoot(Root.fromPath(sourceDir));
+    Path file = sourceDir.getRelative("some-file");
+    FileSystemUtils.createEmptyFile(file);
+    file.setExecutable(/*executable=*/false);
+    Artifact input = ActionsTestUtil.createArtifact(sourceRoot, file);
+    Artifact output =
+        ActionsTestUtil.createArtifact(outputRoot, outputRoot.getRoot().getRelative("some-output"));
+    SymlinkAction action = SymlinkAction.toExecutable(NULL_ACTION_OWNER, input, output, "progress");
+    FakeActionInputFileCache inputMetadataProvider = new FakeActionInputFileCache();
+    inputMetadataProvider.put(
+        input,
+        FileArtifactValue.createForRemoteFileWithMaterializationData(
+            new byte[] {1},
+            /* size= */ 0,
+            /* locationIndex= */ 1,
+            /* expirationTime= */ null,
+            /* inMemoryOutput= */ false));
+
+    ActionExecutionException e =
+        assertThrows(
+            ActionExecutionException.class,
+            () -> action.execute(createContext(inputMetadataProvider)));
+    assertThat(e).hasMessageThat().contains("'some-file' is not executable");
   }
 
   @Test

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -386,6 +386,46 @@ EOF
   || fail "Expected runfile bazel-bin/a/create_bar.sh to be downloaded"
 }
 
+function test_remote_executable_symlink_after_bazel_bin_deletion() {
+  # Regression test for https://github.com/bazelbuild/bazel/issues/26877.
+  add_rules_shell "MODULE.bazel"
+  cat > BUILD <<'EOF'
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+genrule(
+    name = "a",
+    outs = ["subdir/a"],
+    cmd = "printf '#!/bin/sh\\nexit 0\\n' > \"$@\" && chmod +x \"$@\"",
+)
+
+sh_test(
+    name = "b",
+    srcs = [":a"],
+)
+
+sh_test(
+    name = "c",
+    srcs = [":a"],
+)
+EOF
+
+  bazel test \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_download_minimal \
+      -- //:b >& "$TEST_log" || fail "Failed to test //:b"
+
+  local bazel_bin
+  bazel_bin="$(bazel info bazel-bin)"
+  [[ -n "$bazel_bin" && "$bazel_bin" != "/" ]] || fail "Invalid bazel-bin: '$bazel_bin'"
+  bazel shutdown
+  rm -rf -- "$bazel_bin"
+
+  bazel test \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_download_minimal \
+      -- //:c >& "$TEST_log" || fail "Failed to test //:c"
+}
+
 # Test that --remote_download_toplevel fetches inputs to symlink actions. In
 # particular, cc_binary links against a symlinked imported .so file, and only
 # the symlink is in the runfiles.


### PR DESCRIPTION
Executable symlink actions stat their input to verify permissions. A
remote-only derived output whose local parent directory was removed
cannot pass that check, even though it is made executable on download.

Skip the check only for unmaterialized derived outputs. Recreate the
missing input parent for action filesystems so post-action output
validation can resolve the new symlink without materializing its target.
Keep the executable checks for materialized outputs and remote
repository sources. Cover the shutdown and bazel-bin-deletion sequence
with a remote-execution integration test.

Fixes #26877.