### PR TITLE
Validate the execute_wasm() entry point signature

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkWasmModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkWasmModule.java
@@ -29,7 +29,9 @@ import com.dylibso.chicory.runtime.InterpreterMachine;
 import com.dylibso.chicory.runtime.Machine;
 import com.dylibso.chicory.wasm.ChicoryException;
 import com.dylibso.chicory.wasm.WasmModule;
+import com.dylibso.chicory.wasm.types.FunctionType;
 import com.dylibso.chicory.wasm.types.MemoryLimits;
+import com.dylibso.chicory.wasm.types.ValType;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Scheduler;
@@ -91,6 +93,13 @@ final class StarlarkWasmModule implements StarlarkValue {
 
   private static final StarlarkWasmCompilationCache compilationCache =
       new StarlarkWasmCompilationCache();
+
+  // The ABI of the exported entry point: it receives the input pointer and length
+  // followed by the two out-parameter pointers, and returns a status code.
+  private static final FunctionType EXEC_FN_TYPE =
+      FunctionType.of(
+          new ValType[] {ValType.I32, ValType.I32, ValType.I32, ValType.I32},
+          new ValType[] {ValType.I32});
 
   private final StarlarkPath path;
   private final Object origPath;
@@ -236,9 +245,18 @@ final class StarlarkWasmModule implements StarlarkValue {
       throw Starlark.errorf("WebAssembly module doesn't export \"%s\"", allocFnName);
     }
     ExportFunction execFn = instance.export(execFnName);
-    // TODO: #26092 - Validate execFn has the expected signature?
     if (execFn == null) {
       throw Starlark.errorf("WebAssembly module doesn't export \"%s\"", execFnName);
+    }
+    // The exported function is invoked positionally below, and its first result is
+    // read back as the return code. Reject a module whose export doesn't actually
+    // have that type, rather than calling it anyway and reporting whatever comes
+    // back as a successful execution.
+    FunctionType execFnType = instance.exportType(execFnName);
+    if (!EXEC_FN_TYPE.equals(execFnType)) {
+      throw Starlark.errorf(
+          "WebAssembly module export \"%s\" has type %s, but Bazel requires %s",
+          execFnName, execFnType, EXEC_FN_TYPE);
     }
 
     int inputLen = Math.toIntExact(input.length);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkWasmModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkWasmModule.java
@@ -94,12 +94,15 @@ final class StarlarkWasmModule implements StarlarkValue {
   private static final StarlarkWasmCompilationCache compilationCache =
       new StarlarkWasmCompilationCache();
 
-  // The ABI of the exported entry point: it receives the input pointer and length
-  // followed by the two out-parameter pointers, and returns a status code.
+  // (input_ptr, input_len, output_ptr_ptr, output_len_ptr) -> return_code
   private static final FunctionType EXEC_FN_TYPE =
       FunctionType.of(
           new ValType[] {ValType.I32, ValType.I32, ValType.I32, ValType.I32},
           new ValType[] {ValType.I32});
+
+  // (size, align) -> ptr
+  private static final FunctionType ALLOC_FN_TYPE =
+      FunctionType.of(new ValType[] {ValType.I32, ValType.I32}, new ValType[] {ValType.I32});
 
   private final StarlarkPath path;
   private final Object origPath;
@@ -244,20 +247,12 @@ final class StarlarkWasmModule implements StarlarkValue {
     if (allocFn == null) {
       throw Starlark.errorf("WebAssembly module doesn't export \"%s\"", allocFnName);
     }
+    checkFnType(instance, allocFnName, ALLOC_FN_TYPE);
     ExportFunction execFn = instance.export(execFnName);
     if (execFn == null) {
       throw Starlark.errorf("WebAssembly module doesn't export \"%s\"", execFnName);
     }
-    // The exported function is invoked positionally below, and its first result is
-    // read back as the return code. Reject a module whose export doesn't actually
-    // have that type, rather than calling it anyway and reporting whatever comes
-    // back as a successful execution.
-    FunctionType execFnType = instance.exportType(execFnName);
-    if (!EXEC_FN_TYPE.equals(execFnType)) {
-      throw Starlark.errorf(
-          "WebAssembly module export \"%s\" has type %s, but Bazel requires %s",
-          execFnName, execFnType, EXEC_FN_TYPE);
-    }
+    checkFnType(instance, execFnName, EXEC_FN_TYPE);
 
     int inputLen = Math.toIntExact(input.length);
     int inputPtr = alloc(allocFnName, allocFn, inputLen, 1);
@@ -345,6 +340,20 @@ final class StarlarkWasmModule implements StarlarkValue {
       return 1;
     }
     return (int) Math.min((long) MAX_PAGES, Math.ceilDiv(memLimitBytes, PAGE_SIZE));
+  }
+
+  // Both exports are called positionally and their first result is read back, so a
+  // module whose export has a different type would otherwise be invoked anyway --
+  // returning a meaningless value, or throwing ArrayIndexOutOfBoundsException if it
+  // declares no results at all.
+  private static void checkFnType(Instance instance, String fnName, FunctionType want)
+      throws EvalException {
+    FunctionType got = instance.exportType(fnName);
+    if (!want.equals(got)) {
+      throw Starlark.errorf(
+          "WebAssembly module export \"%s\" has type %s, but Bazel requires %s",
+          fnName, got, want);
+    }
   }
 
   static int alloc(String allocFnName, ExportFunction allocFn, int size, int align)


### PR DESCRIPTION
Addresses the first finding in #30455, and the `TODO: #26092 - Validate execFn has the expected signature?` at `StarlarkWasmModule.java:239`.

### Problem

`run()` invokes the exported entry point positionally and reads its first result back as the return code:

```java
execResult = execFn.apply(inputPtr, inputLen, outputPtrPtr, outputLenPtr);
...
long returnCode = execResult[0];
```

Nothing checked that the export actually has that type, so a module exporting a function of a different arity or types was called anyway and whatever came back was reported as a successful execution. The reporter's example exports `(param i64) (result i64 i64)` and gets `return_code=8` — the allocator's `input_ptr` echoed back through a function unrelated to the real contract, indistinguishable from a genuine result.

There is a second case not in the issue: a module whose entry point declares **no** results produces an empty `execResult`, and `execResult[0]` then throws `ArrayIndexOutOfBoundsException`. That surfaces as an internal Java exception rather than a Bazel-level error about the module not meeting the contract.

### Change

Compare the export's declared type against the expected one before calling it:

```java
private static final FunctionType EXEC_FN_TYPE =
    FunctionType.of(
        new ValType[] {ValType.I32, ValType.I32, ValType.I32, ValType.I32},
        new ValType[] {ValType.I32});
```

`Instance.exportType(name)` resolves the function index space internally, so this needs no manual accounting for imported functions. It's only reached after the existing null check on `instance.export(execFnName)`, which routes through `Exports.function(...)` and therefore already guarantees the export exists and is a function.

This cannot reject a module that works today: a correctly-typed entry point compares equal, and every module this now rejects previously either produced a meaningless return code or threw `ArrayIndexOutOfBoundsException`.

### Scope

Deliberately limited to the signature check. I left the `returnCode` range clamp at :266 alone even though the `TODO` at :262 wonders whether signature validation makes it redundant — that's a separate judgement about i32 sign-extension and doesn't belong in the same change. Findings 2 and 3 in #30455 (the output-buffer bound) are also untouched.

### Testing

I asked in #30455 whether you'd prefer this check here or in `validateModule()` off the export/type sections, where the `TODO` at :290 contemplates something similar; happy to move it if that's the preferred shape.

Two caveats I should be upfront about: I can't build Bazel on this machine, so this rests on CI. And I couldn't find any existing test coverage for `load_wasm`/`execute_wasm` to extend — searching the repo turns up no test referencing them. If there's a harness I've missed, or if you'd like WASM fixtures added, point me at the pattern you want and I'll follow up with tests.
