### PR TITLE
[8.8.0] Use available in-memory file metadata while uploading for the BES

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
@@ -29,6 +29,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent.LocalFile;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent.LocalFile.LocalFileType;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
@@ -175,6 +176,47 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
    */
   private PathMetadata readPathMetadata(Path path, LocalFile file) throws IOException {
     DigestUtil digestUtil = new DigestUtil(xattrProvider, path.getFileSystem().getDigestFunction());
+    DigestFunction.Value digestFunction = digestUtil.getDigestFunction();
+    boolean isBuildToolLog =
+        file.type == LocalFileType.LOG || file.type == LocalFileType.PERFORMANCE_LOG;
+    FileArtifactValue metadata = file.artifactMetadata;
+    if (metadata != null) {
+      switch (metadata.getType()) {
+        case DIRECTORY -> {
+          return new PathMetadata(
+              path,
+              /* digest= */ null,
+              /* directory= */ true,
+              /* symlink= */ false,
+              /* remote= */ false,
+              /* isBuildToolLog= */ false,
+              digestFunction);
+        }
+        case SYMLINK -> {
+          return new PathMetadata(
+              path,
+              /* digest= */ null,
+              /* directory= */ false,
+              /* symlink= */ true,
+              /* remote= */ false,
+              /* isBuildToolLog= */ false,
+              digestFunction);
+        }
+        case REGULAR_FILE -> {
+          if (metadata.getDigest() != null) {
+            return new PathMetadata(
+                path,
+                DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize()),
+                /* directory= */ false,
+                /* symlink= */ false,
+                /* remote= */ metadata.isRemote(),
+                isBuildToolLog,
+                digestFunction);
+          }
+        }
+        default -> {}
+      }
+    }
 
     if (file.type == LocalFileType.OUTPUT_DIRECTORY
         || ((file.type == LocalFileType.SUCCESSFUL_TEST_OUTPUT
@@ -188,7 +230,7 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
           /* symlink= */ false,
           /* remote= */ false,
           /* isBuildToolLog= */ false,
-          /* digestFunction= */ digestUtil.getDigestFunction());
+          digestFunction);
     }
     if (file.type == LocalFileType.OUTPUT_SYMLINK) {
       return new PathMetadata(
@@ -198,12 +240,10 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
           /* symlink= */ true,
           /* remote= */ false,
           /* isBuildToolLog= */ false,
-          /* digestFunction= */ digestUtil.getDigestFunction());
+          digestFunction);
     }
 
     Digest digest = digestUtil.compute(path);
-    boolean isBuildToolLog =
-        file.type == LocalFileType.LOG || file.type == LocalFileType.PERFORMANCE_LOG;
     return new PathMetadata(
         path,
         digest,
@@ -211,7 +251,7 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
         /* symlink= */ false,
         isRemoteFile(path),
         isBuildToolLog,
-        digestUtil.getDigestFunction());
+        digestFunction);
   }
 
   private static void processQueryResult(

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -66,6 +66,7 @@ import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.bazel.BazelHashFunctions;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
@@ -525,6 +526,160 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     assertThat(pathConverter.apply(localFile)).contains(localDigest.getHash());
   }
 
