### PR TITLE
Always add additional_compilation_inputs to include scanning roots

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
@@ -62,6 +62,7 @@ import com.google.devtools.build.lib.starlarkbuildapi.FileApi;
 import com.google.devtools.build.lib.starlarkbuildapi.NativeComputedDefaultApi;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.Param;
@@ -1088,9 +1089,11 @@ public class CcStarlarkInternal implements StarlarkValue {
             .setFeatureConfiguration(featureConfigurationForStarlark.getFeatureConfiguration())
             .addExecutionInfo(executionInfo);
     if (additionalCompilationInputs.size() > 0) {
-      builder.addMandatoryInputs(
+      List<Artifact> inputs =
           Sequence.cast(
-              additionalCompilationInputs, Artifact.class, "additional_compilation_inputs"));
+              additionalCompilationInputs, Artifact.class, "additional_compilation_inputs");
+      builder.addMandatoryInputs(inputs);
+      builder.addAdditionalIncludeScanningRoots(inputs);
     }
     if (additionalIncludeScanningRoots.size() > 0) {
       builder.addAdditionalIncludeScanningRoots(

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -2619,4 +2619,35 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
     assertThat(action.getInputs().toList()).contains(getSourceArtifact("foo/compiler_input.txt"));
     assertThat(action.getArguments()).contains("-DFOO=foo/compiler_input.txt");
   }
+
+  @Test
+  public void testAdditionalCompilerInputsAreIncludeScanningRoots() throws Exception {
+    AnalysisMock.get().ccSupport().setupCcToolchainConfig(mockToolsConfig);
+    scratch.file(
+        "foo/BUILD",
+        """
+        load("@rules_cc//cc:cc_library.bzl", "cc_library")
+        cc_library(
+            name = 'foo',
+            srcs = ['hello.cc'],
+            hdrs = ['other.h'],
+            additional_compiler_inputs = ['forced.def'],
+        )
+        """);
+    scratch.file(
+        "foo/hello.cc",
+        """
+        #define FORCED_HEADER "forced.def"
+        #include FORCED_HEADER
+        """);
+    scratch.file("foo/forced.def", "#include \"other.h\"");
+    scratch.file("foo/other.h");
+
+    ConfiguredTarget lib = getConfiguredTarget("//foo:foo");
+    Artifact artifact = getBinArtifact("_objs/foo/hello.o", lib);
+    CppCompileAction action = (CppCompileAction) getGeneratingAction(artifact);
+    Artifact forcedInput = getSourceArtifact("foo/forced.def");
+    assertThat(action.getInputs().toList()).contains(forcedInput);
+    assertThat(action.getIncludeScannerSources()).contains(forcedInput);
+  }
 }


### PR DESCRIPTION
This gives users a rule-level out if something is pruned because it
wasn't imported directly, and also solves a case like the one in the
test where the file is only used in the copts.

Fixes https://github.com/bazelbuild/bazel/issues/29354
