### PR TITLE
[9.3.0] Use a <loading key, module> pair for .bzl files' symbol generator owner

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -108,6 +108,7 @@ import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.packages.Type.LabelClass;
 import com.google.devtools.build.lib.packages.Types;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
+import com.google.devtools.build.lib.skyframe.BzlLoadThreadOwner;
 import com.google.devtools.build.lib.skyframe.BzlLoadValue;
 import com.google.devtools.build.lib.skyframe.serialization.AbstractExportedStarlarkSymbolCodec;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.SerializationConstant;
@@ -530,15 +531,16 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
     }
   }
 
-  private static Symbol<BzlLoadValue.Key> getBzlKeyToken(StarlarkThread thread, String onBehalfOf) {
+  private static Symbol<BzlLoadThreadOwner> getBzlKeyToken(
+      StarlarkThread thread, String onBehalfOf) {
     Symbol<?> untypedToken = thread.getNextIdentityToken();
     checkState(
-        untypedToken.getOwner() instanceof BzlLoadValue.Key,
+        untypedToken.getOwner() instanceof BzlLoadThreadOwner,
         "%s may only be owned by .bzl files (owner=%s)",
         onBehalfOf,
         untypedToken);
     @SuppressWarnings("unchecked")
-    var typedToken = (Symbol<BzlLoadValue.Key>) untypedToken;
+    var typedToken = (Symbol<BzlLoadThreadOwner>) untypedToken;
     return typedToken;
   }
 
@@ -1549,14 +1551,14 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
     @Nullable private Location exportedLocation = null;
 
     /** A token used for equality that may be mutated by {@link #export}. */
-    private Symbol<BzlLoadValue.Key> identityToken;
+    private Symbol<BzlLoadThreadOwner> identityToken;
 
     @Nullable private final String documentation;
 
     public MacroFunction(
         MacroClass.Builder builder,
         Optional<String> documentation,
-        Symbol<BzlLoadValue.Key> identityToken) {
+        Symbol<BzlLoadThreadOwner> identityToken) {
       this.builder = builder;
       this.documentation = documentation.orElse(null);
       this.identityToken = identityToken;
@@ -1587,7 +1589,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
     @Nullable
     public Label getExtensionLabel() {
       if (identityToken.isGlobal()) {
-        return identityToken.getOwner().getLabel();
+        return identityToken.getOwner().key().getLabel();
       }
       return null;
     }
@@ -1654,7 +1656,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
       this.macroClass = builder.build();
       this.builder = null;
       checkArgument(
-          identityToken.getOwner().getLabel().equals(starlarkLabel),
+          identityToken.getOwner().key().getLabel().equals(starlarkLabel),
           "created by %s, exporting as %s:%s",
           identityToken.getOwner(),
           starlarkLabel,
@@ -1915,13 +1917,13 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
       var symbolToken = (Symbol<?>) identityToken; // always a Symbol before export
       this.identityToken =
           switch (symbolToken.getOwner()) {
-            case BzlLoadValue.Key bzlKey -> {
+            case BzlLoadThreadOwner owner -> {
               checkArgument(
-                  bzlKey.getLabel().equals(starlarkLabel),
+                  owner.key().getLabel().equals(starlarkLabel),
                   "Exporting rule as (%s, %s) but doesn't match owner %s",
                   starlarkLabel,
                   ruleClassName,
-                  bzlKey);
+                  owner);
               yield symbolToken.exportAs(ruleClassName);
             }
             default -> AnalysisTestKey.create(starlarkLabel, ruleClassName);
@@ -2281,7 +2283,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
       // TODO: b/326588519 - this does not support AnalysisTestKey but that type does not seem to
       // appear in action lookup values. Make this more robust if necessary.
       var symbol = (GlobalSymbol<?>) obj.identityToken;
-      return (BzlLoadValue.Key) symbol.getOwner();
+      return ((BzlLoadThreadOwner) symbol.getOwner()).key();
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkDefinedAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkDefinedAspect.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.EventHandler;
+import com.google.devtools.build.lib.skyframe.BzlLoadThreadOwner;
 import com.google.devtools.build.lib.skyframe.BzlLoadValue;
 import com.google.devtools.build.lib.skyframe.serialization.AbstractExportedStarlarkSymbolCodec;
 import com.google.devtools.build.lib.starlarkbuildapi.StarlarkSubruleApi;
@@ -101,7 +102,7 @@ public final class StarlarkDefinedAspect implements StarlarkExportable, Starlark
       ImmutableSet<Label> execCompatibleWith,
       ImmutableMap<String, DeclaredExecGroup> execGroups,
       ImmutableSet<? extends StarlarkSubruleApi> subrules,
-      Symbol<BzlLoadValue.Key> identityToken) {
+      Symbol<BzlLoadThreadOwner> identityToken) {
     this.implementation = implementation;
     this.documentation = documentation.orElse(null);
     this.attributeAspects = attributeAspects;
@@ -184,15 +185,15 @@ public final class StarlarkDefinedAspect implements StarlarkExportable, Starlark
       EventHandler handler, Label extensionLabel, String name, Location exportedLocation) {
     Preconditions.checkArgument(!isExported());
     @SuppressWarnings("unchecked")
-    var identityToken = (Symbol<BzlLoadValue.Key>) aspectClassOrIdentityToken;
-    BzlLoadValue.Key owner = identityToken.getOwner();
+    var identityToken = (Symbol<BzlLoadThreadOwner>) aspectClassOrIdentityToken;
+    BzlLoadThreadOwner owner = identityToken.getOwner();
     checkArgument(
-        owner.getLabel().equals(extensionLabel),
+        owner.key().getLabel().equals(extensionLabel),
         "Exporting aspect as (%s, %s) but label did not match owner=%s",
         extensionLabel,
         name,
         owner);
-    this.aspectClassOrIdentityToken = new StarlarkAspectClass(owner, name);
+    this.aspectClassOrIdentityToken = new StarlarkAspectClass(owner.key(), name);
   }
 
   /**
@@ -268,7 +269,7 @@ public final class StarlarkDefinedAspect implements StarlarkExportable, Starlark
     Object castedValue = attrValue;
 
     if (attrType == Type.INTEGER) {
-      castedValue = StarlarkInt.parse(attrValue, /*base=*/ 0);
+      castedValue = StarlarkInt.parse(attrValue, /* base= */ 0);
       attrBuilder = attr.cloneBuilder(Type.INTEGER).value((StarlarkInt) castedValue);
     } else if (attrType == Type.BOOLEAN) {
       castedValue = Boolean.parseBoolean(attrValue);
@@ -390,7 +391,7 @@ public final class StarlarkDefinedAspect implements StarlarkExportable, Starlark
 
   private StarlarkInt parseIntParameter(String name, String value) throws EvalException {
     try {
-      return StarlarkInt.parse(value, /*base=*/ 0);
+      return StarlarkInt.parse(value, /* base= */ 0);
     } catch (NumberFormatException e) {
       throw new EvalException(
           String.format(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -2773,13 +2773,18 @@ java_library(
 
 java_library(
     name = "bzl_load_value",
-    srcs = ["BzlLoadValue.java"],
+    srcs = [
+        "BzlLoadThreadOwner.java",
+        "BzlLoadValue.java",
+    ],
     deps = [
         ":bzl_compile_value",
         ":starlark_builtins_value",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
         "//src/main/java/com/google/devtools/build/lib/packages:bzl_visibility",
+        "//src/main/java/com/google/devtools/build/lib/packages/semantics",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization:visible-for-serialization",
         "//src/main/java/com/google/devtools/build/lib/util:hash_codes",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
@@ -78,7 +78,6 @@ import net.starlark.java.eval.Mutability;
 import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkSemantics;
 import net.starlark.java.eval.StarlarkThread;
-import net.starlark.java.eval.SymbolGenerator;
 import net.starlark.java.syntax.LoadStatement;
 import net.starlark.java.syntax.Location;
 import net.starlark.java.syntax.Program;
@@ -1386,7 +1385,10 @@ public class BzlLoadFunction implements SkyFunction {
     try (Mutability mu = Mutability.create("loading", label)) {
       StarlarkThread thread =
           StarlarkThread.create(
-              mu, starlarkSemantics, /* contextDescription= */ "", SymbolGenerator.create(key));
+              mu,
+              starlarkSemantics,
+              /* contextDescription= */ "",
+              BzlLoadThreadOwner.createGenerator(key, module));
       thread.setLoader(loadedModules::get);
       // This is needed so that any calls to `Label()` will have its used repo mapping entries
       // recorded. See #20721 for more details.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadThreadOwner.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadThreadOwner.java
@@ -1,0 +1,184 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.skyframe;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.devtools.build.lib.skyframe.serialization.ByteStringCodec.byteStringCodec;
+
+import com.google.common.collect.Interner;
+import com.google.devtools.build.lib.cmdline.BazelModuleContext;
+import com.google.devtools.build.lib.concurrent.BlazeInterners;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
+import com.google.devtools.build.lib.skyframe.serialization.AsyncDeserializationContext;
+import com.google.devtools.build.lib.skyframe.serialization.DeferredObjectCodec;
+import com.google.devtools.build.lib.skyframe.serialization.DeferredObjectCodec.DeferredValue;
+import com.google.devtools.build.lib.skyframe.serialization.SerializationContext;
+import com.google.devtools.build.lib.skyframe.serialization.SerializationException;
+import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerialization;
+import com.google.errorprone.annotations.Keep;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HexFormat;
+import net.starlark.java.eval.Module;
+import net.starlark.java.eval.SymbolGenerator;
+
+/**
+ * An evaluated .bzl or .scl file (in the form of a {@link Module}) and its associated {@link
+ * BzlLoadValue.Key}. Intended to be used as the {@link SymbolGenerator#create owner} of {@link
+ * SymbolGenerator} instances created by {@link BzlLoadFunction}.
+ *
+ * <p>This class exists for two reasons: to allow checking that we are evaluating a .bzl or .scl
+ * file (and not some other variety of Starlark environment); and for (de)serialization and
+ * interning of exported Starlark values.
+ *
+ * <p>If a {@link BzlLoadThreadOwner} object differs from one produced from the current {@link
+ * BzlLoadValue} at the same key, it indicates that the first thread owner is a "zombie module" left
+ * over from a previous Bazel invocation, and should not be used.
+ */
+// Note that we rely on (1) Module having identity semantics, and (2) the Module object being
+// owned by BzlLoadValue and therefore being unique for a given key within a single Bazel
+// invocation.
+public record BzlLoadThreadOwner(BzlLoadValue.Key key, Module module) {
+
+  private static final Interner<BzlLoadThreadOwner> interner = BlazeInterners.newWeakInterner();
+
+  public BzlLoadThreadOwner {
+    checkNotNull(key);
+    checkNotNull(module);
+  }
+
+  public static BzlLoadThreadOwner of(BzlLoadValue.Key key, Module module) {
+    return interner.intern(new BzlLoadThreadOwner(key, module));
+  }
+
+  public static BzlLoadThreadOwner of(BzlLoadValue.Key key, BzlLoadValue value) {
+    return of(key, value.getModule());
+  }
+
+  public static SymbolGenerator<BzlLoadThreadOwner> createGenerator(
+      BzlLoadValue.Key key, Module module) {
+    return SymbolGenerator.create(BzlLoadThreadOwner.of(key, module));
+  }
+
+  public static SymbolGenerator<BzlLoadThreadOwner> createGenerator(
+      BzlLoadValue.Key key, BzlLoadValue value) {
+    return SymbolGenerator.create(BzlLoadThreadOwner.of(key, value));
+  }
+
+  @VisibleForSerialization
+  public static DeferredObjectCodec<BzlLoadThreadOwner> codec() {
+    return Codec.INSTANCE;
+  }
+
+  /**
+   * Codec for {@link BzlLoadThreadOwner}.
+   *
+   * <p>We cannot serialize a {@link Module} directly. Instead, we serialize the module's transitive
+   * digest and {@link StarlarkSemantics} fingerprint, and then check at deserialization time
+   * whether the digest and fingerprint still match the module in the {@link BzlLoadValue} in
+   * skyframe. (If they don't match, the deserialized {@link BzlLoadThreadOwner} is a zombie.)
+   */
+  @Keep
+  private static final class Codec extends DeferredObjectCodec<BzlLoadThreadOwner> {
+    private static final Codec INSTANCE = new Codec();
+
+    @Override
+    public Class<BzlLoadThreadOwner> getEncodedClass() {
+      return BzlLoadThreadOwner.class;
+    }
+
+    @Override
+    public void serialize(
+        SerializationContext context, BzlLoadThreadOwner obj, CodedOutputStream codedOut)
+        throws SerializationException, IOException {
+      context.serializeLeaf(obj.key(), BzlLoadValue.bzlLoadKeyCodec(), codedOut);
+      context.serializeLeaf(
+          BuildLanguageOptions.stableFingerprint(obj.module().getSemantics()),
+          byteStringCodec(),
+          codedOut);
+      context.serializeLeaf(
+          ByteString.copyFrom(BazelModuleContext.of(obj.module()).bzlTransitiveDigest()),
+          byteStringCodec(),
+          codedOut);
+    }
+
+    @Override
+    public DeferredValue<BzlLoadThreadOwner> deserializeDeferred(
+        AsyncDeserializationContext context, CodedInputStream codedIn)
+        throws SerializationException, IOException {
+      BzlLoadValue.Key key = context.deserializeLeaf(codedIn, BzlLoadValue.bzlLoadKeyCodec());
+      ByteString starlarkSemanticsFingerprint = context.deserializeLeaf(codedIn, byteStringCodec());
+      byte[] transitiveDigest = context.deserializeLeaf(codedIn, byteStringCodec()).toByteArray();
+      var builder = new DeserializationBuilder(key, starlarkSemanticsFingerprint, transitiveDigest);
+      context.getSkyValue(key, builder, DeserializationBuilder::setBzlLoadValue);
+      return builder;
+    }
+  }
+
+  private static ByteString getSemanticsFingerprint(Module module) {
+    return BuildLanguageOptions.stableFingerprint(module.getSemantics());
+  }
+
+  private static byte[] getTransitiveDigest(Module module) {
+    return BazelModuleContext.of(module).bzlTransitiveDigest();
+  }
+
+  private static final class DeserializationBuilder implements DeferredValue<BzlLoadThreadOwner> {
+    private final BzlLoadValue.Key key;
+    private final ByteString starlarkSemanticsFingerprint;
+    private final byte[] transitiveDigest;
+    private BzlLoadValue loadValue;
+
+    private static final HexFormat HEX_FORMAT = HexFormat.of().withLowerCase();
+
+    private DeserializationBuilder(
+        BzlLoadValue.Key key, ByteString starlarkSemanticsFingerprint, byte[] transitiveDigest) {
+      this.key = key;
+      this.starlarkSemanticsFingerprint = starlarkSemanticsFingerprint;
+      this.transitiveDigest = transitiveDigest;
+    }
+
+    @Override
+    public BzlLoadThreadOwner call() throws SerializationException {
+      if (loadValue == null) {
+        throw new SerializationException(
+            String.format(
+                "Failed to retrieve BzlLoadValue for %s; either Skyframe lookup value is not set,"
+                    + " or we are attempting to retrieve a zombie module.",
+                key));
+      }
+      Module module = loadValue.getModule();
+      if (!(starlarkSemanticsFingerprint.equals(getSemanticsFingerprint(module))
+          && Arrays.equals(transitiveDigest, getTransitiveDigest(module)))) {
+        throw new SerializationException(
+            String.format(
+                "Cannot retrieve a zombie module. Expected semantics fingerprint %s and transitive"
+                    + " digest %s, but got semantics fingerprint %s and transitive digest %s",
+                starlarkSemanticsFingerprint,
+                HEX_FORMAT.formatHex(transitiveDigest),
+                getSemanticsFingerprint(module),
+                HEX_FORMAT.formatHex(getTransitiveDigest(module))));
+      }
+      return BzlLoadThreadOwner.of(key, module);
+    }
+
+    private static void setBzlLoadValue(DeserializationBuilder builder, Object value) {
+      builder.loadValue = (BzlLoadValue) value;
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/ByteStringCodec.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/ByteStringCodec.java
@@ -22,6 +22,14 @@ import java.io.IOException;
 /** Codec for {@link ByteString}. */
 public class ByteStringCodec extends LeafObjectCodec<ByteString> {
 
+  // The default constructor is left intact to allow usual codec registration mechanisms to work.
+  private static final ByteStringCodec INSTANCE = new ByteStringCodec();
+
+  /** An instance to use for delegation by other codecs. */
+  public static ByteStringCodec byteStringCodec() {
+    return INSTANCE;
+  }
+
   @Override
   public Class<? extends ByteString> getEncodedClass() {
     return ByteString.class;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/DeferredObjectCodec.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/DeferredObjectCodec.java
@@ -33,8 +33,8 @@ public abstract class DeferredObjectCodec<T> implements ObjectCodec<T> {
    * <p>This interface should only be used by codec implementations and serialization code.
    */
   public interface DeferredValue<T> extends Callable<T> {
-    @Override // to remove the checked exception
-    T call();
+    @Override // to narrow the exception type.
+    T call() throws SerializationException;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/MemoizingDeserializationContext.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/MemoizingDeserializationContext.java
@@ -222,7 +222,7 @@ abstract class MemoizingDeserializationContext extends DeserializationContext {
    * SharedValueDeserializationContext}.
    */
   @ForOverride
-  abstract Object combineValueWithReadFutures(Object value);
+  abstract Object combineValueWithReadFutures(Object value) throws SerializationException;
 
   /**
    * Adds a new id → object maplet to the memo table.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/SharedValueDeserializationContext.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/SharedValueDeserializationContext.java
@@ -393,8 +393,9 @@ final class SharedValueDeserializationContext extends MemoizingDeserializationCo
       }
       List<ListenableFuture<?>> innerReadStatusFutures = innerContext.readStatusFutures;
       if (innerReadStatusFutures == null || innerReadStatusFutures.isEmpty()) {
-        Object result = deferred.call();
+        Object result;
         try {
+          result = deferred.call();
           setter.set(parent, result);
         } catch (SerializationException e) {
           getOperation.setException(e);
@@ -488,7 +489,7 @@ final class SharedValueDeserializationContext extends MemoizingDeserializationCo
 
   @Override
   @SuppressWarnings("FutureReturnValueIgnored")
-  Object combineValueWithReadFutures(Object value) {
+  Object combineValueWithReadFutures(Object value) throws SerializationException {
     if (readStatusFutures == null) {
       return unwrapIfDeferredValue(value);
     }
@@ -520,7 +521,7 @@ final class SharedValueDeserializationContext extends MemoizingDeserializationCo
     readStatusFutures.add(readStatus);
   }
 
-  private static Object unwrapIfDeferredValue(Object value) {
+  private static Object unwrapIfDeferredValue(Object value) throws SerializationException {
     if (value instanceof DeferredValue) {
       @SuppressWarnings("unchecked")
       DeferredValue<Object> castValue = (DeferredValue<Object>) value;

--- a/src/main/java/net/starlark/java/eval/Module.java
+++ b/src/main/java/net/starlark/java/eval/Module.java
@@ -158,6 +158,11 @@ public final class Module implements Resolver.Module {
     return clientData;
   }
 
+  /** Returns the Starlark semantics used by the execution of this module. */
+  public StarlarkSemantics getSemantics() {
+    return semantics;
+  }
+
   /** Sets the module's doc string. It may be retrieved using {@link #getDocumentation}. */
   public void setDocumentation(String documentation) {
     this.documentation = documentation;

--- a/src/test/java/com/google/devtools/build/docgen/BUILD
+++ b/src/test/java/com/google/devtools/build/docgen/BUILD
@@ -50,7 +50,6 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/rules/cpp",
-        "//src/main/java/com/google/devtools/build/lib/skyframe:bzl_load_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi/core",
         "//src/main/java/com/google/devtools/build/lib/starlarkdocextract:labelrenderer",

--- a/src/test/java/com/google/devtools/build/docgen/StarlarkDocumentationTest.java
+++ b/src/test/java/com/google/devtools/build/docgen/StarlarkDocumentationTest.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.docgen;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.devtools.build.lib.skyframe.BzlLoadValue.keyForBuild;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -918,7 +917,7 @@ public class StarlarkDocumentationTest {
     BazelEvaluationTestCase ev = new BazelEvaluationTestCase(bzlLabelString);
     Module moduleForCompilation = ev.newModule();
     Label bzlLabel = Label.parseCanonical(bzlLabelString);
-    ev.setThreadOwner(keyForBuild(bzlLabel));
+    ev.setBzlLoadThreadOwner(bzlLabel);
     ParserInput input = ParserInput.fromLines(lines);
     StarlarkFile file = StarlarkFile.parse(input, FileOptions.DEFAULT);
     Program program = Program.compileFile(file, moduleForCompilation);

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -2100,6 +2100,25 @@ java_test(
     ],
 )
 
+java_test(
+    name = "BzlLoadThreadOwnerTest",
+    timeout = "moderate",
+    srcs = ["BzlLoadThreadOwnerTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:bzl_load_value",
+        "//src/main/java/com/google/devtools/build/lib/skyframe/serialization",
+        "//src/main/java/com/google/devtools/build/skyframe",
+        "//src/main/java/net/starlark/java/eval",
+        "//src/test/java/com/google/devtools/build/lib/analysis/util",
+        "//src/test/java/com/google/devtools/build/lib/skyframe/util:SkyframeExecutorTestUtils",
+        "//third_party:guava",
+        "//third_party:junit4",
+        "//third_party:truth",
+        "@com_google_protobuf//:protobuf_java",
+    ],
+)
+
 # This test's methods are all ignored. Reason: Test is flaky; see https://github.com/bazelbuild/bazel/issues/10776
 java_test(
     name = "MacOSXFsEventsDiffAwarenessTest",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadThreadOwnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadThreadOwnerTest.java
@@ -1,0 +1,181 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.skyframe;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.cmdline.BazelModuleContext;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.skyframe.serialization.FingerprintValueService;
+import com.google.devtools.build.lib.skyframe.serialization.ObjectCodecs;
+import com.google.devtools.build.lib.skyframe.serialization.SerializationException;
+import com.google.devtools.build.lib.skyframe.serialization.SkyframeDependencyException;
+import com.google.devtools.build.lib.skyframe.serialization.SkyframeLookupContinuation;
+import com.google.devtools.build.lib.skyframe.util.SkyframeExecutorTestUtils;
+import com.google.devtools.build.skyframe.EvaluationResult;
+import com.google.devtools.build.skyframe.state.EnvironmentForUtilities;
+import com.google.protobuf.ByteString;
+import java.util.concurrent.ExecutionException;
+import net.starlark.java.eval.Module;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for BzlLoadFunction. */
+@RunWith(JUnit4.class)
+public class BzlLoadThreadOwnerTest extends BuildViewTestCase {
+
+  private final ObjectCodecs objectCodecs = new ObjectCodecs();
+  private final FingerprintValueService fingerprintValueService =
+      FingerprintValueService.createForTesting();
+
+  @Test
+  public void owner_detectsDirectChange() throws Exception {
+    scratch.file("test/BUILD");
+    scratch.file(
+        "test/lib.bzl",
+        """
+        def f():
+            return 1
+        """);
+    BzlLoadThreadOwner oldOwner = getOwner("//test:lib.bzl");
+    ByteString oldOwnerSerialized = objectCodecs.serializeMemoized(oldOwner);
+
+    scratch.overwriteFile(
+        "test/lib.bzl",
+        """
+        def f():
+            return 2
+        """);
+    invalidatePackages();
+    BzlLoadThreadOwner newOwner = getOwner("//test:lib.bzl");
+
+    assertThat(oldOwner.key()).isEqualTo(newOwner.key());
+    assertThat(oldOwner).isNotEqualTo(newOwner);
+
+    ExecutionException exception =
+        assertThrows(ExecutionException.class, () -> deserializeWithSkyframe(oldOwnerSerialized));
+    assertThat(exception)
+        .hasCauseThat()
+        .hasMessageThat()
+        .contains("Cannot retrieve a zombie module");
+  }
+
+  @Test
+  public void owner_detectsTransitiveChange() throws Exception {
+    scratch.file("test/BUILD");
+    scratch.file("test/dep.bzl", "x = 1");
+    scratch.file(
+        "test/lib.bzl",
+        """
+        load("dep.bzl", "x")
+        def f():
+            return x
+        """);
+    BzlLoadThreadOwner oldOwner = getOwner("//test:lib.bzl");
+    ByteString oldOwnerSerialized = objectCodecs.serializeMemoized(oldOwner);
+
+    scratch.overwriteFile("test/dep.bzl", "x = 2");
+    invalidatePackages();
+    BzlLoadThreadOwner newOwner = getOwner("//test:lib.bzl");
+
+    assertThat(oldOwner.key()).isEqualTo(newOwner.key());
+    assertThat(oldOwner).isNotEqualTo(newOwner);
+
+    ExecutionException exception =
+        assertThrows(ExecutionException.class, () -> deserializeWithSkyframe(oldOwnerSerialized));
+    assertThat(exception)
+        .hasCauseThat()
+        .hasMessageThat()
+        .contains("Cannot retrieve a zombie module");
+  }
+
+  @Test
+  public void owner_ignoresUnrelatedChange() throws Exception {
+    scratch.file("test/BUILD", "load('//test:unrelated.bzl', 'x')");
+    scratch.file("test/unrelated.bzl", "x = 1");
+    scratch.file(
+        "test/lib.bzl",
+        """
+        def f():
+            return 42
+        """);
+    getTarget("//test:BUILD");
+    BzlLoadThreadOwner oldOwner = getOwner("//test:lib.bzl");
+    ByteString oldOwnerSerialized = objectCodecs.serializeMemoized(oldOwner);
+
+    scratch.overwriteFile("test/unrelated.bzl", "x = 2");
+    invalidatePackages();
+    getTarget("//test:BUILD");
+    BzlLoadThreadOwner newOwner = getOwner("//test:lib.bzl");
+
+    assertThat(oldOwner).isEqualTo(newOwner);
+    BzlLoadThreadOwner oldOwnerDeserialized = deserializeWithSkyframe(oldOwnerSerialized);
+    assertThat(oldOwnerDeserialized).isEqualTo(oldOwner);
+  }
+
+  private BzlLoadValue.Key getKey(String label) {
+    return BzlLoadValue.keyForBuild(Label.parseCanonicalUnchecked(label));
+  }
+
+  private BzlLoadValue getBzlLoadValue(BzlLoadValue.Key key) throws InterruptedException {
+    EvaluationResult<BzlLoadValue> result =
+        SkyframeExecutorTestUtils.evaluate(
+            getSkyframeExecutor(), key, /* keepGoing= */ false, reporter);
+    if (result.hasError()) {
+      fail(result.getError(key).getException().getMessage());
+    }
+    return result.get(key);
+  }
+
+  private BzlLoadThreadOwner getOwner(String label) throws InterruptedException {
+    BzlLoadValue.Key key = getKey(label);
+    Module module = getBzlLoadValue(key).getModule();
+    // Ensure that the file has been processed by checking its Module for the label field.
+    assertThat(Label.parseCanonicalUnchecked(label))
+        .isEqualTo(BazelModuleContext.of(module).label());
+    return BzlLoadThreadOwner.of(key, module);
+  }
+
+  private BzlLoadThreadOwner deserializeWithSkyframe(ByteString serialized)
+      throws ExecutionException,
+          InterruptedException,
+          SerializationException,
+          SkyframeDependencyException {
+    // Deserialization always returns a future because there is a Skyframe lookup. The future is
+    // always done because there are no shared values to wait on.
+    SkyframeLookupContinuation continuation =
+        (SkyframeLookupContinuation)
+            Futures.getDone(
+                (ListenableFuture<?>)
+                    objectCodecs.deserializeWithSkyframe(fingerprintValueService, serialized));
+    ListenableFuture<?> resultFuture =
+        continuation.process(
+            new EnvironmentForUtilities(
+                // The only Skyframe lookup our deserializer needs is for one BzlLoadValue.
+                key -> {
+                  try {
+                    return getBzlLoadValue((BzlLoadValue.Key) key);
+                  } catch (InterruptedException e) {
+                    throw new AssertionError(e);
+                  }
+                }));
+    return (BzlLoadThreadOwner) Futures.getDone(resultFuture);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -1005,7 +1005,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
 
   @Test
   public void testLabelListWithAspectsError() throws Exception {
-    ev.setThreadOwner(keyForBuild(FAKE_LABEL));
+    ev.setBzlLoadThreadOwner(FAKE_LABEL);
     ev.checkEvalErrorContains(
         "at index 1 of aspects, got element of type int, want Aspect",
         "def _impl(target, ctx):",
@@ -1675,7 +1675,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
   }
 
   private static void evalAndExport(BazelEvaluationTestCase ev, String... lines) throws Exception {
-    ev.setThreadOwner(keyForBuild(FAKE_LABEL));
+    ev.setBzlLoadThreadOwner(FAKE_LABEL);
     ev.execAndExport(FAKE_LABEL, lines);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/starlark/util/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/starlark/util/BUILD
@@ -30,6 +30,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/pkgcache:package_options",
         "//src/main/java/com/google/devtools/build/lib/rules/config",
         "//src/main/java/com/google/devtools/build/lib/rules/platform",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:bzl_load_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/test/java/com/google/devtools/build/lib/starlark/util/BazelEvaluationTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/util/BazelEvaluationTestCase.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.starlark.util;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.skyframe.BzlLoadValue.keyForBuild;
 import static org.junit.Assert.fail;
 
 import com.google.common.base.Preconditions;
@@ -36,6 +37,7 @@ import com.google.devtools.build.lib.rules.config.ConfigGlobalLibrary;
 import com.google.devtools.build.lib.rules.config.ConfigStarlarkCommon;
 import com.google.devtools.build.lib.rules.platform.PlatformCommon;
 import com.google.devtools.build.lib.skyframe.BzlLoadFunction;
+import com.google.devtools.build.lib.skyframe.BzlLoadThreadOwner;
 import com.google.devtools.build.lib.testutil.TestConstants;
 import com.google.devtools.common.options.Options;
 import com.google.devtools.common.options.OptionsParsingException;
@@ -225,6 +227,11 @@ public final class BazelEvaluationTestCase {
   /** Sets a thread owner, for cases where the default value of {@code "test"} doesn't work. */
   public void setThreadOwner(Object owner) {
     this.threadOwner = owner;
+  }
+
+  /** Sets a fake thread owner suitable for a .bzl/.scl loading thread. */
+  public void setBzlLoadThreadOwner(Label label) {
+    this.threadOwner = BzlLoadThreadOwner.of(keyForBuild(label), getModule());
   }
 
   public StarlarkThread getStarlarkThread() {

--- a/src/test/java/com/google/devtools/build/lib/starlarkdocextract/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdocextract/BUILD
@@ -65,7 +65,6 @@ java_test(
     srcs = ["ModuleInfoExtractorTest.java"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/cmdline",
-        "//src/main/java/com/google/devtools/build/lib/skyframe:bzl_load_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/starlarkdocextract:extractionexception",
         "//src/main/java/com/google/devtools/build/lib/starlarkdocextract:labelrenderer",

--- a/src/test/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractorTest.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.starlarkdocextract;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
-import static com.google.devtools.build.lib.skyframe.BzlLoadValue.keyForBuild;
 import static com.google.devtools.build.lib.starlarkdocextract.ModuleInfoExtractor.IMPLICIT_MACRO_ATTRIBUTES;
 import static com.google.devtools.build.lib.starlarkdocextract.RuleInfoExtractor.IMPLICIT_RULE_ATTRIBUTES;
 import static com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.FunctionParamRole.PARAM_ROLE_KWARGS;
@@ -74,7 +73,7 @@ public final class ModuleInfoExtractorTest {
     ev.setSemantics(options.toArray(new String[0]));
     Module moduleForCompilation = ev.newModule();
     Label fakeLabel = BazelModuleContext.of(moduleForCompilation).label();
-    ev.setThreadOwner(keyForBuild(fakeLabel));
+    ev.setBzlLoadThreadOwner(fakeLabel);
     fakeLabelString = fakeLabel.getCanonicalForm();
     ParserInput input = ParserInput.fromLines(lines);
     StarlarkFile file = StarlarkFile.parse(input, FileOptions.DEFAULT);


### PR DESCRIPTION
... and introduce a BzlLoadThreadOwner record to hold it.

The previous behavior was to use only the loading key. Alas, that was unsound: in several places (e.g. StarlarkActionFactory and ExecutionTransitionFactory) we are caching Starlark functions in static interners (persisting across Bazel invocations) - and sometimes are fetching wrong versions of the functions from those interners.

The new behavior is for function `foo` in module bar.bzl to no longer equal a function of the same name and file which was produced at a different source tree state, or evaluated under different semantics.

Addresses the issue reported at https://github.com/bazelbuild/bazel/pull/29282

PiperOrigin-RevId: 960311894
Change-Id: I78e4f876a194ab5f3ae25bce7b491c0c60b893df

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/859d7faa49c582cf3ed33a2436678a4e853a6a42
