### PR TITLE
Emit a stack trace for failures in `map_directory` impls

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkMapActionTemplate.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkMapActionTemplate.java
@@ -261,8 +261,13 @@ public final class StarlarkMapActionTemplate extends ActionKeyComputer
       checkActionOutputsArtifactOwner(actions, artifactOwner);
       return actions;
     } catch (EvalException e) {
+      var messageWithStack = e.getMessageWithStack();
       throw new ActionExecutionException(
-          e, this, /* catastrophe= */ true, makeDetailedExitCode(e.getMessage()));
+          messageWithStack,
+          e,
+          this,
+          /* catastrophe= */ true,
+          makeDetailedExitCode(messageWithStack));
     } finally {
       context.close();
     }

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkMapActionTemplateTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkMapActionTemplateTest.java
@@ -1066,9 +1066,10 @@ public final class StarlarkMapActionTemplateTest extends BuildIntegrationTestCas
     assertThat(recordingOutErr.errAsLatin1())
         .containsMatch(
             "ERROR: .*/test/BUILD:2:8: Expanding \\[File:\\[.*\\]test/target_input_dir\\] into"
-                + " actions failed: Output directory"
-                + " File:\\[.*\\]test/target_output_dir1"
-                + " cannot be used as an input to template_ctx\\.run\\(\\)");
+            + " actions failed: (.|\\n)"
+            + "*/test/rule_def.bzl\", line 15, column 21, in combined_impl(.|\\n)*Output directory"
+            + " File:\\[.*\\]test/target_output_dir1"
+            + " cannot be used as an input to template_ctx\\.run\\(\\)");
   }
 
   @Test


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
Previously failures would only print the BUILD file location of the target for which the `map_directory` callback failed.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
