### PR TITLE
[8.8.0] Add RepMaxCDC as a selectable remote cache chunking function

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloader.java
@@ -17,9 +17,11 @@ package com.google.devtools.build.lib.remote;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 
+import build.bazel.remote.execution.v2.ChunkingFunction;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.SplitBlobResponse;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.remote.chunking.ChunkingConfig;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.util.DigestOutputStream;
@@ -45,16 +47,19 @@ public class ChunkedBlobDownloader {
   private final CombinedCache combinedCache;
   private final DigestUtil digestUtil;
   private final boolean verifyDownloads;
+  private final ChunkingFunction.Value chunkingFunction;
 
   public ChunkedBlobDownloader(
       GrpcCacheClient grpcCacheClient,
       CombinedCache combinedCache,
+      ChunkingConfig chunkingConfig,
       DigestUtil digestUtil,
       boolean verifyDownloads) {
     this.grpcCacheClient = grpcCacheClient;
     this.combinedCache = combinedCache;
     this.digestUtil = digestUtil;
     this.verifyDownloads = verifyDownloads;
+    this.chunkingFunction = chunkingConfig.chunkingFunction();
   }
 
   /**
@@ -84,7 +89,7 @@ public class ChunkedBlobDownloader {
       return List.of();
     }
     ListenableFuture<SplitBlobResponse> splitResponseFuture =
-        grpcCacheClient.splitBlob(context, blobDigest);
+        grpcCacheClient.splitBlob(context, blobDigest, chunkingFunction);
     if (splitResponseFuture == null) {
       throw new CacheNotFoundException(blobDigest);
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobUploader.java
@@ -17,12 +17,13 @@ package com.google.devtools.build.lib.remote;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 
+import build.bazel.remote.execution.v2.ChunkingFunction;
 import build.bazel.remote.execution.v2.Digest;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.remote.chunking.ChunkingConfig;
-import com.google.devtools.build.lib.remote.chunking.FastCdcChunker;
+import com.google.devtools.build.lib.remote.chunking.ContentDefinedChunker;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.Blob;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
@@ -38,12 +39,12 @@ import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 
 /**
- * Uploads blobs in chunks using Content-Defined Chunking with FastCDC 2020.
+ * Uploads blobs in chunks using Content-Defined Chunking.
  *
  * <p>Upload flow for blobs above threshold:
  *
  * <ol>
- *   <li>Chunk file with FastCDC
+ *   <li>Chunk file with the configured chunking function
  *   <li>Call findMissingDigests on chunk digests
  *   <li>Upload only missing chunks
  *   <li>Call SpliceBlob to register the blob as the concatenation of chunks
@@ -57,7 +58,8 @@ public class ChunkedBlobUploader {
 
   private final GrpcCacheClient grpcCacheClient;
   private final CombinedCache combinedCache;
-  private final FastCdcChunker chunker;
+  private final ContentDefinedChunker chunker;
+  private final ChunkingFunction.Value chunkingFunction;
   private final long chunkingThreshold;
 
   /**
@@ -75,7 +77,8 @@ public class ChunkedBlobUploader {
       DigestUtil digestUtil) {
     this.grpcCacheClient = grpcCacheClient;
     this.combinedCache = combinedCache;
-    this.chunker = new FastCdcChunker(config, digestUtil);
+    this.chunker = config.newChunker(digestUtil);
+    this.chunkingFunction = config.chunkingFunction();
     this.chunkingThreshold = config.chunkingThreshold();
   }
 
@@ -85,9 +88,9 @@ public class ChunkedBlobUploader {
   }
 
   /**
-   * Uploads a blob in content-defined chunks. The file is chunked with FastCDC, missing chunks are
-   * uploaded, and {@code SpliceBlob} is called to register the blob as the concatenation of its
-   * chunks.
+   * Uploads a blob in content-defined chunks. The file is chunked with the configured chunking
+   * function, missing chunks are uploaded, and {@code SpliceBlob} is called to register the blob as
+   * the concatenation of its chunks.
    */
   public void uploadChunked(RemoteActionExecutionContext context, Digest blobDigest, Path file)
       throws IOException, InterruptedException {
@@ -102,7 +105,7 @@ public class ChunkedBlobUploader {
     ImmutableSet<Digest> missingDigests =
         getFromFuture(grpcCacheClient.findMissingDigests(context, chunkDigests));
     uploadMissingChunks(context, missingDigests, chunkDigests, file);
-    getFromFuture(grpcCacheClient.spliceBlob(context, blobDigest, chunkDigests));
+    getFromFuture(grpcCacheClient.spliceBlob(context, blobDigest, chunkDigests, chunkingFunction));
   }
 
   private void uploadMissingChunks(

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -25,6 +25,7 @@ import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.CacheCapabilities;
+import build.bazel.remote.execution.v2.ChunkingFunction;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.collect.ImmutableSet;
@@ -48,6 +49,7 @@ import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.Blob;
 import com.google.devtools.build.lib.remote.disk.DiskCacheClient;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.remote.options.RemoteOptions.ChunkingFunctionValue;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.RemoteExecution;
@@ -106,7 +108,7 @@ public class CombinedCache extends AbstractReferenceCounted {
   @Nullable protected final DiskCacheClient diskCacheClient;
   protected final RemoteOptions options;
   protected final DigestUtil digestUtil;
-  private final boolean chunkingEnabled;
+  @Nullable private final ChunkingFunctionValue chunkingFunction;
 
   // Delays the initialization of the chunking support logic until first use to avoid blocking on
   // a server capabilities check at construction time.
@@ -117,7 +119,7 @@ public class CombinedCache extends AbstractReferenceCounted {
     private volatile boolean initialized = false;
 
     boolean supported() throws IOException {
-      if (!chunkingEnabled) {
+      if (chunkingFunction == null) {
         return false;
       }
       if (!(remoteCacheClient instanceof GrpcCacheClient grpcClient)) {
@@ -125,11 +127,24 @@ public class CombinedCache extends AbstractReferenceCounted {
       }
       if (!initialized) {
         synchronized (this) {
-          config = ChunkingConfig.fromServerCapabilities(getRemoteServerCapabilities());
+          config =
+              switch (chunkingFunction) {
+                case AUTO -> ChunkingConfig.fromServerCapabilities(getRemoteServerCapabilities());
+                case FAST_CDC_2020 ->
+                    ChunkingConfig.fromServerCapabilities(
+                        getRemoteServerCapabilities(), ChunkingFunction.Value.FAST_CDC_2020);
+                case REP_MAX_CDC ->
+                    ChunkingConfig.fromServerCapabilities(
+                        getRemoteServerCapabilities(), ChunkingFunction.Value.REP_MAX_CDC);
+              };
           if (config != null) {
             downloader =
                 new ChunkedBlobDownloader(
-                    grpcClient, CombinedCache.this, digestUtil, options.remoteVerifyDownloads);
+                    grpcClient,
+                    CombinedCache.this,
+                    config,
+                    digestUtil,
+                    options.remoteVerifyDownloads);
             uploader = new ChunkedBlobUploader(grpcClient, CombinedCache.this, config, digestUtil);
           }
           initialized = true;
@@ -165,7 +180,7 @@ public class CombinedCache extends AbstractReferenceCounted {
     this.diskCacheClient = diskCacheClient;
     this.options = options;
     this.digestUtil = digestUtil;
-    this.chunkingEnabled = options.experimentalRemoteCacheChunking;
+    this.chunkingFunction = options.getEffectiveChunkingFunction();
   }
 
   public CacheCapabilities getRemoteCacheCapabilities() throws IOException {

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -181,7 +181,8 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
   public ListenableFuture<Void> spliceBlob(
       RemoteActionExecutionContext context,
       Digest blobDigest,
-      List<Digest> chunkDigests) {
+      List<Digest> chunkDigests,
+      ChunkingFunction.Value chunkingFunction) {
     if (!options.experimentalRemoteCacheChunking) {
       return null;
     }
@@ -191,7 +192,7 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
             .setBlobDigest(blobDigest)
             .addAllChunkDigests(chunkDigests)
             .setDigestFunction(digestUtil.getDigestFunction())
-            .setChunkingFunction(ChunkingFunction.Value.FAST_CDC_2020)
+            .setChunkingFunction(chunkingFunction)
             .build();
     return Futures.catchingAsync(
         Futures.transform(
@@ -216,7 +217,9 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
    */
   @Nullable
   public ListenableFuture<SplitBlobResponse> splitBlob(
-      RemoteActionExecutionContext context, Digest digest) {
+      RemoteActionExecutionContext context,
+      Digest digest,
+      ChunkingFunction.Value chunkingFunction) {
     if (!options.experimentalRemoteCacheChunking) {
       return null;
     }
@@ -225,7 +228,7 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
             .setInstanceName(options.remoteInstanceName)
             .setBlobDigest(digest)
             .setDigestFunction(digestUtil.getDigestFunction())
-            .setChunkingFunction(ChunkingFunction.Value.FAST_CDC_2020)
+            .setChunkingFunction(chunkingFunction)
             .build();
     return Futures.catchingAsync(
         Utils.refreshIfUnauthenticatedAsync(

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
@@ -257,10 +257,28 @@ class RemoteServerCapabilities {
               "--experimental_remote_cache_chunking requested but remote does not support"
                   + " SpliceBlob");
         }
-        if (!cacheCap.hasFastCdc2020Params()) {
-          result.addError(
-              "--experimental_remote_cache_chunking requested but remote does not support"
-                  + " FastCDC 2020 chunking algorithm");
+        switch (remoteOptions.experimentalRemoteCacheChunkingFunction) {
+          case AUTO -> {
+            if (!cacheCap.hasFastCdc2020Params() && !cacheCap.hasRepMaxCdcParams()) {
+              result.addError(
+                  "--experimental_remote_cache_chunking requested but remote does not support"
+                      + " any chunking algorithm supported by Bazel (FastCDC 2020 or RepMaxCDC)");
+            }
+          }
+          case FAST_CDC_2020 -> {
+            if (!cacheCap.hasFastCdc2020Params()) {
+              result.addError(
+                  "--experimental_remote_cache_chunking requested but remote does not support"
+                      + " FastCDC 2020 chunking algorithm");
+            }
+          }
+          case REP_MAX_CDC -> {
+            if (!cacheCap.hasRepMaxCdcParams()) {
+              result.addError(
+                  "--experimental_remote_cache_chunking requested but remote does not support"
+                      + " RepMaxCDC chunking algorithm");
+            }
+          }
         }
       }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/chunking/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/chunking/BUILD
@@ -15,7 +15,12 @@ java_library(
     name = "chunking",
     srcs = [
         "ChunkingConfig.java",
+        "ContentDefinedChunker.java",
         "FastCdcChunker.java",
+        "FastCdcChunkingConfig.java",
+        "GearTable.java",
+        "RepMaxCdcChunker.java",
+        "RepMaxCdcChunkingConfig.java",
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/remote/util:digest_utils",

--- a/src/main/java/com/google/devtools/build/lib/remote/chunking/ChunkingConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/chunking/ChunkingConfig.java
@@ -15,55 +15,84 @@
 package com.google.devtools.build.lib.remote.chunking;
 
 import build.bazel.remote.execution.v2.CacheCapabilities;
-import build.bazel.remote.execution.v2.FastCdc2020Params;
+import build.bazel.remote.execution.v2.ChunkingFunction;
 import build.bazel.remote.execution.v2.ServerCapabilities;
+import com.google.devtools.build.lib.remote.util.DigestUtil;
 import javax.annotation.Nullable;
 
-/** Configuration for content-defined chunking. All sizes are in bytes. */
-public record ChunkingConfig(int avgChunkSize, int normalizationLevel, int seed) {
+/**
+ * Configuration for content-defined chunking. All sizes are in bytes.
+ *
+ * <p>Each implementation corresponds to one of the chunking functions defined by the Remote
+ * Execution API and carries the parameters negotiated from the server capabilities.
+ */
+public sealed interface ChunkingConfig permits FastCdcChunkingConfig, RepMaxCdcChunkingConfig {
 
-  public static final int DEFAULT_AVG_CHUNK_SIZE = 512 * 1024;
-  public static final int DEFAULT_NORMALIZATION_LEVEL = 2;
-  public static final int DEFAULT_SEED = 0;
+  /** The chunking function this configuration applies to. */
+  ChunkingFunction.Value chunkingFunction();
 
-  public int minChunkSize() {
-    return avgChunkSize / 4;
-  }
+  /** The minimum size of a chunk. Only the last chunk of a blob may be smaller. */
+  int minChunkSize();
 
-  public int maxChunkSize() {
-    return avgChunkSize * 4;
-  }
+  /** The maximum size of a chunk. */
+  int maxChunkSize();
 
-  /** Blobs larger than this should be chunked. Equal to maxChunkSize(). */
-  public long chunkingThreshold() {
+  /**
+   * Blobs larger than this should be chunked. Always equal to {@link #maxChunkSize()}: anything
+   * above it splits into at least two chunks, while anything at or below it would come back as a
+   * single chunk, making chunking pointless. Implementations must not override this.
+   */
+  default long chunkingThreshold() {
     return maxChunkSize();
   }
 
-  public static ChunkingConfig defaults() {
-    return new ChunkingConfig(DEFAULT_AVG_CHUNK_SIZE, DEFAULT_NORMALIZATION_LEVEL, DEFAULT_SEED);
+  /** Creates a chunker that splits blobs according to this configuration. */
+  ContentDefinedChunker newChunker(DigestUtil digestUtil);
+
+  /**
+   * Returns a configuration negotiated from the server capabilities: FastCDC 2020 if the server
+   * advertises it, otherwise RepMaxCDC, or {@code null} if the server advertises neither.
+   *
+   * <p>FastCDC 2020 is preferred for backward compatibility, so that a fleet of clients with mixed
+   * versions keeps producing identical chunks against the same server.
+   */
+  @Nullable
+  static ChunkingConfig fromServerCapabilities(ServerCapabilities capabilities) {
+    ChunkingConfig config =
+        fromServerCapabilities(capabilities, ChunkingFunction.Value.FAST_CDC_2020);
+    if (config == null) {
+      config = fromServerCapabilities(capabilities, ChunkingFunction.Value.REP_MAX_CDC);
+    }
+    return config;
   }
 
+  /**
+   * Returns the configuration for the given chunking function based on the parameters advertised by
+   * the server, or {@code null} if the server does not support the function.
+   *
+   * <p>Advertised parameters that are out of the expected range are replaced with defaults.
+   */
   @Nullable
-  public static ChunkingConfig fromServerCapabilities(ServerCapabilities capabilities) {
+  static ChunkingConfig fromServerCapabilities(
+      ServerCapabilities capabilities, ChunkingFunction.Value chunkingFunction) {
     if (!capabilities.hasCacheCapabilities()) {
       return null;
     }
     CacheCapabilities cacheCap = capabilities.getCacheCapabilities();
 
-    if (!cacheCap.hasFastCdc2020Params()) {
-      return null;
+    switch (chunkingFunction) {
+      case FAST_CDC_2020 -> {
+        if (cacheCap.hasFastCdc2020Params()) {
+          return FastCdcChunkingConfig.fromParams(cacheCap.getFastCdc2020Params());
+        }
+      }
+      case REP_MAX_CDC -> {
+        if (cacheCap.hasRepMaxCdcParams()) {
+          return RepMaxCdcChunkingConfig.fromParams(cacheCap.getRepMaxCdcParams());
+        }
+      }
+      default -> {}
     }
-
-    FastCdc2020Params params = cacheCap.getFastCdc2020Params();
-    int avgSize = DEFAULT_AVG_CHUNK_SIZE;
-    long configAvgSize = params.getAvgChunkSizeBytes();
-    if (configAvgSize >= 1024
-        && configAvgSize <= 1024 * 1024
-        && (configAvgSize & (configAvgSize - 1)) == 0) {
-      avgSize = (int) configAvgSize;
-    }
-    int seed = params.getSeed();
-
-    return new ChunkingConfig(avgSize, DEFAULT_NORMALIZATION_LEVEL, seed);
+    return null;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/chunking/ContentDefinedChunker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/chunking/ContentDefinedChunker.java
@@ -1,0 +1,39 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote.chunking;
+
+import build.bazel.remote.execution.v2.Digest;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.io.InputStream;
+
+/** Splits a blob into content-defined chunks. */
+public interface ContentDefinedChunker {
+
+  /**
+   * Chunks a blob and returns the chunk digests in order.
+   *
+   * <p>This method is used for building MerkleTree entries for large files and for chunked uploads.
+   * It only returns the content digests; callers that need the raw chunk data can read it from the
+   * original (seekable) file using the chunk sizes, similar to how whole blobs work.
+   *
+   * <p>Chunking is deterministic: the same input always produces the same chunks for a given
+   * configuration.
+   *
+   * @throws IOException only if reading from {@code input} throws; chunking and digest computation
+   *     themselves do not perform any I/O
+   */
+  ImmutableList<Digest> chunkToDigests(InputStream input) throws IOException;
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/chunking/FastCdcChunker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/chunking/FastCdcChunker.java
@@ -17,11 +17,10 @@ package com.google.devtools.build.lib.remote.chunking;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import build.bazel.remote.execution.v2.Digest;
+import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * FastCDC 2020 implementation for splitting large blobs.
@@ -29,7 +28,7 @@ import java.util.List;
  * <p>This module implements the canonical FastCDC algorithm as described in the
  * [paper](https://ieeexplore.ieee.org/document/9055082) by Wen Xia, et al., in 2020.
  */
-public final class FastCdcChunker {
+public final class FastCdcChunker implements ContentDefinedChunker {
 
   // Masks for each of the desired number of bits, where 0 through 5 are unused.
   // The values for sizes 64 bytes through 128 kilo-bytes come from the C
@@ -66,77 +65,11 @@ public final class FastCdcChunker {
     0x0000d93777577000L, // 24: 16MB
     0x0000db3777577000L, // 25: unused except for NC 3
   };
-
-  // GEAR contains seemingly random numbers which are created by computing the MD5 digest of values
-  // from 0 to 255, using only the high 8 bytes of the 16-byte digest. This is the "gear hash"
-  // referred to in the FastCDC paper.
-  private static final long[] GEAR = {
-    0x3b5d3c7d207e37dcL, 0x784d68ba91123086L, 0xcd52880f882e7298L, 0xeacf8e4e19fdcca7L,
-    0xc31f385dfbd1632bL, 0x1d5f27001e25abe6L, 0x83130bde3c9ad991L, 0xc4b225676e9b7649L,
-    0xaa329b29e08eb499L, 0xb67fcbd21e577d58L, 0x0027baaada2acf6bL, 0xe3ef2d5ac73c2226L,
-    0x0890f24d6ed312b7L, 0xa809e036851d7c7eL, 0xf0a6fe5e0013d81bL, 0x1d026304452cec14L,
-    0x03864632648e248fL, 0xcdaacf3dcd92b9b4L, 0xf5e012e63c187856L, 0x8862f9d3821c00b6L,
-    0xa82f7338750f6f8aL, 0x1e583dc6c1cb0b6fL, 0x7a3145b69743a7f1L, 0xabb20fee404807ebL,
-    0xb14b3cfe07b83a5dL, 0xb9dc27898adb9a0fL, 0x3703f5e91baa62beL, 0xcf0bb866815f7d98L,
-    0x3d9867c41ea9dcd3L, 0x1be1fa65442bf22cL, 0x14300da4c55631d9L, 0xe698e9cbc6545c99L,
-    0x4763107ec64e92a5L, 0xc65821fc65696a24L, 0x76196c064822f0b7L, 0x485be841f3525e01L,
-    0xf652bc9c85974ff5L, 0xcad8352face9e3e9L, 0x2a6ed1dceb35e98eL, 0xc6f483badc11680fL,
-    0x3cfd8c17e9cf12f1L, 0x89b83c5e2ea56471L, 0xae665cfd24e392a9L, 0xec33c4e504cb8915L,
-    0x3fb9b15fc9fe7451L, 0xd7fd1fd1945f2195L, 0x31ade0853443efd8L, 0x255efc9863e1e2d2L,
-    0x10eab6008d5642cfL, 0x46f04863257ac804L, 0xa52dc42a789a27d3L, 0xdaaadf9ce77af565L,
-    0x6b479cd53d87febbL, 0x6309e2d3f93db72fL, 0xc5738ffbaa1ff9d6L, 0x6bd57f3f25af7968L,
-    0x67605486d90d0a4aL, 0xe14d0b9663bfbdaeL, 0xb7bbd8d816eb0414L, 0xdef8a4f16b35a116L,
-    0xe7932d85aaaffed6L, 0x08161cbae90cfd48L, 0x855507beb294f08bL, 0x91234ea6ffd399b2L,
-    0xad70cf4b2435f302L, 0xd289a97565bc2d27L, 0x8e558437ffca99deL, 0x96d2704b7115c040L,
-    0x0889bbcdfc660e41L, 0x5e0d4e67dc92128dL, 0x72a9f8917063ed97L, 0x438b69d409e016e3L,
-    0xdf4fed8a5d8a4397L, 0x00f41dcf41d403f7L, 0x4814eb038e52603fL, 0x9dafbacc58e2d651L,
-    0xfe2f458e4be170afL, 0x4457ec414df6a940L, 0x06e62f1451123314L, 0xbd1014d173ba92ccL,
-    0xdef318e25ed57760L, 0x9fea0de9dfca8525L, 0x459de1e76c20624bL, 0xaeec189617e2d666L,
-    0x126a2c06ab5a83cbL, 0xb1321532360f6132L, 0x65421503dbb40123L, 0x2d67c287ea089ab3L,
-    0x6c93bff5a56bd6b6L, 0x4ffb2036cab6d98dL, 0xce7b785b1be7ad4fL, 0xedb42ef6189fd163L,
-    0xdc905288703988f6L, 0x365f9c1d2c691884L, 0xc640583680d99bfeL, 0x3cd4624c07593ec6L,
-    0x7f1ea8d85d7c5805L, 0x014842d480b57149L, 0x0b649bcb5a828688L, 0xbcd5708ed79b18f0L,
-    0xe987c862fbd2f2f0L, 0x982731671f0cd82cL, 0xbaf13e8b16d8c063L, 0x8ea3109cbd951bbaL,
-    0xd141045bfb385cadL, 0x2acbc1a0af1f7d30L, 0xe6444d89df03bfdfL, 0xa18cc771b8188ff9L,
-    0x9834429db01c39bbL, 0x214add07fe086a1fL, 0x8f07c19b1f6b3ff9L, 0x56a297b1bf4ffe55L,
-    0x94d558e493c54fc7L, 0x40bfc24c764552cbL, 0x931a706f8a8520cbL, 0x32229d322935bd52L,
-    0x2560d0f5dc4fefafL, 0x9dbcc48355969bb6L, 0x0fd81c3985c0b56aL, 0xe03817e1560f2bdaL,
-    0xc1bb4f81d892b2d5L, 0xb0c4864f4e28d2d7L, 0x3ecc49f9d9d6c263L, 0x51307e99b52ba65eL,
-    0x8af2b688da84a752L, 0xf5d72523b91b20b6L, 0x6d95ff1ff4634806L, 0x562f21555458339aL,
-    0xc0ce47f889336346L, 0x487823e5089b40d8L, 0xe4727c7ebc6d9592L, 0x5a8f7277e94970baL,
-    0xfca2f406b1c8bb50L, 0x5b1f8a95f1791070L, 0xd304af9fc9028605L, 0x5440ab7fc930e748L,
-    0x312d25fbca2ab5a1L, 0x10f4a4b234a4d575L, 0x90301d55047e7473L, 0x3b6372886c61591eL,
-    0x293402b77c444e06L, 0x451f34a4d3e97dd7L, 0x3158d814d81bc57bL, 0x034942425b9bda69L,
-    0xe2032ff9e532d9bbL, 0x62ae066b8b2179e5L, 0x9545e10c2f8d71d8L, 0x7ff7483eb2d23fc0L,
-    0x00945fcebdc98d86L, 0x8764bbbe99b26ca2L, 0x1b1ec62284c0bfc3L, 0x58e0fcc4f0aa362bL,
-    0x5f4abefa878d458dL, 0xfd74ac2f9607c519L, 0xa4e3fb37df8cbfa9L, 0xbf697e43cac574e5L,
-    0x86f14a3f68f4cd53L, 0x24a23d076f1ce522L, 0xe725cd8048868cc8L, 0xbf3c729eb2464362L,
-    0xd8f6cd57b3cc1ed8L, 0x6329e52425541577L, 0x62aa688ad5ae1ac0L, 0x0a242566269bf845L,
-    0x168b1a4753aca74bL, 0xf789afefff2e7e3cL, 0x6c3362093b6fccdbL, 0x4ce8f50bd28c09b2L,
-    0x006a2db95ae8aa93L, 0x975b0d623c3d1a8cL, 0x18605d3935338c5bL, 0x5bb6f6136cad3c71L,
-    0x0f53a20701f8d8a6L, 0xab8c5ad2e7e93c67L, 0x40b5ac5127acaa29L, 0x8c7bf63c2075895fL,
-    0x78bd9f7e014a805cL, 0xb2c9e9f4f9c8c032L, 0xefd6049827eb91f3L, 0x2be459f482c16fbdL,
-    0xd92ce0c5745aaa8cL, 0x0aaa8fb298d965b9L, 0x2b37f92c6c803b15L, 0x8c54a5e94e0f0e78L,
-    0x95f9b6e90c0a3032L, 0xe7939faa436c7874L, 0xd16bfe8f6a8a40c9L, 0x44982b86263fd2faL,
-    0xe285fb39f984e583L, 0x779a8df72d7619d3L, 0xf2d79a8de8d5dd1eL, 0xd1037354d66684e2L,
-    0x004c82a4e668a8e5L, 0x31d40a7668b044e6L, 0xd70578538bd02c11L, 0xdb45431078c5f482L,
-    0x977121bb7f6a51adL, 0x73d5ccbd34eff8ddL, 0xe437a07d356e17cdL, 0x47b2782043c95627L,
-    0x9fb251413e41d49aL, 0xccd70b60652513d3L, 0x1c95b31e8a1b49b2L, 0xcae73dfd1bcb4c1bL,
-    0x34d98331b1f5b70fL, 0x784e39f22338d92fL, 0x18613d4a064df420L, 0xf1d8dae25f0bcebeL,
-    0x33f77c15ae855efcL, 0x3c88b3b912eb109cL, 0x956a2ec96bafeea5L, 0x1aa005b5e0ad0e87L,
-    0x5500d70527c4bb8eL, 0xe36c57196421cc44L, 0x13c4d286cc36ee39L, 0x5654a23d818b2a81L,
-    0x77b1dc13d161abdcL, 0x734f44de5f8d5eb5L, 0x60717e174a6c89a2L, 0xd47d9649266a211eL,
-    0x5b13a4322bb69e90L, 0xf7669609f8b5fc3cL, 0x21e6ac55bedcdac9L, 0x9b56b62b61166deaL,
-    0xf48f66b939797e9cL, 0x35f332f9c0e6ae9aL, 0xcc733f6a9a878db0L, 0x3da161e41cc108c2L,
-    0xb7d74ae535914d51L, 0x4d493b0b11d36469L, 0xce264d1dfba9741aL, 0xa9d1f2dc7436dc06L,
-    0x70738016604c2a27L, 0x231d36e96e93f3d5L, 0x7666881197838d19L, 0x4a2a83090aaad40cL,
-    0xf1e761591668b35dL, 0x7363236497f730a7L, 0x301080e37379dd4dL, 0x502dea2971827042L,
-    0xc2c5eb858f32625fL, 0x786afb9edfafbdffL, 0xdaee0d868490b2a4L, 0x617366b3268609f6L,
-    0xae0e35a0fe46173eL, 0xd1a07de93e824f11L, 0x079b8b115ea4cca8L, 0x93a99274558faebbL,
-    0xfb1e6e22e08a03b3L, 0xea635fdba3698dd0L, 0xcf53659328503a5cL, 0xcde3b31e6fd5d780L,
-    0x8e3e4221d3614413L, 0xef14d0d86bf1a22cL, 0xe1d830d3f16c5ddbL, 0xaabd2b2a451504e1L,
-  };
   // @formatter:on
+
+  // The Gear table used for the rolling hash, shared with the other chunking algorithms in this
+  // package. See GearTable for how it is derived.
+  private static final long[] GEAR = GearTable.GEAR;
 
   private static final long[] GEAR_LS = computeGearLs();
 
@@ -160,10 +93,10 @@ public final class FastCdcChunker {
   private final DigestUtil digestUtil;
 
   public FastCdcChunker(DigestUtil digestUtil) {
-    this(ChunkingConfig.defaults(), digestUtil);
+    this(FastCdcChunkingConfig.defaults(), digestUtil);
   }
 
-  public FastCdcChunker(ChunkingConfig config, DigestUtil digestUtil) {
+  public FastCdcChunker(FastCdcChunkingConfig config, DigestUtil digestUtil) {
     this(
         config.minChunkSize(),
         config.avgChunkSize(),
@@ -255,8 +188,9 @@ public final class FastCdcChunker {
    * <p>Note: We don't need the raw data here. We can read from the original file (seekable) when
    * uploading, similar to how whole blobs work.
    */
-  public List<Digest> chunkToDigests(InputStream input) throws IOException {
-    List<Digest> digests = new ArrayList<>();
+  @Override
+  public ImmutableList<Digest> chunkToDigests(InputStream input) throws IOException {
+    ImmutableList.Builder<Digest> digests = ImmutableList.builder();
 
     byte[] buf = new byte[maxSize * 2];
     int cursor = 0;
@@ -293,6 +227,6 @@ public final class FastCdcChunker {
       cursor += chunkLen;
     }
 
-    return digests;
+    return digests.build();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/chunking/FastCdcChunkingConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/chunking/FastCdcChunkingConfig.java
@@ -1,0 +1,70 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote.chunking;
+
+import build.bazel.remote.execution.v2.ChunkingFunction;
+import build.bazel.remote.execution.v2.FastCdc2020Params;
+import com.google.devtools.build.lib.remote.util.DigestUtil;
+
+/** Configuration for the FastCDC 2020 chunking function. All sizes are in bytes. */
+public record FastCdcChunkingConfig(int avgChunkSize, int normalizationLevel, int seed)
+    implements ChunkingConfig {
+
+  public static final int DEFAULT_AVG_CHUNK_SIZE = 512 * 1024;
+  public static final int DEFAULT_NORMALIZATION_LEVEL = 2;
+  public static final int DEFAULT_SEED = 0;
+
+  @Override
+  public ChunkingFunction.Value chunkingFunction() {
+    return ChunkingFunction.Value.FAST_CDC_2020;
+  }
+
+  @Override
+  public int minChunkSize() {
+    return avgChunkSize / 4;
+  }
+
+  @Override
+  public int maxChunkSize() {
+    return avgChunkSize * 4;
+  }
+
+  @Override
+  public ContentDefinedChunker newChunker(DigestUtil digestUtil) {
+    return new FastCdcChunker(this, digestUtil);
+  }
+
+  public static FastCdcChunkingConfig defaults() {
+    return new FastCdcChunkingConfig(
+        DEFAULT_AVG_CHUNK_SIZE, DEFAULT_NORMALIZATION_LEVEL, DEFAULT_SEED);
+  }
+
+  /**
+   * Creates a configuration from the parameters advertised by the server, replacing values outside
+   * the expected range with defaults.
+   */
+  static FastCdcChunkingConfig fromParams(FastCdc2020Params params) {
+    int avgSize = DEFAULT_AVG_CHUNK_SIZE;
+    long configAvgSize = params.getAvgChunkSizeBytes();
+    if (configAvgSize >= 1024
+        && configAvgSize <= 1024 * 1024
+        && (configAvgSize & (configAvgSize - 1)) == 0) {
+      avgSize = (int) configAvgSize;
+    }
+    int seed = params.getSeed();
+
+    return new FastCdcChunkingConfig(avgSize, DEFAULT_NORMALIZATION_LEVEL, seed);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/chunking/GearTable.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/chunking/GearTable.java
@@ -1,0 +1,98 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote.chunking;
+
+/**
+ * The Gear table shared by the content-defined chunking algorithms in this package.
+ *
+ * <p>{@link #GEAR} contains seemingly random numbers which are created by computing the MD5 digest
+ * of values from 0 to 255, using only the high 8 bytes of the 16-byte digest. This is the "gear
+ * hash" referred to in the FastCDC paper. The same table is used by RepMaxCDC, as implemented by <a
+ * href="https://github.com/buildbarn/go-cdc">buildbarn/go-cdc</a>.
+ */
+final class GearTable {
+
+  static final long[] GEAR = {
+    0x3b5d3c7d207e37dcL, 0x784d68ba91123086L, 0xcd52880f882e7298L, 0xeacf8e4e19fdcca7L,
+    0xc31f385dfbd1632bL, 0x1d5f27001e25abe6L, 0x83130bde3c9ad991L, 0xc4b225676e9b7649L,
+    0xaa329b29e08eb499L, 0xb67fcbd21e577d58L, 0x0027baaada2acf6bL, 0xe3ef2d5ac73c2226L,
+    0x0890f24d6ed312b7L, 0xa809e036851d7c7eL, 0xf0a6fe5e0013d81bL, 0x1d026304452cec14L,
+    0x03864632648e248fL, 0xcdaacf3dcd92b9b4L, 0xf5e012e63c187856L, 0x8862f9d3821c00b6L,
+    0xa82f7338750f6f8aL, 0x1e583dc6c1cb0b6fL, 0x7a3145b69743a7f1L, 0xabb20fee404807ebL,
+    0xb14b3cfe07b83a5dL, 0xb9dc27898adb9a0fL, 0x3703f5e91baa62beL, 0xcf0bb866815f7d98L,
+    0x3d9867c41ea9dcd3L, 0x1be1fa65442bf22cL, 0x14300da4c55631d9L, 0xe698e9cbc6545c99L,
+    0x4763107ec64e92a5L, 0xc65821fc65696a24L, 0x76196c064822f0b7L, 0x485be841f3525e01L,
+    0xf652bc9c85974ff5L, 0xcad8352face9e3e9L, 0x2a6ed1dceb35e98eL, 0xc6f483badc11680fL,
+    0x3cfd8c17e9cf12f1L, 0x89b83c5e2ea56471L, 0xae665cfd24e392a9L, 0xec33c4e504cb8915L,
+    0x3fb9b15fc9fe7451L, 0xd7fd1fd1945f2195L, 0x31ade0853443efd8L, 0x255efc9863e1e2d2L,
+    0x10eab6008d5642cfL, 0x46f04863257ac804L, 0xa52dc42a789a27d3L, 0xdaaadf9ce77af565L,
+    0x6b479cd53d87febbL, 0x6309e2d3f93db72fL, 0xc5738ffbaa1ff9d6L, 0x6bd57f3f25af7968L,
+    0x67605486d90d0a4aL, 0xe14d0b9663bfbdaeL, 0xb7bbd8d816eb0414L, 0xdef8a4f16b35a116L,
+    0xe7932d85aaaffed6L, 0x08161cbae90cfd48L, 0x855507beb294f08bL, 0x91234ea6ffd399b2L,
+    0xad70cf4b2435f302L, 0xd289a97565bc2d27L, 0x8e558437ffca99deL, 0x96d2704b7115c040L,
+    0x0889bbcdfc660e41L, 0x5e0d4e67dc92128dL, 0x72a9f8917063ed97L, 0x438b69d409e016e3L,
+    0xdf4fed8a5d8a4397L, 0x00f41dcf41d403f7L, 0x4814eb038e52603fL, 0x9dafbacc58e2d651L,
+    0xfe2f458e4be170afL, 0x4457ec414df6a940L, 0x06e62f1451123314L, 0xbd1014d173ba92ccL,
+    0xdef318e25ed57760L, 0x9fea0de9dfca8525L, 0x459de1e76c20624bL, 0xaeec189617e2d666L,
+    0x126a2c06ab5a83cbL, 0xb1321532360f6132L, 0x65421503dbb40123L, 0x2d67c287ea089ab3L,
+    0x6c93bff5a56bd6b6L, 0x4ffb2036cab6d98dL, 0xce7b785b1be7ad4fL, 0xedb42ef6189fd163L,
+    0xdc905288703988f6L, 0x365f9c1d2c691884L, 0xc640583680d99bfeL, 0x3cd4624c07593ec6L,
+    0x7f1ea8d85d7c5805L, 0x014842d480b57149L, 0x0b649bcb5a828688L, 0xbcd5708ed79b18f0L,
+    0xe987c862fbd2f2f0L, 0x982731671f0cd82cL, 0xbaf13e8b16d8c063L, 0x8ea3109cbd951bbaL,
+    0xd141045bfb385cadL, 0x2acbc1a0af1f7d30L, 0xe6444d89df03bfdfL, 0xa18cc771b8188ff9L,
+    0x9834429db01c39bbL, 0x214add07fe086a1fL, 0x8f07c19b1f6b3ff9L, 0x56a297b1bf4ffe55L,
+    0x94d558e493c54fc7L, 0x40bfc24c764552cbL, 0x931a706f8a8520cbL, 0x32229d322935bd52L,
+    0x2560d0f5dc4fefafL, 0x9dbcc48355969bb6L, 0x0fd81c3985c0b56aL, 0xe03817e1560f2bdaL,
+    0xc1bb4f81d892b2d5L, 0xb0c4864f4e28d2d7L, 0x3ecc49f9d9d6c263L, 0x51307e99b52ba65eL,
+    0x8af2b688da84a752L, 0xf5d72523b91b20b6L, 0x6d95ff1ff4634806L, 0x562f21555458339aL,
+    0xc0ce47f889336346L, 0x487823e5089b40d8L, 0xe4727c7ebc6d9592L, 0x5a8f7277e94970baL,
+    0xfca2f406b1c8bb50L, 0x5b1f8a95f1791070L, 0xd304af9fc9028605L, 0x5440ab7fc930e748L,
+    0x312d25fbca2ab5a1L, 0x10f4a4b234a4d575L, 0x90301d55047e7473L, 0x3b6372886c61591eL,
+    0x293402b77c444e06L, 0x451f34a4d3e97dd7L, 0x3158d814d81bc57bL, 0x034942425b9bda69L,
+    0xe2032ff9e532d9bbL, 0x62ae066b8b2179e5L, 0x9545e10c2f8d71d8L, 0x7ff7483eb2d23fc0L,
+    0x00945fcebdc98d86L, 0x8764bbbe99b26ca2L, 0x1b1ec62284c0bfc3L, 0x58e0fcc4f0aa362bL,
+    0x5f4abefa878d458dL, 0xfd74ac2f9607c519L, 0xa4e3fb37df8cbfa9L, 0xbf697e43cac574e5L,
+    0x86f14a3f68f4cd53L, 0x24a23d076f1ce522L, 0xe725cd8048868cc8L, 0xbf3c729eb2464362L,
+    0xd8f6cd57b3cc1ed8L, 0x6329e52425541577L, 0x62aa688ad5ae1ac0L, 0x0a242566269bf845L,
+    0x168b1a4753aca74bL, 0xf789afefff2e7e3cL, 0x6c3362093b6fccdbL, 0x4ce8f50bd28c09b2L,
+    0x006a2db95ae8aa93L, 0x975b0d623c3d1a8cL, 0x18605d3935338c5bL, 0x5bb6f6136cad3c71L,
+    0x0f53a20701f8d8a6L, 0xab8c5ad2e7e93c67L, 0x40b5ac5127acaa29L, 0x8c7bf63c2075895fL,
+    0x78bd9f7e014a805cL, 0xb2c9e9f4f9c8c032L, 0xefd6049827eb91f3L, 0x2be459f482c16fbdL,
+    0xd92ce0c5745aaa8cL, 0x0aaa8fb298d965b9L, 0x2b37f92c6c803b15L, 0x8c54a5e94e0f0e78L,
+    0x95f9b6e90c0a3032L, 0xe7939faa436c7874L, 0xd16bfe8f6a8a40c9L, 0x44982b86263fd2faL,
+    0xe285fb39f984e583L, 0x779a8df72d7619d3L, 0xf2d79a8de8d5dd1eL, 0xd1037354d66684e2L,
+    0x004c82a4e668a8e5L, 0x31d40a7668b044e6L, 0xd70578538bd02c11L, 0xdb45431078c5f482L,
+    0x977121bb7f6a51adL, 0x73d5ccbd34eff8ddL, 0xe437a07d356e17cdL, 0x47b2782043c95627L,
+    0x9fb251413e41d49aL, 0xccd70b60652513d3L, 0x1c95b31e8a1b49b2L, 0xcae73dfd1bcb4c1bL,
+    0x34d98331b1f5b70fL, 0x784e39f22338d92fL, 0x18613d4a064df420L, 0xf1d8dae25f0bcebeL,
+    0x33f77c15ae855efcL, 0x3c88b3b912eb109cL, 0x956a2ec96bafeea5L, 0x1aa005b5e0ad0e87L,
+    0x5500d70527c4bb8eL, 0xe36c57196421cc44L, 0x13c4d286cc36ee39L, 0x5654a23d818b2a81L,
+    0x77b1dc13d161abdcL, 0x734f44de5f8d5eb5L, 0x60717e174a6c89a2L, 0xd47d9649266a211eL,
+    0x5b13a4322bb69e90L, 0xf7669609f8b5fc3cL, 0x21e6ac55bedcdac9L, 0x9b56b62b61166deaL,
+    0xf48f66b939797e9cL, 0x35f332f9c0e6ae9aL, 0xcc733f6a9a878db0L, 0x3da161e41cc108c2L,
+    0xb7d74ae535914d51L, 0x4d493b0b11d36469L, 0xce264d1dfba9741aL, 0xa9d1f2dc7436dc06L,
+    0x70738016604c2a27L, 0x231d36e96e93f3d5L, 0x7666881197838d19L, 0x4a2a83090aaad40cL,
+    0xf1e761591668b35dL, 0x7363236497f730a7L, 0x301080e37379dd4dL, 0x502dea2971827042L,
+    0xc2c5eb858f32625fL, 0x786afb9edfafbdffL, 0xdaee0d868490b2a4L, 0x617366b3268609f6L,
+    0xae0e35a0fe46173eL, 0xd1a07de93e824f11L, 0x079b8b115ea4cca8L, 0x93a99274558faebbL,
+    0xfb1e6e22e08a03b3L, 0xea635fdba3698dd0L, 0xcf53659328503a5cL, 0xcde3b31e6fd5d780L,
+    0x8e3e4221d3614413L, 0xef14d0d86bf1a22cL, 0xe1d830d3f16c5ddbL, 0xaabd2b2a451504e1L,
+  };
+
+  /** The number of bytes of input data that are covered by the Gear rolling hash function. */
+  static final int GEAR_HASH_WINDOW_SIZE = 64;
+
+  private GearTable() {}
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/chunking/RepMaxCdcChunker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/chunking/RepMaxCdcChunker.java
@@ -1,0 +1,530 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote.chunking;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import build.bazel.remote.execution.v2.Digest;
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.remote.util.DigestUtil;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * RepMaxCDC implementation for splitting large blobs.
+ *
+ * <p>This module implements the RepMaxCDC algorithm as specified by the reference implementation in
+ * <a href="https://github.com/buildbarn/go-cdc">buildbarn/go-cdc</a>. RepMaxCDC expands upon
+ * MaxCDC, in that it repeatedly applies the chunking process until all chunks are within {@code
+ * [minChunkSize, 2 * minChunkSize)} in size.
+ *
+ * <p>Cutting points are selected where the Gear rolling hash (a 64-byte window over the input) is
+ * strictly maximal within a lookahead window. The size of the lookahead window is controlled by the
+ * horizon size. Unlike FastCDC's maximum chunk size, the horizon size only denotes the quality of
+ * the chunking that is performed: setting it to zero leads to uniform chunks of {@code
+ * minChunkSize}, while setting it to a positive value {@code n} means that an optimal cutting point
+ * within offsets {@code [minChunkSize, minChunkSize + n]} will always be respected. The horizon
+ * size can be increased freely without reducing quality, though with diminishing returns.
+ *
+ * <p>The advantage of RepMaxCDC over FastCDC is that the bounds on the chunk size are tight: for a
+ * given input it is trivial to check whether it is already chunked, purely by looking at its size.
+ * It has been observed that RepMaxCDC provides a rate of deduplication that is comparable to
+ * FastCDC.
+ *
+ * <p>All chunks are within {@code [minChunkSize, 2 * minChunkSize)} in size, except for the last
+ * chunk of the input, which may be smaller than {@code minChunkSize} only if the entire input is.
+ *
+ * <p>Chunk boundaries produced by this implementation are identical to those produced by the Go
+ * reference implementation for the same parameters, which is required for clients and servers to
+ * benefit from each other's chunk data.
+ *
+ * <p>Implementation notes: this is a port of the optimized implementation in buildbarn/go-cdc
+ * ({@code rep_max_content_defined_chunker.go}), which hashes every input byte exactly once by
+ * carrying cutting point candidates and rolling hash state across chunks. Because the Gear hash at
+ * a given position only depends on the 64 bytes preceding it, hash values are independent of chunk
+ * boundaries and can be reused. The naive version of the algorithm ({@code
+ * NewSimpleRepMaxContentDefinedChunker} in go-cdc) rehashes the full lookahead window for every
+ * chunk, which makes it several times slower than FastCDC.
+ */
+public final class RepMaxCdcChunker implements ContentDefinedChunker {
+
+  private final int minSize;
+  // The amount of data that must be available (unless the end of the input has been reached) to
+  // determine the next chunk boundary: 2 * minSize + horizonSize. An optimal cutting point is
+  // searched within the horizonSize bytes following the earliest possible cutting point at
+  // minSize, and a further minSize bytes are left behind so that the final chunk of the input is
+  // at least minSize in size as well.
+  private final int peekSize;
+  private final DigestUtil digestUtil;
+
+  public RepMaxCdcChunker(DigestUtil digestUtil) {
+    this(RepMaxCdcChunkingConfig.defaults(), digestUtil);
+  }
+
+  public RepMaxCdcChunker(RepMaxCdcChunkingConfig config, DigestUtil digestUtil) {
+    this(config.minChunkSize(), config.horizonSize(), digestUtil);
+  }
+
+  /**
+   * Creates a chunker producing chunks of {@code [minSize, 2 * minSize)} bytes.
+   *
+   * @param minSize the minimum chunk size in bytes; must be at least the Gear hash window size (64
+   *     bytes)
+   * @param horizonSize the lookahead window in bytes used to find optimal cutting points; must not
+   *     be negative
+   * @throws IllegalArgumentException if the parameters are out of range
+   */
+  public RepMaxCdcChunker(int minSize, int horizonSize, DigestUtil digestUtil) {
+    checkArgument(
+        minSize >= GearTable.GEAR_HASH_WINDOW_SIZE,
+        "minSize must be at least %s, got %s",
+        GearTable.GEAR_HASH_WINDOW_SIZE,
+        minSize);
+    checkArgument(horizonSize >= 0, "horizonSize must not be negative, got %s", horizonSize);
+    // The read buffer is sized at twice the peek size, so make sure that fits in an int.
+    checkArgument(
+        2L * minSize + horizonSize <= Integer.MAX_VALUE / 2,
+        "2 * minSize + horizonSize must be at most %s, got %s",
+        Integer.MAX_VALUE / 2,
+        2L * minSize + horizonSize);
+
+    this.minSize = minSize;
+    this.peekSize = 2 * minSize + horizonSize;
+    this.digestUtil = digestUtil;
+  }
+
+  /**
+   * Chunks a blob and returns chunk digests.
+   *
+   * <p>This method is used for building MerkleTree entries for large files. It returns the content
+   * digests in order for each chunk.
+   *
+   * <p>Note: We don't need the raw data here. We can read from the original file (seekable) when
+   * uploading, similar to how whole blobs work.
+   */
+  @Override
+  public ImmutableList<Digest> chunkToDigests(InputStream input) throws IOException {
+    ImmutableList.Builder<Digest> digests = ImmutableList.builder();
+
+    ChunkingSession session = new ChunkingSession(input);
+    while (true) {
+      int chunkSize = session.nextChunkSize();
+      if (chunkSize == 0) {
+        break;
+      }
+      digests.add(digestUtil.compute(session.buffer(), session.chunkOffset(), chunkSize));
+    }
+
+    return digests.build();
+  }
+
+  /**
+   * The chunking state for a single input stream.
+   *
+   * <p>This is a port of {@code repMaxContentDefinedChunker.ReadNextChunk()} from buildbarn/go-cdc
+   * on top of a sliding read buffer, and mirrors its structure closely. Comments are largely taken
+   * from the Go implementation.
+   */
+  private final class ChunkingSession {
+    private final InputStream input;
+    private final byte[] buf = new byte[peekSize * 2];
+    private int bufStart = 0;
+    private int bufEnd = 0;
+    private boolean eof = false;
+
+    // The size of the previous chunk returned by nextChunkSize(). This amount of data will be
+    // discarded from the buffer at the start of the next call to nextChunkSize().
+    private int previousChunkSize = 0;
+
+    // List of chunks for which no future data can influence their length. For each chunk, its
+    // size is stored. Chunks are stored in reverse order, so that they can be popped from the
+    // end.
+    private final IntList completeChunks = new IntList();
+
+    // List of cutting points that will determine the length of future chunks. The hashes at the
+    // positions of the cutting points in this list will be strictly monotonically increasing.
+    //
+    // Cutting points are addressed relative to the first eligible position at which they may be
+    // placed (i.e., the end of the last complete chunk, plus the minimum chunk size). This means
+    // that the first entry is always equal to zero.
+    //
+    // Even though this list can grow to become proportional to the size of the horizon, this is
+    // highly unlikely. As we progress, it becomes increasingly harder to find even more
+    // preferable cutting points within the minimum chunk size.
+    private final IntList incompleteChunks = new IntList();
+
+    // The rolling hash value corresponding to the position up to where input data has been
+    // processed.
+    private long currentHash;
+
+    // The rolling hash value corresponding to the position of the last incomplete chunk. Any new
+    // incomplete chunk must have a hash value that is higher than this one.
+    private long bestHash;
+
+    ChunkingSession(InputStream input) {
+      this.input = input;
+    }
+
+    byte[] buffer() {
+      return buf;
+    }
+
+    int chunkOffset() {
+      return bufStart;
+    }
+
+    /**
+     * Makes up to {@code n} bytes available at {@link #bufStart} and returns how many of them are
+     * available, which is only less than {@code n} at the end of the input.
+     */
+    private int peek(int n) throws IOException {
+      int available = bufEnd - bufStart;
+      if (available < n && !eof) {
+        if (bufStart > 0 && available > 0) {
+          System.arraycopy(buf, bufStart, buf, 0, available);
+        }
+        bufStart = 0;
+        bufEnd = available;
+
+        while (bufEnd < buf.length) {
+          int read = input.read(buf, bufEnd, buf.length - bufEnd);
+          if (read == -1) {
+            eof = true;
+            break;
+          }
+          bufEnd += read;
+        }
+        available = bufEnd - bufStart;
+      }
+      return Math.min(n, available);
+    }
+
+    /**
+     * Returns the size of the next chunk, whose data is available in {@link #buffer()} at {@link
+     * #chunkOffset()}, or zero at the end of the input.
+     */
+    int nextChunkSize() throws IOException {
+      // Discard data that was handed out by the previous call.
+      bufStart += previousChunkSize;
+      previousChunkSize = 0;
+
+      // If the previous iteration yielded multiple chunks, we can return them without peeking the
+      // full horizon.
+      if (!completeChunks.isEmpty()) {
+        int firstChunk = completeChunks.popLast();
+        checkState(peek(firstChunk) == firstChunk, "complete chunk no longer buffered");
+        previousChunkSize = firstChunk;
+        return firstChunk;
+      }
+
+      // Gain access to the data corresponding to the next chunk(s). If we're reaching the end of
+      // the input, either consume all data or leave at least minSize bytes behind. This ensures
+      // that all chunks of the file are at least minSize in size, assuming the file is as well.
+      int dLen = peek(peekSize);
+      if (dLen < 2 * minSize) {
+        if (dLen == 0) {
+          return 0;
+        }
+        previousChunkSize = dLen;
+        return dLen;
+      }
+      dLen -= minSize;
+
+      long[] gear = GearTable.GEAR;
+      int base = bufStart;
+
+      // Extract the last incomplete chunk from the list, as it denotes where the previous call
+      // stopped hashing the input. incompleteChunks takes over the role of the Go
+      // implementation's oldChunks from here on.
+      int currentChunk;
+      long hash;
+      long best;
+      if (incompleteChunks.size() >= 2) {
+        currentChunk = incompleteChunks.popLast();
+        hash = currentHash;
+        best = bestHash;
+      } else {
+        // This is the very first chunk. We know that the first minSize positions can't contain a
+        // cut. Skip them.
+        incompleteChunks.clear();
+        incompleteChunks.add(0);
+        hash = 0;
+        for (int i = minSize - GearTable.GEAR_HASH_WINDOW_SIZE; i < minSize; i++) {
+          hash = (hash << 1) + gear[buf[base + i] & 0xFF];
+        }
+        best = hash;
+        currentChunk = 0;
+      }
+
+      // The position of the next byte to hash, relative to the start of the peeked data.
+      int pos = minSize + currentChunk;
+      while (true) {
+        // Start hashing data where the previous call left off. Stop hashing before the distance
+        // between two consecutive potential cutting points becomes minSize in size, as this
+        // allows us to complete a chunk.
+        int hashRegionLen = dLen - pos;
+        int originalChunkCount = -1;
+        int bytesBeforeMinChunkSize = incompleteChunks.last() + minSize - 1 - currentChunk;
+        if (hashRegionLen > bytesBeforeMinChunkSize) {
+          hashRegionLen = bytesBeforeMinChunkSize;
+          originalChunkCount = incompleteChunks.size();
+        } else if (hashRegionLen == 0) {
+          break;
+        }
+
+        // Preserve all offsets at which the hash increases. Hash values are compared as unsigned
+        // 64-bit integers, matching the Go reference implementation.
+        //
+        // The Gear hash recurrence is linear, so the hashes of the next four positions can all be
+        // computed directly from the hash at the block start: h(i+k) = (hash << k) + s(k), where
+        // s(k) is the Gear sum of the k block bytes. This shortens the serial dependency chain
+        // from one shift+add per byte to one per four bytes; the rest is independent work. The
+        // unroll factor is an empirical optimum: at two-way the dependency chain still dominates,
+        // while eight-way measured slower than four-way due to register pressure.
+        int idx = 0;
+        for (int p = base + pos; idx + 4 <= hashRegionLen; idx += 4, p += 4) {
+          long s1 = gear[buf[p] & 0xFF];
+          long s2 = (s1 << 1) + gear[buf[p + 1] & 0xFF];
+          long s3 = (s2 << 1) + gear[buf[p + 2] & 0xFF];
+          long s4 = (s3 << 1) + gear[buf[p + 3] & 0xFF];
+          long h1 = (hash << 1) + s1;
+          long h2 = (hash << 2) + s2;
+          long h3 = (hash << 3) + s3;
+          long h4 = (hash << 4) + s4;
+          hash = h4;
+          if (Long.compareUnsigned(best, h1) < 0) {
+            best = h1;
+            incompleteChunks.add(currentChunk + idx + 1);
+          }
+          if (Long.compareUnsigned(best, h2) < 0) {
+            best = h2;
+            incompleteChunks.add(currentChunk + idx + 2);
+          }
+          if (Long.compareUnsigned(best, h3) < 0) {
+            best = h3;
+            incompleteChunks.add(currentChunk + idx + 3);
+          }
+          if (Long.compareUnsigned(best, h4) < 0) {
+            best = h4;
+            incompleteChunks.add(currentChunk + idx + 4);
+          }
+        }
+        for (; idx < hashRegionLen; idx++) {
+          hash = (hash << 1) + gear[buf[base + pos + idx] & 0xFF];
+          if (Long.compareUnsigned(best, hash) < 0) {
+            best = hash;
+            incompleteChunks.add(currentChunk + idx + 1);
+          }
+        }
+
+        if (incompleteChunks.size() == originalChunkCount) {
+          // The loop above did not yield any new cutting points, and the next byte is minSize
+          // away from the last cutting point. This means we can complete all chunks up to this
+          // point.
+          int previousCompleteChunkCount = completeChunks.size();
+          int nextChunk = incompleteChunks.last();
+          for (int i = incompleteChunks.size() - 3; nextChunk >= minSize; i--) {
+            int chunk = incompleteChunks.get(i);
+            if (nextChunk - chunk >= minSize) {
+              completeChunks.add(nextChunk - chunk);
+              nextChunk = chunk;
+              i--;
+            }
+          }
+          completeChunks.add(minSize + nextChunk);
+          completeChunks.reverse(previousCompleteChunkCount, completeChunks.size());
+
+          incompleteChunks.truncate(1);
+          currentChunk = 0;
+          hash = (hash << 1) + gear[buf[base + pos + hashRegionLen] & 0xFF];
+          best = hash;
+          pos += hashRegionLen + 1;
+        } else {
+          currentChunk += hashRegionLen;
+          pos += hashRegionLen;
+        }
+      }
+
+      // Processed the full horizon. Return the first chunk.
+      incompleteChunks.add(currentChunk);
+      int firstChunk;
+      if (!completeChunks.isEmpty()) {
+        completeChunks.reverse(0, completeChunks.size());
+        firstChunk = completeChunks.popLast();
+      } else {
+        // The process above did not yield any complete chunks, either because we reached the end
+        // of the file or the horizon size wasn't large enough.
+        //
+        // Ensure that we pick a cutting point respecting the maximum chunk size, that still
+        // allows us to pick the most optimal cutting point in the horizon later on.
+        int firstChunkIndex = incompleteChunks.size() - 2;
+        for (int maxChunk = incompleteChunks.get(firstChunkIndex) - minSize,
+                i = firstChunkIndex - 2;
+            maxChunk >= 0;
+            i--) {
+          int chunk = incompleteChunks.get(i);
+          if (chunk <= maxChunk) {
+            firstChunkIndex = i;
+            maxChunk = chunk - minSize;
+            i--;
+          }
+        }
+        firstChunk = minSize + incompleteChunks.get(firstChunkIndex);
+
+        // There will be potential cutting points after the selected one that are no longer
+        // eligible, as those would violate the minimum chunk size. These should be removed from
+        // the list.
+        int reusableChunkIndex = firstChunkIndex + 1;
+        while (true) {
+          int offsetInSecondChunk = incompleteChunks.get(reusableChunkIndex) - firstChunk;
+          if (offsetInSecondChunk >= 0) {
+            // This cutting point and the ones after it should be kept.
+            for (int i = reusableChunkIndex; i < incompleteChunks.size(); i++) {
+              incompleteChunks.set(i, incompleteChunks.get(i) - firstChunk);
+            }
+
+            if (offsetInSecondChunk == 0) {
+              // There is no need to recompute any cutting points.
+              incompleteChunks.removePrefix(reusableChunkIndex);
+            } else {
+              // Because the first cutting point to keep resides at an offset beyond the minimum
+              // chunk size, we may have glossed over potential cutting points before it.
+              // Recompute these.
+              //
+              // This should only happen rarely, especially if the horizon size is sufficiently
+              // large.
+              int regionStart = base + firstChunk;
+              long recomputedHash = 0;
+              for (int i = minSize - GearTable.GEAR_HASH_WINDOW_SIZE; i < minSize; i++) {
+                recomputedHash = (recomputedHash << 1) + gear[buf[regionStart + i] & 0xFF];
+              }
+              incompleteChunks.set(0, 0);
+              long bestRecomputedHash = recomputedHash;
+              int recomputedChunkIndex = 1;
+              int originalChunksCount = incompleteChunks.size();
+              for (int i = 0; i < offsetInSecondChunk - 1; i++) {
+                recomputedHash =
+                    (recomputedHash << 1) + gear[buf[regionStart + minSize + i] & 0xFF];
+                if (Long.compareUnsigned(bestRecomputedHash, recomputedHash) < 0) {
+                  bestRecomputedHash = recomputedHash;
+                  int recomputedChunk = i + 1;
+                  if (recomputedChunkIndex < reusableChunkIndex) {
+                    incompleteChunks.set(recomputedChunkIndex, recomputedChunk);
+                    recomputedChunkIndex++;
+                  } else {
+                    incompleteChunks.add(recomputedChunk);
+                  }
+                }
+              }
+              if (recomputedChunkIndex < reusableChunkIndex) {
+                // Recomputing yielded fewer cutting points than we had previously. Make the
+                // cutting points contiguous again.
+                incompleteChunks.removeRange(recomputedChunkIndex, reusableChunkIndex);
+              } else if (incompleteChunks.size() > originalChunksCount) {
+                // Recomputing yielded more cutting points than we had previously. The excess
+                // cutting points were stored at the end. Rotate them into place, so that the
+                // list remains sorted.
+                incompleteChunks.reverse(reusableChunkIndex, originalChunksCount);
+                incompleteChunks.reverse(originalChunksCount, incompleteChunks.size());
+                incompleteChunks.reverse(reusableChunkIndex, incompleteChunks.size());
+              }
+            }
+            break;
+          }
+
+          // The cutting point should be removed.
+          reusableChunkIndex++;
+          if (reusableChunkIndex == incompleteChunks.size()) {
+            incompleteChunks.truncate(1);
+            break;
+          }
+        }
+      }
+      previousChunkSize = firstChunk;
+      currentHash = hash;
+      bestHash = best;
+      return firstChunk;
+    }
+  }
+
+  /** A minimal growable list of ints, to avoid boxing on the chunking path. */
+  private static final class IntList {
+    private int[] elements = new int[32];
+    private int size = 0;
+
+    int size() {
+      return size;
+    }
+
+    boolean isEmpty() {
+      return size == 0;
+    }
+
+    int get(int index) {
+      return elements[index];
+    }
+
+    void set(int index, int value) {
+      elements[index] = value;
+    }
+
+    int last() {
+      return elements[size - 1];
+    }
+
+    void add(int value) {
+      if (size == elements.length) {
+        int[] grown = new int[elements.length * 2];
+        System.arraycopy(elements, 0, grown, 0, size);
+        elements = grown;
+      }
+      elements[size++] = value;
+    }
+
+    int popLast() {
+      return elements[--size];
+    }
+
+    void clear() {
+      size = 0;
+    }
+
+    void truncate(int newSize) {
+      size = newSize;
+    }
+
+    /** Removes the first {@code count} elements, shifting the rest to the front. */
+    void removePrefix(int count) {
+      System.arraycopy(elements, count, elements, 0, size - count);
+      size -= count;
+    }
+
+    /** Removes the elements in {@code [from, to)}, shifting later elements down. */
+    void removeRange(int from, int to) {
+      System.arraycopy(elements, to, elements, from, size - to);
+      size -= to - from;
+    }
+
+    /** Reverses the elements in {@code [from, to)}. */
+    void reverse(int from, int to) {
+      for (int i = from, j = to - 1; i < j; i++, j--) {
+        int tmp = elements[i];
+        elements[i] = elements[j];
+        elements[j] = tmp;
+      }
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/chunking/RepMaxCdcChunkingConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/chunking/RepMaxCdcChunkingConfig.java
@@ -1,0 +1,76 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote.chunking;
+
+import build.bazel.remote.execution.v2.ChunkingFunction;
+import build.bazel.remote.execution.v2.RepMaxCdcParams;
+import com.google.devtools.build.lib.remote.util.DigestUtil;
+
+/**
+ * Configuration for the RepMaxCDC chunking function. All sizes are in bytes.
+ *
+ * <p>RepMaxCDC produces chunks within {@code [minChunkSize, 2 * minChunkSize)} in size. The horizon
+ * size controls the lookahead window used to find optimal cutting points; larger values improve
+ * deduplication quality with diminishing returns, and a value of zero produces uniform chunks of
+ * {@code minChunkSize}.
+ */
+public record RepMaxCdcChunkingConfig(int minChunkSize, int horizonSize) implements ChunkingConfig {
+
+  public static final int DEFAULT_MIN_CHUNK_SIZE = 256 * 1024;
+
+  /** The default horizon size, expressed as a multiple of the minimum chunk size. */
+  public static final int DEFAULT_HORIZON_SIZE_FACTOR = 8;
+
+  @Override
+  public ChunkingFunction.Value chunkingFunction() {
+    return ChunkingFunction.Value.REP_MAX_CDC;
+  }
+
+  @Override
+  public int maxChunkSize() {
+    // Chunks are strictly smaller than twice the minimum chunk size.
+    return 2 * minChunkSize - 1;
+  }
+
+  @Override
+  public ContentDefinedChunker newChunker(DigestUtil digestUtil) {
+    return new RepMaxCdcChunker(this, digestUtil);
+  }
+
+  public static RepMaxCdcChunkingConfig defaults() {
+    return new RepMaxCdcChunkingConfig(
+        DEFAULT_MIN_CHUNK_SIZE, DEFAULT_HORIZON_SIZE_FACTOR * DEFAULT_MIN_CHUNK_SIZE);
+  }
+
+  /**
+   * Creates a configuration from the parameters advertised by the server, replacing values outside
+   * the expected range with defaults.
+   */
+  static RepMaxCdcChunkingConfig fromParams(RepMaxCdcParams params) {
+    int minSize = DEFAULT_MIN_CHUNK_SIZE;
+    long configMinSize = params.getMinChunkSizeBytes();
+    if (configMinSize >= 1024 && configMinSize <= 1024 * 1024) {
+      minSize = (int) configMinSize;
+    }
+
+    int horizonSize = DEFAULT_HORIZON_SIZE_FACTOR * minSize;
+    long configHorizonSize = params.getHorizonSizeBytes();
+    if (configHorizonSize >= 0 && configHorizonSize <= 8 * 1024 * 1024) {
+      horizonSize = (int) configHorizonSize;
+    }
+
+    return new RepMaxCdcChunkingConfig(minSize, horizonSize);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
@@ -18,6 +18,7 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
+import build.bazel.remote.execution.v2.ChunkingFunction;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.annotations.VisibleForTesting;
@@ -233,12 +234,16 @@ public abstract class RemoteCacheClient implements MissingDigestsFinder {
    * @param context the context for the action.
    * @param blobDigest The digest of the complete blob.
    * @param chunkDigests The digests of the chunks that make up the blob, in order.
-   * @return A future representing pending completion of the splice operation, or null if
-   *     SpliceBlob is not supported by this cache client.
+   * @param chunkingFunction The chunking function that was used to produce the chunks.
+   * @return A future representing pending completion of the splice operation, or null if SpliceBlob
+   *     is not supported by this cache client.
    */
   @Nullable
   public ListenableFuture<Void> spliceBlob(
-      RemoteActionExecutionContext context, Digest blobDigest, List<Digest> chunkDigests) {
+      RemoteActionExecutionContext context,
+      Digest blobDigest,
+      List<Digest> chunkDigests,
+      ChunkingFunction.Value chunkingFunction) {
     return null;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/options/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/BUILD
@@ -22,6 +22,7 @@ java_library(
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/protobuf:failure_details_java_proto",
         "//third_party:guava",
+        "//third_party:jsr305",
         "@com_google_protobuf//:protobuf_java",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
+import javax.annotation.Nullable;
 
 /** Options for remote execution and distributed caching for Bazel only. */
 public final class RemoteOptions extends CommonRemoteOptions {
@@ -808,11 +809,53 @@ public final class RemoteOptions extends CommonRemoteOptions {
       metadataTags = OptionMetadataTag.EXPERIMENTAL,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
-          "If enabled, large blobs are split into content-defined chunks using FastCDC 2020 and "
+          "If enabled, large blobs are split into content-defined chunks and "
               + "uploaded/downloaded in chunks, enabling deduplication across blobs. The server "
-              + "must advertise SplitBlob/SpliceBlob RPCs and FastCDC 2020 parameters in its "
+              + "must advertise SplitBlob/SpliceBlob RPCs and the parameters of the chunking "
+              + "function selected by --experimental_remote_cache_chunking_function in its "
               + "capabilities.")
   public boolean experimentalRemoteCacheChunking;
+
+  @Option(
+      name = "experimental_remote_cache_chunking_function",
+      defaultValue = "auto",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      metadataTags = OptionMetadataTag.EXPERIMENTAL,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      converter = ChunkingFunctionConverter.class,
+      help =
+          "The content-defined chunking function used to split large blobs when "
+              + "--experimental_remote_cache_chunking is enabled. If set to 'auto' (the "
+              + "default), the function is negotiated with the server: FastCDC 2020 is used if "
+              + "the server advertises it, otherwise RepMaxCDC. Set to 'fast_cdc_2020' or "
+              + "'rep_max_cdc' to require a specific function, in which case the server must "
+              + "advertise the parameters of that function in its capabilities. All clients "
+              + "sharing a cache should use the same function to maximize chunk reuse.")
+  public ChunkingFunctionValue experimentalRemoteCacheChunkingFunction;
+
+  /**
+   * Returns the chunking function to use for chunked cache transfers, or {@code null} if chunking
+   * is disabled.
+   */
+  @Nullable
+  public ChunkingFunctionValue getEffectiveChunkingFunction() {
+    return experimentalRemoteCacheChunking ? experimentalRemoteCacheChunkingFunction : null;
+  }
+
+  /** Values for --experimental_remote_cache_chunking_function. */
+  public enum ChunkingFunctionValue {
+    /** Negotiate with the server: FastCDC 2020 if advertised, otherwise RepMaxCDC. */
+    AUTO,
+    FAST_CDC_2020,
+    REP_MAX_CDC
+  }
+
+  /** Chunking function flag parser. */
+  public static class ChunkingFunctionConverter extends EnumConverter<ChunkingFunctionValue> {
+    public ChunkingFunctionConverter() {
+      super(ChunkingFunctionValue.class, "chunking function");
+    }
+  }
 
   @Option(
       name = "experimental_throttle_remote_action_building",

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -65,7 +65,9 @@ java_library(
             "BuildWithoutTheBytesIntegrationTest.java",
             "BuildWithoutTheBytesIntegrationTestBase.java",
             "ChunkedTransferBenchmark.java",
-            "ChunkedCacheIntegrationTest.java",
+            "ChunkedCacheIntegrationTestBase.java",
+            "ChunkedCacheFastCdcIntegrationTest.java",
+            "ChunkedCacheRepMaxIntegrationTest.java",
             "ChunkedDiskCacheIntegrationTest.java",
             "DiskCacheIntegrationTest.java",
         ],
@@ -223,6 +225,8 @@ java_opt_binary(
         "//third_party:guava",
         "//third_party:jmh",
         "//third_party:mockito",
+        "@googleapis//google/bytestream:bytestream_java_grpc",
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )
@@ -283,14 +287,9 @@ java_test(
     ],
 )
 
-java_test(
-    name = "ChunkedCacheIntegrationTest",
-    srcs = ["ChunkedCacheIntegrationTest.java"],
-    jvm_flags = ["-Djava.lang.Thread.allowVirtualThreads=true"],
-    tags = ["requires-network"],
-    runtime_deps = [
-        "//third_party/grpc-java:grpc-jar",
-    ],
+java_library(
+    name = "ChunkedCacheIntegrationTestBase",
+    srcs = ["ChunkedCacheIntegrationTestBase.java"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib:runtime",
         "//src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper:credential_module",
@@ -308,6 +307,34 @@ java_test(
         "@grpc-java//api",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+    ],
+)
+
+java_test(
+    name = "ChunkedCacheFastCdcIntegrationTest",
+    srcs = ["ChunkedCacheFastCdcIntegrationTest.java"],
+    jvm_flags = ["-Djava.lang.Thread.allowVirtualThreads=true"],
+    tags = ["requires-network"],
+    runtime_deps = [
+        "//third_party/grpc-java:grpc-jar",
+    ],
+    deps = [
+        ":ChunkedCacheIntegrationTestBase",
+        "//third_party:junit4",
+    ],
+)
+
+java_test(
+    name = "ChunkedCacheRepMaxIntegrationTest",
+    srcs = ["ChunkedCacheRepMaxIntegrationTest.java"],
+    jvm_flags = ["-Djava.lang.Thread.allowVirtualThreads=true"],
+    tags = ["requires-network"],
+    runtime_deps = [
+        "//third_party/grpc-java:grpc-jar",
+    ],
+    deps = [
+        ":ChunkedCacheIntegrationTestBase",
+        "//third_party:junit4",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloaderTest.java
@@ -25,6 +25,8 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.SplitBlobResponse;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.devtools.build.lib.remote.chunking.ChunkingConfig;
+import com.google.devtools.build.lib.remote.chunking.FastCdcChunkingConfig;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
@@ -51,6 +53,9 @@ import org.mockito.junit.MockitoRule;
 public class ChunkedBlobDownloaderTest {
   private static final DigestUtil DIGEST_UTIL =
       new DigestUtil(SyscallCache.NO_CACHE, DigestHashFunction.SHA256);
+  private static final ChunkingConfig CHUNKING_CONFIG =
+      new FastCdcChunkingConfig(
+          /* avgChunkSize= */ 1024, /* normalizationLevel= */ 2, /* seed= */ 0);
   private static final int MAX_IN_FLIGHT_CHUNK_DOWNLOADS = 16;
 
   @Rule public final MockitoRule mockito = MockitoJUnit.rule();
@@ -65,13 +70,13 @@ public class ChunkedBlobDownloaderTest {
   public void setUp() {
     downloader =
         new ChunkedBlobDownloader(
-            grpcCacheClient, combinedCache, DIGEST_UTIL, /* verifyDownloads= */ true);
+            grpcCacheClient, combinedCache, CHUNKING_CONFIG, DIGEST_UTIL, /* verifyDownloads= */ true);
   }
 
   @Test
   public void downloadChunked_splitBlobReturnsNull_throwsCacheNotFound() {
     Digest blobDigest = DIGEST_UTIL.compute(new byte[] {1, 2, 3});
-    when(grpcCacheClient.splitBlob(any(), eq(blobDigest))).thenReturn(null);
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any())).thenReturn(null);
 
     assertThrows(
         CacheNotFoundException.class,
@@ -86,7 +91,7 @@ public class ChunkedBlobDownloaderTest {
 
     SplitBlobResponse splitResponse =
         SplitBlobResponse.newBuilder().addChunkDigests(chunkDigest).build();
-    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any()))
         .thenReturn(Futures.immediateFuture(splitResponse));
     when(combinedCache.downloadBlob(any(), eq(chunkDigest)))
         .thenReturn(Futures.immediateFuture(chunkData));
@@ -113,7 +118,7 @@ public class ChunkedBlobDownloaderTest {
             .addChunkDigests(chunk2Digest)
             .addChunkDigests(chunk3Digest)
             .build();
-    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any()))
         .thenReturn(Futures.immediateFuture(splitResponse));
     when(combinedCache.downloadBlob(any(), eq(chunk1Digest)))
         .thenReturn(Futures.immediateFuture(chunk1Data));
@@ -146,7 +151,7 @@ public class ChunkedBlobDownloaderTest {
     }
     Digest blobDigest = DIGEST_UTIL.compute(expectedData);
 
-    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any()))
         .thenReturn(Futures.immediateFuture(splitResponse.build()));
 
     CountDownLatch firstWindowRequested = new CountDownLatch(MAX_IN_FLIGHT_CHUNK_DOWNLOADS);
@@ -207,7 +212,7 @@ public class ChunkedBlobDownloaderTest {
             .addChunkDigests(chunkDigest)
             .addChunkDigests(chunkDigest)
             .build();
-    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any()))
         .thenReturn(Futures.immediateFuture(splitResponse));
 
     SettableFuture<byte[]> chunkFuture = SettableFuture.create();
@@ -257,7 +262,7 @@ public class ChunkedBlobDownloaderTest {
       splitResponse.addChunkDigests(duplicateChunkDigest);
     }
     splitResponse.addChunkDigests(finalChunkDigest);
-    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any()))
         .thenReturn(Futures.immediateFuture(splitResponse.build()));
 
     SettableFuture<byte[]> firstChunkFuture = SettableFuture.create();
@@ -319,7 +324,7 @@ public class ChunkedBlobDownloaderTest {
     Digest blobDigest = DIGEST_UTIL.compute(new byte[0]);
 
     SplitBlobResponse splitResponse = SplitBlobResponse.getDefaultInstance();
-    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any()))
         .thenReturn(Futures.immediateFuture(splitResponse));
 
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -341,7 +346,7 @@ public class ChunkedBlobDownloaderTest {
             .addChunkDigests(chunk1Digest)
             .addChunkDigests(chunk2Digest)
             .build();
-    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any()))
         .thenReturn(Futures.immediateFuture(splitResponse));
     when(combinedCache.downloadBlob(any(), eq(chunk1Digest)))
         .thenReturn(Futures.immediateFuture(chunk1Data));
@@ -360,7 +365,7 @@ public class ChunkedBlobDownloaderTest {
 
     SplitBlobResponse splitResponse =
         SplitBlobResponse.newBuilder().addChunkDigests(chunkDigest).build();
-    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any()))
         .thenReturn(Futures.immediateFuture(splitResponse));
     when(combinedCache.downloadBlob(any(), eq(chunkDigest)))
         .thenReturn(Futures.immediateFuture(chunkData));
@@ -378,14 +383,18 @@ public class ChunkedBlobDownloaderTest {
   public void downloadChunked_blobDigestMismatchVerificationDisabled_succeeds() throws Exception {
     downloader =
         new ChunkedBlobDownloader(
-            grpcCacheClient, combinedCache, DIGEST_UTIL, /* verifyDownloads= */ false);
+            grpcCacheClient,
+            combinedCache,
+            CHUNKING_CONFIG,
+            DIGEST_UTIL,
+            /* verifyDownloads= */ false);
     byte[] chunkData = new byte[] {1, 2, 3};
     Digest chunkDigest = DIGEST_UTIL.compute(chunkData);
     Digest blobDigest = DIGEST_UTIL.compute(new byte[] {4, 5, 6});
 
     SplitBlobResponse splitResponse =
         SplitBlobResponse.newBuilder().addChunkDigests(chunkDigest).build();
-    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any()))
         .thenReturn(Futures.immediateFuture(splitResponse));
     when(combinedCache.downloadBlob(any(), eq(chunkDigest)))
         .thenReturn(Futures.immediateFuture(chunkData));
@@ -404,7 +413,7 @@ public class ChunkedBlobDownloaderTest {
 
     SplitBlobResponse splitResponse =
         SplitBlobResponse.newBuilder().addChunkDigests(chunkDigest).build();
-    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any()))
         .thenReturn(Futures.immediateFuture(splitResponse));
 
     SettableFuture<byte[]> cancelledDownload = SettableFuture.create();
@@ -429,7 +438,7 @@ public class ChunkedBlobDownloaderTest {
             .addChunkDigests(chunk1Digest)
             .addChunkDigests(chunk2Digest)
             .build();
-    when(grpcCacheClient.splitBlob(any(), eq(blobDigest)))
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any()))
         .thenReturn(Futures.immediateFuture(splitResponse));
 
     SettableFuture<byte[]> failedDownload = SettableFuture.create();

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobUploaderTest.java
@@ -29,8 +29,8 @@ import build.bazel.remote.execution.v2.Digest;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.clock.JavaClock;
-import com.google.devtools.build.lib.remote.chunking.ChunkingConfig;
 import com.google.devtools.build.lib.remote.chunking.FastCdcChunker;
+import com.google.devtools.build.lib.remote.chunking.FastCdcChunkingConfig;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.Blob;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
@@ -88,13 +88,13 @@ public class ChunkedBlobUploaderTest {
     execRoot = fs.getPath("/execroot");
     execRoot.createDirectoryAndParents();
 
-    ChunkingConfig config = new ChunkingConfig(1024, 2, 0);
+    FastCdcChunkingConfig config = new FastCdcChunkingConfig(1024, 2, 0);
     uploader = new ChunkedBlobUploader(grpcCacheClient, combinedCache, config, DIGEST_UTIL);
   }
 
   @Test
   public void getChunkingThreshold_returnsConfiguredValue() {
-    ChunkingConfig config = new ChunkingConfig(512, 2, 0);
+    FastCdcChunkingConfig config = new FastCdcChunkingConfig(512, 2, 0);
     ChunkedBlobUploader uploader =
         new ChunkedBlobUploader(grpcCacheClient, combinedCache, config, DIGEST_UTIL);
 
@@ -119,7 +119,7 @@ public class ChunkedBlobUploaderTest {
             });
     when(combinedCache.uploadBlob(any(), any(Digest.class), any(Blob.class)))
         .thenReturn(immediateVoidFuture());
-    when(grpcCacheClient.spliceBlob(any(), any(), any())).thenReturn(immediateVoidFuture());
+    when(grpcCacheClient.spliceBlob(any(), any(), any(), any())).thenReturn(immediateVoidFuture());
 
     uploader.uploadChunked(context, blobDigest, file);
 
@@ -140,12 +140,12 @@ public class ChunkedBlobUploaderTest {
 
     when(grpcCacheClient.findMissingDigests(any(), any()))
         .thenReturn(immediateFuture(ImmutableSet.of()));
-    when(grpcCacheClient.spliceBlob(any(), any(), any())).thenReturn(immediateVoidFuture());
+    when(grpcCacheClient.spliceBlob(any(), any(), any(), any())).thenReturn(immediateVoidFuture());
 
     uploader.uploadChunked(context, blobDigest, file);
 
     verify(combinedCache, never()).uploadBlob(any(), any(Digest.class), any(Blob.class));
-    verify(grpcCacheClient).spliceBlob(any(), eq(blobDigest), any());
+    verify(grpcCacheClient).spliceBlob(any(), eq(blobDigest), any(), any());
   }
 
   @Test
@@ -157,7 +157,7 @@ public class ChunkedBlobUploaderTest {
     writeFile(file, fileData);
     Digest blobDigest = DIGEST_UTIL.compute(fileData);
 
-    ChunkingConfig config = new ChunkingConfig(1024, 2, 0);
+    FastCdcChunkingConfig config = new FastCdcChunkingConfig(1024, 2, 0);
     FastCdcChunker testChunker = new FastCdcChunker(config, DIGEST_UTIL);
     List<Digest> allChunkDigests;
     try (InputStream input = file.getInputStream()) {
@@ -198,7 +198,7 @@ public class ChunkedBlobUploaderTest {
               }
               return immediateVoidFuture();
             });
-    when(grpcCacheClient.spliceBlob(any(), any(), any())).thenReturn(immediateVoidFuture());
+    when(grpcCacheClient.spliceBlob(any(), any(), any(), any())).thenReturn(immediateVoidFuture());
 
     uploader.uploadChunked(context, blobDigest, file);
 
@@ -206,7 +206,7 @@ public class ChunkedBlobUploaderTest {
     for (Map.Entry<Digest, ByteString> entry : expectedChunkData.entrySet()) {
       assertThat(actualUploads.get(entry.getKey())).isEqualTo(entry.getValue());
     }
-    verify(grpcCacheClient).spliceBlob(any(), eq(blobDigest), eq(allChunkDigests));
+    verify(grpcCacheClient).spliceBlob(any(), eq(blobDigest), eq(allChunkDigests), any());
   }
 
   @Test
@@ -218,7 +218,8 @@ public class ChunkedBlobUploaderTest {
     writeFile(file, data);
     Digest blobDigest = DIGEST_UTIL.compute(data);
 
-    FastCdcChunker testChunker = new FastCdcChunker(new ChunkingConfig(1024, 2, 0), DIGEST_UTIL);
+    FastCdcChunker testChunker =
+        new FastCdcChunker(new FastCdcChunkingConfig(1024, 2, 0), DIGEST_UTIL);
     List<Digest> chunkDigests;
     try (InputStream input = file.getInputStream()) {
       chunkDigests = testChunker.chunkToDigests(input);
@@ -238,7 +239,7 @@ public class ChunkedBlobUploaderTest {
 
     when(grpcCacheClient.findMissingDigests(any(), any()))
         .thenReturn(immediateFuture(ImmutableSet.copyOf(uniqueChunkDigests)));
-    when(grpcCacheClient.spliceBlob(any(), any(), any())).thenReturn(immediateVoidFuture());
+    when(grpcCacheClient.spliceBlob(any(), any(), any(), any())).thenReturn(immediateVoidFuture());
 
     List<SettableFuture<Void>> uploads = new ArrayList<>(uniqueChunkDigests.size());
     for (int i = 0; i < uniqueChunkDigests.size(); i++) {
@@ -286,7 +287,7 @@ public class ChunkedBlobUploaderTest {
     uploadThread.join(TimeUnit.SECONDS.toMillis(1));
 
     assertThat(uploadThread.isAlive()).isFalse();
-    verify(grpcCacheClient).spliceBlob(any(), eq(blobDigest), eq(chunkDigests));
+    verify(grpcCacheClient).spliceBlob(any(), eq(blobDigest), eq(chunkDigests), any());
   }
 
   @Test
@@ -298,7 +299,8 @@ public class ChunkedBlobUploaderTest {
     writeFile(file, data);
     Digest blobDigest = DIGEST_UTIL.compute(data);
 
-    FastCdcChunker testChunker = new FastCdcChunker(new ChunkingConfig(1024, 2, 0), DIGEST_UTIL);
+    FastCdcChunker testChunker =
+        new FastCdcChunker(new FastCdcChunkingConfig(1024, 2, 0), DIGEST_UTIL);
     List<Digest> chunkDigests;
     try (InputStream input = file.getInputStream()) {
       chunkDigests = testChunker.chunkToDigests(input);
@@ -355,7 +357,7 @@ public class ChunkedBlobUploaderTest {
 
     assertThat(uploadThread.isAlive()).isFalse();
     assertThat(cancelledUpload.isCancelled()).isTrue();
-    verify(grpcCacheClient, never()).spliceBlob(any(), any(), any());
+    verify(grpcCacheClient, never()).spliceBlob(any(), any(), any(), any());
   }
 
   @Test
@@ -367,7 +369,8 @@ public class ChunkedBlobUploaderTest {
     writeFile(file, data);
     Digest blobDigest = DIGEST_UTIL.compute(data);
 
-    FastCdcChunker testChunker = new FastCdcChunker(new ChunkingConfig(1024, 2, 0), DIGEST_UTIL);
+    FastCdcChunker testChunker =
+        new FastCdcChunker(new FastCdcChunkingConfig(1024, 2, 0), DIGEST_UTIL);
     List<Digest> chunkDigests;
     try (InputStream input = file.getInputStream()) {
       chunkDigests = testChunker.chunkToDigests(input);
@@ -384,7 +387,7 @@ public class ChunkedBlobUploaderTest {
 
     assertThrows(
         InterruptedException.class, () -> uploader.uploadChunked(context, blobDigest, file));
-    verify(grpcCacheClient, never()).spliceBlob(any(), any(), any());
+    verify(grpcCacheClient, never()).spliceBlob(any(), any(), any(), any());
   }
 
   @Test
@@ -395,7 +398,8 @@ public class ChunkedBlobUploaderTest {
     new Random(42).nextBytes(data);
     Digest blobDigest = DIGEST_UTIL.compute(data);
 
-    FastCdcChunker testChunker = new FastCdcChunker(new ChunkingConfig(1024, 2, 0), DIGEST_UTIL);
+    FastCdcChunker testChunker =
+        new FastCdcChunker(new FastCdcChunkingConfig(1024, 2, 0), DIGEST_UTIL);
     List<Digest> chunkDigests;
     try (InputStream input = new ByteArrayInputStream(data)) {
       chunkDigests = testChunker.chunkToDigests(input);
@@ -428,7 +432,7 @@ public class ChunkedBlobUploaderTest {
     uploadThread.join(TimeUnit.SECONDS.toMillis(1));
     assertThat(uploadThread.isAlive()).isFalse();
     verify(file, times(1)).getInputStream();
-    verify(grpcCacheClient, never()).spliceBlob(any(), any(), any());
+    verify(grpcCacheClient, never()).spliceBlob(any(), any(), any(), any());
   }
 
   @Test
@@ -439,7 +443,8 @@ public class ChunkedBlobUploaderTest {
     new Random(42).nextBytes(data);
     Digest blobDigest = DIGEST_UTIL.compute(data);
 
-    FastCdcChunker testChunker = new FastCdcChunker(new ChunkingConfig(1024, 2, 0), DIGEST_UTIL);
+    FastCdcChunker testChunker =
+        new FastCdcChunker(new FastCdcChunkingConfig(1024, 2, 0), DIGEST_UTIL);
     List<Digest> chunkDigests;
     try (InputStream input = new ByteArrayInputStream(data)) {
       chunkDigests = testChunker.chunkToDigests(input);
@@ -467,7 +472,7 @@ public class ChunkedBlobUploaderTest {
 
     assertThat(e).hasMessageThat().contains("file was concurrently modified during upload");
     assertThat(e).hasCauseThat().isInstanceOf(EOFException.class);
-    verify(grpcCacheClient, never()).spliceBlob(any(), any(), any());
+    verify(grpcCacheClient, never()).spliceBlob(any(), any(), any(), any());
   }
 
   private void writeFile(Path path, byte[] data) throws IOException {

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedCacheFastCdcIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedCacheFastCdcIntegrationTest.java
@@ -1,0 +1,29 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Integration tests for chunked remote cache using SplitBlob/SpliceBlob APIs with the FastCDC 2020
+ * chunking function.
+ */
+@RunWith(JUnit4.class)
+public class ChunkedCacheFastCdcIntegrationTest extends ChunkedCacheIntegrationTestBase {
+  @Override
+  protected String getChunkingFunction() {
+    return "fast_cdc_2020";
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedCacheIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedCacheIntegrationTestBase.java
@@ -53,20 +53,20 @@ import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-/** Integration tests for chunked remote cache using SplitBlob/SpliceBlob APIs. */
-@RunWith(JUnit4.class)
-public class ChunkedCacheIntegrationTest extends BuildIntegrationTestCase {
+/** Base class for integration tests for chunked remote cache using SplitBlob/SpliceBlob APIs. */
+public abstract class ChunkedCacheIntegrationTestBase extends BuildIntegrationTestCase {
   @ClassRule @Rule public static final WorkerInstance worker = IntegrationTestUtils.createWorker();
+
+  protected abstract String getChunkingFunction();
 
   @Override
   protected void setupOptions() throws Exception {
     super.setupOptions();
     addOptions(
         "--remote_cache=grpc://localhost:" + worker.getPort(),
-        "--experimental_remote_cache_chunking");
+        "--experimental_remote_cache_chunking",
+        "--experimental_remote_cache_chunking_function=%s".formatted(getChunkingFunction()));
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedCacheRepMaxIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedCacheRepMaxIntegrationTest.java
@@ -1,0 +1,29 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Integration tests for chunked remote cache using SplitBlob/SpliceBlob APIs with the RepMaxCDC
+ * chunking function.
+ */
+@RunWith(JUnit4.class)
+public class ChunkedCacheRepMaxIntegrationTest extends ChunkedCacheIntegrationTestBase {
+  @Override
+  protected String getChunkingFunction() {
+    return "rep_max_cdc";
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedTransferBenchmark.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedTransferBenchmark.java
@@ -26,8 +26,8 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.clock.JavaClock;
-import com.google.devtools.build.lib.remote.chunking.ChunkingConfig;
 import com.google.devtools.build.lib.remote.chunking.FastCdcChunker;
+import com.google.devtools.build.lib.remote.chunking.FastCdcChunkingConfig;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.Blob;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
@@ -141,12 +141,17 @@ public class ChunkedTransferBenchmark {
 
       SplitBlobResponse splitBlobResponse =
           SplitBlobResponse.newBuilder().addAllChunkDigests(chunkDigests).build();
-      when(grpcCacheClient.splitBlob(any(), any(Digest.class)))
+      when(grpcCacheClient.splitBlob(any(), any(Digest.class), any()))
           .thenReturn(Futures.immediateFuture(splitBlobResponse));
 
+      FastCdcChunkingConfig chunkingConfig = new FastCdcChunkingConfig(chunkSizeBytes, 2, 0);
       downloader =
           new ChunkedBlobDownloader(
-              grpcCacheClient, combinedCache, DIGEST_UTIL, /* verifyDownloads= */ true);
+              grpcCacheClient,
+              combinedCache,
+              chunkingConfig,
+              DIGEST_UTIL,
+              /* verifyDownloads= */ true);
     }
 
     @TearDown(Level.Trial)
@@ -197,7 +202,7 @@ public class ChunkedTransferBenchmark {
         out.write(data);
       }
 
-      ChunkingConfig chunkingConfig = new ChunkingConfig(avgChunkSizeBytes, 2, 0);
+      FastCdcChunkingConfig chunkingConfig = new FastCdcChunkingConfig(avgChunkSizeBytes, 2, 0);
       uploader =
           new ChunkedBlobUploader(grpcCacheClient, combinedCache, chunkingConfig, DIGEST_UTIL);
 
@@ -208,7 +213,7 @@ public class ChunkedTransferBenchmark {
 
       when(grpcCacheClient.findMissingDigests(any(), any()))
           .thenReturn(Futures.immediateFuture(ImmutableSet.copyOf(chunkDigests)));
-      when(grpcCacheClient.spliceBlob(any(), any(Digest.class), any()))
+      when(grpcCacheClient.spliceBlob(any(), any(Digest.class), any(), any()))
           .thenReturn(Futures.immediateVoidFuture());
       when(combinedCache.uploadBlob(any(), any(Digest.class), any(Blob.class)))
           .thenAnswer(

--- a/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
@@ -714,7 +714,7 @@ public class CombinedCacheTest {
               return spliceFuture;
             })
         .when(grpcCacheClient)
-        .spliceBlob(any(), any(), any());
+        .spliceBlob(any(), any(), any(), any());
 
     CombinedCache combinedCache =
         new CombinedCache(grpcCacheClient, /* diskCacheClient= */ null, options, digestUtil);
@@ -735,7 +735,7 @@ public class CombinedCacheTest {
 
       assertThat(grpcCacheClient.getUploadSubscriberCount(digest)).isEqualTo(2);
       verify(grpcCacheClient).findMissingDigests(any(), any());
-      verify(grpcCacheClient).spliceBlob(any(), any(), any());
+      verify(grpcCacheClient).spliceBlob(any(), any(), any(), any());
 
       spliceFuture.set(null);
       getFromFuture(firstUpload);

--- a/src/test/java/com/google/devtools/build/lib/remote/chunking/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/chunking/BUILD
@@ -18,6 +18,7 @@ java_library(
     srcs = [
         "ChunkingConfigTest.java",
         "FastCdcChunkerTest.java",
+        "RepMaxCdcChunkerTest.java",
     ],
     data = [
         # Public domain image by Toriyama Sekien (1712-1788),
@@ -49,6 +50,19 @@ java_test(
 java_opt_binary(
     name = "FastCdcBenchmark",
     srcs = ["FastCdcBenchmark.java"],
+    main_class = "org.openjdk.jmh.Main",
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/remote/chunking",
+        "//src/main/java/com/google/devtools/build/lib/remote/util:digest_utils",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs/bazel",
+        "//third_party:jmh",
+    ],
+)
+
+java_opt_binary(
+    name = "RepMaxCdcBenchmark",
+    srcs = ["RepMaxCdcBenchmark.java"],
     main_class = "org.openjdk.jmh.Main",
     deps = [
         "//src/main/java/com/google/devtools/build/lib/remote/chunking",

--- a/src/test/java/com/google/devtools/build/lib/remote/chunking/ChunkingConfigTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/chunking/ChunkingConfigTest.java
@@ -16,7 +16,9 @@ package com.google.devtools.build.lib.remote.chunking;
 import static com.google.common.truth.Truth.assertThat;
 
 import build.bazel.remote.execution.v2.CacheCapabilities;
+import build.bazel.remote.execution.v2.ChunkingFunction;
 import build.bazel.remote.execution.v2.FastCdc2020Params;
+import build.bazel.remote.execution.v2.RepMaxCdcParams;
 import build.bazel.remote.execution.v2.ServerCapabilities;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,10 +28,23 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ChunkingConfigTest {
 
-  @Test
-  public void defaults_returnsExpectedValues() {
-    ChunkingConfig config = ChunkingConfig.defaults();
+  private static ServerCapabilities capabilitiesWithFastCdcParams(FastCdc2020Params params) {
+    return ServerCapabilities.newBuilder()
+        .setCacheCapabilities(CacheCapabilities.newBuilder().setFastCdc2020Params(params).build())
+        .build();
+  }
 
+  private static ServerCapabilities capabilitiesWithRepMaxCdcParams(RepMaxCdcParams params) {
+    return ServerCapabilities.newBuilder()
+        .setCacheCapabilities(CacheCapabilities.newBuilder().setRepMaxCdcParams(params).build())
+        .build();
+  }
+
+  @Test
+  public void fastCdcDefaults_returnsExpectedValues() {
+    FastCdcChunkingConfig config = FastCdcChunkingConfig.defaults();
+
+    assertThat(config.chunkingFunction()).isEqualTo(ChunkingFunction.Value.FAST_CDC_2020);
     assertThat(config.avgChunkSize()).isEqualTo(512 * 1024);
     assertThat(config.normalizationLevel()).isEqualTo(2);
     assertThat(config.seed()).isEqualTo(0);
@@ -37,51 +52,173 @@ public class ChunkingConfigTest {
   }
 
   @Test
-  public void minChunkSize_returnsQuarterOfAvg() {
-    ChunkingConfig config = new ChunkingConfig(1024, 2, 0);
+  public void fastCdcMinChunkSize_returnsQuarterOfAvg() {
+    FastCdcChunkingConfig config = new FastCdcChunkingConfig(1024, 2, 0);
 
     assertThat(config.minChunkSize()).isEqualTo(256);
   }
 
   @Test
-  public void maxChunkSize_returnsFourTimesAvg() {
-    ChunkingConfig config = new ChunkingConfig(1024, 2, 0);
+  public void fastCdcMaxChunkSize_returnsFourTimesAvg() {
+    FastCdcChunkingConfig config = new FastCdcChunkingConfig(1024, 2, 0);
 
     assertThat(config.maxChunkSize()).isEqualTo(4096);
   }
 
   @Test
-  public void chunkingThreshold_equalsMaxChunkSize() {
-    ChunkingConfig config = new ChunkingConfig(1024, 2, 0);
+  public void fastCdcChunkingThreshold_equalsMaxChunkSize() {
+    FastCdcChunkingConfig config = new FastCdcChunkingConfig(1024, 2, 0);
 
     assertThat(config.chunkingThreshold()).isEqualTo(config.maxChunkSize());
   }
 
   @Test
-  public void minAndMaxChunkSize_withDefaultConfig() {
-    ChunkingConfig config = ChunkingConfig.defaults();
+  public void fastCdcMinAndMaxChunkSize_withDefaultConfig() {
+    FastCdcChunkingConfig config = FastCdcChunkingConfig.defaults();
 
     assertThat(config.minChunkSize()).isEqualTo(128 * 1024);
     assertThat(config.maxChunkSize()).isEqualTo(2048 * 1024);
   }
 
   @Test
-  public void fromServerCapabilities_withoutCacheCapabilities_returnsNull() {
-    ServerCapabilities capabilities = ServerCapabilities.getDefaultInstance();
+  public void fastCdcNewChunker_returnsFastCdcChunker() {
+    FastCdcChunkingConfig config = FastCdcChunkingConfig.defaults();
 
-    ChunkingConfig config = ChunkingConfig.fromServerCapabilities(capabilities);
-
-    assertThat(config).isNull();
+    assertThat(config.newChunker(/* digestUtil= */ null)).isInstanceOf(FastCdcChunker.class);
   }
 
   @Test
-  public void fromServerCapabilities_withoutFastCdcParams_returnsNull() {
+  public void repMaxCdcDefaults_returnsExpectedValues() {
+    RepMaxCdcChunkingConfig config = RepMaxCdcChunkingConfig.defaults();
+
+    assertThat(config.chunkingFunction()).isEqualTo(ChunkingFunction.Value.REP_MAX_CDC);
+    assertThat(config.minChunkSize()).isEqualTo(256 * 1024);
+    assertThat(config.horizonSize()).isEqualTo(8 * 256 * 1024);
+    assertThat(config.chunkingThreshold()).isEqualTo(2 * 256 * 1024 - 1);
+  }
+
+  @Test
+  public void repMaxCdcMaxChunkSize_isBelowTwiceMinChunkSize() {
+    RepMaxCdcChunkingConfig config = new RepMaxCdcChunkingConfig(1024, 8 * 1024);
+
+    assertThat(config.maxChunkSize()).isEqualTo(2047);
+  }
+
+  @Test
+  public void repMaxCdcChunkingThreshold_equalsMaxChunkSize() {
+    RepMaxCdcChunkingConfig config = new RepMaxCdcChunkingConfig(1024, 8 * 1024);
+
+    assertThat(config.chunkingThreshold()).isEqualTo(config.maxChunkSize());
+  }
+
+  @Test
+  public void repMaxCdcNewChunker_returnsRepMaxCdcChunker() {
+    RepMaxCdcChunkingConfig config = RepMaxCdcChunkingConfig.defaults();
+
+    assertThat(config.newChunker(/* digestUtil= */ null)).isInstanceOf(RepMaxCdcChunker.class);
+  }
+
+  @Test
+  public void fromServerCapabilities_negotiation_prefersFastCdcWhenBothAdvertised() {
+    ServerCapabilities capabilities =
+        ServerCapabilities.newBuilder()
+            .setCacheCapabilities(
+                CacheCapabilities.newBuilder()
+                    .setFastCdc2020Params(
+                        FastCdc2020Params.newBuilder().setAvgChunkSizeBytes(512 * 1024).build())
+                    .setRepMaxCdcParams(
+                        RepMaxCdcParams.newBuilder().setMinChunkSizeBytes(256 * 1024).build())
+                    .build())
+            .build();
+
+    ChunkingConfig config = ChunkingConfig.fromServerCapabilities(capabilities);
+
+    assertThat(config).isInstanceOf(FastCdcChunkingConfig.class);
+  }
+
+  @Test
+  public void fromServerCapabilities_negotiation_usesRepMaxCdcWhenOnlyItIsAdvertised() {
+    ServerCapabilities capabilities =
+        capabilitiesWithRepMaxCdcParams(
+            RepMaxCdcParams.newBuilder().setMinChunkSizeBytes(256 * 1024).build());
+
+    ChunkingConfig config = ChunkingConfig.fromServerCapabilities(capabilities);
+
+    assertThat(config).isInstanceOf(RepMaxCdcChunkingConfig.class);
+  }
+
+  @Test
+  public void fromServerCapabilities_negotiation_usesFastCdcWhenOnlyItIsAdvertised() {
+    ServerCapabilities capabilities =
+        capabilitiesWithFastCdcParams(
+            FastCdc2020Params.newBuilder().setAvgChunkSizeBytes(512 * 1024).build());
+
+    ChunkingConfig config = ChunkingConfig.fromServerCapabilities(capabilities);
+
+    assertThat(config).isInstanceOf(FastCdcChunkingConfig.class);
+  }
+
+  @Test
+  public void fromServerCapabilities_negotiation_neitherAdvertised_returnsNull() {
     ServerCapabilities capabilities =
         ServerCapabilities.newBuilder()
             .setCacheCapabilities(CacheCapabilities.getDefaultInstance())
             .build();
 
-    ChunkingConfig config = ChunkingConfig.fromServerCapabilities(capabilities);
+    assertThat(ChunkingConfig.fromServerCapabilities(capabilities)).isNull();
+    assertThat(ChunkingConfig.fromServerCapabilities(ServerCapabilities.getDefaultInstance()))
+        .isNull();
+  }
+
+  @Test
+  public void fromServerCapabilities_withoutCacheCapabilities_returnsNull() {
+    ServerCapabilities capabilities = ServerCapabilities.getDefaultInstance();
+
+    assertThat(
+            ChunkingConfig.fromServerCapabilities(
+                capabilities, ChunkingFunction.Value.FAST_CDC_2020))
+        .isNull();
+    assertThat(
+            ChunkingConfig.fromServerCapabilities(capabilities, ChunkingFunction.Value.REP_MAX_CDC))
+        .isNull();
+  }
+
+  @Test
+  public void fromServerCapabilities_withoutParamsForRequestedFunction_returnsNull() {
+    ServerCapabilities capabilities =
+        ServerCapabilities.newBuilder()
+            .setCacheCapabilities(CacheCapabilities.getDefaultInstance())
+            .build();
+
+    assertThat(
+            ChunkingConfig.fromServerCapabilities(
+                capabilities, ChunkingFunction.Value.FAST_CDC_2020))
+        .isNull();
+    assertThat(
+            ChunkingConfig.fromServerCapabilities(capabilities, ChunkingFunction.Value.REP_MAX_CDC))
+        .isNull();
+  }
+
+  @Test
+  public void fromServerCapabilities_fastCdcRequestedButOnlyRepMaxCdcAdvertised_returnsNull() {
+    ServerCapabilities capabilities =
+        capabilitiesWithRepMaxCdcParams(
+            RepMaxCdcParams.newBuilder().setMinChunkSizeBytes(256 * 1024).build());
+
+    ChunkingConfig config =
+        ChunkingConfig.fromServerCapabilities(capabilities, ChunkingFunction.Value.FAST_CDC_2020);
+
+    assertThat(config).isNull();
+  }
+
+  @Test
+  public void fromServerCapabilities_repMaxCdcRequestedButOnlyFastCdcAdvertised_returnsNull() {
+    ServerCapabilities capabilities =
+        capabilitiesWithFastCdcParams(
+            FastCdc2020Params.newBuilder().setAvgChunkSizeBytes(512 * 1024).build());
+
+    ChunkingConfig config =
+        ChunkingConfig.fromServerCapabilities(capabilities, ChunkingFunction.Value.REP_MAX_CDC);
 
     assertThat(config).isNull();
   }
@@ -89,58 +226,115 @@ public class ChunkingConfigTest {
   @Test
   public void fromServerCapabilities_withFastCdcParams_returnsConfig() {
     ServerCapabilities capabilities =
-        ServerCapabilities.newBuilder()
-            .setCacheCapabilities(
-                CacheCapabilities.newBuilder()
-                    .setFastCdc2020Params(
-                        FastCdc2020Params.newBuilder()
-                            .setAvgChunkSizeBytes(256 * 1024)
-                            .setSeed(42)
-                            .build())
-                    .build())
-            .build();
+        capabilitiesWithFastCdcParams(
+            FastCdc2020Params.newBuilder().setAvgChunkSizeBytes(256 * 1024).setSeed(42).build());
 
-    ChunkingConfig config = ChunkingConfig.fromServerCapabilities(capabilities);
+    ChunkingConfig config =
+        ChunkingConfig.fromServerCapabilities(capabilities, ChunkingFunction.Value.FAST_CDC_2020);
 
-    assertThat(config).isNotNull();
-    assertThat(config.avgChunkSize()).isEqualTo(256 * 1024);
-    assertThat(config.seed()).isEqualTo(42);
-    assertThat(config.chunkingThreshold()).isEqualTo(256 * 1024 * 4);
+    assertThat(config).isInstanceOf(FastCdcChunkingConfig.class);
+    FastCdcChunkingConfig fastCdcConfig = (FastCdcChunkingConfig) config;
+    assertThat(fastCdcConfig.avgChunkSize()).isEqualTo(256 * 1024);
+    assertThat(fastCdcConfig.seed()).isEqualTo(42);
+    assertThat(fastCdcConfig.chunkingThreshold()).isEqualTo(256 * 1024 * 4);
   }
 
   @Test
   public void fromServerCapabilities_withDefaultFastCdcParams_returnsDefaults() {
     ServerCapabilities capabilities =
-        ServerCapabilities.newBuilder()
-            .setCacheCapabilities(
-                CacheCapabilities.newBuilder()
-                    .setFastCdc2020Params(
-                        FastCdc2020Params.newBuilder()
-                            .setAvgChunkSizeBytes(512 * 1024)
-                            .setSeed(0)
-                            .build())
-                    .build())
-            .build();
+        capabilitiesWithFastCdcParams(
+            FastCdc2020Params.newBuilder().setAvgChunkSizeBytes(512 * 1024).setSeed(0).build());
 
-    ChunkingConfig config = ChunkingConfig.fromServerCapabilities(capabilities);
+    ChunkingConfig config =
+        ChunkingConfig.fromServerCapabilities(capabilities, ChunkingFunction.Value.FAST_CDC_2020);
 
-    assertThat(config).isEqualTo(ChunkingConfig.defaults());
+    assertThat(config).isEqualTo(FastCdcChunkingConfig.defaults());
   }
 
   @Test
   public void fromServerCapabilities_nonPowerOfTwoAvgSize_fallsBackToDefault() {
     ServerCapabilities capabilities =
-        ServerCapabilities.newBuilder()
-            .setCacheCapabilities(
-                CacheCapabilities.newBuilder()
-                    .setFastCdc2020Params(
-                        FastCdc2020Params.newBuilder().setAvgChunkSizeBytes(300 * 1024).build())
-                    .build())
-            .build();
+        capabilitiesWithFastCdcParams(
+            FastCdc2020Params.newBuilder().setAvgChunkSizeBytes(300 * 1024).build());
 
-    ChunkingConfig config = ChunkingConfig.fromServerCapabilities(capabilities);
+    ChunkingConfig config =
+        ChunkingConfig.fromServerCapabilities(capabilities, ChunkingFunction.Value.FAST_CDC_2020);
 
-    assertThat(config).isNotNull();
-    assertThat(config.avgChunkSize()).isEqualTo(ChunkingConfig.DEFAULT_AVG_CHUNK_SIZE);
+    assertThat(config).isInstanceOf(FastCdcChunkingConfig.class);
+    assertThat(((FastCdcChunkingConfig) config).avgChunkSize())
+        .isEqualTo(FastCdcChunkingConfig.DEFAULT_AVG_CHUNK_SIZE);
+  }
+
+  @Test
+  public void fromServerCapabilities_withRepMaxCdcParams_returnsConfig() {
+    ServerCapabilities capabilities =
+        capabilitiesWithRepMaxCdcParams(
+            RepMaxCdcParams.newBuilder()
+                .setMinChunkSizeBytes(128 * 1024)
+                .setHorizonSizeBytes(1024 * 1024)
+                .build());
+
+    ChunkingConfig config =
+        ChunkingConfig.fromServerCapabilities(capabilities, ChunkingFunction.Value.REP_MAX_CDC);
+
+    assertThat(config).isInstanceOf(RepMaxCdcChunkingConfig.class);
+    RepMaxCdcChunkingConfig repMaxConfig = (RepMaxCdcChunkingConfig) config;
+    assertThat(repMaxConfig.minChunkSize()).isEqualTo(128 * 1024);
+    assertThat(repMaxConfig.horizonSize()).isEqualTo(1024 * 1024);
+    assertThat(repMaxConfig.chunkingThreshold()).isEqualTo(2 * 128 * 1024 - 1);
+  }
+
+  @Test
+  public void fromServerCapabilities_repMaxCdcMinSizeOutOfRange_fallsBackToDefault() {
+    ServerCapabilities capabilities =
+        capabilitiesWithRepMaxCdcParams(
+            RepMaxCdcParams.newBuilder()
+                .setMinChunkSizeBytes(64)
+                .setHorizonSizeBytes(1024 * 1024)
+                .build());
+
+    ChunkingConfig config =
+        ChunkingConfig.fromServerCapabilities(capabilities, ChunkingFunction.Value.REP_MAX_CDC);
+
+    assertThat(config).isInstanceOf(RepMaxCdcChunkingConfig.class);
+    RepMaxCdcChunkingConfig repMaxConfig = (RepMaxCdcChunkingConfig) config;
+    assertThat(repMaxConfig.minChunkSize())
+        .isEqualTo(RepMaxCdcChunkingConfig.DEFAULT_MIN_CHUNK_SIZE);
+    assertThat(repMaxConfig.horizonSize()).isEqualTo(1024 * 1024);
+  }
+
+  @Test
+  public void fromServerCapabilities_repMaxCdcHorizonSizeOutOfRange_fallsBackToDefault() {
+    ServerCapabilities capabilities =
+        capabilitiesWithRepMaxCdcParams(
+            RepMaxCdcParams.newBuilder()
+                .setMinChunkSizeBytes(128 * 1024)
+                .setHorizonSizeBytes(1024L * 1024 * 1024)
+                .build());
+
+    ChunkingConfig config =
+        ChunkingConfig.fromServerCapabilities(capabilities, ChunkingFunction.Value.REP_MAX_CDC);
+
+    assertThat(config).isInstanceOf(RepMaxCdcChunkingConfig.class);
+    RepMaxCdcChunkingConfig repMaxConfig = (RepMaxCdcChunkingConfig) config;
+    assertThat(repMaxConfig.minChunkSize()).isEqualTo(128 * 1024);
+    assertThat(repMaxConfig.horizonSize())
+        .isEqualTo(RepMaxCdcChunkingConfig.DEFAULT_HORIZON_SIZE_FACTOR * 128 * 1024);
+  }
+
+  @Test
+  public void fromServerCapabilities_repMaxCdcZeroHorizonSize_isAccepted() {
+    ServerCapabilities capabilities =
+        capabilitiesWithRepMaxCdcParams(
+            RepMaxCdcParams.newBuilder()
+                .setMinChunkSizeBytes(128 * 1024)
+                .setHorizonSizeBytes(0)
+                .build());
+
+    ChunkingConfig config =
+        ChunkingConfig.fromServerCapabilities(capabilities, ChunkingFunction.Value.REP_MAX_CDC);
+
+    assertThat(config).isInstanceOf(RepMaxCdcChunkingConfig.class);
+    assertThat(((RepMaxCdcChunkingConfig) config).horizonSize()).isEqualTo(0);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/chunking/FastCdcChunkerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/chunking/FastCdcChunkerTest.java
@@ -54,7 +54,7 @@ public class FastCdcChunkerTest {
 
   @Test
   public void chunkToDigests_smallInput_returnsSingleChunk() throws IOException {
-    ChunkingConfig config = new ChunkingConfig(1024, 2, 0);
+    FastCdcChunkingConfig config = new FastCdcChunkingConfig(1024, 2, 0);
     FastCdcChunker chunker = new FastCdcChunker(config, DIGEST_UTIL);
     byte[] data = new byte[100];
     new Random(42).nextBytes(data);
@@ -67,7 +67,7 @@ public class FastCdcChunkerTest {
 
   @Test
   public void chunkToDigests_dataAtMinSize_returnsSingleChunk() throws IOException {
-    ChunkingConfig config = new ChunkingConfig(1024, 2, 0);
+    FastCdcChunkingConfig config = new FastCdcChunkingConfig(1024, 2, 0);
     FastCdcChunker chunker = new FastCdcChunker(config, DIGEST_UTIL);
     byte[] data = new byte[config.minChunkSize()];
     new Random(42).nextBytes(data);
@@ -80,7 +80,7 @@ public class FastCdcChunkerTest {
 
   @Test
   public void chunkToDigests_largeInput_producesMultipleChunks() throws IOException {
-    ChunkingConfig config = new ChunkingConfig(1024, 2, 0);
+    FastCdcChunkingConfig config = new FastCdcChunkingConfig(1024, 2, 0);
     FastCdcChunker chunker = new FastCdcChunker(config, DIGEST_UTIL);
     byte[] data = new byte[config.maxChunkSize() * 3];
     new Random(42).nextBytes(data);
@@ -106,7 +106,7 @@ public class FastCdcChunkerTest {
 
   @Test
   public void chunkToDigests_chunkSizesWithinBounds() throws IOException {
-    ChunkingConfig config = new ChunkingConfig(1024, 2, 0);
+    FastCdcChunkingConfig config = new FastCdcChunkingConfig(1024, 2, 0);
     FastCdcChunker chunker = new FastCdcChunker(config, DIGEST_UTIL);
     byte[] data = new byte[config.maxChunkSize() * 10];
     new Random(42).nextBytes(data);
@@ -122,7 +122,7 @@ public class FastCdcChunkerTest {
 
   @Test
   public void chunkToDigests_lastChunkCanBeSmallerThanMin() throws IOException {
-    ChunkingConfig config = new ChunkingConfig(1024, 2, 0);
+    FastCdcChunkingConfig config = new FastCdcChunkingConfig(1024, 2, 0);
     FastCdcChunker chunker = new FastCdcChunker(config, DIGEST_UTIL);
     int dataSize = config.maxChunkSize() + config.minChunkSize() / 2;
     byte[] data = new byte[dataSize];
@@ -137,7 +137,7 @@ public class FastCdcChunkerTest {
 
   @Test
   public void chunkToDigests_digestsAreCorrect() throws IOException {
-    ChunkingConfig config = new ChunkingConfig(1024, 2, 0);
+    FastCdcChunkingConfig config = new FastCdcChunkingConfig(1024, 2, 0);
     FastCdcChunker chunker = new FastCdcChunker(config, DIGEST_UTIL);
     byte[] data = new byte[500];
     new Random(42).nextBytes(data);

--- a/src/test/java/com/google/devtools/build/lib/remote/chunking/RepMaxCdcBenchmark.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/chunking/RepMaxCdcBenchmark.java
@@ -1,0 +1,62 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.chunking;
+
+import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.vfs.SyscallCache;
+import com.google.devtools.build.lib.vfs.bazel.BazelHashFunctions;
+import java.io.ByteArrayInputStream;
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.Throughput)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+public class RepMaxCdcBenchmark {
+  private static final int MIN_CHUNK_SIZE = 256 * 1024;
+
+  @Param({"1048576", "8388608", "67108864"})
+  public int size;
+
+  private byte[] data;
+  private RepMaxCdcChunker chunker;
+
+  @Setup(Level.Iteration)
+  public void setup() {
+    BazelHashFunctions.ensureRegistered();
+    data = new byte[size];
+    new SecureRandom().nextBytes(data);
+
+    DigestUtil digestUtil = new DigestUtil(SyscallCache.NO_CACHE, BazelHashFunctions.BLAKE3);
+    chunker = new RepMaxCdcChunker(MIN_CHUNK_SIZE, 8 * MIN_CHUNK_SIZE, digestUtil);
+  }
+
+  @Benchmark
+  public Object chunkToDigests() throws Exception {
+    return chunker.chunkToDigests(new ByteArrayInputStream(data));
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/chunking/RepMaxCdcChunkerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/chunking/RepMaxCdcChunkerTest.java
@@ -1,0 +1,436 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.chunking;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.assertThrows;
+
+import build.bazel.remote.execution.v2.Digest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.hash.Hashing;
+import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.SyscallCache;
+import com.google.devtools.build.runfiles.Runfiles;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link RepMaxCdcChunker}. */
+@RunWith(JUnit4.class)
+public class RepMaxCdcChunkerTest {
+  private static final String TEST_VECTOR_PATH =
+      "io_bazel/src/test/java/com/google/devtools/build/lib/remote/chunking/testdata/SekienAkashita.jpg";
+
+  private static final DigestUtil DIGEST_UTIL =
+      new DigestUtil(SyscallCache.NO_CACHE, DigestHashFunction.SHA256);
+
+  @Test
+  public void chunkToDigests_emptyInput_returnsEmptyList() throws IOException {
+    RepMaxCdcChunker chunker = new RepMaxCdcChunker(DIGEST_UTIL);
+
+    ImmutableList<Digest> digests = chunker.chunkToDigests(new ByteArrayInputStream(new byte[0]));
+
+    assertThat(digests).isEmpty();
+  }
+
+  @Test
+  public void chunkToDigests_smallInput_returnsSingleChunk() throws IOException {
+    RepMaxCdcChunker chunker = new RepMaxCdcChunker(1024, 8 * 1024, DIGEST_UTIL);
+    byte[] data = new byte[100];
+    new Random(42).nextBytes(data);
+
+    ImmutableList<Digest> digests = chunker.chunkToDigests(new ByteArrayInputStream(data));
+
+    assertThat(digests).hasSize(1);
+    assertThat(digests.get(0).getSizeBytes()).isEqualTo(100);
+  }
+
+  @Test
+  public void chunkToDigests_dataAtMinSize_returnsSingleChunk() throws IOException {
+    RepMaxCdcChunker chunker = new RepMaxCdcChunker(1024, 8 * 1024, DIGEST_UTIL);
+    byte[] data = new byte[1024];
+    new Random(42).nextBytes(data);
+
+    ImmutableList<Digest> digests = chunker.chunkToDigests(new ByteArrayInputStream(data));
+
+    assertThat(digests).hasSize(1);
+    assertThat(digests.get(0).getSizeBytes()).isEqualTo(1024);
+  }
+
+  @Test
+  public void chunkToDigests_largeInput_producesMultipleChunks() throws IOException {
+    RepMaxCdcChunkingConfig config = new RepMaxCdcChunkingConfig(1024, 8 * 1024);
+    RepMaxCdcChunker chunker = new RepMaxCdcChunker(config, DIGEST_UTIL);
+    byte[] data = new byte[config.maxChunkSize() * 3];
+    new Random(42).nextBytes(data);
+
+    ImmutableList<Digest> digests = chunker.chunkToDigests(new ByteArrayInputStream(data));
+
+    assertThat(digests.size()).isGreaterThan(1);
+    long totalSize = digests.stream().mapToLong(Digest::getSizeBytes).sum();
+    assertThat(totalSize).isEqualTo(data.length);
+  }
+
+  @Test
+  public void chunkToDigests_sameInputProducesSameChunks() throws IOException {
+    RepMaxCdcChunker chunker = new RepMaxCdcChunker(DIGEST_UTIL);
+    byte[] data = new byte[2 * 1024 * 1024];
+    new Random(123).nextBytes(data);
+
+    ImmutableList<Digest> digests1 = chunker.chunkToDigests(new ByteArrayInputStream(data));
+    ImmutableList<Digest> digests2 = chunker.chunkToDigests(new ByteArrayInputStream(data));
+
+    assertThat(digests1).isEqualTo(digests2);
+  }
+
+  @Test
+  public void chunkToDigests_chunkSizesWithinBounds() throws IOException {
+    int minSize = 1024;
+    RepMaxCdcChunker chunker = new RepMaxCdcChunker(minSize, 8 * 1024, DIGEST_UTIL);
+    byte[] data = new byte[minSize * 50];
+    new Random(42).nextBytes(data);
+
+    ImmutableList<Digest> digests = chunker.chunkToDigests(new ByteArrayInputStream(data));
+
+    // All chunks, including the last one, are within [minSize, 2 * minSize) because the input is
+    // a multiple of minSize.
+    for (Digest digest : digests) {
+      long size = digest.getSizeBytes();
+      assertThat(size).isAtLeast(minSize);
+      assertThat(size).isLessThan(2L * minSize);
+    }
+    long totalSize = digests.stream().mapToLong(Digest::getSizeBytes).sum();
+    assertThat(totalSize).isEqualTo(data.length);
+  }
+
+  @Test
+  public void chunkToDigests_lastChunkIsAtLeastMinSize() throws IOException {
+    int minSize = 1024;
+    RepMaxCdcChunker chunker = new RepMaxCdcChunker(minSize, 8 * 1024, DIGEST_UTIL);
+    // An input that is not a multiple of the minimum chunk size.
+    int dataSize = minSize * 10 + minSize / 2;
+    byte[] data = new byte[dataSize];
+    new Random(42).nextBytes(data);
+
+    ImmutableList<Digest> digests = chunker.chunkToDigests(new ByteArrayInputStream(data));
+
+    // Unlike FastCDC, RepMaxCDC guarantees that all chunks of an input of at least minSize are at
+    // least minSize in size, including the last one.
+    for (Digest digest : digests) {
+      long size = digest.getSizeBytes();
+      assertThat(size).isAtLeast(minSize);
+      assertThat(size).isLessThan(2L * minSize);
+    }
+    long totalSize = digests.stream().mapToLong(Digest::getSizeBytes).sum();
+    assertThat(totalSize).isEqualTo(dataSize);
+  }
+
+  @Test
+  public void chunkToDigests_zeroHorizon_producesUniformChunks() throws IOException {
+    int minSize = 1024;
+    RepMaxCdcChunker chunker = new RepMaxCdcChunker(minSize, 0, DIGEST_UTIL);
+    byte[] data = new byte[minSize * 10];
+    new Random(42).nextBytes(data);
+
+    ImmutableList<Digest> digests = chunker.chunkToDigests(new ByteArrayInputStream(data));
+
+    // A zero horizon degenerates into uniform chunking of minSize.
+    assertThat(digests).hasSize(10);
+    for (Digest digest : digests) {
+      assertThat(digest.getSizeBytes()).isEqualTo(minSize);
+    }
+  }
+
+  @Test
+  public void chunkToDigests_digestsAreCorrect() throws IOException {
+    RepMaxCdcChunker chunker = new RepMaxCdcChunker(1024, 8 * 1024, DIGEST_UTIL);
+    byte[] data = new byte[500];
+    new Random(42).nextBytes(data);
+
+    ImmutableList<Digest> digests = chunker.chunkToDigests(new ByteArrayInputStream(data));
+
+    assertThat(digests).hasSize(1);
+    Digest expected = DIGEST_UTIL.compute(data);
+    assertThat(digests.get(0)).isEqualTo(expected);
+  }
+
+  @Test
+  public void constructor_minSizeBelowGearHashWindow_throws() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new RepMaxCdcChunker(63, 8 * 1024, DIGEST_UTIL));
+  }
+
+  @Test
+  public void constructor_negativeHorizonSize_throws() {
+    assertThrows(IllegalArgumentException.class, () -> new RepMaxCdcChunker(1024, -1, DIGEST_UTIL));
+  }
+
+  @Test
+  public void constructor_peekSizeOverflows_throws() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new RepMaxCdcChunker(1024 * 1024, Integer.MAX_VALUE / 2, DIGEST_UTIL));
+  }
+
+  @Test
+  public void chunkToDigests_withDefaultConfig() throws IOException {
+    RepMaxCdcChunker chunker = new RepMaxCdcChunker(DIGEST_UTIL);
+    byte[] data = new byte[4 * 1024 * 1024];
+    new Random(42).nextBytes(data);
+
+    ImmutableList<Digest> digests = chunker.chunkToDigests(new ByteArrayInputStream(data));
+
+    assertThat(digests.size()).isGreaterThan(1);
+    long totalSize = digests.stream().mapToLong(Digest::getSizeBytes).sum();
+    assertThat(totalSize).isEqualTo(data.length);
+  }
+
+  @Test
+  public void chunkToDigests_randomData_producesValidChunks() throws IOException {
+    Random random = new Random(42);
+    int[][] params = {
+      {64, 0}, {64, 256}, {128, 1024}, {1024, 0}, {1024, 8 * 1024}, {2048, 16 * 1024},
+    };
+    for (int[] param : params) {
+      int minSize = param[0];
+      int horizonSize = param[1];
+      int peekSize = 2 * minSize + horizonSize;
+      int[] sizes = {
+        0,
+        1,
+        minSize - 1,
+        minSize,
+        minSize + 1,
+        2 * minSize - 1,
+        2 * minSize,
+        2 * minSize + 1,
+        peekSize - 1,
+        peekSize,
+        peekSize + 1,
+        // Large enough to force multiple refills of the chunker's read buffer.
+        4 * peekSize + 17,
+        64 * 1024 + 1,
+      };
+      for (int size : sizes) {
+        byte[] data = new byte[size];
+        random.nextBytes(data);
+        assertValidChunks(minSize, horizonSize, data);
+      }
+    }
+  }
+
+  @Test
+  public void chunkToDigests_lowEntropyData_producesValidChunks() throws IOException {
+    // Constant and periodic inputs starve the algorithm of new hash maxima, exercising the chunk
+    // completion and forced-cut paths of the implementation.
+    for (int minSize : new int[] {64, 1024}) {
+      for (int horizonSize : new int[] {0, 8 * minSize}) {
+        byte[] constant = new byte[64 * 1024 + 3];
+        assertValidChunks(minSize, horizonSize, constant);
+
+        byte[] periodic = new byte[64 * 1024 + 3];
+        for (int i = 0; i < periodic.length; i++) {
+          periodic[i] = (byte) (i % 7);
+        }
+        assertValidChunks(minSize, horizonSize, periodic);
+      }
+    }
+  }
+
+  @Test
+  public void chunkToDigests_randomParameters_producesValidChunks() throws IOException {
+    // Random small parameters maximize the rate of forced cuts and cutting point recomputation,
+    // covering the rare paths of the implementation.
+    Random random = new Random(987654321);
+    for (int i = 0; i < 200; i++) {
+      int minSize = 64 + random.nextInt(256);
+      int horizonSize = random.nextInt(4 * 1024);
+      byte[] data = new byte[random.nextInt(32 * 1024)];
+      random.nextBytes(data);
+      assertValidChunks(minSize, horizonSize, data);
+    }
+  }
+
+  @Test
+  public void chunkToDigests_largeInput_producesValidChunks() throws IOException {
+    byte[] data = new byte[4 * 1024 * 1024];
+    new Random(123).nextBytes(data);
+
+    assertValidChunks(/* minSize= */ 1024, /* horizonSize= */ 8 * 1024, data);
+  }
+
+  /**
+   * Chunks {@code data} and verifies the guarantees of the algorithm: all chunks are within {@code
+   * [minSize, 2 * minSize)}, except that the final chunk may be smaller than {@code minSize} only
+   * if the entire input is; the chunk sizes add up to the input size; and chunking is
+   * deterministic.
+   */
+  private static void assertValidChunks(int minSize, int horizonSize, byte[] data)
+      throws IOException {
+    RepMaxCdcChunker chunker = new RepMaxCdcChunker(minSize, horizonSize, DIGEST_UTIL);
+
+    ImmutableList<Digest> digests = chunker.chunkToDigests(new ByteArrayInputStream(data));
+
+    String context =
+        String.format(
+            "minSize=%s, horizonSize=%s, inputSize=%s", minSize, horizonSize, data.length);
+    long totalSize = 0;
+    for (int i = 0; i < digests.size(); i++) {
+      long size = digests.get(i).getSizeBytes();
+      if (i < digests.size() - 1 || data.length >= minSize) {
+        assertWithMessage(context).that(size).isAtLeast(minSize);
+      }
+      assertWithMessage(context).that(size).isLessThan(2L * minSize);
+      totalSize += size;
+    }
+    assertWithMessage(context).that(totalSize).isEqualTo(data.length);
+
+    assertWithMessage(context)
+        .that(chunker.chunkToDigests(new ByteArrayInputStream(data)))
+        .isEqualTo(digests);
+  }
+
+  @Test
+  public void chunkToDigests_testVectors() throws Exception {
+    verifyTestVectors(
+        /* minSize= */ 4096,
+        /* horizonSize= */ 32768,
+        new int[][] {
+          {0, 7026},
+          {7026, 5198},
+          {12224, 5310},
+          {17534, 4271},
+          {21805, 5278},
+          {27083, 5588},
+          {32671, 5017},
+          {37688, 6761},
+          {44449, 5541},
+          {49990, 7612},
+          {57602, 5501},
+          {63103, 4695},
+          {67798, 4362},
+          {72160, 6221},
+          {78381, 7190},
+          {85571, 5858},
+          {91429, 4382},
+          {95811, 8022},
+          {103833, 5633},
+        },
+        new String[] {
+          "3c386537b8c3200dd2ab6623f6096a576d07844a4a0d5d2994d13e24887dae46",
+          "cc7fb08694b471e3ba660b700b347775d1e7a55db8f308c176e2eb6776b5222c",
+          "096a3e0e42f0a8b7a5a3a337e9b5b4c7fc59abcd6f69486fb68fe4c5c156300f",
+          "3f4a0b00f9a04959806c9ce9e530fa5d761930ef6c8477117b58eb93196342e8",
+          "d0c2f82664d8887bd2d289a75baea1d5688e6ee586f8767149bfef9c6df8fe63",
+          "558e6b58c659f7463c846a0d18c155a86520d1ca69102f102635c08e8b0897e2",
+          "c3c66478eb8e1632768e6e13dc31e492ac78befca38e9db85525b4b274c5b5d7",
+          "a5ce22ca3a02323451ddca6db5319c26b5fc1abc5621a033c98cd3de154cd29d",
+          "ec4752962eda083bf78b24cb087e07451ced85d8c0d719f32c474f7dae8fd764",
+          "3d9e8dc0a5f14dee7db5eabf99bb636352081423f122a84fdb160cecc2ad01bb",
+          "f8c747a292f7fd6433945356ee314b978b423ac4c3d248c8fdf36c0693eb6006",
+          "71249e1031dc237ab6393381a30a10ef90d9a93f532c135b11cc0df60a767b5f",
+          "95c42ec307be0ce1efde6de814c668f05a31887fde9501b478faca225cf9b8c7",
+          "8869f4871a0f3fb63775e0fb7f10e170a59b71a6fa0a91a18fa3cf5fff987eba",
+          "d2f91644457863f716071e76e9b1046408820aa95b36471d5e70ee5c91b611a2",
+          "3507024624db4ff48ee546e984d7c60461d6a526aba7e4aa33833b162785e79e",
+          "9b19e98bc5d9b6f486c7c7281fd61044b8e5333363048b20ce3dcb2ee0172980",
+          "e56dbfa2a82695fed3c565857dbc644af91c983b55c13fe20d9e03bb89e009e2",
+          "7d76fde9af9a911c4e580db9227e5109c5de28101f3f26637c527e80215aad38",
+        });
+  }
+
+  @Test
+  public void chunkToDigests_testVectorsZeroHorizon() throws Exception {
+    verifyTestVectors(
+        /* minSize= */ 8192,
+        /* horizonSize= */ 0,
+        new int[][] {
+          {0, 8192},
+          {8192, 8192},
+          {16384, 8192},
+          {24576, 8192},
+          {32768, 8192},
+          {40960, 8192},
+          {49152, 8192},
+          {57344, 8192},
+          {65536, 8192},
+          {73728, 8192},
+          {81920, 8192},
+          {90112, 8192},
+          {98304, 11162},
+        },
+        new String[] {
+          "716c5e702f4bee5f18426da9e9eb77d22aa936486741768b86fff472bc18c363",
+          "33df8556634b77338abee984190d1aa21efb10411edeae3820fd61a93e489f58",
+          "a05018146657a5c999868a9e3f6e94da715c519f929005ca50404eb5a30caf1f",
+          "e124b2b4e8847def80e1b8da2fbfa5b483c3bcab6cf2d88e50d598d6c2d2e65c",
+          "7855d8367f097e33d0d3afbdba0e17749309a0dfb48f3d373bdf94b9b8f378e1",
+          "782a8f7b5367f177b94da16dc14026a3af3dcfc25b6b53f2060eafee0bc16922",
+          "3be28a5d9d67d5f8f9b30fbe742406cfefb46c139b48a47eeb98837fbb55128b",
+          "e6d7615aeefa30776bd0de14ad0e9ac5a738a767c63aa8c3310aa85c49d16d44",
+          "316e9ca063049a490d8f8431f109f2eaf0bf74739b4c3f4be9da46144733c327",
+          "2b4a043bd77df955a9fa30358597a90bca046474917e91d3715205f9d674a3bf",
+          "78abb22658ea5642440139f1bf86382d4bca2d33858fd8e15a170f1c1ac19651",
+          "076758af278b0fb9fd0313db8f6b796639c23241e2c8d831503e272e069d9aea",
+          "e776b8d90b880e10e4fdc4f99ba3b0bfbe471f26362007a1775d4cab46a539c7",
+        });
+  }
+
+  // Test vectors generated with the Go reference implementation of RepMaxCDC:
+  // https://github.com/buildbarn/go-cdc
+  // Test image: "Akashita" by Toriyama Sekien (1712-1788), public domain.
+  // Source: https://commons.wikimedia.org/wiki/File:SekienAkashita.jpg
+  private void verifyTestVectors(
+      int minSize, int horizonSize, int[][] expectedChunks, String[] expectedHashes)
+      throws Exception {
+    Path testVectorPath =
+        Path.of(Runfiles.preload().withSourceRepository("").rlocation(TEST_VECTOR_PATH));
+    byte[] fileData = Files.readAllBytes(testVectorPath);
+
+    RepMaxCdcChunker chunker = new RepMaxCdcChunker(minSize, horizonSize, DIGEST_UTIL);
+    ImmutableList<Digest> digests;
+    try (InputStream input = new ByteArrayInputStream(fileData)) {
+      digests = chunker.chunkToDigests(input);
+    }
+
+    assertThat(digests).hasSize(expectedChunks.length);
+
+    List<int[]> actualChunks = new ArrayList<>();
+    int offset = 0;
+    for (Digest digest : digests) {
+      actualChunks.add(new int[] {offset, (int) digest.getSizeBytes()});
+      offset += (int) digest.getSizeBytes();
+    }
+
+    for (int i = 0; i < expectedChunks.length; i++) {
+      assertThat(actualChunks.get(i)[0]).isEqualTo(expectedChunks[i][0]);
+      assertThat(actualChunks.get(i)[1]).isEqualTo(expectedChunks[i][1]);
+
+      byte[] chunkData = new byte[expectedChunks[i][1]];
+      System.arraycopy(fileData, expectedChunks[i][0], chunkData, 0, chunkData.length);
+      String chunkHash = Hashing.sha256().hashBytes(chunkData).toString();
+      assertThat(chunkHash).isEqualTo(expectedHashes[i]);
+    }
+  }
+}

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CapabilitiesServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CapabilitiesServer.java
@@ -21,6 +21,7 @@ import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.ExecutionCapabilities;
 import build.bazel.remote.execution.v2.FastCdc2020Params;
 import build.bazel.remote.execution.v2.GetCapabilitiesRequest;
+import build.bazel.remote.execution.v2.RepMaxCdcParams;
 import build.bazel.remote.execution.v2.ServerCapabilities;
 import build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy;
 import com.google.devtools.build.lib.remote.ApiVersion;
@@ -69,6 +70,11 @@ final class CapabilitiesServer extends CapabilitiesImplBase {
                     FastCdc2020Params.newBuilder()
                         .setAvgChunkSizeBytes(512 * 1024)
                         .setSeed(0)
+                        .build())
+                .setRepMaxCdcParams(
+                    RepMaxCdcParams.newBuilder()
+                        .setMinChunkSizeBytes(256 * 1024)
+                        .setHorizonSizeBytes(8 * 256 * 1024)
                         .build())
                 .build());
     if (execEnabled) {

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CasServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CasServer.java
@@ -56,7 +56,10 @@ final class CasServer extends ContentAddressableStorageImplBase {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
   static final long MAX_BATCH_SIZE_BYTES = 1024 * 1024 * 4;
   private final OnDiskBlobStoreCache cache;
-  private final Map<Digest, List<Digest>> splicedBlobs = new ConcurrentHashMap<>();
+  private final Map<Digest, SplicedBlob> splicedBlobs = new ConcurrentHashMap<>();
+
+  /** A blob stored via spliceBlob, along with the chunking function reported by the client. */
+  private record SplicedBlob(List<Digest> chunkDigests, ChunkingFunction.Value chunkingFunction) {}
 
   public CasServer(OnDiskBlobStoreCache cache) {
     this.cache = cache;
@@ -167,15 +170,15 @@ final class CasServer extends ContentAddressableStorageImplBase {
       SplitBlobRequest request, StreamObserver<SplitBlobResponse> responseObserver) {
     Digest blobDigest = request.getBlobDigest();
 
-    List<Digest> chunkDigests = splicedBlobs.get(blobDigest);
-    if (chunkDigests == null) {
+    SplicedBlob splicedBlob = splicedBlobs.get(blobDigest);
+    if (splicedBlob == null) {
       responseObserver.onError(StatusUtils.notFoundError(blobDigest));
       return;
     }
     responseObserver.onNext(
         SplitBlobResponse.newBuilder()
-            .addAllChunkDigests(chunkDigests)
-            .setChunkingFunction(ChunkingFunction.Value.FAST_CDC_2020)
+            .addAllChunkDigests(splicedBlob.chunkDigests())
+            .setChunkingFunction(splicedBlob.chunkingFunction())
             .build());
     responseObserver.onCompleted();
   }
@@ -219,7 +222,9 @@ final class CasServer extends ContentAddressableStorageImplBase {
       }
 
       // Record the blob-to-chunks mapping for splitBlob lookups.
-      splicedBlobs.put(blobDigest, new ArrayList<>(chunkDigests));
+      splicedBlobs.put(
+          blobDigest,
+          new SplicedBlob(new ArrayList<>(chunkDigests), request.getChunkingFunction()));
 
       responseObserver.onNext(SpliceBlobResponse.newBuilder().setBlobDigest(blobDigest).build());
       responseObserver.onCompleted();


### PR DESCRIPTION
### Description

Adds support for the RepMaxCDC function to the remote cache chunking feature, selectable via a new flag `--experimental_remote_cache_chunking_function={auto,fast_cdc_2020,rep_max_cdc}`. With `auto` (the default) the function is negotiated from the server capabilities: FastCDC 2020 is used if the server advertises it (including when it advertises both, for backward compatibility), otherwise RepMaxCDC. The explicit values require the selected function to be advertised by the server. Against servers that advertise FastCDC 2020 today, behavior is unchanged.

- `RepMaxCdcChunker` ports the algorithm from the Go reference implementation ([buildbarn/go-cdc](https://github.com/buildbarn/go-cdc)). Chunk boundaries are byte-identical to the reference implementation. The test vectors in `RepMaxCdcChunkerTest` were generated by running it on the same test image used by the FastCDC test vectors.
- `ChunkingConfig` becomes a sealed interface with per-function parameter records (`FastCdcChunkingConfig`, `RepMaxCdcChunkingConfig`) negotiated from the server capabilities (`FastCdc2020Params` / `RepMaxCdcParams`).
- Both chunkers implement `ContentDefinedChunker` and share the Gear table (`GearTable`).
- Capability validation, `SplitBlob`/`SpliceBlob` requests, and the remote worker use the selected function instead of hardcoding `FAST_CDC_2020`.
- Tests mirror the existing FastCDC coverage: chunker unit tests with reference test vectors, config negotiation tests, a JMH benchmark, and an integration test running the chunked cache flow end-to-end with RepMaxCDC against the remote worker.

#### Performance

JMH throughput of `chunkToDigests` (chunking plus BLAKE3 chunk digests, single thread, Apple M-series). Average chunk sizes are measured: FastCDC's 512 KiB parameter is its "expected" size and comes out at ~595 KiB in practice, so RepMaxCDC is shown both with its defaults and with min = 448 KiB, which matches FastCDC's true average chunk size:

| Function | Parameters | True avg chunk size | 64 MiB | 256 MiB | 1 GiB |
|---|---|---|---|---|---|
| FastCDC 2020 | expected 512 KiB (defaults) | ~595 KiB | 1.17 ± 0.06 GiB/s | 1.16 ± 0.05 GiB/s | 1.15 ± 0.04 GiB/s |
| RepMaxCDC | min 256 KiB (defaults) | ~340 KiB | 0.98 ± 0.02 GiB/s | 0.99 ± 0.03 GiB/s | 0.96 ± 0.10 GiB/s |
| RepMaxCDC | min 448 KiB (matched to FastCDC) | ~598 KiB | 1.00 ± 0.02 GiB/s | 1.00 ± 0.04 GiB/s | 0.97 ± 0.14 GiB/s |

RepMaxCDC reaches ~85% of FastCDC throughput.

Note: these numbers include one additional optimization compared to the original Go implementation, a four-way unrolling of the Gear hash loop. Chunk boundaries are unaffected and the test vectors are still the same. Without it, RepMaxCDC sits at ~70-75% of FastCDC.

`RepMaxCdcChunker` carries a small primitive `IntList` helper instead of using `ArrayList<Integer>`: a variant backed by a boxed list measured ~2.2x slower overall.

#### Disclaimer
This PR heavily leveraged Claude Fable to rewrite the Go implementation of RepMaxCDC into Java but the code was manually reviewed by me (which is not saying a lot since I'm not a Java dev :D).

### Motivation

Tracking issue: #30132

`--experimental_remote_cache_chunking` currently always uses FastCDC 2020 to split large blobs. The Remote Execution API also defines the RepMaxCDC chunking function (`REP_MAX_CDC` / `RepMaxCdcParams`), as implemented by [buildbarn/go-cdc](https://github.com/buildbarn/go-cdc), but Bazel does not implement it as a client.

RepMaxCDC provides a deduplication rate comparable to FastCDC while giving tight bounds on chunk sizes: all chunks fall within `[min_chunk_size, 2 * min_chunk_size)`, so for a given blob it is trivial to check whether it is already chunked purely by looking at its size. Supporting it lets Bazel clients share chunk data with servers and other clients that use RepMaxCDC (e.g. future Buildbarn deployments).

### Build API Changes

This PR adds a new experimental command-line flag, `--experimental_remote_cache_chunking_function`, and extends the existing `--experimental_remote_cache_chunking` feature.

1. RepMaxCDC is already part of the Remote Execution API ([`ChunkingFunction.REP_MAX_CDC` / `RepMaxCdcParams`](https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto)); this PR implements the client side in Bazel.
2. The change is fully backward compatible: the new flag defaults to `auto`, which negotiates the function from the server capabilities and prefers FastCDC 2020 whenever the server advertises it, preserving the current behavior of `--experimental_remote_cache_chunking` against existing servers.
3. Not a breaking change.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES[NEW]: Added `--experimental_remote_cache_chunking_function` to select the content-defined chunking function used by `--experimental_remote_cache_chunking`. Supported values are `auto` (the default, which negotiates the function from the server capabilities, preferring FastCDC 2020), `fast_cdc_2020` and `rep_max_cdc`.

Closes #30131.

PiperOrigin-RevId: 954678549
Change-Id: Ib5add5a728a5ef6efb5f21f27a8ae27ba706a516

(cherry picked from commit 41d577015ff451f369a8a939bc2a6a6511998768)


8.8.0 adaptation: the branch predates several master-only refactors of the surrounding code, so the change was reshaped to fit without pulling them in.
- `RemoteOptions` on 8.8.0 is a final class with public option fields rather than abstract getters, so `--experimental_remote_cache_chunking_function` is a field and `getEffectiveChunkingFunction()` reads the fields directly.
- `CombinedCache` and `RemoteExecutionCache` still take the full `RemoteOptions` instead of a symlink template plus a chunking function, so the effective chunking function is derived in the `CombinedCache` constructor rather than passed in by `RemoteModule`.
- `ChunkedBlobDownloader` on 8.8.0 has no `ChunkingConfig` because the SplitBlob chunk-size validation (#29844) is not on the branch. It gains a `ChunkingConfig` parameter purely to obtain the chunking function and keeps its existing `verifyDownloads` parameter; the four chunk-size validation tests in the original diff were dropped along with the validation they cover.
- The two new integration tests keep 8.8.0's `-Djava.lang.Thread.allowVirtualThreads=true` jvm_flags, and `RepMaxCdcBenchmark` depends on `//src/main/java/com/google/devtools/build/lib/remote/util:digest_utils` since 8.8.0 has not split that target.

Closes #30566
