### PR TITLE
Bound the execute_wasm() output buffer read by memory_limit

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkWasmModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkWasmModule.java
@@ -181,7 +181,7 @@ final class StarlarkWasmModule implements StarlarkValue {
       String errMessage;
       try (var executor = Executors.newSingleThreadExecutor(wasmThreadFactory)) {
         return executor.invokeAny(
-            ImmutableList.of(() -> run(execFnName, input, memLimits)),
+            ImmutableList.of(() -> run(execFnName, input, memLimits, memLimitBytes)),
             timeout.toMillis(),
             TimeUnit.MILLISECONDS);
       } catch (TimeoutException e) {
@@ -193,7 +193,8 @@ final class StarlarkWasmModule implements StarlarkValue {
     }
   }
 
-  private StarlarkWasmExecutionResult run(String execFnName, byte[] input, MemoryLimits memLimits)
+  private StarlarkWasmExecutionResult run(
+      String execFnName, byte[] input, MemoryLimits memLimits, long memLimitBytes)
       throws EvalException, InterruptedException {
     Instance instance;
     try {
@@ -272,6 +273,20 @@ final class StarlarkWasmModule implements StarlarkValue {
 
     String output = "";
     if (outputLen > 0) {
+      // Both values were read back out of guest memory, so outputLen can be any
+      // i32 the module chose to write. Sizing the host buffer straight from it
+      // bounds the allocation by the module's honesty rather than by
+      // memory_limit: a large length fails inside the JVM allocator ("Requested
+      // array size exceeds VM limit") before readBytes gets to bounds-check the
+      // access. A module can't return more than it was allowed to allocate, so
+      // reject anything above the limit instead of trying to allocate it.
+      long maxOutputLen = (long) getMemLimitPages(memLimitBytes) * PAGE_SIZE;
+      if (outputLen > maxOutputLen) {
+        throw Starlark.errorf(
+            "WebAssembly module returned an output of %d bytes, which exceeds the memory"
+                + " limit of %d bytes",
+            outputLen, maxOutputLen);
+      }
       try (SilentCloseable c = Profiler.instance().profile(WASM_EXEC, "copy output")) {
         byte[] outputBytes = memory.readBytes(outputPtr, outputLen);
         output = new String(outputBytes, ISO_8859_1);

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -3243,6 +3243,45 @@ EOF
   expect_log 'result_err.error_message: ""'
 }
 
+function test_execute_wasm_output_len_exceeds_memory_limit() {
+  setup_starlark_repository
+
+  declare -r exec_wasm="$(rlocation "io_bazel/src/test/shell/bazel/testdata/exec_wasm.wasm")"
+  cat >test.bzl <<EOF
+def _impl(repository_ctx):
+  wasm_module = repository_ctx.load_wasm("$exec_wasm")
+
+  # run_overflow_len reports an output length of i32 max without allocating a
+  # buffer to match it. The host sizes its own buffer from that length, so a
+  # length the module could not have allocated has to be rejected rather than
+  # allocated.
+  result_default = repository_ctx.execute_wasm(wasm_module, "run_overflow_len", input="")
+  print('result_default.output: %r' % (result_default.output,))
+  print('result_default.return_code: %r' % (result_default.return_code,))
+  print('result_default.error_message: %r' % (result_default.error_message,))
+
+  # Again under a smaller limit, so the assertions below show the bound is
+  # derived from memory_limit rather than being a fixed ceiling.
+  result_small = repository_ctx.execute_wasm(
+      wasm_module, "run_overflow_len", input="", memory_limit=1048576)
+  print('result_small.error_message: %r' % (result_small.error_message,))
+
+  # Symlink so a repository is created
+  repository_ctx.symlink(repository_ctx.path("$repo2"), repository_ctx.path(""))
+
+repo = repository_rule(implementation=_impl, local=True)
+EOF
+
+  # The rejection is reported through error_message, so the build still succeeds.
+  bazel build --experimental_repository_ctx_execute_wasm @foo//:bar >& $TEST_log \
+    || fail "Expected build to succeed"
+
+  expect_log 'result_default.output: ""'
+  expect_log 'result_default.return_code: -1'
+  expect_log 'exceeds the memory limit of 67108864 bytes'
+  expect_log 'exceeds the memory limit of 1048576 bytes'
+}
+
 function test_wasm_compilation() {
   setup_starlark_repository
 

--- a/src/test/shell/bazel/testdata/exec_wasm.wat
+++ b/src/test/shell/bazel/testdata/exec_wasm.wat
@@ -130,4 +130,38 @@
     i32.const 1
     return
   )
+
+  ;; Reports an output length far larger than the module could ever allocate,
+  ;; without allocating a buffer to match it. Used by
+  ;; test_execute_wasm_output_len_exceeds_memory_limit.
+  ;;
+  ;; The host reads the length back out of guest memory and uses it to size a
+  ;; host-side buffer, so a module that lies about it decides how much host
+  ;; memory gets allocated. The length is left as i32 max, which is the value
+  ;; that reached the JVM allocator before the host bounded it.
+  (func (export "run_overflow_len")
+    (param $input_ptr i32)
+    (param $input_len i32)
+    (param $output_ptr_ptr i32)
+    (param $output_len_ptr i32)
+    (result i32)
+
+    ;; *output_len_ptr = 0x7FFFFFFF
+    local.get $output_len_ptr
+    i32.const 0x7FFFFFFF
+    i32.store
+
+    ;; *output_ptr_ptr = 0
+    ;;
+    ;; Deliberately null: the host must reject the length before it dereferences
+    ;; the pointer, so this test fails loudly if the two checks are ever
+    ;; reordered.
+    local.get $output_ptr_ptr
+    i32.const 0
+    i32.store
+
+    ;; return 0
+    i32.const 0
+    return
+  )
 )


### PR DESCRIPTION
Rejects an `outputLen` larger than `memory_limit` instead of trying to allocate it. Finding 2 of #30455, per @jmillikin's direction there:

> Rejecting `outputLen > memory_limit` seems reasonable, on the basis that a plugin can't return a larger buffer than it's allowed to allocate.

## The problem

`outputPtr` and `outputLen` are read back out of guest memory after the entry point returns, and `outputLen` sizes a host-side `byte[]`:

```java
int outputPtr = memory.readInt(outputPtrPtr);
int outputLen = memory.readInt(outputLenPtr);

String output = "";
if (outputLen > 0) {
  byte[] outputBytes = memory.readBytes(outputPtr, outputLen);
```

Negative values are filtered by `outputLen > 0`, but anything up to `Integer.MAX_VALUE` was taken at face value, so the allocation was bounded by the module's honesty rather than by `memory_limit`.

The two out-of-range cases in the issue behave differently, and the difference is the point:

| case | result |
| --- | --- |
| out-of-range **pointer** | `out of bounds memory access: attempted to access address: 1000000 but limit is: 65536` |
| out-of-range **length** | `Requested array size exceeds VM limit` |

The pointer is caught by Chicory's bounds check. The length is not — it fails inside the JVM allocator *before* `readBytes` gets to bounds-check anything. So the ceiling on that path was `Integer.MAX_VALUE`, not `memory_limit`, and a value below the JVM ceiling but well above the limit — a few hundred MB — would simply have been allocated.

## The change

```java
long maxOutputLen = (long) getMemLimitPages(memLimitBytes) * PAGE_SIZE;
if (outputLen > maxOutputLen) {
  throw Starlark.errorf(...);
}
```

The bound is derived through `getMemLimitPages`, the same helper `getMemLimits` already uses, so it is exactly the byte ceiling the instance's memory could reach — including the `MAX_PAGES` clamp for a very large `memory_limit`. `run()` takes `memLimitBytes` alongside the `MemoryLimits` it already received; there is one call site.

As @jmillikin noted on the issue, this does imply a worst case of roughly `2 * memory_limit` for an exec: the guest's memory plus one host-side copy of it. That seemed the right reading of "can't return a larger buffer than it's allowed to allocate", but say the word if you would rather the bound were tighter.

## Notes

Separate from #30469 (entry point signature validation) — that one is about a different failure and lands in a different part of `run()`; the two do not overlap textually.

I still can't build Bazel locally, so this rests on presubmit. The change uses only APIs already exercised in this file (`getMemLimitPages`, `PAGE_SIZE`, `Starlark.errorf`), which is deliberate given I can't compile it myself.

No test is included because `execute_wasm()` has no test coverage in-tree that I could find and adding a harness for it is a larger piece of work than this fix. The issue's reproducer covers it: `run_overflow_len` writes `outputLen = 2147483647` against `memory_limit = 65536`.
