### PR TITLE
Recover evicted cached repos in module extensions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -42,6 +42,7 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/skyframe:detailed_exceptions",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/net/starlark/java/eval",
         "//src/main/protobuf:failure_details_java_proto",
         "//third_party:error_prone_annotations",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ExternalDepsException.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ExternalDepsException.java
@@ -20,6 +20,7 @@ import com.google.devtools.build.lib.server.FailureDetails.ExternalDeps;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.skyframe.DetailedException;
 import com.google.devtools.build.lib.util.DetailedExitCode;
+import com.google.devtools.build.lib.vfs.DetailedIOException;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 import javax.annotation.Nullable;
@@ -34,11 +35,16 @@ public class ExternalDepsException extends Exception implements DetailedExceptio
   private ExternalDepsException(String message, @Nullable Throwable cause, ExternalDeps.Code code) {
     super(message, cause);
     detailedExitCode =
-        DetailedExitCode.of(
-            FailureDetail.newBuilder()
-                .setMessage(message)
-                .setExternalDeps(ExternalDeps.newBuilder().setCode(code).build())
-                .build());
+        cause instanceof DetailedIOException detailedCause
+            ? DetailedExitCode.of(
+                detailedCause.getDetailedExitCode().getFailureDetail().toBuilder()
+                    .setMessage(message)
+                    .build())
+            : DetailedExitCode.of(
+                FailureDetail.newBuilder()
+                    .setMessage(message)
+                    .setExternalDeps(ExternalDeps.newBuilder().setCode(code).build())
+                    .build());
   }
 
   @FormatMethod

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
@@ -43,6 +43,7 @@ import com.google.devtools.build.lib.skyframe.BzlLoadFunction;
 import com.google.devtools.build.lib.skyframe.BzlLoadValue;
 import com.google.devtools.build.lib.skyframe.RepoEnvironmentFunction;
 import com.google.devtools.build.lib.util.OS;
