### PR TITLE
Fix String misencoding in event and terminal printing

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/events/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/events/BUILD
@@ -18,6 +18,7 @@ java_library(
         exclude = ["EventBusEventHandler.java"],
     ),
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/unsafe:string",
         "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/util/io:out-err",
         "//src/main/java/net/starlark/java/eval",

--- a/src/main/java/com/google/devtools/build/lib/events/Event.java
+++ b/src/main/java/com/google/devtools/build/lib/events/Event.java
@@ -15,10 +15,10 @@ package com.google.devtools.build.lib.events;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Comparator.comparing;
 
 import com.google.common.collect.ImmutableClassToInstanceMap;
+import com.google.devtools.build.lib.unsafe.StringUnsafe;
 import com.google.errorprone.annotations.CheckReturnValue;
 import java.io.IOException;
 import java.util.Arrays;
@@ -84,16 +84,21 @@ public final class Event implements Reportable {
   }
 
   public String getMessage() {
-    return message instanceof String ? (String) message : new String((byte[]) message, UTF_8);
+    return message instanceof String
+        ? (String) message
+        : StringUnsafe.newInstance((byte[]) message, StringUnsafe.LATIN1);
   }
 
   /**
-   * Returns this event's message as a {@link byte[]}. If this event was instantiated using a {@link
-   * String}, the returned byte array is encoded using {@link
-   * java.nio.charset.StandardCharsets#UTF_8}.
+   * Returns this event's message as a {@link byte[]} by unwrapping Bazel's {@link
+   * com.google.devtools.build.lib.util.StringEncoding internal string encoding}.
+   *
+   * <p>Caller's must not modify the returned array.
    */
   public byte[] getMessageBytes() {
-    return message instanceof byte[] ? (byte[]) message : ((String) message).getBytes(UTF_8);
+    return message instanceof byte[]
+        ? (byte[]) message
+        : StringUnsafe.getInternalStringBytes((String) message);
   }
 
   /** Returns the property value associated with {@code type} if any, and {@code null} otherwise. */

--- a/src/main/java/com/google/devtools/build/lib/events/PrintingEventHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/events/PrintingEventHandler.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.events;
 
+import com.google.devtools.build.lib.unsafe.StringUnsafe;
 import com.google.devtools.build.lib.util.io.OutErr;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -102,7 +103,7 @@ public class PrintingEventHandler extends AbstractEventHandler
             builder.append(event.getLocation()).append(": ");
           }
           builder.append(event.getMessage()).append("\n");
-          outErr.getErrorStream().write(builder.toString().getBytes(StandardCharsets.UTF_8));
+          outErr.getErrorStream().write(StringUnsafe.getInternalStringBytes(builder.toString()));
           outErr.getErrorStream().flush();
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/util/io/AnsiTerminal.java
+++ b/src/main/java/com/google/devtools/build/lib/util/io/AnsiTerminal.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.util.io;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
+import com.google.devtools.build.lib.unsafe.StringUnsafe;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -139,9 +140,8 @@ public class AnsiTerminal {
   }
 
   /** Set the terminal title. */
-  @SuppressWarnings("DefaultCharset")
   public void setTitle(String title) throws IOException {
-    writeBytes(osc, setTermTitle, title.getBytes(), st);
+    writeBytes(osc, setTermTitle, StringUnsafe.getInternalStringBytes(title), st);
   }
 
   /**
@@ -149,9 +149,8 @@ public class AnsiTerminal {
    *
    * @param text the text to write
    */
