### PR TITLE
Report the JSON profile's start as the origin its events use

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java
@@ -54,6 +54,7 @@ class JsonTraceFileWriter implements Runnable {
 
   private final OutputStream outStream;
   private final long profileStartTimeNanos;
+  private final long profileStartEpochMillis;
   private final ThreadLocal<Boolean> metadataPosted = ThreadLocal.withInitial(() -> Boolean.FALSE);
   private final SlimProfileConfiguration slimProfileConfig;
   private final UUID buildID;
@@ -68,9 +69,18 @@ class JsonTraceFileWriter implements Runnable {
       new TaskData(
           /* threadId= */ 0, /* startTimeNanos= */ 0, /* eventType= */ null, "poison pill");
 
+  /**
+   * @param profileStartTimeNanos the monotonic clock reading that every event in the profile is
+   *     emitted relative to
+   * @param profileStartEpochMillis the same instant on the wall clock. It has to be supplied
+   *     because this class cannot convert between the two clocks; reading the wall clock here
+   *     instead would date the profile to when the writer thread started, which is one client
+   *     startup and command lock wait later than the events the profile contains.
+   */
   JsonTraceFileWriter(
       OutputStream outStream,
       long profileStartTimeNanos,
+      long profileStartEpochMillis,
       SlimProfileConfiguration slimProfileConfig,
       String outputBase,
       UUID buildID,
@@ -79,6 +89,7 @@ class JsonTraceFileWriter implements Runnable {
     this.thread = new Thread(this, "profile-writer-thread");
     this.outStream = outStream;
     this.profileStartTimeNanos = profileStartTimeNanos;
+    this.profileStartEpochMillis = profileStartEpochMillis;
     this.slimProfileConfig = slimProfileConfig;
     this.buildID = buildID;
     this.outputBase = outputBase;
@@ -271,7 +282,7 @@ class JsonTraceFileWriter implements Runnable {
                 // Bazel internally stores strings as raw bytes encoded in ISO_8859_1, so we use the
                 // same encoding here to also write out raw bytes.
                 new OutputStreamWriter(targetOutStream, ISO_8859_1))) {
-          var startDate = Instant.now();
+          var startDate = Instant.ofEpochMilli(profileStartEpochMillis);
           writer.beginObject();
           writer.name("otherData");
           writer.beginObject();

--- a/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java
@@ -72,10 +72,7 @@ class JsonTraceFileWriter implements Runnable {
   /**
    * @param profileStartTimeNanos the monotonic clock reading that every event in the profile is
    *     emitted relative to
-   * @param profileStartEpochMillis the same instant on the wall clock. It has to be supplied
-   *     because this class cannot convert between the two clocks; reading the wall clock here
-   *     instead would date the profile to when the writer thread started, which is one client
-   *     startup and command lock wait later than the events the profile contains.
+   * @param profileStartEpochMillis the same instant on the wall clock
    */
   JsonTraceFileWriter(
       OutputStream outStream,

--- a/src/main/java/com/google/devtools/build/lib/profiler/TraceProfilerServiceImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/TraceProfilerServiceImpl.java
@@ -289,9 +289,17 @@ public final class TraceProfilerServiceImpl implements TraceProfilerService {
                   ? SlimProfileConfiguration.afterSize(slimProfileSizeLimit)
                   : SlimProfileConfiguration.always())
               : SlimProfileConfiguration.disabled();
+      long profileStartEpochMillis =
+          BlazeClock.createNanosToMillisSinceEpochConverter(clock).toEpochMillis(execStartTimeNanos);
       writer =
           new JsonTraceFileWriter(
-              stream, execStartTimeNanos, slimProfileConfig, outputBase, buildID, format);
+              stream,
+              execStartTimeNanos,
+              profileStartEpochMillis,
+              slimProfileConfig,
+              outputBase,
+              buildID,
+              format);
       writer.start();
     }
     this.writerRef.set(writer);


### PR DESCRIPTION
### Description

The JSON profile's time origin is deliberately backdated to when the *client* launched, so that the `LAUNCH` phase and binary extraction appear ahead of the server's own work:

```java
long clientStartTimeNanos = execStartTimeNanos - startupTimeNanos - waitTimeNanos;
Profiler.instance().start(…, clock, clientStartTimeNanos, …);
Profiler.instance().logSimpleTaskDuration(
    clientStartTimeNanos, Duration.ofNanos(startupTimeNanos), ProfilerTask.PHASE,
    ProfilePhase.LAUNCH.description);
```

Every event in the file is emitted as an offset from that reading. The `profile_start_ts` and `date` fields, though, came from an `Instant.now()` evaluated when the profile writer thread starts — one client startup and one command lock wait *later* than the origin the events are measured from.

This PR derives both fields from the profile's own origin rather than sampling the wall clock a second time.

### Motivation

Anything that reconstructs an absolute timeline by adding an event's `ts` to `profile_start_ts` places the entire profile late by `startup_time + command_wait_time`. That is typically tens to hundreds of milliseconds, which is easy to miss — but the command lock wait is unbounded, so it becomes seconds or minutes whenever the invocation had to wait for another command on the same server to finish. Correlating a Bazel profile against any other trace on the machine is off by that much.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
