### PR TITLE
Add `stdout` parameter to `ctx.actions.run`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/Spawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Spawn.java
@@ -130,6 +130,15 @@ public interface Spawn extends DescribableExecutionUnit {
   Collection<? extends ActionInput> getOutputFiles();
 
   /**
+   * Returns the output that captures this spawn's standard output stream, or {@code null} if the
+   * standard output is not captured.
+   */
+  @Nullable
+  default Artifact getStdout() {
+    return null;
+  }
+
+  /**
    * Returns the output files that should be considered to be "generated" by this spawn for purposes
    * of reconstructing the execution graph in {@link
    * com.google.devtools.build.lib.runtime.ExecutionGraphModule}.

--- a/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
@@ -18,9 +18,11 @@ import com.google.common.base.CharMatcher;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.Spawn.Code;
+import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /** Helper methods relating to implementations of {@link Spawn}. */
 public final class Spawns {
@@ -93,7 +95,11 @@ public final class Spawns {
    * according to its execution info tags.
    */
   public static boolean supportsWorkers(Spawn spawn) {
-    return "1".equals(spawn.getExecutionInfo().get(ExecutionRequirements.SUPPORTS_WORKERS));
+    return supportsWorkers(spawn.getExecutionInfo());
+  }
+
+  public static boolean supportsWorkers(Map<String, String> executionInfo) {
+    return "1".equals(executionInfo.get(ExecutionRequirements.SUPPORTS_WORKERS));
   }
 
   /**
@@ -101,8 +107,24 @@ public final class Spawns {
    * strategy according to its execution info tags.
    */
   public static boolean supportsMultiplexWorkers(Spawn spawn) {
-    return "1"
-        .equals(spawn.getExecutionInfo().get(ExecutionRequirements.SUPPORTS_MULTIPLEX_WORKERS));
+    return supportsMultiplexWorkers(spawn.getExecutionInfo());
+  }
+
+  public static boolean supportsMultiplexWorkers(Map<String, String> executionInfo) {
+    return "1".equals(executionInfo.get(ExecutionRequirements.SUPPORTS_MULTIPLEX_WORKERS));
+  }
+
+  /**
+   * Returns the execpath into which the spawn's standard output stream should be redirected, or
+   * {@code null} if its standard output should be captured as regular action output.
+   */
+  @Nullable
+  public static Path getStdoutRedirectPath(Spawn spawn, Path execRoot) {
+    Artifact stdoutOutput = spawn.getStdout();
+    if (stdoutOutput == null) {
+      return null;
+    }
+    return execRoot.getRelative(spawn.getPathMapper().map(stdoutOutput.getExecPath()));
   }
 
   public static boolean supportsWorkerCancellation(Spawn spawn) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -415,6 +415,11 @@ public class SpawnAction extends AbstractAction implements CommandAction {
         actionKeyContext,
         outputPathsMode,
         fp);
+    Artifact stdoutOutput = getStdoutOutput();
+    if (stdoutOutput != null) {
+      fp.addString("stdout:");
+      fp.addPath(stdoutOutput.getExecPath());
+    }
   }
 
   @Override
@@ -523,12 +528,26 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     return mergeMaps(super.getExecutionInfo(), sortedExecutionInfo);
   }
 
+  /**
+   * Returns the output into which the spawn's standard output stream is redirected, or {@code null}
+   * if the spawn's standard output is reported as regular action output (i.e. printed to the
+   * terminal).
+   *
+   * <p>The returned artifact, when non-null, is a regular output of the action (it is included in
+   * {@link #getOutputs} and in the spawn's output files).
+   */
+  @Nullable
+  public Artifact getStdoutOutput() {
+    return null;
+  }
+
   /** A spawn instance that is tied to a specific SpawnAction. */
   private static final class ActionSpawn extends BaseSpawn {
     private final SpawnInputs inputs;
     private final ImmutableMap<String, String> effectiveEnvironment;
     private final boolean reportOutputs;
     private final PathMapper pathMapper;
+    @Nullable private final Artifact stdoutOutput;
 
     /**
      * Creates an ActionSpawn with the given environment variables.
@@ -555,6 +574,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
       this.pathMapper = pathMapper;
       this.effectiveEnvironment = parent.getEffectiveEnvironment(clientEnv, pathMapper);
       this.reportOutputs = reportOutputs;
+      this.stdoutOutput = parent.getStdoutOutput();
     }
 
     @Override
@@ -575,6 +595,12 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     @Override
     public Collection<? extends ActionInput> getOutputFiles() {
       return reportOutputs ? super.getOutputFiles() : ImmutableSet.of();
+    }
+
+    @Nullable
+    @Override
+    public Artifact getStdout() {
+      return stdoutOutput;
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -149,6 +149,7 @@ public class StarlarkAction extends SpawnAction {
 
     private Optional<Artifact> unusedInputsList = Optional.empty();
     private Optional<Action> shadowedAction = Optional.empty();
+    @Nullable private Artifact stdoutOutput = null;
 
     @CanIgnoreReturnValue
     public Builder setUnusedInputsList(Optional<Artifact> unusedInputsList) {
@@ -159,6 +160,16 @@ public class StarlarkAction extends SpawnAction {
     @CanIgnoreReturnValue
     public Builder setShadowedAction(Optional<Action> shadowedAction) {
       this.shadowedAction = shadowedAction;
+      return this;
+    }
+
+    /**
+     * Redirects the spawn's standard output into the given output artifact instead of reporting it
+     * as regular action output. The artifact must also be registered as an output of the action.
+     */
+    @CanIgnoreReturnValue
+    public Builder setStdoutOutput(Artifact stdoutOutput) {
+      this.stdoutOutput = stdoutOutput;
       return this;
     }
 
@@ -187,7 +198,7 @@ public class StarlarkAction extends SpawnAction {
                 .buildOrThrow();
       }
       OutputPathsMode outputPathsMode = PathMappers.getOutputPathsMode(configuration);
-      return unusedInputsList.isPresent() || shadowedAction.isPresent()
+      return unusedInputsList.isPresent() || shadowedAction.isPresent() || stdoutOutput != null
           ? new EnhancedStarlarkAction(
               owner,
               tools,
@@ -201,7 +212,8 @@ public class StarlarkAction extends SpawnAction {
               mnemonic,
               outputPathsMode,
               unusedInputsList,
-              shadowedAction)
+              shadowedAction,
+              stdoutOutput)
           : new StarlarkAction(
               owner,
               tools,
@@ -217,7 +229,10 @@ public class StarlarkAction extends SpawnAction {
     }
   }
 
-  /** A {@link StarlarkAction} with {@code unused_inputs_list} and/or a shadowed action present. */
+  /**
+   * A {@link StarlarkAction} with {@code unused_inputs_list}, a shadowed action, and/or a {@code
+   * stdout} output present.
+   */
   @AutoCodec
   @VisibleForSerialization
   static final class EnhancedStarlarkAction extends StarlarkAction {
@@ -232,6 +247,7 @@ public class StarlarkAction extends SpawnAction {
 
     private final Optional<Artifact> unusedInputsList;
     private final Optional<Action> shadowedAction;
+    @Nullable private final Artifact stdoutOutput;
     private boolean inputsDiscovered = false;
     private boolean prunedInputs = false;
 
@@ -248,7 +264,8 @@ public class StarlarkAction extends SpawnAction {
         String mnemonic,
         OutputPathsMode outputPathsMode,
         Optional<Artifact> unusedInputsList,
-        Optional<Action> shadowedAction) {
+        Optional<Action> shadowedAction,
+        @Nullable Artifact stdoutOutput) {
       super(
           owner,
           tools,
@@ -271,6 +288,7 @@ public class StarlarkAction extends SpawnAction {
               : null;
       this.unusedInputsList = unusedInputsList;
       this.shadowedAction = shadowedAction;
+      this.stdoutOutput = stdoutOutput;
     }
 
     @AutoCodec.Instantiator
@@ -288,7 +306,8 @@ public class StarlarkAction extends SpawnAction {
         String mnemonic,
         OutputPathsMode outputPathsMode,
         Optional<Artifact> unusedInputsList,
-        Optional<Action> shadowedAction) {
+        Optional<Action> shadowedAction,
+        @Nullable Artifact stdoutOutput) {
       super(
           owner,
           tools,
@@ -311,6 +330,13 @@ public class StarlarkAction extends SpawnAction {
               : null;
       this.unusedInputsList = unusedInputsList;
       this.shadowedAction = shadowedAction;
+      this.stdoutOutput = stdoutOutput;
+    }
+
+    @Nullable
+    @Override
+    public Artifact getStdoutOutput() {
+      return stdoutOutput;
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -30,9 +30,11 @@ import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.CommandLine;
 import com.google.devtools.build.lib.actions.ExecException;
+import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ParamFileInfo;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.ResourceSetOrBuilder;
+import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.actions.extra.ExtraActionInfo;
 import com.google.devtools.build.lib.actions.extra.SpawnInfo;
@@ -418,7 +420,8 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       Object execGroupUnchecked,
       Object shadowedActionUnchecked,
       Object resourceSetUnchecked,
-      Object toolchainUnchecked)
+      Object toolchainUnchecked,
+      Object stdoutUnchecked)
       throws EvalException, InterruptedException {
     context.checkMutable("actions.run");
     execGroupUnchecked = context.maybeOverrideExecGroup(execGroupUnchecked);
@@ -469,6 +472,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
         shadowedActionUnchecked,
         resourceSetUnchecked,
         toolchainUnchecked,
+        stdoutUnchecked,
         builder);
   }
 
@@ -682,6 +686,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
         shadowedActionUnchecked,
         resourceSetUnchecked,
         toolchainUnchecked,
+        /* stdoutUnchecked= */ Starlark.NONE,
         builder);
   }
 
@@ -734,6 +739,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       Object shadowedActionUnchecked,
       Object resourceSetUnchecked,
       Object toolchainUnchecked,
+      Object stdoutUnchecked,
       StarlarkAction.Builder builder)
       throws EvalException {
     if (inputs instanceof Sequence) {
@@ -743,10 +749,35 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
     }
 
     List<Artifact> outputArtifacts = Sequence.cast(outputs, Artifact.class, "outputs");
-    if (outputArtifacts.isEmpty()) {
-      throw Starlark.errorf("param 'outputs' may not be empty");
+
+    Artifact stdoutOutput = null;
+    if (stdoutUnchecked != Starlark.NONE) {
+      var artifact = (Artifact) stdoutUnchecked;
+      if (artifact.isSourceArtifact()) {
+        throw Starlark.errorf("param 'stdout' may not be a source file");
+      }
+      if (artifact.isTreeArtifact()) {
+        throw Starlark.errorf("param 'stdout' may not be a declared directory");
+      }
+      if (artifact.isSymlink()) {
+        throw Starlark.errorf("param 'stdout' may not be a declared symlink");
+      }
+      if (outputArtifacts.contains(artifact)) {
+        throw Starlark.errorf(
+            "file '%s' passed to 'stdout' may not also be listed in 'outputs'",
+            artifact.getExecPathString());
+      }
+      stdoutOutput = artifact;
+    }
+
+    if (outputArtifacts.isEmpty() && stdoutOutput == null) {
+      throw Starlark.errorf("param 'outputs' may not be empty while 'stdout' is not set");
     }
     builder.addOutputs(outputArtifacts);
+    if (stdoutOutput != null) {
+      builder.addOutput(stdoutOutput);
+      builder.setStdoutOutput(stdoutOutput);
+    }
 
     if (unusedInputsList != Starlark.NONE) {
       if (unusedInputsList instanceof Artifact artifact) {
@@ -839,6 +870,16 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
             executionRequirementsUnchecked,
             ruleContext.getRule(),
             getSemantics().getBool(BuildLanguageOptions.INCOMPATIBLE_ALLOW_TAGS_PROPAGATION));
+
+    // A persistent worker communicates via stdout, so we cannot capture it.
+    if (stdoutOutput != null
+        && (Spawns.supportsWorkers(executionInfo)
+            || Spawns.supportsMultiplexWorkers(executionInfo))) {
+      throw Starlark.errorf(
+          "parameter 'stdout' of actions.run is incompatible with worker execution (the"
+              + " '%s' or '%s' execution requirement)",
+          ExecutionRequirements.SUPPORTS_WORKERS, ExecutionRequirements.SUPPORTS_MULTIPLEX_WORKERS);
+    }
     builder.setExecutionInfo(executionInfo);
 
     String execGroup = determineExecGroup(ruleContext, execGroupUnchecked, toolchainUnchecked);

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ParamFileInfo;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.ResourceSetOrBuilder;
+import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.actions.extra.ExtraActionInfo;
 import com.google.devtools.build.lib.actions.extra.SpawnInfo;
@@ -418,7 +419,8 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       Object execGroupUnchecked,
       Object shadowedActionUnchecked,
       Object resourceSetUnchecked,
-      Object toolchainUnchecked)
+      Object toolchainUnchecked,
+      Object stdoutUnchecked)
       throws EvalException, InterruptedException {
     context.checkMutable("actions.run");
     execGroupUnchecked = context.maybeOverrideExecGroup(execGroupUnchecked);
@@ -469,6 +471,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
         shadowedActionUnchecked,
         resourceSetUnchecked,
         toolchainUnchecked,
+        stdoutUnchecked,
         builder);
   }
 
@@ -682,6 +685,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
         shadowedActionUnchecked,
         resourceSetUnchecked,
         toolchainUnchecked,
+        /* stdoutUnchecked= */ Starlark.NONE,
         builder);
   }
 
@@ -734,6 +738,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       Object shadowedActionUnchecked,
       Object resourceSetUnchecked,
       Object toolchainUnchecked,
+      Object stdoutUnchecked,
       StarlarkAction.Builder builder)
       throws EvalException {
     if (inputs instanceof Sequence) {
@@ -743,10 +748,35 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
     }
 
     List<Artifact> outputArtifacts = Sequence.cast(outputs, Artifact.class, "outputs");
-    if (outputArtifacts.isEmpty()) {
-      throw Starlark.errorf("param 'outputs' may not be empty");
+
+    Artifact stdoutOutput = null;
+    if (stdoutUnchecked != Starlark.NONE) {
+      var artifact = (Artifact) stdoutUnchecked;
+      if (artifact.isSourceArtifact()) {
+        throw Starlark.errorf("param 'stdout' may not be a source file");
+      }
+      if (artifact.isTreeArtifact()) {
+        throw Starlark.errorf("param 'stdout' may not be a declared directory");
+      }
+      if (artifact.isSymlink()) {
+        throw Starlark.errorf("param 'stdout' may not be a declared symlink");
+      }
+      if (outputArtifacts.contains(artifact)) {
+        throw Starlark.errorf(
+            "file '%s' passed to 'stdout' may not also be listed in 'outputs'",
+            artifact.getExecPathString());
+      }
+      stdoutOutput = artifact;
+    }
+
+    if (outputArtifacts.isEmpty() && stdoutOutput == null) {
+      throw Starlark.errorf("param 'outputs' may not be empty while 'stdout' is not set");
     }
     builder.addOutputs(outputArtifacts);
+    if (stdoutOutput != null) {
+      builder.addOutput(stdoutOutput);
+      builder.setStdoutOutput(stdoutOutput);
+    }
 
     if (unusedInputsList != Starlark.NONE) {
       if (unusedInputsList instanceof Artifact artifact) {
@@ -839,6 +869,16 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
             executionRequirementsUnchecked,
             ruleContext.getRule(),
             getSemantics().getBool(BuildLanguageOptions.INCOMPATIBLE_ALLOW_TAGS_PROPAGATION));
+
+    // A persistent worker communicates via stdout, so we cannot capture it.
+    if (stdoutOutput != null
+        && (Spawns.supportsWorkers(executionInfo)
+            || Spawns.supportsMultiplexWorkers(executionInfo))) {
+      throw Starlark.errorf(
+          "parameter 'stdout' of actions.run is incompatible with worker execution (the"
+              + " '%s' or '%s' execution requirement)",
+          ExecutionRequirements.SUPPORTS_WORKERS, ExecutionRequirements.SUPPORTS_MULTIPLEX_WORKERS);
+    }
     builder.setExecutionInfo(executionInfo);
 
     String execGroup = determineExecGroup(ruleContext, execGroupUnchecked, toolchainUnchecked);

--- a/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
@@ -372,7 +372,12 @@ public class LocalSpawnRunner implements SpawnRunner {
 
         SubprocessBuilder subprocessBuilder = new SubprocessBuilder(context.getClientEnv());
         subprocessBuilder.setWorkingDirectory(execRoot.getPathFile());
-        subprocessBuilder.setStdout(outErr.getOutputPath().getPathFile());
+        // If the spawn redirects its standard output into one of its outputs, write directly to
+        // that file instead of the regular stdout capture buffer. This keeps the captured output
+        // out of the terminal and the build event stream and turns it into a regular output file.
+        Path stdoutPath = Spawns.getStdoutRedirectPath(spawn, execRoot);
+        subprocessBuilder.setStdout(
+            (stdoutPath != null ? stdoutPath : outErr.getOutputPath()).getPathFile());
         subprocessBuilder.setStderr(outErr.getErrorPath().getPathFile());
         subprocessBuilder.setEnv(environment);
         ImmutableList<String> args;

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -771,22 +771,40 @@ public class CombinedCache extends AbstractReferenceCounted {
    */
   public final List<ListenableFuture<Void>> downloadOutErr(
       RemoteActionExecutionContext context, ActionResult result, OutErr outErr) {
+    return downloadOutErr(context, result, outErr, /* downloadStdout= */ true);
+  }
+
+  /**
+   * Download the stdout and stderr of an executed action.
+   *
+   * @param context the context for the action.
+   * @param result the result of the action.
+   * @param outErr the {@link OutErr} that the stdout and stderr will be downloaded to.
+   * @param downloadStdout whether to download stdout.
+   */
+  public final List<ListenableFuture<Void>> downloadOutErr(
+      RemoteActionExecutionContext context,
+      ActionResult result,
+      OutErr outErr,
+      boolean downloadStdout) {
     List<ListenableFuture<Void>> downloads = new ArrayList<>();
-    if (!result.getStdoutRaw().isEmpty()) {
-      try {
-        result.getStdoutRaw().writeTo(outErr.getOutputStream());
-        outErr.getOutputStream().flush();
-      } catch (IOException e) {
-        downloads.add(Futures.immediateFailedFuture(e));
+    if (downloadStdout) {
+      if (!result.getStdoutRaw().isEmpty()) {
+        try {
+          result.getStdoutRaw().writeTo(outErr.getOutputStream());
+          outErr.getOutputStream().flush();
+        } catch (IOException e) {
+          downloads.add(Futures.immediateFailedFuture(e));
+        }
+      } else if (result.hasStdoutDigest()) {
+        downloads.add(
+            downloadBlob(
+                context,
+                /* blobName= */ "<stdout>",
+                /* execPath= */ null,
+                result.getStdoutDigest(),
+                outErr.getOutputStream()));
       }
-    } else if (result.hasStdoutDigest()) {
-      downloads.add(
-          downloadBlob(
-              context,
-              /* blobName= */ "<stdout>",
-              /* execPath= */ null,
-              result.getStdoutDigest(),
-              outErr.getOutputStream()));
     }
     if (!result.getStderrRaw().isEmpty()) {
       try {

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -826,22 +826,40 @@ public class CombinedCache extends AbstractReferenceCounted {
    */
   public final List<ListenableFuture<Void>> downloadOutErr(
       RemoteActionExecutionContext context, ActionResult result, OutErr outErr) {
+    return downloadOutErr(context, result, outErr, /* downloadStdout= */ true);
+  }
+
+  /**
+   * Download the stdout and stderr of an executed action.
+   *
+   * @param context the context for the action.
+   * @param result the result of the action.
+   * @param outErr the {@link OutErr} that the stdout and stderr will be downloaded to.
+   * @param downloadStdout whether to download stdout.
+   */
+  public final List<ListenableFuture<Void>> downloadOutErr(
+      RemoteActionExecutionContext context,
+      ActionResult result,
+      OutErr outErr,
+      boolean downloadStdout) {
     List<ListenableFuture<Void>> downloads = new ArrayList<>();
-    if (!result.getStdoutRaw().isEmpty()) {
-      try {
-        result.getStdoutRaw().writeTo(outErr.getOutputStream());
-        outErr.getOutputStream().flush();
-      } catch (IOException e) {
-        downloads.add(Futures.immediateFailedFuture(e));
+    if (downloadStdout) {
+      if (!result.getStdoutRaw().isEmpty()) {
+        try {
+          result.getStdoutRaw().writeTo(outErr.getOutputStream());
+          outErr.getOutputStream().flush();
+        } catch (IOException e) {
+          downloads.add(Futures.immediateFailedFuture(e));
+        }
+      } else if (result.hasStdoutDigest()) {
+        downloads.add(
+            downloadBlob(
+                context,
+                /* blobName= */ "<stdout>",
+                /* execPath= */ null,
+                result.getStdoutDigest(),
+                outErr.getOutputStream()));
       }
-    } else if (result.hasStdoutDigest()) {
-      downloads.add(
-          downloadBlob(
-              context,
-              /* blobName= */ "<stdout>",
-              /* execPath= */ null,
-              result.getStdoutDigest(),
-              outErr.getOutputStream()));
     }
     if (!result.getStderrRaw().isEmpty()) {
       try {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -54,6 +54,7 @@ import build.bazel.remote.execution.v2.Tree;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -255,6 +256,18 @@ public class RemoteExecutionService {
     this.remoteOutputChecker = remoteOutputChecker;
     this.outputService = outputService;
     this.knownMissingCasDigests = knownMissingCasDigests;
+  }
+
+  /**
+   * Returns the spawn's output files excluding the output into which its standard output is
+   * redirected, if any.
+   */
+  private static Collection<? extends ActionInput> outputsExcludingStdout(Spawn spawn) {
+    Artifact stdoutOutput = spawn.getStdout();
+    if (stdoutOutput == null) {
+      return spawn.getOutputFiles();
+    }
+    return Collections2.filter(spawn.getOutputFiles(), artifact -> !artifact.equals(stdoutOutput));
   }
 
   private Command buildCommand(
@@ -545,7 +558,7 @@ public class RemoteExecutionService {
       Command command =
           buildCommand(
               useOutputPaths(),
-              spawn.getOutputFiles(),
+              outputsExcludingStdout(spawn),
               spawn.getArguments(),
               spawn.getEnvironment(),
               platform,
@@ -718,10 +731,12 @@ public class RemoteExecutionService {
               Iterables.transform(
                   Iterables.concat(outputFiles, outputDirPaths, outputSymlinkPaths),
                   StringEncoding::unicodeToInternal));
-      // Check that all mandatory outputs are created.
+      // Check that all mandatory outputs are created. The stdout output is captured as the action
+      // result's stdout rather than as a regular output file of the RemoteAction, so it has to be
+      // excluded here.
       var spawn = action.getSpawn();
       var remotePathResolver = action.getRemotePathResolver();
-      return spawn.getOutputFiles().stream()
+      return outputsExcludingStdout(spawn).stream()
           .filter(spawn::isMandatoryOutput)
           .filter(
               output -> !allOutputPaths.contains(remotePathResolver.localPathToOutputPath(output)))
@@ -1196,6 +1211,18 @@ public class RemoteExecutionService {
               outputFile.getContents()));
     }
 
+    Artifact stdoutArtifact = context.getSpawn().getStdout();
+    if (stdoutArtifact != null) {
+      Path localPath = stdoutArtifact.getPath();
+      files.put(
+          localPath,
+          new FileMetadata(
+              localPath,
+              result.getStdoutDigest(),
+              /* isExecutable= */ false,
+              result.getStdoutRaw()));
+    }
+
     var symlinkMap = new HashMap<Path, SymlinkMetadata>();
     var outputSymlinks =
         Iterables.concat(
@@ -1374,10 +1401,15 @@ public class RemoteExecutionService {
 
     FileOutErr outErr = action.getSpawnExecutionContext().getFileOutErr();
 
-    // Always download the action stdout/stderr.
+    // Always download the action stdout/stderr, except for stdout that was redirected into an
+    // output above (in which case it must not be reported as regular action stdout).
     FileOutErr tmpOutErr = outErr.childOutErr();
     List<ListenableFuture<Void>> outErrDownloads =
-        combinedCache.downloadOutErr(context, result.actionResult, tmpOutErr);
+        combinedCache.downloadOutErr(
+            context,
+            result.actionResult,
+            tmpOutErr,
+            /* downloadStdout= */ context.getSpawn().getStdout() == null);
     for (ListenableFuture<Void> future : outErrDownloads) {
       downloadsBuilder.add(transform(future, (v) -> null, directExecutor()));
     }
@@ -1665,6 +1697,27 @@ public class RemoteExecutionService {
         }
       }
 
+      // The stdout output is captured as the action result's stdout rather than as a regular
+      // output file, so it isn't part of the command's output paths and has to be copied
+      // separately.
+      Artifact stdoutOutput = action.getSpawn().getStdout();
+      if (stdoutOutput != null) {
+        Artifact previousStdoutOutput = previousExecution.action.getSpawn().getStdout();
+        if (previousStdoutOutput == null) {
+          // The previous spawn reported its stdout as regular action output, so it isn't
+          // available as a file. Rerun the action instead.
+          return null;
+        }
+        Path tmpPath = tempPathGenerator.generateTempPath();
+        tmpPath.getParentDirectory().createDirectoryAndParents();
+        try {
+          FileSystemUtils.copyFile(previousStdoutOutput.getPath(), tmpPath);
+          realToTmpPath.put(stdoutOutput.getPath(), tmpPath);
+        } catch (FileNotFoundException e) {
+          return null;
+        }
+      }
+
       // TODO: FileOutErr is action-scoped, not spawn-scoped, but this is not a problem for the
       //  current use case of supporting deduplication of path mapped spawns:
       //  1. Starlark and C++ compilation actions always create a single spawn.
@@ -1740,8 +1793,16 @@ public class RemoteExecutionService {
       throws IOException, ExecException, InterruptedException {
     try (SilentCloseable c = Profiler.instance().profile("build upload manifest")) {
       ImmutableList.Builder<Path> outputFiles = ImmutableList.builder();
+      // If the spawn redirected its stdout into an output, upload that file as the action's stdout
+      // digest rather than as an output file.
+      Artifact stdoutOutput = action.getSpawn().getStdout();
+      FileOutErr fileOutErr = action.getSpawnExecutionContext().getFileOutErr();
+      if (stdoutOutput != null) {
+        fileOutErr = new FileOutErr(stdoutOutput.getPath(), fileOutErr.getErrorPath());
+      }
+
       // Check that all mandatory outputs are created.
-      for (ActionInput outputFile : action.getSpawn().getOutputFiles()) {
+      for (ActionInput outputFile : outputsExcludingStdout(action.getSpawn())) {
         Symlinks followSymlinks = outputFile.isSymlink() ? Symlinks.NOFOLLOW : Symlinks.FOLLOW;
         Path localPath = execRoot.getRelative(outputFile.getExecPath());
         if (action.getSpawn().isMandatoryOutput(outputFile) && !localPath.exists(followSymlinks)) {
@@ -1759,7 +1820,7 @@ public class RemoteExecutionService {
           action.getAction(),
           action.getCommand(),
           outputFiles.build(),
-          action.getSpawnExecutionContext().getFileOutErr(),
+          fileOutErr,
           spawnResult.exitCode(),
           spawnResult.getStartTime(),
           spawnResult.getWallTimeInMs(),

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -53,6 +53,7 @@ import build.bazel.remote.execution.v2.Tree;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -255,6 +256,18 @@ public class RemoteExecutionService {
     this.remoteOutputChecker = remoteOutputChecker;
     this.outputService = outputService;
     this.knownMissingCasDigests = knownMissingCasDigests;
+  }
+
+  /**
+   * Returns the spawn's output files excluding the output into which its standard output is
+   * redirected, if any.
+   */
+  private static Collection<? extends ActionInput> outputsExcludingStdout(Spawn spawn) {
+    Artifact stdoutOutput = spawn.getStdout();
+    if (stdoutOutput == null) {
+      return spawn.getOutputFiles();
+    }
+    return Collections2.filter(spawn.getOutputFiles(), artifact -> !artifact.equals(stdoutOutput));
   }
 
   private Command buildCommand(
@@ -549,7 +562,7 @@ public class RemoteExecutionService {
       Command command =
           buildCommand(
               useOutputPaths(),
-              spawn.getOutputFiles(),
+              outputsExcludingStdout(spawn),
               spawn.getArguments(),
               spawn.getEnvironment(),
               platform,
@@ -722,10 +735,12 @@ public class RemoteExecutionService {
               Iterables.transform(
                   Iterables.concat(outputFiles, outputDirPaths, outputSymlinkPaths),
                   StringEncoding::unicodeToInternal));
-      // Check that all mandatory outputs are created.
+      // Check that all mandatory outputs are created. The stdout output is captured as the action
+      // result's stdout rather than as a regular output file of the RemoteAction, so it has to be
+      // excluded here.
       var spawn = action.getSpawn();
       var remotePathResolver = action.getRemotePathResolver();
-      return spawn.getOutputFiles().stream()
+      return outputsExcludingStdout(spawn).stream()
           .filter(spawn::isMandatoryOutput)
           .filter(
               output -> !allOutputPaths.contains(remotePathResolver.localPathToOutputPath(output)))
@@ -1213,6 +1228,18 @@ public class RemoteExecutionService {
               outputFile.getContents()));
     }
 
+    Artifact stdoutArtifact = context.getSpawn().getStdout();
+    if (stdoutArtifact != null) {
+      Path localPath = stdoutArtifact.getPath();
+      files.put(
+          localPath,
+          new FileMetadata(
+              localPath,
+              result.getStdoutDigest(),
+              /* isExecutable= */ false,
+              result.getStdoutRaw()));
+    }
+
     var symlinkMap = new HashMap<Path, SymlinkMetadata>();
     var outputSymlinks =
         Iterables.concat(
@@ -1391,10 +1418,15 @@ public class RemoteExecutionService {
 
     FileOutErr outErr = action.getSpawnExecutionContext().getFileOutErr();
 
-    // Always download the action stdout/stderr.
+    // Always download the action stdout/stderr, except for stdout that was redirected into an
+    // output above (in which case it must not be reported as regular action stdout).
     FileOutErr tmpOutErr = outErr.childOutErr();
     List<ListenableFuture<Void>> outErrDownloads =
-        combinedCache.downloadOutErr(context, result.actionResult, tmpOutErr);
+        combinedCache.downloadOutErr(
+            context,
+            result.actionResult,
+            tmpOutErr,
+            /* downloadStdout= */ context.getSpawn().getStdout() == null);
     for (ListenableFuture<Void> future : outErrDownloads) {
       downloadsBuilder.add(transform(future, (v) -> null, directExecutor()));
     }
@@ -1682,6 +1714,27 @@ public class RemoteExecutionService {
         }
       }
 
+      // The stdout output is captured as the action result's stdout rather than as a regular
+      // output file, so it isn't part of the command's output paths and has to be copied
+      // separately.
+      Artifact stdoutOutput = action.getSpawn().getStdout();
+      if (stdoutOutput != null) {
+        Artifact previousStdoutOutput = previousExecution.action.getSpawn().getStdout();
+        if (previousStdoutOutput == null) {
+          // The previous spawn reported its stdout as regular action output, so it isn't
+          // available as a file. Rerun the action instead.
+          return null;
+        }
+        Path tmpPath = tempPathGenerator.generateTempPath();
+        tmpPath.getParentDirectory().createDirectoryAndParents();
+        try {
+          FileSystemUtils.copyFile(previousStdoutOutput.getPath(), tmpPath);
+          realToTmpPath.put(stdoutOutput.getPath(), tmpPath);
+        } catch (FileNotFoundException e) {
+          return null;
+        }
+      }
+
       // TODO: FileOutErr is action-scoped, not spawn-scoped, but this is not a problem for the
       //  current use case of supporting deduplication of path mapped spawns:
       //  1. Starlark and C++ compilation actions always create a single spawn.
@@ -1757,8 +1810,16 @@ public class RemoteExecutionService {
       throws IOException, ExecException, InterruptedException {
     try (SilentCloseable c = Profiler.instance().profile("build upload manifest")) {
       ImmutableList.Builder<Path> outputFiles = ImmutableList.builder();
+      // If the spawn redirected its stdout into an output, upload that file as the action's stdout
+      // digest rather than as an output file.
+      Artifact stdoutOutput = action.getSpawn().getStdout();
+      FileOutErr fileOutErr = action.getSpawnExecutionContext().getFileOutErr();
+      if (stdoutOutput != null) {
+        fileOutErr = new FileOutErr(stdoutOutput.getPath(), fileOutErr.getErrorPath());
+      }
+
       // Check that all mandatory outputs are created.
-      for (ActionInput outputFile : action.getSpawn().getOutputFiles()) {
+      for (ActionInput outputFile : outputsExcludingStdout(action.getSpawn())) {
         Symlinks followSymlinks = outputFile.isSymlink() ? Symlinks.NOFOLLOW : Symlinks.FOLLOW;
         Path localPath = execRoot.getRelative(outputFile.getExecPath());
         if (action.getSpawn().isMandatoryOutput(outputFile) && !localPath.exists(followSymlinks)) {
@@ -1776,7 +1837,7 @@ public class RemoteExecutionService {
           action.getAction(),
           action.getCommand(),
           outputFiles.build(),
-          action.getSpawnExecutionContext().getFileOutErr(),
+          fileOutErr,
           spawnResult.exitCode(),
           spawnResult.getStartTime(),
           spawnResult.getWallTimeInMs(),

--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -214,7 +214,13 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
 
     SubprocessBuilder subprocessBuilder = new SubprocessBuilder(clientEnv);
     subprocessBuilder.setWorkingDirectory(sandbox.getSandboxExecRoot().getPathFile());
-    subprocessBuilder.setStdout(outErr.getOutputPath().getPathFile());
+    // If the spawn redirects its standard output into one of its outputs, write to that output
+    // inside the sandbox instead of the regular stdout capture buffer. The file is a regular
+    // output, so no other special handling is necessary.
+    Path stdoutPath =
+        Spawns.getStdoutRedirectPath(originalSpawn, sandbox.getSandboxExecRoot());
+    subprocessBuilder.setStdout(
+        (stdoutPath != null ? stdoutPath : outErr.getOutputPath()).getPathFile());
     subprocessBuilder.setStderr(outErr.getErrorPath().getPathFile());
     subprocessBuilder.setEnv(sandbox.getEnvironment());
     subprocessBuilder.setArgv(ImmutableList.copyOf(sandbox.getArguments()));

--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -210,7 +210,13 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
 
     SubprocessBuilder subprocessBuilder = new SubprocessBuilder(clientEnv);
     subprocessBuilder.setWorkingDirectory(sandbox.getSandboxExecRoot().getPathFile());
-    subprocessBuilder.setStdout(outErr.getOutputPath().getPathFile());
+    // If the spawn redirects its standard output into one of its outputs, write to that output
+    // inside the sandbox instead of the regular stdout capture buffer. The file is a regular
+    // output, so no other special handling is necessary.
+    Path stdoutPath =
+        Spawns.getStdoutRedirectPath(originalSpawn, sandbox.getSandboxExecRoot());
+    subprocessBuilder.setStdout(
+        (stdoutPath != null ? stdoutPath : outErr.getOutputPath()).getPathFile());
     subprocessBuilder.setStderr(outErr.getErrorPath().getPathFile());
     subprocessBuilder.setEnv(sandbox.getEnvironment());
     subprocessBuilder.setArgv(ImmutableList.copyOf(sandbox.getArguments()));

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -613,6 +613,24 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
                     + " `toolchain` and `exec_group` parameters are both set, `exec_group` will be"
                     + " used. An error is raised in case the `exec_group` doesn't specify the same"
                     + " toolchain.</p>"),
+        @Param(
+            name = "stdout",
+            allowedTypes = {
+              @ParamType(type = FileApi.class),
+              @ParamType(type = NoneType.class),
+            },
+            defaultValue = "None",
+            named = true,
+            positional = false,
+            doc =
+                "If set to a <code>File</code>, the standard output of the action is redirected"
+                    + " into that file. The file becomes a regular additional output of the action"
+                    + " (it must not also be listed in <code>outputs</code>)."
+                    + "<p>When the standard output is captured into the file, it is not displayed"
+                    + " in the terminal as regular action output."
+                    + "<p>This is incompatible with persistent worker execution (the"
+                    + " <code>supports-workers</code> or <code>supports-multiplex-workers</code>"
+                    + " execution requirements)."),
       })
   void run(
       Sequence<?> outputs,
@@ -630,7 +648,8 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
       Object execGroupUnchecked,
       Object shadowedAction,
       Object resourceSetUnchecked,
-      Object toolchainUnchecked)
+      Object toolchainUnchecked,
+      Object stdout)
       throws EvalException, InterruptedException;
 
   @StarlarkMethod(

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -419,6 +419,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/runtime:block_waiting_module",
         "//src/main/java/com/google/devtools/build/lib/runtime:build_summary_stats_module",
         "//src/main/java/com/google/devtools/build/lib/standalone",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/common/options:options_internal",

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -514,6 +514,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/runtime:block_waiting_module",
         "//src/main/java/com/google/devtools/build/lib/runtime:build_summary_stats_module",
         "//src/main/java/com/google/devtools/build/lib/standalone",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/common/options:options_internal",

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -96,6 +96,88 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     assertOutputsDoNotExist("//:foobar");
   }
 
+  // The trailing line break cannot be avoided with a batch tool on Windows.
+  private static final String CAPTURED_STDOUT =
+      OS.getCurrent() == OS.WINDOWS ? "hello stdout\r\n" : "hello stdout";
+
+  private void writeStdoutRule() throws IOException {
+    // A rule whose only output is the captured stdout of a tool invoked via ctx.actions.run.
+    boolean isWindows = OS.getCurrent() == OS.WINDOWS;
+    write(
+        "a/defs.bzl",
+        """
+        def _impl(ctx):
+            tool = ctx.actions.declare_file(ctx.label.name + "%s")
+            ctx.actions.write(
+                tool,
+                %s,
+                is_executable = True,
+            )
+            out = ctx.actions.declare_file(ctx.label.name + ".out")
+            ctx.actions.run(
+                outputs = [],
+                executable = tool,
+                stdout = out,
+                mnemonic = "Capture",
+            )
+            return DefaultInfo(files = depset([out]))
+
+        capture = rule(implementation = _impl)
+        """
+            .formatted(
+                isWindows ? ".bat" : ".sh",
+                isWindows
+                    ? "\"@echo off\\necho hello stdout\\n\""
+                    : "\"#!/bin/bash\\nprintf '%s' 'hello stdout'\\n\""));
+    write(
+        "a/BUILD",
+        """
+        load(":defs.bzl", "capture")
+
+        capture(name = "capture")
+        """);
+  }
+
+  @Test
+  public void stdoutOutput_notDownloadedUnderMinimal() throws Exception {
+    // The stdout output is an ordinary output: under build-without-the-bytes it is not eagerly
+    // downloaded, but its (remote) metadata is available.
+    if (!hasAccessToRemoteOutputs()) {
+      return;
+    }
+    writeStdoutRule();
+
+    buildTarget("//a:capture");
+    waitDownloads();
+
+    assertOnlyOutputRemoteContent("//a:capture", "capture.out", CAPTURED_STDOUT);
+  }
+
+  @Test
+  public void stdoutOutput_downloadedWithRegex() throws Exception {
+    // remote_download_regex matching the stdout file forces it to be downloaded, just like any
+    // other output.
+    writeStdoutRule();
+    addOptions("--remote_download_regex=.*capture\\.out$");
+
+    buildTarget("//a:capture");
+    waitDownloads();
+
+    assertOnlyOutputContent("//a:capture", "capture.out", CAPTURED_STDOUT);
+  }
+
+  @Test
+  public void stdoutOutput_downloadTopLevel() throws Exception {
+    // Requesting top-level outputs downloads the stdout output with its captured content.
+    setDownloadToplevel();
+    writeStdoutRule();
+
+    buildTarget("//a:capture");
+    waitDownloads();
+
+    assertOnlyOutputContent("//a:capture", "capture.out", CAPTURED_STDOUT);
+  }
+
   @Test
   public void disableRunfiles_buildSuccessfully() throws Exception {
     // Disable on Windows since it fails for unknown reasons.

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -119,6 +119,88 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     assertOutputsDoNotExist("//:foobar");
   }
 
+  // The trailing line break cannot be avoided with a batch tool on Windows.
+  private static final String CAPTURED_STDOUT =
+      OS.getCurrent() == OS.WINDOWS ? "hello stdout\r\n" : "hello stdout";
+
+  private void writeStdoutRule() throws IOException {
+    // A rule whose only output is the captured stdout of a tool invoked via ctx.actions.run.
+    boolean isWindows = OS.getCurrent() == OS.WINDOWS;
+    write(
+        "a/defs.bzl",
+        """
+        def _impl(ctx):
+            tool = ctx.actions.declare_file(ctx.label.name + "%s")
+            ctx.actions.write(
+                tool,
+                %s,
+                is_executable = True,
+            )
+            out = ctx.actions.declare_file(ctx.label.name + ".out")
+            ctx.actions.run(
+                outputs = [],
+                executable = tool,
+                stdout = out,
+                mnemonic = "Capture",
+            )
+            return DefaultInfo(files = depset([out]))
+
+        capture = rule(implementation = _impl)
+        """
+            .formatted(
+                isWindows ? ".bat" : ".sh",
+                isWindows
+                    ? "\"@echo off\\necho hello stdout\\n\""
+                    : "\"#!/bin/bash\\nprintf '%s' 'hello stdout'\\n\""));
+    write(
+        "a/BUILD",
+        """
+        load(":defs.bzl", "capture")
+
+        capture(name = "capture")
+        """);
+  }
+
+  @Test
+  public void stdoutOutput_notDownloadedUnderMinimal() throws Exception {
+    // The stdout output is an ordinary output: under build-without-the-bytes it is not eagerly
+    // downloaded, but its (remote) metadata is available.
+    if (!hasAccessToRemoteOutputs()) {
+      return;
+    }
+    writeStdoutRule();
+
+    buildTarget("//a:capture");
+    waitDownloads();
+
+    assertOnlyOutputRemoteContent("//a:capture", "capture.out", CAPTURED_STDOUT);
+  }
+
+  @Test
+  public void stdoutOutput_downloadedWithRegex() throws Exception {
+    // remote_download_regex matching the stdout file forces it to be downloaded, just like any
+    // other output.
+    writeStdoutRule();
+    addOptions("--remote_download_regex=.*capture\\.out$");
+
+    buildTarget("//a:capture");
+    waitDownloads();
+
+    assertOnlyOutputContent("//a:capture", "capture.out", CAPTURED_STDOUT);
+  }
+
+  @Test
+  public void stdoutOutput_downloadTopLevel() throws Exception {
+    // Requesting top-level outputs downloads the stdout output with its captured content.
+    setDownloadToplevel();
+    writeStdoutRule();
+
+    buildTarget("//a:capture");
+    waitDownloads();
+
+    assertOnlyOutputContent("//a:capture", "capture.out", CAPTURED_STDOUT);
+  }
+
   @Test
   public void disableRunfiles_buildSuccessfully() throws Exception {
     // Disable on Windows since it fails for unknown reasons.

--- a/src/test/java/com/google/devtools/build/lib/remote/DiskCacheIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/DiskCacheIntegrationTest.java
@@ -21,6 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import build.bazel.remote.execution.v2.Digest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.ActionUploadFinishedEvent;
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialModule;
 import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
@@ -35,6 +36,8 @@ import com.google.devtools.build.lib.runtime.BlazeRuntime;
 import com.google.devtools.build.lib.runtime.BlockWaitingModule;
 import com.google.devtools.build.lib.runtime.BuildSummaryStatsModule;
 import com.google.devtools.build.lib.standalone.StandaloneModule;
+import com.google.devtools.build.lib.util.OS;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.SyscallCache;
@@ -151,6 +154,103 @@ public class DiskCacheIntegrationTest extends BuildIntegrationTestCase {
     // Assert: Should download action results from cache and refresh mtime on cache entries.
     events.assertContainsInfo("2 disk cache hit");
     assertRecentlyModified(actionDigests, getBlobDigests("foo", "foobar", "out", "err"));
+  }
+
+  private static boolean isWindows() {
+    return OS.getCurrent() == OS.WINDOWS;
+  }
+
+  private void setupStdoutOutputWorkspace() throws IOException {
+    // Rules whose only output is the stdout of a tool captured via the `stdout` parameter of
+    // ctx.actions.run.
+    write(
+        "defs.bzl",
+        """
+        def _impl(ctx):
+            out = ctx.actions.declare_file(ctx.label.name + ".out")
+            ctx.actions.run(
+                outputs = [],
+                executable = "%s",
+                arguments = ["%s", ctx.attr.command],
+                stdout = out,
+                mnemonic = "Capture",
+            )
+            return DefaultInfo(files = depset([out]))
+
+        capture = rule(
+            implementation = _impl,
+            attrs = {"command": attr.string(mandatory = True)},
+        )
+        """
+            .formatted(
+                isWindows() ? "C:/Windows/System32/cmd.exe" : "/bin/bash",
+                isWindows() ? "/c" : "-c"));
+    write(
+        "BUILD",
+        """
+        load(":defs.bzl", "capture")
+
+        capture(
+            name = "capture",
+            command = "%s",
+        )
+
+        capture(
+            name = "capture_empty",
+            command = "%s",
+        )
+        """
+            .formatted(
+                isWindows() ? "echo hello stdout" : "echo -n 'hello stdout'",
+                isWindows() ? "rem" : "true"));
+  }
+
+  private void assertStdoutOutputContents() throws Exception {
+    String expected = isWindows() ? "hello stdout\r\n" : "hello stdout";
+    var out = Iterables.getOnlyElement(getArtifacts("//:capture"));
+    assertThat(FileSystemUtils.readContent(out.getPath(), UTF_8)).isEqualTo(expected);
+    var emptyOut = Iterables.getOnlyElement(getArtifacts("//:capture_empty"));
+    assertThat(FileSystemUtils.readContent(emptyOut.getPath(), UTF_8)).isEmpty();
+  }
+
+  @Test
+  public void stdoutOutput_hitDiskCache() throws Exception {
+    // Arrange: Populate the disk cache from locally executed actions whose stdout is captured
+    // into an output file. The captured stdout is uploaded as the action result's stdout digest
+    // rather than as an output file.
+    setupStdoutOutputWorkspace();
+    buildTarget("//:capture", "//:capture_empty");
+    assertStdoutOutputContents();
+
+    // Act: Do a clean build.
+    cleanAndRestartServer();
+    buildTarget("//:capture", "//:capture_empty");
+
+    // Assert: Should hit the disk cache and reconstruct the stdout outputs from the stdout
+    // digests.
+    events.assertContainsInfo("2 disk cache hit");
+    assertStdoutOutputContents();
+  }
+
+  @Test
+  public void stdoutOutput_hitRemoteCache() throws Exception {
+    // Arrange: Populate the remote cache from locally executed actions whose stdout is captured
+    // into an output file.
+    setupStdoutOutputWorkspace();
+    enableRemoteCache();
+    buildTarget("//:capture", "//:capture_empty");
+    assertStdoutOutputContents();
+
+    // Act: Drop the disk cache so that the clean build can only hit the remote cache.
+    getWorkspace().getFileSystem().getPath(getDiskCacheDir()).deleteTree();
+    cleanAndRestartServer();
+    enableRemoteCache();
+    buildTarget("//:capture", "//:capture_empty");
+
+    // Assert: Should hit the remote cache and reconstruct the stdout outputs from the stdout
+    // digests.
+    events.assertContainsInfo("2 remote cache hit");
+    assertStdoutOutputContents();
   }
 
   private void doBlobsReferencedInAcAreMissingFromCasIgnoresAc(String... additionalOptions)

--- a/src/test/java/com/google/devtools/build/lib/remote/DiskCacheIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/DiskCacheIntegrationTest.java
@@ -21,6 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import build.bazel.remote.execution.v2.Digest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.ActionUploadFinishedEvent;
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialModule;
 import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
@@ -35,6 +36,8 @@ import com.google.devtools.build.lib.runtime.BlazeRuntime;
 import com.google.devtools.build.lib.runtime.BlockWaitingModule;
 import com.google.devtools.build.lib.runtime.BuildSummaryStatsModule;
 import com.google.devtools.build.lib.standalone.StandaloneModule;
+import com.google.devtools.build.lib.util.OS;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.SyscallCache;
@@ -152,6 +155,103 @@ public class DiskCacheIntegrationTest extends BuildIntegrationTestCase {
     // Assert: Should download action results from cache and refresh mtime on cache entries.
     events.assertContainsInfo("2 disk cache hit");
     assertRecentlyModified(actionDigests, getBlobDigests("foo", "foobar", "out", "err"));
+  }
+
+  private static boolean isWindows() {
+    return OS.getCurrent() == OS.WINDOWS;
+  }
+
+  private void setupStdoutOutputWorkspace() throws IOException {
+    // Rules whose only output is the stdout of a tool captured via the `stdout` parameter of
+    // ctx.actions.run.
+    write(
+        "defs.bzl",
+        """
+        def _impl(ctx):
+            out = ctx.actions.declare_file(ctx.label.name + ".out")
+            ctx.actions.run(
+                outputs = [],
+                executable = "%s",
+                arguments = ["%s", ctx.attr.command],
+                stdout = out,
+                mnemonic = "Capture",
+            )
+            return DefaultInfo(files = depset([out]))
+
+        capture = rule(
+            implementation = _impl,
+            attrs = {"command": attr.string(mandatory = True)},
+        )
+        """
+            .formatted(
+                isWindows() ? "C:/Windows/System32/cmd.exe" : "/bin/bash",
+                isWindows() ? "/c" : "-c"));
+    write(
+        "BUILD",
+        """
+        load(":defs.bzl", "capture")
+
+        capture(
+            name = "capture",
+            command = "%s",
+        )
+
+        capture(
+            name = "capture_empty",
+            command = "%s",
+        )
+        """
+            .formatted(
+                isWindows() ? "echo hello stdout" : "echo -n 'hello stdout'",
+                isWindows() ? "rem" : "true"));
+  }
+
+  private void assertStdoutOutputContents() throws Exception {
+    String expected = isWindows() ? "hello stdout\r\n" : "hello stdout";
+    var out = Iterables.getOnlyElement(getArtifacts("//:capture"));
+    assertThat(FileSystemUtils.readContent(out.getPath(), UTF_8)).isEqualTo(expected);
+    var emptyOut = Iterables.getOnlyElement(getArtifacts("//:capture_empty"));
+    assertThat(FileSystemUtils.readContent(emptyOut.getPath(), UTF_8)).isEmpty();
+  }
+
+  @Test
+  public void stdoutOutput_hitDiskCache() throws Exception {
+    // Arrange: Populate the disk cache from locally executed actions whose stdout is captured
+    // into an output file. The captured stdout is uploaded as the action result's stdout digest
+    // rather than as an output file.
+    setupStdoutOutputWorkspace();
+    buildTarget("//:capture", "//:capture_empty");
+    assertStdoutOutputContents();
+
+    // Act: Do a clean build.
+    cleanAndRestartServer();
+    buildTarget("//:capture", "//:capture_empty");
+
+    // Assert: Should hit the disk cache and reconstruct the stdout outputs from the stdout
+    // digests.
+    events.assertContainsInfo("2 disk cache hit");
+    assertStdoutOutputContents();
+  }
+
+  @Test
+  public void stdoutOutput_hitRemoteCache() throws Exception {
+    // Arrange: Populate the remote cache from locally executed actions whose stdout is captured
+    // into an output file.
+    setupStdoutOutputWorkspace();
+    enableRemoteCache();
+    buildTarget("//:capture", "//:capture_empty");
+    assertStdoutOutputContents();
+
+    // Act: Drop the disk cache so that the clean build can only hit the remote cache.
+    getWorkspace().getFileSystem().getPath(getDiskCacheDir()).deleteTree();
+    cleanAndRestartServer();
+    enableRemoteCache();
+    buildTarget("//:capture", "//:capture_empty");
+
+    // Assert: Should hit the remote cache and reconstruct the stdout outputs from the stdout
+    // digests.
+    events.assertContainsInfo("2 remote cache hit");
+    assertStdoutOutputContents();
   }
 
   private void doBlobsReferencedInAcAreMissingFromCas(

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -27,6 +27,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Comparator.naturalOrder;
 import static java.util.function.Function.identity;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -1806,6 +1807,32 @@ public class RemoteExecutionServiceTest {
   }
 
   @Test
+  public void downloadOutputs_stdoutOutput_downloadedAsOutputFile() throws Exception {
+    // arrange
+    Digest dOut = cache.addContents(remoteActionExecutionContext, "hello stdout");
+    ActionResult r = ActionResult.newBuilder().setExitCode(0).setStdoutDigest(dOut).build();
+    RemoteActionResult result = RemoteActionResult.createFromCache(CachedActionResult.remote(r));
+    Path path = execRoot.getRelative("outputs/stdout.txt");
+    Artifact stdoutArtifact = ActionsTestUtil.createArtifact(artifactRoot, path);
+    Spawn spawn =
+        withStdout(newSpawn(ImmutableMap.of(), ImmutableSet.of(stdoutArtifact)), stdoutArtifact);
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    when(remoteOutputChecker.shouldDownloadOutput(ArgumentMatchers.<PathFragment>any(), any()))
+        .thenReturn(true);
+
+    // act
+    service.downloadOutputs(action, result);
+
+    // assert: the captured stdout is materialized as the output file instead of being reported
+    // as regular action stdout.
+    assertThat(readContent(path, UTF_8)).isEqualTo("hello stdout");
+    assertThat(outErr.getOutputPath().exists()).isFalse();
+    assertThat(context.isLockOutputFilesCalled()).isTrue();
+  }
+
+  @Test
   public void downloadOutputs_outputNameClashesWithTempName_success() throws Exception {
     Digest d1 = cache.addContents(remoteActionExecutionContext, "content1");
     Digest d2 = cache.addContents(remoteActionExecutionContext, "content2");
@@ -2611,6 +2638,42 @@ public class RemoteExecutionServiceTest {
   }
 
   @Test
+  public void uploadOutputs_stdoutOutput_uploadedAsStdoutDigest() throws Exception {
+    // arrange
+    Digest stdoutDigest =
+        fakeFileCache.createScratchInput(
+            ActionInputHelper.fromPath("outputs/stdout.txt"), "hello stdout");
+    Path path = execRoot.getRelative("outputs/stdout.txt");
+    Artifact stdoutArtifact = ActionsTestUtil.createArtifact(artifactRoot, path);
+    Spawn spawn =
+        withStdout(newSpawn(ImmutableMap.of(), ImmutableSet.of(stdoutArtifact)), stdoutArtifact);
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    SpawnResult spawnResult =
+        new SpawnResult.Builder()
+            .setExitCode(0)
+            .setStatus(SpawnResult.Status.SUCCESS)
+            .setRunnerName("test")
+            .build();
+
+    // act
+    UploadManifest manifest = service.buildUploadManifest(action, spawnResult);
+    uploadOutputsAndWait(service, action, spawnResult);
+
+    // assert: the captured stdout is stored as the action result's stdout digest rather than as
+    // an output file, consistent with the result of a remotely executed action.
+    ActionResult.Builder expectedResult = ActionResult.newBuilder();
+    expectedResult.setStdoutDigest(stdoutDigest);
+    assertThat(manifest.getActionResult()).isEqualTo(expectedResult.build());
+    assertThat(
+            getFromFuture(
+                cache.findMissingDigests(
+                    remoteActionExecutionContext, ImmutableList.of(stdoutDigest))))
+        .isEmpty();
+  }
+
+  @Test
   public void uploadInputsIfNotPresent_deduplicateFindMissingBlobCalls() throws Exception {
     int taskCount = 100;
     ExecutorService executorService = Executors.newFixedThreadPool(taskCount);
@@ -3146,6 +3209,13 @@ public class RemoteExecutionServiceTest {
         /* inputs= */ inputs,
         /* outputs= */ outputs,
         ResourceSet.ZERO);
+  }
+
+  /** Returns a spawn that redirects its stdout into the given output. */
+  private static Spawn withStdout(Spawn spawn, Artifact stdout) {
+    Spawn spawnWithStdout = mock(Spawn.class, delegatesTo(spawn));
+    doReturn(stdout).when(spawnWithStdout).getStdout();
+    return spawnWithStdout;
   }
 
   private FakeSpawnExecutionContext newSpawnExecutionContext(Spawn spawn) {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -30,6 +30,7 @@ import static java.util.Comparator.naturalOrder;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.function.Function.identity;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -1794,6 +1795,32 @@ public class RemoteExecutionServiceTest {
   }
 
   @Test
+  public void downloadOutputs_stdoutOutput_downloadedAsOutputFile() throws Exception {
+    // arrange
+    Digest dOut = cache.addContents(remoteActionExecutionContext, "hello stdout");
+    ActionResult r = ActionResult.newBuilder().setExitCode(0).setStdoutDigest(dOut).build();
+    RemoteActionResult result = RemoteActionResult.createFromCache(CachedActionResult.remote(r));
+    Path path = execRoot.getRelative("outputs/stdout.txt");
+    Artifact stdoutArtifact = ActionsTestUtil.createArtifact(artifactRoot, path);
+    Spawn spawn =
+        withStdout(newSpawn(ImmutableMap.of(), ImmutableSet.of(stdoutArtifact)), stdoutArtifact);
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    when(remoteOutputChecker.shouldDownloadOutput(ArgumentMatchers.<PathFragment>any(), any()))
+        .thenReturn(true);
+
+    // act
+    service.downloadOutputs(action, result);
+
+    // assert: the captured stdout is materialized as the output file instead of being reported
+    // as regular action stdout.
+    assertThat(readContent(path, UTF_8)).isEqualTo("hello stdout");
+    assertThat(outErr.getOutputPath().exists()).isFalse();
+    assertThat(context.isLockOutputFilesCalled()).isTrue();
+  }
+
+  @Test
   public void downloadOutputs_outputNameClashesWithTempName_success() throws Exception {
     Digest d1 = cache.addContents(remoteActionExecutionContext, "content1");
     Digest d2 = cache.addContents(remoteActionExecutionContext, "content2");
@@ -2778,6 +2805,42 @@ public class RemoteExecutionServiceTest {
   }
 
   @Test
+  public void uploadOutputs_stdoutOutput_uploadedAsStdoutDigest() throws Exception {
+    // arrange
+    Digest stdoutDigest =
+        fakeFileCache.createScratchInput(
+            ActionInputHelper.fromPath("outputs/stdout.txt"), "hello stdout");
+    Path path = execRoot.getRelative("outputs/stdout.txt");
+    Artifact stdoutArtifact = ActionsTestUtil.createArtifact(artifactRoot, path);
+    Spawn spawn =
+        withStdout(newSpawn(ImmutableMap.of(), ImmutableSet.of(stdoutArtifact)), stdoutArtifact);
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    SpawnResult spawnResult =
+        new SpawnResult.Builder()
+            .setExitCode(0)
+            .setStatus(SpawnResult.Status.SUCCESS)
+            .setRunnerName("test")
+            .build();
+
+    // act
+    UploadManifest manifest = service.buildUploadManifest(action, spawnResult);
+    uploadOutputsAndWait(service, action, spawnResult);
+
+    // assert: the captured stdout is stored as the action result's stdout digest rather than as
+    // an output file, consistent with the result of a remotely executed action.
+    ActionResult.Builder expectedResult = ActionResult.newBuilder();
+    expectedResult.setStdoutDigest(stdoutDigest);
+    assertThat(manifest.getActionResult()).isEqualTo(expectedResult.build());
+    assertThat(
+            getFromFuture(
+                cache.findMissingDigests(
+                    remoteActionExecutionContext, ImmutableList.of(stdoutDigest))))
+        .isEmpty();
+  }
+
+  @Test
   public void uploadInputsIfNotPresent_deduplicateFindMissingBlobCalls() throws Exception {
     int taskCount = 100;
     ExecutorService executorService = Executors.newFixedThreadPool(taskCount);
@@ -3298,6 +3361,13 @@ public class RemoteExecutionServiceTest {
         /* inputs= */ inputs,
         /* outputs= */ outputs,
         ResourceSet.ZERO);
+  }
+
+  /** Returns a spawn that redirects its stdout into the given output. */
+  private static Spawn withStdout(Spawn spawn, Artifact stdout) {
+    Spawn spawnWithStdout = mock(Spawn.class, delegatesTo(spawn));
+    doReturn(stdout).when(spawnWithStdout).getStdout();
+    return spawnWithStdout;
   }
 
   private FakeSpawnExecutionContext newSpawnExecutionContext(Spawn spawn) {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -48,7 +49,10 @@ import com.google.devtools.build.lib.actions.ActionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
+import com.google.devtools.build.lib.actions.ArtifactRoot;
+import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
@@ -60,6 +64,7 @@ import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnInputs;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelperException;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
@@ -278,6 +283,33 @@ public class RemoteSpawnCacheTest {
         ResourceSet.ZERO,
         execPath ->
             execPath.subFragment(0, 1).getRelative("cfg").getRelative(execPath.subFragment(2)));
+  }
+
+  /**
+   * Returns a path mapped spawn whose only output is the given artifact, into which its standard
+   * output stream is redirected.
+   */
+  private static Spawn pathMappedSpawnWithStdout(String configSegment, Artifact stdoutOutput) {
+    SimpleSpawn spawn =
+        new SimpleSpawn(
+            new FakeOwner("Mnemonic", "Progress Message", "//dummy:label"),
+            ImmutableList.of("tool"),
+            ImmutableMap.of("VARIABLE", "value"),
+            ImmutableMap.of(ExecutionRequirements.SUPPORTS_PATH_MAPPING, ""),
+            SpawnInputs.of(
+                NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+                ImmutableList.of(
+                    ActionInputHelper.fromPath(
+                        "bazel-bin/%s/bin/input".formatted(configSegment)))),
+            /* tools= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            /* outputs= */ ImmutableSet.of(stdoutOutput),
+            /* mandatoryOutputs= */ null,
+            ResourceSet.ZERO,
+            execPath ->
+                execPath.subFragment(0, 1).getRelative("cfg").getRelative(execPath.subFragment(2)));
+    Spawn spawnWithStdout = mock(Spawn.class, delegatesTo(spawn));
+    doReturn(stdoutOutput).when(spawnWithStdout).getStdout();
+    return spawnWithStdout;
   }
 
   private ActionResult createSuccessfulResult(Spawn spawn) {
@@ -849,6 +881,72 @@ public class RemoteSpawnCacheTest {
             FileSystemUtils.readContent(
                 fs.getPath("/exec/root/bazel-bin/k8-opt/bin/output"), UTF_8))
         .isEqualTo("hello");
+    assertThat(secondCacheHandle.willStore()).isFalse();
+    onUploadComplete.get().run();
+    assertThat(cache.getInFlightExecutionsSize()).isEqualTo(0);
+  }
+
+  @Test
+  public void pathMappedActionWithStdoutIsDeduplicated() throws Exception {
+    // arrange
+    RemoteSpawnCache cache = createRemoteSpawnCache();
+
+    ArtifactRoot outputRoot = ArtifactRoot.asDerivedRoot(execRoot, RootType.OUTPUT, "bazel-bin");
+    Artifact firstStdout =
+        ActionsTestUtil.createArtifact(
+            outputRoot, execRoot.getRelative("bazel-bin/k8-fastbuild/bin/stdout"));
+    Spawn firstSpawn = pathMappedSpawnWithStdout("k8-fastbuild", firstStdout);
+    FakeActionInputFileCache firstFakeFileCache = new FakeActionInputFileCache(execRoot);
+    firstFakeFileCache.createScratchInput(
+        Iterables.getOnlyElement(firstSpawn.getInputFiles().flatten()), "xyz");
+    SpawnExecutionContext firstPolicy =
+        createSpawnExecutionContext(firstSpawn, execRoot, firstFakeFileCache, outErr);
+
+    Artifact secondStdout =
+        ActionsTestUtil.createArtifact(
+            outputRoot, execRoot.getRelative("bazel-bin/k8-opt/bin/stdout"));
+    Spawn secondSpawn = pathMappedSpawnWithStdout("k8-opt", secondStdout);
+    FakeActionInputFileCache secondFakeFileCache = new FakeActionInputFileCache(execRoot);
+    secondFakeFileCache.createScratchInput(
+        Iterables.getOnlyElement(secondSpawn.getInputFiles().flatten()), "xyz");
+    SpawnExecutionContext secondPolicy =
+        createSpawnExecutionContext(secondSpawn, execRoot, secondFakeFileCache, outErr);
+
+    RemoteExecutionService remoteExecutionService = cache.getRemoteExecutionService();
+    Mockito.doCallRealMethod().when(remoteExecutionService).waitForAndReuseOutputs(any(), any());
+    // Simulate a very slow upload to the remote cache to ensure that the second spawn is
+    // deduplicated rather than a cache hit. This is a slight hack, but also avoid introducing
+    // concurrency to this test.
+    AtomicReference<Runnable> onUploadComplete = new AtomicReference<>();
+    Mockito.doAnswer(
+            invocationOnMock -> {
+              onUploadComplete.set(invocationOnMock.getArgument(2));
+              return null;
+            })
+        .when(remoteExecutionService)
+        .uploadOutputs(any(), any(), any(), any());
+
+    // act
+    try (CacheHandle firstCacheHandle = cache.lookup(firstSpawn, firstPolicy)) {
+      FileSystemUtils.writeContent(
+          fs.getPath("/exec/root/bazel-bin/k8-fastbuild/bin/stdout"), UTF_8, "hello stdout");
+      firstCacheHandle.store(
+          new SpawnResult.Builder()
+              .setExitCode(0)
+              .setStatus(Status.SUCCESS)
+              .setRunnerName("test")
+              .build());
+    }
+    CacheHandle secondCacheHandle = cache.lookup(secondSpawn, secondPolicy);
+
+    // assert: the deduplicated spawn's stdout output is populated from the winner's captured
+    // stdout even though it is not part of the command's output paths.
+    assertThat(secondCacheHandle.hasResult()).isTrue();
+    assertThat(secondCacheHandle.getResult().getRunnerName()).isEqualTo("deduplicated");
+    assertThat(
+            FileSystemUtils.readContent(
+                fs.getPath("/exec/root/bazel-bin/k8-opt/bin/stdout"), UTF_8))
+        .isEqualTo("hello stdout");
     assertThat(secondCacheHandle.willStore()).isFalse();
     onUploadComplete.get().run();
     assertThat(cache.getInFlightExecutionsSize()).isEqualTo(0);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -48,7 +49,10 @@ import com.google.devtools.build.lib.actions.ActionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
+import com.google.devtools.build.lib.actions.ArtifactRoot;
+import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
@@ -60,6 +64,7 @@ import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnInputs;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelperException;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
@@ -277,6 +282,33 @@ public class RemoteSpawnCacheTest {
         ResourceSet.ZERO,
         execPath ->
             execPath.subFragment(0, 1).getRelative("cfg").getRelative(execPath.subFragment(2)));
+  }
+
+  /**
+   * Returns a path mapped spawn whose only output is the given artifact, into which its standard
+   * output stream is redirected.
+   */
+  private static Spawn pathMappedSpawnWithStdout(String configSegment, Artifact stdoutOutput) {
+    SimpleSpawn spawn =
+        new SimpleSpawn(
+            new FakeOwner("Mnemonic", "Progress Message", "//dummy:label"),
+            ImmutableList.of("tool"),
+            ImmutableMap.of("VARIABLE", "value"),
+            ImmutableMap.of(ExecutionRequirements.SUPPORTS_PATH_MAPPING, ""),
+            SpawnInputs.of(
+                NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+                ImmutableList.of(
+                    ActionInputHelper.fromPath(
+                        "bazel-bin/%s/bin/input".formatted(configSegment)))),
+            /* tools= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            /* outputs= */ ImmutableSet.of(stdoutOutput),
+            /* mandatoryOutputs= */ null,
+            ResourceSet.ZERO,
+            execPath ->
+                execPath.subFragment(0, 1).getRelative("cfg").getRelative(execPath.subFragment(2)));
+    Spawn spawnWithStdout = mock(Spawn.class, delegatesTo(spawn));
+    doReturn(stdoutOutput).when(spawnWithStdout).getStdout();
+    return spawnWithStdout;
   }
 
   private ActionResult createSuccessfulResult(Spawn spawn) {
@@ -848,6 +880,72 @@ public class RemoteSpawnCacheTest {
             FileSystemUtils.readContent(
                 fs.getPath("/exec/root/bazel-bin/k8-opt/bin/output"), UTF_8))
         .isEqualTo("hello");
+    assertThat(secondCacheHandle.willStore()).isFalse();
+    onUploadComplete.get().run();
+    assertThat(cache.getInFlightExecutionsSize()).isEqualTo(0);
+  }
+
+  @Test
+  public void pathMappedActionWithStdoutIsDeduplicated() throws Exception {
+    // arrange
+    RemoteSpawnCache cache = createRemoteSpawnCache();
+
+    ArtifactRoot outputRoot = ArtifactRoot.asDerivedRoot(execRoot, RootType.OUTPUT, "bazel-bin");
+    Artifact firstStdout =
+        ActionsTestUtil.createArtifact(
+            outputRoot, execRoot.getRelative("bazel-bin/k8-fastbuild/bin/stdout"));
+    Spawn firstSpawn = pathMappedSpawnWithStdout("k8-fastbuild", firstStdout);
+    FakeActionInputFileCache firstFakeFileCache = new FakeActionInputFileCache(execRoot);
+    firstFakeFileCache.createScratchInput(
+        Iterables.getOnlyElement(firstSpawn.getInputFiles().flatten()), "xyz");
+    SpawnExecutionContext firstPolicy =
+        createSpawnExecutionContext(firstSpawn, execRoot, firstFakeFileCache, outErr);
+
+    Artifact secondStdout =
+        ActionsTestUtil.createArtifact(
+            outputRoot, execRoot.getRelative("bazel-bin/k8-opt/bin/stdout"));
+    Spawn secondSpawn = pathMappedSpawnWithStdout("k8-opt", secondStdout);
+    FakeActionInputFileCache secondFakeFileCache = new FakeActionInputFileCache(execRoot);
+    secondFakeFileCache.createScratchInput(
+        Iterables.getOnlyElement(secondSpawn.getInputFiles().flatten()), "xyz");
+    SpawnExecutionContext secondPolicy =
+        createSpawnExecutionContext(secondSpawn, execRoot, secondFakeFileCache, outErr);
+
+    RemoteExecutionService remoteExecutionService = cache.getRemoteExecutionService();
+    Mockito.doCallRealMethod().when(remoteExecutionService).waitForAndReuseOutputs(any(), any());
+    // Simulate a very slow upload to the remote cache to ensure that the second spawn is
+    // deduplicated rather than a cache hit. This is a slight hack, but also avoid introducing
+    // concurrency to this test.
+    AtomicReference<Runnable> onUploadComplete = new AtomicReference<>();
+    Mockito.doAnswer(
+            invocationOnMock -> {
+              onUploadComplete.set(invocationOnMock.getArgument(2));
+              return null;
+            })
+        .when(remoteExecutionService)
+        .uploadOutputs(any(), any(), any(), any());
+
+    // act
+    try (CacheHandle firstCacheHandle = cache.lookup(firstSpawn, firstPolicy)) {
+      FileSystemUtils.writeContent(
+          fs.getPath("/exec/root/bazel-bin/k8-fastbuild/bin/stdout"), UTF_8, "hello stdout");
+      firstCacheHandle.store(
+          new SpawnResult.Builder()
+              .setExitCode(0)
+              .setStatus(Status.SUCCESS)
+              .setRunnerName("test")
+              .build());
+    }
+    CacheHandle secondCacheHandle = cache.lookup(secondSpawn, secondPolicy);
+
+    // assert: the deduplicated spawn's stdout output is populated from the winner's captured
+    // stdout even though it is not part of the command's output paths.
+    assertThat(secondCacheHandle.hasResult()).isTrue();
+    assertThat(secondCacheHandle.getResult().getRunnerName()).isEqualTo("deduplicated");
+    assertThat(
+            FileSystemUtils.readContent(
+                fs.getPath("/exec/root/bazel-bin/k8-opt/bin/stdout"), UTF_8))
+        .isEqualTo("hello stdout");
     assertThat(secondCacheHandle.willStore()).isFalse();
     onUploadComplete.get().run();
     assertThat(cache.getInFlightExecutionsSize()).isEqualTo(0);

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
@@ -40,6 +40,7 @@ import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.PathMapper;
+import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.analysis.CommandHelper;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
@@ -361,6 +362,106 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
     assertArtifactFilenames(action.getInputs().toList(), "a.txt", "b.img", "t.exe");
     assertArtifactFilenames(action.getOutputs(), "a.txt", "b.img");
     MoreAsserts.assertContainsSublist(action.getArguments(), "foo/t.exe", "--a", "--b");
+  }
+
+  @Test
+  public void testCreateSpawnActionWithStdout() throws Exception {
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+    ev.exec(
+        "out = ruleContext.actions.declare_file('stdout.txt')",
+        "ruleContext.actions.run(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = ruleContext.files.srcs,",
+        "  executable = ruleContext.files.tools[0],",
+        "  toolchain = None,",
+        "  stdout = out)");
+    SpawnAction action =
+        (SpawnAction)
+            Iterables.getOnlyElement(
+                ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
+
+    assertArtifactFilenames(action.getOutputs(), "a.txt", "b.img", "stdout.txt");
+    Artifact stdoutOutput = action.getStdoutOutput();
+    assertThat(stdoutOutput).isNotNull();
+    assertThat(stdoutOutput.getFilename()).isEqualTo("stdout.txt");
+
+    Spawn spawn = action.getSpawnForTesting();
+    assertThat(spawn.getOutputFiles()).contains(stdoutOutput);
+    assertThat(spawn.getStdout()).isEqualTo(stdoutOutput);
+  }
+
+  @Test
+  public void testCreateSpawnActionWithStdoutOnlyOutput() throws Exception {
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+    // An empty 'outputs' is allowed as long as 'stdout' provides an output.
+    ev.exec(
+        "out = ruleContext.actions.declare_file('stdout.txt')",
+        "ruleContext.actions.run(",
+        "  outputs = [],",
+        "  executable = ruleContext.files.tools[0],",
+        "  toolchain = None,",
+        "  stdout = out)");
+    SpawnAction action =
+        (SpawnAction)
+            Iterables.getOnlyElement(
+                ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
+    assertArtifactFilenames(action.getOutputs(), "stdout.txt");
+    assertThat(action.getStdoutOutput()).isEqualTo(action.getPrimaryOutput());
+  }
+
+  @Test
+  public void testCreateSpawnActionStdoutAlsoInOutputsFails() throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+    ev.checkEvalErrorContains(
+        "may not also be listed in 'outputs'",
+        "out = ruleContext.actions.declare_file('stdout.txt')",
+        "ruleContext.actions.run(",
+        "  outputs = [out],",
+        "  executable = ruleContext.files.tools[0],",
+        "  toolchain = None,",
+        "  stdout = out)");
+  }
+
+  @Test
+  public void testCreateSpawnActionStdoutWrongType() throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+    ev.checkEvalErrorContains(
+        "parameter 'stdout' got value of type 'string', want 'File or NoneType'",
+        "ruleContext.actions.run(",
+        "  outputs = ruleContext.files.srcs,",
+        "  executable = ruleContext.files.tools[0],",
+        "  toolchain = None,",
+        "  stdout = 'not_a_file')");
+  }
+
+  @Test
+  public void testCreateSpawnActionStdoutWithWorkerFails() throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+    ev.checkEvalErrorContains(
+        "parameter 'stdout' of actions.run is incompatible with worker execution",
+        "out = ruleContext.actions.declare_file('stdout.txt')",
+        "ruleContext.actions.run(",
+        "  outputs = [],",
+        "  executable = ruleContext.files.tools[0],",
+        "  toolchain = None,",
+        "  execution_requirements = {'supports-workers': '1'},",
+        "  stdout = out)");
+  }
+
+  @Test
+  public void testCreateSpawnActionStdoutWithMultiplexWorkerFails() throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+    ev.checkEvalErrorContains(
+        "parameter 'stdout' of actions.run is incompatible with worker execution",
+        "out = ruleContext.actions.declare_file('stdout.txt')",
+        "ruleContext.actions.run(",
+        "  outputs = [],",
+        "  executable = ruleContext.files.tools[0],",
+        "  toolchain = None,",
+        "  execution_requirements = {'supports-multiplex-workers': '1'},",
+        "  stdout = out)");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
@@ -40,6 +40,7 @@ import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.PathMapper;
+import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.analysis.CommandHelper;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
@@ -363,6 +364,106 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
     assertArtifactFilenames(action.getInputs().toList(), "a.txt", "b.img", "t.exe");
     assertArtifactFilenames(action.getOutputs(), "a.txt", "b.img");
     MoreAsserts.assertContainsSublist(action.getArguments(), "foo/t.exe", "--a", "--b");
+  }
+
+  @Test
+  public void testCreateSpawnActionWithStdout() throws Exception {
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+    ev.exec(
+        "out = ruleContext.actions.declare_file('stdout.txt')",
+        "ruleContext.actions.run(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = ruleContext.files.srcs,",
+        "  executable = ruleContext.files.tools[0],",
+        "  toolchain = None,",
+        "  stdout = out)");
+    SpawnAction action =
+        (SpawnAction)
+            Iterables.getOnlyElement(
+                ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
+
+    assertArtifactFilenames(action.getOutputs(), "a.txt", "b.img", "stdout.txt");
+    Artifact stdoutOutput = action.getStdoutOutput();
+    assertThat(stdoutOutput).isNotNull();
+    assertThat(stdoutOutput.getFilename()).isEqualTo("stdout.txt");
+
+    Spawn spawn = action.getSpawnForTesting();
+    assertThat(spawn.getOutputFiles()).contains(stdoutOutput);
+    assertThat(spawn.getStdout()).isEqualTo(stdoutOutput);
+  }
+
+  @Test
+  public void testCreateSpawnActionWithStdoutOnlyOutput() throws Exception {
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+    // An empty 'outputs' is allowed as long as 'stdout' provides an output.
+    ev.exec(
+        "out = ruleContext.actions.declare_file('stdout.txt')",
+        "ruleContext.actions.run(",
+        "  outputs = [],",
+        "  executable = ruleContext.files.tools[0],",
+        "  toolchain = None,",
+        "  stdout = out)");
+    SpawnAction action =
+        (SpawnAction)
+            Iterables.getOnlyElement(
+                ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
+    assertArtifactFilenames(action.getOutputs(), "stdout.txt");
+    assertThat(action.getStdoutOutput()).isEqualTo(action.getPrimaryOutput());
+  }
+
+  @Test
+  public void testCreateSpawnActionStdoutAlsoInOutputsFails() throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+    ev.checkEvalErrorContains(
+        "may not also be listed in 'outputs'",
+        "out = ruleContext.actions.declare_file('stdout.txt')",
+        "ruleContext.actions.run(",
+        "  outputs = [out],",
+        "  executable = ruleContext.files.tools[0],",
+        "  toolchain = None,",
+        "  stdout = out)");
+  }
+
+  @Test
+  public void testCreateSpawnActionStdoutWrongType() throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+    ev.checkEvalErrorContains(
+        "parameter 'stdout' got value of type 'string', want 'File or NoneType'",
+        "ruleContext.actions.run(",
+        "  outputs = ruleContext.files.srcs,",
+        "  executable = ruleContext.files.tools[0],",
+        "  toolchain = None,",
+        "  stdout = 'not_a_file')");
+  }
+
+  @Test
+  public void testCreateSpawnActionStdoutWithWorkerFails() throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+    ev.checkEvalErrorContains(
+        "parameter 'stdout' of actions.run is incompatible with worker execution",
+        "out = ruleContext.actions.declare_file('stdout.txt')",
+        "ruleContext.actions.run(",
+        "  outputs = [],",
+        "  executable = ruleContext.files.tools[0],",
+        "  toolchain = None,",
+        "  execution_requirements = {'supports-workers': '1'},",
+        "  stdout = out)");
+  }
+
+  @Test
+  public void testCreateSpawnActionStdoutWithMultiplexWorkerFails() throws Exception {
+    setRuleContext(createRuleContext("//foo:foo"));
+    ev.checkEvalErrorContains(
+        "parameter 'stdout' of actions.run is incompatible with worker execution",
+        "out = ruleContext.actions.declare_file('stdout.txt')",
+        "ruleContext.actions.run(",
+        "  outputs = [],",
+        "  executable = ruleContext.files.tools[0],",
+        "  toolchain = None,",
+        "  execution_requirements = {'supports-multiplex-workers': '1'},",
+        "  stdout = out)");
   }
 
   @Test

--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -44,6 +44,13 @@ py_library(
 )
 
 py_test(
+    name = "action_stdout_test",
+    size = "medium",
+    srcs = ["action_stdout_test.py"],
+    deps = [":test_base"],
+)
+
+py_test(
     name = "action_temp_test",
     size = "medium",
     srcs = ["action_temp_test.py"],

--- a/src/test/py/bazel/action_stdout_test.py
+++ b/src/test/py/bazel/action_stdout_test.py
@@ -1,0 +1,122 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests the `stdout` parameter of ctx.actions.run under local execution."""
+
+import os
+from absl.testing import absltest
+from src.test.py.bazel import test_base
+
+
+class ActionStdoutTest(test_base.TestBase):
+  """Tests that ctx.actions.run captures stdout under unsandboxed local execution."""
+
+  def _CreateWorkspace(self):
+    if test_base.TestBase.IsWindows():
+      toolname = 'tool.cmd'
+      toolsrc = [
+          '@echo off',
+          'echo hello-from-stdout',
+          'echo hello-from-stderr 1>&2',
+          'if "%1"=="fail" exit /B 1',
+          'exit /B 0',
+      ]
+    else:
+      toolname = 'tool.sh'
+      toolsrc = [
+          '#!/bin/bash',
+          'echo hello-from-stdout',
+          'echo hello-from-stderr 1>&2',
+          'if [ "$1" = "fail" ]; then exit 1; fi',
+      ]
+
+    self.ScratchFile('MODULE.bazel')
+    self.ScratchFile('foo/' + toolname, toolsrc, executable=True)
+    self.ScratchFile(
+        'foo/defs.bzl',
+        [
+            'def _impl(ctx):',
+            '    out = ctx.actions.declare_file(ctx.attr.name + ".out")',
+            '    ctx.actions.run(',
+            '        outputs = [],',
+            '        executable = ctx.executable.tool,',
+            '        arguments = [ctx.attr.mode],',
+            '        stdout = out,',
+            '        mnemonic = "Capture",',
+            '    )',
+            '    return [DefaultInfo(files = depset([out]))]',
+            '',
+            'capture = rule(',
+            '    implementation = _impl,',
+            '    attrs = {',
+            '        "mode": attr.string(default = "ok"),',
+            '        "tool": attr.label(',
+            '            allow_single_file = True,',
+            '            executable = True,',
+            '            cfg = "exec",',
+            '        ),',
+            '    },',
+            ')',
+        ],
+    )
+    self.ScratchFile(
+        'foo/BUILD',
+        [
+            'load(":defs.bzl", "capture")',
+            '',
+            'capture(',
+            '    name = "captured",',
+            '    tool = "%s",' % toolname,
+            ')',
+            '',
+            'capture(',
+            '    name = "captured_fail",',
+            '    mode = "fail",',
+            '    tool = "%s",' % toolname,
+            ')',
+        ],
+    )
+
+  def testStdoutCaptured(self):
+    self._CreateWorkspace()
+    _, stdout, stderr = self.RunBazel(
+        ['build', '--spawn_strategy=standalone', '//foo:captured']
+    )
+    output = '\n'.join(stdout + stderr)
+    # The tool's stderr is reported as regular action output, but its stdout
+    # is captured into the output file instead.
+    self.assertIn('hello-from-stderr', output)
+    self.assertNotIn('hello-from-stdout', output)
+
+    _, stdout, _ = self.RunBazel(['info', 'bazel-bin'])
+    bazel_bin = stdout[0]
+    self.AssertFileContentContains(
+        os.path.join(bazel_bin, 'foo', 'captured.out'), 'hello-from-stdout'
+    )
+
+  def testFailingActionDoesNotReportCapturedStdout(self):
+    self._CreateWorkspace()
+    exit_code, stdout, stderr = self.RunBazel(
+        ['build', '--spawn_strategy=standalone', '//foo:captured_fail'],
+        allow_failure=True,
+    )
+    self.AssertNotExitCode(exit_code, 0, stderr)
+    output = '\n'.join(stdout + stderr)
+    # The failing action's stderr is reported as usual, but its captured
+    # stdout is not.
+    self.assertIn('hello-from-stderr', output)
+    self.assertNotIn('hello-from-stdout', output)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -1528,5 +1528,206 @@ EOF
   [[ $exit_code -eq 0 ]] || fail "Expected success"
 }
 
+function test_path_stripping_stdout_capture() {
+  if is_windows; then
+    echo "Skipping test_path_stripping_stdout_capture on Windows as it requires sandboxing"
+    return
+  fi
+
+  mkdir -p pkg
+  cat > pkg/defs.bzl <<'EOF'
+def _gen_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".txt")
+    ctx.actions.write(out, "hello-from-stdout")
+    return [DefaultInfo(files = depset([out]))]
+
+gen = rule(implementation = _gen_impl)
+
+def _capture_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".out")
+    args = ctx.actions.args()
+    args.add(ctx.files.src[0])
+    ctx.actions.run(
+        outputs = [],
+        inputs = ctx.files.src,
+        executable = ctx.executable.tool,
+        arguments = [args],
+        stdout = out,
+        mnemonic = "Capture",
+        execution_requirements = {"supports-path-mapping": ""},
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+capture = rule(
+    implementation = _capture_impl,
+    attrs = {
+        "src": attr.label(allow_files = True, mandatory = True),
+        "tool": attr.label(
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+EOF
+
+  cat > pkg/cat_tool.sh <<'EOF'
+#!/bin/bash
+cat "$1"
+EOF
+  chmod +x pkg/cat_tool.sh
+
+  cat > pkg/BUILD <<'EOF'
+load(":defs.bzl", "capture", "gen")
+
+gen(name = "gen")
+
+capture(
+    name = "captured",
+    src = ":gen",
+    tool = "cat_tool.sh",
+)
+
+COMMAND = """
+[[ "$$(cat $(execpaths :captured))" == "hello-from-stdout" ]] || exit 1
+touch $@
+"""
+
+genrule(
+    name = "validate_target",
+    outs = ["out_target"],
+    cmd = COMMAND,
+    srcs = [":captured"],
+)
+
+genrule(
+    name = "validate_exec",
+    outs = ["out_exec"],
+    cmd = COMMAND,
+    tools = [":captured"],
+)
+EOF
+
+  # The Capture action takes the generated gen.txt as an input whose
+  # config-dependent path appears in its arguments, so its cache key only
+  # matches across configurations with path stripping.
+  bazel build \
+    --experimental_output_paths=strip \
+    --remote_cache=grpc://localhost:${worker_port} \
+    //pkg:validate_target &> $TEST_log || fail "build failed unexpectedly"
+  expect_not_log 'remote cache hit'
+  # The tool's stdout is captured into the output, not reported as regular
+  # action output.
+  expect_not_log 'hello-from-stdout'
+
+  bazel build \
+    --experimental_output_paths=strip \
+    --remote_cache=grpc://localhost:${worker_port} \
+    //pkg:validate_exec &> $TEST_log || fail "build failed unexpectedly"
+  # The Capture action in the exec configuration gets a cache hit thanks to
+  # path stripping, with its stdout reconstructed at the exec config's output
+  # path (validated by the genrule).
+  expect_log '1 remote cache hit'
+  expect_not_log 'hello-from-stdout'
+}
+
+function test_path_stripping_deduplicated_action_with_stdout_capture() {
+  if is_windows; then
+    echo "Skipping test_path_stripping_deduplicated_action_with_stdout_capture on Windows as it requires sandboxing"
+    return
+  fi
+
+  mkdir -p pkg
+  cat > pkg/defs.bzl <<'EOF'
+def _gen_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".txt")
+    ctx.actions.write(out, "hello-from-stdout")
+    return [DefaultInfo(files = depset([out]))]
+
+gen = rule(implementation = _gen_impl)
+
+def _capture_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".out")
+    args = ctx.actions.args()
+    args.add(ctx.files.src[0])
+    ctx.actions.run(
+        outputs = [],
+        inputs = ctx.files.src,
+        executable = ctx.executable.tool,
+        arguments = [args],
+        stdout = out,
+        mnemonic = "Capture",
+        execution_requirements = {"supports-path-mapping": ""},
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+capture = rule(
+    implementation = _capture_impl,
+    attrs = {
+        "src": attr.label(allow_files = True, mandatory = True),
+        "tool": attr.label(
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+EOF
+
+  cat > pkg/slow_cat_tool.sh <<'EOF'
+#!/bin/bash
+# Sleep to ensure that the two Capture actions are scheduled in parallel.
+sleep 3
+cat "$1"
+EOF
+  chmod +x pkg/slow_cat_tool.sh
+
+  cat > pkg/BUILD <<'EOF'
+load(":defs.bzl", "capture", "gen")
+
+gen(name = "gen")
+
+capture(
+    name = "captured",
+    src = ":gen",
+    tool = "slow_cat_tool.sh",
+)
+
+COMMAND = """
+[[ "$$(cat $(execpaths :captured))" == "hello-from-stdout" ]] || exit 1
+touch $@
+"""
+
+genrule(
+    name = "validate_target",
+    outs = ["out_target"],
+    cmd = COMMAND,
+    srcs = [":captured"],
+)
+
+genrule(
+    name = "validate_exec",
+    outs = ["out_exec"],
+    cmd = COMMAND,
+    tools = [":captured"],
+)
+EOF
+
+  # Both Capture actions (target and exec configuration) run in parallel and
+  # have identical cache keys under path stripping.
+  bazel build \
+    --experimental_output_paths=strip \
+    --remote_cache=grpc://localhost:${worker_port} \
+    //pkg:validate_target //pkg:validate_exec &> $TEST_log \
+    || fail "build failed unexpectedly"
+  # One of the two Capture actions is deduplicated against the other, with its
+  # stdout output populated from the winner's captured stdout (validated by
+  # the genrules).
+  expect_log '1 deduplicated'
+  # The captured stdout is not reported as regular action output, not even for
+  # the deduplicated action.
+  expect_not_log 'hello-from-stdout'
+}
+
 
 run_suite "path mapping tests"

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -1531,5 +1531,206 @@ EOF
   [[ $exit_code -eq 0 ]] || fail "Expected success"
 }
 
+function test_path_stripping_stdout_capture() {
+  if is_windows; then
+    echo "Skipping test_path_stripping_stdout_capture on Windows as it requires sandboxing"
+    return
+  fi
+
+  mkdir -p pkg
+  cat > pkg/defs.bzl <<'EOF'
+def _gen_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".txt")
+    ctx.actions.write(out, "hello-from-stdout")
+    return [DefaultInfo(files = depset([out]))]
+
+gen = rule(implementation = _gen_impl)
+
+def _capture_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".out")
+    args = ctx.actions.args()
+    args.add(ctx.files.src[0])
+    ctx.actions.run(
+        outputs = [],
+        inputs = ctx.files.src,
+        executable = ctx.executable.tool,
+        arguments = [args],
+        stdout = out,
+        mnemonic = "Capture",
+        execution_requirements = {"supports-path-mapping": ""},
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+capture = rule(
+    implementation = _capture_impl,
+    attrs = {
+        "src": attr.label(allow_files = True, mandatory = True),
+        "tool": attr.label(
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+EOF
+
+  cat > pkg/cat_tool.sh <<'EOF'
+#!/bin/bash
+cat "$1"
+EOF
+  chmod +x pkg/cat_tool.sh
+
+  cat > pkg/BUILD <<'EOF'
+load(":defs.bzl", "capture", "gen")
+
+gen(name = "gen")
+
+capture(
+    name = "captured",
+    src = ":gen",
+    tool = "cat_tool.sh",
+)
+
+COMMAND = """
+[[ "$$(cat $(execpaths :captured))" == "hello-from-stdout" ]] || exit 1
+touch $@
+"""
+
+genrule(
+    name = "validate_target",
+    outs = ["out_target"],
+    cmd = COMMAND,
+    srcs = [":captured"],
+)
+
+genrule(
+    name = "validate_exec",
+    outs = ["out_exec"],
+    cmd = COMMAND,
+    tools = [":captured"],
+)
+EOF
+
+  # The Capture action takes the generated gen.txt as an input whose
+  # config-dependent path appears in its arguments, so its cache key only
+  # matches across configurations with path stripping.
+  bazel build \
+    --experimental_output_paths=strip \
+    --remote_cache=grpc://localhost:${worker_port} \
+    //pkg:validate_target &> $TEST_log || fail "build failed unexpectedly"
+  expect_not_log 'remote cache hit'
+  # The tool's stdout is captured into the output, not reported as regular
+  # action output.
+  expect_not_log 'hello-from-stdout'
+
+  bazel build \
+    --experimental_output_paths=strip \
+    --remote_cache=grpc://localhost:${worker_port} \
+    //pkg:validate_exec &> $TEST_log || fail "build failed unexpectedly"
+  # The Capture action in the exec configuration gets a cache hit thanks to
+  # path stripping, with its stdout reconstructed at the exec config's output
+  # path (validated by the genrule).
+  expect_log '1 remote cache hit'
+  expect_not_log 'hello-from-stdout'
+}
+
+function test_path_stripping_deduplicated_action_with_stdout_capture() {
+  if is_windows; then
+    echo "Skipping test_path_stripping_deduplicated_action_with_stdout_capture on Windows as it requires sandboxing"
+    return
+  fi
+
+  mkdir -p pkg
+  cat > pkg/defs.bzl <<'EOF'
+def _gen_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".txt")
+    ctx.actions.write(out, "hello-from-stdout")
+    return [DefaultInfo(files = depset([out]))]
+
+gen = rule(implementation = _gen_impl)
+
+def _capture_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".out")
+    args = ctx.actions.args()
+    args.add(ctx.files.src[0])
+    ctx.actions.run(
+        outputs = [],
+        inputs = ctx.files.src,
+        executable = ctx.executable.tool,
+        arguments = [args],
+        stdout = out,
+        mnemonic = "Capture",
+        execution_requirements = {"supports-path-mapping": ""},
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+capture = rule(
+    implementation = _capture_impl,
+    attrs = {
+        "src": attr.label(allow_files = True, mandatory = True),
+        "tool": attr.label(
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+EOF
+
+  cat > pkg/slow_cat_tool.sh <<'EOF'
+#!/bin/bash
+# Sleep to ensure that the two Capture actions are scheduled in parallel.
+sleep 3
+cat "$1"
+EOF
+  chmod +x pkg/slow_cat_tool.sh
+
+  cat > pkg/BUILD <<'EOF'
+load(":defs.bzl", "capture", "gen")
+
+gen(name = "gen")
+
+capture(
+    name = "captured",
+    src = ":gen",
+    tool = "slow_cat_tool.sh",
+)
+
+COMMAND = """
+[[ "$$(cat $(execpaths :captured))" == "hello-from-stdout" ]] || exit 1
+touch $@
+"""
+
+genrule(
+    name = "validate_target",
+    outs = ["out_target"],
+    cmd = COMMAND,
+    srcs = [":captured"],
+)
+
+genrule(
+    name = "validate_exec",
+    outs = ["out_exec"],
+    cmd = COMMAND,
+    tools = [":captured"],
+)
+EOF
+
+  # Both Capture actions (target and exec configuration) run in parallel and
+  # have identical cache keys under path stripping.
+  bazel build \
+    --experimental_output_paths=strip \
+    --remote_cache=grpc://localhost:${worker_port} \
+    //pkg:validate_target //pkg:validate_exec &> $TEST_log \
+    || fail "build failed unexpectedly"
+  # One of the two Capture actions is deduplicated against the other, with its
+  # stdout output populated from the winner's captured stdout (validated by
+  # the genrules).
+  expect_log '1 deduplicated'
+  # The captured stdout is not reported as regular action output, not even for
+  # the deduplicated action.
+  expect_not_log 'hello-from-stdout'
+}
+
 
 run_suite "path mapping tests"

--- a/src/test/shell/bazel/starlark_rule_test.sh
+++ b/src/test/shell/bazel/starlark_rule_test.sh
@@ -138,4 +138,98 @@ EOF
   rm BUILD bin.sh foo.bzl
 }
 
+# Writes a package with a rule that captures the stdout of a tool via the
+# `stdout` parameter of ctx.actions.run and a rule that consumes the captured
+# output in a downstream action.
+function setup_stdout_capture() {
+  mkdir -p pkg
+  cat > pkg/defs.bzl <<'EOF'
+def _capture_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".out")
+    ctx.actions.run(
+        outputs = [],
+        executable = ctx.executable.tool,
+        arguments = [ctx.attr.text],
+        stdout = out,
+        mnemonic = "Capture",
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+capture = rule(
+    implementation = _capture_impl,
+    attrs = {
+        "text": attr.string(mandatory = True),
+        "tool": attr.label(
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+
+def _consume_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".copy")
+    ctx.actions.run_shell(
+        inputs = ctx.files.src,
+        outputs = [out],
+        command = "cp \"$1\" \"$2\"",
+        arguments = [ctx.files.src[0].path, out.path],
+        mnemonic = "Consume",
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+consume = rule(
+    implementation = _consume_impl,
+    attrs = {"src": attr.label(allow_files = True, mandatory = True)},
+)
+EOF
+
+  cat > pkg/echo_tool.sh <<'EOF'
+#!/usr/bin/env bash
+printf '%s' "$1"
+EOF
+  chmod +x pkg/echo_tool.sh
+
+  cat > pkg/BUILD <<'EOF'
+load(":defs.bzl", "capture", "consume")
+
+capture(
+    name = "captured",
+    text = "hello-from-stdout",
+    tool = "echo_tool.sh",
+)
+
+consume(
+    name = "consumed",
+    src = ":captured",
+)
+EOF
+}
+
+function do_test_stdout_capture() {
+  setup_stdout_capture
+  bazel build //pkg:captured "$@" &> $TEST_log || fail "build failed"
+  assert_equals "hello-from-stdout" "$(cat bazel-bin/pkg/captured.out)"
+  # The captured stdout is not reported as regular action output.
+  expect_not_log "hello-from-stdout"
+}
+
+function test_actions_run_stdout_capture() {
+  do_test_stdout_capture
+}
+
+function test_actions_run_stdout_capture_local() {
+  do_test_stdout_capture --spawn_strategy=local
+}
+
+function test_actions_run_stdout_capture_sandboxed() {
+  do_test_stdout_capture --spawn_strategy=sandboxed
+}
+
+function test_actions_run_stdout_output_consumed_by_downstream_action() {
+  setup_stdout_capture
+  bazel build //pkg:consumed &> $TEST_log || fail "build failed"
+  assert_equals "hello-from-stdout" "$(cat bazel-bin/pkg/consumed.copy)"
+}
+
 run_suite "Starlark rule definition tests"


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
When the new `stdout` parameter of `ctx.actions.run` is set, the stdout of the action is stored in the given file rather than printed in the terminal and reported via the BES. The file is otherwise an ordinary action output and follows BwoB download patterns. Since persistent worker communicate via stdout, actions that opt into them are not allowed to set `stdout`.

Note that adding `stdout` only was the uncontentious part of #5511 as it avoids any discussion of how `stdout` and `stderr` would behave if set to the same file (merging is not supported with remote execution etc.). The current PR does not make it harder to support `stderr` if needed in the future.

### Motivation
Tools commonly emit useful output to `stdout` and going through `ctx.actions.run_shell` just to capture it is overkill and has a worse hermeticity story (dependency on a shell, which is problematic in cross-platform build cases).

Implements the most important part of #5511.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:

-->

Yes:
1. Has this been discussed in a design doc or issue? 
#5511, where the stdout case has seen unanimous support.
3. Is the change backward compatible?
Yes, it's a new parameter.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES[NEW]: `ctx.actions.run` now supports redirecting stdout to a file via the new `stdout` parameter.
