### PR TITLE
[9.3.0] Stop building for ubuntu 20.04

### DIFF
--- a/.bazelci/build_bazel_binaries.yml
+++ b/.bazelci/build_bazel_binaries.yml
@@ -14,16 +14,6 @@ platforms:
     build_flags:
       - "-c"
       - "opt"
-  ubuntu2404_arm64:
-    build_targets:
-      - "//src:bazel"
-      - "//src:bazel_nojdk"
-    build_flags:
-      - "-c"
-      - "opt"
-      # https://github.com/bazelbuild/continuous-integration/issues/2353
-      - "--linkopt=-Wl,--no-fix-cortex-a53-843419"
-      - "--host_linkopt=-Wl,--no-fix-cortex-a53-843419"
   ubuntu2404:
     build_targets:
       - "//src:bazel"

--- a/.bazelci/build_bazel_binaries.yml
+++ b/.bazelci/build_bazel_binaries.yml
@@ -31,6 +31,13 @@ platforms:
     build_flags:
       - "-c"
       - "opt"
+  ubuntu2204:
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_nojdk"
+    build_flags:
+      - "-c"
+      - "opt"
   macos:
     build_targets:
       - "//src:bazel"

--- a/.bazelci/build_bazel_binaries.yml
+++ b/.bazelci/build_bazel_binaries.yml
@@ -14,23 +14,6 @@ platforms:
     build_flags:
       - "-c"
       - "opt"
-  ubuntu2404_arm64:
-    build_targets:
-      - "//src:bazel"
-      - "//src:bazel_nojdk"
-    build_flags:
-      - "-c"
-      - "opt"
-      # https://github.com/bazelbuild/continuous-integration/issues/2353
-      - "--linkopt=-Wl,--no-fix-cortex-a53-843419"
-      - "--host_linkopt=-Wl,--no-fix-cortex-a53-843419"
-  ubuntu2404:
-    build_targets:
-      - "//src:bazel"
-      - "//src:bazel_nojdk"
-    build_flags:
-      - "-c"
-      - "opt"
   ubuntu2204:
     build_targets:
       - "//src:bazel"
@@ -38,7 +21,17 @@ platforms:
     build_flags:
       - "-c"
       - "opt"
+  ubuntu2404:
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_nojdk"
+    build_flags:
+      - "-c"
+      - "opt"
   macos:
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"

--- a/.bazelci/build_bazel_binaries.yml
+++ b/.bazelci/build_bazel_binaries.yml
@@ -14,13 +14,16 @@ platforms:
     build_flags:
       - "-c"
       - "opt"
-  ubuntu2204:
+  ubuntu2404_arm64:
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"
     build_flags:
       - "-c"
       - "opt"
+      # https://github.com/bazelbuild/continuous-integration/issues/2353
+      - "--linkopt=-Wl,--no-fix-cortex-a53-843419"
+      - "--host_linkopt=-Wl,--no-fix-cortex-a53-843419"
   ubuntu2404:
     build_targets:
       - "//src:bazel"
@@ -28,10 +31,14 @@ platforms:
     build_flags:
       - "-c"
       - "opt"
+  ubuntu2204:
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_nojdk"
+    build_flags:
+      - "-c"
+      - "opt"
   macos:
-    environment:
-      ANDROID_HOME: ""
-      ANDROID_NDK_HOME: ""
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"

--- a/.bazelci/build_bazel_binaries.yml
+++ b/.bazelci/build_bazel_binaries.yml
@@ -14,14 +14,7 @@ platforms:
     build_flags:
       - "-c"
       - "opt"
-  ubuntu2004:
-    build_targets:
-      - "//src:bazel"
-      - "//src:bazel_nojdk"
-    build_flags:
-      - "-c"
-      - "opt"
-  ubuntu2004_arm64:
+  ubuntu2404_arm64:
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -103,8 +103,8 @@ tasks:
     include_json_profile:
       - build
       - test
-  ubuntu2004_clang:
-    platform: ubuntu2004
+  ubuntu2404_clang:
+    platform: ubuntu2404
     environment:
       CC: clang
       CC_CONFIGURE_DEBUG: 1
@@ -123,36 +123,6 @@ tasks:
       - "--config=ci-linux"
     test_targets:
       - "//src/test/shell/bazel:cc_integration_test"
-    include_json_profile:
-      - build
-      - test
-  ubuntu2004:
-    shell_commands:
-      - rm -rf $HOME/bazeltest
-      - mkdir $HOME/bazeltest
-    build_flags:
-      - "--config=ci-linux"
-    build_targets:
-      - "//src:bazel"
-      - "//src:bazel_jdk_minimal"
-      - "//src:test_repos"
-      - "//src/main/java/..."
-    test_flags:
-      - "--config=ci-linux"
-    test_targets:
-      - "//scripts/..."
-      - "//src/java_tools/..."
-      - "//src/main/starlark/tests/builtins_bzl/..."
-      - "//src/test/..."
-      - "//src/tools/execlog/..."
-      - "//src/tools/one_version/..."
-      - "//src/tools/singlejar/..."
-      - "//src/tools/workspacelog/..."
-      - "//third_party/ijar/..."
-      - "//tools/aquery_differ/..."
-      - "//tools/python/..."
-      - "//tools/bash/..."
-      - "//tools/test/..."
     include_json_profile:
       - build
       - test

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -1,11 +1,10 @@
 ---
-check_docs: 1
+
 tasks:
   rockylinux8:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
-      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=ci-linux"
     build_targets:
@@ -15,11 +14,26 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//..."
+      - "//src/main/java/..."
+      - "//src/tools/diskcache/..."
+      - "//src/tools/execlog/..."
     test_flags:
       - "--config=ci-linux"
     test_targets:
