### PR TITLE
[8.8.0] Allow toolchain features to mark paths for path mapping

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.rules.cpp;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Collections2;
@@ -32,7 +34,10 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.ExpansionException;
+import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerialization;
+import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.starlarkbuildapi.cpp.CcToolchainVariablesApi;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.LinkedHashMap;
@@ -149,6 +154,27 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
     }
   }
 
+  /** A chunk of an exec path that can be mapped upon expansion. */
+  @Immutable
+  @AutoCodec
+  @VisibleForSerialization
+  record RelativePathChunk(PathFragment execPath) implements StringChunk {
+
+    RelativePathChunk {
+      checkArgument(!execPath.isAbsolute(), "execPath is not relative: %s", execPath);
+    }
+
+    @Override
+    public String expand(CcToolchainVariables variables, PathMapper pathMapper) {
+      return pathMapper.map(execPath).getPathString();
+    }
+
+    @Override
+    public String getString() {
+      return "%{path:" + execPath.getPathString() + "}";
+    }
+  }
+
   /**
    * Parser for toolchain string values.
    *
@@ -163,6 +189,8 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
    * <p>To get a literal percent character, "%%" can be used in the string.
    */
   public static class StringValueParser {
+
+    private static final String PATH_PREFIX = "path:";
 
     private final String value;
 
@@ -247,8 +275,22 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
       }
       int end = value.indexOf('}', current);
       final String name = value.substring(current, end);
-      usedVariables.add(name);
-      chunks.add(new VariableChunk(name));
+      if (name.startsWith(PATH_PREFIX)) {
+        String path = name.substring(PATH_PREFIX.length());
+        if (path.isEmpty()) {
+          abort("expected path after 'path:'");
+        }
+        // The provided path is expected to be an exec path, which always uses '/' as a separator
+        // and is relative. Ensure that it is parsed consistently.
+        var pathFragment = PathFragment.createForOs(path, OS.LINUX);
+        if (pathFragment.isAbsolute()) {
+          abort("expected relative Unix-style path after 'path:'");
+        }
+        chunks.add(new RelativePathChunk(pathFragment));
+      } else {
+        usedVariables.add(name);
+        chunks.add(new VariableChunk(name));
+      }
       current = end + 1;
     }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesTest.java
@@ -369,11 +369,21 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
 
   private static String getExpansionOfFlag(String value, CcToolchainVariables variables)
       throws Exception {
-    return getCommandLineForFlag(value, variables).get(0);
+    return getExpansionOfFlag(value, variables, PathMapper.NOOP);
+  }
+
+  private static String getExpansionOfFlag(
+      String value, CcToolchainVariables variables, PathMapper pathMapper) throws Exception {
+    return getCommandLineForFlag(value, variables, pathMapper).get(0);
   }
 
   private static List<String> getCommandLineForFlagGroups(
       String groups, CcToolchainVariables variables) throws Exception {
+    return getCommandLineForFlagGroups(groups, variables, PathMapper.NOOP);
+  }
+
+  private static List<String> getCommandLineForFlagGroups(
+      String groups, CcToolchainVariables variables, PathMapper pathMapper) throws Exception {
     FeatureConfiguration configuration =
         CcToolchainTestHelper.buildFeatures(
                 "feature {",
@@ -384,12 +394,14 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
                 "  }",
                 "}")
             .getFeatureConfiguration(ImmutableSet.of("a"));
-    return configuration.getCommandLine(CppActionNames.CPP_COMPILE, variables);
+    return configuration.getCommandLine(
+        CppActionNames.CPP_COMPILE, variables, /* expander= */ null, pathMapper);
   }
 
-  private static List<String> getCommandLineForFlag(String value, CcToolchainVariables variables)
-      throws Exception {
-    return getCommandLineForFlagGroups("flag_group { flag: '" + value + "' }", variables);
+  private static List<String> getCommandLineForFlag(
+      String value, CcToolchainVariables variables, PathMapper pathMapper) throws Exception {
+    return getCommandLineForFlagGroups(
+        "flag_group { flag: '" + value + "' }", variables, pathMapper);
   }
 
   private static String getFlagParsingError(String value) {
@@ -429,6 +441,32 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
         .isEmpty();
     assertThat(getFlagExpansionError("%{v}", createVariables()))
         .contains("Invalid toolchain configuration: Cannot find variable named 'v'");
+  }
+
+  @Test
+  public void testPathExpansion() throws Exception {
+    PathMapper pathMapper =
+        (PathFragment path) ->
+            path.startsWith(PathFragment.create("bazel-out"))
+                ? path.subFragment(0, 1).getRelative("cfg").getRelative(path.subFragment(2))
+                : path;
+    assertThat(getExpansionOfFlag("%{path:my/source.c}", CcToolchainVariables.EMPTY, pathMapper))
+        .isEqualTo("my/source.c");
+    assertThat(
+            getExpansionOfFlag(
+                "%{path:bazel-out/foobar/bin/my/artifact.a}",
+                CcToolchainVariables.EMPTY, pathMapper))
+        .isEqualTo("bazel-out/cfg/bin/my/artifact.a");
+
+    assertThat(getFlagParsingError("%{path:/absolute/path}"))
+        .contains(
+            "Invalid toolchain configuration: expected relative Unix-style path after 'path:' at"
+                + " position 2 while parsing a flag containing '%{path:/absolute/path}");
+
+    assertThat(getFlagParsingError("%{path:}"))
+        .contains(
+            "Invalid toolchain configuration: expected path after 'path:' at position 2 while"
+                + " parsing a flag containing '%{path:}");
   }
 
   private static CcToolchainVariables createStructureSequenceVariables(


### PR DESCRIPTION
### Description
rules_cc's rule-based toolchain can now inject paths into toolchain features that will be recognized as exec paths and path mapped appropriately by wrapping them in `${path:<the path>}`.

### Motivation
Work towards https://github.com/cerisier/toolchains_llvm_bootstrapped/issues/335

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #28794.

PiperOrigin-RevId: 892975371
Change-Id: I4178e05786e465feda5af96ee5725bfb31a8684d

(cherry picked from commit 41a36ff029340823700e2f4dec0c7cf71fcbdb31)


8.8.0 adaptation: on this branch `StringChunk` still declares `getString()`, so `RelativePathChunk` implements it as `"%{path:" + execPath + "}"`, and `CcToolchainVariables` needs explicit `AutoCodec`/`VisibleForSerialization` imports. In the test, the helpers are static and build features from proto text format, so the new test asserts parse errors via `getFlagParsingError` (8.8.0 throws `EvalException` rather than reporting an event), uses `CcToolchainVariables.EMPTY` instead of `empty()`, and passes `/* expander= */ null` since `getCommandLine`'s third parameter is still an `ArtifactExpander`. The `vfs:pathfragment` test dep already exists here, so the BUILD change is a no-op. `//src/test/java/com/google/devtools/build/lib/rules/cpp/...` passes locally (39 tests).

Closes #30462
