### PR TITLE
Stream module lockfiles directly to disk

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -28,12 +28,14 @@ import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.Lockfile
 import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.runtime.BlazeModule;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
-import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.skyframe.MemoizingEvaluator;
+import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -307,14 +309,15 @@ public class BazelLockFileModule extends BlazeModule {
    * @param lockfileRoot Root under which the lockfile is located
    * @param updatedLockfile The updated lockfile data to save
    */
-  private static void updateLockfile(Path lockfileRoot, BazelLockFileValue updatedLockfile) {
+  @VisibleForTesting
+  static void updateLockfile(Path lockfileRoot, BazelLockFileValue updatedLockfile) {
     RootedPath lockfilePath =
         RootedPath.toRootedPath(Root.fromPath(lockfileRoot), LabelConstants.MODULE_LOCKFILE_NAME);
-    try {
-      FileSystemUtils.writeContent(
-          lockfilePath.asPath(),
-          UTF_8,
-          GsonTypeAdapterUtil.LOCKFILE_GSON.toJson(updatedLockfile) + "\n");
+    try (Writer writer =
+        new BufferedWriter(
+            new OutputStreamWriter(lockfilePath.asPath().getOutputStream(), UTF_8))) {
+      GsonTypeAdapterUtil.LOCKFILE_GSON.toJson(updatedLockfile, writer);
+      writer.append('\n');
     } catch (IOException e) {
       logger.atSevere().withCause(e).log(
           "Error while updating MODULE.bazel.lock file: %s", e.getMessage());

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModuleTest.java
@@ -15,10 +15,14 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.testutil.Scratch;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import com.google.devtools.build.lib.vfs.Path;
 import java.util.Optional;
 import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.Starlark;
@@ -110,5 +114,16 @@ public class BazelLockFileModuleTest {
                 oldExtensionInfos, newExtensionInfos, id -> true, /* reproducible= */ false))
         .isEqualTo(
             ImmutableMap.of(extensionId, ImmutableMap.of(evalFactors, nonReproducibleResult)));
+  }
+
+  @Test
+  public void updateLockfileWritesJsonWithTrailingNewline() throws Exception {
+    Path workspaceRoot = new Scratch().dir("/workspace");
+
+    BazelLockFileModule.updateLockfile(workspaceRoot, BazelLockFileValue.EMPTY_LOCKFILE);
+
+    assertThat(FileSystemUtils.readContent(workspaceRoot.getRelative("MODULE.bazel.lock"), UTF_8))
+        .isEqualTo(
+            GsonTypeAdapterUtil.LOCKFILE_GSON.toJson(BazelLockFileValue.EMPTY_LOCKFILE) + "\n");
   }
 }


### PR DESCRIPTION
Serializing MODULE.bazel.lock with Gson.toJson(Object) builds the
complete JSON string in memory before writing it. Appending the trailing
newline allocates a second equally large string.

Hidden module lockfiles can exceed 435 MiB, so these intermediate copies
can consume roughly 870 MiB and fail builds with OutOfMemoryError. Stream
Gson output through a buffered UTF-8 writer instead, preserving the
serialized contents and trailing newline.

Add a regression test covering the exact lockfile output.
