### PR TITLE
[9.3.0] Revert "bash launcher: append rather than prepend the bash bin dir" (https://github.com/bazelbuild/bazel/pull/30444)

### DIFF
--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -44,12 +44,7 @@ ExitCode BashBinaryLauncher::Launch() {
     wstring bash_bin_dir = GetParentDirFromPath(bash_binary);
     wstring path_env;
     GetEnv(L"PATH", &path_env);
-    // We want to make sure the bash-adjacent tools (like coreutils) are in the
-    // path somewhere (since most bash scripts are going to assume that) but we
-    // append it rather than prepending it to avoid conflicts between link.exe
-    // (the rarely-used symlink-creator from coreutils) and link.exe (the visual
-    // studio linker)
-    path_env = path_env + L";" + bash_bin_dir;
+    path_env = bash_bin_dir + L";" + path_env;
     SetEnv(L"PATH", path_env);
   } else {
     // If specified bash binary path doesn't exist, then fall back to


### PR DESCRIPTION
### Description
This reverts commit e37ec56c57dd4af03a324aba93bf8b311f1f1391.

### Motivation

While fixing some use cases, this breaks `#!/usr/bin/env bash` in `sh_binary` shebangs on Windows with WSL installed, which is a very common setup.

Fixes #29637

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES[INC]: The Windows shell launcher now again prepends rather than appends the directory containing the shell binary, restoring the behavior of Bazel 8.x. This is technically an incompatible change, but deemed necessary due to the unexpected and widespread implications of the change in 9.0.0. See https://github.com/bazelbuild/bazel/issues/29637 for more context.

Closes #30444.

PiperOrigin-RevId: 957043621
Change-Id: I809b3928ea915fc2c0126bf52a7cbcb7350f9037

Commit https://github.com/bazelbuild/bazel/commit/2cfbaab88867a2d93192997426b841b92c687d62