### PR TITLE
Redact credential header options from SafeRequestLogging.getRequestLogString

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/SafeRequestLogging.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/SafeRequestLogging.java
@@ -82,7 +82,7 @@ public class SafeRequestLogging {
     buf.append('[');
     String sep = "";
     Matcher m = suppressFromLog.matcher("");
-    for (String s : requestStrings) {
+    for (String s : redactArguments(requestStrings)) {
       buf.append(sep);
       m.reset(s);
       if (m.lookingAt()) {

--- a/src/test/java/com/google/devtools/build/lib/runtime/SafeRequestLoggingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/SafeRequestLoggingTest.java
@@ -112,6 +112,22 @@ public class SafeRequestLoggingTest {
   }
 
   @Test
+  public void testGetRequestLogStringStripsCredentialHeaderOptions() {
+    assertThat(
+            SafeRequestLogging.getRequestLogString(
+                ImmutableList.of(
+                    "blaze",
+                    "build",
+                    "--bes_header=Authorization=Bearer123",
+                    "--remote_header",
+                    "Authorization=Bearer456",
+                    "--some_other_flag")))
+        .isEqualTo(
+            "[blaze, build, --bes_header=<REDACTED>, --remote_header, <REDACTED>, "
+                + "--some_other_flag]");
+  }
+
+  @Test
   public void testRedactArgumentsRedactsCredentials() {
     ImmutableList<String> args =
         ImmutableList.of(


### PR DESCRIPTION
SafeRequestLogging has two separate redaction paths: `redactArguments()`, which strips values for `--bes_header`, `--remote_header`, `--remote_cache_header`, `--remote_exec_header`, `--remote_downloader_header`, `--tls_client_key`, and `--google_credentials`, and `getRequestLogString()`, which only recognizes `--client_env=` entries whose key looks like auth/pass/cookie/token/api_key and leaves every other flag untouched.

`getRequestLogString()` is what `BlazeRuntime` and `CommandServer` pass the raw command line through before logging it via `logger.atInfo()`, which lands in Bazel's own java.log / server log on every invocation. Since it doesn't share `redactArguments()`'s credential-option list, a command like `bazel build --remote_header=Authorization=Bearer <token>` writes that token to the log in cleartext, even though the same option is already redacted when reported through the Build Event Protocol.

This change makes `getRequestLogString()` run its input through `redactArguments()` first, so both logging paths use the same credential-option list. The existing `--client_env=` filtering is unaffected since none of those args match the credential-option patterns.