### PR TITLE
docs: fix remote cache execution log links

### DIFF
--- a/docs/remote/cache-remote.mdx
+++ b/docs/remote/cache-remote.mdx
@@ -133,7 +133,7 @@ not happening across machines, do the following:
     bazel ... build ... --execution_log_compact_file=/tmp/exec2.log
    ```
 
-4. [Compare the execution logs](#compare-logs-the-execution-logs) for the two
+4. [Compare the execution logs](#compare-logs) for the two
     runs. If the logs are not identical, investigate your build configurations
     for discrepancies as well as properties from the host environment leaking
     into either of the builds.

--- a/docs/versions/7.6.1/remote/cache-remote.mdx
+++ b/docs/versions/7.6.1/remote/cache-remote.mdx
@@ -65,7 +65,7 @@ If you are not getting the cache hit rate you are expecting, do the following:
       bazel <var>--optional-flags</var> build //<var>your:target</var> --execution_log_compact_file=/tmp/exec1.log
       ```
 
-   b. [Compare the execution logs](#compare-logs-the-execution-logs) between the
+   b. [Compare the execution logs](#compare-logs) between the
       two runs. Ensure that the actions are identical across the two log files.
       Discrepancies provide a clue about the changes that occurred between the
       runs. Update your build to eliminate those discrepancies.
@@ -131,7 +131,7 @@ not happening across machines, do the following:
     bazel ... build ... --execution_log_compact_file=/tmp/exec2.log
    ```
 
-4. [Compare the execution logs](#compare-logs-the-execution-logs) for the two
+4. [Compare the execution logs](#compare-logs) for the two
     runs. If the logs are not identical, investigate your build configurations
     for discrepancies as well as properties from the host environment leaking
     into either of the builds.

--- a/docs/versions/7.7.1/remote/cache-remote.mdx
+++ b/docs/versions/7.7.1/remote/cache-remote.mdx
@@ -65,7 +65,7 @@ If you are not getting the cache hit rate you are expecting, do the following:
       bazel <var>--optional-flags</var> build //<var>your:target</var> --execution_log_compact_file=/tmp/exec1.log
       ```
 
-   b. [Compare the execution logs](#compare-logs-the-execution-logs) between the
+   b. [Compare the execution logs](#compare-logs) between the
       two runs. Ensure that the actions are identical across the two log files.
       Discrepancies provide a clue about the changes that occurred between the
       runs. Update your build to eliminate those discrepancies.
@@ -131,7 +131,7 @@ not happening across machines, do the following:
     bazel ... build ... --execution_log_compact_file=/tmp/exec2.log
    ```
 
-4. [Compare the execution logs](#compare-logs-the-execution-logs) for the two
+4. [Compare the execution logs](#compare-logs) for the two
     runs. If the logs are not identical, investigate your build configurations
     for discrepancies as well as properties from the host environment leaking
     into either of the builds.

--- a/docs/versions/8.0.1/remote/cache-remote.mdx
+++ b/docs/versions/8.0.1/remote/cache-remote.mdx
@@ -131,7 +131,7 @@ not happening across machines, do the following:
     bazel ... build ... --execution_log_compact_file=/tmp/exec2.log
    ```
 
-4. [Compare the execution logs](#compare-logs-the-execution-logs) for the two
+4. [Compare the execution logs](#compare-logs) for the two
     runs. If the logs are not identical, investigate your build configurations
     for discrepancies as well as properties from the host environment leaking
     into either of the builds.

--- a/docs/versions/8.1.1/remote/cache-remote.mdx
+++ b/docs/versions/8.1.1/remote/cache-remote.mdx
@@ -131,7 +131,7 @@ not happening across machines, do the following:
     bazel ... build ... --execution_log_compact_file=/tmp/exec2.log
    ```
 
-4. [Compare the execution logs](#compare-logs-the-execution-logs) for the two
+4. [Compare the execution logs](#compare-logs) for the two
     runs. If the logs are not identical, investigate your build configurations
     for discrepancies as well as properties from the host environment leaking
     into either of the builds.

--- a/docs/versions/8.2.1/remote/cache-remote.mdx
+++ b/docs/versions/8.2.1/remote/cache-remote.mdx
@@ -131,7 +131,7 @@ not happening across machines, do the following:
     bazel ... build ... --execution_log_compact_file=/tmp/exec2.log
    ```
 
-4. [Compare the execution logs](#compare-logs-the-execution-logs) for the two
+4. [Compare the execution logs](#compare-logs) for the two
     runs. If the logs are not identical, investigate your build configurations
     for discrepancies as well as properties from the host environment leaking
     into either of the builds.

--- a/docs/versions/8.3.1/remote/cache-remote.mdx
+++ b/docs/versions/8.3.1/remote/cache-remote.mdx
@@ -131,7 +131,7 @@ not happening across machines, do the following:
     bazel ... build ... --execution_log_compact_file=/tmp/exec2.log
    ```
 
-4. [Compare the execution logs](#compare-logs-the-execution-logs) for the two
+4. [Compare the execution logs](#compare-logs) for the two
     runs. If the logs are not identical, investigate your build configurations
     for discrepancies as well as properties from the host environment leaking
     into either of the builds.

--- a/docs/versions/8.4.2/remote/cache-remote.mdx
+++ b/docs/versions/8.4.2/remote/cache-remote.mdx
@@ -131,7 +131,7 @@ not happening across machines, do the following:
     bazel ... build ... --execution_log_compact_file=/tmp/exec2.log
    ```
 
-4. [Compare the execution logs](#compare-logs-the-execution-logs) for the two
+4. [Compare the execution logs](#compare-logs) for the two
     runs. If the logs are not identical, investigate your build configurations
     for discrepancies as well as properties from the host environment leaking
     into either of the builds.

--- a/docs/versions/8.5.1/remote/cache-remote.mdx
+++ b/docs/versions/8.5.1/remote/cache-remote.mdx
@@ -131,7 +131,7 @@ not happening across machines, do the following:
     bazel ... build ... --execution_log_compact_file=/tmp/exec2.log
    ```
 
-4. [Compare the execution logs](#compare-logs-the-execution-logs) for the two
+4. [Compare the execution logs](#compare-logs) for the two
     runs. If the logs are not identical, investigate your build configurations
     for discrepancies as well as properties from the host environment leaking
     into either of the builds.

--- a/docs/versions/8.6.0/remote/cache-remote.mdx
+++ b/docs/versions/8.6.0/remote/cache-remote.mdx
@@ -131,12 +131,12 @@ not happening across machines, do the following:
     bazel ... build ... --execution_log_compact_file=/tmp/exec2.log
    ```
 
-4. [Compare the execution logs](#compare-logs-the-execution-logs) for the two
+4. [Compare the execution logs](#compare-logs) for the two
     runs. If the logs are not identical, investigate your build configurations
     for discrepancies as well as properties from the host environment leaking
     into either of the builds.
 
-## Comparing the execution logs
+## Comparing the execution logs {#compare-logs}
 
 The execution log contains records of actions executed during the build.
 Each record describes both the inputs (not only files, but also command line

--- a/docs/versions/8.7.0/remote/cache-remote.mdx
+++ b/docs/versions/8.7.0/remote/cache-remote.mdx
@@ -131,7 +131,7 @@ not happening across machines, do the following:
     bazel ... build ... --execution_log_compact_file=/tmp/exec2.log
    ```
 
-4. [Compare the execution logs](#compare-logs-the-execution-logs) for the two
+4. [Compare the execution logs](#compare-logs) for the two
     runs. If the logs are not identical, investigate your build configurations
     for discrepancies as well as properties from the host environment leaking
     into either of the builds.

--- a/docs/versions/9.0.0/remote/cache-remote.mdx
+++ b/docs/versions/9.0.0/remote/cache-remote.mdx
@@ -131,7 +131,7 @@ not happening across machines, do the following:
     bazel ... build ... --execution_log_compact_file=/tmp/exec2.log
    ```
 
-4. [Compare the execution logs](#compare-logs-the-execution-logs) for the two
+4. [Compare the execution logs](#compare-logs) for the two
     runs. If the logs are not identical, investigate your build configurations
     for discrepancies as well as properties from the host environment leaking
     into either of the builds.

--- a/docs/versions/9.1.0/remote/cache-remote.mdx
+++ b/docs/versions/9.1.0/remote/cache-remote.mdx
@@ -131,7 +131,7 @@ not happening across machines, do the following:
     bazel ... build ... --execution_log_compact_file=/tmp/exec2.log
    ```
 
-4. [Compare the execution logs](#compare-logs-the-execution-logs) for the two
+4. [Compare the execution logs](#compare-logs) for the two
     runs. If the logs are not identical, investigate your build configurations
     for discrepancies as well as properties from the host environment leaking
     into either of the builds.


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
Fix broken execution-log anchors in the current remote cache documentation and supported version snapshots.

### Motivation
Fixes broken fragment anchors in published docs.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
