### PR TITLE
Look up PATHEXT extensions when resolving a bare name on the PATH

### DIFF
--- a/src/main/cpp/option_processor_windows.cc
+++ b/src/main/cpp/option_processor_windows.cc
@@ -46,7 +46,7 @@ static void PreprocessEnvString(std::string* env_str) {
 
 static void PreprocessEnvString(std::string* env_str) {
   static constexpr const char* vars_to_uppercase[] = {
-      "PATH", "SYSTEMROOT", "SYSTEMDRIVE", "TEMP", "TEMPDIR", "TMP"};
+      "PATH", "PATHEXT", "SYSTEMROOT", "SYSTEMDRIVE", "TEMP", "TEMPDIR", "TMP"};
 
   std::size_t pos = env_str->find_first_of('=');
   if (pos == std::string::npos) {

--- a/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
@@ -225,7 +225,9 @@ public abstract class AuthAndTLSOptions extends OptionsBase {
           fetching, remote caching and execution, and the build event service.
 
           The path to the credential helper may be absolute, relative to the PATH environment variable,
-          or %workspace%-relative. The path may be optionally prefixed by a scope followed by an '='.
+          or %workspace%-relative. When looking up a bare name on the PATH on Windows, the extensions
+          listed in the PATHEXT environment variable are appended to it, so `my-helper` also finds
+          `my-helper.exe`. The path may be optionally prefixed by a scope followed by an '='.
           The scope is a domain name, optionally with a single leading '*' wildcard component. A helper
           applies to URIs matching its scope, with more specific scopes preferred. If a helper has no
           scope, it applies to every URI.

--- a/src/main/java/com/google/devtools/build/lib/runtime/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BUILD
@@ -138,6 +138,7 @@ java_library(
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/analysis:blaze_directories",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandLinePathFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandLinePathFactory.java
@@ -17,8 +17,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -50,13 +52,29 @@ public final class CommandLinePathFactory {
 
   private static final Splitter PATH_SPLITTER = Splitter.on(File.pathSeparator);
 
+  // Unlike PATH, PATHEXT is always separated by ';', since it only exists on Windows.
+  private static final Splitter PATHEXT_SPLITTER = Splitter.on(';');
+
+  /**
+   * Executable file extensions appended to a bare file name while searching the {@code PATH} on
+   * Windows, used when {@code PATHEXT} is unset or empty. This matches the Windows default value.
+   */
+  private static final ImmutableList<String> DEFAULT_PATH_EXTENSIONS =
+      ImmutableList.of(".COM", ".EXE", ".BAT", ".CMD");
+
   private final FileSystem fileSystem;
   private final ImmutableMap<String, Path> roots;
+  private final OS os;
+
+  public CommandLinePathFactory(FileSystem fileSystem, ImmutableMap<String, Path> roots) {
+    this(fileSystem, roots, OS.getCurrent());
+  }
 
   @VisibleForTesting
-  public CommandLinePathFactory(FileSystem fileSystem, ImmutableMap<String, Path> roots) {
+  public CommandLinePathFactory(FileSystem fileSystem, ImmutableMap<String, Path> roots, OS os) {
     this.fileSystem = Preconditions.checkNotNull(fileSystem);
     this.roots = Preconditions.checkNotNull(roots);
+    this.os = Preconditions.checkNotNull(os);
   }
 
   static CommandLinePathFactory create(FileSystem fileSystem, BlazeDirectories directories) {
@@ -125,6 +143,7 @@ public final class CommandLinePathFactory {
     }
 
     String pathVariable = env.getOrDefault("PATH", "");
+    ImmutableList<String> candidateNames = lookupCandidateNames(env, path.getBaseName());
     if (!Strings.isNullOrEmpty(pathVariable)) {
       for (String lookupPath : PATH_SPLITTER.split(pathVariable)) {
         PathFragment lookupPathFragment = PathFragment.create(lookupPath);
@@ -134,11 +153,14 @@ public final class CommandLinePathFactory {
           continue;
         }
 
-        Path maybePath = fileSystem.getPath(lookupPathFragment).getRelative(path);
-        if (maybePath.exists(Symlinks.FOLLOW)
-            && maybePath.isFile(Symlinks.FOLLOW)
-            && maybePath.isExecutable()) {
-          return maybePath;
+        Path lookupDirectory = fileSystem.getPath(lookupPathFragment);
+        for (String candidateName : candidateNames) {
+          Path maybePath = lookupDirectory.getRelative(candidateName);
+          if (maybePath.exists(Symlinks.FOLLOW)
+              && maybePath.isFile(Symlinks.FOLLOW)
+              && maybePath.isExecutable()) {
+            return maybePath;
+          }
         }
       }
     }
@@ -146,5 +168,43 @@ public final class CommandLinePathFactory {
     throw new FileNotFoundException(
         String.format(
             Locale.US, "Could not find file with name '%s' on PATH '%s'", path, pathVariable));
+  }
+
+  /**
+   * Returns the file names to look for in each {@code PATH} entry, in order of preference.
+   *
+   * <p>On Windows, executables carry an extension, but users generally refer to them without one
+   * (e.g. {@code cmd} rather than {@code cmd.exe}). Mirroring the shell, the bare name is tried
+   * first and the extensions listed in {@code PATHEXT} are appended to it afterwards. Everywhere
+   * else the bare name is the only candidate.
+   */
+  private ImmutableList<String> lookupCandidateNames(Map<String, String> env, String name) {
+    if (os != OS.WINDOWS) {
+      return ImmutableList.of(name);
+    }
+
+    ImmutableList.Builder<String> candidates = ImmutableList.builder();
+    candidates.add(name);
+    for (String extension : pathExtensions(env)) {
+      candidates.add(name + extension);
+    }
+    return candidates.build();
+  }
+
+  private static ImmutableList<String> pathExtensions(Map<String, String> env) {
+    String pathExtVariable = env.getOrDefault("PATHEXT", "");
+    if (Strings.isNullOrEmpty(pathExtVariable)) {
+      return DEFAULT_PATH_EXTENSIONS;
+    }
+
+    ImmutableList.Builder<String> extensions = ImmutableList.builder();
+    for (String extension : PATHEXT_SPLITTER.split(pathExtVariable)) {
+      if (extension.isEmpty()) {
+        continue;
+      }
+      extensions.add(extension.startsWith(".") ? extension : "." + extension);
+    }
+    ImmutableList<String> result = extensions.build();
+    return result.isEmpty() ? DEFAULT_PATH_EXTENSIONS : result;
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/runtime/CommandLinePathFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/CommandLinePathFactoryTest.java
@@ -20,6 +20,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.runtime.CommandLinePathFactory.CommandLinePathFactoryException;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
@@ -62,14 +63,14 @@ public class CommandLinePathFactoryTest {
 
   @Test
   public void emptyPathIsRejected() {
-    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of());
+    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of(), OS.LINUX);
 
     assertThrows(IllegalArgumentException.class, () -> factory.create(ImmutableMap.of(), ""));
   }
 
   @Test
   public void createFromAbsolutePath() throws Exception {
-    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of());
+    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of(), OS.LINUX);
 
     assertThat(factory.create(ImmutableMap.of(), "/absolute/path/1"))
         .isEqualTo(filesystem.getPath("/absolute/path/1"));
@@ -84,7 +85,8 @@ public class CommandLinePathFactoryTest {
             filesystem,
             ImmutableMap.of(
                 "workspace", filesystem.getPath("/path/to/workspace"),
-                "output_base", filesystem.getPath("/path/to/output/base")));
+                "output_base", filesystem.getPath("/path/to/output/base")),
+            OS.LINUX);
 
     assertThat(factory.create(ImmutableMap.of(), "/absolute/path/1"))
         .isEqualTo(filesystem.getPath("/absolute/path/1"));
@@ -109,7 +111,7 @@ public class CommandLinePathFactoryTest {
   public void pathLeakingOutsideOfRoot() {
     CommandLinePathFactory factory =
         new CommandLinePathFactory(
-            filesystem, ImmutableMap.of("a", filesystem.getPath("/path/to/a")));
+            filesystem, ImmutableMap.of("a", filesystem.getPath("/path/to/a")), OS.LINUX);
 
     assertThrows(
         CommandLinePathFactoryException.class,
@@ -123,7 +125,7 @@ public class CommandLinePathFactoryTest {
   public void unknownRoot() {
     CommandLinePathFactory factory =
         new CommandLinePathFactory(
-            filesystem, ImmutableMap.of("a", filesystem.getPath("/path/to/a")));
+            filesystem, ImmutableMap.of("a", filesystem.getPath("/path/to/a")), OS.LINUX);
 
     assertThrows(
         CommandLinePathFactoryException.class,
@@ -135,7 +137,7 @@ public class CommandLinePathFactoryTest {
 
   @Test
   public void relativePathWithMultipleSegments() {
-    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of());
+    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of(), OS.LINUX);
 
     assertThrows(
         CommandLinePathFactoryException.class, () -> factory.create(ImmutableMap.of(), "a/b"));
@@ -145,7 +147,7 @@ public class CommandLinePathFactoryTest {
 
   @Test
   public void pathLookup() throws Exception {
-    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of());
+    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of(), OS.LINUX);
 
     createExecutable("/bin/true");
     createExecutable("/bin/false");
@@ -164,13 +166,96 @@ public class CommandLinePathFactoryTest {
     assertThat(factory.create(path, "baz")).isEqualTo(filesystem.getPath("/usr/local/bin/baz"));
     assertThat(factory.create(path, "abc")).isEqualTo(filesystem.getPath("/home/yannic/bin/abc"));
 
-    // `.exe` is required.
+    // `.exe` is required; extensions are only appended on Windows.
     assertThrows(FileNotFoundException.class, () -> factory.create(path, "foo-bar"));
+  }
+
+  // Note: the tests below run against a case-sensitive in-memory filesystem, so the fixtures spell
+  // extensions with the exact case used by `PATHEXT`. Real Windows filesystems are
+  // case-insensitive, so `foo.exe` is found there for a `PATHEXT` entry of `.EXE` as well.
+
+  @Test
+  public void pathLookupOnWindowsAppendsDefaultExtensions() throws Exception {
+    CommandLinePathFactory factory =
+        new CommandLinePathFactory(filesystem, ImmutableMap.of(), OS.WINDOWS);
+
+    createExecutable("/bin/foo.EXE");
+    createExecutable("/bin/bar.CMD");
+    createExecutable("/bin/baz");
+
+    var path = ImmutableMap.of("PATH", PATH_JOINER.join("/bin"));
+
+    // `PATHEXT` is unset, so the Windows defaults apply.
+    assertThat(factory.create(path, "foo")).isEqualTo(filesystem.getPath("/bin/foo.EXE"));
+    assertThat(factory.create(path, "bar")).isEqualTo(filesystem.getPath("/bin/bar.CMD"));
+
+    // A name that exists verbatim is still found, and spelling out the extension keeps working.
+    assertThat(factory.create(path, "baz")).isEqualTo(filesystem.getPath("/bin/baz"));
+    assertThat(factory.create(path, "foo.EXE")).isEqualTo(filesystem.getPath("/bin/foo.EXE"));
+
+    assertThrows(FileNotFoundException.class, () -> factory.create(path, "quux"));
+  }
+
+  @Test
+  public void pathLookupOnWindowsHonorsPathExt() throws Exception {
+    CommandLinePathFactory factory =
+        new CommandLinePathFactory(filesystem, ImmutableMap.of(), OS.WINDOWS);
+
+    createExecutable("/bin/foo.exe");
+    createExecutable("/bin/bar.py");
+
+    var path =
+        ImmutableMap.of(
+            "PATH", PATH_JOINER.join("/bin"),
+            // Also covers an entry without a leading dot, which Windows tolerates.
+            "PATHEXT", ".com;.exe;py");
+
+    assertThat(factory.create(path, "foo")).isEqualTo(filesystem.getPath("/bin/foo.exe"));
+    assertThat(factory.create(path, "bar")).isEqualTo(filesystem.getPath("/bin/bar.py"));
+  }
+
+  @Test
+  public void pathLookupOnWindowsWithPathExtNotListingExtension() {
+    CommandLinePathFactory factory =
+        new CommandLinePathFactory(filesystem, ImmutableMap.of(), OS.WINDOWS);
+
+    var path = ImmutableMap.of("PATH", PATH_JOINER.join("/bin"), "PATHEXT", ".com;.exe");
+
+    assertThrows(FileNotFoundException.class, () -> factory.create(path, "foo"));
+  }
+
+  @Test
+  public void pathLookupOnWindowsPrefersEarlierPathEntry() throws Exception {
+    CommandLinePathFactory factory =
+        new CommandLinePathFactory(filesystem, ImmutableMap.of(), OS.WINDOWS);
+
+    createExecutable("/bin/foo.cmd");
+    createExecutable("/usr/bin/foo.exe");
+
+    var path =
+        ImmutableMap.of(
+            "PATH", PATH_JOINER.join("/bin", "/usr/bin"), "PATHEXT", ".exe;.cmd");
+
+    // The `PATH` order wins over the `PATHEXT` order.
+    assertThat(factory.create(path, "foo")).isEqualTo(filesystem.getPath("/bin/foo.cmd"));
+  }
+
+  @Test
+  public void pathLookupOnWindowsWithEmptyPathExt() throws Exception {
+    CommandLinePathFactory factory =
+        new CommandLinePathFactory(filesystem, ImmutableMap.of(), OS.WINDOWS);
+
+    createExecutable("/bin/foo.EXE");
+
+    // An empty `PATHEXT` falls back to the defaults rather than disabling the lookup.
+    var path = ImmutableMap.of("PATH", PATH_JOINER.join("/bin"), "PATHEXT", "");
+
+    assertThat(factory.create(path, "foo")).isEqualTo(filesystem.getPath("/bin/foo.EXE"));
   }
 
   @Test
   public void pathLookupWithUndefinedPath() {
-    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of());
+    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of(), OS.LINUX);
 
     assertThrows(FileNotFoundException.class, () -> factory.create(ImmutableMap.of(), "a"));
     assertThrows(FileNotFoundException.class, () -> factory.create(ImmutableMap.of(), "foo"));
@@ -178,7 +263,7 @@ public class CommandLinePathFactoryTest {
 
   @Test
   public void pathLookupWithNonExistingDirectoryOnPath() {
-    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of());
+    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of(), OS.LINUX);
 
     assertThrows(
         FileNotFoundException.class,
@@ -187,7 +272,7 @@ public class CommandLinePathFactoryTest {
 
   @Test
   public void pathLookupWithExistingAndNonExistingDirectoryOnPath() throws Exception {
-    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of());
+    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of(), OS.LINUX);
 
     createExecutable("/bin/foo");
     createExecutable("/usr/bin/bar");
@@ -201,7 +286,7 @@ public class CommandLinePathFactoryTest {
 
   @Test
   public void pathLookupWithInvalidPath() throws Exception {
-    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of());
+    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of(), OS.LINUX);
 
     createExecutable("/bin/true");
     var path = ImmutableMap.of("PATH", PATH_JOINER.join("", ".", "/bin"));


### PR DESCRIPTION
`CommandLinePathFactory` resolves single-segment relative paths against the client's `PATH`. It only ever looked for the literal file name, so on Windows a flag value like `--credential_helper=example.com=my-helper` could never resolve, because the binary on disk is `my-helper.exe`. Users had to fall back to `%workspace%`-relative paths, which in turn forced a platform-specific `.bazelrc` split (`.exe` on Windows, no extension elsewhere) and a checked-in wrapper in the source tree.

Mirror the shell instead: on Windows, try the literal name first and then append each extension listed in `PATHEXT`, falling back to the Windows default (`.COM;.EXE;.BAT;.CMD`) when it is unset or empty. Behavior on other platforms is unchanged. This lets a single `.bazelrc` line work everywhere:

    common --credential_helper=*.example.com=my-helper

`PATHEXT` is also added to the list of environment variables the Windows client upper-cases before forwarding them to the server. Windows environment variables are case-insensitive, but the server stores the client environment in a case-sensitive map, so a `Pathext` from the OS would not have been found. `CommandEnvironment.ALWAYS_INHERITED_REPO_ENV` already assumed the upper-cased spelling, so repository rules reading `PATHEXT` benefit as well.

RELNOTES: On Windows, a credential helper specified by a bare file name is now also looked up on the `PATH` using the extensions in `PATHEXT`, so `--credential_helper=example.com=my-helper` finds `my-helper.exe`.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
