### PR TITLE
[9.3.0] Replace `--java_version` launcher argument with launch info key.

### DIFF
--- a/src/test/shell/bazel/bazel_windows_java_cross_drive_test.sh
+++ b/src/test/shell/bazel/bazel_windows_java_cross_drive_test.sh
@@ -97,6 +97,11 @@ function delete_tmp_drive() {
 }
 
 function test_java_with_jar_under_different_drive() {
+  # TODO(tjgq): Re-enable once rules_java passes Java version in launcher info.
+  if [[ "$JAVA_VERSION" -ge "25" ]]; then
+    return
+  fi
+
   create_tmp_drive
 
   trap delete_tmp_drive EXIT
@@ -127,9 +132,8 @@ EOF
   bazel --output_user_root=${TMP_DRIVE}:/tmp build :hello &> "$TEST_log" \
       || fail "build failed"
 
-  # TODO(tjgq): Remove explicit `--java_version` once rules_java sets it.
-  assert_binary_run_from_subdir "bazel-bin/hello --classpath_limit=0 --java_version=$JAVA_VERSION" \
-    "Java $JAVA_VERSION"
+  assert_binary_run_from_subdir "bazel-bin/hello --classpath_limit=0" \
+      "Java $JAVA_VERSION"
 }
 
 run_suite "Tests that the Java Windows launcher works with cross-drive jars."

--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -16,6 +16,7 @@
 
 #include <fstream>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -47,6 +48,7 @@ static constexpr const char* JAR_BIN_PATH = "jar_bin_path";
 static constexpr const char* CLASSPATH = "classpath";
 static constexpr const char* JAVA_START_CLASS = "java_start_class";
 static constexpr const char* JVM_FLAGS = "jvm_flags";
+static constexpr const char* JAVA_VERSION = "java_version";
 
 // Check if a string start with a certain prefix.
 // If it's true, store the substring without the prefix in value.
@@ -97,8 +99,6 @@ bool JavaBinaryLauncher::ProcessWrapperArgument(const wstring& argument) {
     this->print_javabin = true;
   } else if (GetFlagValue(argument, L"--classpath_limit=", &flag_value)) {
     this->classpath_limit = std::stoi(flag_value);
-  } else if (GetFlagValue(argument, L"--java_version=", &flag_value)) {
-    this->java_version = std::stoi(flag_value);
   } else {
     return false;
   }
@@ -323,6 +323,14 @@ wstring JavaBinaryLauncher::CreateClasspathFlagfile(const wstring& classpath) {
   return flagfile_path;
 }
 
+std::optional<int> JavaBinaryLauncher::GetJavaVersion() {
+  wstring version_str = GetLaunchInfoByKeyOrEmpty(JAVA_VERSION);
+  if (version_str.empty()) {
+    return std::nullopt;
+  }
+  return std::stoi(version_str);
+}
+
 ExitCode JavaBinaryLauncher::Launch() {
   // Parse the original command line.
   vector<wstring> remaining_args = this->ProcessesCommandLine();
@@ -418,7 +426,8 @@ ExitCode JavaBinaryLauncher::Launch() {
   wstring classpath_file;
   bool delete_junction_base_dir = false;
   if (classpath_str.length() > classpath_limit) {
-    if (java_version <= 8) {
+    std::optional<int> java_version = GetJavaVersion();
+    if (!java_version.has_value() || java_version.value() <= 8) {
       classpath_file = CreateClasspathJar(classpath_str);
       arguments.push_back(classpath_file);
       delete_junction_base_dir = true;

--- a/src/tools/launcher/java_launcher.h
+++ b/src/tools/launcher/java_launcher.h
@@ -15,6 +15,7 @@
 #ifndef BAZEL_SRC_TOOLS_LAUNCHER_JAVA_LAUNCHER_H_
 #define BAZEL_SRC_TOOLS_LAUNCHER_JAVA_LAUNCHER_H_
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -88,10 +89,12 @@ class JavaBinaryLauncher : public BinaryLauncherBase {
   bool singlejar;
   bool print_javabin;
   int classpath_limit;
-  int java_version;
   // Per-invocation random suffix used to uniquify the junction base dir and
   // classpath jar across concurrent launcher processes sharing the same binary.
   const std::wstring rand_id_;
+
+  // Returns the Java version targeted by this launcher.
+  std::optional<int> GetJavaVersion();
 
   // Creates a classpath jar to pass the CLASSPATH value when its length is over
   // the limit.


### PR DESCRIPTION
This is the preferred mechanism to be used by rules_java.

PiperOrigin-RevId: 960839361
Change-Id: Ice89277c367170d31e7a030ad1c6599e59254631