### PR TITLE
Presize directory maps when injecting remote repo contents

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -215,6 +215,7 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
             .collect(
                 toImmutableMap(cache.digestUtil::compute, directory -> directory, (a, b) -> a));
     var filesToPrefetch = new ArrayList<PathFragment>();
+    externalFs.createDirectoryAndParents(repoDir.getParentDirectory());
     injectRecursively(
         externalFs,
         repoDir,
@@ -251,7 +252,10 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
       Consumer<PathFragment> filesToPrefetch,
       Instant expirationTime)
       throws IOException {
-    fs.createDirectoryAndParents(path);
+    // The parent directory always exists at this point: the repo's parent is created by
+    // injectRemoteRepo and subdirectories are only visited after their parent has been created.
+    fs.createDirectory(
+        path, dir.getFilesCount() + dir.getSymlinksCount() + dir.getDirectoriesCount());
     for (var file : dir.getFilesList()) {
       var filePath = path.getRelative(unicodeToInternal(file.getName()));
       if (shouldPrefetch(filePath)) {

--- a/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryDirectoryInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryDirectoryInfo.java
@@ -28,10 +28,22 @@ import javax.annotation.Nullable;
  */
 final class InMemoryDirectoryInfo extends InMemoryContentInfo {
 
-  private final Map<String, InMemoryContentInfo> directoryContent = new HashMap<>();
+  private final Map<String, InMemoryContentInfo> directoryContent;
 
   InMemoryDirectoryInfo(Clock clock) {
+    this(clock, /* expectedChildCount= */ -1);
+  }
+
+  /**
+   * Creates a directory info that is presized for the expected number of children if non-negative.
+   *
+   * <p>The expected child count should not include the "." and ".." entries, which every directory
+   * contains in addition to its children.
+   */
+  InMemoryDirectoryInfo(Clock clock, int expectedChildCount) {
     super(clock);
+    this.directoryContent =
+        expectedChildCount < 0 ? new HashMap<>() : HashMap.newHashMap(expectedChildCount + 2);
     setExecutable(true);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileSystem.java
@@ -468,6 +468,14 @@ public class InMemoryFileSystem extends FileSystem {
 
   @Override
   public boolean createDirectory(PathFragment path) throws IOException {
+    return createDirectory(path, /* expectedChildCount= */ -1);
+  }
+
+  /**
+   * Like {@link #createDirectory(PathFragment)}, but if the directory is created and {@code
+   * expectedChildCount} is non-negative, presizes its entry map for that number of children.
+   */
+  public boolean createDirectory(PathFragment path, int expectedChildCount) throws IOException {
     if (isRootDirectory(path)) {
       throw Errno.EACCES.exception(path);
     }
@@ -484,7 +492,8 @@ public class InMemoryFileSystem extends FileSystem {
         }
         return false;
       }
-      error = insertChildDirectory(parent, new InMemoryDirectoryInfo(clock), name);
+      error =
+          insertChildDirectory(parent, new InMemoryDirectoryInfo(clock, expectedChildCount), name);
     }
     if (error != null) {
       throw error.exception(path);


### PR DESCRIPTION
### Description

The in-memory file system backing `--experimental_remote_repo_contents_cache` allocates one `HashMap` per injected directory, which always starts with a table sized for 16 entries even though most directories in a repo have far fewer children (and large directories cause repeated resize churn during injection).

Since the exact child count of each directory is known from the `Directory` proto at injection time, this PR adds an `InMemoryFileSystem#createDirectory(PathFragment, int)` overload that presizes the new directory's entry map (accounting for the `"."` and `".."` entries every directory carries) and uses it in `RemoteExternalOverlayFileSystem#injectRecursively`. As the parent of each injected directory is always created before its children, the recursive step can use plain `createDirectory` instead of `createDirectoryAndParents`, with the repo's parent directory created once up front.

The change is behavior-preserving and covered by the existing `InMemoryFileSystem` and remote tests.

### Motivation

Found while profiling the memory usage of the remote repo contents cache: building Bazel itself with a warm remote repo contents cache injects ~125 repos with ~31.5k files and ~7.7k directories, and the per-directory `HashMap` table is one of the larger fixed overheads of the retained in-memory metadata (0.1% of total retained server heap).

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
