### PR TITLE
[9.3.0] Fix `include_directories()` splitting (https://github.com/bazelbuild/…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/IgnoredSubdirectories.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/IgnoredSubdirectories.java
@@ -128,8 +128,7 @@ public final class IgnoredSubdirectories {
     ImmutableSet<PathFragment> filteredPrefixes =
         prefixes.stream().filter(p -> p.startsWith(directory)).collect(toImmutableSet());
 
-    String[] splitDirectory =
-        Iterables.toArray(SLASH_SPLITTER.split(directory.getPathString()), String.class);
+    String[] splitDirectory = Iterables.toArray(directory.segments(), String.class);
     ImmutableList.Builder<String> filteredPatterns = ImmutableList.builder();
     for (int i = 0; i < patterns.size(); i++) {
       if (UnixGlob.canMatchChild(splitPatterns.get(i), splitDirectory)) {

--- a/src/test/java/com/google/devtools/build/lib/cmdline/IgnoredSubdirectoriesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/IgnoredSubdirectoriesTest.java
@@ -83,6 +83,17 @@ public class IgnoredSubdirectoriesTest {
   }
 
   @Test
+  public void filterPatternsForRootDirectory() throws Exception {
+    // Regression test for https://github.com/bazelbuild/bazel/issues/30526: filtering for the root
+    // directory (which is what happens for the "//..." target pattern) must not drop any pattern.
+    IgnoredSubdirectories original =
+        IgnoredSubdirectories.of(
+            prefixes("prefix"), patterns(".claude", "foo/bar", "**/sub", "*/qux"));
+    IgnoredSubdirectories filtered = original.filterForDirectory(PathFragment.EMPTY_FRAGMENT);
+    assertThat(filtered).isEqualTo(original);
+  }
+
+  @Test
   public void filterPatternsForHiddenFiles() throws Exception {
     IgnoredSubdirectories original =
         IgnoredSubdirectories.of(

--- a/src/test/shell/bazel/bazelignore_test.sh
+++ b/src/test/shell/bazel/bazelignore_test.sh
@@ -236,6 +236,30 @@ EOF
   assert_contains "//foo/notsub:fg" "$TEST_TMPDIR/targets"
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/30526: the target pattern "//..."
+# resolves to the root directory, which used to be handled incorrectly when filtering the patterns
+# passed to ignore_directories.
+test_root_target_pattern_with_wildcards_in_repo_bazel() {
+  rm -rf work && mkdir work && cd work
+  setup_module_dot_bazel
+  cat >REPO.bazel <<'EOF'
+ignore_directories([".ignored", "**/sub"])
+EOF
+
+  for pkg in foo .ignored .ignored/pkg foo/sub foo/sub/subsub foo/notsub; do
+    mkdir -p "$pkg"
+    echo 'filegroup(name="fg")' > "$pkg/BUILD.bazel"
+  done
+
+  bazel query //... > "$TEST_TMPDIR/targets"
+  assert_not_contains "//.ignored:fg" "$TEST_TMPDIR/targets"
+  assert_not_contains "//.ignored/pkg:fg" "$TEST_TMPDIR/targets"
+  assert_not_contains "//foo/sub:fg" "$TEST_TMPDIR/targets"
+  assert_not_contains "//foo/sub/subsub:fg" "$TEST_TMPDIR/targets"
+  assert_contains "//foo:fg" "$TEST_TMPDIR/targets"
+  assert_contains "//foo/notsub:fg" "$TEST_TMPDIR/targets"
+}
+
 test_globs_with_wildcards_in_repo_bazel() {
   rm -rf work && mkdir work && cd work
   setup_module_dot_bazel


### PR DESCRIPTION
…bazel/pull/30536)

`IgnoredSubdirectories#filterForDirectory` computed the directory's segments by splitting its path string on `"/"`. For the root directory the path string is empty, and `Splitter` yields a single empty string rather than no segments at all. `UnixGlob#canMatchChild` then matched that phantom empty segment against the first segment of each pattern, so every pattern whose first segment is not a wildcard was dropped.

Use `PathFragment#segments()` instead, matching what `matchingEntry()` already does.

Fixes #30526

No

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES: Fixed a bug that could cause `ignore_directories()` to not ignore directories.

Closes #30536.

PiperOrigin-RevId: 956539663
Change-Id: Ia7e0982250eb2a2251938ee056a6aa55a2481621

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/ed716f61bcbc83b7e50be0ad46eb27fa03b29d0b