### PR TITLE
[9.3.0] Use no-op path mapper when output paths collide with inputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
@@ -138,7 +138,8 @@ public final class StrippingPathMapper implements PathMapper {
             action.getAdditionalArtifactsForPathMapping().toList(),
             action.discoversInputs()
                 ? action.getAllowedDerivedInputs().toList()
-                : ImmutableSet.of()),
+                : ImmutableSet.of(),
+            action.getOutputs()),
         outputRoot)) {
       return Optional.of(
           new StrippingPathMapper(

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
@@ -21,9 +21,8 @@ import static java.lang.String.format;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.Spawn;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
-import com.google.devtools.build.lib.analysis.FileProvider;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.exec.util.FakeActionInputFileCache;
 import com.google.devtools.build.lib.rules.java.JavaCompilationArgsProvider;
@@ -179,10 +178,7 @@ public class PathMappersTest extends BuildViewTestCase {
     addStarlarkRule(
         Dict.<String, String>builder().put("supports-path-mapping", "1").buildImmutable());
 
-    ConfiguredTarget configuredTarget = getConfiguredTarget("//pkg:my_rule");
-    Artifact outputArtifact =
-        configuredTarget.getProvider(FileProvider.class).getFilesToBuild().toList().get(0);
-    SpawnAction action = (SpawnAction) getGeneratingAction(outputArtifact);
+    SpawnAction action = (SpawnAction) getGeneratingActionForLabel("//pkg:my_rule");
     Spawn spawn =
         action.getSpawn(
             new ActionExecutionContextBuilder()
@@ -211,10 +207,7 @@ public class PathMappersTest extends BuildViewTestCase {
         "--modify_execution_info=MyRuleAction=+supports-path-mapping");
     addStarlarkRule(Dict.empty());
 
-    ConfiguredTarget configuredTarget = getConfiguredTarget("//pkg:my_rule");
-    Artifact outputArtifact =
-        configuredTarget.getProvider(FileProvider.class).getFilesToBuild().toList().get(0);
-    SpawnAction action = (SpawnAction) getGeneratingAction(outputArtifact);
+    SpawnAction action = (SpawnAction) getGeneratingActionForLabel("//pkg:my_rule");
     Spawn spawn =
         action.getSpawn(
             new ActionExecutionContextBuilder()
@@ -280,10 +273,7 @@ public class PathMappersTest extends BuildViewTestCase {
         my_rule(name = "my_rule")
         """);
 
-    ConfiguredTarget configuredTarget = getConfiguredTarget("//:my_rule");
-    Artifact outputArtifact =
-        configuredTarget.getProvider(FileProvider.class).getFilesToBuild().toList().get(0);
-    SpawnAction action = (SpawnAction) getGeneratingAction(outputArtifact);
+    SpawnAction action = (SpawnAction) getGeneratingActionForLabel("//:my_rule");
     Spawn spawn =
         action.getSpawn(
             new ActionExecutionContextBuilder()
@@ -306,5 +296,101 @@ public class PathMappersTest extends BuildViewTestCase {
         .isEqualTo(PathFragment.create("pkg/file"));
     assertThat(pathMapper.map(PathFragment.create("bazel-out/k8-fastbuild-ST-12345/bin/pkg/file")))
         .isEqualTo(PathFragment.create("bazel-out/pm-k8-fastbuild-ST-12345/bin/pkg/file"));
+  }
+
+  @Test
+  public void starlarkRule_inputsOutputsCollision() throws Exception {
+    scratch.file(
+        "defs/defs.bzl",
+        """
+        def _flag_impl(ctx):
+            return []
+
+        bool_flag = rule(implementation = _flag_impl, build_setting = config.bool(flag = True))
+
+        def _transition_impl(settings, attr):
+            return {"//defs:transitioned": True}
+
+        _transitioned = transition(
+            implementation = _transition_impl,
+            inputs = [],
+            outputs = ["//defs:transitioned"],
+        )
+
+        def _my_rule_impl(ctx):
+            out = ctx.actions.declare_file(ctx.label.name + ".out")
+            args = ctx.actions.args()
+            args.add(out)
+            args.add_all(ctx.files.dep)
+            ctx.actions.run(
+                outputs = [out],
+                inputs = ctx.files.dep,
+                executable = ctx.executable._tool,
+                arguments = [args],
+                execution_requirements = {"supports-path-mapping": "1"},
+            )
+            return [DefaultInfo(files = depset([out]))]
+
+        my_rule = rule(
+            implementation = _my_rule_impl,
+            attrs = {
+                "dep": attr.label_list(cfg = _transitioned, allow_files = True),
+                "_tool": attr.label(default = "//tool", executable = True, cfg = "exec"),
+            },
+        )
+        """);
+    scratch.file(
+        "defs/BUILD",
+        """
+        load("//defs:defs.bzl", "bool_flag")
+
+        bool_flag(
+            name = "transitioned",
+            build_setting_default = False,
+            visibility = ["//visibility:public"],
+        )
+
+        config_setting(
+            name = "is_transitioned",
+            flag_values = {":transitioned": "True"},
+            visibility = ["//visibility:public"],
+        )
+        """);
+    scratch.file(
+        "collide/BUILD",
+        """
+        load("//defs:defs.bzl", "my_rule")
+
+        my_rule(
+            name = "a",
+            dep = select({
+                "//defs:is_transitioned": [],
+                "//conditions:default": [":a"],
+            }),
+        )
+        """);
+    scratch.file(
+        "tool/BUILD",
+        """
+        load('//test_defs:foo_binary.bzl', 'foo_binary')
+        foo_binary(
+            name = 'tool',
+            srcs = ['tool.sh'],
+            visibility = ['//visibility:public'],
+        )
+        """);
+
+    SpawnAction action = (SpawnAction) getGeneratingActionForLabel("//collide:a");
+    Spawn spawn =
+        action.getSpawn(
+            new ActionExecutionContextBuilder()
+                .setMetadataProvider(new FakeActionInputFileCache())
+                .build());
+
+    assertThat(spawn.getPathMapper().isNoop()).isTrue();
+    String outDir = analysisMock.getProductName() + "-out";
+    assertThat(spawn.getArguments()).doesNotContain(format("%s/cfg/bin/collide/a.out", outDir));
+    assertThat(spawn.getArguments().stream().anyMatch(arg -> arg.endsWith("/bin/collide/a.out")))
+        .isTrue();
   }
 }


### PR DESCRIPTION
### Description
Prevents the path mapper (#6526, `--experimental_output_paths=strip`) from applying when a collision occurs between mapped input and output paths.

### Motivation
Fixes a discovered edge case where a globally applied Java annotation processor had dependent `.jar` collide when building that same `.jar` under the default configuration, leading to a `AccessDeniedException`.

e.g.
```
$ bazel cquery 'somepath(//product_platform/libs/protogen:protogen, config(//product_platform/libs/protogen:protogen, d373329))'
...
//product_platform/libs/protogen:protogen (e3ee988)
@bazel_tools//tools/jdk:java_plugins_flag_alias (e3ee988)
//tools/error_prone/global_bug_patterns:global_bug_patterns (d373329)
//tools/error_prone/global_bug_patterns/unproducible_value:unproducible_value (d373329)
//product_platform/libs/protogen:protogen (d373329)

$ bazel build //product_platform/libs/protogen:protogen
...
ERROR: /___/product_platform/libs/protogen/BUILD.bazel:7:13: Building product_platform/libs/protogen/libprotogen.jar (18 source files) failed: (Exit 1): java failed: error executing Javac command (from java_library rule target //product_platform/libs/protogen:protogen) external/+java_repositories+openjdk21_linux_x86_64/bin/java '--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED' ... (remaining 20 arguments skipped)
Remote server execution message: Execution result: ___
java.nio.file.AccessDeniedException: bazel-out/cfg/bin/product_platform/libs/protogen/libprotogen.jar
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:90)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
        at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:261)
        at java.base/java.nio.file.spi.FileSystemProvider.newOutputStream(FileSystemProvider.java:482)
        at java.base/java.nio.file.Files.newOutputStream(Files.java:228)
        at com.google.devtools.build.buildjar.jarhelper.JarCreator.execute(JarCreator.java:279)
        at com.google.devtools.build.buildjar.SimpleJavaLibraryBuilder.buildJar(SimpleJavaLibraryBuilder.java:152)
        at com.google.devtools.build.buildjar.SimpleJavaLibraryBuilder.run(SimpleJavaLibraryBuilder.java:119)
        at com.google.devtools.build.buildjar.BazelJavaBuilder.build(BazelJavaBuilder.java:111)
        at com.google.devtools.build.buildjar.BazelJavaBuilder.parseAndBuild(BazelJavaBuilder.java:91)
        at com.google.devtools.build.buildjar.BazelJavaBuilder.lambda$main$0(BazelJavaBuilder.java:52)
        at com.google.devtools.build.lib.worker.WorkRequestHandler$WorkRequestCallback.apply(WorkRequestHandler.java:252)
        at com.google.devtools.build.lib.worker.WorkRequestHandler.respondToRequest(WorkRequestHandler.java:481)
        at com.google.devtools.build.lib.worker.WorkRequestHandler.lambda$startResponseThread$0(WorkRequestHandler.java:433)
        at java.base/java.lang.Thread.run(Thread.java:1583)Use --verbose_failures to see the command lines of failed build steps.
```

### Build API Changes
No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #30440.