### PR TITLE
[9.3.0] Fix `setup_javabase` on Windows

### DIFF
--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -275,6 +275,15 @@ function setup_javabase() {
   fi
   if is_windows; then
     jdk_dir="$(cygpath -m $(cd ${jdk_binary_rlocation}/../..; pwd))"
+    # if this is a java repository, copy out just the runtime and use that
+    if [[ -f "${jdk_dir}/BUILD.bazel" ]]; then
+      tmp_runtime_dir=$(mktemp -d --tmpdir=${TEST_TMPDIR})
+      for f in $(ls -1 ${jdk_dir}); do
+        ln -s ${jdk_dir}/$f -t ${tmp_runtime_dir}
+      done
+      rm ${tmp_runtime_dir}/BUILD.bazel
+      jdk_dir=${tmp_runtime_dir}
+    fi
   else
     jdk_dir="$(dirname $(dirname ${jdk_binary_rlocation}))"
   fi


### PR DESCRIPTION
When a `java_runtime` is added to a test as a `data` dependency, only the jdk files are expected to be present in the test runfiles. On windows, the test sees the entire (local/remote) repository, including the generated `BUILD.bazel` file.

Consequently, attempting to use this as `JAVA_HOME` / a local jdk will fail as the `local_java_repository` rule attempts to both symlink the existing BUILD.bazel file in addition to writing its own version.

In such cases, we simulate runfiles staging by symlinking everything except the BUILD.bazel file.

PiperOrigin-RevId: 950771785
Change-Id: I859c527fadd4aad57fa3a8bddf95e82ae22b7aa2