### PR TITLE
Reject a parenthesized name in a keyword argument

### DIFF
--- a/src/main/java/net/starlark/java/syntax/Parser.java
+++ b/src/main/java/net/starlark/java/syntax/Parser.java
@@ -469,17 +469,16 @@ final class Parser {
     }
 
     // IDENTIFIER  or  IDENTIFIER = test
-    int exprOffset = token.start;
+    // A parenthesized identifier parses to the same Identifier node as a bare one,
+    // because (e) is not materialized, so the name of a keyword argument has to be
+    // recognized before the expression is parsed rather than after.
+    boolean bareIdentifier = token.kind == TokenKind.IDENTIFIER;
     expr = parseTest();
     if (expr instanceof Identifier id) {
       // parse a named argument
       if (token.kind == TokenKind.EQUALS) {
-        // A parenthesized identifier parses to the same Identifier node as a bare
-        // one, because (e) is not materialized, so the offsets are what tells them
-        // apart: for (x) the expression starts at '(' and the identifier at 'x'.
-        if (id.getStartOffset() != exprOffset) {
-          syntaxError(
-              exprOffset, token.kind, token.value, "keyword argument must have form name=expr");
+        if (!bareIdentifier) {
+          syntaxError("keyword argument must have form name=expr");
         }
         nextToken();
         Expression arg = parseTest();

--- a/src/main/java/net/starlark/java/syntax/Parser.java
+++ b/src/main/java/net/starlark/java/syntax/Parser.java
@@ -469,10 +469,18 @@ final class Parser {
     }
 
     // IDENTIFIER  or  IDENTIFIER = test
+    int exprOffset = token.start;
     expr = parseTest();
     if (expr instanceof Identifier id) {
       // parse a named argument
       if (token.kind == TokenKind.EQUALS) {
+        // A parenthesized identifier parses to the same Identifier node as a bare
+        // one, because (e) is not materialized, so the offsets are what tells them
+        // apart: for (x) the expression starts at '(' and the identifier at 'x'.
+        if (id.getStartOffset() != exprOffset) {
+          syntaxError(
+              exprOffset, token.kind, token.value, "keyword argument must have form name=expr");
+        }
         nextToken();
         Expression arg = parseTest();
         return new Argument.Keyword(locs, id, arg);

--- a/src/test/java/net/starlark/java/syntax/ParserTest.java
+++ b/src/test/java/net/starlark/java/syntax/ParserTest.java
@@ -736,6 +736,20 @@ public final class ParserTest {
   }
 
   @Test
+  public void testKeywordArgumentNameMustNotBeParenthesized() throws Exception {
+    assertThat(parseExpressionError("f((x) = 1)"))
+        .contains("keyword argument must have form name=expr");
+    assertThat(parseExpressionError("f(y = 0, (x) = 1)"))
+        .contains("keyword argument must have form name=expr");
+
+    // The forms that stay legal: a bare keyword, and a parenthesized
+    // expression passed positionally.
+    parseExpression("f(x = 1)");
+    parseExpression("f((x))");
+    parseExpression("f((x), y = 1)");
+  }
+
+  @Test
   public void testSuffixPosition() throws Exception {
     assertExpressionLocationCorrect("'a'.len");
     assertExpressionLocationCorrect("'a'[0]");


### PR DESCRIPTION
Fixes #30555

`f((x) = 1)` parses today. The grammar has `arg = ident '=' test`, so the parentheses are not allowed there, and both Python and the reference implementation reject it:

```
$ go run ./probe   # go.starlark.net/syntax
foo((x) = 1)       -> t.star:1:10: keyword argument must have form name=expr
foo(x = 1)         -> <nil>
foo((x))           -> <nil>
```

The parser cannot tell the two forms apart by node type. `(e)` is not materialized -- there is a `TODO(adonovan): materialize paren expressions (for fidelity)` at `Parser.java:721` -- so `(x)` reaches `parseArgument` as the same `Identifier` as a bare `x`. The offsets do differ, and that is what this checks: for `(x)` the expression starts at `(` while the identifier starts at `x`. No new AST node.

Error text taken verbatim from go.starlark.net, so the two implementations report the same thing.

### What I ran

I do not have a Bazel toolchain here, so I compiled `net.starlark.java.syntax` on its own with javac (guava, auto-value, error_prone_annotations) and ran the package's own `ParserTest` against it.

Before the change:

```
1) testKeywordArgumentNameMustNotBeParenthesized(net.starlark.java.syntax.ParserTest)
java.lang.AssertionError: parseExpressionError() succeeded unexpectedly: f((x) = 1)
Tests run: 183,  Failures: 1
```

After:

```
OK (183 tests)
```

So the new test fails without the parser change and the other 182 keep passing. I also checked a spread of legal forms by hand -- `f(x = 1)`, `f( x = 1)`, `f((x))`, `f((x), y = 1)`, `f(*a, **kw)`, `f(x = g(y = 2))`, `f(x = (1))`, a realistic rule call with `name =`, `srcs =`, `deps =` -- all still parse.

`f((a.b) = 1)` was already an error before this change and stays one, with its existing message.

### Worth knowing before merging

This makes a form that used to parse into a syntax error, so a `.bzl` or `BUILD` file in the wild that writes `(name) = value` would start failing. I could not find a reason anyone would write it, and go.starlark.net has rejected it all along, so such a file would already be non-portable -- but the call on whether that needs a migration flag is yours.
