### PR TITLE
Preserve binary test annotations on Windows

### DIFF
--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -203,8 +203,14 @@ class TestWrapperTest(test_base.TestBase):
             '  f.write("Hello b")',
             'with open(os.path.join(root, "c.part"), "wt") as f:',
             '  f.write("Hello c")',
+            'with open(os.path.join(root, "a.pb"), "wb") as f:',
+            '  f.write(b"\\x03\\x0a\\x01\\x00")',
+            'with open(os.path.join(root, "c.pb"), "wb") as f:',
+            '  f.write(b"\\x03\\x0a\\x01\\xff")',
             'with open(os.path.join(dir1, "d.part"), "wt") as f:',
             '  f.write("Hello d")',
+            'with open(os.path.join(dir1, "d.pb"), "wb") as f:',
+            '  f.write(b"\\x03\\x0a\\x01\\x7f")',
             'with open(os.path.join(dir2, "e.part"), "wt") as f:',
             '  f.write("Hello e")',
         ],
@@ -602,6 +608,11 @@ class TestWrapperTest(test_base.TestBase):
       annot_content = [line.strip() for line in f.readlines()]
 
     self.assertListEqual(annot_content, ['Hello aHello c'])
+
+    undecl_annot_pb = undecl_annot + '.pb'
+    self.assertTrue(os.path.exists(undecl_annot_pb))
+    with open(undecl_annot_pb, 'rb') as f:
+      self.assertEqual(f.read(), b'\x03\x0a\x01\x00\x03\x0a\x01\xff')
 
   def _AssertXmlGeneration(self, flags):
     _, bazel_testlogs, _ = self.RunBazel(['info', 'bazel-testlogs'])

--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -204,8 +204,14 @@ class TestWrapperTest(test_base.TestBase):
             '  f.write("Hello b")',
             'with open(os.path.join(root, "c.part"), "wt") as f:',
             '  f.write("Hello c")',
+            'with open(os.path.join(root, "a.pb"), "wb") as f:',
+            '  f.write(b"\\x03\\x0a\\x01\\x00")',
+            'with open(os.path.join(root, "c.pb"), "wb") as f:',
+            '  f.write(b"\\x03\\x0a\\x01\\xff")',
             'with open(os.path.join(dir1, "d.part"), "wt") as f:',
             '  f.write("Hello d")',
+            'with open(os.path.join(dir1, "d.pb"), "wb") as f:',
+            '  f.write(b"\\x03\\x0a\\x01\\x7f")',
             'with open(os.path.join(dir2, "e.part"), "wt") as f:',
             '  f.write("Hello e")',
         ],
@@ -603,6 +609,11 @@ class TestWrapperTest(test_base.TestBase):
       annot_content = [line.strip() for line in f.readlines()]
 
     self.assertListEqual(annot_content, ['Hello aHello c'])
