### PR TITLE
[8.8.0] Stop building for ubuntu 20.04 (#30461)

### DIFF
--- a/.bazelci/build_bazel_binaries.yml
+++ b/.bazelci/build_bazel_binaries.yml
@@ -14,14 +14,7 @@ platforms:
     build_flags:
       - "-c"
       - "opt"
-  ubuntu2004:
-    build_targets:
-      - "//src:bazel"
-      - "//src:bazel_nojdk"
-    build_flags:
-      - "-c"
-      - "opt"
-  ubuntu2004_arm64:
+  ubuntu2404:
     shell_commands:
       # Our Arm64 machine keeps state between builds, so we need to clean it.
       - "bazel clean --expunge"
@@ -31,10 +24,7 @@ platforms:
     build_flags:
       - "-c"
       - "opt"
-      # https://github.com/bazelbuild/continuous-integration/issues/2353
-      - "--linkopt=-Wl,--no-fix-cortex-a53-843419"
-      - "--host_linkopt=-Wl,--no-fix-cortex-a53-843419"
-  ubuntu2404:
+  ubuntu2204:
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -87,8 +87,8 @@ tasks:
     include_json_profile:
       - build
       - test
-  ubuntu2004_clang:
-    platform: ubuntu2004
+  ubuntu2404_clang:
+    platform: ubuntu2404
     environment:
       CC: clang
       CC_CONFIGURE_DEBUG: 1
@@ -110,7 +110,7 @@ tasks:
     include_json_profile:
       - build
       - test
-  ubuntu2004:
+  ubuntu2204:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
@@ -138,9 +138,6 @@ tasks:
       - "//tools/bash/..."
       # Disable some Android tests since we are moving Android rules out of the Bazel repo.
       - "-//src/test/shell/bazel:bazel_android_tools_test"
-    include_json_profile:
-      - build
-      - test
   macos:
     shards: 5
     shell_commands:

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -47,6 +47,7 @@ tasks:
       - "-//src/test/shell/bazel:bazel_java_tools_test"
       - "-//src/test/shell/bazel:bazel_layering_check_test"
       - "-//src/test/shell/bazel:cc_integration_test"
+      - "-//src/test/shell/bazel/remote:remote_execution_test"
       # Disable some Android tests since we are moving Android rules out of the Bazel repo.
       - "-//src/test/shell/bazel:bazel_android_tools_test"
     include_json_profile:

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -38,6 +38,16 @@ tasks:
       - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_gcc"
       - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"
       - "-//src/test/shell/bazel:bazel_coverage_sh_test"
+      # These tests fail on Rocky Linux 8 because of a bug in rules_cc's linker detection logic.
+      # The bug is fixed in https://github.com/bazelbuild/rules_cc/commit/d0fa9b7ad62718bc1cb8ebb2f546d6651cf88ab7,
+      # which is present in rules_cc 0.2.15, but upgrading rules_cc is impossible since newer
+      # versions of rules_cc don't work with Bazel 8.x (which is still on rules_cc 0.1.1).
+      - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_llvm"
+      - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_llvm"
+      - "-//src/test/shell/bazel:bazel_java_tools_test"
+      - "-//src/test/shell/bazel:bazel_layering_check_test"
+      - "-//src/test/shell/bazel:cc_integration_test"
+      - "-//src/test/shell/bazel:remote_execution_test"
       # Disable some Android tests since we are moving Android rules out of the Bazel repo.
       - "-//src/test/shell/bazel:bazel_android_tools_test"
     include_json_profile:

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -47,7 +47,6 @@ tasks:
       - "-//src/test/shell/bazel:bazel_java_tools_test"
       - "-//src/test/shell/bazel:bazel_layering_check_test"
       - "-//src/test/shell/bazel:cc_integration_test"
-      - "-//src/test/shell/bazel:remote_execution_test"
       # Disable some Android tests since we are moving Android rules out of the Bazel repo.
       - "-//src/test/shell/bazel:bazel_android_tools_test"
     include_json_profile:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -107,8 +107,8 @@ tasks:
     include_json_profile:
       - build
       - test
-  ubuntu2004_clang:
-    platform: ubuntu2004
+  ubuntu2404_clang:
+    platform: ubuntu2404
     environment:
       CC: clang
       CC_CONFIGURE_DEBUG: 1
@@ -127,38 +127,6 @@ tasks:
       - "--config=ci-linux"
     test_targets:
       - "//src/test/shell/bazel:cc_integration_test"
-    include_json_profile:
-      - build
-      - test
-  ubuntu2004:
-    shards: 4
-    shell_commands:
-      - rm -rf $HOME/bazeltest
-      - mkdir $HOME/bazeltest
-    build_flags:
-      - "--config=ci-linux"
-    build_targets:
-      - "//src:bazel"
-      - "//src:bazel_jdk_minimal"
-      - "//src:test_repos"
-      - "//src/main/java/..."
-    test_flags:
-      - "--config=ci-linux"
-    test_targets:
-      - "//scripts/..."
-      - "//src/java_tools/..."
-      - "//src/main/starlark/tests/builtins_bzl/..."
-      - "//src/test/..."
-      - "//src/tools/execlog/..."
-      - "//src/tools/one_version/..."
-      - "//src/tools/singlejar/..."
-      - "//src/tools/workspacelog/..."
-      - "//third_party/ijar/..."
-      - "//tools/aquery_differ/..."
-      - "//tools/python/..."
-      - "//tools/bash/..."
-      # Disable some Android tests since we are moving Android rules out of the Bazel repo.
-      - "-//src/test/shell/bazel:bazel_android_tools_test"
     include_json_profile:
       - build
       - test
@@ -389,8 +357,8 @@ tasks:
     index_targets_query: "kind(\"cc_(binary|library|test|proto_library) rule\", ...) union kind(\"java_(binary|import|library|plugin|test|proto_library) rule\", ...) union kind(\"proto_library rule\", ...)"
     index_upload_policy: Always
     index_upload_gcs: False
-  docs_ubuntu2004:
-    platform: ubuntu2004
+  docs_ubuntu2404:
+    platform: ubuntu2404
     name: "Docs"
     build_flags:
       - "--config=docs"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -48,6 +48,7 @@ tasks:
       - "-//src/test/shell/bazel:bazel_java_tools_test"
       - "-//src/test/shell/bazel:bazel_layering_check_test"
       - "-//src/test/shell/bazel:cc_integration_test"
+      - "-//src/test/shell/bazel/remote:remote_execution_test"
       # Disable some Android tests since we are moving Android rules out of the Bazel repo.
       - "-//src/test/shell/bazel:bazel_android_tools_test"
     include_json_profile:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -39,6 +39,16 @@ tasks:
       - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_gcc"
       - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"
       - "-//src/test/shell/bazel:bazel_coverage_sh_test"
+      # These tests fail on Rocky Linux 8 because of a bug in rules_cc's linker detection logic.
+      # The bug is fixed in https://github.com/bazelbuild/rules_cc/commit/d0fa9b7ad62718bc1cb8ebb2f546d6651cf88ab7,
+      # which is present in rules_cc 0.2.15, but upgrading rules_cc is impossible since newer
+      # versions of rules_cc don't work with Bazel 8.x (which is still on rules_cc 0.1.1).
+      - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_llvm"
+      - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_llvm"
+      - "-//src/test/shell/bazel:bazel_java_tools_test"
+      - "-//src/test/shell/bazel:bazel_layering_check_test"
+      - "-//src/test/shell/bazel:cc_integration_test"
+      - "-//src/test/shell/bazel:remote_execution_test"
       # Disable some Android tests since we are moving Android rules out of the Bazel repo.
       - "-//src/test/shell/bazel:bazel_android_tools_test"
     include_json_profile:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -48,7 +48,6 @@ tasks:
       - "-//src/test/shell/bazel:bazel_java_tools_test"
       - "-//src/test/shell/bazel:bazel_layering_check_test"
       - "-//src/test/shell/bazel:cc_integration_test"
-      - "-//src/test/shell/bazel:remote_execution_test"
       # Disable some Android tests since we are moving Android rules out of the Bazel repo.
       - "-//src/test/shell/bazel:bazel_android_tools_test"
     include_json_profile:


### PR DESCRIPTION
Ubuntu 20.04 is EOL.

Note: ubuntu_2404_arm64 platform exists:
https://github.com/bazelbuild/continuous-integration/blob/bf4dd844ae33da5f11cf592b39142ad285dac7f9/buildkite/bazelci.py#L404

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/3df064a381f8de622ac600204c8b0c49f2f1493a