### PR TITLE
Rename external to bazel-external, add a symlink

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
@@ -47,6 +47,7 @@ public class ArtifactFactory implements ArtifactResolver {
   private final Path externalSourceBase;
   private final PathFragment derivedPathPrefix;
   private boolean siblingRepositoryLayout = false;
+  private boolean bazelExternalDirectory = false;
 
   /** Cache of source artifacts. */
   private final SourceArtifactCache sourceArtifactCache = new SourceArtifactCache();
@@ -259,8 +260,10 @@ public class ArtifactFactory implements ArtifactResolver {
     sourceArtifactCache.clear();
   }
 
-  public void setSiblingRepositoryLayout(boolean siblingRepositoryLayout) {
+  public void setRepositoryLayout(
+      boolean siblingRepositoryLayout, boolean bazelExternalDirectory) {
     this.siblingRepositoryLayout = siblingRepositoryLayout;
+    this.bazelExternalDirectory = bazelExternalDirectory;
   }
 
   /**
@@ -548,7 +551,8 @@ public class ArtifactFactory implements ArtifactResolver {
     }
 
     Pair<RepositoryName, PathFragment> repo =
-        RepositoryName.fromPathFragment(dir, siblingRepositoryLayout);
+        RepositoryName.fromPathFragment(
+            dir, siblingRepositoryLayout, bazelExternalDirectory);
     if (repo != null) {
       repositoryName = repo.getFirst();
       dir = repo.getSecond();
@@ -662,7 +666,8 @@ public class ArtifactFactory implements ArtifactResolver {
         !execPath.startsWith(derivedPathPrefix), "%s is derived: %s", execPath, derivedPathPrefix);
 
     Pair<RepositoryName, PathFragment> repo =
-        RepositoryName.fromPathFragment(execPath, siblingRepositoryLayout);
+        RepositoryName.fromPathFragment(
+            execPath, siblingRepositoryLayout, bazelExternalDirectory);
     RepositoryName repositoryName = RepositoryName.MAIN;
     PathFragment repositoryRelativePath = execPath;
     if (repo != null) {

--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
@@ -47,6 +47,8 @@ public class ArtifactFactory implements ArtifactResolver {
   private final Path externalSourceBase;
   private final PathFragment derivedPathPrefix;
 
+  private boolean bazelExternalDirectory = false;
+
   /** Cache of source artifacts. */
   private final SourceArtifactCache sourceArtifactCache = new SourceArtifactCache();
 
@@ -256,6 +258,10 @@ public class ArtifactFactory implements ArtifactResolver {
   public synchronized void clear() {
     packageRoots = null;
     sourceArtifactCache.clear();
+  }
+
+  public void setRepositoryLayout(boolean bazelExternalDirectory) {
+    this.bazelExternalDirectory = bazelExternalDirectory;
   }
 
   /**
@@ -532,7 +538,8 @@ public class ArtifactFactory implements ArtifactResolver {
       return null;
     }
 
-    Pair<RepositoryName, PathFragment> repo = RepositoryName.fromPathFragment(dir);
+    Pair<RepositoryName, PathFragment> repo =
+        RepositoryName.fromPathFragment(dir, bazelExternalDirectory);
     if (repo != null) {
       repositoryName = repo.getFirst();
       dir = repo.getSecond();
@@ -645,7 +652,8 @@ public class ArtifactFactory implements ArtifactResolver {
     Preconditions.checkState(
         !execPath.startsWith(derivedPathPrefix), "%s is derived: %s", execPath, derivedPathPrefix);
 
-    Pair<RepositoryName, PathFragment> repo = RepositoryName.fromPathFragment(execPath);
+    Pair<RepositoryName, PathFragment> repo =
+        RepositoryName.fromPathFragment(execPath, bazelExternalDirectory);
     RepositoryName repositoryName = RepositoryName.MAIN;
     PathFragment repositoryRelativePath = execPath;
     if (repo != null) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTargetFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTargetFactory.java
@@ -329,7 +329,10 @@ public final class ConfiguredTargetFactory {
               inputFile.getExecPath(
                   analysisEnvironment
                       .getStarlarkSemantics()
-                      .getBool(BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT)),
+                      .getBool(BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT),
+                  analysisEnvironment
+                      .getStarlarkSemantics()
+                      .getBool(BuildLanguageOptions.INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY)),
               inputFile.getPackageMetadata().sourceRoot(),
               ConfiguredTargetKey.builder()
                   .setLabel(target.getLabel())

--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTargetFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTargetFactory.java
@@ -68,6 +68,7 @@ import com.google.devtools.build.lib.packages.RuleVisibility;
 import com.google.devtools.build.lib.packages.StarlarkProviderIdentifier;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.packages.TargetRecorder.MacroNamespaceViolationException;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.profiler.memory.CurrentRuleTracker;
 import com.google.devtools.build.lib.server.FailureDetails.FailAction.Code;
 import com.google.devtools.build.lib.skyframe.AspectKeyCreator;
@@ -327,7 +328,10 @@ public final class ConfiguredTargetFactory {
               transitiveVisibility);
       SourceArtifact artifact =
           artifactFactory.getSourceArtifact(
-              inputFile.getExecPath(),
+              inputFile.getExecPath(
+                  analysisEnvironment
+                      .getStarlarkSemantics()
+                      .getBool(BuildLanguageOptions.INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY)),
               inputFile.getPackageMetadata().sourceRoot(),
               ConfiguredTargetKey.builder()
                   .setLabel(target.getLabel())

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -138,6 +138,7 @@ public class BuildConfigurationValue
   private final BuildOptionDetails buildOptionDetails;
 
   private final boolean siblingRepositoryLayout;
+  private final boolean bazelExternalDirectory;
 
   private final FeatureSet defaultFeatures;
 
@@ -196,6 +197,7 @@ public class BuildConfigurationValue
       BuildOptions buildOptions,
       @Nullable BuildOptions baselineOptions,
       boolean siblingRepositoryLayout,
+      boolean bazelExternalDirectory,
       String platformCpu,
       // Arguments below this are server-global.
       BlazeDirectories directories,
@@ -217,6 +219,7 @@ public class BuildConfigurationValue
         buildOptions,
         mnemonic,
         siblingRepositoryLayout,
+        bazelExternalDirectory,
         platformCpu,
         globalProvider.getRunfilesPrefix(),
         directories,
@@ -250,6 +253,7 @@ public class BuildConfigurationValue
         buildOptions,
         mnemonic,
         siblingRepositoryLayout,
+        /* bazelExternalDirectory= */ false,
         "",
         globalProvider.getRunfilesPrefix(),
         directories,
@@ -277,6 +281,7 @@ public class BuildConfigurationValue
       BuildOptions buildOptions,
       String mnemonic,
       boolean siblingRepositoryLayout,
+      boolean bazelExternalDirectory,
       String platformCpu,
       // Arguments below this are either server-global and constant or completely dependent values.
       String workspaceName,
@@ -301,6 +306,7 @@ public class BuildConfigurationValue
             siblingRepositoryLayout);
     this.workspaceName = workspaceName;
     this.siblingRepositoryLayout = siblingRepositoryLayout;
+    this.bazelExternalDirectory = bazelExternalDirectory;
 
     // We can't use an ImmutableMap.Builder here; we need the ability to add entries with keys that
     // are already in the map so that the same define can be specified on the command line twice,
@@ -522,6 +528,10 @@ public class BuildConfigurationValue
 
   public boolean isSiblingRepositoryLayout() {
     return siblingRepositoryLayout;
+  }
+
+  public boolean isBazelExternalDirectory() {
+    return bazelExternalDirectory;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -139,6 +139,8 @@ public class BuildConfigurationValue
   /** Data for introspecting the options used by this configuration. */
   private final BuildOptionDetails buildOptionDetails;
 
+  private final boolean bazelExternalDirectory;
+
   private final FeatureSet defaultFeatures;
 
   @Nullable // lazily initialized
@@ -195,6 +197,7 @@ public class BuildConfigurationValue
   public static BuildConfigurationValue create(
       BuildOptions buildOptions,
       @Nullable BuildOptions baselineOptions,
+      boolean bazelExternalDirectory,
       String platformCpu,
       // Arguments below this are server-global.
       BlazeDirectories directories,
@@ -215,6 +218,7 @@ public class BuildConfigurationValue
     return new BuildConfigurationValue(
         buildOptions,
         mnemonic,
+        bazelExternalDirectory,
         platformCpu,
         globalProvider.getRunfilesPrefix(),
         directories,
@@ -246,6 +250,7 @@ public class BuildConfigurationValue
     return new BuildConfigurationValue(
         buildOptions,
         mnemonic,
+        /* bazelExternalDirectory= */ false,
         "",
         globalProvider.getRunfilesPrefix(),
         directories,
@@ -272,6 +277,7 @@ public class BuildConfigurationValue
   BuildConfigurationValue(
       BuildOptions buildOptions,
       String mnemonic,
+      boolean bazelExternalDirectory,
       String platformCpu,
       // Arguments below this are either server-global and constant or completely dependent values.
       String workspaceName,
@@ -290,6 +296,7 @@ public class BuildConfigurationValue
         new OutputDirectories(
             directories, options, buildOptions.get(PlatformOptions.class), mnemonic, workspaceName);
     this.workspaceName = workspaceName;
+    this.bazelExternalDirectory = bazelExternalDirectory;
 
     // We can't use an ImmutableMap.Builder here; we need the ability to add entries with keys that
     // are already in the map so that the same define can be specified on the command line twice,
@@ -501,6 +508,10 @@ public class BuildConfigurationValue
 
   public ActionEnvironment getActionEnvironment() {
     return actionEnv;
+  }
+
+  public boolean isBazelExternalDirectory() {
+    return bazelExternalDirectory;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -282,6 +282,9 @@ public class ExecutionTool {
               request
                   .getOptions(BuildLanguageOptions.class)
                   .getExperimentalSiblingRepositoryLayout(),
+              request
+                  .getOptions(BuildLanguageOptions.class)
+                  .getIncompatibleBazelExternalDirectory(),
               runtime.getWorkspace().doesAllowExternalRepositories());
       incrementalPackageRoots.eagerlyPlantSymlinksToSingleSourceRoot();
 
@@ -656,7 +659,10 @@ public class ExecutionTool {
               runtime.getProductName(),
               request
                   .getOptions(BuildLanguageOptions.class)
-                  .getExperimentalSiblingRepositoryLayout());
+                  .getExperimentalSiblingRepositoryLayout(),
+              request
+                  .getOptions(BuildLanguageOptions.class)
+                  .getIncompatibleBazelExternalDirectory());
       symlinkForest.plantSymlinkForest();
     } catch (IOException e) {
       String message = String.format("Source forest creation failed: %s", e.getMessage());
@@ -815,6 +821,7 @@ public class ExecutionTool {
     }
 
     String productName = runtime.getProductName();
+    BuildLanguageOptions buildLanguageOptions = request.getOptions(BuildLanguageOptions.class);
     try (SilentCloseable c =
         Profiler.instance().profile("OutputDirectoryLinksUtils.createOutputDirectoryLinks")) {
       return OutputDirectoryLinksUtils.createOutputDirectoryLinks(
@@ -825,7 +832,9 @@ public class ExecutionTool {
           env.getDirectories(),
           getReporter(),
           targetConfigs,
-          productName);
+          productName,
+          buildLanguageOptions.getIncompatibleBazelExternalDirectory()
+              && !buildLanguageOptions.getExperimentalSiblingRepositoryLayout());
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -72,6 +72,7 @@ import com.google.devtools.build.lib.exec.RemoteLocalFallbackRegistry;
 import com.google.devtools.build.lib.exec.SpawnStrategyRegistry;
 import com.google.devtools.build.lib.exec.SpawnStrategyResolver;
 import com.google.devtools.build.lib.exec.SymlinkTreeStrategy;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.profiler.AutoProfiler;
 import com.google.devtools.build.lib.profiler.GoogleAutoProfilerUtils;
 import com.google.devtools.build.lib.profiler.MemoryProfiler;
@@ -279,6 +280,9 @@ public class ExecutionTool {
               env.getEventBus(),
               env.getDirectories().getProductName() + "-",
               skyframeExecutor.getIgnoredPaths(),
+              request
+                  .getOptions(BuildLanguageOptions.class)
+                  .getIncompatibleBazelExternalDirectory(),
               runtime.getWorkspace().doesAllowExternalRepositories(),
               skyframeExecutor::getRootForDonePackage);
       incrementalPackageRoots.eagerlyPlantSymlinksToSingleSourceRoot();
@@ -659,7 +663,12 @@ public class ExecutionTool {
     try (SilentCloseable c = Profiler.instance().profile("plantSymlinkForest")) {
       SymlinkForest symlinkForest =
           new SymlinkForest(
-              packageRoots.getPackageRootsMap(), getExecRoot(), runtime.getProductName());
+              packageRoots.getPackageRootsMap(),
+              getExecRoot(),
+              runtime.getProductName(),
+              request
+                  .getOptions(BuildLanguageOptions.class)
+                  .getIncompatibleBazelExternalDirectory());
       symlinkForest.plantSymlinkForest();
     } catch (IOException e) {
       String message = String.format("Source forest creation failed: %s", e.getMessage());
@@ -816,6 +825,7 @@ public class ExecutionTool {
     }
 
     String productName = runtime.getProductName();
+    BuildLanguageOptions buildLanguageOptions = request.getOptions(BuildLanguageOptions.class);
     try (SilentCloseable c =
         Profiler.instance().profile("OutputDirectoryLinksUtils.createOutputDirectoryLinks")) {
       return OutputDirectoryLinksUtils.createOutputDirectoryLinks(
@@ -826,7 +836,8 @@ public class ExecutionTool {
           env.getDirectories(),
           getReporter(),
           targetConfigs,
-          productName);
+          productName,
+          buildLanguageOptions.getIncompatibleBazelExternalDirectory());
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/buildtool/OutputDirectoryLinksUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/OutputDirectoryLinksUtils.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.analysis.config.SymlinkDefinition;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.ConvenienceSymlink;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.ConvenienceSymlink.Action;
 import com.google.devtools.build.lib.buildtool.BuildRequestOptions.ConvenienceSymlinksMode;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /** Static utilities for managing output directory symlinks. */
 public final class OutputDirectoryLinksUtils {
@@ -54,8 +56,9 @@ public final class OutputDirectoryLinksUtils {
    * <p>The order of the result indicates precedence for {@link PathPrettyPrinter}.
    */
   private static ImmutableList<SymlinkDefinition> getAllLinkDefinitions(
-      Iterable<SymlinkDefinition> symlinkDefinitions) {
+      Iterable<SymlinkDefinition> symlinkDefinitions, @Nullable Path bazelExternalPath) {
     ImmutableList.Builder<SymlinkDefinition> builder = ImmutableList.builder();
+    builder.add(bazelExternalSymlink(bazelExternalPath));
     builder.addAll(STANDARD_LINK_DEFINITIONS);
     builder.addAll(symlinkDefinitions);
     return builder.build();
@@ -97,9 +100,14 @@ public final class OutputDirectoryLinksUtils {
       BlazeDirectories directories,
       EventHandler eventHandler,
       Set<BuildConfigurationValue> targetConfigs,
-      String productName) {
+      String productName,
+      boolean useBazelExternalDirectory) {
     Path execRoot = directories.getExecRoot(workspaceName);
     Path outputPath = directories.getOutputPath(workspaceName);
+    Path bazelExternalPath =
+        useBazelExternalDirectory
+            ? execRoot.getRelative(LabelConstants.BAZEL_EXTERNAL_PATH_PREFIX)
+            : null;
     String symlinkPrefix = buildRequestOptions.getSymlinkPrefix(productName);
     ConvenienceSymlinksMode mode = buildRequestOptions.getExperimentalConvenienceSymlinks();
     if (NO_CREATE_SYMLINKS_PREFIX.equals(symlinkPrefix)) {
@@ -116,7 +124,8 @@ public final class OutputDirectoryLinksUtils {
     RepositoryName repositoryName = RepositoryName.MAIN;
     boolean logOnly = mode == ConvenienceSymlinksMode.LOG_ONLY;
 
-    for (SymlinkDefinition symlink : getAllLinkDefinitions(symlinkDefinitions)) {
+    for (SymlinkDefinition symlink :
+        getAllLinkDefinitions(symlinkDefinitions, bazelExternalPath)) {
       String linkName = symlink.getLinkName(symlinkPrefix, workspaceBaseName);
       if (!createdLinks.add(linkName)) {
         // already created a link by this name
@@ -192,7 +201,7 @@ public final class OutputDirectoryLinksUtils {
 
     String workspaceBaseName = workspace.getBaseName();
 
-    for (SymlinkDefinition link : getAllLinkDefinitions(symlinkDefinitions)) {
+    for (SymlinkDefinition link : getAllLinkDefinitions(symlinkDefinitions, null)) {
       removeLink(
           workspace,
           link.getLinkName(symlinkPrefix, workspaceBaseName),
@@ -361,6 +370,27 @@ public final class OutputDirectoryLinksUtils {
               return ImmutableSet.of(execRoot);
             }
           });
+
+  private static SymlinkDefinition bazelExternalSymlink(@Nullable Path bazelExternalPath) {
+    return new SymlinkDefinition() {
+      @Override
+      public String getLinkName(String symlinkPrefix, String workspaceBaseName) {
+        return symlinkPrefix + "external";
+      }
+
+      @Override
+      public ImmutableSet<Path> getLinkPaths(
+          BuildRequestOptions buildRequestOptions,
+          Set<BuildConfigurationValue> targetConfigs,
+          RepositoryName repositoryName,
+          Path outputPath,
+          Path execRoot) {
+        return bazelExternalPath == null
+            ? ImmutableSet.of()
+            : ImmutableSet.of(bazelExternalPath);
+      }
+    };
+  }
 
   static final SymlinkCreationResult EMPTY_SYMLINK_CREATION_RESULT =
       new SymlinkCreationResult(ImmutableList.of(), ImmutableMap.of());

--- a/src/main/java/com/google/devtools/build/lib/buildtool/OutputDirectoryLinksUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/OutputDirectoryLinksUtils.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.analysis.config.SymlinkDefinition;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.ConvenienceSymlink;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.ConvenienceSymlink.Action;
 import com.google.devtools.build.lib.buildtool.BuildRequestOptions.ConvenienceSymlinksMode;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
@@ -36,6 +37,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /** Static utilities for managing output directory symlinks. */
 public final class OutputDirectoryLinksUtils {
@@ -53,8 +55,9 @@ public final class OutputDirectoryLinksUtils {
    * <p>The order of the result indicates precedence for {@link PathPrettyPrinter}.
    */
   private static ImmutableList<SymlinkDefinition> getAllLinkDefinitions(
-      Iterable<SymlinkDefinition> symlinkDefinitions) {
+      Iterable<SymlinkDefinition> symlinkDefinitions, @Nullable Path bazelExternalPath) {
     ImmutableList.Builder<SymlinkDefinition> builder = ImmutableList.builder();
+    builder.add(bazelExternalSymlink(bazelExternalPath));
     builder.addAll(STANDARD_LINK_DEFINITIONS);
     builder.addAll(symlinkDefinitions);
     return builder.build();
@@ -96,9 +99,14 @@ public final class OutputDirectoryLinksUtils {
       BlazeDirectories directories,
       EventHandler eventHandler,
       Set<BuildConfigurationValue> targetConfigs,
-      String productName) {
+      String productName,
+      boolean useBazelExternalDirectory) {
     Path execRoot = directories.getExecRoot(workspaceName);
     Path outputPath = directories.getOutputPath(workspaceName);
+    Path bazelExternalPath =
+        useBazelExternalDirectory
+            ? execRoot.getRelative(LabelConstants.BAZEL_EXTERNAL_PATH_PREFIX)
+            : null;
     String symlinkPrefix = buildRequestOptions.getSymlinkPrefix(productName);
     ConvenienceSymlinksMode mode = buildRequestOptions.getExperimentalConvenienceSymlinks();
     if (NO_CREATE_SYMLINKS_PREFIX.equals(symlinkPrefix)) {
@@ -114,7 +122,7 @@ public final class OutputDirectoryLinksUtils {
     String workspaceBaseName = workspace.getBaseName();
     boolean logOnly = mode == ConvenienceSymlinksMode.LOG_ONLY;
 
-    for (SymlinkDefinition symlink : getAllLinkDefinitions(symlinkDefinitions)) {
+    for (SymlinkDefinition symlink : getAllLinkDefinitions(symlinkDefinitions, bazelExternalPath)) {
       String linkName = symlink.getLinkName(symlinkPrefix, workspaceBaseName);
       if (!createdLinks.add(linkName)) {
         // already created a link by this name
@@ -189,7 +197,7 @@ public final class OutputDirectoryLinksUtils {
 
     String workspaceBaseName = workspace.getBaseName();
 
-    for (SymlinkDefinition link : getAllLinkDefinitions(symlinkDefinitions)) {
+    for (SymlinkDefinition link : getAllLinkDefinitions(symlinkDefinitions, null)) {
       removeLink(
           workspace,
           link.getLinkName(symlinkPrefix, workspaceBaseName),
@@ -354,6 +362,24 @@ public final class OutputDirectoryLinksUtils {
               return ImmutableSet.of(execRoot);
             }
           });
+
+  private static SymlinkDefinition bazelExternalSymlink(@Nullable Path bazelExternalPath) {
+    return new SymlinkDefinition() {
+      @Override
+      public String getLinkName(String symlinkPrefix, String workspaceBaseName) {
+        return symlinkPrefix + "external";
+      }
+
+      @Override
+      public ImmutableSet<Path> getLinkPaths(
+          BuildRequestOptions buildRequestOptions,
+          Set<BuildConfigurationValue> targetConfigs,
+          Path outputPath,
+          Path execRoot) {
+        return bazelExternalPath == null ? ImmutableSet.of() : ImmutableSet.of(bazelExternalPath);
+      }
+    };
+  }
 
   static final SymlinkCreationResult EMPTY_SYMLINK_CREATION_RESULT =
       new SymlinkCreationResult(ImmutableList.of(), ImmutableMap.of());

--- a/src/main/java/com/google/devtools/build/lib/buildtool/SymlinkForest.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/SymlinkForest.java
@@ -54,11 +54,17 @@ public class SymlinkForest {
   private final String productName;
   private final String prefix;
   private final boolean siblingRepositoryLayout;
+  private final boolean bazelExternalDirectory;
 
   /** Constructor for a symlink forest creator without non-symlinked directories parameter. */
   public SymlinkForest(
       ImmutableMap<PackageIdentifier, Root> packageRoots, Path execroot, String productName) {
-    this(packageRoots, execroot, productName, false);
+    this(
+        packageRoots,
+        execroot,
+        productName,
+        /* siblingRepositoryLayout= */ false,
+        /* bazelExternalDirectory= */ false);
   }
 
   /**
@@ -74,12 +80,14 @@ public class SymlinkForest {
       ImmutableMap<PackageIdentifier, Root> packageRoots,
       Path execroot,
       String productName,
-      boolean siblingRepositoryLayout) {
+      boolean siblingRepositoryLayout,
+      boolean bazelExternalDirectory) {
     this.packageRoots = packageRoots;
     this.execroot = execroot;
     this.productName = productName;
     this.prefix = productName + "-";
     this.siblingRepositoryLayout = siblingRepositoryLayout;
+    this.bazelExternalDirectory = bazelExternalDirectory;
   }
 
   /**
@@ -127,7 +135,12 @@ public class SymlinkForest {
       throws IOException {
     Optional<Path> plantedSymlink =
         plantSingleSymlinkForExternalRepo(
-            repository, source, execroot, siblingRepositoryLayout, externalRepoLinks);
+            repository,
+            source,
+            execroot,
+            siblingRepositoryLayout,
+            bazelExternalDirectory,
+            externalRepoLinks);
     plantedSymlink.ifPresent(plantedSymlinks::add);
   }
 
@@ -141,7 +154,8 @@ public class SymlinkForest {
     for (Path target : mainRepoRoot.getDirectoryEntries()) {
       String baseName = target.getBaseName();
       Path execPath = execroot.getRelative(baseName);
-      if (symlinkShouldBePlanted(prefix, siblingRepositoryLayout, baseName, target)) {
+      if (symlinkShouldBePlanted(
+          prefix, siblingRepositoryLayout, bazelExternalDirectory, baseName, target)) {
         execPath.createSymbolicLink(target);
         plantedSymlinks.add(execPath);
         // TODO(jingwen-external): is this creating execroot/io_bazel/external?
@@ -203,13 +217,19 @@ public class SymlinkForest {
     for (PackageIdentifier dir : dirsParentsFirst) {
       if (!dir.getRepository().isMain()) {
         execroot
-            .getRelative(dir.getRepository().getExecPath(siblingRepositoryLayout))
+            .getRelative(
+                dir.getRepository()
+                    .getExecPath(siblingRepositoryLayout, bazelExternalDirectory))
             .createDirectoryAndParents();
       }
       if (dirRootsMap.get(dir).size() > 1) {
         logger.atFiner().log(
-            "mkdir %s", execroot.getRelative(dir.getExecPath(siblingRepositoryLayout)));
-        execroot.getRelative(dir.getExecPath(siblingRepositoryLayout)).createDirectoryAndParents();
+            "mkdir %s",
+            execroot.getRelative(
+                dir.getExecPath(siblingRepositoryLayout, bazelExternalDirectory)));
+        execroot
+            .getRelative(dir.getExecPath(siblingRepositoryLayout, bazelExternalDirectory))
+            .createDirectoryAndParents();
       }
     }
 
@@ -224,7 +244,9 @@ public class SymlinkForest {
         }
         // This is the top-most dir that can be linked to a single root. Make it so.
         Root root = roots.iterator().next(); // lone root in set
-        Path link = execroot.getRelative(dir.getExecPath(siblingRepositoryLayout));
+        Path link =
+            execroot.getRelative(
+                dir.getExecPath(siblingRepositoryLayout, bazelExternalDirectory));
         logger.atFiner().log("ln -s %s %s", root.getRelative(dir.getSourceRoot()), link);
         link.createSymbolicLink(root.getRelative(dir.getSourceRoot()));
         plantedSymlinks.add(link);
@@ -269,7 +291,9 @@ public class SymlinkForest {
       if (!pkgId.getPackageFragment().equals(PathFragment.EMPTY_FRAGMENT)) {
         continue;
       }
-      Path execrootDirectory = execroot.getRelative(pkgId.getExecPath(siblingRepositoryLayout));
+      Path execrootDirectory =
+          execroot.getRelative(
+              pkgId.getExecPath(siblingRepositoryLayout, bazelExternalDirectory));
       // If there were no subpackages, this directory might not exist yet.
       if (!execrootDirectory.exists()) {
         execrootDirectory.createDirectoryAndParents();
@@ -296,6 +320,7 @@ public class SymlinkForest {
    */
   public ImmutableList<Path> plantSymlinkForest() throws IOException, AbruptExitException {
     deleteTreesBelowNotPrefixed(execroot, prefix);
+    deleteBazelExternalDirectory(execroot);
     deleteSiblingRepositorySymlinks(siblingRepositoryLayout, execroot);
 
     boolean shouldLinkAllTopLevelItems = false;
@@ -330,9 +355,12 @@ public class SymlinkForest {
         } else {
           String baseName = pkgId.getPackageFragment().getSegment(0);
           if (!siblingRepositoryLayout
-              && baseName.equals(LabelConstants.EXTERNAL_PATH_PREFIX.getBaseName())) {
-            // ignore external/ directory if user has it in the source tree
-            // because it conflicts with external repository location.
+              && baseName.equals(
+                  LabelConstants.getExternalPathPrefix(
+                          siblingRepositoryLayout, bazelExternalDirectory)
+                      .getBaseName())) {
+            // Ignore the directory reserved for external repositories if the user has it in the
+            // source tree.
             continue;
           }
           Path execrootLink = execroot.getRelative(baseName);
@@ -374,6 +402,12 @@ public class SymlinkForest {
     }
   }
 
+  private static void deleteBazelExternalDirectory(Path execroot) throws IOException {
+    // Unlike the legacy external directory, bazel-external is preserved by
+    // deleteTreesBelowNotPrefixed because its name starts with the product prefix.
+    execroot.getRelative(LabelConstants.BAZEL_EXTERNAL_PATH_PREFIX).deleteTree();
+  }
+
   /**
    * Eagerly plant the symlinks from execroot to the source root provided by the single package path
    * of the current build. Only works with a single package path. Before planting the new symlinks,
@@ -389,9 +423,11 @@ public class SymlinkForest {
       Path sourceRoot,
       String prefix,
       IgnoredSubdirectories ignoredPaths,
-      boolean siblingRepositoryLayout)
+      boolean siblingRepositoryLayout,
+      boolean bazelExternalDirectory)
       throws IOException {
     deleteTreesBelowNotPrefixed(execroot, prefix);
+    deleteBazelExternalDirectory(execroot);
     deleteSiblingRepositorySymlinks(siblingRepositoryLayout, execroot);
 
     Map<String, List<Path>> symlinkBaseNameToTargets = new HashMap<>();
@@ -412,7 +448,12 @@ public class SymlinkForest {
         String originalBaseName = target.getBaseName();
         Path link = execroot.getRelative(originalBaseName);
         if (symlinkShouldBePlanted(
-            prefix, ignoredPaths, siblingRepositoryLayout, originalBaseName, target)) {
+            prefix,
+            ignoredPaths,
+            siblingRepositoryLayout,
+            bazelExternalDirectory,
+            originalBaseName,
+            target)) {
           link.createSymbolicLink(target);
         }
       } else {
@@ -423,23 +464,36 @@ public class SymlinkForest {
   }
 
   static boolean symlinkShouldBePlanted(
-      String prefix, boolean siblingRepositoryLayout, String baseName, Path target) {
+      String prefix,
+      boolean siblingRepositoryLayout,
+      boolean bazelExternalDirectory,
+      String baseName,
+      Path target) {
     return symlinkShouldBePlanted(
-        prefix, IgnoredSubdirectories.EMPTY, siblingRepositoryLayout, baseName, target);
+        prefix,
+        IgnoredSubdirectories.EMPTY,
+        siblingRepositoryLayout,
+        bazelExternalDirectory,
+        baseName,
+        target);
   }
 
   public static boolean symlinkShouldBePlanted(
       String prefix,
       IgnoredSubdirectories ignoredSubdirectories,
       boolean siblingRepositoryLayout,
+      boolean bazelExternalDirectory,
       String baseName,
       Path target) {
-    // Create any links that don't start with bazel-, and ignore external/ directory if
-    // user has it in the source tree because it conflicts with external repository location.
+    // Create any links that don't start with bazel-, and ignore the directory reserved for
+    // external repositories if the user has it in the source tree.
     return !baseName.startsWith(prefix)
         && ignoredSubdirectories.matchingEntry(target.asFragment().toRelative()) == null
         && (siblingRepositoryLayout
-            || !baseName.equals(LabelConstants.EXTERNAL_PATH_PREFIX.getBaseName()));
+            || !baseName.equals(
+                LabelConstants.getExternalPathPrefix(
+                        siblingRepositoryLayout, bazelExternalDirectory)
+                    .getBaseName()));
   }
 
   /**
@@ -453,20 +507,25 @@ public class SymlinkForest {
       Path source,
       Path execroot,
       boolean siblingRepositoryLayout,
+      boolean bazelExternalDirectory,
       Set<Path> alreadyPlantedExternalRepoLinks)
       throws IOException {
     // For external repositories, create one symlink to each external repository
     // directory.
-    // From <output_base>/execroot/<main repo name>/external/<external repo name>
+    // From <output_base>/execroot/<main repo name>/<external prefix>/<external repo name>
     // to   <output_base>/external/<external repo name>
     //
     // However, if --experimental_sibling_repository_layout is true, symlink:
     // From <output_base>/execroot/<external repo name>
     // to   <output_base>/external/<external repo name>
-    Path execrootLink = execroot.getRelative(repository.getExecPath(siblingRepositoryLayout));
+    PathFragment externalPathPrefix =
+        LabelConstants.getExternalPathPrefix(siblingRepositoryLayout, bazelExternalDirectory);
+    Path execrootLink =
+        execroot.getRelative(
+            repository.getExecPath(siblingRepositoryLayout, bazelExternalDirectory));
 
     if (!siblingRepositoryLayout && alreadyPlantedExternalRepoLinks.isEmpty()) {
-      execroot.getRelative(LabelConstants.EXTERNAL_PATH_PREFIX).createDirectoryAndParents();
+      execroot.getRelative(externalPathPrefix).createDirectoryAndParents();
     }
     // Prevent re-creating existing symlinks.
     if (!alreadyPlantedExternalRepoLinks.add(execrootLink)) {

--- a/src/main/java/com/google/devtools/build/lib/buildtool/SymlinkForest.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/SymlinkForest.java
@@ -54,6 +54,14 @@ public class SymlinkForest {
   private final String productName;
   private final String prefix;
 
+  private final boolean bazelExternalDirectory;
+
+  /** Creates a symlink forest using the default external repository directory. */
+  public SymlinkForest(
+      ImmutableMap<PackageIdentifier, Root> packageRoots, Path execroot, String productName) {
+    this(packageRoots, execroot, productName, /* bazelExternalDirectory= */ false);
+  }
+
   /**
    * Constructor for a symlink forest creator; does not perform any i/o.
    *
@@ -64,11 +72,15 @@ public class SymlinkForest {
    * @param productName {@code BlazeRuntime#getProductName()}
    */
   public SymlinkForest(
-      ImmutableMap<PackageIdentifier, Root> packageRoots, Path execroot, String productName) {
+      ImmutableMap<PackageIdentifier, Root> packageRoots,
+      Path execroot,
+      String productName,
+      boolean bazelExternalDirectory) {
     this.packageRoots = packageRoots;
     this.execroot = execroot;
     this.productName = productName;
     this.prefix = productName + "-";
+    this.bazelExternalDirectory = bazelExternalDirectory;
   }
 
   /**
@@ -115,7 +127,8 @@ public class SymlinkForest {
       Set<Path> externalRepoLinks)
       throws IOException {
     Optional<Path> plantedSymlink =
-        plantSingleSymlinkForExternalRepo(repository, source, execroot, externalRepoLinks);
+        plantSingleSymlinkForExternalRepo(
+            repository, source, execroot, bazelExternalDirectory, externalRepoLinks);
     plantedSymlink.ifPresent(plantedSymlinks::add);
   }
 
@@ -126,7 +139,7 @@ public class SymlinkForest {
     for (Path target : mainRepoRoot.getDirectoryEntries()) {
       String baseName = target.getBaseName();
       Path execPath = execroot.getRelative(baseName);
-      if (symlinkShouldBePlanted(prefix, baseName, target)) {
+      if (symlinkShouldBePlanted(prefix, bazelExternalDirectory, baseName, target)) {
         execPath.createSymbolicLink(target);
         plantedSymlinks.add(execPath);
         // TODO(jingwen-external): is this creating execroot/io_bazel/external?
@@ -184,11 +197,14 @@ public class SymlinkForest {
     // Create output dirs for all dirs that have more than one root and need to be split.
     for (PackageIdentifier dir : dirsParentsFirst) {
       if (!dir.getRepository().isMain()) {
-        execroot.getRelative(dir.getRepository().getExecPath()).createDirectoryAndParents();
+        execroot
+            .getRelative(dir.getRepository().getExecPath(bazelExternalDirectory))
+            .createDirectoryAndParents();
       }
       if (dirRootsMap.get(dir).size() > 1) {
-        logger.atFiner().log("mkdir %s", execroot.getRelative(dir.getExecPath()));
-        execroot.getRelative(dir.getExecPath()).createDirectoryAndParents();
+        logger.atFiner().log(
+            "mkdir %s", execroot.getRelative(dir.getExecPath(bazelExternalDirectory)));
+        execroot.getRelative(dir.getExecPath(bazelExternalDirectory)).createDirectoryAndParents();
       }
     }
 
@@ -203,7 +219,7 @@ public class SymlinkForest {
         }
         // This is the top-most dir that can be linked to a single root. Make it so.
         Root root = roots.iterator().next(); // lone root in set
-        Path link = execroot.getRelative(dir.getExecPath());
+        Path link = execroot.getRelative(dir.getExecPath(bazelExternalDirectory));
         logger.atFiner().log("ln -s %s %s", root.getRelative(dir.getSourceRoot()), link);
         link.createSymbolicLink(root.getRelative(dir.getSourceRoot()));
         plantedSymlinks.add(link);
@@ -248,7 +264,7 @@ public class SymlinkForest {
       if (!pkgId.getPackageFragment().equals(PathFragment.EMPTY_FRAGMENT)) {
         continue;
       }
-      Path execrootDirectory = execroot.getRelative(pkgId.getExecPath());
+      Path execrootDirectory = execroot.getRelative(pkgId.getExecPath(bazelExternalDirectory));
       // If there were no subpackages, this directory might not exist yet.
       if (!execrootDirectory.exists()) {
         execrootDirectory.createDirectoryAndParents();
@@ -275,6 +291,7 @@ public class SymlinkForest {
    */
   public ImmutableList<Path> plantSymlinkForest() throws IOException, AbruptExitException {
     deleteTreesBelowNotPrefixed(execroot, prefix);
+    deleteBazelExternalDirectory(execroot);
 
     boolean shouldLinkAllTopLevelItems = false;
     Map<Path, Path> mainRepoLinks = new LinkedHashMap<>();
@@ -307,9 +324,10 @@ public class SymlinkForest {
           shouldLinkAllTopLevelItems = true;
         } else {
           String baseName = pkgId.getPackageFragment().getSegment(0);
-          if (baseName.equals(LabelConstants.EXTERNAL_PATH_PREFIX.getBaseName())) {
-            // ignore external/ directory if user has it in the source tree
-            // because it conflicts with external repository location.
+          if (baseName.equals(
+              LabelConstants.getExternalPathPrefix(bazelExternalDirectory).getBaseName())) {
+            // Ignore the directory reserved for external repositories if the user has it in the
+            // source tree.
             continue;
           }
           Path execrootLink = execroot.getRelative(baseName);
@@ -339,6 +357,12 @@ public class SymlinkForest {
     return plantedSymlinks.build();
   }
 
+  private static void deleteBazelExternalDirectory(Path execroot) throws IOException {
+    // Unlike the legacy external directory, bazel-external is preserved by
+    // deleteTreesBelowNotPrefixed because its name starts with the product prefix.
+    execroot.getRelative(LabelConstants.BAZEL_EXTERNAL_PATH_PREFIX).deleteTree();
+  }
+
   /**
    * Eagerly plant the symlinks from execroot to the source root provided by the single package path
    * of the current build. Only works with a single package path. Before planting the new symlinks,
@@ -350,9 +374,14 @@ public class SymlinkForest {
    * @return a set of potentially conflicting baseNames, all in lowercase.
    */
   public static ImmutableSet<String> eagerlyPlantSymlinkForestSinglePackagePath(
-      Path execroot, Path sourceRoot, String prefix, IgnoredSubdirectories ignoredPaths)
+      Path execroot,
+      Path sourceRoot,
+      String prefix,
+      IgnoredSubdirectories ignoredPaths,
+      boolean bazelExternalDirectory)
       throws IOException {
     deleteTreesBelowNotPrefixed(execroot, prefix);
+    deleteBazelExternalDirectory(execroot);
 
     Map<String, List<Path>> symlinkBaseNameToTargets = new HashMap<>();
     Set<String> potentiallyConflictingBaseNamesLowercase = new HashSet<>();
@@ -371,7 +400,8 @@ public class SymlinkForest {
         Path target = Iterables.getOnlyElement(targets);
         String originalBaseName = target.getBaseName();
         Path link = execroot.getRelative(originalBaseName);
-        if (symlinkShouldBePlanted(prefix, ignoredPaths, originalBaseName, target)) {
+        if (symlinkShouldBePlanted(
+            prefix, ignoredPaths, bazelExternalDirectory, originalBaseName, target)) {
           link.createSymbolicLink(target);
         }
       } else {
@@ -381,17 +411,24 @@ public class SymlinkForest {
     return ImmutableSet.copyOf(potentiallyConflictingBaseNamesLowercase);
   }
 
-  static boolean symlinkShouldBePlanted(String prefix, String baseName, Path target) {
-    return symlinkShouldBePlanted(prefix, IgnoredSubdirectories.EMPTY, baseName, target);
+  static boolean symlinkShouldBePlanted(
+      String prefix, boolean bazelExternalDirectory, String baseName, Path target) {
+    return symlinkShouldBePlanted(
+        prefix, IgnoredSubdirectories.EMPTY, bazelExternalDirectory, baseName, target);
   }
 
   public static boolean symlinkShouldBePlanted(
-      String prefix, IgnoredSubdirectories ignoredSubdirectories, String baseName, Path target) {
-    // Create any links that don't start with bazel-, and ignore external/ directory if
-    // user has it in the source tree because it conflicts with external repository location.
+      String prefix,
+      IgnoredSubdirectories ignoredSubdirectories,
+      boolean bazelExternalDirectory,
+      String baseName,
+      Path target) {
+    // Create any links that don't start with bazel-, and ignore the directory reserved for
+    // external repositories if the user has it in the source tree.
     return !baseName.startsWith(prefix)
         && ignoredSubdirectories.matchingEntry(target.asFragment().toRelative()) == null
-        && !baseName.equals(LabelConstants.EXTERNAL_PATH_PREFIX.getBaseName());
+        && !baseName.equals(
+            LabelConstants.getExternalPathPrefix(bazelExternalDirectory).getBaseName());
   }
 
   /**
@@ -404,16 +441,18 @@ public class SymlinkForest {
       RepositoryName repository,
       Path source,
       Path execroot,
+      boolean bazelExternalDirectory,
       Set<Path> alreadyPlantedExternalRepoLinks)
       throws IOException {
     // For external repositories, create one symlink to each external repository
     // directory.
-    // From <output_base>/execroot/<main repo name>/external/<external repo name>
+    // From <output_base>/execroot/<main repo name>/<external prefix>/<external repo name>
     // to   <output_base>/external/<external repo name>
-    Path execrootLink = execroot.getRelative(repository.getExecPath());
+    PathFragment externalPathPrefix = LabelConstants.getExternalPathPrefix(bazelExternalDirectory);
+    Path execrootLink = execroot.getRelative(repository.getExecPath(bazelExternalDirectory));
 
     if (alreadyPlantedExternalRepoLinks.isEmpty()) {
-      execroot.getRelative(LabelConstants.EXTERNAL_PATH_PREFIX).createDirectoryAndParents();
+      execroot.getRelative(externalPathPrefix).createDirectoryAndParents();
     }
     // Prevent re-creating existing symlinks.
     if (!alreadyPlantedExternalRepoLinks.add(execrootLink)) {

--- a/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
@@ -375,9 +375,9 @@ public final class Label
   }
 
   /**
-   * Returns the execution root for the workspace, relative to the execroot (e.g., for label
-   * {@code @repo//pkg:b}, it will returns {@code external/repo/pkg} and for label {@code //pkg:a},
-   * it will returns an empty string.
+   * Returns the execution root for the workspace, relative to the execroot (e.g., under the default
+   * layout, for label {@code @repo//pkg:b}, it returns {@code external/repo}; for label {@code
+   * //pkg:a}, it returns an empty string).
    *
    * @deprecated The sole purpose of this method is to implement the workspace_root method. For
    *     other purposes, use {@link RepositoryName#getExecPath} instead.
@@ -387,7 +387,8 @@ public final class Label
       structField = true,
       doc =
           "Returns the execution root for the repository containing the target referred to by this"
-              + " label, relative to the execroot. For instance:<br><pre"
+              + " label, relative to the execroot. Under the default repository layout, for"
+              + " instance:<br><pre"
               + " class=language-python>Label(\"@repo//pkg/foo:abc\").workspace_root =="
               + " \"external/repo\"</pre>",
       useStarlarkSemantics = true)
@@ -396,7 +397,9 @@ public final class Label
     checkRepoVisibilityForStarlark("workspace_root");
     return packageIdentifier
         .getRepository()
-        .getExecPath(semantics.getBool(BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT))
+        .getExecPath(
+            semantics.getBool(BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT),
+            semantics.getBool(BuildLanguageOptions.INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY))
         .toString();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
@@ -359,9 +359,9 @@ public final class Label
   }
 
   /**
-   * Returns the execution root for the workspace, relative to the execroot (e.g., for label
-   * {@code @repo//pkg:b}, it will returns {@code external/repo/pkg} and for label {@code //pkg:a},
-   * it will returns an empty string.
+   * Returns the execution root for the workspace, relative to the execroot (e.g., under the default
+   * layout, for label {@code @repo//pkg:b}, it returns {@code external/repo}; for label {@code
+   * //pkg:a}, it returns an empty string).
    *
    * @deprecated The sole purpose of this method is to implement the workspace_root method. For
    *     other purposes, use {@link RepositoryName#getExecPath} instead.
@@ -371,13 +371,18 @@ public final class Label
       structField = true,
       doc =
           "Returns the execution root for the repository containing the target referred to by this"
-              + " label, relative to the execroot. For instance:<br><pre"
+              + " label, relative to the execroot. Under the default repository layout, for"
+              + " instance:<br><pre"
               + " class=language-python>Label(\"@repo//pkg/foo:abc\").workspace_root =="
-              + " \"external/repo\"</pre>")
+              + " \"external/repo\"</pre>",
+      useStarlarkSemantics = true)
   @Deprecated
-  public String getWorkspaceRootForStarlarkOnly() throws EvalException {
+  public String getWorkspaceRootForStarlarkOnly(StarlarkSemantics semantics) throws EvalException {
     checkRepoVisibilityForStarlark("workspace_root");
-    return packageIdentifier.getRepository().getExecPath().toString();
+    return packageIdentifier
+        .getRepository()
+        .getExecPath(semantics.getBool(BuildLanguageOptions.INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY))
+        .toString();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/cmdline/LabelConstants.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/LabelConstants.java
@@ -46,9 +46,23 @@ public class LabelConstants {
   // With this prefix, non-main repositories are symlinked under
   // $output_base/execution_root/__main__/external
   public static final PathFragment EXTERNAL_PATH_PREFIX = PathFragment.create("external");
+  // With this prefix, non-main repositories are symlinked under
+  // $output_base/execution_root/__main__/bazel-external when
+  // --incompatible_bazel_external_directory is enabled.
+  public static final PathFragment BAZEL_EXTERNAL_PATH_PREFIX =
+      PathFragment.create("bazel-external");
   // With this prefix, non-main repositories are sibling symlinks of
   // $output_base/execution_root/__main__
   public static final PathFragment EXPERIMENTAL_EXTERNAL_PATH_PREFIX = PathFragment.create("..");
+
+  /** Returns the execroot prefix for non-main repositories under the requested layout. */
+  public static PathFragment getExternalPathPrefix(
+      boolean siblingRepositoryLayout, boolean bazelExternalDirectory) {
+    if (siblingRepositoryLayout) {
+      return EXPERIMENTAL_EXTERNAL_PATH_PREFIX;
+    }
+    return bazelExternalDirectory ? BAZEL_EXTERNAL_PATH_PREFIX : EXTERNAL_PATH_PREFIX;
+  }
 
   // The relative path from the runfiles workspace root to external repository runfile top
   // directory.

--- a/src/main/java/com/google/devtools/build/lib/cmdline/LabelConstants.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/LabelConstants.java
@@ -46,6 +46,16 @@ public class LabelConstants {
   // With this prefix, non-main repositories are symlinked under
   // $output_base/execution_root/__main__/external
   public static final PathFragment EXTERNAL_PATH_PREFIX = PathFragment.create("external");
+  // With this prefix, non-main repositories are symlinked under
+  // $output_base/execution_root/__main__/bazel-external when
+  // --incompatible_bazel_external_directory is enabled.
+  public static final PathFragment BAZEL_EXTERNAL_PATH_PREFIX =
+      PathFragment.create("bazel-external");
+
+  /** Returns the execroot prefix for non-main repositories under the requested layout. */
+  public static PathFragment getExternalPathPrefix(boolean bazelExternalDirectory) {
+    return bazelExternalDirectory ? BAZEL_EXTERNAL_PATH_PREFIX : EXTERNAL_PATH_PREFIX;
+  }
 
   // The relative path from the runfiles workspace root to external repository runfile top
   // directory.

--- a/src/main/java/com/google/devtools/build/lib/cmdline/PackageIdentifier.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/PackageIdentifier.java
@@ -97,6 +97,18 @@ public final class PackageIdentifier implements SkyKey, Comparable<PackageIdenti
    */
   public static Optional<PackageIdentifier> discoverFromExecPath(
       PathFragment execPath, boolean forFiles, boolean siblingRepositoryLayout) {
+    return discoverFromExecPath(
+        execPath,
+        forFiles,
+        siblingRepositoryLayout,
+        /* bazelExternalDirectory= */ false);
+  }
+
+  public static Optional<PackageIdentifier> discoverFromExecPath(
+      PathFragment execPath,
+      boolean forFiles,
+      boolean siblingRepositoryLayout,
+      boolean bazelExternalDirectory) {
     Preconditions.checkArgument(!execPath.isAbsolute(), execPath);
     PathFragment tofind =
         forFiles
@@ -104,12 +116,9 @@ public final class PackageIdentifier implements SkyKey, Comparable<PackageIdenti
                 execPath.getParentDirectory(), "Must pass in files, not root directory")
             : execPath;
     PathFragment prefix =
-        siblingRepositoryLayout
-            ? LabelConstants.EXPERIMENTAL_EXTERNAL_PATH_PREFIX
-            : LabelConstants.EXTERNAL_PATH_PREFIX;
+        LabelConstants.getExternalPathPrefix(siblingRepositoryLayout, bazelExternalDirectory);
     if (tofind.startsWith(prefix)) {
-      // Using the path prefix can be either "external" or "..", depending on whether the sibling
-      // repository layout is used.
+      // The path prefix depends on the selected external repository layout.
       try {
         RepositoryName repository = RepositoryName.create(tofind.getSegment(1));
         return Optional.of(PackageIdentifier.create(repository, tofind.subFragment(2)));
@@ -194,7 +203,14 @@ public final class PackageIdentifier implements SkyKey, Comparable<PackageIdenti
   }
 
   public PathFragment getExecPath(boolean siblingRepositoryLayout) {
-    return repository.getExecPath(siblingRepositoryLayout).getRelative(pkgName);
+    return getExecPath(siblingRepositoryLayout, /* bazelExternalDirectory= */ false);
+  }
+
+  public PathFragment getExecPath(
+      boolean siblingRepositoryLayout, boolean bazelExternalDirectory) {
+    return repository
+        .getExecPath(siblingRepositoryLayout, bazelExternalDirectory)
+        .getRelative(pkgName);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/cmdline/PackageIdentifier.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/PackageIdentifier.java
@@ -97,13 +97,20 @@ public final class PackageIdentifier implements SkyKey, Comparable<PackageIdenti
    */
   public static Optional<PackageIdentifier> discoverFromExecPath(
       PathFragment execPath, boolean forFiles) {
+    return discoverFromExecPath(execPath, forFiles, /* bazelExternalDirectory= */ false);
+  }
+
+  public static Optional<PackageIdentifier> discoverFromExecPath(
+      PathFragment execPath, boolean forFiles, boolean bazelExternalDirectory) {
     Preconditions.checkArgument(!execPath.isAbsolute(), execPath);
     PathFragment tofind =
         forFiles
             ? Preconditions.checkNotNull(
                 execPath.getParentDirectory(), "Must pass in files, not root directory")
             : execPath;
-    if (tofind.startsWith(LabelConstants.EXTERNAL_PATH_PREFIX)) {
+    PathFragment prefix = LabelConstants.getExternalPathPrefix(bazelExternalDirectory);
+    if (tofind.startsWith(prefix)) {
+      // The path prefix depends on the selected external repository layout.
       try {
         RepositoryName repository = RepositoryName.create(tofind.getSegment(1));
         return Optional.of(PackageIdentifier.create(repository, tofind.subFragment(2)));
@@ -187,7 +194,11 @@ public final class PackageIdentifier implements SkyKey, Comparable<PackageIdenti
   }
 
   public PathFragment getExecPath() {
-    return repository.getExecPath().getRelative(pkgName);
+    return getExecPath(/* bazelExternalDirectory= */ false);
+  }
+
+  public PathFragment getExecPath(boolean bazelExternalDirectory) {
+    return repository.getExecPath(bazelExternalDirectory).getRelative(pkgName);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
@@ -111,21 +111,26 @@ public final class RepositoryName {
    * Extracts the repository name from a PathFragment that was created with {@code
    * PackageIdentifier.getSourceRoot}.
    *
-   * @return a {@code Pair} of the extracted repository name and the path fragment with stripped of
-   *     "external/"-prefix and repository name, or null if none was found or the repository name
-   *     was invalid.
+   * @return a {@code Pair} of the extracted repository name and the path fragment with the external
+   *     repository prefix and repository name stripped, or null if none was found or the repository
+   *     name was invalid.
    */
   @Nullable
   public static Pair<RepositoryName, PathFragment> fromPathFragment(
       PathFragment path, boolean siblingRepositoryLayout) {
+    return fromPathFragment(
+        path, siblingRepositoryLayout, /* bazelExternalDirectory= */ false);
+  }
+
+  @Nullable
+  public static Pair<RepositoryName, PathFragment> fromPathFragment(
+      PathFragment path, boolean siblingRepositoryLayout, boolean bazelExternalDirectory) {
     if (!path.isMultiSegment()) {
       return null;
     }
 
     PathFragment prefix =
-        siblingRepositoryLayout
-            ? LabelConstants.EXPERIMENTAL_EXTERNAL_PATH_PREFIX
-            : LabelConstants.EXTERNAL_PATH_PREFIX;
+        LabelConstants.getExternalPathPrefix(siblingRepositoryLayout, bazelExternalDirectory);
     if (!path.startsWith(prefix)) {
       return null;
     }
@@ -328,16 +333,21 @@ public final class RepositoryName {
    * (i.e., it is in the main repository), return an empty path fragment.
    *
    * <p>If --experimental_sibling_repository_layout is true, return "$execroot/../repo" (sibling of
-   * __main__), instead of "$execroot/external/repo".
+   * __main__). Otherwise, the prefix is "external" by default and "bazel-external" when
+   * --incompatible_bazel_external_directory is enabled.
    */
   public PathFragment getExecPath(boolean siblingRepositoryLayout) {
+    return getExecPath(siblingRepositoryLayout, /* bazelExternalDirectory= */ false);
+  }
+
+  /** Returns the runfiles/execroot path for this repository under the requested layout. */
+  public PathFragment getExecPath(
+      boolean siblingRepositoryLayout, boolean bazelExternalDirectory) {
     if (isMain()) {
       return PathFragment.EMPTY_FRAGMENT;
     }
     PathFragment prefix =
-        siblingRepositoryLayout
-            ? LabelConstants.EXPERIMENTAL_EXTERNAL_PATH_PREFIX
-            : LabelConstants.EXTERNAL_PATH_PREFIX;
+        LabelConstants.getExternalPathPrefix(siblingRepositoryLayout, bazelExternalDirectory);
     return prefix.getRelative(getName());
   }
 

--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
@@ -81,17 +81,24 @@ public final class RepositoryName {
    * Extracts the repository name from a PathFragment that was created with {@code
    * PackageIdentifier.getSourceRoot}.
    *
-   * @return a {@code Pair} of the extracted repository name and the path fragment with stripped of
-   *     "external/"-prefix and repository name, or null if none was found or the repository name
-   *     was invalid.
+   * @return a {@code Pair} of the extracted repository name and the path fragment with the external
+   *     repository prefix and repository name stripped, or null if none was found or the repository
+   *     name was invalid.
    */
   @Nullable
   public static Pair<RepositoryName, PathFragment> fromPathFragment(PathFragment path) {
+    return fromPathFragment(path, /* bazelExternalDirectory= */ false);
+  }
+
+  @Nullable
+  public static Pair<RepositoryName, PathFragment> fromPathFragment(
+      PathFragment path, boolean bazelExternalDirectory) {
     if (!path.isMultiSegment()) {
       return null;
     }
 
-    if (!path.startsWith(LabelConstants.EXTERNAL_PATH_PREFIX)) {
+    PathFragment prefix = LabelConstants.getExternalPathPrefix(bazelExternalDirectory);
+    if (!path.startsWith(prefix)) {
       return null;
     }
 
@@ -289,15 +296,23 @@ public final class RepositoryName {
   }
 
   /**
-   * Returns the runfiles/execRoot path for this repository, that is "$execroot/external/repo". If
-   * we don't know the name of this repo (i.e., it is in the main repository), return an empty path
-   * fragment.
+   * Returns the runfiles/execRoot path for this repository. If we don't know the name of this repo
+   * (i.e., it is in the main repository), return an empty path fragment.
+   *
+   * <p>The prefix is "external" by default and "bazel-external" when
+   * --incompatible_bazel_external_directory is enabled.
    */
   public PathFragment getExecPath() {
+    return getExecPath(/* bazelExternalDirectory= */ false);
+  }
+
+  /** Returns the runfiles/execroot path for this repository under the requested layout. */
+  public PathFragment getExecPath(boolean bazelExternalDirectory) {
     if (isMain()) {
       return PathFragment.EMPTY_FRAGMENT;
     }
-    return LabelConstants.EXTERNAL_PATH_PREFIX.getRelative(getName());
+    PathFragment prefix = LabelConstants.getExternalPathPrefix(bazelExternalDirectory);
+    return prefix.getRelative(getName());
   }
 
   /** Returns the runfiles path relative to the x.runfiles/main-repo directory. */

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogReconstructor.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogReconstructor.java
@@ -54,14 +54,21 @@ public final class SpawnLogReconstructor implements MessageInputStream<SpawnExec
   // * bazel-out/k8-fastbuild/bin/pkg/file.txt (repo: null, path: "pkg/file.txt")
   // * bazel-out/k8-fastbuild/bin/external/some_repo/pkg/file.txt (repo: "some_repo", path:
   //   "pkg/file.txt")
+  // * bazel-out/k8-fastbuild/bin/bazel-external/some_repo/pkg/file.txt (repo: "some_repo", path:
+  //   "pkg/file.txt")
   private static final Pattern DEFAULT_GENERATED_FILE_RUNFILES_PATH_PATTERN =
-      Pattern.compile("(?:bazel|blaze)-out/[^/]+/[^/]+/(?:external/(?<repo>[^/]+)/)?(?<path>.+)");
+      Pattern.compile(
+          "(?:bazel|blaze)-out/[^/]+/[^/]+/"
+              + "(?:(?:(?:bazel|blaze)-)?external/(?<repo>[^/]+)/)?(?<path>.+)");
 
   // Examples:
   // * pkg/file.txt (repo: null, path: "pkg/file.txt")
   // * external/some_repo/pkg/file.txt (repo: "some_repo", path: "pkg/file.txt")
+  // * bazel-external/some_repo/pkg/file.txt (repo: "some_repo", path: "pkg/file.txt")
+  // * blaze-external/some_repo/pkg/file.txt (repo: "some_repo", path: "pkg/file.txt")
   private static final Pattern DEFAULT_SOURCE_FILE_RUNFILES_PATH_PATTERN =
-      Pattern.compile("(?:external/(?<repo>[^/]+)/)?(?<path>.+)");
+      Pattern.compile(
+          "(?:(?:(?:bazel|blaze)-)?external/(?<repo>[^/]+)/)?(?<path>.+)");
 
   // Examples:
   // * bazel-out/k8-fastbuild/bin/pkg/file.txt (repo: null, path: "pkg/file.txt")

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogReconstructor.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogReconstructor.java
@@ -54,14 +54,20 @@ public final class SpawnLogReconstructor implements MessageInputStream<SpawnExec
   // * bazel-out/k8-fastbuild/bin/pkg/file.txt (repo: null, path: "pkg/file.txt")
   // * bazel-out/k8-fastbuild/bin/external/some_repo/pkg/file.txt (repo: "some_repo", path:
   //   "pkg/file.txt")
+  // * bazel-out/k8-fastbuild/bin/bazel-external/some_repo/pkg/file.txt (repo: "some_repo", path:
+  //   "pkg/file.txt")
   private static final Pattern DEFAULT_GENERATED_FILE_RUNFILES_PATH_PATTERN =
-      Pattern.compile("(?:bazel|blaze)-out/[^/]+/[^/]+/(?:external/(?<repo>[^/]+)/)?(?<path>.+)");
+      Pattern.compile(
+          "(?:bazel|blaze)-out/[^/]+/[^/]+/"
+              + "(?:(?:(?:bazel|blaze)-)?external/(?<repo>[^/]+)/)?(?<path>.+)");
 
   // Examples:
   // * pkg/file.txt (repo: null, path: "pkg/file.txt")
   // * external/some_repo/pkg/file.txt (repo: "some_repo", path: "pkg/file.txt")
+  // * bazel-external/some_repo/pkg/file.txt (repo: "some_repo", path: "pkg/file.txt")
+  // * blaze-external/some_repo/pkg/file.txt (repo: "some_repo", path: "pkg/file.txt")
   private static final Pattern DEFAULT_SOURCE_FILE_RUNFILES_PATH_PATTERN =
-      Pattern.compile("(?:external/(?<repo>[^/]+)/)?(?<path>.+)");
+      Pattern.compile("(?:(?:(?:bazel|blaze)-)?external/(?<repo>[^/]+)/)?(?<path>.+)");
 
   private final ZstdInputStream in;
 

--- a/src/main/java/com/google/devtools/build/lib/packages/InputFile.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/InputFile.java
@@ -109,9 +109,14 @@ public class InputFile extends FileTarget {
    * directory.
    */
   public PathFragment getExecPath(boolean siblingRepositoryLayout) {
+    return getExecPath(siblingRepositoryLayout, /* bazelExternalDirectory= */ false);
+  }
+
+  public PathFragment getExecPath(
+      boolean siblingRepositoryLayout, boolean bazelExternalDirectory) {
     return label
         .getRepository()
-        .getExecPath(siblingRepositoryLayout)
+        .getExecPath(siblingRepositoryLayout, bazelExternalDirectory)
         .getRelative(label.getPackageName())
         .getRelative(label.getName());
   }

--- a/src/main/java/com/google/devtools/build/lib/packages/InputFile.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/InputFile.java
@@ -109,9 +109,13 @@ public class InputFile extends FileTarget {
    * directory.
    */
   public PathFragment getExecPath() {
+    return getExecPath(/* bazelExternalDirectory= */ false);
+  }
+
+  public PathFragment getExecPath(boolean bazelExternalDirectory) {
     return label
         .getRepository()
-        .getExecPath()
+        .getExecPath(bazelExternalDirectory)
         .getRelative(label.getPackageName())
         .getRelative(label.getName());
   }

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -305,6 +305,23 @@ public abstract class BuildLanguageOptions extends OptionsBase {
   public abstract boolean getExperimentalSiblingRepositoryLayout();
 
   @Option(
+      name = "incompatible_bazel_external_directory",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {
+        OptionEffectTag.ACTION_COMMAND_LINES,
+        OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION,
+        OptionEffectTag.LOADING_AND_ANALYSIS,
+        OptionEffectTag.LOSES_INCREMENTAL_STATE
+      },
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          "If set to true, external repositories use the bazel-external directory in the "
+              + "execution root instead of the external directory. This has no effect when "
+              + "--experimental_sibling_repository_layout is enabled.")
+  public abstract boolean getIncompatibleBazelExternalDirectory();
+
+  @Option(
       name = "incompatible_allow_tags_propagation",
       oldName = "experimental_allow_tags_propagation",
       defaultValue = "true",
@@ -884,6 +901,9 @@ public abstract class BuildLanguageOptions extends OptionsBase {
             .setBool(
                 EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT, getExperimentalSiblingRepositoryLayout())
             .setBool(
+                INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY,
+                getIncompatibleBazelExternalDirectory())
+            .setBool(
                 INCOMPATIBLE_ALWAYS_CHECK_DEPSET_ELEMENTS,
                 getIncompatibleAlwaysCheckDepsetElements())
             .setBool(
@@ -1080,6 +1100,8 @@ public abstract class BuildLanguageOptions extends OptionsBase {
   public static final String EXPERIMENTAL_REPO_REMOTE_EXEC = "-experimental_repo_remote_exec";
   public static final String EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT =
       "-experimental_sibling_repository_layout";
+  public static final String INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY =
+      "-incompatible_bazel_external_directory";
   public static final String INCOMPATIBLE_ALWAYS_CHECK_DEPSET_ELEMENTS =
       "+incompatible_always_check_depset_elements";
   public static final String INCOMPATIBLE_CHECK_EXTERNAL_REPO_SOURCE_DIR_PACKAGE_BOUNDARY =

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -286,6 +286,22 @@ public abstract class BuildLanguageOptions extends OptionsBase {
   public abstract boolean getExperimentalSiblingRepositoryLayout();
 
   @Option(
+      name = "incompatible_bazel_external_directory",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {
+        OptionEffectTag.ACTION_COMMAND_LINES,
+        OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION,
+        OptionEffectTag.LOADING_AND_ANALYSIS,
+        OptionEffectTag.LOSES_INCREMENTAL_STATE
+      },
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          "If set to true, external repositories use the bazel-external directory in the "
+              + "execution root instead of the external directory.")
+  public abstract boolean getIncompatibleBazelExternalDirectory();
+
+  @Option(
       name = "incompatible_allow_tags_propagation",
       oldName = "experimental_allow_tags_propagation",
       defaultValue = "true",
@@ -861,6 +877,7 @@ public abstract class BuildLanguageOptions extends OptionsBase {
             .setBool(EXPERIMENTAL_PLATFORMS_API, getExperimentalPlatformsApi())
             .setBool(EXPERIMENTAL_CC_SHARED_LIBRARY, getExperimentalCcSharedLibrary())
             .setBool(EXPERIMENTAL_REPO_REMOTE_EXEC, getExperimentalRepoRemoteExec())
+            .setBool(INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY, getIncompatibleBazelExternalDirectory())
             .setBool(
                 INCOMPATIBLE_ALWAYS_CHECK_DEPSET_ELEMENTS,
                 getIncompatibleAlwaysCheckDepsetElements())
@@ -1062,6 +1079,8 @@ public abstract class BuildLanguageOptions extends OptionsBase {
   public static final String EXPERIMENTAL_GOOGLE_LEGACY_API = "-experimental_google_legacy_api";
   public static final String EXPERIMENTAL_PLATFORMS_API = "-experimental_platforms_api";
   public static final String EXPERIMENTAL_REPO_REMOTE_EXEC = "-experimental_repo_remote_exec";
+  public static final String INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY =
+      "-incompatible_bazel_external_directory";
   public static final String INCOMPATIBLE_ALWAYS_CHECK_DEPSET_ELEMENTS =
       "+incompatible_always_check_depset_elements";
   public static final String INCOMPATIBLE_CHECK_EXTERNAL_REPO_SOURCE_DIR_PACKAGE_BOUNDARY =

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -1524,6 +1524,11 @@ public class CppCompileAction extends AbstractAction
             .getOptions()
             .getOptions(BuildLanguageOptions.class)
             .getExperimentalSiblingRepositoryLayout();
+    boolean bazelExternalDirectory =
+        actionExecutionContext
+            .getOptions()
+            .getOptions(BuildLanguageOptions.class)
+            .getIncompatibleBazelExternalDirectory();
 
     if (shouldParseShowIncludes()) {
       NestedSet<Artifact> discoveredInputs =
@@ -1533,6 +1538,7 @@ public class CppCompileAction extends AbstractAction
               showIncludesFilterForStdout,
               showIncludesFilterForStderr,
               siblingRepositoryLayout,
+              bazelExternalDirectory,
               pathMapper);
       updateActionInputs(discoveredInputs);
       validateInclusions(actionExecutionContext, discoveredInputs);
@@ -1552,6 +1558,7 @@ public class CppCompileAction extends AbstractAction
             scanningContext.getArtifactResolver(),
             dotDContents,
             siblingRepositoryLayout,
+            bazelExternalDirectory,
             pathMapper);
     dotDContents = null; // Garbage collect in-memory .d contents.
 
@@ -1810,6 +1817,7 @@ public class CppCompileAction extends AbstractAction
       ShowIncludesFilter showIncludesFilterForStdout,
       ShowIncludesFilter showIncludesFilterForStderr,
       boolean siblingRepositoryLayout,
+      boolean bazelExternalDirectory,
       PathMapper pathMapper)
       throws ActionExecutionException {
     Collection<Path> stdoutDeps = showIncludesFilterForStdout.getDependencies(execRoot);
@@ -1843,6 +1851,7 @@ public class CppCompileAction extends AbstractAction
         execRoot,
         artifactResolver,
         siblingRepositoryLayout,
+        bazelExternalDirectory,
         pathMapper);
   }
 
@@ -1853,6 +1862,25 @@ public class CppCompileAction extends AbstractAction
       ArtifactResolver artifactResolver,
       byte[] dotDContents,
       boolean siblingRepositoryLayout,
+      PathMapper pathMapper)
+      throws ActionExecutionException {
+    return discoverInputsFromDotdFiles(
+        actionExecutionContext,
+        execRoot,
+        artifactResolver,
+        dotDContents,
+        siblingRepositoryLayout,
+        /* bazelExternalDirectory= */ false,
+        pathMapper);
+  }
+
+  public NestedSet<Artifact> discoverInputsFromDotdFiles(
+      ActionExecutionContext actionExecutionContext,
+      Path execRoot,
+      ArtifactResolver artifactResolver,
+      byte[] dotDContents,
+      boolean siblingRepositoryLayout,
+      boolean bazelExternalDirectory,
       PathMapper pathMapper)
       throws ActionExecutionException {
     Preconditions.checkNotNull(getDotdFile(), "Trying to scan .d file which is unset");
@@ -1866,6 +1894,7 @@ public class CppCompileAction extends AbstractAction
         execRoot,
         artifactResolver,
         siblingRepositoryLayout,
+        bazelExternalDirectory,
         pathMapper);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -70,6 +70,7 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadCompatible;
 import com.google.devtools.build.lib.exec.SpawnStrategyResolver;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
@@ -1511,6 +1512,11 @@ public class CppCompileAction extends AbstractAction
     CppIncludeExtractionContext scanningContext =
         actionExecutionContext.getContext(CppIncludeExtractionContext.class);
     Path execRoot = actionExecutionContext.getExecRoot();
+    boolean bazelExternalDirectory =
+        actionExecutionContext
+            .getOptions()
+            .getOptions(BuildLanguageOptions.class)
+            .getIncompatibleBazelExternalDirectory();
 
     if (shouldParseShowIncludes()) {
       NestedSet<Artifact> discoveredInputs =
@@ -1519,6 +1525,7 @@ public class CppCompileAction extends AbstractAction
               scanningContext.getArtifactResolver(),
               showIncludesFilterForStdout,
               showIncludesFilterForStderr,
+              bazelExternalDirectory,
               pathMapper);
       updateActionInputs(discoveredInputs);
       validateInclusions(actionExecutionContext, discoveredInputs);
@@ -1537,6 +1544,7 @@ public class CppCompileAction extends AbstractAction
             execRoot,
             scanningContext.getArtifactResolver(),
             dotDContents,
+            bazelExternalDirectory,
             pathMapper);
     dotDContents = null; // Garbage collect in-memory .d contents.
 
@@ -1794,6 +1802,7 @@ public class CppCompileAction extends AbstractAction
       ArtifactResolver artifactResolver,
       ShowIncludesFilter showIncludesFilterForStdout,
       ShowIncludesFilter showIncludesFilterForStderr,
+      boolean bazelExternalDirectory,
       PathMapper pathMapper)
       throws ActionExecutionException {
     Collection<Path> stdoutDeps = showIncludesFilterForStdout.getDependencies(execRoot);
@@ -1826,6 +1835,7 @@ public class CppCompileAction extends AbstractAction
         getAllowedDerivedInputs(),
         execRoot,
         artifactResolver,
+        bazelExternalDirectory,
         pathMapper);
   }
 
@@ -1835,6 +1845,23 @@ public class CppCompileAction extends AbstractAction
       Path execRoot,
       ArtifactResolver artifactResolver,
       byte[] dotDContents,
+      PathMapper pathMapper)
+      throws ActionExecutionException {
+    return discoverInputsFromDotdFiles(
+        actionExecutionContext,
+        execRoot,
+        artifactResolver,
+        dotDContents,
+        /* bazelExternalDirectory= */ false,
+        pathMapper);
+  }
+
+  public NestedSet<Artifact> discoverInputsFromDotdFiles(
+      ActionExecutionContext actionExecutionContext,
+      Path execRoot,
+      ArtifactResolver artifactResolver,
+      byte[] dotDContents,
+      boolean bazelExternalDirectory,
       PathMapper pathMapper)
       throws ActionExecutionException {
     Preconditions.checkNotNull(getDotdFile(), "Trying to scan .d file which is unset");
@@ -1847,6 +1874,7 @@ public class CppCompileAction extends AbstractAction
         getAllowedDerivedInputs(),
         execRoot,
         artifactResolver,
+        bazelExternalDirectory,
         pathMapper);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
@@ -77,6 +77,33 @@ final class HeaderDiscovery {
       boolean siblingRepositoryLayout,
       PathMapper pathMapper)
       throws ActionExecutionException {
+    return discoverInputsFromDependencies(
+        action,
+        sourceFile,
+        shouldValidateInclusions,
+        dependencies,
+        permittedSystemIncludePrefixes,
+        allowedDerivedInputs,
+        execRoot,
+        artifactResolver,
+        siblingRepositoryLayout,
+        /* bazelExternalDirectory= */ false,
+        pathMapper);
+  }
+
+  static NestedSet<Artifact> discoverInputsFromDependencies(
+      Action action,
+      Artifact sourceFile,
+      boolean shouldValidateInclusions,
+      Collection<Path> dependencies,
+      List<Path> permittedSystemIncludePrefixes,
+      NestedSet<Artifact> allowedDerivedInputs,
+      Path execRoot,
+      ArtifactResolver artifactResolver,
+      boolean siblingRepositoryLayout,
+      boolean bazelExternalDirectory,
+      PathMapper pathMapper)
+      throws ActionExecutionException {
     Map<PathFragment, Artifact> regularDerivedArtifacts = new HashMap<>();
     Map<PathFragment, SpecialArtifact> treeArtifacts = new HashMap<>();
     for (Artifact a : allowedDerivedInputs.toList()) {
@@ -112,6 +139,7 @@ final class HeaderDiscovery {
         execRoot,
         artifactResolver,
         siblingRepositoryLayout,
+        bazelExternalDirectory,
         pathMapper);
   }
 
@@ -126,6 +154,7 @@ final class HeaderDiscovery {
       Path execRoot,
       ArtifactResolver artifactResolver,
       boolean siblingRepositoryLayout,
+      boolean bazelExternalDirectory,
       PathMapper pathMapper)
       throws ActionExecutionException {
     NestedSetBuilder<Artifact> inputs = NestedSetBuilder.stableOrder();
@@ -198,7 +227,10 @@ final class HeaderDiscovery {
       if (derivedArtifact == null) {
         Optional<PackageIdentifier> pkgId =
             PackageIdentifier.discoverFromExecPath(
-                execPathFragment, false, siblingRepositoryLayout);
+                execPathFragment,
+                false,
+                siblingRepositoryLayout,
+                bazelExternalDirectory);
         if (pkgId.isPresent()) {
           if (possiblyCaseInsensitiveFileSystem) {
             resolvedArtifacts =

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
@@ -75,6 +75,31 @@ final class HeaderDiscovery {
       ArtifactResolver artifactResolver,
       PathMapper pathMapper)
       throws ActionExecutionException {
+    return discoverInputsFromDependencies(
+        action,
+        sourceFile,
+        shouldValidateInclusions,
+        dependencies,
+        permittedSystemIncludePrefixes,
+        allowedDerivedInputs,
+        execRoot,
+        artifactResolver,
+        /* bazelExternalDirectory= */ false,
+        pathMapper);
+  }
+
+  static NestedSet<Artifact> discoverInputsFromDependencies(
+      Action action,
+      Artifact sourceFile,
+      boolean shouldValidateInclusions,
+      Collection<Path> dependencies,
+      List<Path> permittedSystemIncludePrefixes,
+      NestedSet<Artifact> allowedDerivedInputs,
+      Path execRoot,
+      ArtifactResolver artifactResolver,
+      boolean bazelExternalDirectory,
+      PathMapper pathMapper)
+      throws ActionExecutionException {
     Map<PathFragment, Artifact> regularDerivedArtifacts = new HashMap<>();
     Map<PathFragment, SpecialArtifact> treeArtifacts = new HashMap<>();
     for (Artifact a : allowedDerivedInputs.toList()) {
@@ -109,6 +134,7 @@ final class HeaderDiscovery {
         treeArtifacts,
         execRoot,
         artifactResolver,
+        bazelExternalDirectory,
         pathMapper);
   }
 
@@ -122,6 +148,7 @@ final class HeaderDiscovery {
       Map<PathFragment, SpecialArtifact> treeArtifacts,
       Path execRoot,
       ArtifactResolver artifactResolver,
+      boolean bazelExternalDirectory,
       PathMapper pathMapper)
       throws ActionExecutionException {
     NestedSetBuilder<Artifact> inputs = NestedSetBuilder.stableOrder();
@@ -162,7 +189,7 @@ final class HeaderDiscovery {
       Artifact derivedArtifact = regularDerivedArtifacts.get(execPathFragment);
       if (derivedArtifact == null) {
         Optional<PackageIdentifier> pkgId =
-            PackageIdentifier.discoverFromExecPath(execPathFragment, /* forFiles= */ false);
+            PackageIdentifier.discoverFromExecPath(execPathFragment, false, bazelExternalDirectory);
         if (pkgId.isPresent()) {
           if (possiblyCaseInsensitiveFileSystem) {
             resolvedArtifacts =

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHelper.java
@@ -102,7 +102,9 @@ public abstract class JavaHelper {
         ruleContext
             .getLabel()
             .getRepository()
-            .getExecPath(siblingRepositoryLayout);
+            .getExecPath(
+                siblingRepositoryLayout,
+                ruleContext.getConfiguration().isBazelExternalDirectory());
     if (!repoExecPath.isEmpty() && resourcePath.startsWith(repoExecPath)) {
       resourcePath = resourcePath.relativeTo(repoExecPath);
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHelper.java
@@ -97,7 +97,11 @@ public abstract class JavaHelper {
   public static PathFragment getJavaResourcePath(
       JavaSemantics semantics, RuleContext ruleContext, Artifact resource) {
     PathFragment resourcePath = resource.getOutputDirRelativePath();
-    PathFragment repoExecPath = ruleContext.getLabel().getRepository().getExecPath();
+    PathFragment repoExecPath =
+        ruleContext
+            .getLabel()
+            .getRepository()
+            .getExecPath(ruleContext.getConfiguration().isBazelExternalDirectory());
     if (!repoExecPath.isEmpty() && resourcePath.startsWith(repoExecPath)) {
       resourcePath = resourcePath.relativeTo(repoExecPath);
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
@@ -667,6 +667,9 @@ public class ActionExecutionFunction implements SkyFunction {
 
       boolean siblingRepositoryLayout =
           starlarkSemantics.getBool(BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT);
+      boolean bazelExternalDirectory =
+          starlarkSemantics.getBool(
+              BuildLanguageOptions.INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY);
 
       // Create SkyKeys list based on execPaths.
       Map<PathFragment, ContainingPackageLookupValue.Key> depKeys = new HashMap<>();
@@ -675,7 +678,8 @@ public class ActionExecutionFunction implements SkyFunction {
             checkNotNull(path.getParentDirectory(), "Must pass in files, not root directory");
         checkArgument(!parent.isAbsolute(), path);
         Optional<PackageIdentifier> pkgId =
-            PackageIdentifier.discoverFromExecPath(path, true, siblingRepositoryLayout);
+            PackageIdentifier.discoverFromExecPath(
+                path, true, siblingRepositoryLayout, bazelExternalDirectory);
         if (pkgId.isPresent()) {
           ContainingPackageLookupValue.Key depKey = ContainingPackageLookupValue.key(pkgId.get());
           depKeys.put(path, depKey);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
@@ -69,6 +69,7 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.io.InconsistentFilesystemException;
 import com.google.devtools.build.lib.packages.BuildFileNotFoundException;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
@@ -115,6 +116,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.StarlarkSemantics;
 
 /**
  * A {@link SkyFunction} that creates {@link ActionExecutionValue}s. There are four points where
@@ -660,6 +662,14 @@ public class ActionExecutionFunction implements SkyFunction {
           "resolver should only be called once: %s %s",
           packageLookupsRequested,
           execPaths);
+      StarlarkSemantics starlarkSemantics = PrecomputedValue.STARLARK_SEMANTICS.get(env);
+      if (starlarkSemantics == null) {
+        return null;
+      }
+
+      boolean bazelExternalDirectory =
+          starlarkSemantics.getBool(BuildLanguageOptions.INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY);
+
       // Create SkyKeys list based on execPaths.
       Map<PathFragment, ContainingPackageLookupValue.Key> depKeys = new HashMap<>();
       for (PathFragment path : execPaths) {
@@ -667,7 +677,7 @@ public class ActionExecutionFunction implements SkyFunction {
             checkNotNull(path.getParentDirectory(), "Must pass in files, not root directory");
         checkArgument(!parent.isAbsolute(), path);
         Optional<PackageIdentifier> pkgId =
-            PackageIdentifier.discoverFromExecPath(path, /* forFiles= */ true);
+            PackageIdentifier.discoverFromExecPath(path, true, bazelExternalDirectory);
         if (pkgId.isPresent()) {
           ContainingPackageLookupValue.Key depKey = ContainingPackageLookupValue.key(pkgId.get());
           depKeys.put(path, depKey);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ArtifactFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ArtifactFunction.java
@@ -453,14 +453,14 @@ public final class ArtifactFunction implements SkyFunction {
         return String.format("%s '%s'", error, ownerLabel);
       }
     } else {
-      // Not worth threading sibling repository layout config value all the way here: if either
-      // match, we know the label isn't useful.
-      for (boolean siblingRepositoryLayout : ImmutableList.of(Boolean.FALSE, Boolean.TRUE)) {
-        if (ownerLabel
-            .getRepository()
-            .getExecPath(siblingRepositoryLayout)
-            .getRelative(labelFragment)
-            .equals(artifact.getExecPath())) {
+      // Not worth threading the repository layout all the way here: if any layout matches, we know
+      // the label isn't useful.
+      for (PathFragment repositoryExecPath :
+          ImmutableList.of(
+              ownerLabel.getRepository().getExecPath(false, false),
+              ownerLabel.getRepository().getExecPath(false, true),
+              ownerLabel.getRepository().getExecPath(true, false))) {
+        if (repositoryExecPath.getRelative(labelFragment).equals(artifact.getExecPath())) {
           return String.format("%s '%s'", error, ownerLabel);
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ArtifactFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ArtifactFunction.java
@@ -452,12 +452,17 @@ public final class ArtifactFunction implements SkyFunction {
         // No additional useful information from path.
         return String.format("%s '%s'", error, ownerLabel);
       }
-    } else if (ownerLabel
-        .getRepository()
-        .getExecPath()
-        .getRelative(labelFragment)
-        .equals(artifact.getExecPath())) {
-      return String.format("%s '%s'", error, ownerLabel);
+    } else {
+      // Not worth threading the repository layout all the way here: if any layout matches, we know
+      // the label isn't useful.
+      for (PathFragment repositoryExecPath :
+          ImmutableList.of(
+              ownerLabel.getRepository().getExecPath(false),
+              ownerLabel.getRepository().getExecPath(true))) {
+        if (repositoryExecPath.getRelative(labelFragment).equals(artifact.getExecPath())) {
+          return String.format("%s '%s'", error, ownerLabel);
+        }
+      }
     }
 
     // TODO(bazel-team): when is this hit?

--- a/src/main/java/com/google/devtools/build/lib/skyframe/IncrementalPackageRoots.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/IncrementalPackageRoots.java
@@ -85,6 +85,7 @@ public class IncrementalPackageRoots implements PackageRoots {
 
   private final IgnoredSubdirectories ignoredPaths;
   private final boolean useSiblingRepositoryLayout;
+  private final boolean useBazelExternalDirectory;
 
   private final boolean allowExternalRepositories;
   @Nullable private EventBus eventBus;
@@ -99,6 +100,7 @@ public class IncrementalPackageRoots implements PackageRoots {
       String prefix,
       IgnoredSubdirectories ignoredPaths,
       boolean useSiblingRepositoryLayout,
+      boolean useBazelExternalDirectory,
       boolean allowExternalRepositories) {
     this.threadSafeExternalRepoPackageRootsMap = new ConcurrentHashMap<>();
     this.execroot = execroot;
@@ -107,6 +109,7 @@ public class IncrementalPackageRoots implements PackageRoots {
     this.ignoredPaths = ignoredPaths;
     this.eventBus = eventBus;
     this.useSiblingRepositoryLayout = useSiblingRepositoryLayout;
+    this.useBazelExternalDirectory = useBazelExternalDirectory;
     this.allowExternalRepositories = allowExternalRepositories;
     this.symlinkPlantingPool =
         MoreExecutors.listeningDecorator(
@@ -122,6 +125,7 @@ public class IncrementalPackageRoots implements PackageRoots {
       String prefix,
       IgnoredSubdirectories ignoredSubdirectories,
       boolean useSiblingRepositoryLayout,
+      boolean useBazelExternalDirectory,
       boolean allowExternalRepositories) {
     IncrementalPackageRoots incrementalPackageRoots =
         new IncrementalPackageRoots(
@@ -131,6 +135,7 @@ public class IncrementalPackageRoots implements PackageRoots {
             prefix,
             ignoredSubdirectories,
             useSiblingRepositoryLayout,
+            useBazelExternalDirectory,
             allowExternalRepositories);
     eventBus.register(incrementalPackageRoots);
     return incrementalPackageRoots;
@@ -170,7 +175,8 @@ public class IncrementalPackageRoots implements PackageRoots {
               singleSourceRoot.asPath(),
               prefix,
               ignoredPaths,
-              useSiblingRepositoryLayout);
+              useSiblingRepositoryLayout,
+              useBazelExternalDirectory);
     } catch (IOException e) {
       throwAbruptExitException(e);
     }
@@ -284,6 +290,7 @@ public class IncrementalPackageRoots implements PackageRoots {
             pkg.sourceRoot().asPath(),
             execroot,
             useSiblingRepositoryLayout,
+            useBazelExternalDirectory,
             lazilyPlantedSymlinksRef);
       } else if (!maybeConflictingBaseNamesLowercase.isEmpty()) {
         String originalBaseName = pkgId.getTopLevelDir();
@@ -297,7 +304,12 @@ public class IncrementalPackageRoots implements PackageRoots {
         if (originalBaseName.isEmpty()
             || !maybeConflictingBaseNamesLowercase.contains(baseNameLowercase)
             || !SymlinkForest.symlinkShouldBePlanted(
-                prefix, ignoredPaths, useSiblingRepositoryLayout, originalBaseName, target)) {
+                prefix,
+                ignoredPaths,
+                useSiblingRepositoryLayout,
+                useBazelExternalDirectory,
+                originalBaseName,
+                target)) {
           // We should have already eagerly planted a symlink for this, or there's nothing to do.
           return null;
         }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/IncrementalPackageRoots.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/IncrementalPackageRoots.java
@@ -85,6 +85,8 @@ public class IncrementalPackageRoots implements PackageRoots {
 
   private final IgnoredSubdirectories ignoredPaths;
 
+  private final boolean useBazelExternalDirectory;
+
   private final boolean allowExternalRepositories;
   @Nullable private EventBus eventBus;
   @Nullable private final PackageRootLookup fallbackPackageRootLookup;
@@ -98,6 +100,7 @@ public class IncrementalPackageRoots implements PackageRoots {
       EventBus eventBus,
       String prefix,
       IgnoredSubdirectories ignoredPaths,
+      boolean useBazelExternalDirectory,
       boolean allowExternalRepositories,
       @Nullable PackageRootLookup fallbackPackageRootLookup) {
     this.threadSafeExternalRepoPackageRootsMap = new ConcurrentHashMap<>();
@@ -106,6 +109,7 @@ public class IncrementalPackageRoots implements PackageRoots {
     this.prefix = prefix;
     this.ignoredPaths = ignoredPaths;
     this.eventBus = eventBus;
+    this.useBazelExternalDirectory = useBazelExternalDirectory;
     this.allowExternalRepositories = allowExternalRepositories;
     this.fallbackPackageRootLookup = fallbackPackageRootLookup;
     this.symlinkPlantingPool =
@@ -128,6 +132,7 @@ public class IncrementalPackageRoots implements PackageRoots {
         eventBus,
         prefix,
         ignoredSubdirectories,
+        /* useBazelExternalDirectory= */ false,
         allowExternalRepositories,
         /* fallbackPackageRootLookup= */ null);
   }
@@ -138,6 +143,7 @@ public class IncrementalPackageRoots implements PackageRoots {
       EventBus eventBus,
       String prefix,
       IgnoredSubdirectories ignoredSubdirectories,
+      boolean useBazelExternalDirectory,
       boolean allowExternalRepositories,
       @Nullable PackageRootLookup fallbackPackageRootLookup) {
     IncrementalPackageRoots incrementalPackageRoots =
@@ -147,6 +153,7 @@ public class IncrementalPackageRoots implements PackageRoots {
             eventBus,
             prefix,
             ignoredSubdirectories,
+            useBazelExternalDirectory,
             allowExternalRepositories,
             fallbackPackageRootLookup);
     eventBus.register(incrementalPackageRoots);
@@ -183,7 +190,7 @@ public class IncrementalPackageRoots implements PackageRoots {
     try {
       maybeConflictingBaseNamesLowercase =
           SymlinkForest.eagerlyPlantSymlinkForestSinglePackagePath(
-              execroot, singleSourceRoot.asPath(), prefix, ignoredPaths);
+              execroot, singleSourceRoot.asPath(), prefix, ignoredPaths, useBazelExternalDirectory);
     } catch (IOException e) {
       throwAbruptExitException(e);
     }
@@ -337,6 +344,7 @@ public class IncrementalPackageRoots implements PackageRoots {
             pkgId.getRepository(),
             pkg.sourceRoot().asPath(),
             execroot,
+            useBazelExternalDirectory,
             lazilyPlantedSymlinksRef);
       } else if (!maybeConflictingBaseNamesLowercase.isEmpty()) {
         String originalBaseName = pkgId.getTopLevelDir();
@@ -350,7 +358,7 @@ public class IncrementalPackageRoots implements PackageRoots {
         if (originalBaseName.isEmpty()
             || !maybeConflictingBaseNamesLowercase.contains(baseNameLowercase)
             || !SymlinkForest.symlinkShouldBePlanted(
-                prefix, ignoredPaths, originalBaseName, target)) {
+                prefix, ignoredPaths, useBazelExternalDirectory, originalBaseName, target)) {
           // We should have already eagerly planted a symlink for this, or there's nothing to do.
           return null;
         }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ProcessPackageDirectory.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ProcessPackageDirectory.java
@@ -177,7 +177,9 @@ public final class ProcessPackageDirectory {
             rootedPath,
             repositoryName,
             excludedPaths,
-            starlarkSemantics.getBool(BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT)),
+            starlarkSemantics.getBool(BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT),
+            starlarkSemantics.getBool(
+                BuildLanguageOptions.INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY)),
         /*additionalValuesToAggregate=*/ ImmutableMap.of());
   }
 
@@ -263,7 +265,8 @@ public final class ProcessPackageDirectory {
       RootedPath rootedPath,
       RepositoryName repositoryName,
       IgnoredSubdirectories excludedPaths,
-      boolean siblingRepositoryLayout) {
+      boolean siblingRepositoryLayout,
+      boolean bazelExternalDirectory) {
     Root root = rootedPath.getRoot();
     PathFragment rootRelativePath = rootedPath.getRootRelativePath();
     boolean followSymlinks = shouldFollowSymlinksWhenTraversing(dirListingValue.getDirents());
@@ -283,10 +286,11 @@ public final class ProcessPackageDirectory {
       String basename = dirent.getName();
       PathFragment subdirectory = rootRelativePath.getRelative(basename);
       if (!siblingRepositoryLayout
+          && !bazelExternalDirectory
           && subdirectory.equals(LabelConstants.EXTERNAL_PACKAGE_NAME)
           && repositoryName.isMain()) {
-        // Subpackages under //external in the main repo can be processed only
-        // when --experimental_sibling_repository_layout is set.
+        // Subpackages under //external in the main repo can be processed only when the execroot's
+        // external repository directory no longer occupies that path.
         continue;
       }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ProcessPackageDirectory.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ProcessPackageDirectory.java
@@ -13,7 +13,6 @@
 // limitations under the License.
 package com.google.devtools.build.lib.skyframe;
 
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -31,6 +30,7 @@ import com.google.devtools.build.lib.io.FileSymlinkInfiniteExpansionUniquenessFu
 import com.google.devtools.build.lib.io.InconsistentFilesystemException;
 import com.google.devtools.build.lib.io.ProcessPackageDirectoryException;
 import com.google.devtools.build.lib.packages.NoSuchPackageException;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.StarlarkSemantics;
 
 /**
  * Processes a directory that may contain a package and subdirectories for the benefit of processes
@@ -81,6 +82,11 @@ public final class ProcessPackageDirectory {
       IgnoredSubdirectories excludedPaths,
       SkyFunction.Environment env)
       throws InterruptedException, ProcessPackageDirectorySkyFunctionException {
+    StarlarkSemantics starlarkSemantics = PrecomputedValue.STARLARK_SEMANTICS.get(env);
+    if (starlarkSemantics == null) {
+      return null;
+    }
+
     PathFragment rootRelativePath = rootedPath.getRootRelativePath();
 
     SkyKey fileKey = FileValue.key(rootedPath);
@@ -169,7 +175,12 @@ public final class ProcessPackageDirectory {
         dirListingValue, "%s %s %s", rootedPath, repositoryName, dirListingKey);
     return new ProcessPackageDirectoryResult(
         pkgLookupValue.packageExists() && pkgLookupValue.getRoot().equals(rootedPath.getRoot()),
-        getSubdirDeps(dirListingValue, rootedPath, repositoryName, excludedPaths),
+        getSubdirDeps(
+            dirListingValue,
+            rootedPath,
+            repositoryName,
+            excludedPaths,
+            starlarkSemantics.getBool(BuildLanguageOptions.INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY)),
         /* additionalValuesToAggregate= */ ImmutableMap.of());
   }
 
@@ -254,7 +265,8 @@ public final class ProcessPackageDirectory {
       DirectoryListingValue dirListingValue,
       RootedPath rootedPath,
       RepositoryName repositoryName,
-      IgnoredSubdirectories excludedPaths) {
+      IgnoredSubdirectories excludedPaths,
+      boolean bazelExternalDirectory) {
     Root root = rootedPath.getRoot();
     PathFragment rootRelativePath = rootedPath.getRootRelativePath();
     boolean followSymlinks = shouldFollowSymlinksWhenTraversing(dirListingValue.getDirents());
@@ -273,8 +285,11 @@ public final class ProcessPackageDirectory {
       }
       String basename = dirent.getName();
       PathFragment subdirectory = rootRelativePath.getRelative(basename);
-      if (subdirectory.equals(LabelConstants.EXTERNAL_PACKAGE_NAME) && repositoryName.isMain()) {
-        // //external in the main repo is a reserved package name and never hosts subpackages.
+      if (!bazelExternalDirectory
+          && subdirectory.equals(LabelConstants.EXTERNAL_PACKAGE_NAME)
+          && repositoryName.isMain()) {
+        // Subpackages under //external in the main repo can be processed only when the execroot's
+        // external repository directory no longer occupies that path.
         continue;
       }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -1795,8 +1795,10 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
 
     StarlarkSemantics starlarkSemantics = getEffectiveStarlarkSemantics(buildLanguageOptions);
     setStarlarkSemantics(starlarkSemantics);
-    setSiblingDirectoryLayout(
-        starlarkSemantics.getBool(BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT));
+    setRepositoryLayout(
+        starlarkSemantics.getBool(BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT),
+        starlarkSemantics.getBool(
+            BuildLanguageOptions.INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY));
     setPackageLocator(pkgLocator);
     setLazyMacroExpansionPackages(packageOptions.getLazyMacroExpansionPackages());
     setStampSettingMarker();
@@ -1821,8 +1823,10 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     analysisCacheCleared = false;
   }
 
-  private void setSiblingDirectoryLayout(boolean experimentalSiblingRepositoryLayout) {
-    this.artifactFactory.setSiblingRepositoryLayout(experimentalSiblingRepositoryLayout);
+  private void setRepositoryLayout(
+      boolean experimentalSiblingRepositoryLayout, boolean bazelExternalDirectory) {
+    this.artifactFactory.setRepositoryLayout(
+        experimentalSiblingRepositoryLayout, bazelExternalDirectory);
   }
 
   public StarlarkSemantics getEffectiveStarlarkSemantics(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -1809,6 +1809,8 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
 
     StarlarkSemantics starlarkSemantics = getEffectiveStarlarkSemantics(buildLanguageOptions);
     setStarlarkSemantics(starlarkSemantics);
+    setRepositoryLayout(
+        starlarkSemantics.getBool(BuildLanguageOptions.INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY));
     setPackageLocator(pkgLocator);
     setLazyMacroExpansionPackages(packageOptions.getLazyMacroExpansionPackages());
     setStampSettingMarker();
@@ -1831,6 +1833,10 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     // Reset the stateful SkyframeCycleReporter, which contains cycles from last run.
     cyclesReporter = createCyclesReporter();
     analysisCacheCleared = false;
+  }
+
+  private void setRepositoryLayout(boolean bazelExternalDirectory) {
+    this.artifactFactory.setRepositoryLayout(bazelExternalDirectory);
   }
 
   public StarlarkSemantics getEffectiveStarlarkSemantics(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationFunction.java
@@ -81,6 +81,8 @@ public final class BuildConfigurationFunction implements SkyFunction {
               baselineOptions.orElse(null),
               starlarkSemantics.getBool(
                   BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT),
+              starlarkSemantics.getBool(
+                  BuildLanguageOptions.INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY),
               platformCpu,
               // Arguments below this are server-global.
               directories,

--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationFunction.java
@@ -30,12 +30,15 @@ import com.google.devtools.build.lib.analysis.platform.PlatformValue;
 import com.google.devtools.build.lib.analysis.test.TestConfiguration;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.RuleClassProvider;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
+import com.google.devtools.build.lib.skyframe.PrecomputedValue;
 import com.google.devtools.build.skyframe.SkyFunction;
 import com.google.devtools.build.skyframe.SkyFunctionException;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.StarlarkSemantics;
 
 /** A builder for {@link BuildConfigurationValue} instances. */
 public final class BuildConfigurationFunction implements SkyFunction {
@@ -54,6 +57,11 @@ public final class BuildConfigurationFunction implements SkyFunction {
   @Nullable
   public SkyValue compute(SkyKey skyKey, Environment env)
       throws InterruptedException, BuildConfigurationFunctionException {
+    StarlarkSemantics starlarkSemantics = PrecomputedValue.STARLARK_SEMANTICS.get(env);
+    if (starlarkSemantics == null) {
+      return null;
+    }
+
     BuildConfigurationKey key = (BuildConfigurationKey) skyKey.argument();
 
     BuildOptions targetOptions = key.getOptions();
@@ -72,6 +80,7 @@ public final class BuildConfigurationFunction implements SkyFunction {
           BuildConfigurationValue.create(
               targetOptions,
               baselineOptions.orElse(null),
+              starlarkSemantics.getBool(BuildLanguageOptions.INCOMPATIBLE_BAZEL_EXTERNAL_DIRECTORY),
               platformCpu,
               // Arguments below this are server-global.
               directories,

--- a/src/test/java/com/google/devtools/build/lib/buildtool/ConvenienceSymlinkTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/ConvenienceSymlinkTest.java
@@ -35,6 +35,7 @@ import com.google.devtools.build.lib.analysis.config.transitions.TransitionFacto
 import com.google.devtools.build.lib.analysis.util.MockRule;
 import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
 import com.google.devtools.build.lib.buildtool.util.TestRuleModule;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.exec.FileWriteStrategy;
@@ -801,6 +802,49 @@ public final class ConvenienceSymlinkTest extends BuildIntegrationTestCase {
     buildTarget("//target:target");
 
     assertThat(getWorkspace().getChild("prefix-genfiles").isSymbolicLink()).isTrue();
+  }
+
+  @Test
+  public void bazelExternalLink_presentWithIncompatibleFlag() throws Exception {
+    addOptions(
+        "--incompatible_bazel_external_directory",
+        "--symlink_prefix=prefix-");
+
+    write("target/BUILD", "basic_rule(name='target')");
+    buildTarget("//target:target");
+
+    assertThat(getConvenienceSymlinks())
+        .containsEntry(
+            "prefix-external",
+            getExecRoot().getRelative(LabelConstants.BAZEL_EXTERNAL_PATH_PREFIX));
+  }
+
+  @Test
+  public void bazelExternalLink_removedWithoutIncompatibleFlag() throws Exception {
+    addOptions("--symlink_prefix=prefix-");
+    Path externalLink = getWorkspace().getChild("prefix-external");
+    externalLink.createSymbolicLink(getExecRoot().getRelative("old-external"));
+
+    write("target/BUILD", "basic_rule(name='target')");
+    buildTarget("//target:target");
+
+    assertThat(externalLink.exists(Symlinks.NOFOLLOW)).isFalse();
+  }
+
+  @Test
+  public void bazelExternalLink_removedByClean() throws Exception {
+    addOptions(
+        "--incompatible_bazel_external_directory",
+        "--symlink_prefix=prefix-");
+
+    write("target/BUILD", "basic_rule(name='target')");
+    buildTarget("//target:target");
+    Path externalLink = getWorkspace().getChild("prefix-external");
+    assertThat(externalLink.isSymbolicLink()).isTrue();
+
+    clean();
+
+    assertThat(externalLink.exists(Symlinks.NOFOLLOW)).isFalse();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/buildtool/ConvenienceSymlinkTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/ConvenienceSymlinkTest.java
@@ -35,6 +35,7 @@ import com.google.devtools.build.lib.analysis.config.transitions.TransitionFacto
 import com.google.devtools.build.lib.analysis.util.MockRule;
 import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
 import com.google.devtools.build.lib.buildtool.util.TestRuleModule;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.exec.FileWriteStrategy;
 import com.google.devtools.build.lib.exec.ModuleActionContextRegistry;
@@ -797,6 +798,45 @@ public final class ConvenienceSymlinkTest extends BuildIntegrationTestCase {
     buildTarget("//target:target");
 
     assertThat(getWorkspace().getChild("prefix-genfiles").isSymbolicLink()).isTrue();
+  }
+
+  @Test
+  public void bazelExternalLink_presentWithIncompatibleFlag() throws Exception {
+    addOptions("--incompatible_bazel_external_directory", "--symlink_prefix=prefix-");
+
+    write("target/BUILD", "basic_rule(name='target')");
+    buildTarget("//target:target");
+
+    assertThat(getConvenienceSymlinks())
+        .containsEntry(
+            "prefix-external",
+            getExecRoot().getRelative(LabelConstants.BAZEL_EXTERNAL_PATH_PREFIX));
+  }
+
+  @Test
+  public void bazelExternalLink_removedWithoutIncompatibleFlag() throws Exception {
+    addOptions("--symlink_prefix=prefix-");
+    Path externalLink = getWorkspace().getChild("prefix-external");
+    externalLink.createSymbolicLink(getExecRoot().getRelative("old-external"));
+
+    write("target/BUILD", "basic_rule(name='target')");
+    buildTarget("//target:target");
+
+    assertThat(externalLink.exists(Symlinks.NOFOLLOW)).isFalse();
+  }
+
+  @Test
+  public void bazelExternalLink_removedByClean() throws Exception {
+    addOptions("--incompatible_bazel_external_directory", "--symlink_prefix=prefix-");
+
+    write("target/BUILD", "basic_rule(name='target')");
+    buildTarget("//target:target");
+    Path externalLink = getWorkspace().getChild("prefix-external");
+    assertThat(externalLink.isSymbolicLink()).isTrue();
+
+    clean();
+
+    assertThat(externalLink.exists(Symlinks.NOFOLLOW)).isFalse();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/buildtool/SymlinkForestTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/SymlinkForestTest.java
@@ -218,7 +218,12 @@ public class SymlinkForestTest {
     Path linkRoot = fileSystem.getPath("/linkRoot");
     linkRoot.createDirectoryAndParents();
     ImmutableList<Path> plantedSymlinks =
-        new SymlinkForest(packageRootMap, linkRoot, TestConstants.PRODUCT_NAME, false)
+        new SymlinkForest(
+                packageRootMap,
+                linkRoot,
+                TestConstants.PRODUCT_NAME,
+                /* siblingRepositoryLayout= */ false,
+                /* bazelExternalDirectory= */ false)
             .plantSymlinkForest();
 
     assertLinksTo(linkRoot, rootA, "pkgA");
@@ -258,7 +263,12 @@ public class SymlinkForestTest {
             .buildOrThrow();
 
     ImmutableList<Path> plantedSymlinks =
-        new SymlinkForest(packageRootMap, linkRoot, TestConstants.PRODUCT_NAME, false)
+        new SymlinkForest(
+                packageRootMap,
+                linkRoot,
+                TestConstants.PRODUCT_NAME,
+                /* siblingRepositoryLayout= */ false,
+                /* bazelExternalDirectory= */ false)
             .plantSymlinkForest();
     assertLinksTo(linkRoot, rootX, "file");
     assertThat(plantedSymlinks)
@@ -293,7 +303,12 @@ public class SymlinkForestTest {
             .build();
 
     ImmutableList<Path> plantedSymlinks =
-        new SymlinkForest(packageRootMap, linkRoot, TestConstants.PRODUCT_NAME, false)
+        new SymlinkForest(
+                packageRootMap,
+                linkRoot,
+                TestConstants.PRODUCT_NAME,
+                /* siblingRepositoryLayout= */ false,
+                /* bazelExternalDirectory= */ false)
             .plantSymlinkForest();
 
     assertLinksTo(linkRoot, mainRepo, "dir_main");
@@ -352,7 +367,12 @@ public class SymlinkForestTest {
             .build();
 
     ImmutableList<Path> plantedSymlinks =
-        new SymlinkForest(packageRootMap, linkRoot, TestConstants.PRODUCT_NAME, true)
+        new SymlinkForest(
+                packageRootMap,
+                linkRoot,
+                TestConstants.PRODUCT_NAME,
+                /* siblingRepositoryLayout= */ true,
+                /* bazelExternalDirectory= */ false)
             .plantSymlinkForest();
 
     // Expected sibling repository layout (X, Y and Z are siblings of ws_name):
@@ -416,7 +436,12 @@ public class SymlinkForestTest {
             .buildOrThrow();
 
     ImmutableList<Path> plantedSymlinks =
-        new SymlinkForest(packageRootMap, linkRoot, TestConstants.PRODUCT_NAME, false)
+        new SymlinkForest(
+                packageRootMap,
+                linkRoot,
+                TestConstants.PRODUCT_NAME,
+                /* siblingRepositoryLayout= */ false,
+                /* bazelExternalDirectory= */ false)
             .plantSymlinkForest();
 
     assertLinksTo(linkRoot, mainRepo, "dir1");
@@ -458,7 +483,12 @@ public class SymlinkForestTest {
             .build();
 
     ImmutableList<Path> plantedSymlinks =
-        new SymlinkForest(packageRootMap, linkRoot, TestConstants.PRODUCT_NAME, false)
+        new SymlinkForest(
+                packageRootMap,
+                linkRoot,
+                TestConstants.PRODUCT_NAME,
+                /* siblingRepositoryLayout= */ false,
+                /* bazelExternalDirectory= */ false)
             .plantSymlinkForest();
 
     assertLinksTo(linkRoot, mainRepo, "dir1");
@@ -498,7 +528,12 @@ public class SymlinkForestTest {
             .build();
 
     ImmutableList<Path> plantedSymlinks =
-        new SymlinkForest(packageRootMap, linkRoot, TestConstants.PRODUCT_NAME, false)
+        new SymlinkForest(
+                packageRootMap,
+                linkRoot,
+                TestConstants.PRODUCT_NAME,
+                /* siblingRepositoryLayout= */ false,
+                /* bazelExternalDirectory= */ false)
             .plantSymlinkForest();
 
     assertLinksTo(linkRoot, mainRepo, "dir1");
@@ -538,7 +573,12 @@ public class SymlinkForestTest {
             .build();
 
     ImmutableList<Path> plantedSymlinks =
-        new SymlinkForest(packageRootMap, linkRoot, TestConstants.PRODUCT_NAME, true)
+        new SymlinkForest(
+                packageRootMap,
+                linkRoot,
+                TestConstants.PRODUCT_NAME,
+                /* siblingRepositoryLayout= */ true,
+                /* bazelExternalDirectory= */ false)
             .plantSymlinkForest();
 
     // Expected output base layout with sibling repositories in the execroot where
@@ -606,7 +646,12 @@ public class SymlinkForestTest {
             .buildOrThrow();
 
     ImmutableList<Path> plantedSymlinks =
-        new SymlinkForest(packageRootMap, linkRoot, TestConstants.PRODUCT_NAME, true)
+        new SymlinkForest(
+                packageRootMap,
+                linkRoot,
+                TestConstants.PRODUCT_NAME,
+                /* siblingRepositoryLayout= */ true,
+                /* bazelExternalDirectory= */ false)
             .plantSymlinkForest();
 
     // Expected output base layout with sibling repositories in the execroot where
@@ -654,7 +699,12 @@ public class SymlinkForestTest {
             .build();
 
     ImmutableList<Path> plantedSymlinks =
-        new SymlinkForest(packageRootMap, linkRoot, TestConstants.PRODUCT_NAME, false)
+        new SymlinkForest(
+                packageRootMap,
+                linkRoot,
+                TestConstants.PRODUCT_NAME,
+                /* siblingRepositoryLayout= */ false,
+                /* bazelExternalDirectory= */ false)
             .plantSymlinkForest();
     assertThat(linkRoot.getRelative(LabelConstants.EXTERNAL_PATH_PREFIX).exists()).isFalse();
     assertThat(plantedSymlinks).isEmpty();

--- a/src/test/java/com/google/devtools/build/lib/cmdline/LabelTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/LabelTest.java
@@ -337,9 +337,10 @@ public class LabelTest {
   @Test
   public void testGetWorkspaceRoot() throws Exception {
     Label label = Label.parseCanonical("//bar/baz");
-    assertThat(label.getWorkspaceRootForStarlarkOnly()).isEmpty();
+    assertThat(label.getWorkspaceRootForStarlarkOnly(StarlarkSemantics.DEFAULT)).isEmpty();
     label = Label.parseCanonical("@repo//bar/baz");
-    assertThat(label.getWorkspaceRootForStarlarkOnly()).isEqualTo("external/repo");
+    assertThat(label.getWorkspaceRootForStarlarkOnly(StarlarkSemantics.DEFAULT))
+        .isEqualTo("external/repo");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryNameTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryNameTest.java
@@ -78,6 +78,37 @@ public class RepositoryNameTest {
   }
 
   @Test
+  public void getExecPath_bazelExternalDirectory() throws Exception {
+    RepositoryName repositoryName = RepositoryName.create("foo");
+
+    assertThat(repositoryName.getExecPath(false, false))
+        .isEqualTo(PathFragment.create("external/foo"));
+    assertThat(repositoryName.getExecPath(false, true))
+        .isEqualTo(PathFragment.create("bazel-external/foo"));
+    assertThat(repositoryName.getExecPath(true, true))
+        .isEqualTo(PathFragment.create("../foo"));
+  }
+
+  @Test
+  public void fromPathFragment_bazelExternalDirectory() {
+    var parsed =
+        RepositoryName.fromPathFragment(
+            PathFragment.create("bazel-external/foo/pkg/file"),
+            /* siblingRepositoryLayout= */ false,
+            /* bazelExternalDirectory= */ true);
+
+    assertThat(parsed).isNotNull();
+    assertThat(parsed.getFirst()).isEqualTo(RepositoryName.createUnvalidated("foo"));
+    assertThat(parsed.getSecond()).isEqualTo(PathFragment.create("pkg/file"));
+    assertThat(
+            RepositoryName.fromPathFragment(
+                PathFragment.create("external/foo/pkg/file"),
+                /* siblingRepositoryLayout= */ false,
+                /* bazelExternalDirectory= */ true))
+        .isNull();
+  }
+
+  @Test
   public void testGetDefaultCanonicalForm() throws Exception {
     assertThat(RepositoryName.create("").getCanonicalForm()).isEqualTo("");
     assertThat(RepositoryName.create("foo").getCanonicalForm()).isEqualTo("@@foo");

--- a/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryNameTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryNameTest.java
@@ -78,6 +78,30 @@ public class RepositoryNameTest {
   }
 
   @Test
+  public void getExecPath_bazelExternalDirectory() throws Exception {
+    RepositoryName repositoryName = RepositoryName.create("foo");
+
+    assertThat(repositoryName.getExecPath(false)).isEqualTo(PathFragment.create("external/foo"));
+    assertThat(repositoryName.getExecPath(true))
+        .isEqualTo(PathFragment.create("bazel-external/foo"));
+  }
+
+  @Test
+  public void fromPathFragment_bazelExternalDirectory() {
+    var parsed =
+        RepositoryName.fromPathFragment(
+            PathFragment.create("bazel-external/foo/pkg/file"), /* bazelExternalDirectory= */ true);
+
+    assertThat(parsed).isNotNull();
+    assertThat(parsed.getFirst()).isEqualTo(RepositoryName.createUnvalidated("foo"));
+    assertThat(parsed.getSecond()).isEqualTo(PathFragment.create("pkg/file"));
+    assertThat(
+            RepositoryName.fromPathFragment(
+                PathFragment.create("external/foo/pkg/file"), /* bazelExternalDirectory= */ true))
+        .isNull();
+  }
+
+  @Test
   public void testGetDefaultCanonicalForm() throws Exception {
     assertThat(RepositoryName.create("").getCanonicalForm()).isEqualTo("");
     assertThat(RepositoryName.create("foo").getCanonicalForm()).isEqualTo("@@foo");

--- a/src/test/java/com/google/devtools/build/lib/exec/SpawnLogReconstructorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SpawnLogReconstructorTest.java
@@ -34,6 +34,14 @@ public class SpawnLogReconstructorTest {
         .isEqualTo(new Result("some_repo", "pkg/file.txt"));
     assertThat(matchDefault("external/some-repo+/pkg/file.txt"))
         .isEqualTo(new Result("some-repo+", "pkg/file.txt"));
+    assertThat(matchDefault("bazel-external/some_repo/pkg/file.txt"))
+        .isEqualTo(new Result("some_repo", "pkg/file.txt"));
+    assertThat(matchDefault("bazel-external/some-repo+/pkg/file.txt"))
+        .isEqualTo(new Result("some-repo+", "pkg/file.txt"));
+    assertThat(matchDefault("blaze-external/some_repo/pkg/file.txt"))
+        .isEqualTo(new Result("some_repo", "pkg/file.txt"));
+    assertThat(matchDefault("blaze-external/some-repo+/pkg/file.txt"))
+        .isEqualTo(new Result("some-repo+", "pkg/file.txt"));
     assertThat(matchDefault(PRODUCT_NAME + "-out/k8-fastbuild/bin/pkg/file.txt"))
         .isEqualTo(new Result(null, "pkg/file.txt"));
     assertThat(matchDefault(PRODUCT_NAME + "-out/k8-fastbuild/bin/pkg/external/file.txt"))
@@ -42,6 +50,14 @@ public class SpawnLogReconstructorTest {
         .isEqualTo(new Result("some_repo", "pkg/file.txt"));
     assertThat(
             matchDefault(PRODUCT_NAME + "-out/k8-fastbuild/bin/external/some-repo+/pkg/file.txt"))
+        .isEqualTo(new Result("some-repo+", "pkg/file.txt"));
+    assertThat(
+            matchDefault(
+                PRODUCT_NAME + "-out/k8-fastbuild/bin/bazel-external/some_repo/pkg/file.txt"))
+        .isEqualTo(new Result("some_repo", "pkg/file.txt"));
+    assertThat(
+            matchDefault(
+                PRODUCT_NAME + "-out/k8-fastbuild/bin/blaze-external/some-repo+/pkg/file.txt"))
         .isEqualTo(new Result("some-repo+", "pkg/file.txt"));
   }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscoveryTest.java
@@ -126,6 +126,32 @@ public final class HeaderDiscoveryTest {
   }
 
   @Test
+  public void nonWindowsPlatform_resolvesBazelExternalSourcePath() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    RepositoryName repositoryName = RepositoryName.createUnvalidated("some_repo");
+    SourceArtifact resolvedArtifact = sourceArtifact("pkg/header.h");
+    PathFragment depPath = PathFragment.create("bazel-external/some_repo/pkg/header.h");
+    when(artifactResolver.resolveSourceArtifact(eq(depPath), eq(repositoryName)))
+        .thenReturn(resolvedArtifact);
+
+    NestedSet<Artifact> result =
+        HeaderDiscovery.discoverInputsFromDependencies(
+            nonWindowsAction(),
+            ActionsTestUtil.createArtifact(derivedArtifactRoot, derivedRoot.getRelative("foo.cc")),
+            /* shouldValidateInclusions= */ true,
+            ImmutableList.of(execRoot.getRelative(depPath)),
+            /* permittedSystemIncludePrefixes= */ ImmutableList.of(),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            execRoot,
+            artifactResolver,
+            /* siblingRepositoryLayout= */ false,
+            /* bazelExternalDirectory= */ true,
+            PathMapper.NOOP);
+
+    assertThat(result.toList()).containsExactly(resolvedArtifact);
+  }
+
+  @Test
   public void windowsPlatform_singleCaseInsensitiveMatch_addsToInputs() throws Exception {
     ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
     SourceArtifact resolvedArtifact = sourceArtifact("pkg/Include/BaseTsd.h");

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscoveryTest.java
@@ -126,6 +126,31 @@ public final class HeaderDiscoveryTest {
   }
 
   @Test
+  public void nonWindowsPlatform_resolvesBazelExternalSourcePath() throws Exception {
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    RepositoryName repositoryName = RepositoryName.createUnvalidated("some_repo");
+    SourceArtifact resolvedArtifact = sourceArtifact("pkg/header.h");
+    PathFragment depPath = PathFragment.create("bazel-external/some_repo/pkg/header.h");
+    when(artifactResolver.resolveSourceArtifact(eq(depPath), eq(repositoryName)))
+        .thenReturn(resolvedArtifact);
+
+    NestedSet<Artifact> result =
+        HeaderDiscovery.discoverInputsFromDependencies(
+            nonWindowsAction(),
+            ActionsTestUtil.createArtifact(derivedArtifactRoot, derivedRoot.getRelative("foo.cc")),
+            /* shouldValidateInclusions= */ true,
+            ImmutableList.of(execRoot.getRelative(depPath)),
+            /* permittedSystemIncludePrefixes= */ ImmutableList.of(),
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            execRoot,
+            artifactResolver,
+            /* bazelExternalDirectory= */ true,
+            PathMapper.NOOP);
+
+    assertThat(result.toList()).containsExactly(resolvedArtifact);
+  }
+
+  @Test
   public void windowsPlatform_singleCaseInsensitiveMatch_addsToInputs() throws Exception {
     ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
     SourceArtifact resolvedArtifact = sourceArtifact("pkg/Include/BaseTsd.h");

--- a/src/test/shell/bazel/execroot_test.sh
+++ b/src/test/shell/bazel/execroot_test.sh
@@ -143,6 +143,56 @@ EOF
 
 }
 
+function test_bazel_external_directory() {
+  mkdir -p external/foo other
+  cat > external/foo/BUILD <<'EOF'
+genrule(
+  name = "use-srcs",
+  srcs = ["BUILD"],
+  cmd = "cp $< $@",
+  outs = ["used-srcs"],
+)
+EOF
+  cat > other/MODULE.bazel <<'EOF'
+module(name = "other", version = "1.0")
+EOF
+  cat > other/BUILD <<'EOF'
+exports_files(["data.txt"])
+EOF
+  echo external-repository-data > other/data.txt
+  cat > MODULE.bazel <<'EOF'
+module(name = "main")
+bazel_dep(name = "other", version = "1.0")
+local_path_override(module_name = "other", path = "other")
+EOF
+  cat > BUILD <<'EOF'
+genrule(
+  name = "copy-external",
+  srcs = ["@other//:data.txt"],
+  cmd = "cp $< $@",
+  outs = ["copied.txt"],
+)
+EOF
+
+  bazel build --incompatible_bazel_external_directory \
+      //external/foo:use-srcs //:copy-external \
+      || fail "build failed"
+
+  execroot="$(bazel info --incompatible_bazel_external_directory execution_root)"
+  test -e "$execroot/external/foo/BUILD"
+  test -e "$execroot/bazel-external/other+/data.txt"
+  test ! -e "$execroot/external/other+/data.txt"
+  test -L bazel-external
+  [[ "$(readlink bazel-external)" == "$execroot/bazel-external" ]] \
+      || fail "bazel-external convenience symlink has the wrong target"
+
+  bazel build --noincompatible_bazel_external_directory //:copy-external \
+      || fail "build after disabling flag failed"
+  test -e "$execroot/external/other+/data.txt"
+  test ! -e "$execroot/bazel-external"
+  test ! -L bazel-external
+}
+
 function test_external_directory_globs() {
   mkdir -p external/a external/c
   echo file_ab > external/a/b

--- a/src/test/shell/bazel/execroot_test.sh
+++ b/src/test/shell/bazel/execroot_test.sh
@@ -96,4 +96,54 @@ EOF
 
 }
 
+function test_bazel_external_directory() {
+  mkdir -p external/foo other
+  cat > external/foo/BUILD <<'EOF'
+genrule(
+  name = "use-srcs",
+  srcs = ["BUILD"],
+  cmd = "cp $< $@",
+  outs = ["used-srcs"],
+)
+EOF
+  cat > other/MODULE.bazel <<'EOF'
+module(name = "other", version = "1.0")
+EOF
+  cat > other/BUILD <<'EOF'
+exports_files(["data.txt"])
+EOF
+  echo external-repository-data > other/data.txt
+  cat > MODULE.bazel <<'EOF'
+module(name = "main")
+bazel_dep(name = "other", version = "1.0")
+local_path_override(module_name = "other", path = "other")
+EOF
+  cat > BUILD <<'EOF'
+genrule(
+  name = "copy-external",
+  srcs = ["@other//:data.txt"],
+  cmd = "cp $< $@",
+  outs = ["copied.txt"],
+)
+EOF
+
+  bazel build --incompatible_bazel_external_directory \
+      //external/foo:use-srcs //:copy-external \
+      || fail "build failed"
+
+  execroot="$(bazel info --incompatible_bazel_external_directory execution_root)"
+  test -e "$execroot/external/foo/BUILD"
+  test -e "$execroot/bazel-external/other+/data.txt"
+  test ! -e "$execroot/external/other+/data.txt"
+  test -L bazel-external
+  [[ "$(readlink bazel-external)" == "$execroot/bazel-external" ]] \
+      || fail "bazel-external convenience symlink has the wrong target"
+
+  bazel build --noincompatible_bazel_external_directory //:copy-external \
+      || fail "build after disabling flag failed"
+  test -e "$execroot/external/other+/data.txt"
+  test ! -e "$execroot/bazel-external"
+  test ! -L bazel-external
+}
+
 run_suite "execution root tests"


### PR DESCRIPTION
This flag makes bazel build external repos in a bazel-external
subdirectory, and also creates a top level bazel-external symlink in the
project directory. This type of symlink is commonly created for
debugging binaries, where external code requires that path to exist at
debug time, and for compile_commands style tooling which require the
same paths that existed at compile time to exist for tooling.

This will require an incremental rollout since rulesets often hardcode
`external/` and will have to be updated to work with either.

RELNOTES[NEW]: Add `--incompatible_bazel_external_directory` for a top level `bazel-external` symlink. See https://github.com/bazelbuild/bazel/issues/30642 for details