### PR TITLE
Allow a credential helper to be a batch script on Windows

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/BUILD
@@ -36,6 +36,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/shell",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//third_party:auth",
         "//third_party:auto_value",

--- a/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelper.java
@@ -18,6 +18,8 @@ import static com.google.devtools.build.lib.profiler.ProfilerTask.CREDENTIAL_HEL
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ascii;
+import com.google.common.base.CharMatcher;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -26,6 +28,7 @@ import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.shell.Subprocess;
 import com.google.devtools.build.lib.shell.SubprocessBuilder;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.errorprone.annotations.Immutable;
 import com.google.gson.Gson;
@@ -164,12 +167,61 @@ public final class CredentialHelper {
 
     ImmutableMap<String, String> clientEnv = environment.clientEnvironment().get();
     return new SubprocessBuilder(clientEnv)
-        .setArgv(ImmutableList.<String>builder().add(path.getPathString()).add(args).build())
+        .setArgv(getArgv(OS.getCurrent(), path.getPathString(), args))
         .setWorkingDirectory(
             environment.workspacePath() != null ? environment.workspacePath().getPathFile() : null)
         .setEnv(clientEnv)
         .setTimeoutMillis(environment.helperExecutionTimeout().toMillis())
         .start();
+  }
+
+  /**
+   * Returns the command line used to invoke the helper.
+   *
+   * <p>Batch scripts get special treatment on Windows: {@code CreateProcess}, which Bazel uses to
+   * spawn subprocesses there, can only start executable images, so a {@code .bat} or {@code .cmd}
+   * file has to be handed to the command interpreter instead. This lets a credential helper ship as
+   * a small wrapper script on Windows, the way a shell script can be used everywhere else.
+   */
+  @VisibleForTesting
+  static ImmutableList<String> getArgv(OS os, String pathString, String... args) {
+    if (os != OS.WINDOWS || !isBatchScript(pathString)) {
+      return ImmutableList.<String>builder().add(pathString).add(args).build();
+    }
+
+    // `cmd.exe` lives in C:\Windows\System32, which is always on the Windows search path.
+    //
+    // The entire command is wrapped in one extra pair of quotes: `/S` strips the first and the last
+    // quote and executes what remains verbatim, which is the only reliable way to keep a program
+    // path containing spaces in one piece.
+    StringBuilder command = new StringBuilder("\"");
+    command.append(quoteForCmd(pathString.replace('/', '\\')));
+    for (String arg : args) {
+      command.append(' ').append(quoteForCmd(arg));
+    }
+    command.append('"');
+
+    return ImmutableList.of(
+        "cmd.exe",
+        "/S", // Strip the outer quotes and execute the rest as is.
+        "/D", // Ignore AutoRun registry entries.
+        "/C", // Execute the command that follows. Must be the last option.
+        command.toString());
+  }
+
+  private static boolean isBatchScript(String path) {
+    String lowerCasePath = Ascii.toLowerCase(path);
+    return lowerCasePath.endsWith(".bat") || lowerCasePath.endsWith(".cmd");
+  }
+
+  /**
+   * Quotes an argument for {@code cmd.exe}, but only when it would otherwise be split apart.
+   *
+   * <p>Quotes are left off whenever possible because a batch script sees them as part of {@code %1}
+   * and friends.
+   */
+  private static String quoteForCmd(String arg) {
+    return arg.isEmpty() || CharMatcher.whitespace().matchesAnyOf(arg) ? "\"" + arg + "\"" : arg;
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelperTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.authandtls.credentialhelper;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -25,6 +26,8 @@ import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.shell.WindowsSubprocessFactory;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.util.FileSystems;
 import com.google.devtools.build.runfiles.Runfiles;
@@ -205,6 +208,70 @@ public class CredentialHelperTest {
             OS.getCurrent().equals(OS.WINDOWS)
                 ? "cannot find the file specified"
                 : "Cannot run program");
+  }
+
+  @Test
+  public void argvForRegularHelper() {
+    // A helper that is a plain executable is invoked directly on every platform, including one
+    // whose name merely contains `.bat`.
+    assertThat(CredentialHelper.getArgv(OS.LINUX, "/usr/bin/helper", "get"))
+        .containsExactly("/usr/bin/helper", "get")
+        .inOrder();
+    assertThat(CredentialHelper.getArgv(OS.WINDOWS, "C:/tools/helper.exe", "get"))
+        .containsExactly("C:/tools/helper.exe", "get")
+        .inOrder();
+    assertThat(CredentialHelper.getArgv(OS.WINDOWS, "C:/tools/helper.bat.exe", "get"))
+        .containsExactly("C:/tools/helper.bat.exe", "get")
+        .inOrder();
+
+    // Batch scripts are only special on Windows.
+    assertThat(CredentialHelper.getArgv(OS.LINUX, "/usr/bin/helper.bat", "get"))
+        .containsExactly("/usr/bin/helper.bat", "get")
+        .inOrder();
+  }
+
+  @Test
+  public void argvForBatchScriptHelperOnWindows() {
+    assertThat(CredentialHelper.getArgv(OS.WINDOWS, "C:/tools/helper.bat", "get"))
+        .containsExactly("cmd.exe", "/S", "/D", "/C", "\"C:\\tools\\helper.bat get\"")
+        .inOrder();
+
+    // `.cmd` and upper-case extensions are recognized too.
+    assertThat(CredentialHelper.getArgv(OS.WINDOWS, "C:/tools/helper.CMD", "get"))
+        .containsExactly("cmd.exe", "/S", "/D", "/C", "\"C:\\tools\\helper.CMD get\"")
+        .inOrder();
+
+    // A path containing spaces stays in one piece: `/S` strips only the outer quotes, leaving the
+    // inner ones for cmd.exe to parse.
+    assertThat(CredentialHelper.getArgv(OS.WINDOWS, "C:/Program Files/h.bat", "get"))
+        .containsExactly("cmd.exe", "/S", "/D", "/C", "\"\"C:\\Program Files\\h.bat\" get\"")
+        .inOrder();
+  }
+
+  @Test
+  public void batchScriptHelper() throws Exception {
+    assumeTrue(OS.getCurrent() == OS.WINDOWS);
+
+    FileSystem fs = FileSystems.getNativeFileSystem();
+    // Deliberately place the script in a directory whose name contains a space.
+    Path helper = fs.getPath(TEST_WORKSPACE_PATH).getRelative("cred helper/helper.bat");
+    helper.getParentDirectory().createDirectoryAndParents();
+    // Batch scripts want CRLF line endings.
+    FileSystemUtils.writeContentAsLatin1(
+        helper,
+        String.join(
+            "\r\n",
+            "@echo off",
+            // Verifies that the argument survives the trip through cmd.exe unquoted.
+            "if not \"%1\"==\"get\" exit /b 1",
+            "echo {\"headers\":{\"header1\":[\"value1\"]}}",
+            ""));
+    helper.setExecutable(true);
+
+    GetCredentialsResponse response =
+        getCredentialsFromHelper(
+            helper.getPathString(), "https://example.com", /* env= */ ImmutableMap.of());
+    assertThat(response.headers()).containsExactly("header1", ImmutableList.of("value1"));
   }
 
   @Test


