### PR TITLE
[8.8.0] Materialize source directory inputs from the remote repo contents cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -435,6 +435,18 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
         return immediateVoidFuture();
       }
       Path inputPath = resolveExecPath(execPath);
+
+      if (metadata.getType() == FileStateType.DIRECTORY) {
+        // Tree artifacts have already been expanded into their children, so this is a source
+        // directory. If it lies in an external repo backed by the remote repo contents cache, its
+        // contents may only be available in memory and must be materialized to the local file
+        // system for local actions to access them.
+        if (inputPath.getFileSystem() instanceof SubtreeMaterializer subtreeMaterializer) {
+          subtreeMaterializer.ensureSubtreeMaterialized(inputPath.asFragment());
+        }
+        return immediateVoidFuture();
+      }
+
       var symlinks = getSymlinks(input, inputPath, metadata, metadataSupplier);
       // On Windows, the type of symlink depends on the target file and the target may have to
       // exist, so we plant symlinks in reverse order and only after any download has completed.

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -43,6 +43,7 @@ java_library(
             "LeaseService.java",
             "Scrubber.java",
             "Store.java",
+            "SubtreeMaterializer.java",
         ],
     ),
     exports = [
@@ -60,6 +61,7 @@ java_library(
         ":remote_output_checker",
         ":scrubber",
         ":store",
+        ":subtree_materializer",
         "//src/main/java/com/google/devtools/build/lib:build-request-options",
         "//src/main/java/com/google/devtools/build/lib:runtime",
         "//src/main/java/com/google/devtools/build/lib:runtime/command_line_path_factory",
@@ -249,6 +251,7 @@ java_library(
     srcs = ["AbstractActionInputPrefetcher.java"],
     deps = [
         ":remote_output_checker",
+        ":subtree_materializer",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:action_output_directory_helper",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
@@ -266,6 +269,14 @@ java_library(
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party:rxjava3",
+    ],
+)
+
+java_library(
+    name = "subtree_materializer",
+    srcs = ["SubtreeMaterializer.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -27,7 +27,7 @@ import build.bazel.remote.execution.v2.Tree;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
@@ -46,6 +46,7 @@ import com.google.devtools.build.lib.vfs.DetailedIOException;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.FileStatus;
+import com.google.devtools.build.lib.vfs.FileSymlinkLoopException;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
@@ -56,6 +57,7 @@ import com.google.devtools.build.skyframe.MemoizingEvaluator;
 import com.google.devtools.build.skyframe.SkyFunctionException;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
@@ -65,7 +67,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -82,8 +85,8 @@ import javax.annotation.Nullable;
  * <p>Each external repository can either be materialized to the native file system or kept in
  * memory in the {@link RemoteExternalFileSystem}.
  */
-public final class RemoteExternalOverlayFileSystem extends FileSystem {
-
+public final class RemoteExternalOverlayFileSystem extends FileSystem
+    implements SubtreeMaterializer {
   private final PathFragment externalDirectory;
   private final int externalDirectorySegmentCount;
   private final FileSystem nativeFs;
@@ -319,16 +322,7 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
   private void doMaterialize(RepositoryName repo, ExtendedEventHandler reporter)
       throws IOException, InterruptedException {
     reporter.handle(Event.debug("Materializing remote repo %s".formatted(repo)));
-    var repoPath = externalDirectory.getChild(repo.getName());
-    var remoteRepo = externalFs.getPath(repoPath);
-    var walkResult = walk(remoteRepo);
-    for (var directory : walkResult.directories()) {
-      nativeFs.getPath(directory).createDirectory();
-    }
-    prefetch(walkResult.files());
-    // Create symlinks last as some platforms don't allow creating a symlink to a non-existent
-    // target.
-    prefetch(walkResult.symlinks());
+    materializeSubtree(externalDirectory.getChild(repo.getName()));
 
     // After the repo has been copied, atomically materialize the marker file. This ensures that the
     // repo doesn't have to be refetched after the next server restart.
@@ -340,12 +334,12 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
     markerFileSibling.renameTo(markerFile);
   }
 
-  private void prefetch(List<PathFragment> paths) throws IOException, InterruptedException {
+  private void prefetch(Iterable<PathFragment> paths) throws IOException, InterruptedException {
     var unused =
         getFromFuture(
             inputPrefetcher.prefetchFiles(
                 /* action= */ null,
-                Lists.transform(paths, ActionInputHelper::fromPath),
+                Iterables.transform(paths, ActionInputHelper::fromPath),
                 actionInput -> externalFs.getMetadata(actionInput.getExecPath()),
                 ActionInputPrefetcher.Priority.CRITICAL,
                 ActionInputPrefetcher.Reason.INPUTS));
@@ -363,25 +357,70 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
     invalidateRepoDirectories(evaluator, reposToDiscard);
   }
 
-  private record WalkResult(
-      List<PathFragment> files, List<PathFragment> symlinks, List<PathFragment> directories) {}
-
-  private static WalkResult walk(Path root) throws IOException {
-    var result = new WalkResult(new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
-    walk(root, result);
-    return result;
+  /**
+   * Materializes the subtree rooted at the given path to the native file system if it lies in a
+   * repo whose contents are currently only available in memory.
+   *
+   * <p>This is used to make the files below a source directory action input available to local
+   * actions, which access them through the native file system.
+   */
+  @Override
+  public void ensureSubtreeMaterialized(PathFragment path)
+      throws IOException, InterruptedException {
+    if (fsForPath(path) != externalFs) {
+      return;
+    }
+    materializeSubtree(path);
   }
 
-  private static void walk(Path root, WalkResult result) throws IOException {
-    for (var dirent : root.readdir(Symlinks.NOFOLLOW)) {
-      var fromChild = root.getChild(dirent.getName());
+  private void materializeSubtree(PathFragment path) throws IOException, InterruptedException {
+    var files = new LinkedHashSet<PathFragment>();
+    var symlinks = new LinkedHashSet<PathFragment>();
+    var root = externalFs.getPath(path);
+    if (root.isSymbolicLink()) {
+      symlinks.add(path);
+      root = root.resolveSymbolicLinks();
+    }
+    collectAndCreateDirectories(root, files, symlinks, new HashSet<>());
+    prefetch(files);
+    // Create symlinks last as some platforms don't allow creating a symlink to a non-existent
+    // target.
+    prefetch(symlinks);
+  }
+
+  private void collectAndCreateDirectories(
+      Path dir, Set<PathFragment> files, Set<PathFragment> symlinks, Set<PathFragment> visitedDirs)
+      throws IOException {
+    if (!visitedDirs.add(dir.asFragment())) {
+      return;
+    }
+    nativeFs.createDirectoryAndParents(dir.asFragment());
+    for (var dirent : dir.readdir(Symlinks.NOFOLLOW)) {
+      var child = dir.getChild(dirent.getName());
       switch (dirent.getType()) {
-        case FILE -> result.files.add(fromChild.asFragment());
-        case SYMLINK -> result.symlinks.add(fromChild.asFragment());
-        case DIRECTORY -> {
-          result.directories.add(fromChild.asFragment());
-          walk(fromChild, result);
+        case FILE -> files.add(child.asFragment());
+        case SYMLINK -> {
+          symlinks.add(child.asFragment());
+          // The symlink chain is reproduced verbatim on the native file system, but its target may
+          // lie outside the materialized subtree and has to be materialized as well so that the
+          // chain doesn't dangle.
+          Path target;
+          try {
+            target = child.resolveSymbolicLinks();
+          } catch (FileNotFoundException | FileSymlinkLoopException e) {
+            // Dangling symlinks and symlink loops are reproduced verbatim.
+            continue;
+          }
+          // TODO(#30160): RepositoryUtils.replantSymlinks currently ensures that all symlinks
+          // within a remotely cacheable external repo stay within that repo. If that changes, new
+          // logic has to be added here to prefetch such files correctly.
+          if (target.isDirectory(Symlinks.NOFOLLOW)) {
+            collectAndCreateDirectories(target, files, symlinks, visitedDirs);
+          } else {
+            files.add(target.asFragment());
+          }
         }
+        case DIRECTORY -> collectAndCreateDirectories(child, files, symlinks, visitedDirs);
         default -> throw new IOException("Unsupported file type: " + dirent);
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/SubtreeMaterializer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SubtreeMaterializer.java
@@ -1,0 +1,31 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
+
+/**
+ * A file system that may keep the contents of certain directory trees in memory, backed by remote
+ * storage, and that supports materializing them to the local file system on demand.
+ */
+public interface SubtreeMaterializer {
+  /**
+   * Materializes the subtree rooted at the given path to the local file system if its contents are
+   * currently only available in memory, together with the targets of any symlinks below it.
+   *
+   * <p>Does nothing if the subtree is already backed by the local file system.
+   */
+  void ensureSubtreeMaterialized(PathFragment path) throws IOException, InterruptedException;
+}

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -941,6 +941,252 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
         extra_flags=['--sandbox_base=' + tmpdir]
     )
 
+  def testUseSourceDirectoryInBuildRule_actionDoesNotUseCache(self):
+    # Regression test for https://github.com/bazelbuild/bazel/issues/30217.
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            (
+                '  rctx.file("BUILD", "filegroup(name=\'sysroot_dir\','
+                " srcs=['sysroot'], visibility=['//visibility:public'])\")"
+            ),
+            '  rctx.file("sysroot/include/data.txt", "source-directory-data")',
+            # Verify that empty directories are materialized correctly.
+            '  rctx.file("sysroot/empty_dir/.keep")',
+            '  rctx.delete("sysroot/empty_dir/.keep")',
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(_repo_impl)',
+        ],
+    )
+    self.ScratchFile(
+        'main/BUILD.bazel',
+        [
+            'genrule(',
+            '  name = "read_source_directory",',
+            '  srcs = ["@my_repo//:sysroot_dir"],',
+            '  outs = ["out.txt"],',
+            (
+                '  cmd = "cat $(location @my_repo//:sysroot_dir)/include/'
+                'data.txt > $@",'
+            ),
+            '  tags = ["no-cache"],',
+            ')',
+        ],
+    )
+
+    repo_dir = self.RepoDir('my_repo')
+    out = self.Path('bazel-bin/main/out.txt')
+
+    # First fetch: not cached
+    _, _, stderr = self.RunBazel(['build', '//main:read_source_directory'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+    with open(out) as f:
+      self.assertEqual(f.read(), 'source-directory-data')
+
+    # After expunging: the repo is a remote cache hit and is not fully
+    # materialized, but the no-cache action still runs locally and must be able
+    # to read the files below the source directory it depends on.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '//main:read_source_directory'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertFalse(os.path.exists(os.path.join(repo_dir, 'BUILD')))
+    self.assertTrue(
+        os.path.exists(os.path.join(repo_dir, 'sysroot/include/data.txt'))
+    )
+    self.assertTrue(os.path.isdir(os.path.join(repo_dir, 'sysroot/empty_dir')))
+    with open(out) as f:
+      self.assertEqual(f.read(), 'source-directory-data')
+
+  def testUseSourceDirectoryWithSymlinksInBuildRule_actionDoesNotUseCache(
+      self,
+  ):
+    # Regression test for https://github.com/bazelbuild/bazel/issues/30217 with
+    # symlinks below the source directory that point out of it, at a file and a
+    # directory that are not themselves inputs of the action.
+    if self.IsWindows():
+      self.ScratchFile(
+          '.bazelrc',
+          ['startup --windows_enable_symlinks'],
+          mode='a',
+      )
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            (
+                '  rctx.file("BUILD", "filegroup(name=\'sysroot_dir\','
+                " srcs=['sysroot'], visibility=['//visibility:public'])\")"
+            ),
+            '  rctx.file("shared/data.txt", "shared-data\\n")',
+            '  rctx.file("shared/dir/nested.txt", "nested-data\\n")',
+            '  rctx.symlink("shared/data.txt", "sysroot/link_to_file.txt")',
+            '  rctx.symlink("shared/dir", "sysroot/link_to_dir")',
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(_repo_impl)',
+        ],
+    )
+    self.ScratchFile(
+        'main/BUILD.bazel',
+        [
+            'genrule(',
+            '  name = "read_source_directory",',
+            '  srcs = ["@my_repo//:sysroot_dir"],',
+            '  outs = ["out.txt"],',
+            (
+                '  cmd = "cat $(location @my_repo//:sysroot_dir)/'
+                'link_to_file.txt $(location @my_repo//:sysroot_dir)/'
+                'link_to_dir/nested.txt > $@",'
+            ),
+            '  tags = ["no-cache"],',
+            ')',
+        ],
+    )
+
+    repo_dir = self.RepoDir('my_repo')
+    out = self.Path('bazel-bin/main/out.txt')
+
+    # First fetch: not cached
+    _, _, stderr = self.RunBazel(['build', '//main:read_source_directory'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+    with open(out) as f:
+      self.assertEqual(f.read(), 'shared-data\nnested-data\n')
+
+    # After expunging: the repo is a remote cache hit and is not fully
+    # materialized, but the no-cache action still runs locally and must be able
+    # to read all files reachable through the source directory it depends on,
+    # including via symlinks that point out of it.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '//main:read_source_directory'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertFalse(os.path.exists(os.path.join(repo_dir, 'BUILD')))
+    self.assertTrue(
+        os.path.islink(os.path.join(repo_dir, 'sysroot/link_to_file.txt'))
+    )
+    self.assertTrue(os.path.exists(os.path.join(repo_dir, 'shared/data.txt')))
+    self.assertTrue(
+        os.path.exists(os.path.join(repo_dir, 'shared/dir/nested.txt'))
+    )
+    with open(out) as f:
+      self.assertEqual(f.read(), 'shared-data\nnested-data\n')
+
+  def testUseSourceDirectoryAndFileInputsInBuildRule_actionsDoNotUseCache(
+      self,
+  ):
+    # A source directory input can overlap with regular source file inputs of
+    # other actions (e.g. via glob). Both are materialized out of the remote
+    # repo contents cache in the same build, through subtree materialization
+    # and per-file prefetching respectively, and must not conflict.
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            (
+                '  rctx.file("BUILD", "filegroup(name=\'sysroot_dir\','
+                " srcs=['sysroot'], visibility=['//visibility:public'])\\n"
+                "exports_files(glob(['sysroot/**']))\")"
+            ),
+            (
+                '  rctx.file("sysroot/include/data.txt",'
+                ' "source-directory-data\\n")'
+            ),
+            '  rctx.file("sysroot/include/other.txt", "file-input-data\\n")',
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(_repo_impl)',
+        ],
+    )
+    self.ScratchFile(
+        'main/BUILD.bazel',
+        [
+            'genrule(',
+            '  name = "read_source_directory",',
+            '  srcs = ["@my_repo//:sysroot_dir"],',
+            '  outs = ["dir_out.txt"],',
+            (
+                '  cmd = "cat $(location @my_repo//:sysroot_dir)/include/'
+                'data.txt $(location @my_repo//:sysroot_dir)/include/'
+                'other.txt > $@",'
+            ),
+            '  tags = ["no-cache"],',
+            ')',
+            'genrule(',
+            '  name = "read_files",',
+            (
+                '  srcs = ["@my_repo//:sysroot/include/data.txt",'
+                ' "@my_repo//:sysroot/include/other.txt"],'
+            ),
+            '  outs = ["files_out.txt"],',
+            (
+                '  cmd = "cat $(location @my_repo//:sysroot/include/data.txt)'
+                ' $(location @my_repo//:sysroot/include/other.txt) > $@",'
+            ),
+            '  tags = ["no-cache"],',
+            ')',
+        ],
+    )
+
+    repo_dir = self.RepoDir('my_repo')
+    dir_out = self.Path('bazel-bin/main/dir_out.txt')
+    files_out = self.Path('bazel-bin/main/files_out.txt')
+    expected = 'source-directory-data\nfile-input-data\n'
+
+    # First fetch: not cached
+    _, _, stderr = self.RunBazel(
+        ['build', '//main:read_source_directory', '//main:read_files']
+    )
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+    with open(dir_out) as f:
+      self.assertEqual(f.read(), expected)
+    with open(files_out) as f:
+      self.assertEqual(f.read(), expected)
+
+    # After expunging: the repo is a remote cache hit and both no-cache actions
+    # run locally in the same build, materializing the same files through the
+    # source directory subtree walk and per-file prefetching respectively.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(
+        ['build', '//main:read_source_directory', '//main:read_files']
+    )
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertFalse(os.path.exists(os.path.join(repo_dir, 'BUILD')))
+    self.assertTrue(
+        os.path.exists(os.path.join(repo_dir, 'sysroot/include/data.txt'))
+    )
+    self.assertTrue(
+        os.path.exists(os.path.join(repo_dir, 'sysroot/include/other.txt'))
+    )
+    with open(dir_out) as f:
+      self.assertEqual(f.read(), expected)
+    with open(files_out) as f:
+      self.assertEqual(f.read(), expected)
+
   def testUseRepoSymlinkInBuildRule_actionDoesNotUseCache(self):
     # Regression test for https://github.com/bazelbuild/bazel/issues/29656.
     if self.IsWindows():


### PR DESCRIPTION
### Description

With `--experimental_remote_repo_contents_cache`, source directory inputs to local actions were not correctly materialized as the prefetcher skipped metadata of type `DIRECTORY`. This is correct for action outputs with BwoB where tree artifacts are expanded into their individual files in an earlier stage of the process, but needs to be replaced by a partial materialization of the subtree for directories in remote repositories, including the targets of any symlinks.

### Motivation

Fixes #30217.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #30222.

PiperOrigin-RevId: 948344418
Change-Id: I15be86960f58a1324fe3964f4eefac76a8e2ca9c
(cherry picked from commit 0d1d517b5b2bf46e1ff1a3ced3517351dc2de6e7)

Closes #30224
