### PR TITLE
site: Fix rolling releases page

### DIFF
--- a/docs/release/rolling.mdx
+++ b/docs/release/rolling.mdx
@@ -11,4 +11,4 @@ these releases.
 
 ## Index {#index}
 
-<iframe src="https://releases.bazel.build/rolling.html" style="height: 3000px; width: 100%" ></iframe>
+<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%"}} />

--- a/docs/release/rolling.mdx
+++ b/docs/release/rolling.mdx
@@ -11,6 +11,6 @@ these releases.
 
 ## Index {#index}
 
-<div style={{background: "white", borderRadius: "8px", padding: "8px", border: "1px solid #e5e7eb"}}>
+<div style={{background: "white", borderRadius: "12px", padding: "6px"}}>
 <iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%", border: "none"}} />
 </div>

--- a/docs/release/rolling.mdx
+++ b/docs/release/rolling.mdx
@@ -11,4 +11,6 @@ these releases.
 
 ## Index {#index}
 
-<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%"}} />
+<div style={{background: "white", borderRadius: "8px", padding: "8px", border: "1px solid #e5e7eb"}}>
+<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%", border: "none"}} />
+</div>


### PR DESCRIPTION
Fixes the broken https://bazel.build/release/rolling page.

RELNOTES: None
