### PR TITLE
Don't build BEP paths on an action filesystem in Bazel

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputService.java
@@ -20,9 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.eventbus.Subscribe;
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
-import com.google.devtools.build.lib.actions.ActionInputMap;
 import com.google.devtools.build.lib.actions.Artifact;
-import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.LostInputsActionExecutionException;
 import com.google.devtools.build.lib.actions.OutputChecker;
@@ -207,24 +205,6 @@ public class RemoteOutputService implements OutputService {
   @Override
   public void clean() {
     // Intentionally left empty.
-  }
-
-  @Override
-  public boolean supportsPathResolverForArtifactValues() {
-    return actionFileSystemType() != ActionFileSystemType.DISABLED;
-  }
-
-  @Override
-  public ArtifactPathResolver createPathResolverForArtifactValues(
-      PathFragment execRoot,
-      String relativeOutputPath,
-      FileSystem fileSystem,
-      ImmutableList<Root> pathEntries,
-      ActionInputMap actionInputMap) {
-    FileSystem remoteFileSystem =
-        new RemoteActionFileSystem(
-            fileSystem, execRoot, relativeOutputPath, actionInputMap, actionInputFetcher);
-    return ArtifactPathResolver.createPathResolver(remoteFileSystem, fileSystem.getPath(execRoot));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/runtime/BuildEventStreamer.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BuildEventStreamer.java
@@ -509,7 +509,7 @@ public class BuildEventStreamer {
       for (NestedSet<?> succ : set.getNonLeaves()) {
         maybeReportArtifactSet(ctx, succ);
       }
-      post(new NamedArtifactGroup(lockedName.getName(), ctx, set));
+      post(new NamedArtifactGroup(lockedName.getName(), ctx.pathResolver(), set));
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/NamedArtifactGroup.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/NamedArtifactGroup.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.CompletionContext;
 import com.google.devtools.build.lib.actions.CompletionContext.ArtifactReceiver;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
@@ -45,16 +46,16 @@ import java.util.Collection;
  */
 class NamedArtifactGroup implements BuildEvent {
   private final String name;
-  private final CompletionContext completionContext;
+  private final ArtifactPathResolver pathResolver;
   private final NestedSet<?> set; // of Artifact or ExpandedArtifact
 
   /**
    * Create a {@link NamedArtifactGroup}. Although the set may contain a mixture of Artifacts and
    * ExpandedArtifacts, all its leaf successors ("direct elements") are ExpandedArtifacts.
    */
-  NamedArtifactGroup(String name, CompletionContext completionContext, NestedSet<?> set) {
+  NamedArtifactGroup(String name, ArtifactPathResolver pathResolver, NestedSet<?> set) {
     this.name = name;
-    this.completionContext = completionContext;
+    this.pathResolver = pathResolver;
     this.set = set;
   }
 
@@ -76,14 +77,14 @@ class NamedArtifactGroup implements BuildEvent {
         case NormalExpandedArtifact(Artifact artifact, FileArtifactValue metadata) -> {
           artifacts.add(
               new LocalFile(
-                  completionContext.pathResolver().toPath(artifact),
+                  pathResolver.toPath(artifact),
                   LocalFileType.forArtifact(artifact, metadata),
                   metadata));
         }
         case FilesetExpandedArtifact(Artifact fileset, FilesetOutputSymlink link) -> {
           artifacts.add(
               new LocalFile(
-                  completionContext.pathResolver().toPath(link.target()),
+                  pathResolver.toPath(link.target()),
                   LocalFileType.forArtifact(link.target(), link.metadata()),
                   link.metadata()));
         }
@@ -103,12 +104,11 @@ class NamedArtifactGroup implements BuildEvent {
       BuildEventStreamProtos.File file =
           switch ((ExpandedArtifact) elem) {
             case NormalExpandedArtifact(Artifact artifact, FileArtifactValue metadata) -> {
-              String uri = pathConverter.apply(completionContext.pathResolver().toPath(artifact));
+              String uri = pathConverter.apply(pathResolver.toPath(artifact));
               yield TargetCompleteEvent.newFile(artifact, metadata, uri);
             }
             case FilesetExpandedArtifact(Artifact fileset, FilesetOutputSymlink link) -> {
-              String uri =
-                  pathConverter.apply(completionContext.pathResolver().toPath(link.target()));
+              String uri = pathConverter.apply(pathResolver.toPath(link.target()));
               yield TargetCompleteEvent.newFile(
                   fileset.getRoot(),
                   fileset.getRootRelativePath().getRelative(link.name()),


### PR DESCRIPTION
### Description

`CompletionContext` asks the `OutputService` for an `ArtifactPathResolver`, which `TargetCompleteEvent` and `NamedArtifactGroup` use to turn artifacts into `Path`s for `referencedLocalFiles()` and for the URIs in `asStreamProto()`. `RemoteOutputService` answered with a `RemoteActionFileSystem` wrapping the target's `ActionInputMap`.

Build events are uploaded asynchronously, so that filesystem — and the input map behind it — stayed reachable until the last transport had drained. This drops the override, so Bazel falls back to the default `ArtifactPathResolver.IDENTITY`.

Two changes:

1. `RemoteOutputService` no longer overrides `supportsPathResolverForArtifactValues()`/`createPathResolverForArtifactValues()`. **The `OutputService` hook itself is deliberately left in place** — an implementation whose action filesystem takes full control of the output base still needs to hand the build event stream a filesystem of its own, since its outputs may not exist on the local filesystem at all.
2. `NamedArtifactGroup` now retains just the `ArtifactPathResolver` rather than the whole `CompletionContext`.

### Why this is safe for Bazel

Every path the resolver produces is consumed by `BuildEventArtifactUploader#upload` or by `PathConverter#apply`, and both `referencedLocalFiles()` and `asStreamProto()` change together, so the `Path` keys still match (`Path` equality includes filesystem identity). `IDENTITY.toPath(artifact)` is `artifact.getPath()`, i.e. the same absolute path string the action filesystem produced.

`ByteStreamBuildEventArtifactUploader` only touches the filesystem when it cannot get what it needs from `LocalFile#artifactMetadata`. For these two events the metadata always comes from `CompletionContext#visitArtifacts`, which `checkNotNull`s it, and since 9a849d92d4 the uploader short-circuits on it. Sweeping `FileArtifactValue`, the only implementations that return a null digest are `DirectoryArtifactValue` (type `DIRECTORY`, which the uploader handles without touching the filesystem) and the singleton markers; runfiles tree markers are skipped by `visitArtifacts`, and a missing-file marker resolves to a non-existent path under either resolver, so its behaviour is unchanged.

I did check the remaining consumers: `pathResolver()` has exactly six call sites, all in these two events. `ImportantOutputHandler` receives the `CompletionContext` but never asks it for paths, and `CompletionContext`'s other accessors (`visitArtifacts`, `getFileArtifactValue`, `getTreeMetadata`, `getFileset`) read the input map directly.

### Why this is a win

`TargetCompleteEvent` keeps `importantInputMap` alive by itself, so removing the filesystem does not shrink that event. The win is elsewhere:

- No `RemoteActionFileSystem` (with its `PathCanonicalizer`, tree artifact directory cache and in-memory output tree) is constructed per completed target or aspect any more.
- `NamedArtifactGroup` stops pinning the target's `ActionInputMap`. `BuildEventStreamer` creates one of these per nested set node of every target's output groups and holds them until they are posted, so they outnumber `TargetCompleteEvent`s considerably. With `IDENTITY` being a singleton, they now retain nothing beyond the artifacts and metadata they already store.

### Motivation

The build event protocol should not keep execution-phase data structures alive. This is one half of the retention described in https://github.com/bazelbuild/bazel/issues/24527#issuecomment-2541683398; the per-action half is #30692.

Progress towards #24527.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
