### PR TITLE
Track `peak_used_memory_bytes` in BEP

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -1020,6 +1020,16 @@ message BuildMetrics {
     // phase.
     int64 peak_post_gc_tenured_space_heap_size_during_execution = 6;
 
+    // Peak of the total JVM memory (heap + non-heap) used by Bazel during the
+    // invocation, in bytes. This is the peak of the same value that is sampled
+    // and written to the JSON trace profile as the "Memory usage (Bazel)"
+    // counter series (which the profile reports in megabytes). Unlike
+    // peak_post_gc_heap_size, this is sampled periodically and does not depend
+    // on a full GC occurring. It is only populated when the profiler's local
+    // resource collection is active (e.g. when --profile is set, or slow
+    // operations profiling is enabled); it reports 0 otherwise.
+    int64 peak_used_memory_bytes = 7;
+
     message GarbageMetrics {
       // Type of garbage collected, e.g. G1 Old Gen.
       string type = 1;

--- a/src/main/java/com/google/devtools/build/lib/metrics/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/metrics/BUILD
@@ -49,6 +49,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/packages/metrics",
         "//src/main/java/com/google/devtools/build/lib/packages/metrics:package_load_metrics_java_proto",
         "//src/main/java/com/google/devtools/build/lib/profiler",
+        "//src/main/java/com/google/devtools/build/lib/profiler:collect_local_resource_usage",
         "//src/main/java/com/google/devtools/build/lib/profiler:memory_profiler",
         "//src/main/java/com/google/devtools/build/lib/profiler:network_metrics_collector",
         "//src/main/java/com/google/devtools/build/lib/runtime:blaze_command_cluster",

--- a/src/main/java/com/google/devtools/build/lib/metrics/MetricsCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/metrics/MetricsCollector.java
@@ -67,6 +67,7 @@ import com.google.devtools.build.lib.packages.metrics.ExtremaPackageMetricsRecor
 import com.google.devtools.build.lib.packages.metrics.PackageLoadMetrics;
 import com.google.devtools.build.lib.packages.metrics.PackageMetricsPackageLoadingListener;
 import com.google.devtools.build.lib.packages.metrics.PackageMetricsRecorder;
+import com.google.devtools.build.lib.profiler.LocalResourceUsageCollectors;
 import com.google.devtools.build.lib.profiler.MemoryProfiler;
 import com.google.devtools.build.lib.profiler.NetworkMetricsCollector;
 import com.google.devtools.build.lib.profiler.Profiler;
@@ -629,6 +630,13 @@ class MetricsCollector {
     setPeakHeapSize(
         PostGCMemoryUseRecorder.get().getPeakPostGcHeapTenuredSpaceDuringExecution(),
         memoryMetrics::setPeakPostGcTenuredSpaceHeapSizeDuringExecution);
+
+    // Peak of the "Memory usage (Bazel)" counter series written to the JSON trace profile. Only
+    // nonzero when the profiler's local resource collection sampled at least once this invocation.
+    long peakUsedMemoryBytes = LocalResourceUsageCollectors.getPeakBazelMemoryUsageBytes();
+    if (peakUsedMemoryBytes > 0) {
+      memoryMetrics.setPeakUsedMemoryBytes(peakUsedMemoryBytes);
+    }
 
     Map<String, Long> garbageStats = PostGCMemoryUseRecorder.get().getGarbageStats();
     for (Map.Entry<String, Long> garbageEntry : garbageStats.entrySet()) {

--- a/src/main/java/com/google/devtools/build/lib/profiler/LocalResourceUsageCollectors.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/LocalResourceUsageCollectors.java
@@ -19,6 +19,7 @@ import static com.google.devtools.build.lib.util.ResourceUsage.PressureStallIndi
 import static com.google.devtools.build.lib.util.ResourceUsage.PressureStallIndicatorResource.IO;
 import static com.google.devtools.build.lib.util.ResourceUsage.PressureStallIndicatorResource.MEMORY;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableMap;
@@ -39,6 +40,7 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 
 /** An assortment of classes that collects various interesting metrics about the local system. */
@@ -63,6 +65,23 @@ public class LocalResourceUsageCollectors {
     this.workerProcessMetricsCollector = workerProcessMetricsCollector;
     this.resourceEstimator = resourceEstimator;
     this.systemNetworkStatsService = systemNetworkStatsService;
+  }
+
+  /**
+   * Returns the peak of the total JVM memory usage (heap + non-heap, in bytes) sampled during the
+   * current invocation, or 0 if it was not sampled (e.g. profiling was disabled). This is the peak
+   * of the same value that is written to the JSON trace profile's "Memory usage (Bazel)" counter
+   * series (which reports it in megabytes).
+   */
+  public static long getPeakBazelMemoryUsageBytes() {
+    return LocalMemoryUsageCollector.peakUsedMemoryBytes.get();
+  }
+
+  /**
+   * Resets the peak Bazel memory usage tracker. Must be called once at the start of each command.
+   */
+  public static void resetPeakBazelMemoryUsage() {
+    LocalMemoryUsageCollector.peakUsedMemoryBytes.set(0);
   }
 
   public void addCollectors(
@@ -143,10 +162,19 @@ public class LocalResourceUsageCollectors {
   static class LocalMemoryUsageCollector implements CounterSeriesCollector {
     private static final CounterSeriesTask LOCAL_MEMORY_USAGE =
         new CounterSeriesTask("Memory usage (Bazel)", "memory", CounterSeriesTask.Color.OLIVE);
+
+    // Tracks the peak of the used-memory value (heap + non-heap, in bytes) that is written to the
+    // JSON trace profile below, so that it can also be reported in BuildMetrics.MemoryMetrics. This
+    // is static because the collector instance is recreated for each invocation, whereas the peak
+    // is read at the end of the build by MetricsCollector; it is reset once per command via
+    // LocalResourceUsageCollectors#resetPeakBazelMemoryUsage.
+    private static final AtomicLong peakUsedMemoryBytes = new AtomicLong(0);
+
     private final MemoryMXBean memoryBean;
     private final BugReporter bugReporter;
 
-    private LocalMemoryUsageCollector(MemoryMXBean memoryBean, BugReporter bugReporter) {
+    @VisibleForTesting
+    LocalMemoryUsageCollector(MemoryMXBean memoryBean, BugReporter bugReporter) {
       this.memoryBean = memoryBean;
       this.bugReporter = bugReporter;
     }
@@ -164,6 +192,9 @@ public class LocalResourceUsageCollectors {
         memoryUsage = -1;
       }
       if (memoryUsage != -1) {
+        // Record the peak in bytes (full precision) before converting to the MB value that is
+        // written to the profile, so both reflect the same measurement.
+        peakUsedMemoryBytes.accumulateAndGet(memoryUsage, Math::max);
         memoryUsage = memoryUsage / (1024 * 1024);
         consumer.accept(LOCAL_MEMORY_USAGE, (double) memoryUsage);
       }

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -371,6 +371,9 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
       CommandEnvironment env,
       long execStartTimeNanos,
       long waitTimeInMs) {
+    // Clear any peak memory usage recorded by a previous command on this server, so that the value
+    // reported for this invocation only reflects samples taken during it.
+    LocalResourceUsageCollectors.resetPeakBazelMemoryUsage();
     BuildEventProtocolOptions bepOptions = options.getOptions(BuildEventProtocolOptions.class);
     CommonCommandOptions commandOptions = options.getOptions(CommonCommandOptions.class);
     OutputStream out = null;

--- a/src/test/java/com/google/devtools/build/lib/profiler/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/profiler/BUILD
@@ -23,6 +23,7 @@ java_test(
         "//src/test/java/com/google/devtools/build/lib:test_runner",
     ],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/bugreport",
         "//src/main/java/com/google/devtools/build/lib/clock",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/profiler:auto_profiler",

--- a/src/test/java/com/google/devtools/build/lib/profiler/LocalResourceUsageCollectorsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/profiler/LocalResourceUsageCollectorsTest.java
@@ -1,0 +1,100 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.profiler;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.devtools.build.lib.bugreport.BugReporter;
+import com.google.devtools.build.lib.profiler.LocalResourceUsageCollectors.LocalMemoryUsageCollector;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+/** Tests for {@link LocalResourceUsageCollectors}. */
+@RunWith(JUnit4.class)
+public class LocalResourceUsageCollectorsTest {
+
+  private static final long MB = 1024 * 1024;
+
+  private final MemoryMXBean memoryBean = Mockito.mock(MemoryMXBean.class);
+  private final BugReporter bugReporter = Mockito.mock(BugReporter.class);
+
+  @Before
+  public void resetPeak() {
+    // The peak is tracked in static state, so reset it before each test for isolation.
+    LocalResourceUsageCollectors.resetPeakBazelMemoryUsage();
+  }
+
+  @Test
+  public void peakUsedMemory_isZeroBeforeAnySample() {
+    assertThat(LocalResourceUsageCollectors.getPeakBazelMemoryUsageBytes()).isEqualTo(0L);
+  }
+
+  @Test
+  public void localMemoryUsageCollector_recordsPeakOfHeapPlusNonHeap() {
+    LocalMemoryUsageCollector collector = new LocalMemoryUsageCollector(memoryBean, bugReporter);
+
+    // First sample: 100 MB heap + 20 MB non-heap = 120 MB.
+    setUsedMemory(100 * MB, 20 * MB);
+    collector.collect(/* deltaNanos= */ 1.0, (task, value) -> {});
+    assertThat(LocalResourceUsageCollectors.getPeakBazelMemoryUsageBytes()).isEqualTo(120 * MB);
+
+    // A larger sample raises the peak: 200 MB heap + 30 MB non-heap = 230 MB.
+    setUsedMemory(200 * MB, 30 * MB);
+    collector.collect(1.0, (task, value) -> {});
+    assertThat(LocalResourceUsageCollectors.getPeakBazelMemoryUsageBytes()).isEqualTo(230 * MB);
+
+    // A smaller sample does not lower the peak.
+    setUsedMemory(50 * MB, 10 * MB);
+    collector.collect(1.0, (task, value) -> {});
+    assertThat(LocalResourceUsageCollectors.getPeakBazelMemoryUsageBytes()).isEqualTo(230 * MB);
+  }
+
+  @Test
+  public void localMemoryUsageCollector_stillReportsSampleToProfile() {
+    LocalMemoryUsageCollector collector = new LocalMemoryUsageCollector(memoryBean, bugReporter);
+    setUsedMemory(100 * MB, 20 * MB);
+
+    long[] reported = {-1};
+    // The value written to the JSON trace profile is in megabytes.
+    collector.collect(1.0, (task, value) -> reported[0] = value.longValue());
+
+    assertThat(reported[0]).isEqualTo(120);
+  }
+
+  @Test
+  public void resetPeakBazelMemoryUsage_clearsPeak() {
+    LocalMemoryUsageCollector collector = new LocalMemoryUsageCollector(memoryBean, bugReporter);
+    setUsedMemory(100 * MB, 20 * MB);
+    collector.collect(1.0, (task, value) -> {});
+    assertThat(LocalResourceUsageCollectors.getPeakBazelMemoryUsageBytes()).isGreaterThan(0L);
+
+    LocalResourceUsageCollectors.resetPeakBazelMemoryUsage();
+
+    assertThat(LocalResourceUsageCollectors.getPeakBazelMemoryUsageBytes()).isEqualTo(0L);
+  }
+
+  private void setUsedMemory(long heapUsedBytes, long nonHeapUsedBytes) {
+    when(memoryBean.getHeapMemoryUsage())
+        .thenReturn(new MemoryUsage(/* init= */ -1, heapUsedBytes, heapUsedBytes, /* max= */ -1));
+    when(memoryBean.getNonHeapMemoryUsage())
+        .thenReturn(
+            new MemoryUsage(/* init= */ -1, nonHeapUsedBytes, nonHeapUsedBytes, /* max= */ -1));
+  }
+}


### PR DESCRIPTION
In order identify memory bottlenecks for the host machine. This should be similar to the value stored in the JSON trace profile

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
