### PR TITLE
[9.3.0] Clean up remote repo contents cache lifecycle logic (https://github.c…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -88,6 +88,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/clock",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
+        "//src/main/java/com/google/devtools/build/lib/concurrent:task_deduplicator",
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/exec:abstract_spawn_strategy",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.remote;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static com.google.common.util.concurrent.Futures.immediateCancelledFuture;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 import static com.google.devtools.build.lib.remote.util.Utils.waitForBulkTransfer;
 import static com.google.devtools.build.lib.util.StringEncoding.unicodeToInternal;
@@ -29,10 +28,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
+import com.google.devtools.build.lib.concurrent.TaskDeduplicator;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.events.Reporter;
@@ -72,9 +74,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
@@ -91,8 +91,9 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
   private final int externalDirectorySegmentCount;
   private final FileSystem nativeFs;
   private final RemoteExternalFileSystem externalFs;
-  private final ConcurrentHashMap<String, Future<Void>> materializations =
-      new ConcurrentHashMap<>();
+  private final TaskDeduplicator<String, Void> materializations = new TaskDeduplicator<>();
+  // The names of the repos whose contents have been fully materialized to nativeFs.
+  private final Set<String> materializedRepos = ConcurrentHashMap.newKeySet();
   // As long as a repo name appears as a key in this map, the repo contents are available in
   // externalFs.
   private final ConcurrentHashMap<String, String> markerFileContents = new ConcurrentHashMap<>();
@@ -106,7 +107,7 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
   @Nullable private String commandId;
   @Nullable private MemoizingEvaluator evaluator;
   @Nullable private Duration remoteCacheTtl;
-  @Nullable private ExecutorService materializationExecutor;
+  @Nullable private ListeningExecutorService materializationExecutor;
 
   public RemoteExternalOverlayFileSystem(PathFragment externalDirectory, FileSystem nativeFs) {
     super(nativeFs.getDigestFunction());
@@ -142,8 +143,9 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
     this.evaluator = evaluator;
     this.remoteCacheTtl = remoteCacheTtl;
     this.materializationExecutor =
-        Executors.newThreadPerTaskExecutor(
-            Thread.ofVirtual().name("remote-repo-materialization-", 0).factory());
+        MoreExecutors.listeningDecorator(
+            Executors.newThreadPerTaskExecutor(
+                Thread.ofVirtual().name("remote-repo-materialization-", 0).factory()));
   }
 
   public void afterCommand() {
@@ -166,14 +168,8 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
     // be refetched to recover files that the remote cache has lost. This wouldn't be safe to do
     // eagerly as ongoing repo rule evaluations may still refer to the in-memory content and
     // refetching is not atomic.
-    materializations.forEach(
-        1,
-        (repoName, materializationState) ->
-            materializationState.state() == Future.State.SUCCESS
-                    || reposWithLostFiles.contains(repoName)
-                ? repoName
-                : null,
-        this::evictInMemoryRepo);
+    materializedRepos.forEach(this::evictInMemoryRepo);
+    reposWithLostFiles.forEach(this::evictInMemoryRepo);
     invalidateRepoDirectories(evaluator, reposWithLostFiles);
     reposWithLostFiles.clear();
     this.evaluator = null;
@@ -186,7 +182,7 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
     } catch (IOException e) {
       throw new IllegalStateException("In-memory file system is not expected to throw", e);
     }
-    materializations.remove(repoName);
+    materializedRepos.remove(repoName);
     markerFileContents.remove(repoName);
   }
 
@@ -210,6 +206,7 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
       throws IOException, InterruptedException {
     var repoDir = externalDirectory.getChild(repo.getName());
     deleteTree(repoDir);
+    materializedRepos.remove(repo.getName());
     var unused = delete(externalDirectory.getChild(repo.getMarkerFileName()));
     var childMap =
         remoteContents.getChildrenList().stream()
@@ -315,9 +312,9 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
     }
     var unused =
         getFromFuture(
-            materializations.computeIfAbsent(
+            materializations.executeIfNew(
                 repo.getName(),
-                unusedRepoName ->
+                () ->
                     materializationExecutor.submit(
                         () -> {
                           doMaterialize(repo, reporter);
@@ -329,6 +326,7 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
       throws IOException, InterruptedException {
     reporter.handle(Event.debug("Materializing remote repo %s".formatted(repo)));
     materializeSubtree(externalDirectory.getChild(repo.getName()));
+    materializedRepos.add(repo.getName());
 
     // After the repo has been copied, atomically materialize the marker file. This ensures that the
     // repo doesn't have to be refetched after the next server restart.
@@ -469,16 +467,14 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
     if (path.startsWith(externalDirectory) && !path.equals(externalDirectory)) {
       String repoName = path.getSegment(externalDirectorySegmentCount);
       var hasBeenInjected = markerFileContents.containsKey(repoName);
-      var hasBeenMaterialized =
-          materializations.getOrDefault(repoName, immediateCancelledFuture()).state()
-              == Future.State.SUCCESS;
+      var hasBeenMaterialized = materializedRepos.contains(repoName);
       if (hasBeenInjected && !hasBeenMaterialized) {
         // The repo may have been deleted due to refetching. Clean up in-memory state if that is the
         // case.
         if (externalFs.getPath(externalDirectory.getChild(repoName)).exists()) {
           return externalFs;
         }
-        materializations.remove(repoName);
+        materializedRepos.remove(repoName);
         markerFileContents.remove(repoName);
       }
       // Fall back to the native file system if the repo has been materialized, deleted, or never


### PR DESCRIPTION
…om/bazelbuild/bazel/pull/30514)

Use `TaskDeduplicator` as a proven primitive for deduplicating work plus a separate map that tracks completed tasks instead of basing decision on future completion state, which didn't handle failed or canceled futures correctly.

I am not aware of any bugs this causes, but it makes it easier to reason about the materialization state of a remote repo, especially in a `--keep_going` build.

No

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES: None

Closes #30514.

PiperOrigin-RevId: 956641690
Change-Id: Ica641efedccf1c664ea074af427485a8f782a9dc

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/15b8ef351dab4c246d2de9c79811643d3aa7ff5a