### PR TITLE
Use a portable offset type in SingleJar

### DIFF
--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -449,7 +449,6 @@ cc_library(
     visibility = ["//visibility:private"],
     deps = [
         ":diag",
-        ":port",
         "//src/main/cpp/util",
     ],
 )

--- a/src/tools/singlejar/mapped_file.h
+++ b/src/tools/singlejar/mapped_file.h
@@ -16,9 +16,8 @@
 #define BAZEL_SRC_TOOLS_SINGLEJAR_MAPPED_FILE_H_ 1
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
-
-#include "src/tools/singlejar/port.h"
 
 /*
  * A mapped read-only file with auto closing.
@@ -51,10 +50,10 @@ class MappedFile {
 
   const unsigned char* start() const { return mapped_start_; }
   const unsigned char* end() const { return mapped_end_; }
-  const unsigned char* address(off64_t offset) const {
+  const unsigned char* address(int64_t offset) const {
     return mapped_start_ + offset;
   }
-  off64_t offset(const void* address) const {
+  int64_t offset(const void* address) const {
     return reinterpret_cast<const unsigned char*>(address) - mapped_start_;
   }
 

--- a/src/tools/singlejar/output_jar.cc
+++ b/src/tools/singlejar/output_jar.cc
@@ -590,7 +590,7 @@ bool OutputJar::AddJar(int jar_path_index) {
     //  local header
     //  file data
     //  data descriptor, if present.
-    off64_t copy_from = jar_entry->local_header_offset();
+    int64_t copy_from = jar_entry->local_header_offset();
     size_t num_bytes = lh->size();
     if (jar_entry->no_size_in_local_header()) {
       const DDR* ddr = reinterpret_cast<const DDR*>(
@@ -603,7 +603,7 @@ bool OutputJar::AddJar(int jar_path_index) {
     } else {
       num_bytes += lh->compressed_file_size();
     }
-    off64_t local_header_offset = Position();
+    int64_t local_header_offset = Position();
 
     // When normalize_timestamps is set, entry's timestamp is to be set to
     // 01/01/2010 00:00:00 (or to 01/01/2010 00:00:02, if an entry is a .class
@@ -673,7 +673,7 @@ bool OutputJar::AddJar(int jar_path_index) {
   return input_jar.Close();
 }
 
-off64_t OutputJar::Position() {
+int64_t OutputJar::Position() {
   if (file_ == nullptr) {
     diag_err(1, "%s:%d: output file is not open", __FILE__, __LINE__);
   }
@@ -726,7 +726,7 @@ void OutputJar::WriteEntry(void* buffer) {
   }
 
   uint8_t* data = reinterpret_cast<uint8_t*>(entry);
-  off64_t output_position = Position();
+  int64_t output_position = Position();
   if (!WriteBytes(data, entry->data() + entry->in_zip_size() - data)) {
     diag_err(1, "%s:%d: write", __FILE__, __LINE__);
   }
@@ -854,7 +854,7 @@ void OutputJar::WriteDirEntry(std::string_view name,
 }
 
 // Create output Central Directory entry for the input jar entry.
-void OutputJar::AppendToDirectoryBuffer(const CDH* cdh, off64_t lh_pos,
+void OutputJar::AppendToDirectoryBuffer(const CDH* cdh, int64_t lh_pos,
                                         uint16_t normalized_time,
                                         bool fix_timestamp) {
   // While copying from the input CDH pointed to by 'cdh', we may need to drop
@@ -1002,7 +1002,7 @@ bool OutputJar::Close() {
   WriteEntry(
       log4j2_plugin_dat_combiner_.OutputEntry(options_->force_compression));
   // TODO(asmundak): handle manifest;
-  off64_t output_position = Position();
+  int64_t output_position = Position();
   bool write_zip64_ecd = output_position >= 0xFFFFFFFF || entries_ >= 0xFFFF ||
                          cen_size_ >= 0xFFFFFFFF;
 
@@ -1138,12 +1138,12 @@ ssize_t OutputJar::CopyAppendData(int in_fd, size_t count) {
     if (written < 0) {
       return written;
     } else if (written == 0) {
-      outpos_ += static_cast<off64_t>(count - to_write);
+      outpos_ += static_cast<int64_t>(count - to_write);
       return static_cast<ssize_t>(count - to_write);
     }
     to_write -= static_cast<size_t>(written);
   }
-  outpos_ += static_cast<off64_t>(count);
+  outpos_ += static_cast<int64_t>(count);
   return static_cast<ssize_t>(count);
 #endif
 
@@ -1211,10 +1211,10 @@ size_t OutputJar::AppendFile(Options* options, const char* const file_path) {
   return statbuf.st_size;
 }
 
-off64_t OutputJar::PageAlignedAppendFile(const std::string& file_path,
+int64_t OutputJar::PageAlignedAppendFile(const std::string& file_path,
                                          size_t* file_size) {
   // Align the file start offset at page boundary.
-  off64_t cur_offset = Position();
+  int64_t cur_offset = Position();
   size_t pagesize;
 #ifdef _WIN32
   SYSTEM_INFO si;
@@ -1223,7 +1223,7 @@ off64_t OutputJar::PageAlignedAppendFile(const std::string& file_path,
 #else
   pagesize = sysconf(_SC_PAGESIZE);
 #endif
-  off64_t aligned_offset = (cur_offset + (pagesize - 1)) & ~(pagesize - 1);
+  int64_t aligned_offset = (cur_offset + (pagesize - 1)) & ~(pagesize - 1);
   size_t gap = aligned_offset - cur_offset;
   size_t written;
   if (gap > 0) {
@@ -1250,7 +1250,7 @@ void OutputJar::AppendPageAlignedFile(
   // Align the shared archive start offset at page alignment, which is
   // required by mmap.
   size_t file_size;
-  off64_t aligned_offset = OutputJar::PageAlignedAppendFile(file, &file_size);
+  int64_t aligned_offset = OutputJar::PageAlignedAppendFile(file, &file_size);
 
   // Write the start offset of the copied content as a manifest attribute.
   char offset_manifest_attr[50];

--- a/src/tools/singlejar/output_jar.h
+++ b/src/tools/singlejar/output_jar.h
@@ -66,7 +66,7 @@ class OutputJar {
   // Add the contents of the given input jar.
   bool AddJar(int jar_path_index);
   // Returns the current output position.
-  off64_t Position();
+  int64_t Position();
   // Write Jar entry.
   void WriteEntry(void* local_header_and_payload);
   // Write META_INF/ entry (the first entry on output).
@@ -76,7 +76,7 @@ class OutputJar {
                      const uint16_t n_extra_fields);
   // Create output Central Directory Header for the given input entry and
   // append it to CEN (Central Directory) buffer.
-  void AppendToDirectoryBuffer(const CDH* cdh, off64_t lh_pos,
+  void AppendToDirectoryBuffer(const CDH* cdh, int64_t lh_pos,
                                uint16_t normalized_time, bool fix_timestamp);
   // Reserve space in CEN buffer.
   uint8_t* ReserveCdr(size_t chunk_size);
@@ -90,7 +90,7 @@ class OutputJar {
   void ClasspathResource(const std::string& resource_name,
                          const std::string& resource_path);
   // Append file starting at page boundary.
-  off64_t PageAlignedAppendFile(const std::string& file_path,
+  int64_t PageAlignedAppendFile(const std::string& file_path,
                                 size_t* file_size);
   void AppendPageAlignedFile(const std::string& file,
                              const std::string& offset_manifest_attr_name,
@@ -119,7 +119,7 @@ class OutputJar {
   absl::flat_hash_map<std::string, struct EntryInfo> known_members_;
   int fd_;
   FILE* file_;
-  off64_t outpos_;
+  int64_t outpos_;
   std::unique_ptr<char[]> buffer_;
   int entries_;
   int duplicate_entries_;

--- a/src/tools/singlejar/port.h
+++ b/src/tools/singlejar/port.h
@@ -28,15 +28,6 @@
 #include <sys/types.h>
 #include <time.h>
 
-#if defined(__APPLE__)
-typedef off_t off64_t;
-#elif defined(_WIN32)
-typedef __int64 off64_t;
-#elif defined(__OpenBSD__) || defined(__FreeBSD__)
-typedef int64_t off64_t;
-#endif
-static_assert(sizeof(off64_t) == 8, "File offset type must be 64-bit");
-
 #ifdef _WIN32
 
 #define F_OK 0


### PR DESCRIPTION
SingleJar uses the nonstandard off64_t alias only for internal ZIP and
mapped-file offsets. The alias is absent on musl, so SingleJar cannot
compile there, while platform-specific typedefs and a width assertion
add unnecessary portability plumbing.

Use int64_t for those offsets and remove the obsolete port dependency
and typedef block. The filesystem-call boundaries continue to use
their native types.

Fixes #29530.