### PR TITLE
[9.3.0] Include resolved test timeout in TestRunnerAction action key.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
@@ -525,6 +525,7 @@ public class TestRunnerAction extends AbstractAction
     // The 'requiredClientEnvVariables' are handled by Skyframe and don't need to be added here.
     fp.addString(testProperties.getSize().toString());
     fp.addString(testProperties.getTimeout().toString());
+    fp.addString(getTimeout().toString());
     fp.addStrings(testProperties.getTags());
     fp.addBoolean(testProperties.isRemotable());
     fp.addInt(shardNum);

--- a/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
@@ -394,6 +394,24 @@ public class TestActionBuilderTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testTimeoutChangesActionKey() throws Exception {
+    useConfiguration("--test_timeout=10");
+    Artifact testStatus1 = Iterables.getOnlyElement(getTestStatusArtifacts("//tests:small_test_1"));
+    TestRunnerAction action1 = (TestRunnerAction) getGeneratingAction(testStatus1);
+
+    initializeSkyframeExecutor();
+
+    useConfiguration("--test_timeout=1");
+    Artifact testStatus2 = Iterables.getOnlyElement(getTestStatusArtifacts("//tests:small_test_1"));
+    TestRunnerAction action2 = (TestRunnerAction) getGeneratingAction(testStatus2);
+
+    String key1 = action1.getKey(actionKeyContext, /* inputMetadataProvider= */ null);
+    String key2 = action2.getKey(actionKeyContext, /* inputMetadataProvider= */ null);
+
+    assertThat(key1).isNotEqualTo(key2);
+  }
+
+  @Test
   public void testRunsPerTestWithSharding() throws Exception {
     useConfiguration("--runs_per_test=2");
     scratch.file(


### PR DESCRIPTION
When `--test_timeout` is changed on the command line, the local action cache previously reused cached test pass results even when the test runtime exceeded the new timeout.

Fixes https://github.com/bazelbuild/bazel/issues/30576

PiperOrigin-RevId: 959660647
Change-Id: I9048089c2d0941a2b5e731ac7c94dba8be8e0ae7

Commit https://github.com/bazelbuild/bazel/commit/a05f041e4714a324d23d731641674deeac9e2744