### PR TITLE
[8.8.0] Add Starlark access methods InstrumentedFilesInfo.get_coverage_enviro…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/InstrumentedFilesInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/InstrumentedFilesInfo.java
@@ -20,9 +20,12 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.packages.BuiltinProvider;
+import com.google.devtools.build.lib.packages.BuiltinRestriction;
 import com.google.devtools.build.lib.packages.NativeInfo;
 import com.google.devtools.build.lib.starlarkbuildapi.test.InstrumentedFilesInfoApi;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.Tuple;
 
 /** An implementation class for the InstrumentedFilesProvider interface. */
@@ -126,8 +129,21 @@ public final class InstrumentedFilesInfo extends NativeInfo implements Instrumen
     return coverageSupportFiles;
   }
 
+  @Override
+  public Depset getCoverageSupportFilesForStarlark(StarlarkThread thread) throws EvalException {
+    BuiltinRestriction.failIfCalledOutsideDefaultAllowlist(thread);
+    return Depset.of(Artifact.class, coverageSupportFiles);
+  }
+
   /** Environment variables that need to be set for tests collecting code coverage. */
   public ImmutableMap<String, String> getCoverageEnvironment() {
+    return coverageEnvironment;
+  }
+
+  @Override
+  public ImmutableMap<String, String> getCoverageEnvironmentForStarlark(StarlarkThread thread)
+      throws EvalException {
+    BuiltinRestriction.failIfCalledOutsideDefaultAllowlist(thread);
     return coverageEnvironment;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/InstrumentedFilesInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/InstrumentedFilesInfoApi.java
@@ -14,11 +14,14 @@
 
 package com.google.devtools.build.lib.starlarkbuildapi.test;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.docgen.annot.DocCategory;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.StarlarkThread;
 
 /** Contains information about instrumented files sources and instrumentation metadata. */
 @StarlarkBuiltin(
@@ -61,4 +64,11 @@ public interface InstrumentedFilesInfoApi extends StructApi {
               + " <code>gcc</code> is run with <code>-ftest-coverage</code>.",
       structField = true)
   Depset getInstrumentationMetadataFilesForStarlark();
+
+  @StarlarkMethod(name = "get_coverage_environment", documented = false, useStarlarkThread = true)
+  ImmutableMap<String, String> getCoverageEnvironmentForStarlark(StarlarkThread thread)
+      throws EvalException;
+
+  @StarlarkMethod(name = "get_coverage_support_files", documented = false, useStarlarkThread = true)
+  Depset getCoverageSupportFilesForStarlark(StarlarkThread thread) throws EvalException;
 }


### PR DESCRIPTION
…nment() and get_coverage_support_files(), for rules_cc analysis_tests.

These fields are exposed via new Starlark methods on InstrumentedFilesInfoApi, restricted to being called only from builtins.

PiperOrigin-RevId: 931193893
Change-Id: Ie2174ae4fe9b45859d3e24ff6080d511258d6b1a

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/eb04a244719598f5a15b7257e1cf29a8714640a6