-      - "//..."
+      - "//scripts/..."
+      - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/one_version/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/compliance/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+      - "//tools/test/..."
       # These tests are not compatible with the gcov version of Rocky Linux 8.
       - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
       - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_gcc"
@@ -32,7 +46,6 @@ tasks:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
-      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=ci-linux"
     build_targets:
@@ -42,14 +55,15 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//..."
+      - "//src/main/java/..."
+      - "//src/tools/diskcache/..."
+      - "//src/tools/execlog/..."
     include_json_profile:
       - build
   fedora39:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
-      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=ci-linux"
     build_targets:
@@ -63,23 +77,34 @@ tasks:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
-      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=ci-linux"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//..."
+      - "//src/main/java/..."
     test_flags:
       - "--config=ci-linux"
     test_targets:
-      - "//..."
+      - "//scripts/..."
+      - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/one_version/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+      - "//tools/test/..."
     include_json_profile:
       - build
       - test
-  ubuntu2204_clang:
-    platform: ubuntu2204
+  ubuntu2404_clang:
+    platform: ubuntu2404
     environment:
       CC: clang
       CC_CONFIGURE_DEBUG: 1
@@ -87,37 +112,17 @@ tasks:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
-      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=ci-linux"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//..."
+      - "//src/main/java/..."
     test_flags:
       - "--config=ci-linux"
     test_targets:
       - "//src/test/shell/bazel:cc_integration_test"
-    include_json_profile:
-      - build
-      - test
-  ubuntu2204:
-    shell_commands:
-      - rm -rf $HOME/bazeltest
-      - mkdir $HOME/bazeltest
-      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
-    build_flags:
-      - "--config=ci-linux"
-    build_targets:
-      - "//src:bazel"
-      - "//src:bazel_jdk_minimal"
-      - "//src:test_repos"
-      - "//..."
-    test_flags:
-      - "--config=ci-linux"
-    test_targets:
-      - "//..."
     include_json_profile:
       - build
       - test
@@ -127,10 +132,6 @@ tasks:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
       - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
-      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
-    environment:
-      ANDROID_HOME: ""
-      ANDROID_NDK_HOME: ""
     build_flags:
       - "--config=ci-macos"
     build_targets:
@@ -142,10 +143,22 @@ tasks:
       # Fine tune the number of test jobs running in parallel to avoid timeout
       - "--local_test_jobs=2"
     test_targets:
-      - "//..."
+      - "//scripts/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/one_version/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+      - "//tools/test/..."
       # Disable python and shell integration tests on Intel Macs
       - "-//src/test/shell/..."
       - "-//src/test/py/..."
+      - "-//src/main/starlark/tests/builtins_bzl:cc_builtin_tests"
       # https://github.com/bazelbuild/bazel/issues/17410
       - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
       # Disable android tests since we are moving Android rules out of the Bazel repo.
@@ -164,14 +177,12 @@ tasks:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
       - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
-      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=ci-macos"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//..."
     test_flags:
       - "--config=ci-macos"
       # Fine tune the number of test jobs running in parallel to avoid timeout
@@ -179,7 +190,18 @@ tasks:
       # Increase the test timeout by 20% to avoid flaky test failures due to timeout
       - "--test_timeout=72,360,1080,4320"
     test_targets:
-      - "//..."
+      - "//scripts/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/one_version/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+      - "//tools/test/..."
       # https://github.com/bazelbuild/bazel/issues/17410
       - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
     include_json_profile:
@@ -189,7 +211,6 @@ tasks:
     setup:
       - mkdir C:\b
       - mklink /J C:\b\bazeltest_external %OUTPUT_BASE:/=\%\external
-      - IF DEFINED UPDATE_BAZEL_LOCK_FILE bazel mod deps --lockfile_mode=update
     build_flags:
       - "--config=ci-windows"
     build_targets:
@@ -201,12 +222,14 @@ tasks:
       - "--config=ci-windows"
     test_targets:
       - "//src:embedded_tools_size_test"
+      - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/cpp/..."
       - "//src/test/java/com/google/devtools/build/lib/..."
       - "//src/test/java/com/google/devtools/build/skyframe/..."
       - "//src/test/java/com/google/devtools/common/options/..."
       - "//src/test/native/windows/..."
       - "//src/test/py/bazel/..."
+      - "//src/test/res/..."
       - "//src/test/shell/..."
       - "//src/tools/launcher/..."
       - "//src/tools/one_version/..."
@@ -223,6 +246,9 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/4292
       - "-//src/test/shell/bazel/remote/..."
       - "-//tools/python:pywrapper_test"
+      # Temporarily disable this test which is failing on Windows due to a clang update.
+      # TODO(b/530925565): Re-enable.
+      - "-//src/test/py/bazel:launcher_test"
     include_json_profile:
       - build
       - test
@@ -232,7 +258,6 @@ tasks:
     setup:
       - mkdir C:\b
       - mklink /J C:\b\bazeltest_external %OUTPUT_BASE:/=\%\external
-      - IF DEFINED UPDATE_BAZEL_LOCK_FILE bazel mod deps --lockfile_mode=update
     build_flags:
       - "--config=ci-windows"
       - "--config=windows_arm64"
@@ -244,25 +269,26 @@ tasks:
   rbe_ubuntu2404:
     platform: ubuntu2404
     name: "RBE"
-    shell_commands:
-      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=remote"
-      - "--config=ci-common"
+      - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"
       - "--jobs=200"
+      - "--remote_download_minimal"
       - "--experimental_output_paths=strip"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
-      - "//..."
+      - "//src/main/java/..."
     test_flags:
       - "--config=remote"
