### PR TITLE
[8.8.0] Use available in-memory file metadata while uploading for the BES (ht…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -173,30 +173,6 @@ java_library(
 )
 
 java_library(
-    name = "byte_stream_build_event_artifact_uploader",
-    srcs = ["ByteStreamBuildEventArtifactUploader.java"],
-    deps = [
-        ":combined_cache",
-        ":remote_action_file_system",
-        "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
-        "//src/main/java/com/google/devtools/build/lib/buildeventstream",
-        "//src/main/java/com/google/devtools/build/lib/events",
-        "//src/main/java/com/google/devtools/build/lib/remote/common",
-        "//src/main/java/com/google/devtools/build/lib/remote/options",
-        "//src/main/java/com/google/devtools/build/lib/remote/util:digest_util",
-        "//src/main/java/com/google/devtools/build/lib/remote/util:rx_futures",
-        "//src/main/java/com/google/devtools/build/lib/remote/util:tracing_metadata_utils",
-        "//src/main/java/com/google/devtools/build/lib/remote/util:utils",
-        "//src/main/java/com/google/devtools/build/lib/vfs",
-        "//third_party:guava",
-        "//third_party:jsr305",
-        "//third_party:netty",
-        "//third_party:rxjava3",
-        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
-    ],
-)
-
-java_library(
     name = "ExecutionStatusException",
     srcs = ["ExecutionStatusException.java"],
     deps = [

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -173,6 +173,30 @@ java_library(
 )
 
 java_library(
+    name = "byte_stream_build_event_artifact_uploader",
+    srcs = ["ByteStreamBuildEventArtifactUploader.java"],
+    deps = [
+        ":combined_cache",
+        ":remote_action_file_system",
+        "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
+        "//src/main/java/com/google/devtools/build/lib/buildeventstream",
+        "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/remote/options",
+        "//src/main/java/com/google/devtools/build/lib/remote/util:digest_util",
+        "//src/main/java/com/google/devtools/build/lib/remote/util:rx_futures",
+        "//src/main/java/com/google/devtools/build/lib/remote/util:tracing_metadata_utils",
+        "//src/main/java/com/google/devtools/build/lib/remote/util:utils",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//third_party:guava",
+        "//third_party:jsr305",
+        "//third_party:netty",
+        "//third_party:rxjava3",
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+    ],
+)
+
+java_library(
     name = "ExecutionStatusException",
     srcs = ["ExecutionStatusException.java"],
     deps = [

--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
@@ -29,6 +29,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent.LocalFile;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent.LocalFile.LocalFileType;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
@@ -175,6 +176,47 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
    */
   private PathMetadata readPathMetadata(Path path, LocalFile file) throws IOException {
     DigestUtil digestUtil = new DigestUtil(xattrProvider, path.getFileSystem().getDigestFunction());
+    DigestFunction.Value digestFunction = digestUtil.getDigestFunction();
+    boolean isBuildToolLog =
+        file.type == LocalFileType.LOG || file.type == LocalFileType.PERFORMANCE_LOG;
+    FileArtifactValue metadata = file.artifactMetadata;
+    if (metadata != null) {
+      switch (metadata.getType()) {
+        case DIRECTORY -> {
+          return new PathMetadata(
+              path,
+              /* digest= */ null,
+              /* directory= */ true,
+              /* symlink= */ false,
+              /* remote= */ false,
+              /* isBuildToolLog= */ false,
+              digestFunction);
+        }
+        case SYMLINK -> {
+          return new PathMetadata(
+              path,
+              /* digest= */ null,
+              /* directory= */ false,
+              /* symlink= */ true,
+              /* remote= */ false,
+              /* isBuildToolLog= */ false,
+              digestFunction);
+        }
+        case REGULAR_FILE -> {
+          if (metadata.getDigest() != null) {
+            return new PathMetadata(
+                path,
+                DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize()),
+                /* directory= */ false,
+                /* symlink= */ false,
+                /* remote= */ metadata.isRemote(),
+                isBuildToolLog,
+                digestFunction);
+          }
+        }
+        default -> {}
+      }
+    }
 
     if (file.type == LocalFileType.OUTPUT_DIRECTORY
         || ((file.type == LocalFileType.SUCCESSFUL_TEST_OUTPUT
@@ -188,7 +230,7 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
           /* symlink= */ false,
           /* remote= */ false,
           /* isBuildToolLog= */ false,
-          /* digestFunction= */ digestUtil.getDigestFunction());
+          digestFunction);
     }
     if (file.type == LocalFileType.OUTPUT_SYMLINK) {
       return new PathMetadata(
@@ -198,12 +240,10 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
           /* symlink= */ true,
           /* remote= */ false,
           /* isBuildToolLog= */ false,
-          /* digestFunction= */ digestUtil.getDigestFunction());
+          digestFunction);
     }
 
     Digest digest = digestUtil.compute(path);
-    boolean isBuildToolLog =
-        file.type == LocalFileType.LOG || file.type == LocalFileType.PERFORMANCE_LOG;
     return new PathMetadata(
         path,
         digest,
@@ -211,7 +251,7 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
         /* symlink= */ false,
         isRemoteFile(path),
         isBuildToolLog,
-        digestUtil.getDigestFunction());
+        digestFunction);
   }
 
   private static void processQueryResult(

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -54,6 +54,7 @@ import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.events.StoredEventHandler;
 import com.google.devtools.build.lib.remote.ByteStreamUploaderTest.FixedBackoff;
 import com.google.devtools.build.lib.remote.ByteStreamUploaderTest.MaybeFailOnceUploadService;
+import com.google.devtools.build.lib.remote.Retrier.ResultClassifier.Result;
 import com.google.devtools.build.lib.remote.common.MissingDigestsFinder;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.Blob;

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -66,6 +66,7 @@ import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.bazel.BazelHashFunctions;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
@@ -525,6 +526,160 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     assertThat(pathConverter.apply(localFile)).contains(localDigest.getHash());
   }
 
+  @Test
+  public void fileWithMetadata_digestReusedAndFileNotRead() throws Exception {
+    // arrange
+    byte[] blob = "contents of a file that is not present locally".getBytes(StandardCharsets.UTF_8);
+    Digest digest = DIGEST_UTIL.compute(blob);
+    Path file = fs.getPath("/file");
+    FileArtifactValue metadata =
+        FileArtifactValue.createForVirtualActionInput(
+            HashCode.fromString(digest.getHash()).asBytes(), digest.getSizeBytes());
+
+    StaticMissingDigestsFinder digestQuerier =
+        Mockito.spy(new StaticMissingDigestsFinder(ImmutableSet.of(digest)));
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(
+            () -> new FixedBackoff(1, 0), (e) -> Result.TRANSIENT_FAILURE, retryService);
+    ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
+    CombinedCache combinedCache = spy(newCombinedCache(refCntChannel, retrier, digestQuerier));
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(combinedCache);
+
+    // act
+    PathConverter pathConverter =
+        artifactUploader
+            .upload(ImmutableMap.of(file, new LocalFile(file, LocalFileType.OUTPUT_FILE, metadata)))
+            .get();
+
+    // assert
+    verify(digestQuerier).findMissingDigests(any(), any());
+    verify(combinedCache, times(0)).uploadFile(any(), any(), any());
+    assertThat(pathConverter.apply(file))
+        .isEqualTo(
+            "bytestream://localhost/instance/blobs/"
+                + digest.getHash()
+                + "/"
+                + digest.getSizeBytes());
+    assertThat(eventHandler.getEvents()).isEmpty();
+  }
+
+  @Test
+  public void fileWithRemoteMetadata_notQueriedOrUploaded() throws Exception {
+    // arrange
+    byte[] blob = "contents of a remote file".getBytes(StandardCharsets.UTF_8);
+    Digest digest = DIGEST_UTIL.compute(blob);
+    Path file = fs.getPath("/file");
+    FileArtifactValue metadata =
+        FileArtifactValue.createForRemoteFile(
+            HashCode.fromString(digest.getHash()).asBytes(),
+            digest.getSizeBytes(),
+            /* locationIndex= */ 1);
+
+    StaticMissingDigestsFinder digestQuerier =
+        Mockito.spy(new StaticMissingDigestsFinder(ImmutableSet.of()));
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(
+            () -> new FixedBackoff(1, 0), (e) -> Result.TRANSIENT_FAILURE, retryService);
+    ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
+    CombinedCache combinedCache = spy(newCombinedCache(refCntChannel, retrier, digestQuerier));
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(combinedCache);
+
+    // act
+    PathConverter pathConverter =
+        artifactUploader
+            .upload(ImmutableMap.of(file, new LocalFile(file, LocalFileType.OUTPUT_FILE, metadata)))
+            .get();
+
+    // assert
+    verify(digestQuerier, times(0)).findMissingDigests(any(), any());
+    verify(combinedCache, times(0)).uploadFile(any(), any(), any());
+    assertThat(pathConverter.apply(file))
+        .isEqualTo(
+            "bytestream://localhost/instance/blobs/"
+                + digest.getHash()
+                + "/"
+                + digest.getSizeBytes());
+    assertThat(eventHandler.getEvents()).isEmpty();
+  }
+
+  @Test
+  public void fileWithMetadata_minimalMode_digestReusedAndFileNotRead() throws Exception {
+    // arrange
+    byte[] blob = "contents of a file that is not present locally".getBytes(StandardCharsets.UTF_8);
+    Digest digest = DIGEST_UTIL.compute(blob);
+    Path file = fs.getPath("/file");
+    FileArtifactValue metadata =
+        FileArtifactValue.createForVirtualActionInput(
+            HashCode.fromString(digest.getHash()).asBytes(), digest.getSizeBytes());
+
+    StaticMissingDigestsFinder digestQuerier =
+        Mockito.spy(new StaticMissingDigestsFinder(ImmutableSet.of()));
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(
+            () -> new FixedBackoff(1, 0), (e) -> Result.TRANSIENT_FAILURE, retryService);
+    ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
+    CombinedCache combinedCache = spy(newCombinedCache(refCntChannel, retrier, digestQuerier));
+    ByteStreamBuildEventArtifactUploader artifactUploader =
+        newArtifactUploader(combinedCache, RemoteBuildEventUploadMode.MINIMAL);
+
+    // act
+    PathConverter pathConverter =
+        artifactUploader
+            .upload(ImmutableMap.of(file, new LocalFile(file, LocalFileType.OUTPUT_FILE, metadata)))
+            .get();
+
+    // assert
+    verify(digestQuerier, times(0)).findMissingDigests(any(), any());
+    verify(combinedCache, times(0)).uploadFile(any(), any(), any());
+    assertThat(pathConverter.apply(file))
+        .isEqualTo(
+            "bytestream://localhost/instance/blobs/"
+                + digest.getHash()
+                + "/"
+                + digest.getSizeBytes());
+    assertThat(eventHandler.getEvents()).isEmpty();
+  }
+
+  @Test
+  public void fileWithDirectoryMetadata_notUploaded() throws Exception {
+    Path dir = fs.getPath("/dir");
+    FileArtifactValue metadata = FileArtifactValue.createForDirectoryWithMtime(0);
+    Map<Path, LocalFile> filesToUpload = new HashMap<>();
+    filesToUpload.put(dir, new LocalFile(dir, LocalFileType.SUCCESSFUL_TEST_OUTPUT, metadata));
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(
+            () -> new FixedBackoff(1, 0), (e) -> Result.TRANSIENT_FAILURE, retryService);
+    ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
+    CombinedCache combinedCache = newCombinedCache(refCntChannel, retrier);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(combinedCache);
+
+    PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
+    assertThat(pathConverter.apply(dir)).isNull();
+    assertThat(eventHandler.getEvents()).isEmpty();
+    artifactUploader.release();
+  }
+
+  @Test
+  public void fileWithSymlinkMetadata_notUploaded() throws Exception {
+    Path sym = fs.getPath("/sym");
+    sym.createSymbolicLink(PathFragment.create("target"));
+    FileArtifactValue metadata = FileArtifactValue.createForUnresolvedSymlink(sym);
+    sym.delete();
+    Map<Path, LocalFile> filesToUpload = new HashMap<>();
+    filesToUpload.put(sym, new LocalFile(sym, LocalFileType.OUTPUT_FILE, metadata));
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(
+            () -> new FixedBackoff(1, 0), (e) -> Result.TRANSIENT_FAILURE, retryService);
+    ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
+    CombinedCache combinedCache = newCombinedCache(refCntChannel, retrier);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(combinedCache);
+
+    PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
+    assertThat(pathConverter.apply(sym)).isNull();
+    assertThat(eventHandler.getEvents()).isEmpty();
+    artifactUploader.release();
+  }
+
   /** Returns a remote artifact and puts its metadata into the action input map. */
   private Artifact createRemoteArtifact(
       String pathFragment, String contents, ActionInputMap inputs) {
@@ -567,6 +722,11 @@ public class ByteStreamBuildEventArtifactUploaderTest {
   }
 
   private ByteStreamBuildEventArtifactUploader newArtifactUploader(CombinedCache combinedCache) {
+    return newArtifactUploader(combinedCache, RemoteBuildEventUploadMode.ALL);
+  }
+
+  private ByteStreamBuildEventArtifactUploader newArtifactUploader(
+      CombinedCache combinedCache, RemoteBuildEventUploadMode remoteBuildEventUploadMode) {
 
     return new ByteStreamBuildEventArtifactUploader(
         MoreExecutors.directExecutor(),
@@ -578,7 +738,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         /* buildRequestId= */ "none",
         /* commandId= */ "none",
         SyscallCache.NO_CACHE,
-        RemoteBuildEventUploadMode.ALL);
+        remoteBuildEventUploadMode);
   }
 
   private static class StaticMissingDigestsFinder implements MissingDigestsFinder {


### PR DESCRIPTION
…tps://github.com/bazelbuild/bazel/pull/30412)

Fixes #20576
Fixes #30410

No

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES: None

Closes #30412.

PiperOrigin-RevId: 952732111
Change-Id: Ib057cce14ade0ddc0aa372ba3dd4d60e6b0c242c

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/9a849d92d478d7eb02358e831f20fc94aaee3ed9
