### PR TITLE
Deduplicate include scanning flags

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -823,7 +823,7 @@ public final class CppConfiguration extends Fragment
 
   /** Returns true iff we should do "include scanning" during this build. */
   public boolean shouldScanIncludes() {
-    return cppOptions.getIncludeScanning() || cppOptions.getIncludeScanningInternal();
+    return cppOptions.getCcIncludeScanning();
   }
 
   @StarlarkMethod(name = "include_scanning", documented = false, useStarlarkThread = true)

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -883,28 +883,9 @@ public abstract class CppOptions extends FragmentOptions {
   public abstract boolean getUseArgsParamsFile();
 
   @Option(
-      name = "experimental_unsupported_and_brittle_include_scanning",
-      defaultValue = "false",
-      documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,
-      effectTags = {
-        OptionEffectTag.LOADING_AND_ANALYSIS,
-        OptionEffectTag.EXECUTION,
-        OptionEffectTag.CHANGES_INPUTS
-      },
-      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
-      help =
-          "Whether to narrow inputs to C/C++ compilation by parsing #include lines from input"
-              + " files. This can improve performance and incrementality by decreasing the size of"
-              + " compilation input trees. However, it can also break builds because the include"
-              + " scanner does not fully implement C preprocessor semantics. In particular, it does"
-              + " not understand dynamic #include directives and ignores preprocessor conditional"
-              + " logic. Use at your own risk. Any issues relating to this flag that are filed will"
-              + " be closed."
-              + " At Google without this flag your build will most likely fail.")
-  public abstract boolean getIncludeScanning();
-
-  @Option(
       name = "cc_include_scanning",
+      oldName = "experimental_unsupported_and_brittle_include_scanning",
+      oldNameWarning = false,
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,
       effectTags = {
@@ -922,7 +903,7 @@ public abstract class CppOptions extends FragmentOptions {
               + " logic. Use at your own risk. Any issues relating to this flag that are filed will"
               + " be closed."
               + " At Google without this flag your build will most likely fail.")
-  public abstract boolean getIncludeScanningInternal();
+  public abstract boolean getCcIncludeScanning();
 
   @Option(
       name = "cc_dotd_files",

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -263,7 +263,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:strict_system_includes",
         "//command_line_option:experimental_use_cpp_compile_action_args_params_file",
         "//command_line_option:cc_include_scanning",
-        "//command_line_option:experimental_unsupported_and_brittle_include_scanning",
         "//command_line_option:incompatible_use_cpp_compile_header_mnemonic",
         "//command_line_option:experimental_cpp_compile_resource_estimation",
         "//command_line_option:experimental_generate_llvm_lcov",

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1341,7 +1341,7 @@ EOF
 
   touch pkg/dep.h
 
-  bazel build --experimental_unsupported_and_brittle_include_scanning --features=cc_include_scanning //pkg:bin &>"$TEST_log" && fail 'include scanning did not (wrongly) remove dependency' || true
+  bazel build --cc_include_scanning --features=cc_include_scanning //pkg:bin &>"$TEST_log" && fail 'include scanning did not (wrongly) remove dependency' || true
   expect_log "fatal error: '\?dep.h'\?"
 }
 

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -143,7 +143,7 @@ EOF
 int main() { return 1; }
 EOF
   bazel build \
-        --experimental_unsupported_and_brittle_include_scanning \
+        --cc_include_scanning \
         --features=cc_include_scanning \
         --remote_cache=grpc://localhost:${worker_port} \
         --remote_download_minimal \


### PR DESCRIPTION
Google added --cc_include_scanning recently, we can make the scary old
flag an alias of that as users could use either one now anyways.
