### PR TITLE
Bootstrap the distfile test with a hermetic JDK 21

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -1241,11 +1241,18 @@ sh_test(
         "//:bazel-distfile",
         "//src:embedded_jdk_allmodules",
         "@bazel_tools//tools/bash/runfiles",
+        "@rules_java//toolchains:remotejdk_21",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for setup_javabase
+    },
     exec_compatible_with = ["//:highcpu_machine"],
     tags = [
         "block-network",
         "no_presubmit",
+    ],
+    toolchains = [
+        "@rules_java//toolchains:remotejdk_21",
     ],
 )
 
@@ -1262,12 +1269,19 @@ sh_test(
         "//:bazel-distfile-tar",
         "//src:embedded_jdk_allmodules",
         "@bazel_tools//tools/bash/runfiles",
+        "@rules_java//toolchains:remotejdk_21",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for setup_javabase
+    },
     exec_compatible_with = ["//:highcpu_machine"],
     tags = [
         "block-network",
         "no_presubmit",
         "no_windows",
+    ],
+    toolchains = [
+        "@rules_java//toolchains:remotejdk_21",
     ],
 )
 

--- a/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
+++ b/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
@@ -54,6 +54,18 @@ else
   declare -r EMBEDDED_JDK=""
 fi
 
+# The prerequisites documented at
+# https://bazel.build/install/compile-source#bootstrap-unix-prereq ask for a JDK
+# 21, so bootstrap with a hermetic JDK 21 from the runfiles rather than with
+# whichever JDK happens to be installed on the machine running this test. This
+# both keeps the test hermetic and verifies that a JDK 21 is in fact sufficient.
+setup_javabase
+export JAVA_HOME="${bazel_javabase}"
+declare -r JAVAC_VERSION="$("${JAVA_HOME}/bin/javac" -version 2>&1)"
+if [[ ! "${JAVAC_VERSION}" =~ ^javac\ 21(\.|$) ]]; then
+  log_fatal "expected a JDK 21 in JAVA_HOME, but got '${JAVAC_VERSION}'"
+fi
+
 function test_bootstrap() {
     cd "$(mktemp -d ${TEST_TMPDIR}/bazelbootstrap.XXXXXXXX)"
     export SOURCE_DATE_EPOCH=1501234567


### PR DESCRIPTION
### Description

The bootstrap prerequisites documented at https://bazel.build/install/compile-source#bootstrap-unix-prereq require a JDK 21, but `bazel_bootstrap_distfile_test` bootstrapped with whichever JDK `scripts/bootstrap/buildenv.sh` happened to discover on the machine running the test: `JAVA_HOME` if it is set, otherwise `/usr/libexec/java_home -v 21+` on macOS or the `javac` on `PATH` on Linux.

This adds `@rules_java//toolchains:remotejdk_21` to the runfiles of both distfile tests and points `JAVA_HOME` at it via `setup_javabase`. `compile.sh` runs the entire bootstrap as `"${JAVA_HOME}/bin/java" ... --default_system_javabase="${JAVA_HOME}"`, so this single export makes both the JVM running the bootstrapping Bazel and `@local_jdk` hermetic and the host JDK discovery in `buildenv.sh` is never reached. The test additionally asserts that the runtime is a JDK 21, so that it keeps verifying the documented prerequisite instead of silently passing on a newer host JDK.

### Motivation

On a CI machine whose default `javac` is 17, the test fails up front with `ERROR: JDK version (1.17) is lower than 21, please set $JAVA_HOME.`, which has nothing to do with the change under test. On a machine with a JDK newer than 21 it instead exercises a configuration that the installation instructions do not describe.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any). — N/A, this is a test-only change.
- [ ] I have updated the documentation (if applicable). — N/A.

### Release Notes

RELNOTES: None
