### PR TITLE
Close the coverage post-processing `FileOutErr` before deleting its files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -801,11 +801,13 @@ public class StandaloneTestStrategy extends TestStrategy {
           if (e.isCatastrophic()) {
             closeSuppressed(e, streamed);
             closeSuppressed(e, fileOutErr);
+            closeSuppressed(e, coverageOutErr);
             throw e;
           }
           if (!e.getSpawnResult().setupSuccess()) {
             closeSuppressed(e, streamed);
             closeSuppressed(e, fileOutErr);
+            closeSuppressed(e, coverageOutErr);
             // Rethrow as the test could not be run and thus there's no point in retrying.
             throw e;
           }
@@ -816,10 +818,12 @@ public class StandaloneTestStrategy extends TestStrategy {
         } catch (ExecException | InterruptedException e) {
           closeSuppressed(e, streamed);
           closeSuppressed(e, fileOutErr);
+          closeSuppressed(e, coverageOutErr);
           throw e;
         }
 
         // Append all output from the coverage spawn to the test log.
+        coverageOutErr.close();
         appendCoverageLog(coverageOutErr, fileOutErr);
       } else {
         Artifact coverageData = testAction.getCoverageData();


### PR DESCRIPTION
### Description

`appendCoverageLog` copies `coverage.log` and `coverage.err` into the test log and then deletes them, but the `FileOutErr` that the coverage post-processing spawn wrote them through was never closed. This closes it before the delete, and also closes it on the paths that rethrow, which previously leaked the handles.

### Motivation

Deleting a file that still has an open handle is fine on POSIX, but not on Windows. Every affected test then fails with:

```
ERROR: ... Testing //tests/alwayslink_srcs:alwayslink_test failed: java.io.IOException: C:/b/skckkmg2/execroot/_main/bazel-out/x64_windows-fastbuild/testlogs/tests/alwayslink_srcs/alwayslink_test/coverage.err (Permission denied)
```

The bug is older than that, but it only became reachable for Bazel users with 8e68c24713f7d9b83d4eb364a64c8d6df26b261c, which flipped `--experimental_split_coverage_postprocessing` to default true.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes
