### PR TITLE
Parse certificate notAfter locale-independently in SSL monitor

### DIFF
--- a/.github/scripts/check_ssl.py
+++ b/.github/scripts/check_ssl.py
@@ -67,11 +67,14 @@ class SSLMonitor:
         if not cert:
           raise ValueError(f"No certificate found for {domain}")
 
-        expires_str = cert["notAfter"]
-        # Format: '%b %d %H:%M:%S %Y GMT' (e.g., 'Mar 26 20:13:28 2026 GMT')
-        expires_dt = datetime.datetime.strptime(
-            expires_str, "%b %d %H:%M:%S %Y GMT"
-        ).replace(tzinfo=datetime.timezone.utc)
+        # OpenSSL always emits the notAfter month as a fixed English
+        # abbreviation, but datetime.strptime's %b is LC_TIME-dependent and
+        # would raise on non-English locales. ssl.cert_time_to_seconds parses
+        # it with a hardcoded English table, so it is locale-independent.
+        expires_ts = ssl.cert_time_to_seconds(cert["notAfter"])
+        expires_dt = datetime.datetime.fromtimestamp(
+            expires_ts, datetime.timezone.utc
+        )
 
         delta = expires_dt - datetime.datetime.now(datetime.timezone.utc)
         return delta.days


### PR DESCRIPTION
## Problem

`get_days_until_expiration` parses the certificate `notAfter` field with `datetime.strptime(expires_str, "%b %d %H:%M:%S %Y GMT")`. The `%b` directive is interpreted using the process `LC_TIME` locale, but OpenSSL always emits the month as a fixed **English** abbreviation (e.g. `Mar 26 20:13:28 2026 GMT`).

On any runner, container, or machine whose locale is not English (`de_DE`, `fr_FR`, `ja_JP`, …), `strptime` raises `ValueError`, which is swallowed by the broad `except (OSError, ValueError)` and reported as a generic `ERROR`. Every domain is then reported as failing and its real expiration is never computed — turning the monitor into a wall of false alarms that also **masks genuinely near-expiry certificates**, defeating its purpose. (GitHub-hosted runners default to a C locale today, so this is latent there — but the correctness silently depends on an unrelated environment variable.)

## Fix

Use `ssl.cert_time_to_seconds` (already available via the imported `ssl` module), which parses the month with a hardcoded English table and is therefore independent of `LC_TIME`. Verified to produce an identical timestamp in the default locale and to parse correctly under non-English locales.


## Tracking issue

Tracking issue: #30366
