### PR TITLE
Fix `Could not chdir` in `tw.exe` for long runfiles paths on Windows

### DIFF
--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import string
 import zipfile
 
 from absl.testing import absltest
@@ -754,6 +755,42 @@ class TestWrapperTest(test_base.TestBase):
     self._AssertXmlGeneration(flags)
     self._AssertXmlGeneratedByTestIsRetained(flags)
     self._AssertAddCurrentDirectoryToPathTest(flags)
+
+  # Test that chdir'ing into a runfiles directory longer than MAX_PATH works.
+  # See https://github.com/bazelbuild/bazel/issues/30609
+  def testChdirToRunfilesWithPathLongerThanMaxPath(self):
+    # Used for both the package directory and the target name so the overall
+    # runfiles path exceeds MAX_PATH, while each individual path component
+    # remains well below the separate 255-character per-component limit:
+    # https://support.microsoft.com/en-us/onedrive/what-are-file-path-length-limits
+    _130_chars = string.ascii_lowercase * 5
+    self.ScratchFile(
+        'MODULE.bazel', ['bazel_dep(name = "rules_python", version = "0.40.0")']
+    )
+    self.CopyFile(
+        src_path=self.Rlocation('io_bazel/src/test/py/bazel/native_test.bzl'),
+        dst_path='%s/native_test.bzl' % _130_chars)
+    self.CopyFile(
+        src_path=self.Rlocation('io_bazel/src/test/py/bazel/printargs.exe'),
+        dst_path='%s/printargs.exe' % _130_chars,
+        executable=True)
+    self.ScratchFile(
+        '%s/BUILD' % _130_chars,
+        [
+            'load(":native_test.bzl", "exe_test")',
+            'exe_test(',
+            '    name = "%s",' % _130_chars,
+            '    src = "printargs.exe",',
+            ')',
+        ],
+    )
+    self.RunBazel([
+        'test',
+        '//%s:%s' % (_130_chars, _130_chars),
+        '-t-',
+        '--shell_executable=',
+        '--test_output=errors',
+    ])
 
 
 if __name__ == '__main__':

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -1,6 +1,7 @@
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("//tools/res:win_res.bzl", "windows_resources")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -50,7 +51,16 @@ cc_binary(
     }),
     target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//visibility:private"],
-    deps = [":tw_lib"],
+    deps = [
+        ":tw_lib",
+        ":tw_resources",
+    ],
+)
+
+windows_resources(
+    name = "tw_resources",
+    rc_files = ["windows/tw_resources.rc"],
+    resources = ["windows/tw_manifest.xml"],
 )
 
 cc_binary(

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -1301,9 +1301,16 @@ bool StartSubprocess(const Path& path, const std::wstring& args,
     return false;
   }
 
+  // CreateProcessW's implicit cwd inheritance fails when cwd exceeds MAX_PATH:
+  // populate it so that `process->Create` may shorten it.
+  Path cwd;
+  if (!GetCwd(&cwd)) {
+    return false;
+  }
+
   std::wstring werror;
-  if (!process->Create(path.Get(), args, nullptr, L"", devnull_read, pipe_write,
-                       pipe_write_dup, start_time, &werror)) {
+  if (!process->Create(path.Get(), args, nullptr, cwd.Get(), devnull_read,
+                       pipe_write, pipe_write_dup, start_time, &werror)) {
     LogError(__LINE__, werror);
     return false;
   }

--- a/tools/test/windows/tw_manifest.xml
+++ b/tools/test/windows/tw_manifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <!-- tw.exe would otherwise fail to chdir into runfiles paths over MAX_PATH -->
+      <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/tools/test/windows/tw_resources.rc
+++ b/tools/test/windows/tw_resources.rc
@@ -1,0 +1,2 @@
+// id 1 (CREATEPROCESS_MANIFEST_RESOURCE_ID), type 24 (RT_MANIFEST)
+1 24 "tw_manifest.xml"


### PR DESCRIPTION
### Description
On Windows, `bazel test` fails for tests run through the native test wrapper (`tw.exe`) whose runfiles directory path exceeds `MAX_PATH` (260 characters), with `ERROR_FILENAME_EXCED_RANGE` (206) from `ChdirToRunfiles`'s call to `SetCurrentDirectoryW`.

The `\\?\` extended-length prefix used by #29921 for `CreateProcessW`'s `lpApplicationName` would not help here: `SetCurrentDirectoryW` ignores that prefix regardless of length, as stated by MicrosoftDocs/feedback#1441.
=> declare `longPathAware` in `tw.exe`'s manifest (`tw_manifest.xml`, embedded via `tw_resources.rc` and `windows_resources` in `tools/test/BUILD`), which Windows 10 1607+ honors for `SetCurrentDirectoryW` once paired with the `LongPathsEnabled` registry opt-in.

Once `ChdirToRunfiles` succeeds into a long directory, `StartSubprocess`'s `CreateProcessW` call also needs its current directory passed explicitly: implicit inheritance (`lpCurrentDirectory=nullptr`) otherwise fails with `ERROR_INVALID_PARAMETER` once `cwd` exceeds `MAX_PATH`, _even from a `longPathAware` process_.
=> populate it so that `windows::WaitableProcess::Create` can shorten it internally (through `AsShortPath`), like it does for the executable's own path.

The new `testLongRunfilesPathChdir` in `test_wrapper_test.py` exercises both fixes: the cwd fix always fails in `StartSubprocess` when missing, while a missing manifest can surface as either `ChdirToRunfiles`'s error or `rules_cc`'s `Runfiles::Create` (`FindTestBinary`) failing first, depending on path length.

### Motivation
Fixes #30609

### Build API Changes
No

### Checklist
- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes
RELNOTES: Fix `Could not chdir` in `tw.exe` for long runfiles paths on Windows.