### PR TITLE
Build xcode-locator as a universal platform-aware binary

### DIFF
--- a/src/MODULE.tools
+++ b/src/MODULE.tools
@@ -6,6 +6,7 @@ module(name = "bazel_tools")
 
 bazel_dep(name = "rules_license", version = "1.0.0")
 
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "buildozer", version = "8.5.1")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")

--- a/src/test/shell/bazel/apple/bazel_objc_test.sh
+++ b/src/test/shell/bazel/apple/bazel_objc_test.sh
@@ -25,6 +25,10 @@ if ! is_darwin; then
 fi
 
 function test_xcodelocator_embedded_tool() {
+  # Declare apple_support directly so its Apple C++ toolchain is registered
+  # before the generic rules_cc toolchain inherited through @bazel_tools.
+  add_bazel_dep "apple_support" MODULE.bazel
+
   rm -rf ios
   mkdir -p ios
 

--- a/tools/osx/BUILD
+++ b/tools/osx/BUILD
@@ -1,3 +1,7 @@
+load("@apple_support//rules:universal_binary.bzl", "universal_binary")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
     "//tools/osx:xcode_version_flag.bzl",
     "ios_sdk_version_flag",
@@ -26,24 +30,37 @@ exports_files([
     "xcode_configure.bzl",
 ])
 
-DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """
-  /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices \
-      -framework Foundation -arch arm64 -arch x86_64 -o $@ $<
-"""
+objc_library(
+    name = "xcode-locator-lib",
+    srcs = ["xcode_locator.m"],
+    sdk_frameworks = [
+        "CoreServices",
+        "Foundation",
+    ],
+    target_compatible_with = ["@platforms//os:macos"],
+)
 
-genrule(
-    name = "xcode-locator-genrule",
-    srcs = select({
-        "//src/conditions:darwin": ["xcode_locator.m"],
-        "//conditions:default": ["xcode_locator_stub.sh"],
+cc_binary(
+    name = "xcode-locator-native",
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [":xcode-locator-lib"],
+)
+
+universal_binary(
+    name = "xcode-locator-universal",
+    binary = ":xcode-locator-native",
+    target_compatible_with = ["@platforms//os:macos"],
+)
+
+copy_file(
+    name = "xcode-locator-copy",
+    src = select({
+        "//src/conditions:darwin": ":xcode-locator-universal",
+        "//conditions:default": "xcode_locator_stub.sh",
     }),
-    outs = ["xcode-locator"],
-    cmd = select({
-        "//src/conditions:darwin": DARWIN_XCODE_LOCATOR_COMPILE_COMMAND,
-        "//conditions:default": "cp $< $@",
-    }),
-    local = 1,
-    output_to_bindir = 1,
+    out = "xcode-locator",
+    allow_symlink = True,
+    is_executable = True,
 )
 
 # TODO(cparsons): Consolidate with config_settings under //src


### PR DESCRIPTION
Replace the shell-based Xcode locator rule with `objc_library`, `cc_binary`, `@apple_support//rules:universal_binary.bzl`, and `@bazel_skylib//rules:copy_file.bzl`. Declare `bazel_skylib` 1.8.2 in `src/MODULE.tools` so embedded `@bazel_tools` can load its copy rule. Preserve the universal `x86_64`/`arm64` macOS executable and select the existing executable stub on other platforms without running `xcrun` or `cp` from a genrule.

Verified with:

```sh
bazel --output_base=/private/tmp/codex-bazel-xcode-locator-output build --jobs=4 //tools/osx:xcode-locator
lipo -archs bazel-bin/tools/osx/xcode-locator
```

`lipo` reports `x86_64 arm64`.
