### PR TITLE
[8.8.0] Remote: include failure statistics in circuit breaker rejection messa…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
@@ -14,13 +14,17 @@
 
 package com.google.devtools.build.lib.remote;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.AsyncCallable;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.remote.Retrier.CircuitBreaker.State;
 import com.google.devtools.build.lib.remote.logging.RpcLogContext;
 import io.grpc.Context;
@@ -108,12 +112,22 @@ public class Retrier {
 
     /** Called after an execution succeeded. */
     void recordSuccess();
+
+    /**
+     * Returns a human-readable description of the breaker's current failure statistics (for example
+     * the observed failure rate and the configured threshold), for appending to the {@link
+     * CircuitBreakerException} message when a call is rejected. Implementations that have no
+     * details to report should return an empty string.
+     */
+    String failureDetails();
   }
 
   /** Thrown if the call was stopped by a circuit breaker. */
   public static class CircuitBreakerException extends IOException {
-    private CircuitBreakerException() {
-      super("Call not executed due to a high failure rate.");
+    private CircuitBreakerException(String failureDetails) {
+      super(
+          "Call not executed due to a high failure rate."
+              + (isNullOrEmpty(failureDetails) ? "" : " " + failureDetails));
     }
   }
 
@@ -138,6 +152,11 @@ public class Retrier {
 
         @Override
         public void recordSuccess() {}
+
+        @Override
+        public String failureDetails() {
+          return "";
+        }
       };
 
   /** Disables retries. */
@@ -268,7 +287,7 @@ public class Retrier {
       final State circuitState;
       circuitState = circuitBreaker.state();
       if (State.REJECT_CALLS.equals(circuitState)) {
-        throw new CircuitBreakerException();
+        throw new CircuitBreakerException(circuitBreaker.failureDetails());
       }
       try {
         if (Thread.interrupted()) {
@@ -347,7 +366,7 @@ public class Retrier {
       AsyncCallable<T> call, Backoff backoff, @Nullable String rpcId) {
     final State circuitState = circuitBreaker.state();
     if (State.REJECT_CALLS.equals(circuitState)) {
-      return Futures.immediateFailedFuture(new CircuitBreakerException());
+      return immediateFailedFuture(new CircuitBreakerException(circuitBreaker.failureDetails()));
     }
     try {
       ListenableFuture<T> future =
@@ -355,14 +374,14 @@ public class Retrier {
               callWithContext(call, backoff, rpcId),
               (f) -> {
                 circuitBreaker.recordSuccess();
-                return Futures.immediateFuture(f);
+                return immediateFuture(f);
               },
-              MoreExecutors.directExecutor());
+              directExecutor());
       return Futures.catchingAsync(
           future,
           Exception.class,
           t -> onExecuteAsyncFailure(t, call, backoff, circuitState, rpcId),
-          MoreExecutors.directExecutor());
+          directExecutor());
     } catch (Exception e) {
       return onExecuteAsyncFailure(e, call, backoff, circuitState, rpcId);
     }
@@ -373,7 +392,7 @@ public class Retrier {
     if (isRetriable(t)) {
       circuitBreaker.recordFailure();
       if (circuitState.equals(State.TRIAL_CALL)) {
-        return Futures.immediateFailedFuture(t);
+        return immediateFailedFuture(t);
       }
       long waitMillis = backoff.nextDelayMillis(t);
       if (waitMillis >= 0) {
@@ -385,18 +404,18 @@ public class Retrier {
               retryService);
         } catch (RejectedExecutionException e) {
           // May be thrown by .scheduleAsync(...) if i.e. the executor is shutdown.
-          return Futures.immediateFailedFuture(new IOException(e));
+          return immediateFailedFuture(new IOException(e));
         }
       } else {
         onRetriesExhausted(t, backoff, rpcId);
-        return Futures.immediateFailedFuture(t);
+        return immediateFailedFuture(t);
       }
     } else {
       // gRPC Errors NOT_FOUND, OUT_OF_RANGE, ALREADY_EXISTS etc. are non-retriable error, and they
       // don't represent an
       // issue in Server. So treating these errors as successful api call.
       circuitBreaker.recordSuccess();
-      return Futures.immediateFailedFuture(t);
+      return immediateFailedFuture(t);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.remote.circuitbreaker;
 
 import com.google.devtools.build.lib.remote.Retrier;
+import java.util.Locale;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -94,5 +95,25 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
           scheduledExecutor.schedule(
               successes::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
     }
+  }
+
+  @Override
+  public String failureDetails() {
+    int failureCount = failures.get();
+    int totalCallCount = successes.get() + failureCount;
+    double failureRate = totalCallCount == 0 ? 0.0 : (failureCount * 100.0) / totalCallCount;
+    String window =
+        slidingWindowSize > 0
+            ? String.format(Locale.US, "the last %dms", slidingWindowSize)
+            : "the whole build";
+    return String.format(
+        Locale.US,
+        "%d out of %d remote calls failed (%.2f%%) within %s, exceeding the %d%% failure rate"
+            + " threshold.",
+        failureCount,
+        totalCallCount,
+        failureRate,
+        window,
+        failureRateThreshold);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
@@ -202,6 +202,37 @@ public class RetrierTest {
   }
 
   @Test
+  public void circuitBreakerExceptionIncludesFailureDetails() throws Exception {
+    // The details reported by the circuit breaker are appended to the exception message.
+    CircuitBreaker cb =
+        new CircuitBreaker() {
+          @Override
+          public State state() {
+            return State.REJECT_CALLS;
+          }
+
+          @Override
+          public void recordFailure() {}
+
+          @Override
+          public void recordSuccess() {}
+
+          @Override
+          public String failureDetails() {
+            return "42 out of 50 remote calls failed";
+          }
+        };
+    Retrier r = new Retrier(() -> new ZeroBackoff(3), RETRY_ALL, retryService, cb);
+
+    CircuitBreakerException e =
+        assertThrows(CircuitBreakerException.class, () -> r.execute(() -> 10));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Call not executed due to a high failure rate. 42 out of 50 remote calls failed");
+  }
+
+  @Test
   public void circuitBreakerCanRecover() throws Exception {
     // Test that a circuit breaker can recover from REJECT_CALLS to ACCEPT_CALLS by
     // utilizing the TRIAL_CALL state.
@@ -541,6 +572,11 @@ public class RetrierTest {
     public synchronized void recordSuccess() {
       consecutiveFailures = 0;
       state = State.ACCEPT_CALLS;
+    }
+
+    @Override
+    public String failureDetails() {
+      return "";
     }
 
     void trialCall() {

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
@@ -89,4 +89,29 @@ public class FailureCircuitBreakerTest {
     failureCircuitBreaker.recordFailure();
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
   }
+
+  @Test
+  public void testFailureDetails_reportsStats() {
+    final int failureRateThreshold = 10;
+    final int windowInterval = 100;
+    ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
+    FailureCircuitBreaker failureCircuitBreaker =
+        new FailureCircuitBreaker(
+            failureRateThreshold,
+            windowInterval,
+            /* minCallCountToComputeFailureRate= */ 0,
+            /* minFailCountToComputeFailureRate= */ 0,
+            mockScheduler);
+
+    failureCircuitBreaker.recordSuccess();
+    failureCircuitBreaker.recordFailure();
+    failureCircuitBreaker.recordFailure();
+    failureCircuitBreaker.recordFailure();
+
+    String details = failureCircuitBreaker.failureDetails();
+    assertThat(details).contains("3 out of 4 remote calls failed");
+    assertThat(details).contains("75.00%");
+    assertThat(details).contains("the last 100ms");
+    assertThat(details).contains("10% failure rate threshold");
+  }
 }


### PR DESCRIPTION
…ge (https://github.com/bazelbuild/bazel/pull/30179)

When the remote failure circuit breaker (`--experimental_circuit_breaker_strategy=failure`) trips, every subsequent remote call is rejected immediately with:

> Call not executed due to a high failure rate.

This message is user-visible — during build-without-the-bytes it is wrapped in a `BulkTransferException` and shown in the build error — but it gives no indication of *why* the breaker tripped. `FailureCircuitBreaker` also logs nothing on the state transition and exposes no metric, so today there is no built-in way to tell:

- what failure rate was observed,
- what threshold was configured, or
- how many calls failed in the window.

This makes a tripped breaker hard to diagnose in practice: the gRPC log (`--remote_grpc_log`) can't show it either, because rejected calls never become RPCs.

Append the breaker's current statistics to the `CircuitBreakerException` message, so the reason is visible at the exact point of failure:

> Call not executed due to a high failure rate. 104 out of 104 remote calls failed (100.00%) within the last 80000ms, exceeding the 15% failure rate threshold.

Implementation:

- Add a `CircuitBreaker.failureDetails()` interface method with a default that returns an empty string, so `ALLOW_ALL_CALLS` and any other implementation are unaffected.
- Implement it in `FailureCircuitBreaker` to report failures/total, the observed failure rate, the window, and the configured threshold.
- Append the details to the `CircuitBreakerException` message at both the synchronous (`execute`) and asynchronous (`executeAsync`) rejection sites. The existing sentence is kept as a stable prefix, so anything matching the old string still works.

Closes #30179.

PiperOrigin-RevId: 949939600
Change-Id: Ibd0641957f062c09c794271f115abde25c956393

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/e9e7d623a3d2d41803564b03a2e051a9f1c912d9