### PR TITLE
[9.3.0] Support dots in configuration segments for path mapping

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
@@ -287,10 +287,10 @@ public final class StrippingPathMapper implements PathMapper {
      */
     private static Pattern stripPathsPattern(String outputRoot) {
       // Match "bazel-out" followed by a slash followed by any combination of word characters, "_",
-      // and "-", followed by another slash. This would miss substrings like
+      // ".", and "-", followed by another slash. This would miss substrings like
       // "bazel-out/k8-fastbuild". But those don't represent actual outputs (all outputs would have
       // to have names beneath that path). So we're not trying to replace those.
-      return Pattern.compile(outputRoot + "/[\\w_-]+/");
+      return Pattern.compile(outputRoot + "/[\\w_.-]+/");
     }
 
     public String strip(String str) {

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -1194,4 +1194,36 @@ EOF
   expect_log_n 'Hello, stdout!' 2
 }
 
+# Verifies that path mapping works for platform names with dots and hyphens.
+function test_path_stripping_with_dots() {
+  local -r pkg="src/main/java/com/example"
+
+  cat >> "${pkg}/BUILD" <<EOF
+platform(
+    name = "linux_aarch64_gnu.2.28-one",
+)
+platform(
+    name = "linux_aarch64_gnu.2.28-two",
+)
+EOF
+
+  bazel build -c fastbuild \
+    --experimental_output_paths=strip \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --experimental_platform_in_output_dir=yes \
+    --experimental_override_platform_cpu_name=//${pkg}:linux_aarch64_gnu.2.28-one=linux_aarch64_gnu.2.28-one \
+    --platforms=//${pkg}:linux_aarch64_gnu.2.28-one \
+    "//${pkg}:lib" &> $TEST_log || fail "First build failed"
+
+  bazel build -c fastbuild \
+    --experimental_output_paths=strip \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --experimental_platform_in_output_dir=yes \
+    --experimental_override_platform_cpu_name=//${pkg}:linux_aarch64_gnu.2.28-two=linux_aarch64_gnu.2.28-two \
+    --platforms=//${pkg}:linux_aarch64_gnu.2.28-two \
+    "//${pkg}:lib" &> $TEST_log || fail "Second build failed"
+
+  expect_log 'remote cache hit'
+}
+
 run_suite "path mapping tests"


### PR DESCRIPTION
Backport a7f3c98636b04b7295735a129ce6d27479baa3cd to `release-9.3.0` for #29314.

`StrippingPathMapper.StringStripper` rewrites structured artifact paths to `bazel-out/cfg/`, but the release matcher `[\w_-]+` leaves command-line paths containing dotted configuration names unchanged. A platform such as `linux_aarch64_gnu.2.28` consequently passes a compiler an unmapped generated-header path even though the sandbox contains the header at its mapped path.

Use the master fix `[\w_.-]+` without importing unrelated archived-tree-artifact changes. Backport the existing remote path-mapping regression using two `linux_aarch64_gnu.2.28` platform names containing dots, underscores, and hyphens, and assert that the second configuration obtains a remote cache hit.

Released Bazel 9.2.0 is also affected; please consider this change for the next 9.2.x patch release if one is planned.

Validation:
- `git diff --check`
- `bash -n src/test/shell/bazel/path_mapping_test.sh`
- `shellcheck --severity=error --exclude=SC1091 src/test/shell/bazel/path_mapping_test.sh`
- Verified old and fixed regex behavior against dotted and hyphenated configuration names, existing `k8-fastbuild` paths, and invalid path prefixes.
- Added `//src/test/shell/bazel:path_mapping_test` regression; full Bazel source integration test is left to upstream CI.