### PR TITLE
Don't crash on a constraint value repeated via an alias

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollection.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollection.java
@@ -86,10 +86,17 @@ public abstract class ConstraintCollection
     public ConstraintCollection build() throws DuplicateConstraintException {
       ImmutableList<ConstraintValueInfo> constraintValues = this.constraintValues.build();
       validateConstraints(constraintValues);
+      // validateConstraints allows repeated instances of the same constraint value, which can e.g.
+      // happen if a constraint value is referenced both directly and via an alias. Keep the first
+      // one instead of failing on the duplicate key.
       return new AutoValue_ConstraintCollection(
           this.parent,
           constraintValues.stream()
-              .collect(toImmutableMap(ConstraintValueInfo::constraint, Function.identity())));
+              .collect(
+                  toImmutableMap(
+                      ConstraintValueInfo::constraint,
+                      Function.identity(),
+                      (first, second) -> first)));
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollectionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollectionTest.java
@@ -80,6 +80,27 @@ public class ConstraintCollectionTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testRepeatedConstraintValue() throws Exception {
+    // Referencing the same constraint value twice, e.g. once directly and once through an alias,
+    // must not fail.
+    ConstraintSettingInfo setting1 =
+        ConstraintSettingInfo.create(Label.parseCanonicalUnchecked("//foo:s1"));
+    ConstraintValueInfo value1 =
+        ConstraintValueInfo.create(setting1, Label.parseCanonicalUnchecked("//foo:value1"));
+    ConstraintSettingInfo setting2 =
+        ConstraintSettingInfo.create(Label.parseCanonicalUnchecked("//foo:s2"));
+    ConstraintValueInfo value2 =
+        ConstraintValueInfo.create(setting2, Label.parseCanonicalUnchecked("//foo:value2"));
+
+    ConstraintCollection collection =
+        ConstraintCollection.builder().addConstraints(value1, value2, value1).build();
+    assertThat(collection.constraintSettings()).containsExactly(setting1, setting2);
+    assertThat(collection.get(setting1)).isEqualTo(value1);
+    assertThat(collection.get(setting2)).isEqualTo(value2);
+    assertThat(collection.containsAll(ImmutableList.of(value1, value2))).isTrue();
+  }
+
+  @Test
   public void testDiff() throws Exception {
     ConstraintSettingInfo setting1 =
         ConstraintSettingInfo.create(Label.parseCanonicalUnchecked("//foo:s1"));

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/PlatformInfoApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/PlatformInfoApiTest.java
@@ -95,6 +95,43 @@ public class PlatformInfoApiTest extends PlatformTestCase {
   }
 
   @Test
+  public void constraints_repeatedViaAlias() throws Exception {
+    scratch.file(
+        "foo/BUILD",
+        """
+        constraint_setting(name = "basic")
+
+        constraint_value(
+            name = "value1",
+            constraint_setting = ":basic",
+        )
+
+        alias(
+            name = "value1_alias",
+            actual = ":value1",
+        )
+
+        platform(
+            name = "my_platform",
+            constraint_values = [
+                ":value1",
+                ":value1_alias",
+            ],
+        )
+        """);
+
+    PlatformInfo platformInfo = fetchPlatformInfo("//foo:my_platform");
+    assertNoEvents();
+    assertThat(platformInfo).isNotNull();
+    ConstraintSettingInfo constraintSetting =
+        ConstraintSettingInfo.create(Label.parseCanonicalUnchecked("//foo:basic"));
+    ConstraintValueInfo constraintValue =
+        ConstraintValueInfo.create(
+            constraintSetting, Label.parseCanonicalUnchecked("//foo:value1"));
+    assertThat(platformInfo.constraints().get(constraintSetting)).isEqualTo(constraintValue);
+  }
+
+  @Test
   public void constraints_refinesConstraintValue_satisfied() throws Exception {
     scratch.file(
         "libc/BUILD",


### PR DESCRIPTION



<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
`ConstraintCollection.validateConstraints` explicitly permits multiple instances of the *same* constraint value and only rejects different values for the same constraint setting. `ConstraintCollection.Builder#build` then collected the values into an `ImmutableMap` keyed by constraint setting without a merge function, so any repetition crashed Bazel with

    Multiple entries with same key: ConstraintSettingInfo(...)=ConstraintValueInfo(...)

This is easy to hit accidentally when a constraint value is referenced both directly and through an `alias`, e.g. `@bazel_tools//tools/cpp:mingw` and `@rules_cc//cc/private/toolchain:mingw` in a `toolchain`'s `target_compatible_with`.

Since validation guarantees that all values for a given setting are equal at this point, keep the first one.

### Motivation
Fixes https://github.com/bazel-contrib/rules_go/issues/4665


### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
