### PR TITLE
Re-sample the execution graph clock converter per command

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/ExecutionGraphModule.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/ExecutionGraphModule.java
@@ -193,8 +193,7 @@ public class ExecutionGraphModule extends BlazeModule {
   private ActionDumpWriter writer;
   private CommandEnvironment env;
   private WalkableGraph graph;
-  private NanosToMillisSinceEpochConverter nanosToMillis =
-      BlazeClock.createNanosToMillisSinceEpochConverter();
+  private NanosToMillisSinceEpochConverter nanosToMillis;
   // Only relevant for Skymeld: there may be multiple events and we only count the first one.
   private final AtomicBoolean executionStarted = new AtomicBoolean();
 
@@ -216,13 +215,20 @@ public class ExecutionGraphModule extends BlazeModule {
   }
 
   @VisibleForTesting
-  void setNanosToMillis(NanosToMillisSinceEpochConverter nanosToMillis) {
-    this.nanosToMillis = nanosToMillis;
+  void resetNanosToMillis() {
+    this.nanosToMillis = BlazeClock.createNanosToMillisSinceEpochConverter();
+  }
+
+  @VisibleForTesting
+  NanosToMillisSinceEpochConverter getNanosToMillis() {
+    return nanosToMillis;
   }
 
   @Override
   public void beforeCommand(CommandEnvironment env) {
     this.env = env;
+    // The offset between monotonic and wall clock time may change between commands.
+    resetNanosToMillis();
 
     if (env.getCommand().buildPhase().executes()) {
       ExecutionGraphOptions options =

--- a/src/test/java/com/google/devtools/build/lib/runtime/ExecutionGraphModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/ExecutionGraphModuleTest.java
@@ -56,7 +56,6 @@ import com.google.devtools.build.lib.bugreport.BugReporter;
 import com.google.devtools.build.lib.buildtool.BuildResult;
 import com.google.devtools.build.lib.buildtool.BuildResult.BuildToolLogCollection;
 import com.google.devtools.build.lib.buildtool.buildevent.BuildCompleteEvent;
-import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.exec.util.FakeActionInputFileCache;
@@ -100,8 +99,9 @@ public final class ExecutionGraphModuleTest extends FoundationTestCase {
   private ArtifactRoot artifactRoot;
 
   @Before
-  public void initializeRoots() {
+  public void setUp() {
     artifactRoot = ArtifactRoot.asDerivedRoot(scratch.resolve("/"), RootType.OUTPUT, "output");
+    module.resetNanosToMillis();
   }
 
   private static ImmutableList<ExecutionGraph.Node> parse(ByteArrayOutputStream buffer)
@@ -668,8 +668,6 @@ public final class ExecutionGraphModuleTest extends FoundationTestCase {
   public void spawnAndAction_withDifferentOutputs() throws Exception {
     var buffer = new ByteArrayOutputStream();
     startLogging(eventBus, buffer, DependencyInfo.ALL);
-    var nanosToMillis = BlazeClock.createNanosToMillisSinceEpochConverter();
-    module.setNanosToMillis(nanosToMillis);
 
     module.spawnExecuted(
         new SpawnExecutedEvent(
@@ -708,7 +706,7 @@ public final class ExecutionGraphModuleTest extends FoundationTestCase {
                 .setIndex(1)
                 .setMetrics(
                     ExecutionGraph.Metrics.newBuilder()
-                        .setStartTimestampMillis(nanosToMillis.toEpochMillis(0)))
+                        .setStartTimestampMillis(module.getNanosToMillis().toEpochMillis(0)))
                 .setRuleClass("dummy-kind")
                 .build());
   }
@@ -717,8 +715,6 @@ public final class ExecutionGraphModuleTest extends FoundationTestCase {
   public void noSpawnAction_hasCorrectDuration() throws Exception {
     var buffer = new ByteArrayOutputStream();
     startLogging(eventBus, buffer, DependencyInfo.ALL);
-    var nanosToMillis = BlazeClock.createNanosToMillisSinceEpochConverter();
-    module.setNanosToMillis(nanosToMillis);
 
     var action = new ActionsTestUtil.NullAction(createOutputArtifact("foo/out"));
     module.actionComplete(
@@ -736,7 +732,7 @@ public final class ExecutionGraphModuleTest extends FoundationTestCase {
             executionGraphNodeBuilderForAction(action)
                 .setMetrics(
                     ExecutionGraph.Metrics.newBuilder()
-                        .setStartTimestampMillis(nanosToMillis.toEpochMillis(1000000))
+                        .setStartTimestampMillis(module.getNanosToMillis().toEpochMillis(1000000))
                         .setDurationMillis(1)
                         .setProcessMillis(1))
                 .setRuleClass("dummy-kind")


### PR DESCRIPTION
### Description

`ExecutionGraphModule` built its `NanosToMillisSinceEpochConverter` in a *field initializer*:

```java
private NanosToMillisSinceEpochConverter nanosToMillis =
    BlazeClock.createNanosToMillisSinceEpochConverter();
```

Modules are instantiated once per server, so that converter captures the offset between the monotonic and the wall clock as it stood at server startup, and is then reused for every command that server ever serves. Build it in `beforeCommand` instead, so each command converts through an offset sampled during that command.

### Motivation

`System.nanoTime()` and `System.currentTimeMillis()` are backed by different operating system clocks, and the offset between them is not constant. NTP steps the wall clock when it corrects it. A virtual machine does so more dramatically: shortly after boot, and again whenever a snapshot is resumed — while the monotonic clock never steps and does not advance across the pause.

A long-lived server that survives a snapshot resume keeps converting with an offset captured before the snapshot, so every `start_timestamp_millis` it writes into the execution graph log afterwards is shifted by the entire time the snapshot spent on disk. Anything that reconstructs a timeline from the log — critical path, action concurrency, correlation against other traces on the machine — is wrong by that amount. On bare metal an NTP step produces the same corruption at a smaller magnitude.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
