### PR TITLE
Introduce a debug message for non remote cacheable repos when using `--experimental_remote_repo_contents_cache`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryFetchFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryFetchFunction.java
@@ -390,6 +390,18 @@ public final class RepositoryFetchFunction implements SkyFunction {
             return null;
           }
         }
+      } else if (remoteRepoContentsCache != null
+          && !repoDefinition.repoRule().local()
+          && result.reproducible() != Reproducibility.YES) {
+        // Surface why an otherwise-cacheable repo wasn't offered to the remote repo contents
+        // cache. Local repos are intentionally never cached remotely, so they aren't reported
+        // here to avoid noise.
+        env.getListener()
+            .handle(
+                Event.debug(
+                    ("Not storing repo %s in the remote repo contents cache: its repo rule did"
+                            + " not mark the fetched contents as reproducible")
+                        .formatted(repositoryName)));
       }
       return new Success(Root.fromPath(repoRoot), excludeRepoFromVendoring);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description

If the remote_repo_contents_cache was opted-in, and a repo is encountered which is not local (opted-out) but still couldn't be cached because it was not marked as reproducible, print a debug message.

I'm aware this could lead to potentially a lot of spam. But it will only print when someone has actually enabled `--experimental_remote_repo_contents_cache`, so I feel like they would want to see all this feedback and repos they could potentially optimise.

### Motivation

I am trying to enable`--experimental_remote_repo_contents_cache` in my org, but it's not bringing as large a benefit as I was expecting. I suspect it's because we have a bunch of repos that are not marked as reproducible. But currently there's no easy way to work out what those repos actually are. Making it obvious like this will hopefully incentivise people to act to make it reproducible faster, allowing for a larger benefit.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