-      - "--config=ci-common"
+      - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"
       - "--jobs=200"
+      - "--remote_download_minimal"
       - "--experimental_output_paths=strip"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/..."
       - "//src/tools/execlog/..."
       - "//src/tools/one_version/..."
@@ -289,6 +315,14 @@ tasks:
       - "-//src/test/py/bazel:bzlmod_query_test"
       - "-//src/test/py/bazel:mod_command_test"
       - "-//src/test/shell/bazel:starlark_repository_test"
+      # Disable tests that fail on RBE due to sandboxing/mount restrictions
+      - "-//src/test/shell/integration:sandboxing_test"
+      - "-//src/test/java/com/google/devtools/build/lib/shell:CommandUsingLinuxSandboxTest"
+      - "-//src/test/shell/bazel:bazel_spawnstats_test"
+      - "-//src/test/shell/integration:bazel_hardened_sandboxed_worker_test"
+      - "-//src/test/shell/integration:test_test"
+      - "-//src/test/tools:linux-sandbox_test"
+      - "-//src/test/tools:daemonize_test"
     include_json_profile:
       - build
       - test

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -126,6 +126,25 @@ tasks:
     include_json_profile:
       - build
       - test
+  ubuntu2204:
+    shell_commands:
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
+    build_flags:
+      - "--config=ci-linux"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+      - "//..."
+    test_flags:
+      - "--config=ci-linux"
+    test_targets:
+      - "//..."
+    include_json_profile:
+      - build
+      - test
   macos:
     shards: 5
     shell_commands:

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -1,10 +1,11 @@
 ---
-
+check_docs: 1
 tasks:
   rockylinux8:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
+      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=ci-linux"
     build_targets:
@@ -14,26 +15,11 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//src/main/java/..."
-      - "//src/tools/diskcache/..."
-      - "//src/tools/execlog/..."
+      - "//..."
     test_flags:
       - "--config=ci-linux"
     test_targets:
-      - "//scripts/..."
-      - "//src/java_tools/..."
-      - "//src/main/starlark/tests/builtins_bzl/..."
-      - "//src/test/..."
-      - "//src/tools/execlog/..."
-      - "//src/tools/one_version/..."
-      - "//src/tools/singlejar/..."
-      - "//src/tools/workspacelog/..."
-      - "//third_party/ijar/..."
-      - "//tools/aquery_differ/..."
-      - "//tools/compliance/..."
-      - "//tools/python/..."
-      - "//tools/bash/..."
-      - "//tools/test/..."
+      - "//..."
       # These tests are not compatible with the gcov version of Rocky Linux 8.
       - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
       - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_gcc"
@@ -46,6 +32,7 @@ tasks:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
+      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=ci-linux"
     build_targets:
@@ -55,15 +42,14 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//src/main/java/..."
-      - "//src/tools/diskcache/..."
-      - "//src/tools/execlog/..."
+      - "//..."
     include_json_profile:
       - build
   fedora39:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
+      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=ci-linux"
     build_targets:
@@ -77,34 +63,23 @@ tasks:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
+      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=ci-linux"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//src/main/java/..."
+      - "//..."
     test_flags:
       - "--config=ci-linux"
     test_targets:
-      - "//scripts/..."
-      - "//src/java_tools/..."
-      - "//src/main/starlark/tests/builtins_bzl/..."
-      - "//src/test/..."
-      - "//src/tools/execlog/..."
-      - "//src/tools/one_version/..."
-      - "//src/tools/singlejar/..."
-      - "//src/tools/workspacelog/..."
-      - "//third_party/ijar/..."
-      - "//tools/aquery_differ/..."
-      - "//tools/python/..."
-      - "//tools/bash/..."
-      - "//tools/test/..."
+      - "//..."
     include_json_profile:
       - build
       - test
-  ubuntu2404_clang:
-    platform: ubuntu2404
+  ubuntu2204_clang:
+    platform: ubuntu2204
     environment:
       CC: clang
       CC_CONFIGURE_DEBUG: 1
@@ -112,17 +87,37 @@ tasks:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
+      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=ci-linux"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//src/main/java/..."
+      - "//..."
     test_flags:
       - "--config=ci-linux"
     test_targets:
       - "//src/test/shell/bazel:cc_integration_test"
+    include_json_profile:
+      - build
+      - test
+  ubuntu2204:
+    shell_commands:
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
+    build_flags:
+      - "--config=ci-linux"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+      - "//..."
+    test_flags:
+      - "--config=ci-linux"
+    test_targets:
+      - "//..."
     include_json_profile:
       - build
       - test
@@ -132,6 +127,10 @@ tasks:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
       - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
+      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
     build_flags:
       - "--config=ci-macos"
     build_targets:
@@ -143,22 +142,10 @@ tasks:
       # Fine tune the number of test jobs running in parallel to avoid timeout
       - "--local_test_jobs=2"
     test_targets:
-      - "//scripts/..."
-      - "//src/main/starlark/tests/builtins_bzl/..."
-      - "//src/test/..."
-      - "//src/tools/execlog/..."
-      - "//src/tools/one_version/..."
-      - "//src/tools/singlejar/..."
-      - "//src/tools/workspacelog/..."
-      - "//third_party/ijar/..."
-      - "//tools/aquery_differ/..."
-      - "//tools/python/..."
-      - "//tools/bash/..."
-      - "//tools/test/..."
+      - "//..."
       # Disable python and shell integration tests on Intel Macs
       - "-//src/test/shell/..."
       - "-//src/test/py/..."
-      - "-//src/main/starlark/tests/builtins_bzl:cc_builtin_tests"
       # https://github.com/bazelbuild/bazel/issues/17410
       - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
       # Disable android tests since we are moving Android rules out of the Bazel repo.
