### PR TITLE
Preserve the URL file extension when the downloader config blocks all URLs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -220,18 +220,24 @@ public class DownloadManager {
           rewriter.updateAuthHeaders(rewrittenUrlMappings, authHeaders, netrcCreds);
     }
 
-    URI mainUrl; // The "main" URL for this request
-    // Used for reporting only and determining the file name only.
+    URI mainUrl; // The "main" URL for this request, used for reporting.
+    // The URL used to derive the download's file name. When the rewriter blocks all URLs, this
+    // falls back to the first original URL so that its extension (used, e.g., by
+    // download_and_extract to infer the archive type) is preserved instead of being lost to the
+    // "cacheprobe" placeholder.
+    URI fileNameUrl;
     if (rewrittenUrls.isEmpty()) {
       if (type.isPresent() && !Strings.isNullOrEmpty(type.get())) {
         mainUrl = URI.create("http://nonexistent.example.org/cacheprobe." + type.get());
       } else {
         mainUrl = URI.create("http://nonexistent.example.org/cacheprobe");
       }
+      fileNameUrl = originalUrls.isEmpty() ? mainUrl : originalUrls.get(0);
     } else {
       mainUrl = rewrittenUrls.get(0);
+      fileNameUrl = mainUrl;
     }
-    Path destination = getDownloadDestination(mainUrl, type, output);
+    Path destination = getDownloadDestination(fileNameUrl, type, output);
     ImmutableSet<String> candidateFileNames = getCandidateFileNames(mainUrl, destination);
 
     // Is set to true if the value should be cached by the checksum value provided

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -21,9 +21,11 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -39,6 +41,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.StringReader;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -290,6 +293,51 @@ public class HttpDownloaderTest {
             DownloadManager.getCandidateFileNames(
                 URI.create("file:../foo%3Fbar.tgz"), fs.getPath("/tmp/foo_bar.tgz")))
         .containsExactly("foo?bar.tgz", "foo_bar.tgz");
+  }
+
+  @Test
+  public void rewriterBlocksAllUrls_cacheHitPreservesUrlFileName() throws Exception {
+    // When an all-blocking --downloader_config removes every URL, the request can only be served
+    // from the repository cache by checksum. The resulting file name must still be derived from the
+    // original URL so that its extension is preserved: download_and_extract infers the archive type
+    // from the file suffix, so a name like "cacheprobe" (with no suffix) breaks extraction.
+    UrlRewriter blockAll =
+        new UrlRewriter(ImmutableList.of("/dev/null"), ImmutableList.of(new StringReader("block *")));
+    DownloadManager downloadManager =
+        new DownloadManager(downloadCache, httpDownloader, httpDownloader, eventHandler);
+    downloadManager.setUrlRewriter(blockAll);
+
+    byte[] data = "content".getBytes(UTF_8);
+    when(downloadCache.isEnabled()).thenReturn(true);
+    when(downloadCache.get(any(), any(), any(), any(), anyBoolean()))
+        .thenAnswer(
+            (Answer<Path>)
+                invocationOnMock -> {
+                  Path targetPath = invocationOnMock.getArgument(1, Path.class);
+                  try (OutputStream outputStream = targetPath.getOutputStream()) {
+                    ByteStreams.copy(new ByteArrayInputStream(data), outputStream);
+                  }
+                  return targetPath;
+                });
+    Checksum checksum =
+        Checksum.fromString(
+            DownloadCache.KeyType.SHA256, Hashing.sha256().hashBytes(data).toString());
+
+    Path result =
+        download(
+            downloadManager,
+            ImmutableList.of(URI.create("http://mirror.example/archive.tar.gz")),
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            Optional.of(checksum),
+            "testCanonicalId",
+            // download_and_extract passes an (often empty) type and relies on the file extension.
+            Optional.of(""),
+            fs.getPath(workingDir.newFolder().getAbsolutePath()),
+            ImmutableMap.of(),
+            "testRepo");
+
+    assertThat(result.getBaseName()).isEqualTo("archive.tar.gz");
   }
 
   @Test


### PR DESCRIPTION
### Description

When `--downloader_config` rewrites away every URL for a download (e.g. `block *`), the rewritten URL list becomes empty and the request can only be satisfied from the repository cache by checksum. In that case the downloaded file's name was derived from the synthetic `http://nonexistent.example.org/cacheprobe` placeholder, which carries no file extension.

`repository_ctx.download_and_extract` infers the archive type from the file extension (it passes no explicit decompressor type and relies on the downloaded file's suffix). A repository cache hit was therefore written to a file named `cacheprobe` and extraction failed with:

```
Error in download_and_extract: Expected a file with a .zip, .jar, .war, ... or .7z suffix (got .../cacheprobe)
```

This derives the download file name from the first original (pre-rewrite) URL when the rewriter blocks all URLs, so its extension is preserved. The `cacheprobe` placeholder is unchanged and still used for progress/cache-hit reporting.

### Motivation

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Fixed `repository_ctx.download_and_extract` failing with an "Expected a file with a ... suffix" error when `--downloader_config` blocks all URLs and the archive is served from the repository cache.
