### PR TITLE
Intern transitive packages `NestedSet`s by equality

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/packages/BUILD
@@ -102,6 +102,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/cmdline:LabelValidator",
         "//src/main/java/com/google/devtools/build/lib/collect:collection_utils",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
+        "//src/main/java/com/google/devtools/build/lib/collect/nestedset:nested_sets_should_be_interned_by_equality",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
         "//src/main/java/com/google/devtools/build/lib/events",

--- a/src/main/java/com/google/devtools/build/lib/packages/Package.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Package.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.StarlarkThreadContext;
 import com.google.devtools.build.lib.collect.CollectionUtils;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetsShouldBeInternedByEquality;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.packages.Package.Builder.PackageLimits;
@@ -1414,7 +1415,8 @@ public class Package extends Packageoid {
       Optional<String> associatedModuleVersion,
       @Nullable ConfigSettingVisibilityPolicy configSettingVisibilityPolicy,
       boolean succinctTargetNotFoundErrors,
-      Root sourceRoot) {
+      Root sourceRoot)
+      implements NestedSetsShouldBeInternedByEquality {
 
     // See class-level Javadoc for an explanation of why we need this.
     @Override


### PR DESCRIPTION
### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
Bazel (but not Blaze) relies on transitive package tracking for the repo mapping manifests and lazy symlink planting. These sets can be very large and commonly have a lot of overlap. Since `Package.Metadata` satisfies the conditions required for equality-based `NestedSet` interning, it can benefit from this optimization. 

On Bazel itself, this reduces retained heap by ~1.5%:
```
┌──────────────────────────────────────────┬──────────┬────────┐
│                                          │ baseline │ opt-in │
├──────────────────────────────────────────┼──────────┼────────┤
│ Package$Metadata DAG nodes               │ 32,577   │ 5,888  │
├──────────────────────────────────────────┼──────────┼────────┤
│ Package$Metadata duplicate nodes         │ 16,053   │ 6      │
├──────────────────────────────────────────┼──────────┼────────┤
│ Package$Metadata set objects             │ 56,900   │ 6,859  │
├──────────────────────────────────────────┼──────────┼────────┤
│ used-heap-after-gc                       │ 165MB    │ 163MB  │
├──────────────────────────────────────────┼──────────┼────────┤
│ wall time (4 interleaved pairs, medians) │ 5.69s    │ 5.70s  │
└──────────────────────────────────────────┴──────────┴────────┘
```

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
