### PR TITLE
[8.8.0] Fix handling of symbolic/hard links when using `strip_components`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunction.java
@@ -41,7 +41,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -69,7 +68,8 @@ public abstract class CompressedTarFunction implements Decompressor {
     if (Thread.interrupted()) {
       throw new InterruptedException();
     }
-    Optional<String> prefix = descriptor.prefix();
+    String prefix = descriptor.prefix();
+    int stripComponents = descriptor.stripComponents();
     Map<String, String> renameFiles = descriptor.renameFiles();
     boolean foundPrefix = false;
     Set<String> availablePrefixes = new HashSet<>();
@@ -90,10 +90,11 @@ public abstract class CompressedTarFunction implements Decompressor {
         String entryName = toRawBytesString(entry.getName());
         entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath =
-            StripPrefixedPath.maybeDeprefix(entryName.getBytes(ISO_8859_1), prefix);
+            StripPrefixedPath.maybeDeprefix(
+                entryName.getBytes(ISO_8859_1), prefix, stripComponents);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
 
-        if (prefix.isPresent() && !foundPrefix) {
+        if (!prefix.isEmpty() && !foundPrefix) {
           CouldNotFindPrefixException.maybeMakePrefixSuggestion(entryPath.getPathFragment())
               .ifPresent(availablePrefixes::add);
         }
@@ -102,13 +103,7 @@ public abstract class CompressedTarFunction implements Decompressor {
           continue;
         }
 
-        PathFragment strippedRelativePath = entryPath.getPathFragment();
-        strippedRelativePath = strippedRelativePath.stripComponents(descriptor.stripComponents());
-        if (Objects.equals(strippedRelativePath, PathFragment.EMPTY_FRAGMENT)) {
-          continue;
-        }
-
-        Path filePath = descriptor.destinationPath().getRelative(strippedRelativePath);
+        Path filePath = descriptor.destinationPath().getRelative(entryPath.getPathFragment());
         filePath.getParentDirectory().createDirectoryAndParents();
         if (entry.isDirectory()) {
           filePath.createDirectoryAndParents();
@@ -118,7 +113,10 @@ public abstract class CompressedTarFunction implements Decompressor {
                 maybeDeprefixSymlink(
                     toRawBytesString(entry.getLinkName()).getBytes(ISO_8859_1),
                     prefix,
-                    descriptor.destinationPath());
+                    stripComponents,
+                    descriptor.destinationPath(),
+                    // Hard link target paths should be relative to the extraction directory.
+                    /* forceExtractRootRelative= */ entry.isLink());
             if (entry.isSymbolicLink()) {
               symlinks.put(filePath, targetName);
             } else {
@@ -167,8 +165,8 @@ public abstract class CompressedTarFunction implements Decompressor {
         FileSystemUtils.ensureSymbolicLink(linkPath, symlink.getValue());
       }
 
-      if (prefix.isPresent() && !foundPrefix) {
-        throw new CouldNotFindPrefixException(prefix.get(), availablePrefixes);
+      if (!prefix.isEmpty() && !foundPrefix) {
+        throw new CouldNotFindPrefixException(prefix, availablePrefixes);
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorDescriptor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorDescriptor.java
@@ -20,7 +20,6 @@ import com.google.auto.value.AutoBuilder;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.vfs.Path;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Description of an archive to be decompressed.
@@ -32,7 +31,7 @@ public record DecompressorDescriptor(
     String context,
     Path archivePath,
     Path destinationPath,
-    Optional<String> prefix,
+    String prefix,
     int stripComponents,
     ImmutableMap<String, String> renameFiles) {
   public DecompressorDescriptor {
@@ -46,6 +45,7 @@ public record DecompressorDescriptor(
   public static Builder builder() {
     return new AutoBuilder_DecompressorDescriptor_Builder()
         .setContext("")
+        .setPrefix("")
         .setStripComponents(0)
         .setRenameFiles(ImmutableMap.of());
   }
@@ -73,7 +73,7 @@ public record DecompressorDescriptor(
       if (d.stripComponents() < 0) {
         throw new IllegalArgumentException("'strip_components' must be non-negative");
       }
-      if (d.stripComponents() != 0 && d.prefix().isPresent() && !d.prefix().get().isEmpty()) {
+      if (d.stripComponents() != 0 && !d.prefix().isEmpty()) {
         throw new IllegalArgumentException(
             "Only one of 'strip_prefix' or 'strip_components' can be set");
       }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/StripPrefixedPath.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/StripPrefixedPath.java
@@ -20,37 +20,58 @@ import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.concurrent.ThreadSafety;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import java.util.Optional;
+import java.util.Objects;
 
 /**
  * Utility class for removing a prefix from an archive's path.
+ *
+ * <p>A "prefix" can be a string of path segments or an integer representing the number of path
+ * segments to remove. Given an example path <code>/tmp/path/to/file</code>, removing the string
+ * prefix <code>/tmp/path</code> or stripping two components will result in the same de-prefixed
+ * path: <code>to/file</code>
  */
 @ThreadSafety.Immutable
 public final class StripPrefixedPath {
   private final PathFragment pathFragment;
-  private final boolean found;
+  private final boolean foundPrefix;
   private final boolean skip;
 
   /**
-   * If a prefix is given, it will be removed from the entry's path. This also turns absolute paths
-   * into relative paths (e.g., /usr/bin/bash will become usr/bin/bash, same as unzip's default
-   * behavior) and normalizes the paths (foo/../bar////baz will become bar/baz). Note that this
-   * could cause collisions, if a zip file had one entry for bin/some-binary and another entry for
-   * /bin/some-binary.
+   * Removes the given prefix or the specified number of components.
+   *
+   * <p>If a prefix of number of components is given, it will be removed from the entry's path. This
+   * also turns absolute paths into relative paths (e.g., /usr/bin/bash will become usr/bin/bash,
+   * same as unzip's default behavior) and normalizes the paths (foo/../bar////baz will become
+   * bar/baz). Note that this could cause collisions, if a zip file had one entry for
+   * bin/some-binary and another entry for /bin/some-binary.
    *
    * <p>Note that the prefix is stripped to move the files up one level, so if you have an entry
    * "foo/../bar" and a prefix of "foo", the result will be "bar" not "../bar".
+   *
+   * <p>Only one of <code>prefix</code> or <code>stripComponents</code> is allowed.
    */
-  public static StripPrefixedPath maybeDeprefix(byte[] entry, Optional<String> prefix) {
+  public static StripPrefixedPath maybeDeprefix(byte[] entry, String prefix, int stripComponents) {
     Preconditions.checkNotNull(entry);
+    Preconditions.checkArgument(
+        prefix.isEmpty() || stripComponents == 0,
+        "Only one of prefix or strip_components can be set.");
+
     PathFragment entryPath = relativize(entry);
+    if (stripComponents != 0) {
+      return maybeStripComponent(entryPath, stripComponents);
+    } else {
+      return maybeStripPrefix(entryPath, prefix);
+    }
+  }
+
+  private static StripPrefixedPath maybeStripPrefix(PathFragment entryPath, String prefix) {
     if (prefix.isEmpty()) {
       return new StripPrefixedPath(entryPath, false, false);
     }
 
     // Bazel parses Starlark files, which are the ultimate source of prefixes, as Latin-1
     // (ISO-8859-1).
-    PathFragment prefixPath = relativize(prefix.get().getBytes(ISO_8859_1));
+    PathFragment prefixPath = relativize(prefix.getBytes(ISO_8859_1));
     boolean found = false;
     boolean skip = false;
     if (entryPath.startsWith(prefixPath)) {
@@ -65,6 +86,19 @@ public final class StripPrefixedPath {
     return new StripPrefixedPath(entryPath, found, skip);
   }
 
+  private static StripPrefixedPath maybeStripComponent(
+      PathFragment entryPath, int stripComponents) {
+    if (stripComponents == 0) {
+      return new StripPrefixedPath(entryPath, /* foundPrefix= */ false, false);
+    }
+    PathFragment strippedPath = entryPath.stripComponents(stripComponents);
+    boolean skipEntry = false;
+    if (Objects.equals(strippedPath, PathFragment.EMPTY_FRAGMENT)) {
+      skipEntry = true;
+    }
+    return new StripPrefixedPath(strippedPath, /* foundPrefix= */ false, skipEntry);
+  }
+
   /**
    * Normalize the path and, if it is absolute, make it relative (e.g., /foo/bar becomes foo/bar).
    */
@@ -76,23 +110,60 @@ public final class StripPrefixedPath {
     return entryPath;
   }
 
-  private StripPrefixedPath(PathFragment pathFragment, boolean found, boolean skip) {
+  private StripPrefixedPath(PathFragment pathFragment, boolean foundPrefix, boolean skip) {
     this.pathFragment = pathFragment;
-    this.found = found;
+    this.foundPrefix = foundPrefix;
     this.skip = skip;
   }
 
   public static PathFragment maybeDeprefixSymlink(
-      byte[] rawTarget, Optional<String> prefix, Path root) {
+      byte[] rawTarget, String prefix, int stripComponents, Path root) {
+    return maybeDeprefixSymlink(rawTarget, prefix, stripComponents, root, false);
+  }
+
+  /**
+   * Normalizes and possibly deprefixes a target link.
+   *
+   * <p>A target link will only be deprefixed and relative to the given root if any of the
+   * following:
+   *
+   * <ul>
+   *   <li>The link is absolute
+   *   <li>The link is known to be relative to the root (<code>forceExtractRootRelative</code>)
+   * </ul>
+   *
+   * Otherwise, no deprefixing will occur.
+   *
+   * @param rawTarget The target path for the link.
+   * @param prefix The prefix to remove. If set, <code>stripComponents</code> must be 0.
+   * @param stripComponents The number of path segements to remove. If nonzero, <code>prefix</code>
+   *     must be Optional.empty().
+   * @param root The path for absolute or <code>forceExtractRootRelative</code> to be relative to.
+   * @param forceExtractRootRelative Forces the given <code>rawTarget</code> to be relative to the
+   *     <code>root</code>.
+   * @return The normalized and possibly deprefixed link target.
+   */
+  public static PathFragment maybeDeprefixSymlink(
+      byte[] rawTarget,
+      String prefix,
+      int stripComponents,
+      Path root,
+      boolean forceExtractRootRelative) {
+    Preconditions.checkArgument(
+        prefix.isEmpty() || stripComponents == 0,
+        "Only one of prefix or strip_components can be set.");
     boolean wasAbsolute = createPathFragment(rawTarget).isAbsolute();
-    // Strip the prefix from the link path if set.
-    PathFragment linkPathFragment = maybeDeprefix(rawTarget, prefix).getPathFragment();
-    if (wasAbsolute) {
+    if (wasAbsolute || forceExtractRootRelative) {
+      // Strip the prefix from the link path if set
+      PathFragment linkPathFragment =
+          maybeDeprefix(rawTarget, prefix, stripComponents).getPathFragment();
       // Recover the path to an absolute path as maybeDeprefix() relativize the path
       // even if the prefix is not set
       return root.getRelative(linkPathFragment).asFragment();
+    } else {
+      // No deprefixing needed if not relative to extraction root.
+      return relativize(rawTarget);
     }
-    return linkPathFragment;
   }
 
   public PathFragment getPathFragment() {
@@ -100,7 +171,7 @@ public final class StripPrefixedPath {
   }
 
   public boolean foundPrefix() {
-    return found;
+    return foundPrefix;
   }
 
   public boolean skip() {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/ZipDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/ZipDecompressor.java
@@ -33,8 +33,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -79,7 +77,8 @@ public class ZipDecompressor implements Decompressor {
   public Path decompress(DecompressorDescriptor descriptor)
       throws IOException, InterruptedException {
     Path destinationDirectory = descriptor.destinationPath();
-    Optional<String> prefix = descriptor.prefix();
+    String prefix = descriptor.prefix();
+    int stripComponents = descriptor.stripComponents();
     Map<String, String> renameFiles = descriptor.renameFiles();
     boolean foundPrefix = false;
     // Store link, target info of symlinks, we create them after regular files are extracted.
@@ -91,28 +90,30 @@ public class ZipDecompressor implements Decompressor {
         String entryName = entry.getName();
         entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath =
-            StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix);
+            StripPrefixedPath.maybeDeprefix(entryName.getBytes(UTF_8), prefix, stripComponents);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
         if (entryPath.skip()) {
           continue;
         }
-        PathFragment pathFragment =
-            entryPath.getPathFragment().stripComponents(descriptor.stripComponents());
-        if (Objects.equals(pathFragment, PathFragment.EMPTY_FRAGMENT)) {
-          continue;
-        }
-        extractZipEntry(reader, entry, destinationDirectory, pathFragment, prefix, symlinks);
+        extractZipEntry(
+            reader,
+            entry,
+            destinationDirectory,
+            entryPath.getPathFragment(),
+            prefix,
+            stripComponents,
+            symlinks);
       }
 
-      if (prefix.isPresent() && !foundPrefix) {
+      if (!prefix.isEmpty() && !foundPrefix) {
         Set<String> prefixes = new HashSet<>();
         for (ZipFileEntry entry : entries) {
           StripPrefixedPath entryPath =
-              StripPrefixedPath.maybeDeprefix(entry.getName().getBytes(UTF_8), Optional.empty());
+              StripPrefixedPath.maybeDeprefix(entry.getName().getBytes(UTF_8), "", 0);
           CouldNotFindPrefixException.maybeMakePrefixSuggestion(entryPath.getPathFragment())
               .ifPresent(prefixes::add);
         }
-        throw new CouldNotFindPrefixException(prefix.get(), prefixes);
+        throw new CouldNotFindPrefixException(prefix, prefixes);
       }
     }
 
@@ -128,7 +129,8 @@ public class ZipDecompressor implements Decompressor {
       ZipFileEntry entry,
       Path destinationDirectory,
       PathFragment strippedRelativePath,
-      Optional<String> prefix,
+      String prefix,
+      int stripComponents,
       Map<Path, PathFragment> symlinks)
       throws IOException, InterruptedException {
     if (strippedRelativePath.isAbsolute()) {
@@ -164,7 +166,14 @@ public class ZipDecompressor implements Decompressor {
         }
       }
 
-      symlinks.put(outputPath, maybeDeprefixSymlink(buffer, prefix, destinationDirectory));
+      symlinks.put(
+          outputPath,
+          maybeDeprefixSymlink(
+              buffer,
+              prefix,
+              stripComponents,
+              destinationDirectory,
+              /* forceExtractRootRelative= */ false));
     } else {
       try (InputStream input = reader.getInputStream(entry);
           OutputStream output = outputPath.getOutputStream()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -1145,15 +1145,18 @@ Strip the given number of leading components from file paths on extraction. Only
           .post(
               new ExtractProgress(
                   outputPath.getPath().toString(), "Extracting " + downloadedPath.getBaseName()));
-      DecompressorValue.decompress(
+      DecompressorDescriptor.Builder descriptorBuilder =
           DecompressorDescriptor.builder()
               .setContext(identifyingStringForLogging)
               .setArchivePath(downloadedPath)
               .setDestinationPath(outputPath.getPath())
-              .setPrefix(stripPrefix)
               .setStripComponents(stripComponents)
-              .setRenameFiles(renameFilesMap)
-              .build());
+              .setRenameFiles(renameFilesMap);
+      if (!stripPrefix.isEmpty()) {
+        descriptorBuilder.setPrefix(stripPrefix);
+      }
+      DecompressorValue.decompress(descriptorBuilder.build());
+
       env.getListener().post(new ExtractProgress(outputPath.getPath().toString()));
     }
 
@@ -1336,15 +1339,17 @@ Strip the given number of leading components from file paths on extraction. Only
         .post(
             new ExtractProgress(
                 outputPath.getPath().toString(), "Extracting " + archivePath.getBasename()));
-    DecompressorValue.decompress(
+    DecompressorDescriptor.Builder descriptorBuilder =
         DecompressorDescriptor.builder()
             .setContext(identifyingStringForLogging)
             .setArchivePath(archivePath.getPath())
             .setDestinationPath(outputPath.getPath())
-            .setPrefix(stripPrefix)
             .setStripComponents(stripComponents)
-            .setRenameFiles(renameFilesMap)
-            .build());
+            .setRenameFiles(renameFilesMap);
+    if (!stripPrefix.isEmpty()) {
+      descriptorBuilder.setPrefix(stripPrefix);
+    }
+    DecompressorValue.decompress(descriptorBuilder.build());
     env.getListener().post(new ExtractProgress(outputPath.getPath().toString()));
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
@@ -46,6 +46,8 @@ java_library(
         "//src/test/java/com/google/devtools/build/lib/testutil",
         "//src/test/java/com/google/devtools/build/lib/testutil:TestConstants",
         "//src/test/java/com/google/devtools/build/lib/testutil:TestUtils",
+        "//src/test/java/com/google/devtools/build/lib/vfs/util",
+        "//third_party:apache_commons_compress",
         "//third_party:guava",
         "//third_party:java-diff-utils",
         "//third_party:junit4",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunctionTest.java
@@ -15,31 +15,55 @@
 package com.google.devtools.build.lib.bazel.repository;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.devtools.build.lib.bazel.repository.TestArchiveDescriptor.INNER_FOLDER_NAME;
 import static com.google.devtools.build.lib.bazel.repository.TestArchiveDescriptor.ROOT_FOLDER_NAME;
 
+import com.google.devtools.build.lib.unix.UnixFileSystem;
+import com.google.devtools.build.lib.util.OS;
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.JavaIoFileSystem;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.Symlinks;
+import com.google.devtools.build.lib.vfs.util.FileSystems;
 import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.zip.GZIPInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests decompressing archives. */
 @RunWith(JUnit4.class)
 public class CompressedTarFunctionTest {
+  @Rule public TestName name = new TestName();
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
   /* Tarball, created by "tar -czf <ARCHIVE_NAME> <files...>" */
   private static final String ARCHIVE_NAME = "test_decompress_archive.tar.gz";
 
   private TestArchiveDescriptor archiveDescriptor;
 
+  /** Provides a test filesystem descriptor for a test. NOTE: unique per individual test ONLY. */
   @Before
-  public void setUpFs() throws Exception {
-    archiveDescriptor = new TestArchiveDescriptor(ARCHIVE_NAME, "out", true);
+  public void setUpFs() {
+    archiveDescriptor =
+        new TestArchiveDescriptor(
+            ARCHIVE_NAME,
+            /* outDirName= */ this.getClass().getSimpleName() + "_" + name.getMethodName(),
+            true);
   }
 
   /**
@@ -131,6 +155,113 @@ public class CompressedTarFunctionTest {
 
     Path innerDir = outputDir.getRelative(INNER_FOLDER_NAME);
     assertThat(innerDir.getRelative("renamedFile").exists()).isTrue();
+  }
+
+
+  @Test
+  public void decompressTarWithSymlinkSharingStripPrefix() throws Exception {
+    // Creates the example archive described in https://github.com/bazelbuild/bazel/issues/30015.
+    // Also includes an absolute symlink to show it's deprefixed correctly.
+    FileSystem fs =
+        OS.getCurrent() == OS.WINDOWS
+            ? new JavaIoFileSystem(DigestHashFunction.SHA256)
+            : new UnixFileSystem(DigestHashFunction.SHA256, /*hashAttributeName=*/ "");
+    File archive = folder.newFile("symlink_with_same_strip_prefix.tar.gz");
+    try (FileOutputStream fos = new FileOutputStream(archive);
+        GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(fos);
+        TarArchiveOutputStream tos = new TarArchiveOutputStream(gzos)) {
+
+      // Create two directory entries:
+      //  - a_prefix
+      //  - a_prefix/a_prefix
+      TarArchiveEntry directory = new TarArchiveEntry("a_prefix/");
+      tos.putArchiveEntry(directory);
+      tos.closeArchiveEntry();
+      TarArchiveEntry subdirectory = new TarArchiveEntry("a_prefix/a_prefix/");
+      tos.putArchiveEntry(subdirectory);
+      tos.closeArchiveEntry();
+
+      // Create the two regular files:
+      // - a_prefix/regular_file
+      // - a_prefix/a_prefix/other_file
+      TarArchiveEntry regularFile = new TarArchiveEntry("a_prefix/regular_file");
+      byte[] regularFileContents = "hello".getBytes();
+      regularFile.setSize(regularFileContents.length);
+      tos.putArchiveEntry(regularFile);
+      tos.write(regularFileContents);
+      tos.closeArchiveEntry();
+
+      TarArchiveEntry otherFile = new TarArchiveEntry("a_prefix/a_prefix/other_file");
+      byte[] otherFileContents = "world".getBytes();
+      otherFile.setSize(otherFileContents.length);
+      tos.putArchiveEntry(otherFile);
+      tos.write(otherFileContents);
+      tos.closeArchiveEntry();
+
+      // Create the symbolic link pointing to other_file:
+      // - a_prefix/symbolic_file -> a_prefix/other_file
+      TarArchiveEntry symbolicFile =
+          new TarArchiveEntry("a_prefix/symbolic_file", TarArchiveEntry.LF_SYMLINK);
+      symbolicFile.setLinkName("a_prefix/other_file");
+      symbolicFile.setSize(0);
+      tos.putArchiveEntry(symbolicFile);
+      tos.closeArchiveEntry();
+
+      // Create an absolute symbolic link pointing to other_file:
+      // - a_prefix/abs_symbolic_file -> /a_prefix/a_prefix/other_file
+      TarArchiveEntry absSymbolicFile =
+          new TarArchiveEntry("a_prefix/abs_symbolic_file", TarArchiveEntry.LF_SYMLINK);
+      absSymbolicFile.setLinkName("/a_prefix/a_prefix/other_file");
+      absSymbolicFile.setSize(0);
+      tos.putArchiveEntry(absSymbolicFile);
+      tos.closeArchiveEntry();
+    }
+    Path archivePath = fs.getPath(archive.getAbsolutePath());
+    Path extractPath = fs.getPath(folder.newFolder().getAbsolutePath());
+
+    DecompressorDescriptor descriptor =
+        DecompressorDescriptor.builder()
+            .setArchivePath(archivePath)
+            .setDestinationPath(extractPath)
+            .setPrefix("a_prefix")
+            .build();
+    Path outputDir = decompress(descriptor);
+
+    // Verify the relative symbolic link.
+    Path outputSymbolicFile = outputDir.getRelative("symbolic_file");
+    assertWithMessage("symbolic_file should exist")
+        .that(outputSymbolicFile.exists(Symlinks.NOFOLLOW))
+        .isTrue();
+
+    Path symlinkTarget = outputDir.getRelative(outputSymbolicFile.readSymbolicLink());
+    assertWithMessage("symbolic_file target should exist: " + symlinkTarget.toString())
+        .that(symlinkTarget.exists())
+        .isTrue();
+
+    assertWithMessage("a_prefix/other_file and symbolic_file should be the same file")
+        .that(
+            Files.isSameFile(
+                java.nio.file.Paths.get(outputDir.getRelative("a_prefix/other_file").toString()),
+                java.nio.file.Paths.get(outputDir.getRelative("symbolic_file").toString())))
+        .isTrue();
+
+    // Verify the absolute symbolic link.
+    Path outputAbsSymbolicFile = outputDir.getRelative("abs_symbolic_file");
+    assertWithMessage("abs_symbolic_file should exist")
+        .that(outputSymbolicFile.exists(Symlinks.NOFOLLOW))
+        .isTrue();
+
+    Path absSymlinkTarget = outputDir.getRelative(outputAbsSymbolicFile.readSymbolicLink());
+    assertWithMessage("abs_symbolic_file target should exist: " + symlinkTarget.toString())
+        .that(absSymlinkTarget.exists())
+        .isTrue();
+
+    assertWithMessage("a_prefix/other_file and abs_symbolic_file should be the same file")
+        .that(
+            Files.isSameFile(
+                java.nio.file.Paths.get(outputDir.getRelative("a_prefix/other_file").toString()),
+                java.nio.file.Paths.get(outputDir.getRelative("abs_symbolic_file").toString())))
+        .isTrue();
   }
 
   private Path decompress(DecompressorDescriptor descriptor) throws Exception {

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/StripPrefixedPathTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/StripPrefixedPathTest.java
@@ -16,13 +16,13 @@ package com.google.devtools.build.lib.bazel.repository;
 
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertThrows;
 
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
-import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -33,33 +33,56 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class StripPrefixedPathTest {
   @Test
-  public void testStrip() {
-    StripPrefixedPath result =
-        StripPrefixedPath.maybeDeprefix("foo/bar".getBytes(UTF_8), Optional.of("foo"));
+  public void testStripPrefix() {
+    StripPrefixedPath result = StripPrefixedPath.maybeDeprefix("foo/bar".getBytes(UTF_8), "foo", 0);
     assertThat(PathFragment.create("bar")).isEqualTo(result.getPathFragment());
     assertThat(result.foundPrefix()).isTrue();
     assertThat(result.skip()).isFalse();
 
-    result = StripPrefixedPath.maybeDeprefix("foo".getBytes(UTF_8), Optional.of("foo"));
+    result = StripPrefixedPath.maybeDeprefix("foo".getBytes(UTF_8), "foo", 0);
     assertThat(result.skip()).isTrue();
 
-    result = StripPrefixedPath.maybeDeprefix("bar/baz".getBytes(UTF_8), Optional.of("foo"));
+    result = StripPrefixedPath.maybeDeprefix("bar/baz".getBytes(UTF_8), "foo", 0);
     assertThat(result.foundPrefix()).isFalse();
 
-    result = StripPrefixedPath.maybeDeprefix("foof/bar".getBytes(UTF_8), Optional.of("foo"));
+    result = StripPrefixedPath.maybeDeprefix("foof/bar".getBytes(UTF_8), "foo", 0);
     assertThat(result.foundPrefix()).isFalse();
   }
 
   @Test
+  public void stripComponents() {
+    StripPrefixedPath result = StripPrefixedPath.maybeDeprefix("foo/bar".getBytes(UTF_8), "", 1);
+    assertThat(PathFragment.create("bar")).isEqualTo(result.getPathFragment());
+    assertThat(result.foundPrefix()).isFalse();
+    assertThat(result.skip()).isFalse();
+
+    result = StripPrefixedPath.maybeDeprefix("foo".getBytes(UTF_8), "", 1);
+    assertThat(result.foundPrefix()).isFalse();
+    assertThat(result.skip()).isTrue();
+  }
+
+  @Test
+  public void stripPrefixAndComponents() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> StripPrefixedPath.maybeDeprefix("foo/bar".getBytes(UTF_8), "foo", 1));
+
+    assertThat(e).hasMessageThat().contains("Only one of prefix or strip_components can be set.");
+  }
+
+  @Test
   public void testAbsolute() {
-    StripPrefixedPath result =
-        StripPrefixedPath.maybeDeprefix("/foo/bar".getBytes(UTF_8), Optional.empty());
+    StripPrefixedPath result = StripPrefixedPath.maybeDeprefix("/foo/bar".getBytes(UTF_8), "", 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("foo/bar"));
 
-    result = StripPrefixedPath.maybeDeprefix("///foo/bar/baz".getBytes(UTF_8), Optional.empty());
+    result = StripPrefixedPath.maybeDeprefix("///foo/bar/baz".getBytes(UTF_8), "", 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("foo/bar/baz"));
 
-    result = StripPrefixedPath.maybeDeprefix("/foo/bar/baz".getBytes(UTF_8), Optional.of("/foo"));
+    result = StripPrefixedPath.maybeDeprefix("/foo/bar/baz".getBytes(UTF_8), "/foo", 0);
+    assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("bar/baz"));
+
+    result = StripPrefixedPath.maybeDeprefix("/foo/bar/baz".getBytes(UTF_8), "", 1);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("bar/baz"));
   }
 
@@ -68,22 +91,23 @@ public class StripPrefixedPathTest {
     if (OS.getCurrent() != OS.WINDOWS) {
       return;
     }
-    StripPrefixedPath result =
-        StripPrefixedPath.maybeDeprefix("c:/foo/bar".getBytes(UTF_8), Optional.empty());
+    StripPrefixedPath result = StripPrefixedPath.maybeDeprefix("c:/foo/bar".getBytes(UTF_8), "", 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("foo/bar"));
   }
 
   @Test
   public void testNormalize() {
-    StripPrefixedPath result =
-        StripPrefixedPath.maybeDeprefix("../bar".getBytes(UTF_8), Optional.empty());
+    StripPrefixedPath result = StripPrefixedPath.maybeDeprefix("../bar".getBytes(UTF_8), "", 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("../bar"));
 
-    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), Optional.empty());
+    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), "", 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("baz"));
 
-    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), Optional.of("foo"));
+    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), "foo", 0);
     assertThat(result.getPathFragment()).isEqualTo(PathFragment.create("baz"));
+
+    result = StripPrefixedPath.maybeDeprefix("foo/../baz".getBytes(UTF_8), "", 1);
+    assertThat(result.getPathFragment()).isEqualTo(PathFragment.EMPTY_FRAGMENT);
   }
 
   @Test
@@ -93,24 +117,45 @@ public class StripPrefixedPathTest {
 
     PathFragment relativeNoPrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "a/b".getBytes(UTF_8), Optional.empty(), fileSystem.getPath("/usr"));
+            "a/b".getBytes(UTF_8), "", 0, fileSystem.getPath("/usr"));
     // there is no attempt to get absolute path for the relative symlinks target path
     assertThat(relativeNoPrefix).isEqualTo(PathFragment.create("a/b"));
 
     PathFragment absoluteNoPrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "/a/b".getBytes(UTF_8), Optional.empty(), fileSystem.getPath("/usr"));
+            "/a/b".getBytes(UTF_8), "", 0, fileSystem.getPath("/usr"));
     assertThat(absoluteNoPrefix).isEqualTo(PathFragment.create("/usr/a/b"));
 
     PathFragment absolutePrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "/root/a/b".getBytes(UTF_8), Optional.of("root"), fileSystem.getPath("/usr"));
+            "/root/a/b".getBytes(UTF_8), "root", 0, fileSystem.getPath("/usr"));
     assertThat(absolutePrefix).isEqualTo(PathFragment.create("/usr/a/b"));
+
+    PathFragment absoluteStripComponents =
+        StripPrefixedPath.maybeDeprefixSymlink(
+            "/root/a/b".getBytes(UTF_8), "", 1, fileSystem.getPath("/usr"));
+    assertThat(absoluteStripComponents).isEqualTo(PathFragment.create("/usr/a/b"));
 
     PathFragment relativePrefix =
         StripPrefixedPath.maybeDeprefixSymlink(
-            "root/a/b".getBytes(UTF_8), Optional.of("root"), fileSystem.getPath("/usr"));
-    // there is no attempt to get absolute path for the relative symlinks target path
-    assertThat(relativePrefix).isEqualTo(PathFragment.create("a/b"));
+            "root/a/b".getBytes(UTF_8), "root", 0, fileSystem.getPath("/usr"));
+    // Only absolute paths or paths relative to extraction root are deprefixed.
+    assertThat(relativePrefix).isEqualTo(PathFragment.create("root/a/b"));
+
+    PathFragment relativeStripComponents =
+        StripPrefixedPath.maybeDeprefixSymlink(
+            "root/a/b".getBytes(UTF_8), "", 1, fileSystem.getPath("/usr"));
+    assertThat(relativeStripComponents).isEqualTo(PathFragment.create("root/a/b"));
+
+    PathFragment forceDeprefixRelativePrefix =
+        StripPrefixedPath.maybeDeprefixSymlink(
+            "root/a/b".getBytes(UTF_8), "root", 0, fileSystem.getPath("/usr"), true);
+    // Forced deprefixing into root relative path.
+    assertThat(forceDeprefixRelativePrefix).isEqualTo(PathFragment.create("/usr/a/b"));
+
+    PathFragment forceDeprefixRelativeComponents =
+        StripPrefixedPath.maybeDeprefixSymlink(
+            "root/a/b".getBytes(UTF_8), "", 1, fileSystem.getPath("/usr"), true);
+    assertThat(forceDeprefixRelativeComponents).isEqualTo(PathFragment.create("/usr/a/b"));
   }
 }


### PR DESCRIPTION
### Description
See #29999 which describes a case where using `strip_components` does not properly handle symbolic links. This change consolidates the logic for handling `strip_components` into the `StripPrefixedPath` class which already handled `strip_prefix` logic. With the consolidation, we no longer miss the handling of symbolic and hard links.

This code builds on top of the pull request in https://github.com/bazelbuild/bazel/pull/30042 - those commits are included here.  It is recommended that you review that pull request before reviewing this pull request (so you don't have to review the same commits twice and to ensure this code is still relevant, since it builds on top of the decisions there).

### Motivation
Fixes #29999 - the code that introduced support for `strip_components` didn't handle symbolic links correctly. Fixes #30015

### Build API Changes

No, this is a bug fix.

### Checklist

- [X] I have added tests for the new use cases (if any).
- [N/A] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Fixes an error when using `strip_components` with archives containing symbolic//hard links.

Closes #30044.
Closes #30071

PiperOrigin-RevId: 953463943
Change-Id: I5da2d3182cc99fb152124c2abb4cc437f6e224d8

