### PR TITLE
[8.8.0] Compare paths as fragments in `AbstractActionInputPrefetcher`…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -134,15 +134,9 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
     }
 
     private void setWritable(Path dir, DirectoryState newState) throws IOException {
-      // External repo paths (which live directly under the output base) are not build outputs and
-      // don't need output permission management. Check this first (comparing fragments, since the
-      // dir may be on the host file system while the output base is on an overlay) so that the exec
-      // root, which is only resolvable during the loading phase and later, is not resolved during
-      // external repo materialization.
-      if (dir.asFragment()
-              .startsWith(
-                  outputBase.getRelative(LabelConstants.EXTERNAL_REPOSITORY_LOCATION).asFragment())
-          || !dir.startsWith(execRoot())) {
+      // Compare as fragments since execRoot may be located on a file system overlaying the host
+      // file system where downloads are written to.
+      if (!dir.asFragment().startsWith(execRoot.asFragment())) {
         return;
       }
       AtomicReference<IOException> caughtException = new AtomicReference<>();


### PR DESCRIPTION
…. (#27627)

This is required because `execRoot` might be located on an action file system overlaying the host file system where downloads are written (see the changes in
https://github.com/bazelbuild/bazel/commit/b8589c3b278e3f5cee6ef85b0dcabb1cdcd69839 for context).

PiperOrigin-RevId: 830480221
Change-Id: I217b81a81da80f2050c4ec9082ef5f18cb9a0bc9

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/1e9d843fa6362b88d5ca1b6cc04b38f69823fb76