### PR TITLE
Flip incompatible_use_cpp_compile_header_mnemonic for 10.x

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -864,7 +864,7 @@ public abstract class CppOptions extends FragmentOptions {
 
   @Option(
       name = "incompatible_use_cpp_compile_header_mnemonic",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.EXECUTION},
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -1159,13 +1159,16 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testHeaderCompileActionMnemonic() throws Exception {
+  public void testNoIncompatibleUseCppCompileHeaderMnemonic() throws Exception {
     AnalysisMock.get()
         .ccSupport()
         .setupCcToolchainConfig(
             mockToolsConfig,
             CcToolchainConfig.builder().withFeatures(CppRuleClasses.PARSE_HEADERS));
-    useConfiguration("--features=parse_headers", "--process_headers_in_dependencies");
+    useConfiguration(
+        "--noincompatible_use_cpp_compile_header_mnemonic",
+        "--features=parse_headers",
+        "--process_headers_in_dependencies");
 
     ConfiguredTarget x =
         scratchConfiguredTarget(
@@ -1181,16 +1184,13 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testIncompatibleUseCppCompileHeaderMnemonic() throws Exception {
+  public void testUseCppCompileHeaderMnemonicByDefault() throws Exception {
     AnalysisMock.get()
         .ccSupport()
         .setupCcToolchainConfig(
             mockToolsConfig,
             CcToolchainConfig.builder().withFeatures(CppRuleClasses.PARSE_HEADERS));
-    useConfiguration(
-        "--incompatible_use_cpp_compile_header_mnemonic",
-        "--features=parse_headers",
-        "--process_headers_in_dependencies");
+    useConfiguration("--features=parse_headers", "--process_headers_in_dependencies");
 
     ConfiguredTarget x =
         scratchConfiguredTarget(

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -1985,10 +1985,13 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   }
 
   @Test
-  public void testHeaderCompileActionMnemonic() throws Exception {
+  public void testNoIncompatibleUseCppCompileHeaderMnemonic() throws Exception {
     MockObjcSupport.setupCcToolchainConfig(
         mockToolsConfig, MockObjcSupport.darwinX86_64().withFeatures(CppRuleClasses.PARSE_HEADERS));
-    useConfiguration("--features=parse_headers", "--process_headers_in_dependencies");
+    useConfiguration(
+        "--noincompatible_use_cpp_compile_header_mnemonic",
+        "--features=parse_headers",
+        "--process_headers_in_dependencies");
 
     ConfiguredTarget x =
         scratchConfiguredTarget(
@@ -2004,13 +2007,10 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   }
 
   @Test
-  public void testIncompatibleUseCppCompileHeaderMnemonic() throws Exception {
+  public void testUseCppCompileHeaderMnemonicByDefault() throws Exception {
     MockObjcSupport.setupCcToolchainConfig(
         mockToolsConfig, MockObjcSupport.darwinX86_64().withFeatures(CppRuleClasses.PARSE_HEADERS));
-    useConfiguration(
-        "--incompatible_use_cpp_compile_header_mnemonic",
-        "--features=parse_headers",
-        "--process_headers_in_dependencies");
+    useConfiguration("--features=parse_headers", "--process_headers_in_dependencies");
 
     ConfiguredTarget x =
         scratchConfiguredTarget(


### PR DESCRIPTION
RELNOTES[inc]: Flip --incompatible_use_cpp_compile_header_mnemonic so the CppCompileHeader mnemonic is used by defeault