### PR TITLE
[8.8.0] Pass Host header to curl in remote-ip sandboxing networking test.

### DIFF
--- a/src/test/shell/bazel/bazel_sandboxing_networking_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_networking_test.sh
@@ -106,7 +106,7 @@ EOF
 genrule(
   name = "remote-ip",
   outs = [ "remote-ip.txt" ],
-  cmd = "curl -fo \$@ ${remote_ip}:80",
+  cmd = "curl -fo \$@ -H 'Host: ${hostname}' ${remote_ip}:80",
   tags = [ ${tags} ],
 )
 


### PR DESCRIPTION
When REMOTE_NETWORK_ADDRESS resolves to a CDN IP (such as Cloudflare does now for `bazel.build`), making direct HTTP requests to the IP without a Host header returns HTTP 403 Forbidden. This causes curl -f to fail with exit code 22 during `test_sandbox_network_access`.

Adding `-H 'Host: ${hostname}'` fixes that.

PiperOrigin-RevId: 960235153
Change-Id: I2f79105b055a6378d588906d61b0da55e0c4e7e8

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/27aaf57930ab5edf6b24101d791712a949f5617a