+  @Test
+  public void fileWithMetadata_digestReusedAndFileNotRead() throws Exception {
+    // arrange
+    byte[] blob = "contents of a file that is not present locally".getBytes(StandardCharsets.UTF_8);
+    Digest digest = DIGEST_UTIL.compute(blob);
+    Path file = fs.getPath("/file");
+    FileArtifactValue metadata =
+        FileArtifactValue.createForVirtualActionInput(
+            HashCode.fromString(digest.getHash()).asBytes(), digest.getSizeBytes());
+
+    StaticMissingDigestsFinder digestQuerier =
+        Mockito.spy(new StaticMissingDigestsFinder(ImmutableSet.of(digest)));
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(
+            () -> new FixedBackoff(1, 0), (e) -> true, retryService);
+    ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
+    CombinedCache combinedCache = spy(newCombinedCache(refCntChannel, retrier, digestQuerier));
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(combinedCache);
+
+    // act
+    PathConverter pathConverter =
+        artifactUploader
+            .upload(ImmutableMap.of(file, new LocalFile(file, LocalFileType.OUTPUT_FILE, metadata)))
+            .get();
+
+    // assert
+    verify(digestQuerier).findMissingDigests(any(), any());
+    verify(combinedCache, times(0)).uploadFile(any(), any(), any());
+    assertThat(pathConverter.apply(file))
+        .isEqualTo(
+            "bytestream://localhost/instance/blobs/"
+                + digest.getHash()
+                + "/"
+                + digest.getSizeBytes());
+    assertThat(eventHandler.getEvents()).isEmpty();
+  }
+
+  @Test
+  public void fileWithRemoteMetadata_notQueriedOrUploaded() throws Exception {
+    // arrange
+    byte[] blob = "contents of a remote file".getBytes(StandardCharsets.UTF_8);
+    Digest digest = DIGEST_UTIL.compute(blob);
+    Path file = fs.getPath("/file");
+    FileArtifactValue metadata =
+        RemoteFileArtifactValue.create(
+            HashCode.fromString(digest.getHash()).asBytes(),
+            digest.getSizeBytes(),
+            /* locationIndex= */ 1);
+
+    StaticMissingDigestsFinder digestQuerier =
+        Mockito.spy(new StaticMissingDigestsFinder(ImmutableSet.of()));
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(
+            () -> new FixedBackoff(1, 0), (e) -> true, retryService);
+    ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
+    CombinedCache combinedCache = spy(newCombinedCache(refCntChannel, retrier, digestQuerier));
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(combinedCache);
+
+    // act
+    PathConverter pathConverter =
+        artifactUploader
+            .upload(ImmutableMap.of(file, new LocalFile(file, LocalFileType.OUTPUT_FILE, metadata)))
+            .get();
+
+    // assert
+    verify(digestQuerier, times(0)).findMissingDigests(any(), any());
+    verify(combinedCache, times(0)).uploadFile(any(), any(), any());
+    assertThat(pathConverter.apply(file))
+        .isEqualTo(
+            "bytestream://localhost/instance/blobs/"
+                + digest.getHash()
+                + "/"
+                + digest.getSizeBytes());
+    assertThat(eventHandler.getEvents()).isEmpty();
+  }
+
+  @Test
+  public void fileWithMetadata_minimalMode_digestReusedAndFileNotRead() throws Exception {
+    // arrange
+    byte[] blob = "contents of a file that is not present locally".getBytes(StandardCharsets.UTF_8);
+    Digest digest = DIGEST_UTIL.compute(blob);
+    Path file = fs.getPath("/file");
+    FileArtifactValue metadata =
+        FileArtifactValue.createForVirtualActionInput(
+            HashCode.fromString(digest.getHash()).asBytes(), digest.getSizeBytes());
+
+    StaticMissingDigestsFinder digestQuerier =
+        Mockito.spy(new StaticMissingDigestsFinder(ImmutableSet.of()));
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(
+            () -> new FixedBackoff(1, 0), (e) -> true, retryService);
+    ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
+    CombinedCache combinedCache = spy(newCombinedCache(refCntChannel, retrier, digestQuerier));
+    ByteStreamBuildEventArtifactUploader artifactUploader =
+        newArtifactUploader(combinedCache, RemoteBuildEventUploadMode.MINIMAL);
+
+    // act
+    PathConverter pathConverter =
+        artifactUploader
+            .upload(ImmutableMap.of(file, new LocalFile(file, LocalFileType.OUTPUT_FILE, metadata)))
+            .get();
+
+    // assert
+    verify(digestQuerier, times(0)).findMissingDigests(any(), any());
+    verify(combinedCache, times(0)).uploadFile(any(), any(), any());
+    assertThat(pathConverter.apply(file))
+        .isEqualTo(
+            "bytestream://localhost/instance/blobs/"
+                + digest.getHash()
+                + "/"
+                + digest.getSizeBytes());
+    assertThat(eventHandler.getEvents()).isEmpty();
+  }
+
+  @Test
+  public void fileWithDirectoryMetadata_notUploaded() throws Exception {
+    Path dir = fs.getPath("/dir");
+    FileArtifactValue metadata = FileArtifactValue.createForDirectoryWithMtime(0);
+    Map<Path, LocalFile> filesToUpload = new HashMap<>();
+    filesToUpload.put(dir, new LocalFile(dir, LocalFileType.SUCCESSFUL_TEST_OUTPUT, metadata));
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(
+            () -> new FixedBackoff(1, 0), (e) -> true, retryService);
+    ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
+    CombinedCache combinedCache = newCombinedCache(refCntChannel, retrier);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(combinedCache);
+
+    PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
+    assertThat(pathConverter.apply(dir)).isNull();
+    assertThat(eventHandler.getEvents()).isEmpty();
+    artifactUploader.release();
+  }
+
+  @Test
+  public void fileWithSymlinkMetadata_notUploaded() throws Exception {
+    Path sym = fs.getPath("/sym");
+    sym.createSymbolicLink(PathFragment.create("target"));
+    FileArtifactValue metadata = FileArtifactValue.createForUnresolvedSymlink(sym);
+    sym.delete();
+    Map<Path, LocalFile> filesToUpload = new HashMap<>();
+    filesToUpload.put(sym, new LocalFile(sym, LocalFileType.OUTPUT_FILE, metadata));
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(
+            () -> new FixedBackoff(1, 0), (e) -> true, retryService);
+    ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
+    CombinedCache combinedCache = newCombinedCache(refCntChannel, retrier);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(combinedCache);
+
+    PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
+    assertThat(pathConverter.apply(sym)).isNull();
+    assertThat(eventHandler.getEvents()).isEmpty();
+    artifactUploader.release();
+  }
+
   /** Returns a remote artifact and puts its metadata into the action input map. */
   private Artifact createRemoteArtifact(
       String pathFragment, String contents, ActionInputMap inputs) {
@@ -567,6 +722,11 @@ public class ByteStreamBuildEventArtifactUploaderTest {
   }
 
   private ByteStreamBuildEventArtifactUploader newArtifactUploader(CombinedCache combinedCache) {
+    return newArtifactUploader(combinedCache, RemoteBuildEventUploadMode.ALL);
+  }
+
+  private ByteStreamBuildEventArtifactUploader newArtifactUploader(
+      CombinedCache combinedCache, RemoteBuildEventUploadMode remoteBuildEventUploadMode) {
 
     return new ByteStreamBuildEventArtifactUploader(
         MoreExecutors.directExecutor(),
@@ -578,7 +738,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         /* buildRequestId= */ "none",
         /* commandId= */ "none",
         SyscallCache.NO_CACHE,
-        RemoteBuildEventUploadMode.ALL);
+        remoteBuildEventUploadMode);
   }
 
   private static class StaticMissingDigestsFinder implements MissingDigestsFinder {


### PR DESCRIPTION
### Description

### Motivation
Fixes #20576
Fixes #30410

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #30412.

PiperOrigin-RevId: 952732111
Change-Id: Ib057cce14ade0ddc0aa372ba3dd4d60e6b0c242c

(cherry picked from commit 9a849d92d478d7eb02358e831f20fc94aaee3ed9)

8.8.0 adaptation: the `//src/main/java/com/google/devtools/build/lib/actions:file_metadata` dep needs no `BUILD` change because 8.x still has a monolithic `remote/BUILD` whose `:remote` target globs `*.java` and already declares that dep. In the test, `FileArtifactValue.createForRemoteFile` does not exist on 8.x and becomes `RemoteFileArtifactValue.create` (already imported), and `TestUtils.newRemoteRetrier` takes a `Predicate<? super Exception>` rather than master's `Function<Exception, Result>`, so the new call sites use `(e) -> true` like every other one in the file. The production change applies verbatim.

Closes #30414
