### PR TITLE
Add classname to generated test XML

### DIFF
--- a/src/test/shell/bazel/generate_xml_test.sh
+++ b/src/test/shell/bazel/generate_xml_test.sh
@@ -80,4 +80,12 @@ function test_invalid_two_byte_seq() {
   assert_equals '??' "$(encode '\xc0\xc0')"
 }
 
+function test_generated_testcase_has_classname() {
+  TEST_BINARY="../some/smoke_test" "$GENERATE_XML" \
+      "$TEST_TMPDIR/missing-test.log" "$TEST_TMPDIR/test.xml" 1 0
+
+  assert_contains '<testcase[^>]* classname=""' \
+      "$TEST_TMPDIR/test.xml"
+}
+
 run_suite "generate-xml.sh tests"

--- a/tools/test/generate-xml.sh
+++ b/tools/test/generate-xml.sh
@@ -119,7 +119,7 @@ cat >"${XML_OUTPUT_FILE}" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite name="${test_name}" tests="1" failures="0" errors="${errors}">
-    <testcase name="${test_name}" status="run" duration="${DURATION_IN_SECONDS}" time="${DURATION_IN_SECONDS}">${error_msg}</testcase>
+    <testcase name="${test_name}" classname="" status="run" duration="${DURATION_IN_SECONDS}" time="${DURATION_IN_SECONDS}">${error_msg}</testcase>
       <system-out>
 Generated test.log (if the file is not UTF-8, then this may be unreadable):
 <![CDATA[${ENCODED_LOG}]]>

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -1736,8 +1736,9 @@ bool CreateXmlLog(const Path& output, const Path& test_outerr,
        << acp_test_name << "\" tests=\"1\" failures=\"0\" errors=\"" << errors
        << "\">\n"
           "<testcase name=\""
-       << acp_test_name << "\" status=\"run\" duration=\"" << duration.seconds
-       << "\" time=\"" << duration.seconds << "\">" << error_msg
+       << acp_test_name << "\" classname=\"\" status=\"run\" duration=\""
+       << duration.seconds << "\" time=\"" << duration.seconds << "\">"
+       << error_msg
        << "</testcase>\n"
           "<system-out><![CDATA[";
   if (!ostm.good()) {

--- a/tools/test/windows/tw_test.cc
+++ b/tools/test/windows/tw_test.cc
@@ -475,6 +475,31 @@ TEST_F(TestWrapperWindowsTest, TestTee) {
   write1 = INVALID_HANDLE_VALUE;  // closes handle so the Tee thread can exit
 }
 
+TEST_F(TestWrapperWindowsTest, TestXmlWriterTestcaseHasClassname) {
+  std::wstring tmpdir;
+  GET_TEST_TMPDIR(&tmpdir);
+  std::wstring test_log = tmpdir + L"\\test.log";
+  std::wstring test_xml = tmpdir + L"\\test.xml";
+  ASSERT_TRUE(blaze_util::CreateDummyFile(test_log, ""));
+
+  wchar_t program[] = L"xml_writer";
+  wchar_t duration[] = L"1";
+  wchar_t exit_code[] = L"0";
+  wchar_t* argv[] = {program, &test_log[0], &test_xml[0], duration, exit_code};
+  ASSERT_EQ(bazel::tools::test_wrapper::XmlWriterMain(5, argv), 0);
+
+  HANDLE h = FopenRead(test_xml);
+  ASSERT_NE(h, INVALID_HANDLE_VALUE);
+  char content[4096];
+  DWORD read;
+  ASSERT_TRUE(ReadFile(h, content, sizeof(content), &read, nullptr));
+  CloseHandle(h);
+  std::string xml(content, read);
+  const auto testcase = xml.find("<testcase ");
+  ASSERT_NE(testcase, std::string::npos);
+  EXPECT_LT(xml.find(" classname=\"\"", testcase), xml.find('>', testcase));
+}
+
 void AssertCdataEncodeBuffer(const wchar_t* wline, const char* input,
                              DWORD size, const char* expected_output) {
   bazel::windows::AutoHandle h(FopenContents(wline, input, size));


### PR DESCRIPTION
Fallback test XML omits the testcase classname attribute, so consumers
that require it can reject timeout and crash reports.

Emit an empty classname in both fallback writers, as the shell test
harness does, and cover the POSIX and Windows reports with focused
regressions.

Fixes #16759.