### PR TITLE
Make bazel-distfile.tar reproducible and fail loudly on unknown inputs

### DIFF
--- a/combine_distfiles_to_tar.sh
+++ b/combine_distfiles_to_tar.sh
@@ -36,6 +36,7 @@ do
     case "$i" in
         *.zip) UNPACK="unzip -q" ;;
         *.tar) UNPACK="tar xf" ;;
+        *) echo "unknown archive type: $i" >&2; exit 1 ;;
     esac
     (cd "${PACKAGE_DIR}" && ${UNPACK} "${ARCHIVE}")
 done
@@ -49,6 +50,6 @@ fi
   cd "${PACKAGE_DIR}"
   FILE_LIST="$(mktemp ${TMP_DIR%%/}/bazel-distfile-files.XXXXXXXX)"
   trap "rm -fr \"${FILE_LIST}\"" EXIT
-  find . -type f | sort > "${FILE_LIST}"
+  find . -type f | LC_ALL=C sort > "${FILE_LIST}"
   tar -c -f "${OUTPUT}" ${ID_OPTS} -T "${FILE_LIST}"
 )


### PR DESCRIPTION
## Problem

`combine_distfiles_to_tar.sh` builds `bazel-distfile.tar`, Bazel's source-distribution tarball. Its header states it produces reproducible output, but two things undercut that:

1. **Locale-dependent member order.** The tar member list is built with `find . -type f | sort`. `sort` honors `LC_COLLATE`, so an official release runner and a downstream rebuilder (Debian, Nixpkgs, independent reproducers) in different locales order members differently and compute **different checksums for identical sources** — breaking the reproducibility/signature verification the script promises.
2. **Silent mishandling of unexpected inputs.** The archive-type `case` has no default arm. An input ending in neither `.zip` nor `.tar` leaves `UNPACK` unset (`set -u` → `unbound variable`) or silently reuses the previous iteration's unpacker, failing opaquely instead of naming the offending file.

## Fix

1. Order the member list with `LC_ALL=C sort` for a stable byte ordering.
2. Add a default `case` arm that prints `unknown archive type: <file>` and exits non-zero, matching the existing guard in the sibling `combine_distfiles.py`.


## Tracking issue

Tracking issue: #30368
