### PR TITLE
Allow --test_tmpdir to clear an rc value

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -275,7 +275,7 @@ public abstract class ExecutionOptions extends OptionsBase {
   @Option(
       name = "test_tmpdir",
       defaultValue = "null",
-      converter = OptionsUtils.PathFragmentConverter.class,
+      converter = OptionsUtils.EmptyToNullPathFragmentConverter.class,
       documentationCategory = OptionDocumentationCategory.TESTING,
       effectTags = {OptionEffectTag.UNKNOWN},
       help = "Specifies the base temporary directory for 'bazel test' to use.")

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -113,6 +113,15 @@ EOF
     >& $TEST_log || fail "Running sh_test failed"
   expect_log "TEST_TMPDIR=$TEST_TMPDIR"
   expect_log "HOME=$TEST_TMPDIR"
+
+  add_to_bazelrc "test --test_tmpdir=${TEST_TMPDIR}/from_bazelrc"
+  bazel test --nocache_test_results --test_output=all --test_tmpdir= //foo:bar_test \
+    >& $TEST_log || fail "Running sh_test with empty --test_tmpdir failed"
+  expect_log "TEST_TMPDIR=/.*"
+  expect_log "HOME=/.*"
+  expect_not_log "from_bazelrc"
+  [[ ! -e _tmp ]] || fail "Empty --test_tmpdir created _tmp in the workspace"
+  write_default_bazelrc
 }
 
 function test_env_vars() {


### PR DESCRIPTION
An explicit empty --test_tmpdir currently converts to an empty path
instead of the null default. TestStrategy therefore treats it as
workspace-relative, creates _tmp in the workspace, and cannot clear a
value set in a bazelrc.

Use the existing empty-to-null path converter so the command-line value
restores the default execroot temp directory. Extend the shell
regression to cover the rc override and verify that no workspace _tmp is
created.

RELNOTES[INC]: `--test_tmpdir=` now resets a value from a bazelrc to
the default execroot temp directory instead of creating `_tmp` in the
workspace. Use `--test_tmpdir=.` to retain workspace-relative behavior.

Fixes #22209.