### PR TITLE
Add regression coverage for external repo ctime changes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileStateValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileStateValue.java
@@ -230,8 +230,9 @@ public abstract class FileStateValue extends RegularFileValue implements HasDige
    * Returns whether this value is equal to {@code other}, except that a change to ctime (last
    * change time) only is permitted.
    *
-   * <p>Use this rather than {@link #equals} when 1) hardlinks are involved, and 2) missing certain
-   * modifications in edge cases is acceptable.
+   * <p>Use this rather than {@link #equals} when 1) metadata-only operations such as hardlink or
+   * extended-attribute changes can update ctime, and 2) missing certain modifications in edge cases
+   * is acceptable.
    */
   public boolean equalsIgnoringChangeTime(FileStateValue other) {
     if (this.equals(other)) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/DirtinessCheckerUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/DirtinessCheckerUtils.java
@@ -148,8 +148,8 @@ public class DirtinessCheckerUtils {
       if (cacheable) {
         return SkyValueDirtinessChecker.DirtyResult.dirtyWithNewValue(newValue);
       }
-      // The hermetic Linux sandbox uses hardlinks to stage inputs, which affects ctimes. Don't
-      // report files as modified and trigger a refetch of the repo just due to that.
+      // Hardlink and extended-attribute changes can update ctime without changing contents. Don't
+      // report external repository files as modified and trigger a refetch just due to that.
       if (fileType == FileType.EXTERNAL_REPO
           && !(oldValue instanceof FileStateValue oldFileState
               && newValue instanceof FileStateValue newFileState

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1320,6 +1320,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
+        "//src/test/java/com/google/devtools/build/lib/testutil",
         "//src/test/java/com/google/devtools/build/lib/testutil:TestConstants",
         "//third_party:guava",
         "//third_party:junit4",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/DirtinessCheckerUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/DirtinessCheckerUtilsTest.java
@@ -27,12 +27,16 @@ import com.google.devtools.build.lib.actions.FileStateValue;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
 import com.google.devtools.build.lib.skyframe.DirtinessCheckerUtils.UnionDirtinessChecker;
 import com.google.devtools.build.lib.skyframe.ExternalFilesHelper.ExternalFileAction;
+import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.testutil.TestConstants;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
@@ -158,6 +162,55 @@ public final class DirtinessCheckerUtilsTest {
     Mockito.verifyNoInteractions(mockCache);
   }
 
+  // Regression test for https://github.com/bazelbuild/bazel/issues/29794.
+  @Test
+  public void externalRepoCtimeOnlyChange_doesntMarkRepositoryDirty() throws Exception {
+    NoFastDigestExternalRepoFixture fixture = new NoFastDigestExternalRepoFixture();
+    RootedPath rootedPath = fixture.makeExternalRepoFile("initial");
+    Path path = rootedPath.asPath();
+    FileStateValue oldValue =
+        FileStateValue.create(rootedPath, SyscallCache.NO_CACHE, /* tsgm= */ null);
+    FileStatus oldStat = path.stat();
+    long originalSize = oldStat.getSize();
+    long originalMtime = oldStat.getLastModifiedTime();
+    long originalCtime = oldStat.getLastChangeTime();
+    long originalNodeId = oldStat.getNodeId();
+
+    fixture.clock.advanceMillis(1);
+    // Setting mtime to its current value changes only ctime.
+    path.setLastModifiedTime(originalMtime);
+
+    FileStatus newStat = path.stat();
+    assertThat(newStat.getSize()).isEqualTo(originalSize);
+    assertThat(newStat.getLastModifiedTime()).isEqualTo(originalMtime);
+    assertThat(newStat.getNodeId()).isEqualTo(originalNodeId);
+    assertThat(newStat.getLastChangeTime()).isNotEqualTo(originalCtime);
+
+    DirtinessCheckerUtils.ExternalDirtinessChecker underTest = fixture.newExternalRepoChecker();
+    assertThat(underTest.check(rootedPath, oldValue, null, SyscallCache.NO_CACHE, null))
+        .isEqualTo(SkyValueDirtinessChecker.DirtyResult.dirty());
+    assertThat(underTest.getDirtyExternalRepos()).isEmpty();
+  }
+
+  @Test
+  public void externalRepoContentChange_marksRepositoryDirty() throws Exception {
+    NoFastDigestExternalRepoFixture fixture = new NoFastDigestExternalRepoFixture();
+    RootedPath rootedPath = fixture.makeExternalRepoFile("initial");
+    long originalSize = rootedPath.asPath().getFileSize();
+    FileStateValue oldValue =
+        FileStateValue.create(rootedPath, SyscallCache.NO_CACHE, /* tsgm= */ null);
+
+    fixture.clock.advanceMillis(1);
+    FileSystemUtils.writeContentAsLatin1(rootedPath.asPath(), "changed");
+    assertThat(rootedPath.asPath().getFileSize()).isEqualTo(originalSize);
+
+    DirtinessCheckerUtils.ExternalDirtinessChecker underTest = fixture.newExternalRepoChecker();
+    assertThat(underTest.check(rootedPath, oldValue, null, SyscallCache.NO_CACHE, null))
+        .isEqualTo(SkyValueDirtinessChecker.DirtyResult.dirty());
+    assertThat(underTest.getDirtyExternalRepos())
+        .containsExactly(RepositoryName.create("extrepo"), rootedPath);
+  }
+
   @Test
   public void externalDiffChecker_doesntMatchType() {
     DirtinessCheckerUtils.ExternalDirtinessChecker underTest =
@@ -209,5 +262,51 @@ public final class DirtinessCheckerUtilsTest {
 
   private DirtinessCheckerUtils.MissingDiffDirtinessChecker createMissingDiffChecker() {
     return new DirtinessCheckerUtils.MissingDiffDirtinessChecker(ImmutableSet.of(srcRoot));
+  }
+
+  private static final class NoFastDigestExternalRepoFixture {
+    private final ManualClock clock = new ManualClock();
+    // Match the default open-source Unix filesystem, which does not provide a fast digest.
+    private final FileSystem fs =
+        new InMemoryFileSystem(clock, DigestHashFunction.SHA256) {
+          @Override
+          public synchronized byte[] getFastDigest(PathFragment path) {
+            return null;
+          }
+        };
+    private final Path pkgRoot = fs.getPath("/testroot");
+    private final Root srcRoot = Root.fromPath(pkgRoot);
+    private final Path outputBase = fs.getPath("/outputroot/user/outputBase");
+    private final AtomicReference<PathPackageLocator> pkgLocator =
+        new AtomicReference<>(
+            new PathPackageLocator(
+                outputBase,
+                ImmutableList.of(srcRoot),
+                BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY));
+    private final BlazeDirectories directories =
+        new BlazeDirectories(
+            new ServerDirectories(pkgRoot, outputBase, outputBase.getParentDirectory()),
+            pkgRoot,
+            TestConstants.PRODUCT_NAME);
+    private final ExternalFilesHelper externalFilesHelper =
+        ExternalFilesHelper.createForTesting(
+            pkgLocator,
+            ExternalFileAction.DEPEND_ON_EXTERNAL_PKG_FOR_EXTERNAL_REPO_PATHS,
+            directories);
+
+    private DirtinessCheckerUtils.ExternalDirtinessChecker newExternalRepoChecker() {
+      return new DirtinessCheckerUtils.ExternalDirtinessChecker(
+          externalFilesHelper, EnumSet.of(ExternalFilesHelper.FileType.EXTERNAL_REPO));
+    }
+
+    private RootedPath makeExternalRepoFile(String contents) throws IOException {
+      RootedPath rootedPath =
+          RootedPath.toRootedPath(
+              Root.fromPath(outputBase),
+              LabelConstants.EXTERNAL_REPOSITORY_LOCATION.getRelative("extrepo/file"));
+      rootedPath.asPath().getParentDirectory().createDirectoryAndParents();
+      FileSystemUtils.writeContentAsLatin1(rootedPath.asPath(), contents);
+      return rootedPath;
+    }
   }
 }


### PR DESCRIPTION
### Description

This PR adds deterministic unit coverage for ctime-only changes to files in external repositories.

The new test:

- Uses a filesystem without fast digests, matching the open-source Unix filesystem behavior.
- Changes only ctime while preserving file size, mtime, and node ID.
- Verifies that Bazel does not record the repository as externally modified.
- Uses a same-size content mutation as a control and verifies that Bazel does record that repository as modified.

This PR also updates the relevant Javadoc and code comments to cover both hardlink and extended-attribute operations. It does not change production behavior.

### Motivation

#29794 reports external repositories being refetched after metadata-only operations changed file ctime on macOS.

Bazel already ignores ctime-only changes in this dirtiness check. Existing regression coverage tests hardlink staging through the Linux hermetic sandbox, but there was no deterministic, platform-independent unit test for this behavior.

During investigation, ctime-only changes from extended attributes and hardlinks were reproduced on macOS. However, the reported warning and repository refetch could not be reproduced with Bazel 9.2.0 or the current source. This PR closes the missing unit-test coverage without claiming to fix the remaining unreproduced report.

Refs #29794, https://github.com/bazel-io/bazel/commit/6e6bae029cf37495300f3d9efba668cb53e0b880 (what causes these tests to pass v.s. historically)

### Build API Changes

No.

### Checklist

- [x] I have added tests for the new use cases.
- [x] I have updated the relevant code comments and Javadoc. No user-facing documentation change is required.

### Testing

- `DirtinessCheckerUtilsTest` passed (14 tests).
- `FileStateValueTest` passed.
- `buildifier` passed.
- The existing hermetic sandbox regression test is Linux-only and was skipped on macOS.

### Release Notes

RELNOTES: None