### PR TITLE
Add an integration test for ignoring unresolvable type syntax

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkTypesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkTypesTest.java
@@ -79,6 +79,41 @@ public class StarlarkTypesTest extends BuildViewTestCase {
   }
 
   @Test
+  public void unresolvableTypeSyntax_ignoredWhenTypeCheckingDisabled() throws Exception {
+    // When type checking is disabled, type syntax must be tolerated even if nothing in it can be
+    // resolved: a .bzl file written for a newer Bazel version may use types (such as providers or
+    // aliases) that this version cannot evaluate, and must still load. Everything below is
+    // representative of such a file and must not be resolved or checked in any way.
+    setBuildLanguageOptions("--experimental_starlark_type_syntax");
+    scratch.file(
+        "test/foo.bzl",
+        """
+        FooInfo = provider()
+
+        type Pair[T] = tuple[T, T]
+
+        def f(
+                a: FooInfo,
+                b: list[str],
+                c: tuple[()],
+                d: struct[{"a": int}],
+                e: Pair[UnknownType] | None = None,
+                *args: int,
+                **kwargs: Literal["x"]) -> FooInfo:
+            g: UnknownLocalType = a
+            return g
+
+        CONST: int = 42
+        RESULT = f(FooInfo(), ["b"], (), struct(a = 1))
+        """);
+    scratch.file("test/BUILD", "load(':foo.bzl', 'CONST', 'RESULT')");
+
+    getTarget("//test:BUILD");
+
+    assertNoEvents();
+  }
+
+  @Test
   public void experimentalStarlarkTypes_off_disallowsTypeAnnotations() throws Exception {
     setBuildLanguageOptions(
         "--noexperimental_starlark_type_syntax",


### PR DESCRIPTION
### Description

Adds an integration test to `StarlarkTypesTest` asserting that, with `--experimental_starlark_type_syntax` enabled (the default) and type checking disabled (also the default), a `.bzl` file whose type annotations cannot be resolved still loads and evaluates, with the annotations ignored. The test file uses a provider as a type, `list[str]`, `tuple[()]`, `struct[{"a": int}]`, a parameterized `type` alias, unknown type names, `Literal["x"]`, annotated `*args`/`**kwargs`, a local variable annotation, and an annotated module-level assignment that must actually execute.

### Motivation

This is the forward-compatibility contract behind Starlark types: `.bzl` files written for newer Bazel versions must load on Bazel versions that ignore types. The existing tests in `StarlarkTypesTest` only ever annotate with `int`, which happens to resolve in every configuration, so they cannot detect a Bazel that eagerly resolves annotations instead of ignoring them.

That is not hypothetical: Bazel 9.2.0 rejects `def f(x: list[str])` at loading time with `unexpected expression 'list[str]'` under default flags, because the 9.x line received the type syntax commits but not the resolver gating later introduced in 89841592fa1 — and no cherry-picked test could notice, since the only integration test asserting that the resolver stays off (`typeResolverDoesNotRunByDefault`) landed in the same commit as the gating itself and also only uses `int`.

This test is written to be cherry-pickable as a tripwire: it only relies on `--experimental_starlark_type_syntax`, which exists on all affected release branches. Verified: it passes on master, fails on release-9.3.0 as of 8220c619884 with `type 'FooInfo' is not defined`, and passes again once the resolver-gating commits (887b6b1bd24 through 89841592fa1) are applied there.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

https://claude.ai/code/session_015C8RjuPByebheZs82nuUrE