@@ -177,12 +164,14 @@ tasks:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
       - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
+      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=ci-macos"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
+      - "//..."
     test_flags:
       - "--config=ci-macos"
       # Fine tune the number of test jobs running in parallel to avoid timeout
@@ -190,18 +179,7 @@ tasks:
       # Increase the test timeout by 20% to avoid flaky test failures due to timeout
       - "--test_timeout=72,360,1080,4320"
     test_targets:
-      - "//scripts/..."
-      - "//src/main/starlark/tests/builtins_bzl/..."
-      - "//src/test/..."
-      - "//src/tools/execlog/..."
-      - "//src/tools/one_version/..."
-      - "//src/tools/singlejar/..."
-      - "//src/tools/workspacelog/..."
-      - "//third_party/ijar/..."
-      - "//tools/aquery_differ/..."
-      - "//tools/python/..."
-      - "//tools/bash/..."
-      - "//tools/test/..."
+      - "//..."
       # https://github.com/bazelbuild/bazel/issues/17410
       - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
     include_json_profile:
@@ -211,6 +189,7 @@ tasks:
     setup:
       - mkdir C:\b
       - mklink /J C:\b\bazeltest_external %OUTPUT_BASE:/=\%\external
+      - IF DEFINED UPDATE_BAZEL_LOCK_FILE bazel mod deps --lockfile_mode=update
     build_flags:
       - "--config=ci-windows"
     build_targets:
@@ -222,14 +201,12 @@ tasks:
       - "--config=ci-windows"
     test_targets:
       - "//src:embedded_tools_size_test"
-      - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/cpp/..."
       - "//src/test/java/com/google/devtools/build/lib/..."
       - "//src/test/java/com/google/devtools/build/skyframe/..."
       - "//src/test/java/com/google/devtools/common/options/..."
       - "//src/test/native/windows/..."
       - "//src/test/py/bazel/..."
-      - "//src/test/res/..."
       - "//src/test/shell/..."
       - "//src/tools/launcher/..."
       - "//src/tools/one_version/..."
@@ -246,9 +223,6 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/4292
       - "-//src/test/shell/bazel/remote/..."
       - "-//tools/python:pywrapper_test"
-      # Temporarily disable this test which is failing on Windows due to a clang update.
-      # TODO(b/530925565): Re-enable.
-      - "-//src/test/py/bazel:launcher_test"
     include_json_profile:
       - build
       - test
@@ -258,6 +232,7 @@ tasks:
     setup:
       - mkdir C:\b
       - mklink /J C:\b\bazeltest_external %OUTPUT_BASE:/=\%\external
+      - IF DEFINED UPDATE_BAZEL_LOCK_FILE bazel mod deps --lockfile_mode=update
     build_flags:
       - "--config=ci-windows"
       - "--config=windows_arm64"
@@ -269,26 +244,25 @@ tasks:
   rbe_ubuntu2404:
     platform: ubuntu2404
     name: "RBE"
+    shell_commands:
+      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=remote"
-      - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"
+      - "--config=ci-common"
       - "--jobs=200"
-      - "--remote_download_minimal"
       - "--experimental_output_paths=strip"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
-      - "//src/main/java/..."
+      - "//..."
     test_flags:
       - "--config=remote"
-      - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"
+      - "--config=ci-common"
       - "--jobs=200"
-      - "--remote_download_minimal"
       - "--experimental_output_paths=strip"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
-      - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/..."
       - "//src/tools/execlog/..."
       - "//src/tools/one_version/..."
@@ -315,14 +289,6 @@ tasks:
       - "-//src/test/py/bazel:bzlmod_query_test"
       - "-//src/test/py/bazel:mod_command_test"
       - "-//src/test/shell/bazel:starlark_repository_test"
-      # Disable tests that fail on RBE due to sandboxing/mount restrictions
-      - "-//src/test/shell/integration:sandboxing_test"
-      - "-//src/test/java/com/google/devtools/build/lib/shell:CommandUsingLinuxSandboxTest"
-      - "-//src/test/shell/bazel:bazel_spawnstats_test"
-      - "-//src/test/shell/integration:bazel_hardened_sandboxed_worker_test"
-      - "-//src/test/shell/integration:test_test"
-      - "-//src/test/tools:linux-sandbox_test"
-      - "-//src/test/tools:daemonize_test"
     include_json_profile:
       - build
       - test

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -130,21 +130,29 @@ tasks:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
-      - if [ -n "${UPDATE_BAZEL_LOCK_FILE:-}" ]; then bazel mod deps --lockfile_mode=update; fi
     build_flags:
       - "--config=ci-linux"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//..."
+      - "//src/main/java/..."
     test_flags:
       - "--config=ci-linux"
     test_targets:
-      - "//..."
-    include_json_profile:
-      - build
-      - test
+      - "//scripts/..."
+      - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/one_version/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+      - "//tools/test/..."
   macos:
     shards: 5
     shell_commands:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -105,8 +105,8 @@ tasks:
     include_json_profile:
       - build
       - test
-  ubuntu2004_clang:
-    platform: ubuntu2004
+  ubuntu2404_clang:
+    platform: ubuntu2404
     environment:
       CC: clang
       CC_CONFIGURE_DEBUG: 1
@@ -125,37 +125,6 @@ tasks:
       - "--config=ci-linux"
     test_targets:
       - "//src/test/shell/bazel:cc_integration_test"
