### PR TITLE
Propagate credential helper failures during downloads

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import com.google.common.base.Ascii;
-import com.google.common.base.Function;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -52,6 +51,12 @@ import javax.net.ssl.SSLException;
  */
 @ThreadSafe
 class HttpConnector {
+
+  /** Supplies request headers, including credentials, before a connection is opened. */
+  @FunctionalInterface
+  interface RequestHeadersProvider {
+    ImmutableMap<String, List<String>> get(URI url) throws IOException;
+  }
 
   private static final int MAX_ATTEMPTS = 8;
   private static final int MAX_REDIRECTS = 40;
@@ -107,9 +112,7 @@ class HttpConnector {
     return Math.round(unscaled * timeoutScaling);
   }
 
-  URLConnection connect(
-      URI originalUrl, Function<URI, ImmutableMap<String, List<String>>> requestHeaders)
-      throws IOException {
+  URLConnection connect(URI originalUrl, RequestHeadersProvider requestHeaders) throws IOException {
 
     if (Thread.interrupted()) {
       throw new InterruptedIOException();
@@ -123,6 +126,9 @@ class HttpConnector {
     int redirects = 0;
     int connectTimeout = scale(MIN_CONNECT_TIMEOUT_MS);
     while (true) {
+      // Resolve credentials before opening a connection so failures are not retried as network
+      // errors or followed by an unauthenticated request.
+      ImmutableMap<String, List<String>> headers = requestHeaders.get(url);
       HttpURLConnection connection = null;
       try {
         ProxyInfo proxyInfo = proxyHelper.createProxyIfNeeded(url);
@@ -138,7 +144,7 @@ class HttpConnector {
             COMPRESSED_EXTENSIONS.contains(HttpUtils.getExtension(url.getPath()))
                 || COMPRESSED_EXTENSIONS.contains(HttpUtils.getExtension(originalUrl.getPath()));
         connection.setInstanceFollowRedirects(false);
-        for (Map.Entry<String, List<String>> entry : requestHeaders.apply(url).entrySet()) {
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
           if (isAlreadyCompressed && Ascii.equalsIgnoreCase(entry.getKey(), "Accept-Encoding")) {
             // We're not going to ask for compression if we're downloading a file that already
             // appears to be compressed.

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
@@ -17,7 +17,6 @@ package com.google.devtools.build.lib.bazel.repository.downloader;
 import com.google.auth.Credentials;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -111,8 +110,8 @@ final class HttpConnectorMultiplexer {
     // REQUEST_HEADERS should not be overridable by user provided headers
     baseHeaders.putAll(REQUEST_HEADERS);
 
-    Function<URI, ImmutableMap<String, List<String>>> headerFunction =
-        getHeaderFunction(url, baseHeaders.buildKeepingLast(), credentials, eventHandler);
+    HttpConnector.RequestHeadersProvider headerFunction =
+        getHeaderFunction(url, baseHeaders.buildKeepingLast(), credentials);
     URLConnection connection = connector.connect(url, headerFunction);
     return httpStreamFactory.create(
         connection,
@@ -125,7 +124,7 @@ final class HttpConnectorMultiplexer {
               HttpUtils.toUri(connection),
               newUrl ->
                   new ImmutableMap.Builder<String, List<String>>()
-                      .putAll(headerFunction.apply(newUrl))
+                      .putAll(headerFunction.get(newUrl))
                       .putAll(extraHeaders)
                       .buildOrThrow());
         },
@@ -133,11 +132,8 @@ final class HttpConnectorMultiplexer {
   }
 
   @VisibleForTesting
-  static Function<URI, ImmutableMap<String, List<String>>> getHeaderFunction(
-      URI originalUrl,
-      Map<String, List<String>> baseHeaders,
-      Credentials credentials,
-      EventHandler eventHandler) {
+  static HttpConnector.RequestHeadersProvider getHeaderFunction(
+      URI originalUrl, Map<String, List<String>> baseHeaders, Credentials credentials) {
     Preconditions.checkNotNull(originalUrl);
     Preconditions.checkNotNull(baseHeaders);
     Preconditions.checkNotNull(credentials);
@@ -161,14 +157,7 @@ final class HttpConnectorMultiplexer {
           }
         }
       }
-      try {
-        headers.putAll(credentials.getRequestMetadata(url));
-      } catch (IOException e) {
-        // If fetching credentials fails for any reason, still try to do the connection, not adding
-        // authentication information as we cannot look it up.
-        eventHandler.handle(
-            Event.warn("Error retrieving auth headers, continuing without: " + e.getMessage()));
-      }
+      headers.putAll(credentials.getRequestMetadata(url));
       return headers.buildKeepingLast();
     };
   }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Function;
+import com.google.auth.Credentials;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.authandtls.StaticCredentials;
@@ -81,7 +81,8 @@ public class HttpConnectorMultiplexerTest {
 
   @Before
   public void before() throws Exception {
-    when(connector.connect(eq(TEST_URL), any(Function.class))).thenReturn(connection);
+    when(connector.connect(eq(TEST_URL), any(HttpConnector.RequestHeadersProvider.class)))
+        .thenReturn(connection);
     when(streamFactory.create(
             same(connection),
             any(URI.class),
@@ -127,7 +128,7 @@ public class HttpConnectorMultiplexerTest {
   @Test
   public void success() throws Exception {
     assertThat(toByteArray(multiplexer.connect(TEST_URL, DUMMY_CHECKSUM))).isEqualTo(TEST_DATA);
-    verify(connector).connect(eq(TEST_URL), any(Function.class));
+    verify(connector).connect(eq(TEST_URL), any(HttpConnector.RequestHeadersProvider.class));
     verify(streamFactory)
         .create(
             any(URLConnection.class),
@@ -140,12 +141,28 @@ public class HttpConnectorMultiplexerTest {
 
   @Test
   public void failure() throws Exception {
-    when(connector.connect(any(URI.class), any(Function.class))).thenThrow(new IOException("oops"));
+    when(connector.connect(any(URI.class), any(HttpConnector.RequestHeadersProvider.class)))
+        .thenThrow(new IOException("oops"));
     IOException e =
         assertThrows(IOException.class, () -> multiplexer.connect(TEST_URL, Optional.empty()));
     assertThat(e).hasMessageThat().contains("oops");
-    verify(connector).connect(any(URI.class), any(Function.class));
+    verify(connector).connect(any(URI.class), any(HttpConnector.RequestHeadersProvider.class));
     verifyNoMoreInteractions(connector, streamFactory);
+  }
+
+  @Test
+  public void credentialFailureIsPropagated() throws Exception {
+    IOException credentialFailure = new IOException("credential helper failed");
+    Credentials credentials = mock(Credentials.class);
+    when(credentials.getRequestMetadata(TEST_URL)).thenThrow(credentialFailure);
+
+    HttpConnector.RequestHeadersProvider headerFunction =
+        HttpConnectorMultiplexer.getHeaderFunction(TEST_URL, ImmutableMap.of(), credentials);
+
+    IOException thrown = assertThrows(IOException.class, () -> headerFunction.get(TEST_URL));
+
+    assertThat(thrown).isSameInstanceAs(credentialFailure);
+    verifyNoInteractions(eventHandler);
   }
 
   @Test
@@ -162,12 +179,12 @@ public class HttpConnectorMultiplexerTest {
             originalUrl,
             ImmutableMap.of("Authentication", ImmutableList.of("Zm9vOmZvb3NlY3JldA==")));
 
-    Function<URI, ImmutableMap<String, List<String>>> headerFunction =
+    HttpConnector.RequestHeadersProvider headerFunction =
         HttpConnectorMultiplexer.getHeaderFunction(
-            originalUrl, baseHeaders, new StaticCredentials(additionalHeaders), eventHandler);
+            originalUrl, baseHeaders, new StaticCredentials(additionalHeaders));
 
     // Unrelated URL
-    assertThat(headerFunction.apply(URI.create("http://example.org/some/path/file.txt")))
+    assertThat(headerFunction.get(URI.create("http://example.org/some/path/file.txt")))
         .containsExactly(
             "Accept-Encoding",
             ImmutableList.of("gzip"),
@@ -175,7 +192,7 @@ public class HttpConnectorMultiplexerTest {
             ImmutableList.of("Bazel/testing"));
 
     // With auth headers
-    assertThat(headerFunction.apply(URI.create("http://hosting.example.com/user/foo/file.txt")))
+    assertThat(headerFunction.get(URI.create("http://hosting.example.com/user/foo/file.txt")))
         .containsExactly(
             "Accept-Encoding",
             ImmutableList.of("gzip"),
@@ -185,26 +202,26 @@ public class HttpConnectorMultiplexerTest {
             ImmutableList.of("Zm9vOmZvb3NlY3JldA=="));
 
     // Other hosts
-    assertThat(headerFunction.apply(URI.create("http://hosting2.example.com/user/foo/file.txt")))
+    assertThat(headerFunction.get(URI.create("http://hosting2.example.com/user/foo/file.txt")))
         .containsExactly(
             "Accept-Encoding",
             ImmutableList.of("gzip"),
             "User-Agent",
             ImmutableList.of("Bazel/testing"));
-    assertThat(headerFunction.apply(URI.create("http://sub.hosting.example.com/user/foo/file.txt")))
+    assertThat(headerFunction.get(URI.create("http://sub.hosting.example.com/user/foo/file.txt")))
         .containsExactly(
             "Accept-Encoding",
             ImmutableList.of("gzip"),
             "User-Agent",
             ImmutableList.of("Bazel/testing"));
-    assertThat(headerFunction.apply(URI.create("http://example.com/user/foo/file.txt")))
+    assertThat(headerFunction.get(URI.create("http://example.com/user/foo/file.txt")))
         .containsExactly(
             "Accept-Encoding",
             ImmutableList.of("gzip"),
             "User-Agent",
             ImmutableList.of("Bazel/testing"));
     assertThat(
-            headerFunction.apply(
+            headerFunction.get(
                 URI.create("http://hosting.example.com.evil.example/user/foo/file.txt")))
         .containsExactly(
             "Accept-Encoding",
@@ -215,12 +232,12 @@ public class HttpConnectorMultiplexerTest {
     // Verify that URL-specific headers overwrite
     ImmutableMap<String, List<String>> annonAuth =
         ImmutableMap.of("Authentication", ImmutableList.of("YW5vbnltb3VzOmZvb0BleGFtcGxlLm9yZw=="));
-    Function<URI, ImmutableMap<String, List<String>>> combinedHeaders =
+    HttpConnector.RequestHeadersProvider combinedHeaders =
         HttpConnectorMultiplexer.getHeaderFunction(
-            originalUrl, annonAuth, new StaticCredentials(additionalHeaders), eventHandler);
-    assertThat(combinedHeaders.apply(URI.create("http://hosting.example.com/user/foo/file.txt")))
+            originalUrl, annonAuth, new StaticCredentials(additionalHeaders));
+    assertThat(combinedHeaders.get(URI.create("http://hosting.example.com/user/foo/file.txt")))
         .containsExactly("Authentication", ImmutableList.of("Zm9vOmZvb3NlY3JldA=="));
-    assertThat(combinedHeaders.apply(URI.create("http://unreleated.example.org/user/foo/file.txt")))
+    assertThat(combinedHeaders.get(URI.create("http://unreleated.example.org/user/foo/file.txt")))
         .containsExactly(
             "Authentication", ImmutableList.of("YW5vbnltb3VzOmZvb0BleGFtcGxlLm9yZw=="));
   }
@@ -237,13 +254,13 @@ public class HttpConnectorMultiplexerTest {
 
     URI originalUrl = URI.create("http://EXAMPLE.COM/file.txt");
 
-    Function<URI, ImmutableMap<String, List<String>>> headerFunction =
+    HttpConnector.RequestHeadersProvider headerFunction =
         HttpConnectorMultiplexer.getHeaderFunction(
-            originalUrl, baseHeaders, StaticCredentials.EMPTY, eventHandler);
+            originalUrl, baseHeaders, StaticCredentials.EMPTY);
 
     // Same origin (case-insensitive host matching e.g. EXAMPLE.COM vs example.com and default port
     // 80 normalization)
-    assertThat(headerFunction.apply(URI.create("http://example.com:80/other.txt")))
+    assertThat(headerFunction.get(URI.create("http://example.com:80/other.txt")))
         .containsExactly(
             "Authorization", ImmutableList.of("Bearer token"),
             "Proxy-Authorization", ImmutableList.of("Basic proxy"),
@@ -252,15 +269,15 @@ public class HttpConnectorMultiplexerTest {
             "User-Agent", ImmutableList.of("Bazel/testing"));
 
     // Cross origin (host change)
-    assertThat(headerFunction.apply(URI.create("http://other.org/file.txt")))
+    assertThat(headerFunction.get(URI.create("http://other.org/file.txt")))
         .containsExactly("User-Agent", ImmutableList.of("Bazel/testing"));
 
     // Cross origin (port change)
-    assertThat(headerFunction.apply(URI.create("http://example.com:8080/file.txt")))
+    assertThat(headerFunction.get(URI.create("http://example.com:8080/file.txt")))
         .containsExactly("User-Agent", ImmutableList.of("Bazel/testing"));
 
     // Cross origin (scheme change)
-    assertThat(headerFunction.apply(URI.create("https://example.com/file.txt")))
+    assertThat(headerFunction.get(URI.create("https://example.com/file.txt")))
         .containsExactly("User-Agent", ImmutableList.of("Bazel/testing"));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
@@ -20,12 +20,13 @@ import static com.google.devtools.build.lib.bazel.repository.downloader.HttpPars
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
@@ -119,6 +120,27 @@ public class HttpConnectorTest {
     thrown.expect(IOException.class);
     thrown.expectMessage("Unknown host: bad.example");
     connector.connect(URI.create("http://bad.example"), url -> ImmutableMap.of());
+  }
+
+  @Test
+  public void requestHeadersFailure_doesNotConnectOrRetry() throws Exception {
+    IOException headerFailure = new IOException("credential helper failed");
+    AtomicInteger calls = new AtomicInteger();
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () ->
+                connector.connect(
+                    URI.create("http://test.example"),
+                    url -> {
+                      calls.incrementAndGet();
+                      throw headerFailure;
+                    }));
+
+    assertThat(thrown).isSameInstanceAs(headerFailure);
+    assertThat(calls.get()).isEqualTo(1);
+    verifyNoInteractions(proxyHelper);
   }
 
   @Test
@@ -698,17 +720,14 @@ public class HttpConnectorTest {
               });
       // Header function that provides different auth headers for
       // the two servers.
-      Function<URI, ImmutableMap<String, List<String>>> authHeaders =
-          new Function<>() {
-            @Override
-            public ImmutableMap<String, List<String>> apply(URI url) {
-              if (url.getPort() == server1.getLocalPort()) {
-                return ImmutableMap.of("Authentication", ImmutableList.of(basic1));
-              } else if (url.getPort() == server2.getLocalPort()) {
-                return ImmutableMap.of("Authentication", ImmutableList.of(basic2));
-              } else {
-                return ImmutableMap.of();
-              }
+      HttpConnector.RequestHeadersProvider authHeaders =
+          url -> {
+            if (url.getPort() == server1.getLocalPort()) {
+              return ImmutableMap.of("Authentication", ImmutableList.of(basic1));
+            } else if (url.getPort() == server2.getLocalPort()) {
+              return ImmutableMap.of("Authentication", ImmutableList.of(basic2));
+            } else {
+              return ImmutableMap.of();
             }
           };
       URLConnection connection =


### PR DESCRIPTION
### Description

Propagate request-metadata lookup failures through the HTTP downloader instead of warning and continuing without authentication. A checked request-header provider now resolves credentials before proxy or socket creation, while preserving per-URL header computation for redirects.

Add regressions covering both layers of the failure path: credential exceptions reach the caller unchanged, and a failed header lookup does not open a connection or enter the network retry loop.

### Motivation

Fixes #24548.

A failing scoped credential helper could previously be reduced to a warning and followed by an anonymous registry request. The later registry response could then mask the actionable helper exit code and stderr. Credential helper failures should abort the operation instead.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (not applicable: no public API or configuration change).

### Tests

- `bazel test //src/test/java/com/google/devtools/build/lib/authandtls/credentialhelper:credentialhelper //src/test/java/com/google/devtools/build/lib/bazel/repository/downloader:DownloaderTestSuite`
- `bazel build //src:bazel-dev`
- Manual HTTP registry replay with a host-scoped helper that exits with code 2: the helper diagnostic was surfaced and the registry received no request.

### Release Notes

RELNOTES: Credential helper failures now abort HTTP downloads instead of continuing without authentication.
