### PR TITLE
Permit C++ build variables to be `Label`-valued

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Sets.SetView;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.PathMapper;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.concurrent.BlazeInterners;
@@ -828,6 +829,7 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
       case NoneType ignored -> null; // null has the same behavior as omitted field
       case Boolean b -> BooleanValue.of(b);
       case String s -> new StringValue(s);
+      case Label label -> new StringValue(label.expandToCommandLine());
       case Artifact artifact -> new ArtifactValue(artifact);
       case PathFragment pathFragment -> new PathFragmentValue(pathFragment);
       case Iterable<?> iterable -> new Sequence(ImmutableList.copyOf(iterable));


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
This enables further memory savings for module maps (see https://github.com/bazelbuild/rules_cc/pull/789).


### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