-    include_json_profile:
-      - build
-      - test
-  ubuntu2004:
-    shards: 4
-    shell_commands:
-      - rm -rf $HOME/bazeltest
-      - mkdir $HOME/bazeltest
-    build_flags:
-      - "--config=ci-linux"
-    build_targets:
-      - "//src:bazel"
-      - "//src:bazel_jdk_minimal"
-      - "//src:test_repos"
-      - "//src/main/java/..."
-    test_flags:
-      - "--config=ci-linux"
-    test_targets:
-      - "//scripts/..."
-      - "//src/java_tools/..."
-      - "//src/main/starlark/tests/builtins_bzl/..."
-      - "//src/test/..."
-      - "//src/tools/execlog/..."
-      - "//src/tools/one_version/..."
-      - "//src/tools/singlejar/..."
-      - "//src/tools/workspacelog/..."
-      - "//third_party/ijar/..."
-      - "//tools/aquery_differ/..."
-      - "//tools/python/..."
-      - "//tools/bash/..."
-      - "//tools/test/..."
     include_json_profile:
       - build
       - test
@@ -367,8 +336,8 @@ tasks:
     include_json_profile:
       - build
       - test
-  docs_ubuntu2004:
-    platform: ubuntu2004
+  docs_ubuntu2404:
+    platform: ubuntu2404
     name: "Docs"
     build_flags:
       - "--config=docs"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,8 +1,7 @@
 ---
-
+check_docs: 1
 tasks:
   rockylinux8:
-    shards: 4
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
@@ -15,31 +14,20 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//src/main/java/..."
-      - "//src/tools/diskcache/..."
-      - "//src/tools/execlog/..."
+      - "//..."
     test_flags:
       - "--config=ci-linux"
+      - "--test_tag_filters=-no_presubmit"
     test_targets:
-      - "//scripts/..."
-      - "//src/java_tools/..."
-      - "//src/main/starlark/tests/builtins_bzl/..."
-      - "//src/test/..."
-      - "//src/tools/execlog/..."
-      - "//src/tools/one_version/..."
-      - "//src/tools/singlejar/..."
-      - "//src/tools/workspacelog/..."
-      - "//third_party/ijar/..."
-      - "//tools/aquery_differ/..."
-      - "//tools/compliance/..."
-      - "//tools/python/..."
-      - "//tools/bash/..."
-      - "//tools/test/..."
-      # These tests are not compatible with the gcov version of Rocky Linux 8.
-      - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
-      - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_gcc"
-      - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"
-      - "-//src/test/shell/bazel:bazel_coverage_sh_test"
+      - "//src:embedded_tools_size_test"
+      - "//src/test/py/bazel:bazel_module_test"
+      - "//src/test/py/bazel:mod_command_test"
+      - "//src/test/shell/bazel:bazel_example_test"
+      - "//src/test/shell/bazel:bazel_java_test"
+      - "//src/test/shell/bazel:cc_integration_test"
+      - "//src/test/shell/bazel:external_integration_test"
+      - "//src/test/shell/bazel:help_test"
+      - "//src/test/shell/integration:bazel_query_test"
     include_json_profile:
       - build
       - test
@@ -56,9 +44,7 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//src/main/java/..."
-      - "//src/tools/diskcache/..."
-      - "//src/tools/execlog/..."
+      - "//..."
     include_json_profile:
       - build
   fedora39:
@@ -75,7 +61,7 @@ tasks:
       - build
       - test
   ubuntu2404:
-    shards: 4
+    shards: 8
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
@@ -85,23 +71,12 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//src/main/java/..."
+      - "//..."
     test_flags:
       - "--config=ci-linux"
+      - "--test_tag_filters=-no_presubmit"
     test_targets:
-      - "//scripts/..."
-      - "//src/java_tools/..."
-      - "//src/main/starlark/tests/builtins_bzl/..."
-      - "//src/test/..."
-      - "//src/tools/execlog/..."
-      - "//src/tools/one_version/..."
-      - "//src/tools/singlejar/..."
-      - "//src/tools/workspacelog/..."
-      - "//third_party/ijar/..."
-      - "//tools/aquery_differ/..."
-      - "//tools/python/..."
-      - "//tools/bash/..."
-      - "//tools/test/..."
+      - "//..."
     include_json_profile:
       - build
       - test
@@ -120,7 +95,7 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//src/main/java/..."
+      - "//..."
     test_flags:
       - "--config=ci-linux"
     test_targets:
@@ -128,51 +103,50 @@ tasks:
     include_json_profile:
       - build
       - test
-  macos:
-    shards: 10
+  ubuntu2204:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
-      - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
     build_flags:
-      - "--config=ci-macos"
+      - "--config=ci-linux"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
+      - "//..."
     test_flags:
-      - "--config=ci-macos"
-      # Fine tune the number of test jobs running in parallel to avoid timeout
-      - "--local_test_jobs=2"
+      - "--config=ci-linux"
+      - "--test_tag_filters=-no_presubmit"
     test_targets:
-      - "//scripts/..."
-      - "//src/main/starlark/tests/builtins_bzl/..."
-      - "//src/test/..."
-      - "//src/tools/execlog/..."
-      - "//src/tools/one_version/..."
-      - "//src/tools/singlejar/..."
-      - "//src/tools/workspacelog/..."
-      - "//third_party/ijar/..."
-      - "//tools/aquery_differ/..."
-      - "//tools/python/..."
-      - "//tools/bash/..."
-      - "//tools/test/..."
-      # Disable python and shell integration tests on Intel Macs
-      - "-//src/test/shell/..."
-      - "-//src/test/py/..."
-      - "-//src/main/starlark/tests/builtins_bzl:cc_builtin_tests"
-      # https://github.com/bazelbuild/bazel/issues/17410
-      - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
-      # Disable android tests since we are moving Android rules out of the Bazel repo.
-      # ServerTests frequently runs into deadlocks on Intel Macs
-      - "-//src/test/java/com/google/devtools/build/lib/server:ServerTests"
-      # Add back a few Apple specific tests
-      - "+//src/test/shell/bazel/apple/..."
+      - "//src:embedded_tools_size_test"
+      - "//src/test/py/bazel:bazel_module_test"
+      - "//src/test/py/bazel:mod_command_test"
+      - "//src/test/shell/bazel:bazel_example_test"
+      - "//src/test/shell/bazel:bazel_java_test"
+      - "//src/test/shell/bazel:cc_integration_test"
+      - "//src/test/shell/bazel:external_integration_test"
+      - "//src/test/shell/bazel:help_test"
+      - "//src/test/shell/integration:bazel_query_test"
     include_json_profile:
       - build
       - test
