### PR TITLE
[9.3.0] Provide the length when assigning a string from Java (https://github.com/bazelbuild/bazel/pull/30606)

### DIFF
--- a/src/main/native/windows/jni-util.cc
+++ b/src/main/native/windows/jni-util.cc
@@ -37,10 +37,12 @@ static_assert(sizeof(jchar) == sizeof(WCHAR),
 wstring GetJavaWstring(JNIEnv* env, jstring str) {
   wstring result;
   if (str != nullptr) {
+    const jsize len = env->GetStringLength(str);
     const jchar* jstr = env->GetStringChars(str, nullptr);
     // We can safely reinterpret_cast because of the static_assert checking that
     // sizeof(jchar) = sizeof(WCHAR).
-    result.assign(reinterpret_cast<const WCHAR*>(jstr));
+    result.assign(reinterpret_cast<const WCHAR*>(jstr),
+                  static_cast<size_t>(len));
     env->ReleaseStringChars(str, jstr);
   }
   return result;


### PR DESCRIPTION
### Description
Ensures that the result always gets given the length of the Java string to ensure no overruns.

### Motivation
When running Bazel on Windows Arm64, I was able to consistently get a JNI crash by running our builds on CI/Parallels on MacOS. The original crash I managed to get was `Unhandled exception: C0000005.ACCESS_VIOLATION`:

```
 # RetAddr               : Args to Child                                                           : Call Site
00 00007fff`ae16814c     : 00000022`043ff040 00007fff`ae16814c 00000003`00000005 00000169`67667cb8 : jvm!topLevelExceptionFilter+0x2229a0
01 00007fff`ae1677fc     : 00000169`6b71f700 00000169`6b71f718 00000169`6b71faf0 00000000`000003d8 : jvm!AsyncGetCallTrace+0xf0aac
02 00007fff`ae1ef998     : 00000022`043ff110 00007fff`ae1ef998 00000022`043ff310 00000000`0000005c : jvm!AsyncGetCallTrace+0xf015c
03 00007fff`ae1ee70c     : 00000022`043ff130 00007fff`ae1ee70c 00007fff`ae815a18 00000169`6b21e220 : jvm!JNI_GetDefaultJavaVMInitArgs+0x1c6f8
04 00007fff`ae1d855c     : 00000022`043ff160 00007fff`ae1d855c 00000169`6b21e220 00000000`00000043 : jvm!JNI_GetDefaultJavaVMInitArgs+0x1b46c
05 00007ff8`205c715c     : 00000022`043ff1a0 00007ff8`205c715c 00000022`043ff1d0 00000004`2036d188 : jvm!JNI_GetDefaultJavaVMInitArgs+0x52bc
06 00007ff8`205c6ba4     : 00000022`043ff230 00007ff8`205c6ba4 00000169`751a1df8 00000000`00000000 : windows_jni!JNIEnv_::GetStringChars+0x3c [C:\bzl\jeb6symc\execroot\_main\bazel-out\arm64_windows-fastbuild\bin\src\main\native\jni.h @ 1614]
07 00007ff8`205c41a4     : 00000004`00000000 00000022`043ff310 00000004`00709ec0 00000169`751a1df8 : windows_jni!bazel::windows::GetJavaWstring+0x5c [C:\bzl\jeb6symc\execroot\_main\src\main\native\windows\jni-util.cc @ 40]
08 00000169`41a9e050     : 00000004`20360128 00000169`751a1df8 00000004`00709ec0 00000169`3ad43910 : windows_jni!Java_com_google_devtools_build_lib_windows_WindowsFileOperations_nativeGetChangeTime+0x3c [C:\bzl\jeb6symc\execroot\_main\src\main\native\windows\file-jni.cc @ 70]
09 00000000`00000000     : 00000004`2036d1f0 00000169`8406da06 00000004`2036d170 00000004`2036d188 : 0x00000169`41a9e050
```

It seems likely, to me, that if the memory surrounding the string doesn't contain a null character then there's an opportunity for the assign may end up overrunning into other pages and trigger an access violation.

### Build API Changes
No

### Checklist

- [X] I have added tests for the new use cases (if any).
- [X] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Fixes a possible crash on Windows Arm64 related to JNI strings

Closes #30606.

PiperOrigin-RevId: 960773816
Change-Id: Ifce108d9fe3968021b7451f3c3ac3f7235469a76

Commit https://github.com/bazelbuild/bazel/commit/b247857d9934ba9b6fb8c8eff9531f0fd18ec725