### PR TITLE
Make .bzl files in @bazel_tools//tools/cpp visible

### DIFF
--- a/tools/cpp/BUILD.tools
+++ b/tools/cpp/BUILD.tools
@@ -15,6 +15,8 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(glob(["*.bzl"]))
+
 licenses(["notice"])
 
 # The toolchain type used to distinguish cc toolchains.


### PR DESCRIPTION
This change [Retry protobuf 35 upgrade](https://github.com/bazelbuild/bazel/pull/30162) is breaking our [downstream pipeline ](https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/5628)

The Problem:
Bazel upgraded to protobuf v35, which declares a bzl_library dependency on @bazel_tools//tools/cpp:toolchain_utils.bzl

When Bazel builds itself (@bazel_tools), it copies **_tools/cpp/BUILD.tools_** as its BUILD file which -unlike tools/cpp/BUILD- doesn't export its .bzl files, so **_toolchain_utils.bzl_** stayed private inside @bazel_tools, blocking protobuf v35 and breaking downstream builds with a [visibility error.](https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/5628#019f88c2-71d2-4f3f-80db-118877f20395/L398)


The Fix: Added exports_files(glob(["*.bzl"])) to _**tools/cpp/BUILD.tools**_ so that .bzl source files are publicly visible when embedded in the Bazel release binary.

The change is tested [here](https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/5629#_)