+  macos:
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
+    shell_commands:
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+      - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
+    build_flags:
+      - "--config=ci-macos"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+    include_json_profile:
+      - build
   macos_arm64:
-    shards: 10
+    shards: 6
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
@@ -185,34 +159,32 @@ tasks:
       - "//src:test_repos"
     test_flags:
       - "--config=ci-macos"
+      - "--test_tag_filters=-no_presubmit,-no_macos"
       # Fine tune the number of test jobs running in parallel to avoid timeout
       - "--local_test_jobs=2"
       # Increase the test timeout by 20% to avoid flaky test failures due to timeout
       - "--test_timeout=72,360,1080,4320"
     test_targets:
-      - "//scripts/..."
-      - "//src/main/starlark/tests/builtins_bzl/..."
-      - "//src/test/..."
-      - "//src/tools/execlog/..."
-      - "//src/tools/one_version/..."
-      - "//src/tools/singlejar/..."
-      - "//src/tools/workspacelog/..."
-      - "//third_party/ijar/..."
-      - "//tools/aquery_differ/..."
-      - "//tools/python/..."
-      - "//tools/bash/..."
-      - "//tools/test/..."
-      # https://github.com/bazelbuild/bazel/issues/17410
-      - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
-      # Disable some slow tests
-      - "-//src/test/shell/bazel:bazel_bootstrap_distfile_test"
-      - "-//src/test/shell/bazel:bazel_bootstrap_distfile_tar_test"
-      - "-//src/test/shell/bazel:bazel_determinism_test"
+      - "//src:embedded_tools_size_test"
+      - "//src/test/java/com/google/devtools/build/lib/rules/apple:AppleRulesTests"
+      - "//src/test/java/com/google/devtools/build/lib/rules/objc:ObjcRulesTests"
+      - "//src/test/java/com/google/devtools/build/lib/skyframe:MacOSXFsEventsDiffAwarenessTest"
+      - "//src/test/py/bazel:bazel_module_test"
+      - "//src/test/py/bazel:mod_command_test"
+      - "//src/test/shell/bazel:bazel_example_test"
+      - "//src/test/shell/bazel:bazel_java_test"
+      - "//src/test/shell/bazel:cc_integration_test"
+      - "//src/test/shell/bazel:cpp_darwin_integration_test"
+      - "//src/test/shell/bazel:external_integration_test"
+      - "//src/test/shell/bazel:help_test"
+      - "//src/test/shell/bazel/apple:bazel_apple_test"
+      - "//src/test/shell/bazel/apple:bazel_objc_test"
+      - "//src/test/shell/integration:bazel_query_test"
     include_json_profile:
       - build
       - test
   windows:
-    shards: 4
+    shards: 10
     setup:
       - mkdir C:\b
       - mklink /J C:\b\bazeltest_external %OUTPUT_BASE:/=\%\external
@@ -226,17 +198,15 @@ tasks:
     test_flags:
       - "--config=ci-windows"
       # We need to keep --test_tag_filters here for the bazel-diff integration.
-      - "--test_tag_filters=-no_windows,-slow"
+      - "--test_tag_filters=-no_presubmit,-no_windows,-slow"
     test_targets:
       - "//src:embedded_tools_size_test"
-      - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/cpp/..."
       - "//src/test/java/com/google/devtools/build/lib/..."
       - "//src/test/java/com/google/devtools/build/skyframe/..."
       - "//src/test/java/com/google/devtools/common/options/..."
       - "//src/test/native/windows/..."
       - "//src/test/py/bazel/..."
-      - "//src/test/res/..."
       - "//src/test/shell/..."
       - "//src/tools/launcher/..."
       - "//src/tools/one_version/..."
@@ -253,9 +223,6 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/4292
       - "-//src/test/shell/bazel/remote/..."
       - "-//tools/python:pywrapper_test"
-      # Temporarily disable this test which is failing on Windows due to a clang update.
-      # TODO(b/530925565): Re-enable.
-      - "-//src/test/py/bazel:launcher_test"
     include_json_profile:
       - build
       - test
@@ -278,24 +245,22 @@ tasks:
     name: "RBE"
     build_flags:
       - "--config=remote"
-      - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"
+      - "--config=ci-common"
       - "--jobs=200"
-      - "--remote_download_minimal"
       - "--experimental_output_paths=strip"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
-      - "//src/main/java/..."
+      - "//..."
     test_flags:
       - "--config=remote"
-      - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"
+      - "--config=ci-common"
+      - "--test_tag_filters=-no_presubmit"
       - "--jobs=200"
-      - "--remote_download_minimal"
       - "--experimental_output_paths=strip"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
-      - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/..."
       - "//src/tools/execlog/..."
       - "//src/tools/one_version/..."
@@ -325,14 +290,10 @@ tasks:
       # Flaky on rbe_ubuntu2004
       # https://github.com/bazelbuild/continuous-integration/issues/1631
       - "-//src/test/shell/bazel:bazel_sandboxing_networking_test"
