### PR TITLE
Revert "bash launcher: append rather than prepend the bash bin dir"

### DIFF
--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -44,12 +44,7 @@ ExitCode BashBinaryLauncher::Launch() {
     wstring bash_bin_dir = GetParentDirFromPath(bash_binary);
     wstring path_env;
     GetEnv(L"PATH", &path_env);
-    // We want to make sure the bash-adjacent tools (like coreutils) are in the
-    // path somewhere (since most bash scripts are going to assume that) but we
-    // append it rather than prepending it to avoid conflicts between link.exe
-    // (the rarely-used symlink-creator from coreutils) and link.exe (the visual
-    // studio linker)
-    path_env = path_env + L";" + bash_bin_dir;
+    path_env = bash_bin_dir + L";" + path_env;
     SetEnv(L"PATH", path_env);
   } else {
     // If specified bash binary path doesn't exist, then fall back to


### PR DESCRIPTION

### Description
This reverts commit e37ec56c57dd4af03a324aba93bf8b311f1f1391.

### Motivation

While fixing some use cases, this breaks `#!/usr/bin/env bash` in `sh_binary` shebangs on Windows with WSL installed, which is a very common setup.

Fixes #29637

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES[INC]: The Windows shell launcher now again prepends rather than appends the directory containing the shell binary, restoring the behavior of Bazel 8.x. This is technically an incompatible change, but deemed necessary due to the unexpected and widespread implications of the change in 9.0.0. See https://github.com/bazelbuild/bazel/issues/29637 for more context.
