### PR TITLE
[8.8.0] Disable lease service with `--rewind_lost_inputs`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -1162,28 +1162,49 @@ public final class RemoteModule extends BlazeModule {
       builder.setActionInputPrefetcher(actionInputFetcher);
       actionContextProvider.setActionInputFetcher(actionInputFetcher);
 
-      LeaseExtension leaseExtension = null;
-      if (remoteOptions.remoteCacheLeaseExtension) {
-        leaseExtension =
-            new RemoteLeaseExtension(
+      BuildRequestOptions buildRequestOptions =
+          env.getOptions().getOptions(BuildRequestOptions.class);
+      boolean rewindLostInputs =
+          buildRequestOptions != null && buildRequestOptions.rewindLostInputs;
+      LeaseService leaseService = null;
+      if (rewindLostInputs) {
+        // Action rewinding regenerates lost inputs within the build, so there is no need for the
+        // lease service to extend leases or to discard all remote metadata after a build that
+        // encountered lost inputs.
+        if (remoteOptions.remoteCacheLeaseExtension) {
+          env.getReporter()
+              .handle(
+                  Event.warn(
+                      "--experimental_remote_cache_lease_extension has no effect since"
+                          + " --rewind_lost_inputs is enabled, which recovers from lost remote"
+                          + " cache entries as they are encountered."));
+        }
+      } else {
+        LeaseExtension leaseExtension = null;
+        if (remoteOptions.remoteCacheLeaseExtension) {
+          leaseExtension =
+              new RemoteLeaseExtension(
+                  env.getSkyframeExecutor().getEvaluator(),
+                  env.getBlazeWorkspace().getPersistentActionCache(),
+                  env.getBuildRequestId(),
+                  env.getCommandId().toString(),
+                  actionContextProvider.getCombinedCache(),
+                  remoteOptions.remoteCacheTtl);
+        }
+        leaseService =
+            new LeaseService(
                 env.getSkyframeExecutor().getEvaluator(),
-                env.getBlazeWorkspace().getPersistentActionCache(),
-                env.getBuildRequestId(),
-                env.getCommandId().toString(),
-                actionContextProvider.getCombinedCache(),
-                remoteOptions.remoteCacheTtl);
+                () -> env.getBlazeWorkspace().getPersistentActionCache(),
+                leaseExtension);
+        env.getEventBus().register(leaseService);
       }
-      var leaseService =
-          new LeaseService(
-              env.getSkyframeExecutor().getEvaluator(),
-              () -> env.getBlazeWorkspace().getPersistentActionCache(),
-              leaseExtension);
-      env.getEventBus().register(leaseService);
 
       if (outputService instanceof RemoteOutputService remoteOutputService) {
         remoteOutputService.setRemoteOutputChecker(remoteOutputChecker);
         remoteOutputService.setActionInputFetcher(actionInputFetcher);
-        remoteOutputService.setLeaseService(leaseService);
+        if (leaseService != null) {
+          remoteOutputService.setLeaseService(leaseService);
+        }
         remoteOutputService.setFileCacheSupplier(env::getFileCache);
         env.getEventBus().register(outputService);
       }


### PR DESCRIPTION
### Description
The lease service approach of a known TTL doesn't pair well with action rewinding. It can even regress the latter's performance by invalidating all actions with remote outputs when targeted rewinding would recover after https://github.com/bazelbuild/bazel/pull/30266.

### Motivation
This prepares for the removal of the lease service in favor of action rewinding being enabled by default.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #30269.

PiperOrigin-RevId: 950379096
Change-Id: Ic64c6e563682d16c7696b7ca7d8e67a052c3b37f

(cherry picked from commit e167b9e5e46a89fa5f09272826e4df2dd31097d7)


8.8.0 adaptation: `RemoteOptions` and `BuildRequestOptions` flags are accessed as fields instead of getters on this branch and the branch-only `setFileCacheSupplier` call is preserved next to the now null-guarded `setLeaseService` call.

Closes #30271
