### PR TITLE
[8.8.0] Reland: Bootstrap the distfile test with a hermetic JDK 21 (https://g…

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -119,6 +119,13 @@ sh_test(
     data = [
         ":test-deps",
         "@bazel_tools//tools/bash/runfiles",
+        "@rules_java//toolchains:current_java_runtime",
+    ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 
@@ -151,9 +158,18 @@ sh_test(
     name = "bazel_embedded_starlark_test",
     size = "medium",
     srcs = ["bazel_embedded_starlark_test.sh"],
-    data = [":test-deps"],
+    data = [
+        ":test-deps",
+        "@rules_java//toolchains:current_java_runtime",
+    ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     tags = [
         "no_windows",  # TODO(laszlocsomor): make this run on Windows
+    ],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 
@@ -778,9 +794,18 @@ sh_test(
     name = "external_starlark_execute_test",
     size = "large",
     srcs = ["external_starlark_execute_test.sh"],
-    data = [":test-deps"],
+    data = [
+        ":test-deps",
+        "@rules_java//toolchains:current_java_runtime",
+    ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     shard_count = 2,
     tags = ["no_windows"],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
+    ],
 )
 
 sh_test(
@@ -806,12 +831,18 @@ sh_test(
     data = [
         ":test-deps",
         "//src/test/shell/bazel/testdata:zstd_test_archive.tar.zst",
-        "@local_jdk//:jdk",  # for remote_helpers setup_localjdk_javabase
+        "@rules_java//toolchains:current_java_runtime",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     shard_count = 15,
     tags = [
         "no_windows",
         "requires-network",
+    ],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 
@@ -844,9 +875,16 @@ sh_test(
     data = [
         ":test-deps",
         "@bazel_tools//tools/bash/runfiles",
+        "@rules_java//toolchains:current_java_runtime",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     shard_count = 6,
     tags = ["no_windows"],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
+    ],
 )
 
 sh_test(
@@ -906,11 +944,17 @@ sh_test(
     data = [
         ":test-deps",
         "@bazel_tools//tools/bash/runfiles",
-        "@local_jdk//:jdk",  # for remote_helpers setup_localjdk_javabase
+        "@rules_java//toolchains:current_java_runtime",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     shard_count = 10,
     tags = [
         "requires-network",
+    ],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 
@@ -1088,11 +1132,18 @@ sh_test(
     data = [
         ":test-deps",
         "//src/test/shell:sandboxing_test_utils.sh",
+        "@rules_java//toolchains:current_java_runtime",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     tags = [
         "no-sandbox",
         "no_windows",
         "requires-network",
+    ],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 
@@ -1166,11 +1217,20 @@ sh_test(
     name = "bazel_repository_cache_test",
     size = "large",
     srcs = ["bazel_repository_cache_test.sh"],
-    data = [":test-deps"],
+    data = [
+        ":test-deps",
+        "@rules_java//toolchains:current_java_runtime",
+    ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     shard_count = 6,
     tags = [
         "no_windows",
         "requires-network",
+    ],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 
@@ -1420,11 +1480,17 @@ sh_test(
     data = [
         ":test-deps",
         "//src/tools/remote:worker",
-        "@local_jdk//:jdk",  # for remote_helpers
+        "@rules_java//toolchains:current_java_runtime",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     tags = [
         "no_windows",
         "requires-network",  # for Bzlmod
+    ],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
     deps = [
         "//src/test/shell/bazel/remote:remote_utils",

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -1211,9 +1211,16 @@ sh_test(
         "//:bazel-distfile",
         "//src:embedded_jdk_allmodules",
         "@bazel_tools//tools/bash/runfiles",
+        "@rules_java//toolchains:remotejdk_21",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for setup_javabase
+    },
     exec_compatible_with = ["//:highcpu_machine"],
     tags = ["block-network"],
+    toolchains = [
+        "@rules_java//toolchains:remotejdk_21",
+    ],
 )
 
 sh_test(
@@ -1229,11 +1236,18 @@ sh_test(
         "//:bazel-distfile-tar",
         "//src:embedded_jdk_allmodules",
         "@bazel_tools//tools/bash/runfiles",
+        "@rules_java//toolchains:remotejdk_21",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for setup_javabase
+    },
     exec_compatible_with = ["//:highcpu_machine"],
     tags = [
         "block-network",
         "no_windows",
+    ],
+    toolchains = [
+        "@rules_java//toolchains:remotejdk_21",
     ],
 )
 

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -1397,11 +1397,19 @@ sh_test(
     data = [
         ":test-deps",
         "//src/tools/workspacelog:parser",
+        "@bazel_tools//tools/bash/runfiles",
+        "@rules_java//toolchains:current_java_runtime",
     ],
     shard_count = 3,
     tags = [
         "no_windows",
         "requires-network",
+    ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 

--- a/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
+++ b/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
@@ -69,6 +69,21 @@ else
   declare -r EMBEDDED_JDK=""
 fi
 
+# The prerequisites documented at
+# https://bazel.build/install/compile-source#bootstrap-unix-prereq ask for a JDK
+# 21, so bootstrap with a hermetic JDK 21 from the runfiles rather than with
+# whichever JDK happens to be installed on the machine running this test. This
+# both keeps the test hermetic and verifies that a JDK 21 is in fact sufficient.
+setup_javabase
+export JAVA_HOME="${bazel_javabase}"
+# JAVA_TOOL_OPTIONS and _JAVA_OPTIONS make the JVM print an extra line, so unset
+# them for this check just like compile.sh does for the bootstrap itself.
+declare -r JAVAC_VERSION="$(unset JAVA_TOOL_OPTIONS _JAVA_OPTIONS; \
+  "${JAVA_HOME}/bin/javac" -version 2>&1)"
+if [[ ! "${JAVAC_VERSION}" =~ ^javac\ 21(\.|$) ]]; then
+  log_fatal "expected a JDK 21 in JAVA_HOME, but got '${JAVAC_VERSION}'"
+fi
+
 function test_bootstrap() {
     cd "$(mktemp -d ${TEST_TMPDIR}/bazelbootstrap.XXXXXXXX)"
     export SOURCE_DATE_EPOCH=1501234567

--- a/src/test/shell/bazel/bazel_windows_example_test.sh
+++ b/src/test/shell/bazel/bazel_windows_example_test.sh
@@ -63,7 +63,7 @@ if ! "$is_windows"; then
   exit 0
 fi
 
-setup_localjdk_javabase
+setup_javabase
 
 function set_up() {
   copy_examples
@@ -396,4 +396,3 @@ EOF
 }
 
 run_suite "examples on Windows"
-

--- a/src/test/shell/bazel/remote/BUILD
+++ b/src/test/shell/bazel/remote/BUILD
@@ -28,11 +28,17 @@ sh_test(
         "//src/test/shell/bazel:test-deps",
         "//src/tools/remote:worker",
         "@bazel_tools//tools/bash/runfiles",
-        "@local_jdk//:jdk",  # for remote_helpers setup_localjdk_javabase
+        "@rules_java//toolchains:current_java_runtime",
     ],
+    env = {
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",  # for remote_helpers setup_javabase
+    },
     shard_count = 5,
     tags = [
         "requires-network",  # for Bzlmod (apple_support)
+    ],
+    toolchains = [
+        "@rules_java//toolchains:current_java_runtime",
     ],
 )
 

--- a/src/test/shell/bazel/remote_helpers.sh
+++ b/src/test/shell/bazel/remote_helpers.sh
@@ -16,7 +16,7 @@
 
 set -eu
 
-setup_localjdk_javabase
+setup_javabase
 
 # Serves $1 as a file on localhost:$nc_port.  Sets the following variables:
 #   * nc_port - the port nc is listening on.

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -270,16 +270,15 @@ function try_with_timeout() {
   done
 }
 
-function setup_localjdk_javabase() {
-  if is_windows; then
-    jdk_binary=local_jdk/bin/java.exe
-  else
-    jdk_binary=local_jdk/bin/java
+function setup_javabase() {
+  if [[ -z "${JAVA_ROOTPATH:-}" ]]; then
+    log_fatal "set JAVA_ROOTPATH to the rootpath of a java binary to use setup_javabase"
   fi
-  jdk_binary_rlocation=$(rlocation ${jdk_binary})
+  jdk_binary_rlocation=$(rlocation ${JAVA_ROOTPATH#../}) || {
+    log_fatal "error: failed to find $JAVA_ROOTPATH, make sure you have added it to data" >&2
+  }
   if [[ -z "${jdk_binary_rlocation}" ]]; then
-    echo "error: failed to find $jdk_binary, make sure you have java \
-installed or pass --java_runtime_verison=XX with the correct version" >&2
+    log_fatal "error: failed to find $JAVA_ROOTPATH, make sure you have added it to data" >&2
   fi
   if is_windows; then
     jdk_dir="$(cygpath -m $(cd ${jdk_binary_rlocation}/../..; pwd))"

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -282,6 +282,15 @@ function setup_javabase() {
   fi
   if is_windows; then
     jdk_dir="$(cygpath -m $(cd ${jdk_binary_rlocation}/../..; pwd))"
+    # if this is a java repository, copy out just the runtime and use that
+    if [[ -f "${jdk_dir}/BUILD.bazel" ]]; then
+      tmp_runtime_dir=$(mktemp -d --tmpdir=${TEST_TMPDIR})
+      for f in $(ls -1 ${jdk_dir}); do
+        ln -s ${jdk_dir}/$f -t ${tmp_runtime_dir}
+      done
+      rm ${tmp_runtime_dir}/BUILD.bazel
+      jdk_dir=${tmp_runtime_dir}
+    fi
   else
     jdk_dir="$(dirname $(dirname ${jdk_binary_rlocation}))"
   fi

--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -265,8 +265,8 @@ cc_test(
         "output_jar_simple_test.cc",
     ],
     copts = select({
-        "//src/conditions:windows": ["-DJAR_TOOL_PATH=\\\"local_jdk/bin/jar.exe\\\""],
-        "//conditions:default": ["-DJAR_TOOL_PATH=\\\"local_jdk/bin/jar\\\""],
+        "//src/conditions:windows": ["-DJAR_TOOL_PATH=\\\"$(JAVABASE_ROOTPATH)/bin/jar.exe\\\""],
+        "//conditions:default": ["-DJAR_TOOL_PATH=\\\"$(JAVABASE_ROOTPATH)/bin/jar\\\""],
     }),
     data = [
         ":data1",
@@ -275,11 +275,7 @@ cc_test(
         ":test1",
         ":test2",
         "@rules_java//toolchains:current_java_runtime",
-    ] + select({
-        # TODO: Use the current java runtime instead of local_jdk
-        "//src/conditions:windows": ["@local_jdk//:bin/jar.exe"],
-        "//conditions:default": ["@local_jdk//:bin/jar"],
-    }),
+    ],
     toolchains = ["@rules_java//toolchains:current_java_runtime"],
     deps = [
         ":input_jar",

--- a/src/tools/singlejar/output_jar_simple_test.cc
+++ b/src/tools/singlejar/output_jar_simple_test.cc
@@ -66,6 +66,10 @@ static bool EndsWith(const string &s, const string &what) {
   return what.size() <= s.size() && s.substr(s.size() - what.size()) == what;
 }
 
+static bool StartsWith(const string& s, const string& what) {
+  return what.size() <= s.size() && s.substr(0, what.size()) == what;
+}
+
 // A subclass of the OutputJar which concatenates the contents of each
 // entry in the data/ directory from the input archives.
 class CustomOutputJar : public OutputJar {
@@ -652,7 +656,11 @@ TEST_F(OutputJarSimpleTest, Normalize) {
   string out_path = OutputFilePath("out.jar");
   string testjar_path = OutputFilePath("testinput.jar");
   {
-    std::string jar_tool_path = runfiles->Rlocation(JAR_TOOL_PATH);
+    // Skip over the leading ../ to get the rlocationpath.
+    std::string jar_tool_rlocationpath =
+        StartsWith(JAR_TOOL_PATH, "../") ? std::string(JAR_TOOL_PATH).substr(3)
+                                         : JAR_TOOL_PATH;
+    std::string jar_tool_path = runfiles->Rlocation(jar_tool_rlocationpath);
     string textfile_path = CreateTextFile("jar_testinput.txt", "jar_inputtext");
     string classfile_path = CreateTextFile("JarTestInput.class", "Dummy");
     unlink(testjar_path.c_str());
@@ -729,7 +737,11 @@ TEST_F(OutputJarSimpleTest, AddMissingDirectories) {
   string out_path = OutputFilePath("out.jar");
   string testjar_path = OutputFilePath("testinput.jar");
 
-  std::string jar_tool_path = runfiles->Rlocation(JAR_TOOL_PATH);
+  // Skip over the leading ../ to get the rlocationpath.
+  std::string jar_tool_rlocationpath =
+      StartsWith(JAR_TOOL_PATH, "../") ? std::string(JAR_TOOL_PATH).substr(3)
+                                       : JAR_TOOL_PATH;
+  std::string jar_tool_path = runfiles->Rlocation(jar_tool_rlocationpath);
   string textfile_path =
       CreateTextFile("a/b/jar_testinput.txt", "jar_inputtext");
   string classfile1_path = CreateTextFile("a/c/Foo.class", "Dummy");


### PR DESCRIPTION
…ithub.com/bazelbuild/bazel/pull/30494)

Relands c143d206f6220f6501c07aa83390e68bf5b7657c (#30473), which was rolled back in 8fd8ead59547c686ebccc418b1dc6409ed03ba96 because it broke the macOS postsubmit.

The bootstrap prerequisites documented at https://bazel.build/install/compile-source#bootstrap-unix-prereq require a JDK 21, but `bazel_bootstrap_distfile_test` bootstrapped with whichever JDK `scripts/bootstrap/buildenv.sh` happened to discover on the machine running the test: `JAVA_HOME` if it is set, otherwise `/usr/libexec/java_home -v 21+` on macOS or the `javac` on `PATH` on Linux.

This adds `@rules_java//toolchains:remotejdk_21` to the runfiles of both distfile tests and points `JAVA_HOME` at it via `setup_javabase`. `compile.sh` runs the entire bootstrap as `"${JAVA_HOME}/bin/java" ... --default_system_javabase="${JAVA_HOME}"`, so this single export makes both the JVM running the bootstrapping Bazel and `@local_jdk` hermetic and the host JDK discovery in `buildenv.sh` is never reached. The test additionally asserts that the runtime is a JDK 21, so that it keeps verifying the documented prerequisite instead of silently passing on a newer host JDK.

The macOS CI machines have `JAVA_TOOL_OPTIONS` set, which makes the JVM print an extra line in front of the `javac -version` output, so the new JDK 21 assertion rejected a perfectly good JDK 21:

```
ERROR[bazel_bootstrap_distfile_test] expected a JDK 21 in JAVA_HOME, but got 'Picked up JAVA_TOOL_OPTIONS: -Djava.net.preferIPv6Addresses=true
javac 21.0.9'
```

`JAVA_TOOL_OPTIONS` and `_JAVA_OPTIONS` are now unset for that check, just like `scripts/bootstrap/compile.sh` already does for the bootstrap itself. Nothing else differs from the original commit.

On a CI machine whose default `javac` is 17, the test fails up front with `ERROR: JDK version (1.17) is lower than 21, please set $JAVA_HOME.`, which has nothing to do with the change under test. On a machine with a JDK newer than 21 it instead exercises a configuration that the installation instructions do not describe.

No

- [ ] I have added tests for the new use cases (if any). — N/A, this is a test-only change.
- [ ] I have updated the documentation (if applicable). — N/A.

RELNOTES: None

Closes #30494.

PiperOrigin-RevId: 955890390
Change-Id: Ie5c0a30115f63a80009a7270d47f94b0168fc6e2

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/ec3c34a7e9a0223d135330d1edab4e2d1280329b and https://github.com/bazelbuild/bazel/pull/30533/commits/3a710fdb69c937152b12663ba578b44b4ad664df
