### PR TITLE
Avoid copying downloaded blobs before parsing or wrapping them

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -469,6 +469,28 @@ public class CombinedCache extends AbstractReferenceCounted {
     return Futures.transform(download, (v) -> bOut.toByteArray(), directExecutor());
   }
 
+  /**
+   * Downloads a blob with content hash {@code digest} and stores its content in memory.
+   *
+   * <p>Unlike {@link #downloadBlob(RemoteActionExecutionContext, String, PathFragment, Digest)},
+   * the content is returned as a {@link ByteString} without an extra copy of the downloaded bytes.
+   *
+   * @return a future that completes after the download completes (succeeds / fails). If successful,
+   *     the content is stored in the future's {@link ByteString}.
+   */
+  public ListenableFuture<ByteString> downloadBlobAsByteString(
+      RemoteActionExecutionContext context,
+      String blobName,
+      @Nullable PathFragment execPath,
+      Digest digest) {
+    if (digest.getSizeBytes() == 0) {
+      return immediateFuture(ByteString.empty());
+    }
+    ByteString.Output bOut = ByteString.newOutput((int) digest.getSizeBytes());
+    var download = downloadBlob(context, blobName, execPath, digest, bOut);
+    return Futures.transform(download, (v) -> bOut.toByteString(), directExecutor());
+  }
+
   private ListenableFuture<Void> downloadBlob(
       RemoteActionExecutionContext context,
       String blobName,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1156,7 +1156,7 @@ public class RemoteExecutionService {
         dirMetadataDownloads.put(
             localPath,
             Futures.transformAsync(
-                combinedCache.downloadBlob(
+                combinedCache.downloadBlobAsByteString(
                     context,
                     outputPath,
                     remotePathResolver.localPathToExecPath(localPath.asFragment()),
@@ -1326,13 +1326,13 @@ public class RemoteExecutionService {
             } else {
               downloadsBuilder.add(
                   transform(
-                      combinedCache.downloadBlob(
+                      combinedCache.downloadBlobAsByteString(
                           context,
                           inMemoryOutputPath.getPathString(),
                           inMemoryOutputPath,
                           file.digest()),
                       data -> {
-                        inMemoryOutputData.set(ByteString.copyFrom(data));
+                        inMemoryOutputData.set(data);
                         return null;
                       },
                       directExecutor()));

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
@@ -271,7 +271,7 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
     var repoDirectory = finalEntry.repoDirectory();
     var repoDirectoryContentFuture =
         transformAsync(
-            cache.downloadBlob(
+            cache.downloadBlobAsByteString(
                 context, REPO_DIRECTORY_PATH, /* execPath= */ null, repoDirectory.getTreeDigest()),
             (treeBytes) -> immediateFuture(Tree.parseFrom(treeBytes)),
             directExecutor());

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -69,7 +69,6 @@ import com.google.rpc.RequestInfo;
 import com.google.rpc.ResourceInfo;
 import com.google.rpc.RetryInfo;
 import com.google.rpc.Status;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.Instant;
@@ -391,13 +390,13 @@ public final class Utils {
   public static ListenableFuture<ActionResult> downloadAsActionResult(
       ActionKey actionDigest,
       BiFunction<Digest, OutputStream, ListenableFuture<Void>> downloadFunction) {
-    ByteArrayOutputStream data = new ByteArrayOutputStream(/* size= */ 1024);
+    ByteString.Output data = ByteString.newOutput(/* initialCapacity= */ 1024);
     ListenableFuture<Void> download = downloadFunction.apply(actionDigest.digest(), data);
     return FluentFuture.from(download)
         .transformAsync(
             (v) -> {
               try {
-                return Futures.immediateFuture(ActionResult.parseFrom(data.toByteArray()));
+                return Futures.immediateFuture(ActionResult.parseFrom(data.toByteString()));
               } catch (InvalidProtocolBufferException e) {
                 return immediateFailedFuture(e);
               }


### PR DESCRIPTION
### Description

Several download paths buffer a blob in a `ByteArrayOutputStream` and then call `toByteArray()`, which makes a full defensive copy, only to immediately parse the bytes as a proto or wrap them in a `ByteString`.

This PR adds a `CombinedCache#downloadBlobAsByteString` variant that returns the downloaded blob as a `ByteString`. The `ByteString.Output` is presized to the digest's size, so the (digest-verified) download fills its buffer exactly and `toByteString()` hands the buffer over without copying, producing a single flat `ByteString`. Parsing a proto from a flat `ByteString` uses the same `CodedInputStream` array decoder as parsing from a `byte[]`, so the parse itself is unchanged; the intermediate copy is simply gone.

Call sites converted:
- `RemoteRepoContentsCacheImpl`: the repo contents `Tree` downloaded on a remote repo contents cache hit, which is several MiB for large repos.
- `RemoteExecutionService#createDirMetadataDownloads`: the `Tree` downloaded for every tree artifact output of a remote or cached action.
- `RemoteExecutionService#downloadOutputs`: in-memory output files (e.g. `.jdeps` files) previously copied the downloaded `byte[]` into a `ByteString` via `ByteString.copyFrom`; the copy is now eliminated entirely.
- `Utils#downloadAsActionResult` (the AC read path of the disk and HTTP cache clients): the `ByteArrayOutputStream` grew by doubling, recopying all previously written content whenever an action result exceeded 1 KiB, and then copied once more via `toByteArray()`. `ByteString.Output` chains buffers instead of recopying and avoids the final copy.

### Motivation

Found while profiling the memory usage of the remote repo contents cache; the same double-buffering pattern turned out to be shared by the hot download paths of remote execution and the disk cache.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
