### PR TITLE
Paginate PR reviews fetch in Community Review Labeler

### DIFF
--- a/.github/scripts/community_review_labeler.sh
+++ b/.github/scripts/community_review_labeler.sh
@@ -27,7 +27,7 @@ echo "$PRS" | jq -c '.[]' | while read -r pr; do
   HAS_LABEL=$(echo "$pr" | jq -r '.labels[]?.name' | grep -c "^community-reviewed$" || true)
 
   # Fetch reviews for this PR
-  REVIEWS=$(gh api "repos/bazelbuild/bazel/pulls/$PR_NUMBER/reviews" --jq '.[] | {user: .user.login, state: .state, submitted_at: .submitted_at}' || echo "[]")
+  REVIEWS=$(gh api --paginate "repos/bazelbuild/bazel/pulls/$PR_NUMBER/reviews" --jq '.[] | {user: .user.login, state: .state, submitted_at: .submitted_at}' || echo "[]")
 
   if [[ -z "$REVIEWS" || "$REVIEWS" == "[]" ]]; then
     continue

--- a/.github/scripts/community_review_labeler.sh
+++ b/.github/scripts/community_review_labeler.sh
@@ -27,7 +27,12 @@ echo "$PRS" | jq -c '.[]' | while read -r pr; do
   HAS_LABEL=$(echo "$pr" | jq -r '.labels[]?.name' | grep -c "^community-reviewed$" || true)
 
   # Fetch reviews for this PR
-  REVIEWS=$(gh api --paginate "repos/bazelbuild/bazel/pulls/$PR_NUMBER/reviews" --jq '.[] | {user: .user.login, state: .state, submitted_at: .submitted_at}' || echo "[]")
+  if ! REVIEWS=$(gh api --paginate "repos/bazelbuild/bazel/pulls/$PR_NUMBER/reviews" --jq '.[] | {user: .user.login, state: .state, submitted_at: .submitted_at}'); then
+    # A later page can fail after gh has already emitted earlier pages. Never
+    # update labels from that incomplete review history.
+    echo "Failed to fetch complete review history for PR #$PR_NUMBER; skipping label update." >&2
+    continue
+  fi
 
   if [[ -z "$REVIEWS" || "$REVIEWS" == "[]" ]]; then
     continue


### PR DESCRIPTION
## Problem

The hourly Community Review Labeler queried each PR's reviews without pagination, so it only received the first page (30 reviews). Because the endpoint lists reviews oldest-first and the script selects the latest trusted review, PRs with more than 30 reviews could be labeled from stale data.

A simple `--paginate` addition has a second edge case: if a later page fails, `gh api` may already have emitted earlier pages. Treating that partial output as complete could still produce an incorrect label decision.

## Fix

- Fetch every review page with `gh api --paginate`.
- Fail closed when any page fails: log the PR number and skip its label update.
- Preserve the existing newline-delimited output consumed by the downstream `jq -s` selection.

## Verification

- `bash -n .github/scripts/community_review_labeler.sh`
- `shellcheck .github/scripts/community_review_labeler.sh`
- Behavioral harness covering:
  - successful multi-page output selects the newest trusted review;
  - empty review history causes no update;
  - a later-page failure after partial output causes no label mutation.
- Verified pagination against a real PR with `per_page=1`: without `--paginate` only the first review is returned; with it, all reviews are streamed and the newest review is selected.

## Tracking issue

Fixes #30362
