### PR TITLE
[9.3.0] Use valid digests in rewinding tests

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
@@ -746,13 +746,11 @@ public class RewindingTestsHelper {
       addSpawnShim(
           "Executing genrule //test:consume_" + target,
           (spawn, context) -> {
-            ImmutableSetMultimap.Builder<String, ActionInput> inputMap =
-                ImmutableSetMultimap.builder();
+            ImmutableList.Builder<ActionInput> lostInputs = ImmutableList.builder();
             for (int e = 1; e <= target; e++) {
-              ActionInput input = SpawnInputUtils.getInputWithName(spawn, "out_" + e + ".txt");
-              inputMap.put("fake_digest_" + target + "_" + e, input);
+              lostInputs.add(SpawnInputUtils.getInputWithName(spawn, "out_" + e + ".txt"));
             }
-            return ExecResult.ofException(new LostInputsExecException(inputMap.build()));
+            return createLostInputsExecException(context, lostInputs.build());
           });
     }
     List<SkyKey> rewoundKeys = collectOrderedRewoundKeys();


### PR DESCRIPTION
This simplifies future work in this area.

Closes #30185.

PiperOrigin-RevId: 947060913
Change-Id: Ib23a536d410d126b19948257b402ce9767d504bf

(cherry picked from commit 317d98e214b5c4b30f959dd8f79daf187d1b79b4)


Closes #30191
