### PR TITLE
Reset download cache for refetched remote repos

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -806,6 +806,17 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
         forceRefetch(linkPath));
   }
 
+  /**
+   * Forgets about completed downloads of the given paths so that the next prefetch of each of them
+   * verifies it against the local file system instead of assuming that it is still in place.
+   */
+  public void invalidateDownloads(Iterable<PathFragment> execPaths) {
+    for (PathFragment path : execPaths) {
+      // Downloads are written to the actual host file system, not any overlays.
+      downloadCache.invalidate(execRoot.getRelative(path).forHostFileSystem());
+    }
+  }
+
   public ImmutableSet<Path> downloadedFiles() {
     return downloadCache.getFinishedTasks();
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -312,6 +312,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote/util:tracing_metadata_utils",
         "//src/main/java/com/google/devtools/build/lib/util:temp_path_generator",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:guava",
         "//third_party:jsr305",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -36,6 +36,7 @@ import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.util.TempPathGenerator;
 import com.google.devtools.build.lib.vfs.OutputPermissions;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Symlinks;
 import java.io.IOException;
 import java.util.Collection;
@@ -100,7 +101,12 @@ public class RemoteActionInputFetcher extends AbstractActionInputPrefetcher {
   protected boolean forceRefetch(Path path) {
     // Caches for download operations and output directory creation need to be disregarded for the
     // outputs of rewound actions as they may have been deleted after they were first created.
-    return path.startsWith(execRoot) && rewoundActionOutputs.contains(path.relativeTo(execRoot));
+    // Compare as fragments since execRoot may be located on a file system overlaying the host file
+    // system where downloads are written to.
+    PathFragment execRootFragment = execRoot.asFragment();
+    PathFragment pathFragment = path.asFragment();
+    return pathFragment.startsWith(execRootFragment)
+        && rewoundActionOutputs.contains(pathFragment.relativeTo(execRootFragment));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -422,6 +422,11 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
   }
 
   private void prefetch(Iterable<PathFragment> paths) throws IOException, InterruptedException {
+    // These paths may have been prefetched and then deleted again earlier in this invocation, e.g.
+    // by an injection whose fetch was subsequently restarted due to memory pressure. The
+    // prefetcher's download cache would otherwise consider them downloaded already and not even
+    // verify they exist on the local file system.
+    inputPrefetcher.invalidateDownloads(paths);
     var unused =
         getFromFuture(
             inputPrefetcher.prefetchFilesInterruptibly(

--- a/src/main/java/com/google/devtools/build/lib/remote/util/AsyncTaskCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/AsyncTaskCache.java
@@ -543,6 +543,13 @@ public final class AsyncTaskCache<KeyT, ValueT> {
       return cache.getFinishedTasks();
     }
 
+    /**
+     * @see AsyncTaskCache#invalidate
+     */
+    public void invalidate(KeyT key) {
+      cache.invalidate(key);
+    }
+
     /** Returns a set of keys for tasks which is still executing. */
     public ImmutableSet<KeyT> getInProgressTasks() {
       return cache.getInProgressTasks();

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -327,6 +328,59 @@ public abstract class ActionInputPrefetcherTestBase {
     assertThat(prefetcher.downloadedFiles()).containsExactly(a.getPath());
     assertThat(prefetcher.downloadsInProgress()).isEmpty();
     assertThat(FileSystemUtils.readContent(a.getPath(), UTF_8)).isEqualTo("hello world remote");
+  }
+
+  @Test
+  public void invalidateDownloads_redownloadsFileDeletedAfterDownload() throws Exception {
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+    Map<HashCode, byte[]> cas = new HashMap<>();
+    Artifact invalidated = createRemoteArtifact("file1", "hello world", metadata, cas);
+    Artifact notInvalidated = createRemoteArtifact("file2", "fizz buzz", metadata, cas);
+    AbstractActionInputPrefetcher prefetcher = createPrefetcher(cas);
+
+    wait(
+        prefetcher.prefetchFilesInterruptibly(
+            action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
+    assertThat(FileSystemUtils.readContent(invalidated.getPath(), UTF_8)).isEqualTo("hello world");
+
+    // Both files are deleted behind the prefetcher's back, but only one of them is invalidated.
+    invalidated.getPath().delete();
+    notInvalidated.getPath().delete();
+    prefetcher.invalidateDownloads(ImmutableList.of(invalidated.getExecPath()));
+
+    wait(
+        prefetcher.prefetchFilesInterruptibly(
+            action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
+
+    assertThat(FileSystemUtils.readContent(invalidated.getPath(), UTF_8)).isEqualTo("hello world");
+    // Downloads that weren't invalidated are still assumed to be in place.
+    assertThat(notInvalidated.getPath().exists()).isFalse();
+  }
+
+  @Test
+  public void invalidateDownloads_intactFileNotRedownloaded() throws Exception {
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+    Map<HashCode, byte[]> cas = new HashMap<>();
+    Artifact a = createRemoteArtifact("file", "hello world", metadata, cas);
+    AbstractActionInputPrefetcher prefetcher = spy(createPrefetcher(cas));
+
+    wait(
+        prefetcher.prefetchFilesInterruptibly(
+            action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
+    assertThat(FileSystemUtils.readContent(a.getPath(), UTF_8)).isEqualTo("hello world");
+
+    reset(fs);
+    prefetcher.invalidateDownloads(ImmutableList.of(a.getExecPath()));
+    wait(
+        prefetcher.prefetchFilesInterruptibly(
+            action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
+
+    // The second prefetch checks the file against the file system rather than assuming that it is
+    // still in place, but doesn't download it again as it is intact.
+    verify(fs).statIfFound(a.getPath().asFragment(), /* followSymlinks= */ true);
+    verify(prefetcher, times(1))
+        .doDownloadFile(eq(action), any(), eq(a), any(), any(), any(), any());
+    assertThat(FileSystemUtils.readContent(a.getPath(), UTF_8)).isEqualTo("hello world");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -215,6 +215,44 @@ public class RemoteActionInputFetcherTest extends ActionInputPrefetcherTestBase 
     }
   }
 
+  @Test
+  public void rewoundActionOutput_execRootOnOverlayFileSystem_redownloaded() throws Exception {
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+    Map<HashCode, byte[]> cas = new HashMap<>();
+    Artifact a = createRemoteArtifact("file", "hello world", metadata, cas);
+    // When the remote repo contents cache is enabled, the exec root lies on the file system
+    // overlaying the host file system that downloads are written to.
+    RemoteExternalOverlayFileSystem overlayFs =
+        new RemoteExternalOverlayFileSystem(PathFragment.create("/output_base/external"), fs);
+    RemoteActionInputFetcher actionInputFetcher =
+        new RemoteActionInputFetcher(
+            new Reporter(new EventBusEventHandler(eventBus)),
+            "none",
+            "none",
+            newCombinedCache(digestUtil, cas),
+            overlayFs.getPath(execRoot.getPathString()),
+            tempPathGenerator,
+            DUMMY_REMOTE_OUTPUT_CHECKER,
+            ActionOutputDirectoryHelper.createForTesting(),
+            OutputPermissions.READONLY);
+
+    wait(
+        actionInputFetcher.prefetchFilesInterruptibly(
+            action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
+    assertThat(FileSystemUtils.readContent(a.getPath(), StandardCharsets.UTF_8))
+        .isEqualTo("hello world");
+
+    // Rewinding deletes the output and requires it to be downloaded again.
+    a.getPath().delete();
+    actionInputFetcher.handleRewoundActionOutputs(ImmutableList.of(a));
+
+    wait(
+        actionInputFetcher.prefetchFilesInterruptibly(
+            action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
+    assertThat(FileSystemUtils.readContent(a.getPath(), StandardCharsets.UTF_8))
+        .isEqualTo("hello world");
+  }
+
   private CombinedCache newCombinedCache(DigestUtil digestUtil, Map<HashCode, byte[]> cas) {
     Map<Digest, byte[]> cacheEntries = Maps.newHashMapWithExpectedSize(cas.size());
     for (Map.Entry<HashCode, byte[]> entry : cas.entrySet()) {

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -1977,6 +1977,146 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     self.assertFalse(os.path.exists(os.path.join(repo_dir, 'sub/BUILD')))
     self.assertTrue(os.path.exists(os.path.join(repo_dir, 'sub/sub.txt')))
 
+  def testMemoryPressureRestartDuringCachedFetch(self):
+    # Regression test for a cached repo fetch that is interrupted by memory
+    # pressure (Skyframe drops the fetch's WorkerSkyKeyComputeState, which
+    # cancels the worker thread) and restarted within the same command. The
+    # restarted fetch must not lose the native copies of prefetched files
+    # (REPO.bazel and .bzl files) downloaded by the interrupted attempt.
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo")',
+            'churn = use_repo_rule("//:churn.bzl", "churn")',
+            'churn(name = "churn_repo")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    # The many sizable .bzl files make the prefetching phase of the cached
+    # fetch long enough that a memory-pressure state drop reliably lands while
+    # some prefetched files have been downloaded and others haven't.
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            '  rctx.file("REPO.bazel", "# repo boundary\\n")',
+            '  rctx.file("defs.bzl", "x = 1\\n")',
+            '  for i in range(400):',
+            (
+                '  '
+                '  rctx.file("bulk_%d.bzl" % i,'
+                ' "s = \'%d %s\'\\n" % (i, "a" * 1000000))'
+            ),
+            (
+                '  rctx.file("BUILD",'
+                ' "load(\':defs.bzl\', \'x\')\\nfilegroup(name=\'target\')")'
+            ),
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(_repo_impl)',
+        ],
+    )
+    # An uncacheable repo whose fetch allocates lots of garbage to trigger
+    # minor GC events. Together with --skyframe_high_water_mark_threshold=0,
+    # each such event drops all SkyKeyComputeStates, cancelling and restarting
+    # the concurrent cached fetch of my_repo.
+    self.ScratchFile(
+        'churn.bzl',
+        [
+            'def _churn_impl(rctx):',
+            '  rctx.file("BUILD", "filegroup(name=\'churn\')")',
+            '  total = 0',
+            '  for i in range(300):',
+            '    total += len([str(j) for j in range(200000)])',
+            '  print("CHURNED %d" % total)',
+            'churn = repository_rule(_churn_impl)',
+        ],
+    )
+
+    repo_dir = self.RepoDir('my_repo')
+
+    # Populate the remote repo contents cache and verify that the repo is
+    # served from it afterwards. addToCache uploads the repo contents
+    # synchronously as part of the fetch, so a single build suffices.
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:target'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:target'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+
+    # Fetch from the cache while the concurrent fetch of churn_repo triggers
+    # memory-pressure state drops. The drop budget is bounded: with an
+    # unlimited budget, every fetch attempt of churn_repo would be cancelled
+    # by the GC events it itself causes and the build would never finish, and
+    # a fetch attempt whose remote cache lookup is cancelled mid-flight may
+    # legitimately fall back to a full fetch. Since the timing of GC events is
+    # inherently nondeterministic, retry a few times until a run in which the
+    # cached fetch of my_repo was interrupted and still served from the cache.
+    # A restart is only reported as a transient fetch progress update, which
+    # the UI renders into the progress bar. The bar only lists ongoing fetches
+    # in its long form, which requires cursor control, and only emits every
+    # update without a rate limit. A wide terminal keeps the message on a
+    # single line and thus greppable.
+    restart_message = (
+        'Fetching repository @@%s; fetch interrupted due to memory pressure'
+        % os.path.basename(repo_dir)
+    )
+
+    def assert_repo_file(name, expected):
+      path = os.path.join(repo_dir, name)
+      self.assertTrue(os.path.exists(path), '%s is missing' % name)
+      with open(path, 'r') as f:
+        actual = f.read()
+      if actual != expected:
+        # Don't include the full contents in the message, they can be large.
+        self.fail(
+            '%s is corrupt: expected %d bytes, got %d bytes starting with %r'
+            % (name, len(expected), len(actual), actual[:100])
+        )
+
+    for attempt in range(5):
+      self.RunBazel(['clean', '--expunge'])
+      exit_code, _, stderr = self.RunBazel(
+          [
+              # A small heap makes minor GC events frequent under allocation
+              # pressure.
+              '--host_jvm_args=-Xmx512m',
+              'build',
+              '--skyframe_high_water_mark_threshold=0',
+              '--skyframe_high_water_mark_minor_gc_drops_per_invocation=8',
+              '--skyframe_high_water_mark_full_gc_drops_per_invocation=8',
+              '--curses=yes',
+              '--color=no',
+              '--show_progress_rate_limit=0',
+              '--terminal_columns=500',
+              '@my_repo//:target',
+              '@churn_repo//:churn',
+          ],
+          allow_failure=True,
+      )
+      stderr = '\n'.join(stderr)
+      # An interrupted fetch must never corrupt the repo, in particular not
+      # lose or truncate the native copies of prefetched files.
+      self.assertEqual(exit_code, 0, stderr)
+      assert_repo_file('REPO.bazel', '# repo boundary\n')
+      assert_repo_file('defs.bzl', 'x = 1\n')
+      for i in (0, 399):
+        assert_repo_file('bulk_%d.bzl' % i, "s = '%d %s'\n" % (i, 'a' * 1000000))
+      interrupted = restart_message in stderr
+      refetched = 'JUST FETCHED' in stderr
+      print(
+          'poison attempt %d: interrupted=%s refetched=%s'
+          % (attempt, interrupted, refetched)
+      )
+      if interrupted and not refetched:
+        break
+    else:
+      self.fail(
+          'the cached fetch of my_repo was never both interrupted by a'
+          ' memory-pressure compute state drop and served from the cache'
+      )
+
   def doTestMaterializationWithInternalAndExternalSymlinks(
       self, *, expect_symlinks, watch_dep_file=True
   ):


### PR DESCRIPTION
### Description
When a repo fetch is interrupted by memory pressure, the restarted fetch looks up the remote repo contents cache again and reinjects the repo. Reinjection starts by deleting the repo directory, including the native copies of `REPO.bazel` and `.bzl` files prefetched by the first attempt. However, the per-invocation `AsyncTaskCache` in `AbstractActionInputPrefetcher` still remembers those downloads as finished and silently skips re-downloading them. The repo then ends up injected in memory with its prefetched native copies missing, and the next read of any `REPO.bazel` or `.bzl` file fails with a loading error such as "error reading REPO.bazel file at ...".

Prefetches issued by `RemoteExternalOverlayFileSystem` therefore first drop the paths they are about to prefetch from the download cache, so that those paths are always verified against the local file system.

Along the way and to get the new tests to pass, this fixes a bug: `RemoteActionInputFetcher#forceRefetch` compared the path to prefetch against the exec root with `Path#startsWith`, which returns false whenever the two paths lie on different `FileSystem` instances such as `RemoteExternalOverlayFileSystem`.

### Motivation
User reports of `error reading REPO.bazel file at ...` when the Bazel server is under memory pressure.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
