### PR TITLE
Fix angle bracket rendering of cquery docs

### DIFF
--- a/docs/query/cquery.mdx
+++ b/docs/query/cquery.mdx
@@ -29,11 +29,11 @@ sh_library(name = "white-ash")
 sh_library(name = "common-ash")
 config_setting(
     name = "excelsior",
-    values = \{"define": "species=excelsior"\},
+    values = {"define": "species=excelsior"},
 )
 config_setting(
     name = "americana",
-    values = \{"define": "species=americana"\},
+    values = {"define": "species=americana"},
 )
 EOF
 ```
@@ -493,7 +493,7 @@ Extract a value from a user defined Provider.
 ```
   $ cat some_package/my_rule.bzl
 
-  MyRuleInfo = provider(fields=\{"color": "the name of a color"\})
+  MyRuleInfo = provider(fields={"color": "the name of a color"})
 
   def _my_rule_impl(ctx):
       ...

--- a/docs/query/cquery.mdx
+++ b/docs/query/cquery.mdx
@@ -15,7 +15,7 @@ Bazel's loading phase, before options are evaluated.
 For example:
 
 ```
-$ cat > tree/BUILD &lt;&lt;EOF
+$ cat > tree/BUILD <<EOF
 sh_library(
     name = "ash",
     deps = select({
@@ -209,7 +209,7 @@ genrule(
      name = "my_gen",
      srcs = ["x.in"],
      outs = ["x.cc"],
-     cmd = "$(locations :tool) $&lt; >$@",
+     cmd = "$(locations :tool) $< >$@",
      tools = [":tool"],
 )
 cc_binary(
@@ -546,7 +546,7 @@ that is, it configures its tools in the [exec configuration](https://bazel.build
 You can see the lingering effects of that transition below.
 
 ```
-$ cat > foo/BUILD &lt;&lt;&lt;EOF
+$ cat > foo/BUILD <<<EOF
 genrule(
     name = "my_gen",
     srcs = ["x.in"],
@@ -608,7 +608,7 @@ constituent packages with a pre-processing query:
 
 ```
 # Replace "//foo/..." with a subshell query call (not cquery!) outputting each package, piped into
-# a sed call converting "&lt;pkg&gt;" to "//&lt;pkg&gt;:*", piped into a "+"-delimited line merge.
+# a sed call converting "<pkg>" to "//<pkg>:*", piped into a "+"-delimited line merge.
 # Output looks like "//foo:*+//foo/bar:*+//foo/baz".
 #
 $  bazel cquery --universe_scope=//foo:app "somepath(//foo:app, $(bazel query //foo/...


### PR DESCRIPTION
Fixes rendering for `<` and `>` in the `.mdx` version of the cquery docs. Unlike in DevSite, mintlify doesn't evaluate HTML entities in code blocks.

RELNOTES: None
