### PR TITLE
Don't update the lockfile from commands that didn't sync Skyframe

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -131,8 +131,6 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/bazel/repository:repository_options",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/runtime:blaze_command_cluster",
-        "//src/main/java/com/google/devtools/build/lib/skyframe:precomputed_value",
-        "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/skyframe",
         "//third_party:flogger",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -61,8 +61,8 @@ public class BazelLockFileModule extends BlazeModule {
     CommandEnvironment env = this.env;
     this.env = null;
     if (env == null || !env.hasSyncedPackageLoading()) {
-      // The current command (e.g. shutdown) didn't evaluate the lockfile values and they may
-      // thus be stale, e.g., if a server with a different output base changed the lockfile
+      // The current command (e.g. shutdown) didn't evaluate the lockfile values so they may
+      // be stale, e.g., if a server with a different output base changed the lockfile
       // in the meantime.
       return;
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
-import static com.google.devtools.build.lib.bazel.bzlmod.BazelLockFileFunction.LOCKFILE_MODE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -29,8 +28,6 @@ import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.Lockfile
 import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.runtime.BlazeModule;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
-import com.google.devtools.build.lib.skyframe.PrecomputedValue;
-import com.google.devtools.build.lib.skyframe.SkyframeExecutor;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.Root;
@@ -47,10 +44,7 @@ import java.util.function.Predicate;
  */
 public class BazelLockFileModule extends BlazeModule {
 
-  private SkyframeExecutor executor;
-  private Path workspaceRoot;
-  private Path outputBase;
-  private LockfileMode optionsLockfileMode;
+  private CommandEnvironment env;
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
@@ -59,34 +53,35 @@ public class BazelLockFileModule extends BlazeModule {
 
   @Override
   public void beforeCommand(CommandEnvironment env) {
-    executor = env.getSkyframeExecutor();
-    workspaceRoot = env.getWorkspace();
-    outputBase = env.getOutputBase();
-    optionsLockfileMode = env.getOptions().getOptions(RepositoryOptions.class).getLockfileMode();
+    this.env = env;
   }
 
   @Override
   public void afterCommand() {
-    MemoizingEvaluator evaluator = executor.getEvaluator();
+    CommandEnvironment env = this.env;
+    this.env = null;
+    if (env == null || !env.hasSyncedPackageLoading()) {
+      // The current command (e.g. shutdown, which the client also sends before restarting a
+      // server whose startup options changed) didn't sync the Skyframe graph: its options
+      // weren't propagated to Skyframe and external changes to the lockfile on disk weren't
+      // picked up. All existing Skyframe values are stale snapshots from an earlier command,
+      // so writing them to disk could clobber changes made since then, e.g. by a server
+      // running on a different output base.
+      return;
+    }
+    LockfileMode lockfileMode =
+        env.getOptions().getOptions(RepositoryOptions.class).getLockfileMode();
+    if (!ENABLED_IN_MODES.contains(lockfileMode)) {
+      return;
+    }
+    Path workspaceRoot = env.getWorkspace();
+    Path outputBase = env.getOutputBase();
+    MemoizingEvaluator evaluator = env.getSkyframeExecutor().getEvaluator();
     BazelModuleResolutionValue moduleResolutionValue;
     BazelDepGraphValue depGraphValue;
     BazelLockFileValue oldLockfile;
     BazelLockFileValue oldHiddenLockfile;
     try {
-      PrecomputedValue lockfileModeValue =
-          (PrecomputedValue) evaluator.getExistingValue(LOCKFILE_MODE.getKey());
-      if (lockfileModeValue == null) {
-        // No command run on this server has triggered module resolution yet.
-        return;
-      }
-      // Check the Skyframe value in addition to the option since some commands (e.g. shutdown)
-      // don't propagate the options to Skyframe, but we can only operate on Skyframe values that
-      // were generated in UPDATE mode.
-      LockfileMode skyframeLockfileMode = (LockfileMode) lockfileModeValue.get();
-      if (!(ENABLED_IN_MODES.contains(optionsLockfileMode)
-          && ENABLED_IN_MODES.contains(skyframeLockfileMode))) {
-        return;
-      }
       moduleResolutionValue =
           (BazelModuleResolutionValue) evaluator.getExistingValue(BazelModuleResolutionValue.KEY);
       depGraphValue = (BazelDepGraphValue) evaluator.getExistingValue(BazelDepGraphValue.KEY);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -61,12 +61,9 @@ public class BazelLockFileModule extends BlazeModule {
     CommandEnvironment env = this.env;
     this.env = null;
     if (env == null || !env.hasSyncedPackageLoading()) {
-      // The current command (e.g. shutdown, which the client also sends before restarting a
-      // server whose startup options changed) didn't sync the Skyframe graph: its options
-      // weren't propagated to Skyframe and external changes to the lockfile on disk weren't
-      // picked up. All existing Skyframe values are stale snapshots from an earlier command,
-      // so writing them to disk could clobber changes made since then, e.g. by a server
-      // running on a different output base.
+      // The current command (e.g. shutdown) didn't evaluate the lockfile values and they may
+      // thus be stale, e.g., if a server with a different output base changed the lockfile
+      // in the meantime.
       return;
     }
     LockfileMode lockfileMode =

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -96,6 +96,32 @@ class BazelLockfileTest(test_base.TestBase):
         stderr,
     )
 
+  def testShutdownKeepsExternallyChangedLockfile(self):
+    # Regression test for https://github.com/bazelbuild/bazel/issues/30347.
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'bazel_dep(name = "aaa", version = "1.0")',
+        ],
+    )
+    self.ScratchFile('BUILD', ['filegroup(name = "hello")'])
+    # This build updates the lockfile on disk at the end of the command, so the
+    # lockfile state tracked by the server's Skyframe graph predates the write.
+    self.RunBazel(['build', '--nobuild', '//:all'])
+
+    # Simulate an update to the lockfile by another server running on a
+    # different output base (or by the user, e.g. via git).
+    external_content = '{"lockFileVersion": 99}\n'
+    with open(self.Path('MODULE.bazel.lock'), 'w') as f:
+      f.write(external_content)
+
+    # The shutdown command (which the client also uses to replace a server
+    # whose startup options changed) runs no Skyframe evaluation and thus must
+    # not write the stale lockfile state tracked by the server.
+    self.RunBazel(['shutdown'])
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      self.assertEqual(f.read(), external_content)
+
   def testChangeModuleInRegistryWithoutLockfile(self):
     # Add module 'sss' to the registry with dep on 'aaa'
     self.main_registry.createShModule('sss', '1.3', {'aaa': '1.1'})


### PR DESCRIPTION
### Description
Skip the lockfile update for commands that never called `syncPackageLoading` as they reflect the lockfile state of the last command that did, which may be outdated. 

This also makes the previous double-check of the Skyframe `LOCKFILE_MODE` value redundant, since a command that runs a Skyframe evaluation always injects its own lockfile mode.

### Motivation
Fixes https://github.com/bazelbuild/bazel/issues/30347

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Running `bazel shutdown` no longer results in stale lockfile data being written.
