### PR TITLE
Set direct/transitive module sets for CppCompileAction without include scanning

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationContext.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationContext.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.collect.compacthashset.CompactHashSet;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.StarlarkInfo;
 import com.google.devtools.build.lib.rules.cpp.IncludeScanner.IncludeScanningHeaderData;
@@ -391,6 +392,47 @@ public final class CcCompilationContext {
     // 2. compiles of other translation units of the same rule.
     modules.remove(separate ? headerInfo.getSeparateModule(usePic) : headerInfo.getModule(usePic));
     return modules;
+  }
+
+  /**
+   * Returns the modules that a compilation in this context could use directly: the modules of its
+   * direct dependencies as well as the separate module of this context (except for the compile of
+   * the separate module itself, which is indicated by {@code separate}).
+   *
+   * <p>Just like in {@link #computeUsedModules}, the main module of this context is never included:
+   * it is either the output of the compilation or, for other compiles of the same rule, its headers
+   * are included textually.
+   *
+   * <p>This is an upper bound for the top-level modules of a compilation, used when include
+   * scanning is disabled and thus the exact set of used headers is unknown.
+   */
+  NestedSet<Artifact> getDirectModules(boolean usePic, boolean separate) {
+    HeaderInfo headerInfo = getHeaderInfo();
+    CompactHashSet<Artifact> modules = CompactHashSet.create();
+    for (HeaderInfo dep : headerInfo.deps) {
+      collectModules(dep, usePic, modules);
+    }
+    // The separate module can be used by all compiles of this context except for its own compile.
+    DerivedArtifact separateModule = headerInfo.getSeparateModule(usePic);
+    if (separateModule != null && !separate) {
+      modules.add(separateModule);
+    }
+    return NestedSetBuilder.wrap(Order.STABLE_ORDER, modules);
+  }
+
+  private static void collectModules(
+      HeaderInfo headerInfo, boolean usePic, Set<Artifact> modules) {
+    DerivedArtifact module = headerInfo.getModule(usePic);
+    if (module == null) {
+      // If we don't have a main module, there is also not going to be a separate module. This is
+      // verified when constructing HeaderInfo instances.
+      return;
+    }
+    modules.add(module);
+    DerivedArtifact separateModule = headerInfo.getSeparateModule(usePic);
+    if (separateModule != null) {
+      modules.add(separateModule);
+    }
   }
 
   private static void removeArtifactsFromSet(Set<Artifact> set, ImmutableList<Artifact> artifacts) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationContext.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationContext.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.collect.compacthashset.CompactHashSet;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.StarlarkInfo;
 import com.google.devtools.build.lib.rules.cpp.IncludeScanner.IncludeScanningHeaderData;
@@ -392,6 +393,47 @@ public final class CcCompilationContext {
     // 2. compiles of other translation units of the same rule.
     modules.remove(separate ? headerInfo.getSeparateModule(usePic) : headerInfo.getModule(usePic));
     return modules;
+  }
+
+  /**
+   * Returns the modules that a compilation in this context could use directly: the modules of its
+   * direct dependencies as well as the separate module of this context (except for the compile of
+   * the separate module itself, which is indicated by {@code separate}).
+   *
+   * <p>Just like in {@link #computeUsedModules}, the main module of this context is never included:
+   * it is either the output of the compilation or, for other compiles of the same rule, its headers
+   * are included textually.
+   *
+   * <p>This is an upper bound for the top-level modules of a compilation, used when include
+   * scanning is disabled and thus the exact set of used headers is unknown.
+   */
+  NestedSet<Artifact> getDirectModules(boolean usePic, boolean separate) {
+    HeaderInfo headerInfo = getHeaderInfo();
+    CompactHashSet<Artifact> modules = CompactHashSet.create();
+    for (HeaderInfo dep : headerInfo.deps) {
+      collectModules(dep, usePic, modules);
+    }
+    // The separate module can be used by all compiles of this context except for its own compile.
+    DerivedArtifact separateModule = headerInfo.getSeparateModule(usePic);
+    if (separateModule != null && !separate) {
+      modules.add(separateModule);
+    }
+    return NestedSetBuilder.wrap(Order.STABLE_ORDER, modules);
+  }
+
+  private static void collectModules(
+      HeaderInfo headerInfo, boolean usePic, Set<Artifact> modules) {
+    DerivedArtifact module = headerInfo.getModule(usePic);
+    if (module == null) {
+      // If we don't have a main module, there is also not going to be a separate module. This is
+      // verified when constructing HeaderInfo instances.
+      return;
+    }
+    modules.add(module);
+    DerivedArtifact separateModule = headerInfo.getSeparateModule(usePic);
+    if (separateModule != null) {
+      modules.add(separateModule);
+    }
   }
 
   private static void removeArtifactsFromSet(Set<Artifact> set, ImmutableList<Artifact> artifacts) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -195,8 +195,9 @@ public class CppCompileAction extends AbstractAction
    * building users of this module. Such users can get to this data through this action's {@link
    * com.google.devtools.build.lib.skyframe.ActionExecutionValue}
    *
