### PR TITLE
[9.3.0] Fix scope leak in ParsedFlagsValue.applyTo()

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildOptions.java
@@ -81,9 +81,10 @@ public final class BuildOptions implements Cloneable {
 
   /**
    * Converts the map containing String representation of scopes attributes to a map of {@link
-   * Label} of Starlark options to their corresponding {@link Scope.ScopeType}.
+   * Label} of Starlark options to their corresponding {@link Scope.ScopeType}, keeping only entries
+   * for flags present in {@code starlarkOptions}.
    */
-  private static ImmutableMap<Label, Scope.ScopeType> convertScopesAttributes(
+  public static ImmutableMap<Label, Scope.ScopeType> convertScopesAttributes(
       Map<String, String> scopesAttributes, Map<String, Object> starlarkOptions) {
     return scopesAttributes.entrySet().stream()
         .filter(e -> starlarkOptions.containsKey(e.getKey()))

--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/ParsedFlagsValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/ParsedFlagsValue.java
@@ -143,8 +143,10 @@ public class ParsedFlagsValue implements SkyValue {
    *   <li>Any native flags in this instance, for fragments that are kept, are set to the value from
    *       this instance.
    *   <li>All Starlark flags from the original {@link BuildOptions} are kept, then all Starlark
-   *       options from this instance are added.
+   *       options from this instance are added, along with the scope from their parsed {@code
+   *       scope} attribute when known.
    *   <li>Any Starlark flags which are present in both, the value from this instance is kept.
+   *   <li>Any Starlark flags set back to their default value are removed, along with their scope.
    * </ul>
    *
    * <p>To preserve fragment trimming, this method will not expand the set of included native
@@ -179,12 +181,18 @@ public class ParsedFlagsValue implements SkyValue {
       updateOptionValue(fragment, optionDefinition, optionValue);
     }
 
-    // Also copy Starlark options.
+    // Merge Starlark options. The scope info from the source options is already in the builder,
+    // copied by source.toBuilder(). Add the scope info from this instance's parsed scope
+    // attributes on top of it, then merge the values: flags reset to their default value are
+    // removed by removeStarlarkOption, which also deletes the scope info just added.
+    builder.addScopeTypeMap(
+        BuildOptions.convertScopesAttributes(
+            parsingResult.getScopesAttributes(), parsingResult.getStarlarkOptions()));
     for (Map.Entry<String, Object> starlarkOption : parsingResult.getStarlarkOptions().entrySet()) {
       updateStarlarkFlag(builder, starlarkOption.getKey(), starlarkOption.getValue());
     }
 
-    return BuildConfigurationKey.create(builder.addScopeTypeMap(source.getScopeTypeMap()).build());
+    return BuildConfigurationKey.create(builder.build());
   }
 
   private static void updateOptionValue(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/config/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/config/BUILD
@@ -43,6 +43,7 @@ java_test(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/analysis/config:build_options",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:fragment_options",
+        "//src/main/java/com/google/devtools/build/lib/analysis/config:scope",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/skyframe/config",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/config/ParsedFlagsValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/config/ParsedFlagsValueTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.BuildOptionsTest;
 import com.google.devtools.build.lib.analysis.config.FragmentOptions;
+import com.google.devtools.build.lib.analysis.config.Scope;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.common.options.Converters.CommaSeparatedOptionListConverter;
 import com.google.devtools.common.options.Option;
@@ -286,5 +287,123 @@ public final class ParsedFlagsValueTest {
     // The Starlark flag should not be present since it was reset to the default value
     assertThat(modified.getStarlarkOptions())
         .doesNotContainKey(Label.parseCanonicalUnchecked("//custom:flag"));
+  }
+
+  @Test
+  public void mergeWith_starlark_resetToDefault_removesScope() throws Exception {
+    // Regression test: when a starlark flag is reset to its default value, the scope entry
+    // should also be removed. Previously, addScopeTypeMap(source.getScopeTypeMap()) would
+    // re-introduce the scope even after removeStarlarkOption cleaned it up, causing two
+    // configs to have different checksums despite identical visible state.
+    Label flagLabel = Label.parseCanonicalUnchecked("//custom:flag");
+    BuildOptions original =
+        BuildOptions.of(BUILD_CONFIG_OPTIONS).toBuilder()
+            .addStarlarkOption(flagLabel, "non_default")
+            .addScopeType(flagLabel, Scope.ScopeType.DEFAULT)
+            .build();
+
+    NativeAndStarlarkFlags flags =
+        NativeAndStarlarkFlags.builder()
+            .optionsClasses(BUILD_CONFIG_OPTIONS)
+            .starlarkFlags(ImmutableMap.of("//custom:flag", "default"))
+            .starlarkFlagDefaults(ImmutableMap.of("//custom:flag", "default"))
+            .scopesAttributes(ImmutableMap.of("//custom:flag", "project"))
+            .build();
+    ParsedFlagsValue parsedFlags = ParsedFlagsValue.parseAndCreate(flags);
+
+    BuildOptions modified = parsedFlags.mergeWith(original).getOptions();
+
+    // The flag should be removed (at default).
+    assertThat(modified.getStarlarkOptions()).doesNotContainKey(flagLabel);
+    // The scope should also be removed - not leaked from the source.
+    assertThat(modified.getScopeTypeMap()).doesNotContainKey(flagLabel);
+  }
+
+  @Test
+  public void mergeWith_scopePreservedForRetainedFlag() throws Exception {
+    // Verifies that scopes already present in the source are preserved through mergeWith
+    // when the flag is not removed.
+    Label flagLabel = Label.parseCanonicalUnchecked("//custom:flag");
+    Scope.ScopeType scopeType = Scope.ScopeType.TARGET;
+    BuildOptions original =
+        BuildOptions.of(BUILD_CONFIG_OPTIONS).toBuilder()
+            .addStarlarkOption(flagLabel, "original_value")
+            .addScopeType(flagLabel, scopeType)
+            .build();
+
+    // mergeWith with no starlark flags - original flags should be untouched.
+    NativeAndStarlarkFlags flags =
+        NativeAndStarlarkFlags.builder().optionsClasses(BUILD_CONFIG_OPTIONS).build();
+    ParsedFlagsValue parsedFlags = ParsedFlagsValue.parseAndCreate(flags);
+
+    BuildOptions modified = parsedFlags.mergeWith(original).getOptions();
+
+    assertThat(modified.getStarlarkOptions()).containsEntry(flagLabel, "original_value");
+    assertThat(modified.getScopeTypeMap()).containsEntry(flagLabel, scopeType);
+  }
+
+  @Test
+  public void mergeWith_scopePreservedForNewFlag() throws Exception {
+    // When mergeWith introduces a new starlark flag that already has a scope in the source,
+    // the scope should be preserved in the result.
+    Label existingFlag = Label.parseCanonicalUnchecked("//custom:existing");
+    Label newFlag = Label.parseCanonicalUnchecked("//custom:new_flag");
+    Scope.ScopeType existingScope = Scope.ScopeType.TARGET;
+    Scope.ScopeType newFlagScope = Scope.ScopeType.UNIVERSAL;
+    BuildOptions original =
+        BuildOptions.of(BUILD_CONFIG_OPTIONS).toBuilder()
+            .addStarlarkOption(existingFlag, "val")
+            .addScopeType(existingFlag, existingScope)
+            .addStarlarkOption(newFlag, "source_val")
+            .addScopeType(newFlag, newFlagScope)
+            .build();
+
+    NativeAndStarlarkFlags flags =
+        NativeAndStarlarkFlags.builder()
+            .optionsClasses(BUILD_CONFIG_OPTIONS)
+            .starlarkFlags(ImmutableMap.of("//custom:new_flag", "new_val"))
+            .starlarkFlagDefaults(ImmutableMap.of("//custom:new_flag", "default"))
+            .build();
+    ParsedFlagsValue parsedFlags = ParsedFlagsValue.parseAndCreate(flags);
+
+    BuildOptions modified = parsedFlags.mergeWith(original).getOptions();
+
+    assertThat(modified.getStarlarkOptions()).containsEntry(newFlag, "new_val");
+    // Both flags' scopes should be preserved.
+    assertThat(modified.getScopeTypeMap()).containsEntry(newFlag, newFlagScope);
+    assertThat(modified.getScopeTypeMap()).containsEntry(existingFlag, existingScope);
+  }
+
+  @Test
+  public void mergeWith_newFlagNotInSource() throws Exception {
+    // A flag not present in the source config is added by the merged flags, together with the
+    // scope from its parsed scope attribute.
+    Label existingFlag = Label.parseCanonicalUnchecked("//custom:existing");
+    Scope.ScopeType existingScope = Scope.ScopeType.TARGET;
+    BuildOptions original =
+        BuildOptions.of(BUILD_CONFIG_OPTIONS).toBuilder()
+            .addStarlarkOption(existingFlag, "val")
+            .addScopeType(existingFlag, existingScope)
+            .build();
+
+    Label newFlag = Label.parseCanonicalUnchecked("//custom:new_flag");
+    NativeAndStarlarkFlags flags =
+        NativeAndStarlarkFlags.builder()
+            .optionsClasses(BUILD_CONFIG_OPTIONS)
+            .starlarkFlags(ImmutableMap.of("//custom:new_flag", "new_val"))
+            .starlarkFlagDefaults(ImmutableMap.of("//custom:new_flag", "default"))
+            .scopesAttributes(ImmutableMap.of("//custom:new_flag", "project"))
+            .build();
+    ParsedFlagsValue parsedFlags = ParsedFlagsValue.parseAndCreate(flags);
+
+    BuildOptions modified = parsedFlags.mergeWith(original).getOptions();
+
+    // New flag should be present with the merged value and the scope from its parsed scope
+    // attribute.
+    assertThat(modified.getStarlarkOptions()).containsEntry(newFlag, "new_val");
+    assertThat(modified.getScopeTypeMap()).containsEntry(newFlag, Scope.ScopeType.PROJECT);
+    // Existing flag and its scope should be unaffected.
+    assertThat(modified.getStarlarkOptions()).containsEntry(existingFlag, "val");
+    assertThat(modified.getScopeTypeMap()).containsEntry(existingFlag, existingScope);
   }
 }


### PR DESCRIPTION
### Description

When a starlark flag is removed (because it equals its default value), removeStarlarkOption correctly removes both the flag and its scope entry. However, addScopeTypeMap(source.getScopeTypeMap()) immediately re-adds all scopes from the source config, including scopes for flags that were just removed.

This causes two configs to have different checksums despite having identical visible state (same native options, same starlark options), because one carries a ghost scope entry. This triggers spurious 'Duplicate paths' errors when --experimental_output_paths=strip is enabled.

Fix: only re-add scopes for flags that are still present in starlark options after processing.

/cc @aranguyen

### Motivation

Fixes https://github.com/bazelbuild/bazel/issues/29319

### Build API Changes

I believe it only fixes a bug that is nontrivial to trigger and should not have any visible effect otherwise. But @fmeum suggested there may be a reason why we keep all the scopes around, so :shrug:

### Checklist

- [X] I have added tests for the new use cases (if any).
- I have updated the documentation (if applicable). _(Not applicable AFAIU)_

### Release Notes

RELNOTES: None

Closes #29494.

PiperOrigin-RevId: 951537419
Change-Id: Id12f0a968863cd91ae66b21ebdbfb603dcab4437 (cherry picked from commit 2fbf9dba4907073c67e3895ab9cef866f5661c62)

Closes #30429
