### PR TITLE
Hash ByteStrings without copying in UploadManifest

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -443,7 +443,7 @@ public class UploadManifest {
         }
         ByteString dirBlob = builder.build().toByteString();
 
-        dirToDigest.put(dir, digestUtil.compute(dirBlob.toByteArray()));
+        dirToDigest.put(dir, digestUtil.compute(dirBlob));
         dirBlobs.add(dirBlob);
       }
 
@@ -553,7 +553,7 @@ public class UploadManifest {
 
   private void addDirectory(Path dir) throws ExecException, IOException, InterruptedException {
     ByteString treeBlob = new DirectoryBuilder(dir).build();
-    Digest treeDigest = digestUtil.compute(treeBlob.toByteArray());
+    Digest treeDigest = digestUtil.compute(treeBlob);
 
     result
         .addOutputDirectoriesBuilder()

--- a/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hasher;
 import com.google.common.io.BaseEncoding;
 import com.google.devtools.build.lib.remote.common.ActionKey;
 import com.google.devtools.build.lib.util.DeterministicWriter;
@@ -36,6 +37,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Comparator;
 
@@ -86,6 +88,15 @@ public class DigestUtil {
    */
   public Digest compute(byte[] data, int offset, int length) {
     return buildDigest(hashFn.getHashFunction().hashBytes(data, offset, length).toString(), length);
+  }
+
+  /** Computes a digest of the given {@link ByteString} without copying its contents. */
+  public Digest compute(ByteString blob) {
+    Hasher hasher = hashFn.getHashFunction().newHasher();
+    for (ByteBuffer buffer : blob.asReadOnlyByteBufferList()) {
+      hasher.putBytes(buffer);
+    }
+    return buildDigest(hasher.hash().toString(), blob.size());
   }
 
   /**


### PR DESCRIPTION
### Description

`UploadManifest` computes the digest of every serialized `Directory` blob as well as the final `Tree` blob by first copying the entire `ByteString` with `toByteArray()` and then hashing the copy.

This PR adds a `DigestUtil#compute(ByteString)` overload that feeds the `ByteString`'s backing buffers directly into the hasher via `Hasher#putBytes(ByteBuffer)` and uses it at both call sites, eliminating the copies. For the `Tree` blob of a large output directory or a repo cached by `--experimental_remote_repo_contents_cache`, the avoided copy is several MiB per upload.

Digest correctness is covered by the existing `UploadManifestTest` assertions on exact directory and tree digests.

### Motivation

Found while profiling the memory usage of the remote repo contents cache: the upload path's transient allocations are dominated by redundant full-blob copies made only to compute digests.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
