### PR TITLE
Exclude the source file from C++ include scanning results

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/includescanning/CppIncludeScanningContextImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/CppIncludeScanningContextImpl.java
@@ -118,7 +118,8 @@ public final class CppIncludeScanningContextImpl implements CppIncludeScanningCo
       if (actionExecutionContext.getEnvironmentForDiscoveringInputs().valuesMissing()) {
         return null;
       }
-      return collect(actionExecutionContext, includes, absoluteBuiltInIncludeDirs);
+      return collect(
+          actionExecutionContext, includes, absoluteBuiltInIncludeDirs, action.getSourceFile());
     } catch (IOException e) {
       throw new EnvironmentalExecException(
           e, createFailureDetail("Include scanning IOException", Code.SCANNING_IO_EXCEPTION));
@@ -173,11 +174,19 @@ public final class CppIncludeScanningContextImpl implements CppIncludeScanningCo
   private static List<Artifact> collect(
       ActionExecutionContext actionExecutionContext,
       Set<Artifact> includes,
-      List<PathFragment> absoluteBuiltInIncludeDirs)
+      List<PathFragment> absoluteBuiltInIncludeDirs,
+      Artifact sourceFile)
       throws ExecException {
     // Collect inputs and output
     List<Artifact> inputs = new ArrayList<>(includes.size());
     for (Artifact included : includes) {
+      // The include scanner adds the sources it scans to the includes, but the source file is
+      // already a mandatory input of the action and thus doesn't need to be discovered. Skipping it
+      // also ensures that a tree file artifact source doesn't pull in its parent tree artifact as
+      // an input below, which would duplicate the source file in the action's inputs.
+      if (included.equals(sourceFile)) {
+        continue;
+      }
       // Check for absolute includes -- we assign the file system root as
       // the root path for such includes
       if (included.getRoot().getRoot().isAbsolute()) {

--- a/src/test/java/com/google/devtools/build/lib/includescanning/CppIncludeScanningContextImplTest.java
+++ b/src/test/java/com/google/devtools/build/lib/includescanning/CppIncludeScanningContextImplTest.java
@@ -18,6 +18,7 @@ import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.collect.Streams.stream;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -56,6 +57,7 @@ import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.build.skyframe.ValueOrUntypedException;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.junit.Before;
@@ -171,6 +173,93 @@ public final class CppIncludeScanningContextImplTest extends BuildViewTestCase {
     verify(includeScanner)
         .processAsync(any(), collector.capture(), any(), any(), any(), any(), any(), any(), any());
     assertThat(collector.getValue()).containsExactly(headerTreeFile, getArtifact("//foo:header.h"));
+  }
+
+  @Test
+  public void sourceFileAddedByScanner_notReturnedAsInput() throws Exception {
+    scratch.file(
+        "foo/BUILD",
+        """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+        package(features = ["cc_include_scanning"])
+
+        cc_library(
+            name = "foo",
+            srcs = ["foo.cc"],
+            hdrs = ["header.h"],
+        )
+        """);
+    scratch.file("foo/foo.cc");
+    scratch.file("foo/header.h");
+    IncludeScanner includeScanner = mock(IncludeScanner.class);
+    CppIncludeScanningContextImpl includeScanningContext =
+        createIncludeScanningContext(includeScanner);
+    CppCompileAction action = getCppCompileAction("//foo");
+    Artifact header = getSourceArtifact("foo/header.h");
+    // The include scanner adds the sources it scans to the set of includes.
+    doAnswer(
+            invocation -> {
+              Set<Artifact> includes = invocation.getArgument(4);
+              includes.add(action.getSourceFile());
+              includes.add(header);
+              return null;
+            })
+        .when(includeScanner)
+        .processAsync(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    var actionExecutionContext = createActionExecutionContext(emptyEnvironment());
+
+    var result =
+        includeScanningContext.findAdditionalInputs(
+            action, actionExecutionContext, EMPTY_HEADER_DATA);
+
+    assertThat(result).contains(header);
+    assertThat(result).doesNotContain(action.getSourceFile());
+  }
+
+  @Test
+  public void treeFileArtifactAddedByScanner_returnsParentTreeArtifact() throws Exception {
+    writeTreeRuleBzl(scratch.file("foo/def.bzl"));
+    scratch.file(
+        "foo/BUILD",
+        """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+        load(":def.bzl", "tree")
+
+        package(features = ["cc_include_scanning"])
+
+        tree(name = "headers")
+
+        cc_library(
+            name = "foo",
+            srcs = ["foo.cc"],
+            hdrs = [":headers"],
+        )
+        """);
+    scratch.file("foo/foo.cc");
+    IncludeScanner includeScanner = mock(IncludeScanner.class);
+    CppIncludeScanningContextImpl includeScanningContext =
+        createIncludeScanningContext(includeScanner);
+    CppCompileAction action = getCppCompileAction("//foo");
+    var headerTree = (SpecialArtifact) getArtifact("//foo:headers");
+    var headerTreeFile = TreeFileArtifact.createTreeOutput(headerTree, "file1.h");
+    doAnswer(
+            invocation -> {
+              Set<Artifact> includes = invocation.getArgument(4);
+              includes.add(headerTreeFile);
+              return null;
+            })
+        .when(includeScanner)
+        .processAsync(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    var environment = environmentWithTreeValue(headerTree, headerTreeFile);
+    var actionExecutionContext = createActionExecutionContext(environment);
+
+    var result =
+        includeScanningContext.findAdditionalInputs(
+            action, actionExecutionContext, EMPTY_HEADER_DATA);
+
+    assertThat(result).contains(headerTree);
+    assertThat(result).doesNotContain(headerTreeFile);
   }
 
   @Test


### PR DESCRIPTION
### Description

Excludes the compile action's source file from the results of C++ include scanning.

### Motivation

The include scanner adds all files it scans, including the compile action's own source file, to the set of found includes, and `CppIncludeScanningContextImpl#collect` replaces tree file artifacts in this set with their parent tree artifact. For an action that compiles a tree file artifact source (created by an action template), the spawn thus contained both the source file and its entire parent tree artifact as inputs, which Bazel's `MerkleTreeComputer` isn't set up (and meant to) handle.

Since the source file is always a mandatory input of the action, it doesn't need to be discovered and is now excluded from the include scanning results.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