+
+    undecl_annot_pb = undecl_annot + '.pb'
+    self.assertTrue(os.path.exists(undecl_annot_pb))
+    with open(undecl_annot_pb, 'rb') as f:
+      self.assertEqual(f.read(), b'\x03\x0a\x01\x00\x03\x0a\x01\xff')
 
   def _AssertXmlGeneration(self, flags):
     _, bazel_testlogs, _ = self.RunBazel(['info', 'bazel-testlogs'])

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -1345,10 +1345,11 @@ bool ArchiveUndeclaredOutputs(const UndeclaredOutputs& undecl) {
 
 // Creates the Undeclared Outputs Annotations file.
 //
-// This file is a concatenation of every *.part file directly under
+// This file is a concatenation of every file with `suffix` directly under
 // `undecl_annot_dir`. The file is written to `output`.
 bool CreateUndeclaredOutputsAnnotations(const Path& undecl_annot_dir,
-                                        const Path& output) {
+                                        const Path& output,
+                                        const std::wstring& suffix) {
   if (undecl_annot_dir.Get().empty()) {
     // The directory's environment variable
     // (TEST_UNDECLARED_OUTPUTS_ANNOTATIONS_DIR) was probably undefined, nothing
@@ -1362,8 +1363,12 @@ bool CreateUndeclaredOutputsAnnotations(const Path& undecl_annot_dir,
                     undecl_annot_dir.Get());
     return false;
   }
-  // There are no *.part files under `undecl_annot_dir`, nothing to do.
-  if (files.empty()) {
+  const auto is_annotation = [&suffix](const FileInfo& file) {
+    return !file.IsDirectory() && file.RelativePath().size() >= suffix.size() &&
+           file.RelativePath().rfind(suffix) ==
+               file.RelativePath().size() - suffix.size();
+  };
+  if (std::none_of(files.begin(), files.end(), is_annotation)) {
     return true;
   }
 
@@ -1374,9 +1379,7 @@ bool CreateUndeclaredOutputsAnnotations(const Path& undecl_annot_dir,
   }
 
   for (const auto& e : files) {
-    if (!e.IsDirectory() &&
-        e.RelativePath().rfind(L".part") == e.RelativePath().size() - 5) {
-      // Only consume "*.part" files.
+    if (is_annotation(e)) {
       Path path;
       if (!path.Set(undecl_annot_dir.Get() + L"\\" + e.RelativePath()) ||
           !AppendFileTo(path, e.Size(), handle)) {
@@ -1948,11 +1951,15 @@ int TestWrapperMain(int argc, wchar_t** argv) {
 
   Duration test_duration;
   int result = RunSubprocess(executable, args, test_outerr, &test_duration);
+  Path annotations_pb;
   if (!CreateXmlLog(xml_log, test_outerr, test_duration, result,
                     DeleteAfterwards::kEnabled, MainType::kTestWrapperMain) ||
       !ArchiveUndeclaredOutputs(undecl) ||
       !CreateUndeclaredOutputsAnnotations(undecl.annotations_dir,
-                                          undecl.annotations)) {
+                                          undecl.annotations, L".part") ||
+      !annotations_pb.Set(undecl.annotations.Get() + L".pb") ||
+      !CreateUndeclaredOutputsAnnotations(undecl.annotations_dir,
+                                          annotations_pb, L".pb")) {
     return 1;
   }
   return result;
@@ -2019,7 +2026,7 @@ bool TestOnly_CreateUndeclaredOutputsAnnotations(
   Path root, output;
   return blaze_util::IsAbsolute(abs_root) && root.Set(abs_root) &&
          blaze_util::IsAbsolute(abs_output) && output.Set(abs_output) &&
-         CreateUndeclaredOutputsAnnotations(root, output);
+         CreateUndeclaredOutputsAnnotations(root, output, L".part");
 }
 
 bool TestOnly_AsMixedPath(const std::wstring& path, std::string* result) {

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -1352,10 +1352,11 @@ bool ArchiveUndeclaredOutputs(const UndeclaredOutputs& undecl) {
 
 // Creates the Undeclared Outputs Annotations file.
 //
-// This file is a concatenation of every *.part file directly under
+// This file is a concatenation of every file with `suffix` directly under
 // `undecl_annot_dir`. The file is written to `output`.
 bool CreateUndeclaredOutputsAnnotations(const Path& undecl_annot_dir,
-                                        const Path& output) {
+                                        const Path& output,
+                                        const std::wstring& suffix) {
   if (undecl_annot_dir.Get().empty()) {
     // The directory's environment variable
     // (TEST_UNDECLARED_OUTPUTS_ANNOTATIONS_DIR) was probably undefined, nothing
@@ -1369,8 +1370,12 @@ bool CreateUndeclaredOutputsAnnotations(const Path& undecl_annot_dir,
                     undecl_annot_dir.Get());
     return false;
   }
-  // There are no *.part files under `undecl_annot_dir`, nothing to do.
-  if (files.empty()) {
+  const auto is_annotation = [&suffix](const FileInfo& file) {
+    return !file.IsDirectory() && file.RelativePath().size() >= suffix.size() &&
+           file.RelativePath().rfind(suffix) ==
+               file.RelativePath().size() - suffix.size();
+  };
+  if (std::none_of(files.begin(), files.end(), is_annotation)) {
     return true;
   }
 
@@ -1381,9 +1386,7 @@ bool CreateUndeclaredOutputsAnnotations(const Path& undecl_annot_dir,
   }
 
   for (const auto& e : files) {
-    if (!e.IsDirectory() &&
-        e.RelativePath().rfind(L".part") == e.RelativePath().size() - 5) {
-      // Only consume "*.part" files.
+    if (is_annotation(e)) {
       Path path;
       if (!path.Set(undecl_annot_dir.Get() + L"\\" + e.RelativePath()) ||
           !AppendFileTo(path, e.Size(), handle)) {
@@ -1956,11 +1959,15 @@ int TestWrapperMain(int argc, wchar_t** argv) {
 
   Duration test_duration;
   int result = RunSubprocess(executable, args, test_outerr, &test_duration);
+  Path annotations_pb;
   if (!CreateXmlLog(xml_log, test_outerr, test_duration, result,
                     DeleteAfterwards::kEnabled, MainType::kTestWrapperMain) ||
       !ArchiveUndeclaredOutputs(undecl) ||
       !CreateUndeclaredOutputsAnnotations(undecl.annotations_dir,
-                                          undecl.annotations)) {
+                                          undecl.annotations, L".part") ||
+      !annotations_pb.Set(undecl.annotations.Get() + L".pb") ||
+      !CreateUndeclaredOutputsAnnotations(undecl.annotations_dir,
+                                          annotations_pb, L".pb")) {
     return 1;
   }
   return result;
@@ -2027,7 +2034,7 @@ bool TestOnly_CreateUndeclaredOutputsAnnotations(
   Path root, output;
   return blaze_util::IsAbsolute(abs_root) && root.Set(abs_root) &&
          blaze_util::IsAbsolute(abs_output) && output.Set(abs_output) &&
-         CreateUndeclaredOutputsAnnotations(root, output);
+         CreateUndeclaredOutputsAnnotations(root, output, L".part");
 }
 
 bool TestOnly_AsMixedPath(const std::wstring& path, std::string* result) {

--- a/tools/test/windows/tw_test.cc
+++ b/tools/test/windows/tw_test.cc
@@ -418,6 +418,7 @@ TEST_F(TestWrapperWindowsTest, TestCreateUndeclaredOutputsAnnotations) {
   EXPECT_TRUE(CreateDirectoryW((root + L"\\foo").c_str(), nullptr));
   EXPECT_TRUE(CreateDirectoryW((root + L"\\bar.part").c_str(), nullptr));
   EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\a.part", "Hello a"));
+  EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\a.pb", "Proto a"));
   EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\b.txt", "Hello b"));
   EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\c.part", "Hello c"));
   EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\foo\\d.part", "Hello d"));


### PR DESCRIPTION
The Windows test wrapper concatenates only .part fragments, so passing
tests silently lose .pb undeclared-output annotations even though
TestRunnerAction already publishes ANNOTATIONS.pb. POSIX handles both
suffixes.

Concatenate top-level .pb fragments into the expected output, preserve
the nested-file exclusion, and guard suffix matching so short names
cannot contaminate the .part output. Cover suffix filtering and
end-to-end wrapper execution with binary annotation records.