### PR TITLE
[9.3.0] Fix crash when digesting a directory in the remote repo contents cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -725,8 +725,10 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
         return nativeFs.getInputStream(path);
       }
       var relativePath = path.relativeTo(externalDirectory);
-      var info =
-          (RemoteActionFileSystem.RemoteInMemoryFileInfo) stat(path, /* followSymlinks= */ true);
+      if (!(stat(path, /* followSymlinks= */ true)
+          instanceof RemoteActionFileSystem.RemoteInMemoryFileInfo info)) {
+        throw Errno.EISDIR.exception(path);
+      }
       reporter.post(
           new ExtendedEventHandler.FetchProgress() {
             @Override
@@ -794,14 +796,11 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem {
 
     @Override
     public byte[] getDigest(PathFragment path) throws IOException {
-      var info =
-          (RemoteActionFileSystem.RemoteInMemoryFileInfo) stat(path, /* followSymlinks= */ true);
-      return info.getMetadata().getDigest();
-    }
-
-    @Override
-    public synchronized byte[] getFastDigest(PathFragment path) throws IOException {
-      return getDigest(path);
+      // All regular files in this file system are remote files, whose digest is known in advance
+      // and returned by the base implementation of getFastDigest, which also correctly reports
+      // errors such as EISDIR for paths that don't resolve to regular files. The base
+      // implementation of getDigest would instead download the file contents to hash them.
+      return getFastDigest(path);
     }
   }
 }

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -1011,6 +1011,78 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     with open(out) as f:
       self.assertEqual(f.read(), 'hello')
 
+  def testSourceDirectoryWithSymlinkToDirectory_expandedExecutionLog(self):
+    # Regression test for https://github.com/bazelbuild/bazel/issues/30264:
+    # the expanded execution log walks directory inputs on the overlay file
+    # system and used to crash Bazel on a symlink that resolves to a directory.
+    if self.IsWindows():
+      self.ScratchFile(
+          '.bazelrc',
+          ['startup --windows_enable_symlinks'],
+          mode='a',
+      )
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            (
+                '  rctx.file("BUILD", "filegroup(name=\'dir\','
+                " srcs=['pkg'], visibility=['//visibility:public'])\")"
+            ),
+            '  rctx.file("pkg/sub/data.txt", "hello")',
+            # A symlink pointing at a sibling directory.
+            '  rctx.symlink("pkg/sub", "pkg/sub_link")',
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(_repo_impl)',
+        ],
+    )
+    self.ScratchFile(
+        'main/BUILD.bazel',
+        [
+            'genrule(',
+            '  name = "use_dir",',
+            '  srcs = ["@my_repo//:dir"],',
+            '  outs = ["out.txt"],',
+            '  cmd = "cat $(location @my_repo//:dir)/sub/data.txt > $@",',
+            ')',
+        ],
+    )
+
+    # First build: the repo is fetched to disk and the action executes locally,
+    # seeding the remote cache.
+    _, _, stderr = self.RunBazel(['build', '//main:use_dir'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+    with open(self.Path('bazel-bin/main/out.txt')) as f:
+      self.assertEqual(f.read(), 'hello')
+
+    # After expunging, the repo is served from the in-memory overlay file
+    # system and the action is a remote cache hit, so its inputs are never
+    # staged locally. Logging the expanded execution log still walks the source
+    # directory input on the overlay file system and encounters the symlink
+    # that resolves to a directory.
+    self.RunBazel(['clean', '--expunge'])
+    exec_log = self.Path('exec_log.json')
+    _, _, stderr = self.RunBazel([
+        'build',
+        '//main:use_dir',
+        '--remote_download_outputs=minimal',
+        '--execution_log_json_file=' + exec_log,
+    ])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    with open(exec_log) as f:
+      log = f.read()
+    self.assertIn('pkg/sub/data.txt', log)
+    self.assertIn('main/out.txt', log)
+
   def testRepoSymlinkChainMaterializationIsConsistent(self):
     # Full repo materialization (triggered by another repo accessing my_repo)
     # and lazy action-input materialization (triggered by a local action


### PR DESCRIPTION
### Description
The in-memory file system backing the remote repo contents cache unconditionally cast the result of stat to RemoteInMemoryFileInfo in getDigest and getInputStream. When the given path resolves to a directory, for example when the expanded execution log walks a source directory input that contains a symlink to a directory, the cast failed with a ClassCastException that crashed Bazel.

getDigest now delegates to the base implementation of getFastDigest, which returns the digest of a remote file without reading its contents and throws EISDIR for directories instead of crashing. getInputStream also throws EISDIR instead of failing the cast. This behavior matches that of the native filesystem implementations.

### Motivation
Fixes #30264.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #30272.

PiperOrigin-RevId: 950372282
Change-Id: I40d1dece910cf9e6aad998c0418069287975e82a

(cherry picked from commit 3cdd0835e0b56cf8408b25c4d1ff49a7eb4accec)


Closes #30273
