### PR TITLE
ConfiguredTargetFactory: let analysis_test impls run when deps have AnalysisFailureInfo

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTargetFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTargetFactory.java
@@ -410,7 +410,10 @@ public final class ConfiguredTargetFactory {
 
     ImmutableList<NestedSet<AnalysisFailure>> analysisFailures =
         depAnalysisFailures(ruleContext, ImmutableList.of());
-    if (!analysisFailures.isEmpty()) {
+    // analysis_test rules exist specifically to inspect dep analysis failures via AnalysisFailureInfo
+    // — their impl must run even when deps have failures. The short-circuit is only appropriate for
+    // ordinary rules that should propagate failures upward rather than consume them.
+    if (!analysisFailures.isEmpty() && !ruleContext.getRule().isAnalysisTest()) {
       return erroredConfiguredTargetWithFailures(ruleContext, analysisFailures);
     }
     if (ruleContext.hasErrors()) {

--- a/src/test/java/com/google/devtools/build/lib/analysis/AnalysisFailureInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/AnalysisFailureInfoTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.truth.Correspondence;
 import com.google.devtools.build.lib.analysis.test.AnalysisFailure;
 import com.google.devtools.build.lib.analysis.test.AnalysisFailureInfo;
+import com.google.devtools.build.lib.analysis.test.AnalysisTestResultInfo;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.analysis.util.MockRule;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -119,8 +120,126 @@ public final class AnalysisFailureInfoTest extends BuildViewTestCase {
     }
   }
 
+  /**
+   * Regression test: when {@code --allow_analysis_failures=true} is set globally, an {@code
+   * analysis_test} rule whose subject dep fails analysis must still have its impl invoked so it can
+   * return {@link AnalysisTestResultInfo}. Previously, {@code ConfiguredTargetFactory} short-
+   * circuited the impl for any rule whose deps had {@code AnalysisFailureInfo}, including {@code
+   * analysis_test} rules that exist specifically to inspect such failures.
+   */
   @Test
-  public void analysisTestNotReturningAnalysisTestResultInfo_cannotPropagate() throws Exception {
+  public void analysisTestWithExpectFailureTransition_implRunsWhenGlobalFlagAlsoSet()
+      throws Exception {
+    // setUp() already sets --allow_analysis_failures=true globally. The analysis_test rule below
+    // additionally applies it via analysis_test_transition on its dep — the same pattern used by
+    // bazel_skylib's analysistest.make(expect_failure=True).
+    scratch.file(
+        "test/extension.bzl",
+        """
+        def failing_rule_impl(ctx):
+            fail("subject always fails")
+
+        failing_rule = rule(implementation = failing_rule_impl)
+
+        def analysis_test_impl(ctx):
+            # analysis_test_transition is a Starlark transition, so isSplit()=True
+            # and ctx.attr.dep is a list even for a label attribute. Index in to
+            # get the single ConfiguredTarget before checking for AnalysisFailureInfo.
+            dep = ctx.attr.dep[0]
+            return [AnalysisTestResultInfo(
+                success = AnalysisFailureInfo in dep,
+                message = "",
+            )]
+
+        _transition = analysis_test_transition(
+            settings = {"//command_line_option:allow_analysis_failures": "True"},
+        )
+
+        expect_failure_test = rule(
+            implementation = analysis_test_impl,
+            analysis_test = True,
+            attrs = {"dep": attr.label(cfg = _transition)},
+        )
+        """);
+
+    scratch.file(
+        "test/BUILD",
+        """
+        load("//test:extension.bzl", "expect_failure_test", "failing_rule")
+
+        expect_failure_test(
+            name = "test",
+            dep = ":subject",
+        )
+
+        failing_rule(name = "subject")
+        """);
+
+    ConfiguredTarget target = getConfiguredTarget("//test:test");
+    AnalysisTestResultInfo testResultInfo =
+        (AnalysisTestResultInfo) target.get(AnalysisTestResultInfo.STARLARK_CONSTRUCTOR.getKey());
+    assertThat(testResultInfo).isNotNull();
+    assertThat(testResultInfo.getSuccess()).isTrue();
+  }
+
+  /**
+   * Companion to {@link
+   * #analysisTestWithExpectFailureTransition_implRunsWhenGlobalFlagAlsoSet}: when the subject dep
+   * does <em>not</em> fail, the analysis test impl still runs but should report {@code success =
+   * false} because the expected failure never occurred.
+   */
+  @Test
+  public void analysisTestWithExpectFailureTransition_reportsFailureWhenDepSucceeds()
+      throws Exception {
+    scratch.file(
+        "test/extension.bzl",
+        """
+        def succeeding_rule_impl(ctx):
+            pass
+
+        succeeding_rule = rule(implementation = succeeding_rule_impl)
+
+        def analysis_test_impl(ctx):
+            dep = ctx.attr.dep[0]
+            return [AnalysisTestResultInfo(
+                success = AnalysisFailureInfo in dep,
+                message = "dep did not fail",
+            )]
+
+        _transition = analysis_test_transition(
+            settings = {"//command_line_option:allow_analysis_failures": "True"},
+        )
+
+        expect_failure_test = rule(
+            implementation = analysis_test_impl,
+            analysis_test = True,
+            attrs = {"dep": attr.label(cfg = _transition)},
+        )
+        """);
+
+    scratch.file(
+        "test/BUILD",
+        """
+        load("//test:extension.bzl", "expect_failure_test", "succeeding_rule")
+
+        expect_failure_test(
+            name = "test",
+            dep = ":subject",
+        )
+
+        succeeding_rule(name = "subject")
+        """);
+
+    ConfiguredTarget target = getConfiguredTarget("//test:test");
+    AnalysisTestResultInfo testResultInfo =
+        (AnalysisTestResultInfo) target.get(AnalysisTestResultInfo.STARLARK_CONSTRUCTOR.getKey());
+    assertThat(testResultInfo).isNotNull();
+    assertThat(testResultInfo.getSuccess()).isFalse();
+  }
+
+  @Test
+  public void analysisTestNotReturningAnalysisTestResultInfo_cannotPropagate()
+      throws Exception {
     scratch.file(
         "test/BUILD", //
         "providerless_analysis_lib(name = 'providerless')");

--- a/src/test/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/BUILD
@@ -97,6 +97,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
         "//src/main/java/com/google/devtools/build/lib/analysis:test/analysis_failure",
         "//src/main/java/com/google/devtools/build/lib/analysis:test/analysis_failure_info",
+        "//src/main/java/com/google/devtools/build/lib/analysis:test/analysis_test_result_info",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/packages",


### PR DESCRIPTION
### Description
When --allow_analysis_failures=true is set globally, ConfiguredTargetFactory short-circuited the rule impl for any rule whose deps had AnalysisFailureInfo. This broke analysis_test=True rules: their impl never ran, so no AnalysisTestResultInfo was returned, and the build errored with:

  "rules with analysis_test=true must return an instance of AnalysisTestResultInfo"

analysis_test rules exist specifically to inspect dep analysis failures. The short-circuit is correct for ordinary rules that should propagate failures upward, but wrong for analysis_test rules whose impl is the intended consumer of AnalysisFailureInfo.

The fix adds a narrow guard: skip the short-circuit when the rule is an analysis_test. This allows bazel_skylib's analysistest.make(expect_failure=True) to work correctly even when --allow_analysis_failures is also set globally.

### Motivation
Fixes #30500 

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
