### PR TITLE
Drop C.UTF-8 check in determinism check

### DIFF
--- a/src/test/shell/bazel/bazel_determinism_test.sh
+++ b/src/test/shell/bazel/bazel_determinism_test.sh
@@ -77,13 +77,7 @@ function test_determinism()  {
     # Bazel supports this. Characters with a 4-byte UTF-8 encoding would cause
     # Java compilation to fail due to
     # https://bugs.openjdk.org/browse/JDK-8258246.
-    # On Linux, the host needs to provide the C.UTF-8 locale for this to work,
-    # otherwise the DumpPlatformClasspath action will fail.
-    if is_linux && [[ "$(LC_CTYPE=C.UTF-8 locale charmap)" != "UTF-8" ]]; then
-      output_base_1="${TEST_TMPDIR}/out 1"
-    else
-      output_base_1="${TEST_TMPDIR}/ouäöü€t 1"
-    fi
+    output_base_1="${TEST_TMPDIR}/ouäöü€t 1"
     # TODO: Remove once rules_python exports runtime_env_toolchain_interpreter.sh
     # See https://github.com/bazel-contrib/rules_python/pull/3471
     bazel \
@@ -104,11 +98,7 @@ function test_determinism()  {
     hash_outputs >"${TEST_TMPDIR}/sum1"
 
     # Build Bazel twice.
-    if is_linux && [[ "$(LC_CTYPE=C.UTF-8 locale charmap)" != "UTF-8" ]]; then
-      output_base_2="${TEST_TMPDIR}/out 2"
-    else
-      output_base_2="${TEST_TMPDIR}/ouäöü€t 2"
-    fi
+    output_base_2="${TEST_TMPDIR}/ouäöü€t 2"
     bazel-bin/src/bazel \
       --bazelrc="${TEST_TMPDIR}/bazelrc" \
       --install_base="${TEST_TMPDIR}/install_baseäöü€t 2" \


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
All Linux distros that aren't EOL now have this.


### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
