### PR TITLE
Stream module lockfiles directly to disk

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -134,6 +134,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/skyframe",
         "//third_party:flogger",
+        "//third_party:gson",
         "//third_party:guava",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -320,6 +320,9 @@ public class BazelLockFileModule extends BlazeModule {
         GsonTypeAdapterUtil.LOCKFILE_GSON.toJson(updatedLockfile, writer);
       } catch (JsonIOException e) {
         // Gson.toJson(Object, Appendable) documents JsonIOException for writer failures.
+        if (e.getCause() instanceof IOException ioException) {
+          throw ioException;
+        }
         throw new IOException(e);
       }
       writer.append('\n');

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -320,10 +320,7 @@ public class BazelLockFileModule extends BlazeModule {
         GsonTypeAdapterUtil.LOCKFILE_GSON.toJson(updatedLockfile, writer);
       } catch (JsonIOException e) {
         // Gson.toJson(Object, Appendable) documents JsonIOException for writer failures.
-        if (e.getCause() instanceof IOException ioException) {
-          throw ioException;
-        }
-        throw e;
+        throw new IOException(e);
       }
       writer.append('\n');
     } catch (IOException e) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -28,12 +28,14 @@ import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.Lockfile
 import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.runtime.BlazeModule;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
-import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.skyframe.MemoizingEvaluator;
+import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -307,14 +309,22 @@ public class BazelLockFileModule extends BlazeModule {
    * @param lockfileRoot Root under which the lockfile is located
    * @param updatedLockfile The updated lockfile data to save
    */
-  private static void updateLockfile(Path lockfileRoot, BazelLockFileValue updatedLockfile) {
+  @VisibleForTesting
+  static void updateLockfile(Path lockfileRoot, BazelLockFileValue updatedLockfile) {
     RootedPath lockfilePath =
         RootedPath.toRootedPath(Root.fromPath(lockfileRoot), LabelConstants.MODULE_LOCKFILE_NAME);
-    try {
-      FileSystemUtils.writeContent(
-          lockfilePath.asPath(),
-          UTF_8,
-          GsonTypeAdapterUtil.LOCKFILE_GSON.toJson(updatedLockfile) + "\n");
+    try (Writer writer =
+        new BufferedWriter(
+            new OutputStreamWriter(lockfilePath.asPath().getOutputStream(), UTF_8))) {
+      try {
+        GsonTypeAdapterUtil.LOCKFILE_GSON.toJson(updatedLockfile, writer);
+      } catch (RuntimeException e) {
+        if (e.getCause() instanceof IOException ioException) {
+          throw ioException;
+        }
+        throw e;
+      }
+      writer.append('\n');
     } catch (IOException e) {
       logger.atSevere().withCause(e).log(
           "Error while updating MODULE.bazel.lock file: %s", e.getMessage());

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -32,10 +32,10 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.skyframe.MemoizingEvaluator;
+import com.google.gson.JsonIOException;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -313,12 +313,13 @@ public class BazelLockFileModule extends BlazeModule {
   static void updateLockfile(Path lockfileRoot, BazelLockFileValue updatedLockfile) {
     RootedPath lockfilePath =
         RootedPath.toRootedPath(Root.fromPath(lockfileRoot), LabelConstants.MODULE_LOCKFILE_NAME);
-    try (Writer writer =
-        new BufferedWriter(
-            new OutputStreamWriter(lockfilePath.asPath().getOutputStream(), UTF_8))) {
+    try (var outputStream = lockfilePath.asPath().getOutputStream();
+        var outputStreamWriter = new OutputStreamWriter(outputStream, UTF_8);
+        var writer = new BufferedWriter(outputStreamWriter)) {
       try {
         GsonTypeAdapterUtil.LOCKFILE_GSON.toJson(updatedLockfile, writer);
-      } catch (RuntimeException e) {
+      } catch (JsonIOException e) {
+        // Gson.toJson(Object, Appendable) documents JsonIOException for writer failures.
         if (e.getCause() instanceof IOException ioException) {
           throw ioException;
         }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModuleTest.java
@@ -15,10 +15,14 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.testutil.Scratch;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import com.google.devtools.build.lib.vfs.Path;
 import java.util.Optional;
 import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.Starlark;
@@ -110,5 +114,16 @@ public class BazelLockFileModuleTest {
                 oldExtensionInfos, newExtensionInfos, id -> true, /* reproducible= */ false))
         .isEqualTo(
             ImmutableMap.of(extensionId, ImmutableMap.of(evalFactors, nonReproducibleResult)));
+  }
+
+  @Test
+  public void updateLockfileWritesJsonWithTrailingNewline() throws Exception {
+    Path workspaceRoot = new Scratch().dir("/workspace");
+
+    BazelLockFileModule.updateLockfile(workspaceRoot, BazelLockFileValue.EMPTY_LOCKFILE);
+
+    assertThat(FileSystemUtils.readContent(workspaceRoot.getRelative("MODULE.bazel.lock"), UTF_8))
+        .isEqualTo(
+            GsonTypeAdapterUtil.LOCKFILE_GSON.toJson(BazelLockFileValue.EMPTY_LOCKFILE) + "\n");
   }
 }


### PR DESCRIPTION
### Description

Stream `MODULE.bazel.lock` serialization through a buffered UTF-8 writer instead of building the complete JSON as a `String`. The same helper writes both workspace and hidden lockfiles. Preserve the existing trailing newline and I/O failure logging, and add a regression test for the exact persisted JSON and newline.

### Motivation

A real hidden lockfile reached 456,397,262 bytes (435.254 MiB). `Gson.toJson(updatedLockfile) + "\n"` creates two full strings, about 870 MiB of transient heap, and can fail in `BazelLockFileModule.updateLockfile` with `java.lang.OutOfMemoryError: Java heap space`.

Streaming Gson directly to disk removes those full-size intermediate strings.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