-      # Disable tests that fail on RBE due to sandboxing/mount restrictions
-      - "-//src/test/shell/integration:sandboxing_test"
-      - "-//src/test/java/com/google/devtools/build/lib/shell:CommandUsingLinuxSandboxTest"
-      - "-//src/test/shell/bazel:bazel_spawnstats_test"
-      - "-//src/test/shell/integration:bazel_hardened_sandboxed_worker_test"
-      - "-//src/test/shell/integration:test_test"
-      - "-//src/test/tools:linux-sandbox_test"
-      - "-//src/test/tools:daemonize_test"
+      # TODO(pcloudy): Re-enable once https://github.com/bazelbuild/bazel/issues/27982 is fixed.
+      - "-//src/test/shell/bazel:srcs_test"
+      # Disable this test since it takes too long on RBE.
+      - "-//src/test/shell/bazel:bazel_proto_library_test"
     include_json_profile:
       - build
       - test

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,7 +1,8 @@
 ---
-check_docs: 1
+
 tasks:
   rockylinux8:
+    shards: 4
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
@@ -14,20 +15,31 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//..."
+      - "//src/main/java/..."
+      - "//src/tools/diskcache/..."
+      - "//src/tools/execlog/..."
     test_flags:
       - "--config=ci-linux"
-      - "--test_tag_filters=-no_presubmit"
     test_targets:
-      - "//src:embedded_tools_size_test"
-      - "//src/test/py/bazel:bazel_module_test"
-      - "//src/test/py/bazel:mod_command_test"
-      - "//src/test/shell/bazel:bazel_example_test"
-      - "//src/test/shell/bazel:bazel_java_test"
-      - "//src/test/shell/bazel:cc_integration_test"
-      - "//src/test/shell/bazel:external_integration_test"
-      - "//src/test/shell/bazel:help_test"
-      - "//src/test/shell/integration:bazel_query_test"
+      - "//scripts/..."
+      - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/one_version/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/compliance/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+      - "//tools/test/..."
+      # These tests are not compatible with the gcov version of Rocky Linux 8.
+      - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
+      - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_gcc"
+      - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"
+      - "-//src/test/shell/bazel:bazel_coverage_sh_test"
     include_json_profile:
       - build
       - test
@@ -44,7 +56,9 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//..."
+      - "//src/main/java/..."
+      - "//src/tools/diskcache/..."
+      - "//src/tools/execlog/..."
     include_json_profile:
       - build
   fedora39:
@@ -61,7 +75,7 @@ tasks:
       - build
       - test
   ubuntu2404:
-    shards: 8
+    shards: 4
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
@@ -71,12 +85,23 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//..."
+      - "//src/main/java/..."
     test_flags:
       - "--config=ci-linux"
-      - "--test_tag_filters=-no_presubmit"
     test_targets:
-      - "//..."
+      - "//scripts/..."
+      - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/one_version/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+      - "//tools/test/..."
     include_json_profile:
       - build
       - test
@@ -95,58 +120,16 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
-      - "//..."
+      - "//src/main/java/..."
     test_flags:
       - "--config=ci-linux"
     test_targets:
       - "//src/test/shell/bazel:cc_integration_test"
-    include_json_profile:
-      - build
-      - test
-  ubuntu2204:
-    shell_commands:
-      - rm -rf $HOME/bazeltest
-      - mkdir $HOME/bazeltest
-    build_flags:
-      - "--config=ci-linux"
-    build_targets:
-      - "//src:bazel"
-      - "//src:bazel_jdk_minimal"
-      - "//src:test_repos"
-      - "//..."
-    test_flags:
-      - "--config=ci-linux"
-      - "--test_tag_filters=-no_presubmit"
-    test_targets:
-      - "//src:embedded_tools_size_test"
-      - "//src/test/py/bazel:bazel_module_test"
-      - "//src/test/py/bazel:mod_command_test"
-      - "//src/test/shell/bazel:bazel_example_test"
-      - "//src/test/shell/bazel:bazel_java_test"
-      - "//src/test/shell/bazel:cc_integration_test"
-      - "//src/test/shell/bazel:external_integration_test"
-      - "//src/test/shell/bazel:help_test"
-      - "//src/test/shell/integration:bazel_query_test"
     include_json_profile:
       - build
       - test
   macos:
-    environment:
-      ANDROID_HOME: ""
-      ANDROID_NDK_HOME: ""
-    shell_commands:
-      - rm -rf $HOME/bazeltest
-      - mkdir $HOME/bazeltest
-      - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
-    build_flags:
-      - "--config=ci-macos"
-    build_targets:
-      - "//src:bazel"
-      - "//src:bazel_jdk_minimal"
-    include_json_profile:
-      - build
-  macos_arm64:
-    shards: 6
+    shards: 10
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
@@ -159,32 +142,77 @@ tasks:
       - "//src:test_repos"
     test_flags:
       - "--config=ci-macos"
-      - "--test_tag_filters=-no_presubmit,-no_macos"
+      # Fine tune the number of test jobs running in parallel to avoid timeout
+      - "--local_test_jobs=2"
+    test_targets:
+      - "//scripts/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/one_version/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+      - "//tools/test/..."
+      # Disable python and shell integration tests on Intel Macs
+      - "-//src/test/shell/..."
+      - "-//src/test/py/..."
+      - "-//src/main/starlark/tests/builtins_bzl:cc_builtin_tests"
+      # https://github.com/bazelbuild/bazel/issues/17410
+      - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
+      # Disable android tests since we are moving Android rules out of the Bazel repo.
+      # ServerTests frequently runs into deadlocks on Intel Macs
+      - "-//src/test/java/com/google/devtools/build/lib/server:ServerTests"
+      # Add back a few Apple specific tests
+      - "+//src/test/shell/bazel/apple/..."
+    include_json_profile:
+      - build
+      - test
+  macos_arm64:
+    shards: 10
+    shell_commands:
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+      - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
+    build_flags:
+      - "--config=ci-macos"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+    test_flags:
+      - "--config=ci-macos"
       # Fine tune the number of test jobs running in parallel to avoid timeout
       - "--local_test_jobs=2"
       # Increase the test timeout by 20% to avoid flaky test failures due to timeout
       - "--test_timeout=72,360,1080,4320"
     test_targets:
