### PR TITLE
[8.8.0] Honor read_offset and read_limit in the test worker's ByteStreamServer (https://github.com/bazelbuild/bazel/pull/30337)

### DIFF
--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ByteStreamServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ByteStreamServer.java
@@ -79,14 +79,37 @@ final class ByteStreamServer extends ByteStreamImplBase {
           StatusUtils.invalidArgumentError(
               "resource_name",
               "Failed parsing digest from resource_name:" + request.getResourceName()));
+      return;
     }
 
     try {
       // This still relies on the blob size to be small enough to fit in memory.
       // TODO(olaola): refactor to fix this if the need arises.
       byte[] bytes = getFromFuture(cache.downloadBlob(context, digest));
+      long readOffset = request.getReadOffset();
+      long readLimit = request.getReadLimit();
+      if (readOffset < 0 || readOffset > bytes.length) {
+        responseObserver.onError(
+            StatusUtils.outOfRangeError(
+                "read_offset",
+                "Expected a value in [0, %d], received: %d".formatted(bytes.length, readOffset)));
+        return;
+      }
+      if (readLimit < 0) {
+        responseObserver.onError(
+            StatusUtils.invalidArgumentError(
+                "read_limit", "Expected a non-negative value, received: %d".formatted(readLimit)));
+        return;
+      }
+      int offset = (int) readOffset;
+      int length =
+          readLimit > 0
+              ? (int) Math.min(bytes.length - readOffset, readLimit)
+              : bytes.length - offset;
       try (Chunker c =
-          Chunker.builder().setInput(bytes.length, () -> new ByteArrayInputStream(bytes)).build()) {
+          Chunker.builder()
+              .setInput(length, () -> new ByteArrayInputStream(bytes, offset, length))
+              .build()) {
         while (c.hasNext()) {
           responseObserver.onNext(ReadResponse.newBuilder().setData(c.next().getData()).build());
         }

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/StatusUtils.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/StatusUtils.java
@@ -67,6 +67,16 @@ final class StatusUtils {
     return StatusProto.toStatusException(invalidArgumentStatus(field, desc));
   }
 
+  static StatusException outOfRangeError(String field, String desc) {
+    FieldViolation v = FieldViolation.newBuilder().setField(field).setDescription(desc).build();
+    return StatusProto.toStatusException(
+        Status.newBuilder()
+            .setCode(Code.OUT_OF_RANGE.getNumber())
+            .setMessage("out of range: %s: %s".formatted(field, desc))
+            .addDetails(Any.pack(BadRequest.newBuilder().addFieldViolations(v).build()))
+            .build());
+  }
+
   static Status invalidArgumentStatus(String field, String desc) {
     FieldViolation v = FieldViolation.newBuilder().setField(field).setDescription(desc).build();
     return Status.newBuilder()


### PR DESCRIPTION
### Description

`ByteStreamServer#read` in the example remote worker ignored the `read_offset` and `read_limit` fields of ByteStream read requests and always streamed the requested blob from the beginning. It now honors both fields, fails with `OUT_OF_RANGE` for offsets past the end of the blob and with `INVALID_ARGUMENT` for negative limits, and returns after responding with an error when the resource name cannot be parsed instead of continuing with a null digest.

### Motivation

When a client resumes an interrupted download from a nonzero offset, as `GrpcCacheClient` does after a transient mid-stream error, it received the entire blob appended after the already received prefix and failed the download with a digest verification mismatch. Since `RemoteActionInputFetcher` converts all download errors into `CacheNotFoundException`s, this surfaced as spurious "Missing digest" errors in integration tests that put the connection to the example worker under enough stress to cause transient mid-stream errors, and may explain rare flakes in other tests that exercise download retries against it.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

None: this only affects the example remote worker used in tests.

Closes #30337.

PiperOrigin-RevId: 951360835
Change-Id: I8e8f408613da8ddca042b391b7c0ba2d1ebeeed3

Commit https://github.com/bazelbuild/bazel/commit/febc17d13b580fee061dd97071ea63603bb3162a