### PR TITLE
Reuse fresh stats when manually computing file digests

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -357,6 +357,10 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
       return new DirectoryArtifactValue(path.getLastModifiedTime());
     }
     if (digest == null) {
+      if (stat == null && proxy != null) {
+        // The proxy preserves the components of the stat that make up the digest cache key.
+        stat = proxy.asFileStatus(size);
+      }
       digest = DigestUtils.getDigestWithManualFallback(path, xattrProvider, stat);
     }
     checkState(digest != null, path);
@@ -384,16 +388,21 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
   /**
    * Create a FileArtifactValue using the {@link Path} and size. FileArtifactValue#create will
    * handle getting the digest using the Path and size values.
+   *
+   * <p>If a {@link FileContentsProxy} for the current state of the file is available, it is used to
+   * look up the digest in the digest cache without an additional stat, but is not retained in the
+   * returned metadata.
    */
   public static FileArtifactValue createForNormalFileUsingPath(
-      Path path, long size, XattrProvider xattrProvider) throws IOException {
+      Path path, long size, @Nullable FileContentsProxy proxy, XattrProvider xattrProvider)
+      throws IOException {
     return create(
         path,
         /* isFile= */ true,
         size,
         /* proxy= */ null,
         /* digest= */ null,
-        /* stat= */ null,
+        /* stat= */ proxy != null ? proxy.asFileStatus(size) : null,
         xattrProvider);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -307,6 +307,7 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
         isFile ? fileValue.getSize() : 0,
         isFile ? fileValue.realFileStateValue().getContentsProxy() : null,
         isFile ? fileValue.getDigest() : null,
+        /* stat= */ null,
         xattrProvider);
   }
 
@@ -336,6 +337,7 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
         stat.getSize(),
         FileContentsProxy.create(stat),
         stat instanceof FileStatusWithDigest statWithDigest ? statWithDigest.getDigest() : null,
+        stat,
         xattrProvider);
   }
 
@@ -345,6 +347,7 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
       long size,
       FileContentsProxy proxy,
       @Nullable byte[] digest,