-      - "//src:embedded_tools_size_test"
-      - "//src/test/java/com/google/devtools/build/lib/rules/apple:AppleRulesTests"
-      - "//src/test/java/com/google/devtools/build/lib/rules/objc:ObjcRulesTests"
-      - "//src/test/java/com/google/devtools/build/lib/skyframe:MacOSXFsEventsDiffAwarenessTest"
-      - "//src/test/py/bazel:bazel_module_test"
-      - "//src/test/py/bazel:mod_command_test"
-      - "//src/test/shell/bazel:bazel_example_test"
-      - "//src/test/shell/bazel:bazel_java_test"
-      - "//src/test/shell/bazel:cc_integration_test"
-      - "//src/test/shell/bazel:cpp_darwin_integration_test"
-      - "//src/test/shell/bazel:external_integration_test"
-      - "//src/test/shell/bazel:help_test"
-      - "//src/test/shell/bazel/apple:bazel_apple_test"
-      - "//src/test/shell/bazel/apple:bazel_objc_test"
-      - "//src/test/shell/integration:bazel_query_test"
+      - "//scripts/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/one_version/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+      - "//tools/test/..."
+      # https://github.com/bazelbuild/bazel/issues/17410
+      - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
+      # Disable some slow tests
+      - "-//src/test/shell/bazel:bazel_bootstrap_distfile_test"
+      - "-//src/test/shell/bazel:bazel_bootstrap_distfile_tar_test"
+      - "-//src/test/shell/bazel:bazel_determinism_test"
     include_json_profile:
       - build
       - test
   windows:
-    shards: 10
+    shards: 4
     setup:
       - mkdir C:\b
       - mklink /J C:\b\bazeltest_external %OUTPUT_BASE:/=\%\external
@@ -198,15 +226,17 @@ tasks:
     test_flags:
       - "--config=ci-windows"
       # We need to keep --test_tag_filters here for the bazel-diff integration.
-      - "--test_tag_filters=-no_presubmit,-no_windows,-slow"
+      - "--test_tag_filters=-no_windows,-slow"
     test_targets:
       - "//src:embedded_tools_size_test"
+      - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/cpp/..."
       - "//src/test/java/com/google/devtools/build/lib/..."
       - "//src/test/java/com/google/devtools/build/skyframe/..."
       - "//src/test/java/com/google/devtools/common/options/..."
       - "//src/test/native/windows/..."
       - "//src/test/py/bazel/..."
+      - "//src/test/res/..."
       - "//src/test/shell/..."
       - "//src/tools/launcher/..."
       - "//src/tools/one_version/..."
@@ -223,6 +253,9 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/4292
       - "-//src/test/shell/bazel/remote/..."
       - "-//tools/python:pywrapper_test"
+      # Temporarily disable this test which is failing on Windows due to a clang update.
+      # TODO(b/530925565): Re-enable.
+      - "-//src/test/py/bazel:launcher_test"
     include_json_profile:
       - build
       - test
@@ -245,22 +278,24 @@ tasks:
     name: "RBE"
     build_flags:
       - "--config=remote"
-      - "--config=ci-common"
+      - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"
       - "--jobs=200"
+      - "--remote_download_minimal"
       - "--experimental_output_paths=strip"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
-      - "//..."
+      - "//src/main/java/..."
     test_flags:
       - "--config=remote"
-      - "--config=ci-common"
-      - "--test_tag_filters=-no_presubmit"
+      - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"
       - "--jobs=200"
+      - "--remote_download_minimal"
       - "--experimental_output_paths=strip"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
       - "//src/test/..."
       - "//src/tools/execlog/..."
       - "//src/tools/one_version/..."
@@ -290,10 +325,14 @@ tasks:
       # Flaky on rbe_ubuntu2004
       # https://github.com/bazelbuild/continuous-integration/issues/1631
       - "-//src/test/shell/bazel:bazel_sandboxing_networking_test"
-      # TODO(pcloudy): Re-enable once https://github.com/bazelbuild/bazel/issues/27982 is fixed.
-      - "-//src/test/shell/bazel:srcs_test"
-      # Disable this test since it takes too long on RBE.
-      - "-//src/test/shell/bazel:bazel_proto_library_test"
+      # Disable tests that fail on RBE due to sandboxing/mount restrictions
+      - "-//src/test/shell/integration:sandboxing_test"
+      - "-//src/test/java/com/google/devtools/build/lib/shell:CommandUsingLinuxSandboxTest"
+      - "-//src/test/shell/bazel:bazel_spawnstats_test"
+      - "-//src/test/shell/integration:bazel_hardened_sandboxed_worker_test"
+      - "-//src/test/shell/integration:test_test"
+      - "-//src/test/tools:linux-sandbox_test"
+      - "-//src/test/tools:daemonize_test"
     include_json_profile:
       - build
       - test


### PR DESCRIPTION
Ubuntu 20.04 is EOL.

Note: ubuntu_2404_arm64 platform exists: https://github.com/bazelbuild/continuous-integration/blob/bf4dd844ae33da5f11cf592b39142ad285dac7f9/buildkite/bazelci.py#L404