### PR DESCRIPTION
Bazel spawns subprocesses on Windows through `CreateProcess`, which can only start executable images. A `.bat` or `.cmd` file therefore fails to launch, which is why a credential helper on Windows has to be a real `.exe`.

That asymmetry is awkward in practice. On Unix a helper is typically a small shell script that locates or bootstraps the actual binary and `exec`s it; there is no equivalent on Windows, so the binary itself has to be placed in the workspace, and `.bazelrc` needs a platform-specific split to name it.

Run a helper whose name ends in `.bat` or `.cmd` through the command interpreter instead, using the same `cmd.exe /S /D /C` form as `WindowsBatchCommandConstructor`. The whole command is wrapped in one extra pair of quotes, which `/S` strips before executing the rest verbatim; this keeps a helper path containing spaces in one piece. Arguments are only quoted when they would otherwise be split, since a batch script sees the quotes as part of `%1`. `/D` skips AutoRun registry entries, and delayed expansion is deliberately left off so that a `!` in the path is not interpreted.

This is scoped to the credential helper call site rather than `SubprocessBuilder`, because the argument vector here is a fixed, trusted constant, whereas quoting arbitrary argument vectors through `cmd.exe` is error-prone.

RELNOTES: A credential helper can now be a `.bat` or `.cmd` script on Windows.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