-   * <p>This field is populated either based on the discovered headers in {@link #discoverInputs} or
-   * extracted from the action inputs when restoring it from the action cache.
+   * <p>This field is populated either based on the discovered headers in {@link #discoverInputs},
+   * extracted from the action inputs when restoring it from the action cache, or set to all
+   * transitive modules as an upper bound when include scanning is disabled.
    */
   private NestedSet<Artifact> discoveredModules = null;
 
@@ -328,6 +329,7 @@ public class CppCompileAction extends AbstractAction
     this.allowedDerivedInputs = allowedDerivedInputsBuilder.build();
     this.moduleFiles = moduleFiles;
     this.modmapInputFile = modmapInputFile;
+    initializeModulesUpperBoundsIfNotScanningIncludes();
   }
 
   /** Constructor for serialization. */
@@ -387,6 +389,31 @@ public class CppCompileAction extends AbstractAction
     this.builtInIncludeDirectories = builtInIncludeDirectories;
     this.moduleFiles = moduleFiles;
     this.modmapInputFile = modmapInputFile;
+    initializeModulesUpperBoundsIfNotScanningIncludes();
+  }
+
+  /**
+   * Without include scanning, the exact set of modules used by this compilation is unknown, so use
+   * a suitable upper bound: any directly usable module may be used as a top-level module and any
+   * transitive module may be needed as an input.
+   *
+   * <p>With include scanning, these values are computed in {@link #discoverInputs} instead.
+   */
+  private void initializeModulesUpperBoundsIfNotScanningIncludes() {
+    if (shouldScanIncludes || !useHeaderModules) {
+      return;
+    }
+    boolean separate =
+        getPrimaryOutput().equals(ccCompilationContext.getSeparateHeaderModule(usePic));
+    NestedSet<Artifact> topLevelModules = ccCompilationContext.getDirectModules(usePic, separate);
+    this.topLevelModules = topLevelModules;
+    if (getPrimaryOutput().isFileType(CppFileTypes.CPP_MODULE)
+        && !isCpp20ModuleCompilationAction(actionName)) {
+      this.discoveredModules =
+          NestedSetBuilder.fromNestedSet(ccCompilationContext.getTransitiveModules(usePic))
+              .addTransitive(topLevelModules)
+              .build();
+    }
   }
 
   private static ImmutableSet<Artifact> collectOutputs(
@@ -766,8 +793,8 @@ public class CppCompileAction extends AbstractAction
   }
 
   /**
-   * Set by {@link #discoverInputs}. Returns a subset of {@link #getAdditionalInputs} or an empty
-   * {@link NestedSet}, if this is not a compile action producing a C++ module.
+   * Set by {@link #discoverInputs} or, when include scanning is disabled, in the constructor.
+   * Returns an empty {@link NestedSet}, if this is not a compile action producing a C++ module.
    */
   @Override
   public NestedSet<Artifact> getDiscoveredModules() {
@@ -1236,14 +1263,16 @@ public class CppCompileAction extends AbstractAction
   CcToolchainVariables getOverwrittenVariables() {
     if (useHeaderModules) {
       // TODO(cmita): Avoid keeping state in CppCompileAction.
-      // There are two cases for when this method might be called:
-      // 1. After input discovery, after which toplevelModules is set (in discoverInputs()).
-      // 2. After the action is loaded from the local action cache, leaving topLevelModules null.
-      //
-      // Ideally the same thing would be done in both cases, but as is, we just overestimate modules
-      // in the latter case using the inputs from the action cache.
+      // There are three cases for when this method might be called:
+      // 1. After input discovery, after which topLevelModules is set (in discoverInputs()).
+      // 2. Without include scanning, in which case topLevelModules is set to an upper bound in the
+      //    constructor.
+      // 3. After the action is loaded from the local action cache, leaving topLevelModules null in
+      //    the case of include scanning.
+      // Ideally the same thing would be done in all cases, but as is, we just overestimate modules
+      // in the last case using the inputs from the action cache.
       // Note that this breaks the invariant that Actions are immutable after the analysis phase.
-      NestedSet<Artifact> modules = shouldScanIncludes ? getTopLevelModules() : null;
+      NestedSet<Artifact> modules = getTopLevelModules();
       if (modules != null) {
         return calculateModuleVariable(modules);
       } else {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
@@ -367,8 +367,15 @@ public final class CppCompileActionBuilder implements StarlarkValue {
     NestedSetBuilder<Artifact> realMandatoryInputsBuilder = NestedSetBuilder.compileOrder();
     realMandatoryInputsBuilder.addTransitive(mandatoryInputsBuilder.build());
     realMandatoryInputsBuilder.addAll(getBuiltinIncludeFiles());
-    if (useHeaderModules() && !getShouldScanIncludes()) {
+    if ((useHeaderModules() || loadHeaderModules()) && !getShouldScanIncludes()) {
       realMandatoryInputsBuilder.addTransitive(ccCompilationContext.getTransitiveModules(usePic));
+      // The separate module of this compilation context is not part of the transitive modules, but
+      // may be used by all compiles of this context except for its own compile; see
+      // CcCompilationContext#getDirectModules.
+      Artifact separateModule = ccCompilationContext.getSeparateHeaderModule(usePic);
+      if (separateModule != null && !separateModule.equals(outputFile)) {
+        realMandatoryInputsBuilder.add(separateModule);
+      }
     }
     ccCompilationContext.addAdditionalInputs(realMandatoryInputsBuilder);
     realMandatoryInputsBuilder.add(Preconditions.checkNotNull(sourceFile));
@@ -404,6 +411,18 @@ public final class CppCompileActionBuilder implements StarlarkValue {
 
   private boolean useHeaderModules() {
     return useHeaderModules(sourceFile);
+  }
+
+  /**
+   * Whether this is a module codegen action that may load (but doesn't compile against) transitive
+   * modules.
+   */
+  private boolean loadHeaderModules() {
+    Preconditions.checkNotNull(featureConfiguration);
+    Preconditions.checkNotNull(sourceFile);
+    // The module file imports the modules of dependencies iff it was built with USE_HEADER_MODULES.
+    return featureConfiguration.isEnabled(CppRuleClasses.USE_HEADER_MODULES)
+        && sourceFile.isFileType(CppFileTypes.CPP_MODULE);
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -688,6 +688,92 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
     assertNoEvents();
   }
 
+  @Test
+  public void testModuleUpperBoundsWithoutIncludeScanning() throws Exception {
+    AnalysisMock.get()
+        .ccSupport()
+        .setupCcToolchainConfig(
+            mockToolsConfig,
+            CcToolchainConfig.builder()
+                .withFeatures(MockCcSupport.HEADER_MODULES_FEATURES, CppRuleClasses.SUPPORTS_PIC));
+    useConfiguration("--platforms=" + TestConstants.PLATFORM_LABEL);
+    scratch.file(
+        "module/BUILD",
+        """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+        package(features = ['header_modules', 'use_header_modules'])
+        cc_library(
+            name = 'a',
+            srcs = ['a.h'],
+        )
+        cc_library(
+            name = 'b',
+            srcs = ['b.h'],
+            deps = [':a'],
+        )
+        cc_library(
+            name = 'c',
+            srcs = ['c.cc'],
+            deps = [':b'],
+        )
+        """);
+    Artifact aModuleArtifact =
+        getBinArtifact("_objs/a/a.pic.pcm", getConfiguredTarget("//module:a"));
+    Artifact bModuleArtifact =
+        getBinArtifact("_objs/b/b.pic.pcm", getConfiguredTarget("//module:b"));
+
+    // Without include scanning, all transitive modules are inputs to the object compile, but only
+    // the modules of direct dependencies are passed to the compiler as top-level modules.
+    Artifact cObjectArtifact = getBinArtifact("_objs/c/c.pic.o", getConfiguredTarget("//module:c"));
+    CppCompileAction cObjectAction = (CppCompileAction) getGeneratingAction(cObjectArtifact);
+    assertThat(getHeaderModules(cObjectAction.getInputs()))
+        .containsExactly(aModuleArtifact, bModuleArtifact);
+    assertThat(getHeaderModuleFlags(cObjectAction.getArguments())).containsExactly("b.pic.pcm");
+
+    // The same holds for the module compile of b, which additionally advertises all transitive
+    // modules as discovered modules for use by dependent actions.
+    CppCompileAction bModuleAction = (CppCompileAction) getGeneratingAction(bModuleArtifact);
+    assertThat(getHeaderModules(bModuleAction.getInputs())).containsExactly(aModuleArtifact);
+    assertThat(bModuleAction.getDiscoveredModules().toList()).containsExactly(aModuleArtifact);
+    assertNoEvents();
+  }
+
+  @Test
+  public void testModuleCodegenInputsWithoutIncludeScanning() throws Exception {
+    AnalysisMock.get()
+        .ccSupport()
+        .setupCcToolchainConfig(
+            mockToolsConfig,
+            CcToolchainConfig.builder().withFeatures(MockCcSupport.HEADER_MODULES_FEATURES));
+    useConfiguration("--platforms=" + TestConstants.PLATFORM_LABEL);
+    scratch.file(
+        "module/BUILD",
+        """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+        package(features = ['header_modules', 'use_header_modules', 'header_module_codegen'])
+        cc_library(
+            name = 'a',
+            srcs = ['a.h'],
+        )
+        cc_library(
+            name = 'b',
+            srcs = ['b.h'],
+            deps = [':a'],
+        )
+        """);
+    Artifact aModuleArtifact = getBinArtifact("_objs/a/a.pcm", getConfiguredTarget("//module:a"));
+
+    // Compiling b's module file to an object file loads the module file, which in turn loads the
+    // module files it imports, so those are inputs even though the source of the codegen action is
+    // not itself compiled with header modules.
+    Artifact bModuleObjectArtifact =
+        getBinArtifact("_objs/b/b.pcm.o", getConfiguredTarget("//module:b"));
+    CppCompileAction bModuleCodegenAction =
+        (CppCompileAction) getGeneratingAction(bModuleObjectArtifact);
+    assertThat(getHeaderModules(bModuleCodegenAction.getInputs())).contains(aModuleArtifact);
+    assertNoEvents();
+  }
+
   private void setupPackagesForSourcesWithSameBaseNameTests() throws Exception {
     scratch.file(
         "foo/BUILD",


### PR DESCRIPTION

### Description
When include scanning is disabled, `CppCompileAction` never populated its top-level modules nor its discovered (transitive) modules: the former caused `getOverwrittenVariables()` to fall back to putting every transitive `.pcm` on the command line, and the latter left `ActionExecutionValue` without discovered modules for module-producing compiles.

Fix this by computing a suitable upper bound at action construction time when header modules are used without include scanning:

* Top-level modules: the modules of direct dependencies plus the separate module of the current context (except for its own compile), mirroring the exclusions of `CcCompilationContext#computeUsedModules`. Modules that are only used transitively are found by the compiler through the paths embedded in the direct `.pcm` files, just as in the include scanning case.
* Discovered (transitive) modules: all transitive modules plus the top-level bound, which are all provided as inputs.

Since the separate module of the current context is not part of the transitive modules, `CppCompileActionBuilder` now also adds it as an input to all compiles of the context other than its own compile, matching the existing `allowedDerivedInputs` special case.

### Motivation
Fixing header module compilation in Bazel with default settings, i.e., without include scanning.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
