### PR TITLE
docs: Starlark ints are not limited to 32 bits

### DIFF
--- a/site/en/rules/language.md
+++ b/site/en/rules/language.md
@@ -133,7 +133,8 @@ illegal, and 2) `*args` and `**kwargs` arguments are not allowed.
 
 * Recursion is not allowed.
 
-* Int type is limited to 32-bit signed integers. Overflows will throw an error.
+* Integers may be of any magnitude, and arithmetic on them is exact. See
+  [`int`](lib/int).
 
 * Modifying a collection during iteration is an error.
 


### PR DESCRIPTION
Part of #27257

`/rules/language` says:

> Int type is limited to 32-bit signed integers. Overflows will throw an error.

`StarlarkInt` says the opposite, and has for a while:

> The type of integers in Starlark. Starlark integers may be of any magnitude; arithmetic is exact

That docstring is what generates `/rules/lib/int`, so the two pages on the same site contradict each other. This replaces the stale bullet and links to the generated page so they stay together

So one line, no other changes

The float and set half of #27257 is already gone from this page, so I left the issue open rather than closing it with this