+      @Nullable FileStatus stat,
       XattrProvider xattrProvider)
       throws IOException {
     if (!isFile) {
@@ -354,7 +357,7 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
       return new DirectoryArtifactValue(path.getLastModifiedTime());
     }
     if (digest == null) {
-      digest = DigestUtils.getDigestWithManualFallback(path, xattrProvider);
+      digest = DigestUtils.getDigestWithManualFallback(path, xattrProvider, stat);
     }
     checkState(digest != null, path);
     return createForNormalFile(digest, proxy, size);
@@ -385,7 +388,13 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
   public static FileArtifactValue createForNormalFileUsingPath(
       Path path, long size, XattrProvider xattrProvider) throws IOException {
     return create(
-        path, /* isFile= */ true, size, /* proxy= */ null, /* digest= */ null, xattrProvider);
+        path,
+        /* isFile= */ true,
+        size,
+        /* proxy= */ null,
+        /* digest= */ null,
+        /* stat= */ null,
+        xattrProvider);
   }
 
   public static FileArtifactValue createForDirectoryWithHash(byte[] digest) {

--- a/src/main/java/com/google/devtools/build/lib/actions/FileContentsProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileContentsProxy.java
@@ -88,6 +88,54 @@ public final class FileContentsProxy {
     fp.addLong(nodeId);
   }
 
+  /**
+   * Returns a {@link FileStatus} for a regular file of the given size with this proxy's timestamps
+   * and node id.
+   */
+  public FileStatus asFileStatus(long size) {
+    return new FileStatus() {
+      @Override
+      public boolean isFile() {
+        return true;
+      }
+
+      @Override
+      public boolean isDirectory() {
+        return false;
+      }
+
+      @Override
+      public boolean isSymbolicLink() {
+        return false;
+      }
+
+      @Override
+      public boolean isSpecialFile() {
+        return false;
+      }
+
+      @Override
+      public long getSize() {
+        return size;
+      }
+
+      @Override
+      public long getLastModifiedTime() {
+        return mtime;
+      }
+
+      @Override
+      public long getLastChangeTime() {
+        return ctime;
+      }
+
+      @Override
+      public long getNodeId() {
+        return nodeId;
+      }
+    };
+  }
+
   @Override
   public String toString() {
     return prettyPrint();

--- a/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.analysis.RunfilesSupport;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue.RunfileSymlinksMode;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.DigestUtils;
+import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Symlinks;
@@ -105,7 +106,8 @@ public class RunfilesTreeUpdater {
     Path runfilesDir = execRoot.getRelative(tree.getExecPath());
     Path inputManifest =
         execRoot.getRelative(RunfilesSupport.inputManifestExecPath(tree.getExecPath()));
-    if (!inputManifest.exists()) {
+    FileStatus inputManifestStatus = inputManifest.statNullable(Symlinks.FOLLOW);
+    if (inputManifestStatus == null) {
       return;
     }
     Path outputManifest =
@@ -120,11 +122,17 @@ public class RunfilesTreeUpdater {
       // which we must not treat as up to date, but we also don't want to unnecessarily rebuild the
       // runfiles directory all the time. Instead, check for the presence of the first runfile in
       // the manifest. If it is present, we can be certain that the previous mode wasn't SKIP.
+      // The output manifest is only digested if it is not a symlink, in which case its no-follow
+      // stat also describes the file it is digested from.
+      FileStatus outputManifestStatus = outputManifest.statNullable(Symlinks.NOFOLLOW);
       if (tree.getSymlinksMode() == RunfileSymlinksMode.CREATE
-          && !outputManifest.isSymbolicLink()
+          && outputManifestStatus != null
+          && !outputManifestStatus.isSymbolicLink()
           && Arrays.equals(
-              DigestUtils.getDigestWithManualFallback(outputManifest, xattrProvider),
-              DigestUtils.getDigestWithManualFallback(inputManifest, xattrProvider))
+              DigestUtils.getDigestWithManualFallback(
+                  outputManifest, xattrProvider, outputManifestStatus),
+              DigestUtils.getDigestWithManualFallback(
+                  inputManifest, xattrProvider, inputManifestStatus))
           && (OS.getCurrent() != OS.WINDOWS
               || isRunfilesDirectoryPopulated(runfilesDir, outputManifest))) {
         return;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
@@ -441,16 +441,17 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
       // We don't have an injected digest and there is no digest in the file value (which attempts a
       // fast digest). Manually compute the digest instead.
       Path path = statAndValue.pathNoFollow();
-      if (statAndValue.statNoFollow() != null
-          && statAndValue.statNoFollow().isSymbolicLink()
-          && statAndValue.realPath() != null) {
+      FileStatus status = statAndValue.statNoFollow();
+      if (status != null && status.isSymbolicLink() && statAndValue.realPath() != null) {
         // If the file is a symlink, we compute the digest using the target path so that it's
         // possible to hit the digest cache - we probably already computed the digest for the
         // target during previous action execution.
         path = statAndValue.realPath();
+        // The status describes the symlink, not its target.
+        status = null;
       }
 
-      digest = DigestUtils.manuallyComputeDigest(path);
+      digest = DigestUtils.manuallyComputeDigest(path, status);
     }
     return FileArtifactValue.createFromInjectedDigest(value, digest);
   }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunction.java
@@ -475,7 +475,8 @@ public final class RecursiveFilesystemTraversalFunction implements SkyFunction {
       if (fsv instanceof RegularFileStateValueWithDigest rfsv) {
         return FileArtifactValue.createForVirtualActionInput(rfsv.getDigest(), rfsv.getSize());
       } else if (fsv instanceof RegularFileStateValueWithContentsProxy rfsv) {
-        return FileArtifactValue.createForNormalFileUsingPath(path, rfsv.getSize(), syscallCache);
+        return FileArtifactValue.createForNormalFileUsingPath(
+            path, rfsv.getSize(), rfsv.getContentsProxy(), syscallCache);
       }
 
       return new HasDigest.ByteStringDigest(fsv.getValueFingerprint());
@@ -487,7 +488,8 @@ public final class RecursiveFilesystemTraversalFunction implements SkyFunction {
       // In the case there is a directory, the HasDigest value should not be converted. Otherwise,
       // if the HasDigest value is a file, convert it using the Path and size values.
       return fav.getType().isFile()
-          ? FileArtifactValue.createForNormalFileUsingPath(path, fav.getSize(), syscallCache)
+          ? FileArtifactValue.createForNormalFileUsingPath(
+              path, fav.getSize(), fav.getContentsProxy(), syscallCache)
           : new HasDigest.ByteStringDigest(fav.getValueFingerprint());
     }
     return fsVal;


### PR DESCRIPTION
### Description

`DigestUtils.manuallyComputeDigest(Path)` stats the path to construct the cache key. Both `ActionOutputMetadataStore#constructFileArtifactValue` and `FileArtifactValue#createFromStat` already hold a fresh `FileStatus` for the path at that point, but did not pass it on, resulting in a redundant stat syscall for every file that is digested without a fast digest - once per output on the local action execution and action cache verification paths.

This change passes the already obtained `FileStatus` through to the digest cache key computation.

### Motivation

Work towards #30422 (finding 2). On large builds without a fast xattr digest filesystem, this saves one stat syscall per output file digested during local execution or action cache verification.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None.
