### PR TITLE
Materialize stripped Git repository contents

### DIFF
--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -183,10 +183,56 @@ function test_git_repository_strip_prefix() {
   do_git_repository_test "dbf9236251a9ea01b7a2eb563ca8e911060fc97c" "pluto"
 }
 
+function test_git_repository_strip_prefix_root() {
+  do_git_repository_test "52f9a3f87a2dd17ae0e5847bbae9734f09354afd" "."
+}
+
 function test_git_repository_add_and_strip_prefix() {
   # Same as above, this commit has a 'pluto' subdirectory. The added prefix
   # 'subfolder' is added, and the 'pluto' prefix is stripped.
   do_git_repository_test "dbf9236251a9ea01b7a2eb563ca8e911060fc97c" "pluto" "" "subfolder"
+}
+
+function test_git_repository_strip_prefix_query() {
+  local repo_dir="$TEST_TMPDIR/repos/query-strip-prefix"
+  mkdir -p "$repo_dir/included/.bazel_git_strip_prefix_" "$repo_dir/discarded" \
+    "$repo_dir/.BAZEL_GIT_STRIP_PREFIX"
+  if ! is_windows; then
+    ln -s does-not-exist "$repo_dir/.BAZEL_GIT_STRIP_PREFIX__"
+  fi
+  cat > "$repo_dir/included/BUILD.bazel" <<'EOF'
+filegroup(name = "included")
+EOF
+  cat > "$repo_dir/discarded/BUILD.bazel" <<'EOF'
+filegroup(name = "discarded")
+EOF
+  cat > "$repo_dir/included/.bazel_git_strip_prefix_/BUILD.bazel" <<'EOF'
+filegroup(name = "included_collision_underscore")
+EOF
+  cat > "$repo_dir/.BAZEL_GIT_STRIP_PREFIX/BUILD.bazel" <<'EOF'
+filegroup(name = "discarded_tmp")
+EOF
+  git -C "$repo_dir" init -q
+  git -C "$repo_dir" add .
+  git -C "$repo_dir" -c user.name=bazel -c user.email=bazel@example.com \
+    commit -qm initial
+  local commit_hash
+  commit_hash="$(git -C "$repo_dir" rev-parse HEAD)"
+
+  cat >> MODULE.bazel <<EOF
+git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+git_repository(
+    name = "foo",
+    remote = "$repo_dir",
+    commit = "$commit_hash",
+    strip_prefix = "included",
+)
+EOF
+
+  bazel query '@foo//...' >& "$TEST_log" || fail "Expected query to succeed"
+  expect_log "//:included"
+  expect_log ":included_collision_underscore$"
+  expect_not_log "discarded"
 }
 
 function test_git_repository_shallow_since() {
@@ -671,6 +717,64 @@ EOF
   bazel fetch //planets:planet-info >& $TEST_log \
     || echo "Expect run to fail."
   expect_log "strip_prefix at dir_does_not_exist does not exist in repo"
+}
+
+function assert_strip_prefix_error() {
+  local repo_name="$1"
+  local repo_dir="$2"
+  local commit_hash="$3"
+  local strip_prefix="$4"
+  local expected_error="$5"
+  cat >> MODULE.bazel <<EOF
+git_repository(
+    name = "$repo_name",
+    remote = "$repo_dir",
+    commit = "$commit_hash",
+    strip_prefix = "$strip_prefix",
+)
+EOF
+
+  bazel fetch "@$repo_name//..." >& "$TEST_log" && fail "Expected fetch to fail"
+  expect_log "$expected_error"
+  assert_not_exists "$(bazel info output_base)/external/+git_repository+$repo_name/config"
+}
+
+function test_strip_prefix_errors() {
+  local repo_dir="$TEST_TMPDIR/repos/invalid-strip-prefix"
+  mkdir -p "$repo_dir"
+  touch "$repo_dir/not-a-directory"
+  git -C "$repo_dir" init -q
+  if ! is_windows; then
+    ln -s ../.. "$repo_dir/escape"
+    ln -s .git "$repo_dir/metadata"
+  fi
+  git -C "$repo_dir" add .
+  git -C "$repo_dir" -c user.name=bazel -c user.email=bazel@example.com \
+    commit --allow-empty -qm initial
+  local commit_hash
+  commit_hash="$(git -C "$repo_dir" rev-parse HEAD)"
+
+  local metadata_prefix=".git/objects"
+  if is_darwin || is_windows; then
+    metadata_prefix=".GIT/OBJECTS"
+  fi
+
+  cat >> MODULE.bazel <<'EOF'
+git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+EOF
+
+  assert_strip_prefix_error strip_file "$repo_dir" "$commit_hash" \
+    not-a-directory "strip_prefix at not-a-directory is not a directory"
+  assert_strip_prefix_error strip_traversal "$repo_dir" "$commit_hash" \
+    ../.. "strip_prefix at ../.. escaped the checkout directory"
+  assert_strip_prefix_error strip_metadata "$repo_dir" "$commit_hash" \
+    "$metadata_prefix" "strip_prefix at $metadata_prefix refers to Git metadata"
+  if ! is_windows; then
+    assert_strip_prefix_error strip_escape "$repo_dir" "$commit_hash" \
+      escape "strip_prefix at escape escaped the checkout directory"
+    assert_strip_prefix_error strip_metadata_symlink "$repo_dir" "$commit_hash" \
+      metadata "strip_prefix at metadata refers to Git metadata"
+  fi
 }
 
 

