### PR TITLE
Measure the wait for the server to start on the steady clock

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -874,7 +874,10 @@ static void ConnectOrDie(const OptionProcessor &option_processor,
                          BlazeServer *server) {
   // Give the server two minutes to start up. That's enough to connect with a
   // debugger.
-  const auto start_time = std::chrono::system_clock::now();
+  // Measured on the steady clock: a wall-clock step, which a VM commonly takes
+  // shortly after boot or when resuming from a snapshot, must not be mistaken
+  // for the server taking too long to come up.
+  const auto start_time = std::chrono::steady_clock::now();
   const auto try_until_time =
       start_time +
       std::chrono::seconds(startup_options.local_startup_timeout_secs);
@@ -882,8 +885,8 @@ static void ConnectOrDie(const OptionProcessor &option_processor,
   // connect.
   const auto min_message_interval = std::chrono::seconds(10);
   auto last_message_time = start_time;
-  while (std::chrono::system_clock::now() < try_until_time) {
-    const auto attempt_time = std::chrono::system_clock::now();
+  while (std::chrono::steady_clock::now() < try_until_time) {
+    const auto attempt_time = std::chrono::steady_clock::now();
     const auto next_attempt_time =
         attempt_time + std::chrono::milliseconds(100);
 


### PR DESCRIPTION
### Description

`ConnectOrDie` budgeted `--local_startup_timeout_secs` on `std::chrono::system_clock`, and used the same clock for the "still trying to connect" progress messages and for pacing the retry loop with `sleep_until`. Switch all three to `steady_clock`.

### Motivation

Those three are durations, so correcting the wall clock underneath them changes how long the client actually waits. A forward step makes it give up early with `couldn't connect to server (pid) after N seconds` even though the server is coming up perfectly normally; a backward step makes it wait longer than the flag asked for.

Machines step their wall clock whenever NTP corrects it. A virtual machine does so shortly after boot — which is precisely the window in which the first Bazel invocation on that machine sits waiting for a server to start. On a microVM whose image carries a stale RTC, that first correction can be large.

### Related

#30594, #30595, #30596 and #30593 are further fixes in the same area, all independent of this one.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None