+import com.google.devtools.build.lib.vfs.DetailedIOException;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import com.google.devtools.build.skyframe.WorkerSkyKeyComputeState;
@@ -312,6 +313,13 @@ final class RegularRunnableExtension implements RunnableExtension {
       return new RunModuleExtensionResult(
           moduleContext.getRecordedInputs(), threadContext.createRepos(), moduleExtensionMetadata);
     } catch (EvalException e) {
+      if (e.getCause() instanceof DetailedIOException detailedCause) {
+        throw ExternalDepsException.withCauseAndMessage(
+            ExternalDeps.Code.EXTENSION_EVAL_ERROR,
+            detailedCause,
+            "error evaluating module extension %s",
+            extensionId);
+      }
       if (!(e.getCause() instanceof ExternalDepsException)) {
         // ExternalDepsException events should already have been reported.
         env.getListener().handle(Event.error(e.getInnermostLocation(), e.getMessageWithStack()));

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -36,6 +36,7 @@ import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor;
 import com.google.devtools.build.lib.server.FailureDetails.ExternalDeps.Code;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue;
 import com.google.devtools.build.lib.skyframe.RepositoryMappingValue;
+import com.google.devtools.build.lib.vfs.DetailedIOException;
 import com.google.devtools.build.skyframe.SkyFunction;
 import com.google.devtools.build.skyframe.SkyFunctionException;
 import com.google.devtools.build.skyframe.SkyKey;
@@ -478,7 +479,11 @@ public class SingleExtensionEvalFunction implements SkyFunction {
 
   private static final class SingleExtensionEvalFunctionException extends SkyFunctionException {
     SingleExtensionEvalFunctionException(ExternalDepsException cause) {
-      super(cause, Transience.PERSISTENT);
+      super(
+          cause,
+          cause.getCause() instanceof DetailedIOException detailedCause
+              ? detailedCause.getTransience()
+              : Transience.PERSISTENT);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -2396,8 +2396,10 @@ func(
       try {
         remoteFs.ensureMaterialized(label.getRepository(), env.getListener());
       } catch (IOException e) {
-        throw Starlark.errorf(
-            "Failed to materialize remote repo %s: %s", label.getRepository(), e.getMessage());
+        throw new EvalException(
+            "Failed to materialize remote repo %s: %s"
+                .formatted(label.getRepository(), e.getMessage()),
+            e);
       }
     }
     StarlarkPath starlarkPath = new StarlarkPath(this, rootedPath.asPath());

--- a/src/main/java/com/google/devtools/build/lib/packages/RepositoryFetchException.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RepositoryFetchException.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.packages;
 
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
+import com.google.devtools.build.lib.util.DetailedExitCode;
 import java.io.IOException;
 
 /** Exception indicating an attempt to access a package which is not found or does not exist. */
@@ -27,5 +28,13 @@ public class RepositoryFetchException extends NoSuchPackageException {
   public RepositoryFetchException(
       PackageIdentifier packageIdentifier, String message, IOException cause) {
     super(packageIdentifier, message, cause);
+  }
+
+  public RepositoryFetchException(
+      PackageIdentifier packageIdentifier,
+      String message,
+      Exception cause,
+      DetailedExitCode detailedExitCode) {
+    super(packageIdentifier, message, cause, detailedExitCode);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -757,6 +757,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
         "//src/main/java/com/google/devtools/build/lib/remote/common:bulk_transfer_exception",
+        "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/util:digest_util",
         "//src/main/java/com/google/devtools/build/lib/remote/util:tracing_metadata_utils",
         "//src/main/java/com/google/devtools/build/lib/remote/util:utils",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.remote.common.BulkTransferException;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
@@ -97,6 +98,7 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
   // externalFs.
   private final ConcurrentHashMap<String, String> markerFileContents = new ConcurrentHashMap<>();
   private final Set<String> reposWithLostFiles = ConcurrentHashMap.newKeySet();
+  private final Set<String> reposToRefetch = ConcurrentHashMap.newKeySet();
 
   // Per-build information that is set in beforeCommand and cleared in afterCommand.
   @Nullable private CombinedCache cache;
@@ -174,8 +176,19 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
                 : null,
         this::evictInMemoryRepo);
     invalidateRepoDirectories(evaluator, reposWithLostFiles);
+    reposToRefetch.addAll(reposWithLostFiles);
     reposWithLostFiles.clear();
     this.evaluator = null;
+  }
+
+  /** Returns whether the repository must be refetched to replace missing remote contents. */
+  public boolean shouldRefetch(RepositoryName repo) {
+    return reposToRefetch.contains(repo.getName());
+  }
+
+  /** Records that a refetched repository has been successfully uploaded to the remote cache. */
+  public void repoContentsUploaded(RepositoryName repo) {
+    reposToRefetch.remove(repo.getName());
   }
 
   /** Removes the contents of the given repo from the in-memory overlay file system. */
@@ -387,10 +400,34 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
       root = root.resolveSymbolicLinks();
     }
     collectAndCreateDirectories(root, files, symlinks, new HashSet<>());
-    prefetch(files);
-    // Create symlinks last as some platforms don't allow creating a symlink to a non-existent
-    // target.
-    prefetch(symlinks);
+    try {
+      prefetch(files);
+      // Create symlinks last as some platforms don't allow creating a symlink to a non-existent
+      // target.
+      prefetch(symlinks);
+    } catch (BulkTransferException e) {
+      if (!e.allCausedByCacheNotFoundException()) {
+        throw e;
+      }
+      var missing = (CacheNotFoundException) e.getSuppressed()[0];
+      var execPath = missing.getExecPath();
+      var relativePath =
+          execPath != null && execPath.startsWith(path)
+              ? execPath.relativeTo(externalDirectory)
+              : path.relativeTo(externalDirectory);
+      throw lostRemoteFile(relativePath, missing.getMissingDigest(), e);
+    }
+  }
+
+  private DetailedIOException lostRemoteFile(
+      PathFragment relativePath, Digest digest, BulkTransferException cause) {
+    reposWithLostFiles.add(relativePath.getSegment(0));
+    return new DetailedIOException(
+        "%s/%s with digest %s is no longer available in the remote cache"
+            .formatted(externalDirectory.getBaseName(), relativePath, DigestUtil.toString(digest)),
+        cause,
+        FailureDetails.Filesystem.Code.REMOTE_FILE_EVICTED,
+        SkyFunctionException.Transience.TRANSIENT);
   }
 
   private void collectAndCreateDirectories(
@@ -803,14 +840,7 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
         throw new InterruptedIOException("interrupted while waiting for remote file transfer");
       } catch (BulkTransferException e) {
         if (e.allCausedByCacheNotFoundException()) {
-          reposWithLostFiles.add(relativePath.getSegment(0));
-          throw new DetailedIOException(
-              "%s/%s with digest %s is no longer available in the remote cache"
-                  .formatted(
-                      externalDirectory.getBaseName(), relativePath, DigestUtil.toString(digest)),
-              e,
-              FailureDetails.Filesystem.Code.REMOTE_FILE_EVICTED,
-              SkyFunctionException.Transience.TRANSIENT);
+          throw lostRemoteFile(relativePath, digest, e);
         }
         throw e;
       } catch (ExecutionException e) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
@@ -169,7 +169,7 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
       String predeclaredInputHash,
       ExtendedEventHandler reporter)
       throws InterruptedException {
-    if (!(fetchedRepoDir.getFileSystem() instanceof RemoteExternalOverlayFileSystem)) {
+    if (!(fetchedRepoDir.getFileSystem() instanceof RemoteExternalOverlayFileSystem remoteFs)) {
       return;
     }
     var context = buildContext(repoName, CacheOp.UPLOAD);
@@ -214,6 +214,7 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
                   /* wallTimeInMs= */ 0,
                   /* preserveExecutableBit= */ true)
               .upload(context, cache, reporter);
+      remoteFs.repoContentsUploaded(repoName);
     } catch (ExecException | IOException e) {
       reporter.handle(
           Event.warn(
@@ -246,6 +247,9 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
       SkyFunction.Environment env)
       throws IOException, InterruptedException {
     if (!(repoDir.getFileSystem() instanceof RemoteExternalOverlayFileSystem remoteFs)) {
+      return false;
+    }
+    if (remoteFs.shouldRefetch(repoName)) {
       return false;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.skyframe;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.FileStateValue;
@@ -354,6 +355,22 @@ public class PackageLookupFunction implements SkyFunction {
       throw new PackageLookupFunctionException(
           new BuildFileNotFoundException(id, e.getMessage()), Transience.PERSISTENT);
     } catch (IOException | EvalException | AlreadyReportedException e) {
+      for (Throwable cause : Throwables.getCausalChain(e)) {
+        if (cause instanceof DetailedIOException detailedCause) {
+          String message =
+              e.getMessage() != null ? e.getMessage() : detailedCause.getMessage();
+          throw new PackageLookupFunctionException(
+              new RepositoryFetchException(
+                  id,
+                  message,
+                  e,
+                  DetailedExitCode.of(
+                      detailedCause.getDetailedExitCode().getFailureDetail().toBuilder()
+                          .setMessage(message)
+                          .build())),
+              detailedCause.getTransience());
+        }
+      }
       throw new PackageLookupFunctionException(
           new RepositoryFetchException(id, e.getMessage()), Transience.PERSISTENT);
     }

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -534,6 +534,8 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     dir_b = self.ScratchDir('b')
     self.ScratchFile('a/MODULE.bazel', module_bazel_lines)
     self.ScratchFile('b/MODULE.bazel', module_bazel_lines)
+    self.CopyFile(self.Path('MODULE.bazel.lock'), 'a/MODULE.bazel.lock')
+    self.CopyFile(self.Path('MODULE.bazel.lock'), 'b/MODULE.bazel.lock')
     self.ScratchFile('a/BUILD.bazel')
     self.ScratchFile('b/BUILD.bazel')
     self.ScratchFile('a/repo.bzl', repo_bzl_lines)
@@ -1976,6 +1978,90 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     self.assertFalse(os.path.exists(os.path.join(repo_dir, 'root.txt')))
     self.assertFalse(os.path.exists(os.path.join(repo_dir, 'sub/BUILD')))
     self.assertTrue(os.path.exists(os.path.join(repo_dir, 'sub/sub.txt')))
+
+  def testLostRemoteFile_moduleExtensionMaterialization(self):
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo")',
+            'ext = use_extension("//:extension.bzl", "ext")',
+            'use_repo(ext, "other")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            '  rctx.file("BUILD", "filegroup(name=\'root\')")',
+            (
+                '  rctx.file("examples/basic_gazelle/.bazelrc",'
+                ' "build --color=no\\n")'
+            ),
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(_repo_impl)',
+        ],
+    )
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def _other_repo_impl(rctx):',
+            '  rctx.file("BUILD", "filegroup(name=\'root\')")',
+            'other_repo = repository_rule(_other_repo_impl)',
+            'def _extension_impl(module_ctx):',
+            '  module_ctx.path(Label("@my_repo//:BUILD"))',
+            '  other_repo(name="other")',
+            'ext = module_extension(implementation=_extension_impl)',
+        ],
+    )
+
+    repo_dir = self.RepoDir('my_repo')
+
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:root'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:root'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertFalse(os.path.exists(os.path.join(repo_dir, 'BUILD')))
+    self.assertFalse(
+        os.path.exists(
+            os.path.join(repo_dir, 'examples/basic_gazelle/.bazelrc')
+        )
+    )
+
+    self.DeleteCasEntry(b'build --color=no\n')
+
+    _, _, stderr = self.RunBazel(['build', '@other//:root'])
+    stderr = '\n'.join(stderr)
+    self.assertEqual(
+        1,
+        stderr.count(
+            'Found transient remote cache error, retrying the build...'
+        ),
+    )
+    self.assertIn('JUST FETCHED', stderr)
+    self.assertTrue(
+        os.path.exists(
+            os.path.join(repo_dir, 'examples/basic_gazelle/.bazelrc')
+        )
+    )
+
+    # The refetch must repair the remote entry, not just the current output
+    # base, so a cold build can use the repository cache again.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:root'])
+    stderr = '\n'.join(stderr)
+    self.assertNotIn('JUST FETCHED', stderr)
+
+    _, _, stderr = self.RunBazel(['build', '@other//:root'])
+    stderr = '\n'.join(stderr)
+    self.assertNotIn(
+        'Found transient remote cache error, retrying the build...', stderr
+    )
+    self.assertNotIn('JUST FETCHED', stderr)
 
   def doTestMaterializationWithInternalAndExternalSymlinks(
       self, *, expect_symlinks, watch_dep_file=True


### PR DESCRIPTION
## Summary

Builds on the full-repository materialization recovery proposed in #30226, which is still open, and extends that recovery to Bzlmod module-extension evaluation.

A remote repository-contents-cache entry can outlive one of its CAS blobs. When a module extension requests full materialization, error wrapping currently converts the retryable `REMOTE_FILE_EVICTED` failure into a persistent module-extension failure. Preserve the original `DetailedIOException` and transient `SkyFunctionException` through Starlark, package lookup, and module-extension evaluation; evict the incomplete in-memory repository; and bypass its stale repository-contents-cache entry until a successful repository refetch and upload repair the remote cache.

Add `RemoteRepoContentsCacheTest.testLostRemoteFile_moduleExtensionMaterialization` to exercise an evicted `.bazelrc` blob, exactly one automatic retry, a successful repository refetch, and a subsequent cold-cache hit. Preserve registry lockfiles in secondary test workspaces so the existing remote repository-contents-cache tests remain hermetic.

Fixes #30218.

## Validation

- `git diff --check 453df7957d3740263521f55baf6fa74bc8b1aa72 HEAD`
- `buildifier -mode=check src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD src/main/java/com/google/devtools/build/lib/remote/BUILD`
- `python3 -X pycache_prefix=/private/tmp/bazel-r2c2-module-extension-recovery-upstream-pycache -m py_compile src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py`
- Buildkite presubmit [#35013](https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/35013) is running.