--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -159,16 +159,21 @@ function test_git_repository_add_prefix() {
 }
 
 function test_git_repository_add_prefix_prevent_uproot() {
-      cat >> MODULE.bazel <<EOF
+  local victim_dir="$(bazel info output_base)/external/+git_repository+pluto-victim"
+  mkdir -p "$victim_dir"
+  touch "$victim_dir/sentinel"
+
+  cat >> MODULE.bazel <<EOF
 git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
 git_repository(
     name = "pluto",
     remote = "does-not-matter",
     tag = "1-build",
-    add_prefix = "../uplevel/attempt",
+    add_prefix = "../+git_repository+pluto-victim",
 )
 EOF
   bazel build @pluto >& $TEST_log && fail "Build succeeded"
+  assert_exists "$victim_dir/sentinel"
   expect_log "escaped the base directory"
 }
 

--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -755,7 +755,7 @@ function test_strip_prefix_errors() {
   commit_hash="$(git -C "$repo_dir" rev-parse HEAD)"
 
   local metadata_prefix=".git/objects"
-  if is_darwin || is_windows; then
+  if [[ -d "$repo_dir/.GIT/OBJECTS" ]]; then
     metadata_prefix=".GIT/OBJECTS"
   fi
 

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -71,7 +71,7 @@ def _checkout_path(ctx):
     root = ctx.path(".")
     if ctx.attr.add_prefix:
         add_prefix_root = root.get_child(ctx.attr.add_prefix)
-        if not str(add_prefix_root).startswith(str(root)):
+        if add_prefix_root != root and not str(add_prefix_root).startswith(str(root) + "/"):
             fail(
                 "add_prefix '%s' escaped the base directory of '%s': '%s'" %
                 (ctx.attr.add_prefix, str(root), str(add_prefix_root)),

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -41,18 +41,45 @@ def _clone_or_update_repo(ctx):
         fail("At most one of commit, tag, or branch may be provided")
 
     checkout_path = _checkout_path(ctx)
-    directory = str(checkout_path)
-    if ctx.attr.strip_prefix:
-        directory = str(checkout_path.get_child(".tmp_git_root"))
-
-    git_ = git_repo(ctx, directory)
+    git_ = git_repo(ctx, str(checkout_path))
 
     if ctx.attr.strip_prefix:
-        dest_link = "{}/{}".format(directory, ctx.attr.strip_prefix)
-        if not ctx.path(dest_link).exists:
+        strip_prefix_path = checkout_path.get_child(ctx.attr.strip_prefix)
+        if not strip_prefix_path.exists:
             fail("strip_prefix at {} does not exist in repo".format(ctx.attr.strip_prefix))
-        for item in ctx.path(dest_link).readdir():
-            ctx.symlink(item, checkout_path.get_child(item.basename))
+        if not strip_prefix_path.is_dir:
+            fail("strip_prefix at {} is not a directory".format(ctx.attr.strip_prefix))
+
+        strip_prefix_path = strip_prefix_path.realpath
+        checkout_realpath = checkout_path.realpath
+        strip_prefix_realpath = str(strip_prefix_path).lower()
+        git_metadata_path = str(checkout_realpath.get_child(".git")).lower()
+        if (strip_prefix_realpath == git_metadata_path or
+            strip_prefix_realpath.startswith(git_metadata_path + "/")):
+            fail("strip_prefix at {} refers to Git metadata".format(ctx.attr.strip_prefix))
+        if strip_prefix_path != checkout_realpath:
+            if not str(strip_prefix_path).startswith(str(checkout_realpath) + "/"):
+                fail("strip_prefix at {} escaped the checkout directory".format(ctx.attr.strip_prefix))
+
+            existing_entries = {
+                entry.basename.lower(): True
+                for entry in checkout_path.readdir() + strip_prefix_path.readdir()
+            }
+            strip_prefix_tmp_name = ".bazel_git_strip_prefix"
+            for _ in existing_entries:
+                if strip_prefix_tmp_name not in existing_entries:
+                    break
+                strip_prefix_tmp_name += "_"
+            strip_prefix_tmp_path = checkout_path.get_child(strip_prefix_tmp_name)
+
+            # Keep the selected subtree while removing the rest of the checkout.
+            ctx.rename(strip_prefix_path, strip_prefix_tmp_path)
+            for entry in checkout_path.readdir():
+                if entry.basename != strip_prefix_tmp_name:
+                    ctx.delete(entry)
+            for entry in strip_prefix_tmp_path.readdir():
+                ctx.rename(entry, checkout_path.get_child(entry.basename))
+            ctx.delete(strip_prefix_tmp_path)
 
     if ctx.attr.shallow_since:
         return {"commit": git_.commit, "shallow_since": git_.shallow_since}
@@ -261,11 +288,7 @@ def _git_repository_implementation(ctx):
             integrity = ctx.attr.remote_module_file_integrity,
         )
 
-    checkout_path = _checkout_path(ctx)
-    dot_git_path = checkout_path.get_child(".git")
-    if ctx.attr.strip_prefix:
-        dot_git_path = checkout_path.get_child(".tmp_git_root/.git")
-    ctx.delete(dot_git_path)
+    ctx.delete(_checkout_path(ctx).get_child(".git"))
 
     if ctx.attr.commit:
         return ctx.repo_metadata(reproducible = True)

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -165,7 +165,11 @@ _common_attrs = {
     ),
     "strip_prefix": attr.string(
         default = "",
-        doc = "A directory prefix to strip from the extracted files.",
+        doc = """A directory prefix to strip from the extracted files.
+
+For large repositories, consider combining this with `sparse_checkout_patterns`
+to limit the files checked out before this prefix is stripped. Patterns match
+paths in the original Git repository.""",
     ),
     "add_prefix": attr.string(
         default = "",


### PR DESCRIPTION
git_repository keeps a complete checkout under .tmp_git_root and
symlinks the selected strip_prefix entries into the repository root.
Recursive package discovery can then see discarded sibling packages,
and traversal or an escaping directory symlink can expose data outside
the checkout.

Complete Git operations before stripping, reject paths that escape the
checkout or resolve into Git metadata, and move only the selected
subtree into place. Remove discarded entries and .git, preserve
add_prefix and patch behavior, and cover recursive queries, collisions,
and escape cases.

Fixes #26628.

— Description updated by Codex, on Tamir’s behalf.