-  @SuppressWarnings("DefaultCharset")
   public void writeString(String text) throws IOException {
-    out.write(text.getBytes());
+    out.write(StringUnsafe.getInternalStringBytes(text));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/util/io/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/util/io/BUILD
@@ -73,6 +73,7 @@ java_library(
     srcs = OUT_ERR_SRCS,
     deps = [
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
+        "//src/main/java/com/google/devtools/build/lib/unsafe:string",
         "//third_party:flogger",
         "//third_party:guava",
     ],

--- a/src/test/java/com/google/devtools/build/lib/events/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/events/BUILD
@@ -19,6 +19,8 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/events:event_bus_event_handler",
+        "//src/main/java/com/google/devtools/build/lib/unsafe:string",
+        "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/util/io:out-err",
         "//src/main/java/net/starlark/java/eval",
         "//src/main/java/net/starlark/java/syntax",

--- a/src/test/java/com/google/devtools/build/lib/events/EventTest.java
+++ b/src/test/java/com/google/devtools/build/lib/events/EventTest.java
@@ -14,7 +14,8 @@
 package com.google.devtools.build.lib.events;
 
 import static com.google.common.truth.Truth.assertThat;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -22,6 +23,8 @@ import static org.mockito.Mockito.verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.events.Event.ProcessOutput;
+import com.google.devtools.build.lib.unsafe.StringUnsafe;
+import com.google.devtools.build.lib.util.StringEncoding;
 import net.starlark.java.eval.Mutability;
 import net.starlark.java.eval.StarlarkSemantics;
 import net.starlark.java.eval.StarlarkThread;
@@ -47,22 +50,17 @@ public class EventTest {
 
   @Test
   public void eventMessageEncoding() {
-    String message = "Bazel \u1f33f";
+    String message = StringEncoding.unicodeToInternal("Bazel ἳf");
 
     Event stringEvent = Event.of(EventKind.WARNING, message);
-    Event stringEvent2 = Event.of(EventKind.WARNING, "Bazel \u1f33f");
     assertThat(stringEvent.getMessage()).isEqualTo(message);
-    assertThat(stringEvent.getMessageBytes()).isEqualTo(message.getBytes(UTF_8));
+    assertThat(stringEvent.getMessageBytes()).isEqualTo(message.getBytes(ISO_8859_1));
 
-    Event byteArrayEvent = Event.of(EventKind.WARNING, message.getBytes(UTF_8));
-    Event byteArrayEvent2 = Event.of(EventKind.WARNING, "Bazel \u1f33f".getBytes(UTF_8));
+    Event byteArrayEvent = Event.of(EventKind.WARNING, StringUnsafe.getByteArray(message));
     assertThat(byteArrayEvent.getMessage()).isEqualTo(message);
-    assertThat(byteArrayEvent.getMessageBytes()).isEqualTo(message.getBytes(UTF_8));
+    assertThat(byteArrayEvent.getMessageBytes()).isEqualTo(message.getBytes(ISO_8859_1));
 
-    new EqualsTester()
-        .addEqualityGroup(stringEvent, stringEvent2)
-        .addEqualityGroup(byteArrayEvent, byteArrayEvent2)
-        .testEquals();
+    assertThat(stringEvent).isNotEqualTo(byteArrayEvent);
   }
 
   @Test
@@ -77,7 +75,7 @@ public class EventTest {
 
   @Test
   public void messageReference() throws Exception {
-    byte[] messageBytes = "message".getBytes(UTF_8);
+    byte[] messageBytes = "message".getBytes(US_ASCII);
     Event event = Event.of(EventKind.WARNING, messageBytes);
     assertThat(event.getMessageBytes()).isEqualTo(messageBytes);
   }
@@ -182,9 +180,9 @@ public class EventTest {
   @Test
   public void testWithProcessOutput() throws Exception {
     String stdoutPath = "/stdout";
-    byte[] stdout = "some stdout output".getBytes(UTF_8);
+    byte[] stdout = "some stdout output".getBytes(US_ASCII);
     String stderrPath = "/stderr";
-    byte[] stderr = "some stderr error".getBytes(UTF_8);
+    byte[] stderr = "some stderr error".getBytes(US_ASCII);
 
     ProcessOutput testProcessOutput =
         new ProcessOutput() {


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
The new warning supressions masked real encoding issues that could be reached via `Event` messages. 

Fix all of them by enforcing the internal string encoding. Update the tests to verify the correct handling of Bazel's internal encoding rather than UTF-8, which isn't used in prod.

### Motivation
d4cd8d91e76f46c2919eda1f98deb02a9d8a8f53

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
