### PR TITLE
[8.8.0] Bootstrap the distfile test with a hermetic JDK 21 (https://github.co…

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -1211,9 +1211,16 @@ sh_test(
         "//:bazel-distfile",
         "//src:embedded_jdk_allmodules",
         "@bazel_tools//tools/bash/runfiles",
+        "@rules_java//toolchains:remotejdk_21",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for setup_javabase
+    },
     exec_compatible_with = ["//:highcpu_machine"],
     tags = ["block-network"],
+    toolchains = [
+        "@rules_java//toolchains:remotejdk_21",
+    ],
 )
 
 sh_test(
@@ -1229,11 +1236,18 @@ sh_test(
         "//:bazel-distfile-tar",
         "//src:embedded_jdk_allmodules",
         "@bazel_tools//tools/bash/runfiles",
+        "@rules_java//toolchains:remotejdk_21",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for setup_javabase
+    },
     exec_compatible_with = ["//:highcpu_machine"],
     tags = [
         "block-network",
         "no_windows",
+    ],
+    toolchains = [
+        "@rules_java//toolchains:remotejdk_21",
     ],
 )
 

--- a/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
+++ b/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
@@ -69,6 +69,18 @@ else
   declare -r EMBEDDED_JDK=""
 fi
 
+# The prerequisites documented at
+# https://bazel.build/install/compile-source#bootstrap-unix-prereq ask for a JDK
+# 21, so bootstrap with a hermetic JDK 21 from the runfiles rather than with
+# whichever JDK happens to be installed on the machine running this test. This
+# both keeps the test hermetic and verifies that a JDK 21 is in fact sufficient.
+setup_javabase
+export JAVA_HOME="${bazel_javabase}"
+declare -r JAVAC_VERSION="$("${JAVA_HOME}/bin/javac" -version 2>&1)"
+if [[ ! "${JAVAC_VERSION}" =~ ^javac\ 21(\.|$) ]]; then
+  log_fatal "expected a JDK 21 in JAVA_HOME, but got '${JAVAC_VERSION}'"
+fi
+
 function test_bootstrap() {
     cd "$(mktemp -d ${TEST_TMPDIR}/bazelbootstrap.XXXXXXXX)"
     export SOURCE_DATE_EPOCH=1501234567


### PR DESCRIPTION
…m/bazelbuild/bazel/pull/30473)

The bootstrap prerequisites documented at https://bazel.build/install/compile-source#bootstrap-unix-prereq require a JDK 21, but `bazel_bootstrap_distfile_test` bootstrapped with whichever JDK `scripts/bootstrap/buildenv.sh` happened to discover on the machine running the test: `JAVA_HOME` if it is set, otherwise `/usr/libexec/java_home -v 21+` on macOS or the `javac` on `PATH` on Linux.

This adds `@rules_java//toolchains:remotejdk_21` to the runfiles of both distfile tests and points `JAVA_HOME` at it via `setup_javabase`. `compile.sh` runs the entire bootstrap as `"${JAVA_HOME}/bin/java" ... --default_system_javabase="${JAVA_HOME}"`, so this single export makes both the JVM running the bootstrapping Bazel and `@local_jdk` hermetic and the host JDK discovery in `buildenv.sh` is never reached. The test additionally asserts that the runtime is a JDK 21, so that it keeps verifying the documented prerequisite instead of silently passing on a newer host JDK.

On a CI machine whose default `javac` is 17, the test fails up front with `ERROR: JDK version (1.17) is lower than 21, please set $JAVA_HOME.`, which has nothing to do with the change under test. On a machine with a JDK newer than 21 it instead exercises a configuration that the installation instructions do not describe.

No

- [ ] I have added tests for the new use cases (if any). — N/A, this is a test-only change.
- [ ] I have updated the documentation (if applicable). — N/A.

RELNOTES: None

Closes #30473.

PiperOrigin-RevId: 955249601
Change-Id: I9bb119b110c9f7ec82ee4b4335a5c8ad2225852c

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/c143d206f6220f6501c07aa83390e68bf5b7657c