### PR TITLE
Release the action filesystem's input view once the action is done

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -40,6 +40,7 @@ import com.google.devtools.build.lib.actions.ImportantOutputHandler.LostArtifact
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.LostInputsActionExecutionException;
 import com.google.devtools.build.lib.actions.LostInputsExecException;
+import com.google.devtools.build.lib.actions.StaticInputMetadataProvider;
 import com.google.devtools.build.lib.clock.Clock;
 import com.google.devtools.build.lib.remote.common.BulkTransferException;
 import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
@@ -106,7 +107,16 @@ import javax.annotation.Nullable;
 public class RemoteActionFileSystem extends FileSystem implements PathCanonicalizer.Resolver {
   private final PathFragment execRoot;
   private final PathFragment outputBase;
-  private final InputMetadataProvider inputArtifactData;
+
+  /**
+   * The action's inputs, or {@link StaticInputMetadataProvider#empty()} once {@link
+   * #releaseActionContext} has been called.
+   *
+   * <p>Volatile so that a thread reading this filesystem while the input view is released observes
+   * one of the two providers rather than keeping the released one alive indefinitely.
+   */
+  private volatile InputMetadataProvider inputArtifactData;
+
   private final TreeArtifactDirectoryCache inputTreeArtifactDirectoryCache;
   private final PathCanonicalizer pathCanonicalizer;
   private final RemoteActionInputFetcher inputFetcher;
@@ -193,6 +203,11 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
     public synchronized Collection<Dirent> get(PathFragment execPath) {
       ensureCached(execPath);
       return dirToEntries.get(execPath);
+    }
+
+    synchronized void clear() {
+      cachedTrees.clear();
+      dirToEntries.clear();
     }
 
     private void ensureCached(PathFragment execPath) {
@@ -303,6 +318,25 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
 
   public void updateContext(ActionExecutionMetadata action) {
     this.action = action;
+  }
+
+  /**
+   * Releases the parts of this filesystem that are only needed while the action is executing.
+   *
+   * <p>This filesystem outlives its action, and build events are not the only reason. They
+   * reference {@link com.google.devtools.build.lib.vfs.Path}s in it and are uploaded
+   * asynchronously, so it stays reachable until the last of them has been delivered; with {@code
+   * --remote_cache_async}, the action result upload reads it from a background thread as well.
+   *
+   * <p>All of these only ever reference outputs, which remain served by the remote output tree and
+   * the local filesystem. The input view is therefore dropped here instead of retaining the
+   * metadata of every input of every action that something is still holding on to. See
+   * https://github.com/bazelbuild/bazel/issues/24527.
+   */
+  public void releaseActionContext() {
+    inputArtifactData = StaticInputMetadataProvider.empty();
+    inputTreeArtifactDirectoryCache.clear();
+    action = null;
   }
 
   void injectRemoteFile(

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputService.java
@@ -115,6 +115,11 @@ public class RemoteOutputService implements OutputService {
   }
 
   @Override
+  public void releaseActionFileSystemContext(FileSystem actionFileSystem) {
+    ((RemoteActionFileSystem) actionFileSystem).releaseActionContext();
+  }
+
+  @Override
   public String getFileSystemName(String outputBaseFileSystemName) {
     return "remoteActionFS";
   }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -690,6 +690,9 @@ public final class SkyframeActionExecutor {
     }
 
     if (result != null || finalException != null) {
+      if (actionFileSystem != null) {
+        outputService.releaseActionFileSystemContext(actionFileSystem);
+      }
       closeContext(actionExecutionContext, action, finalException);
     }
     return result;

--- a/src/main/java/com/google/devtools/build/lib/vfs/OutputService.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/OutputService.java
@@ -237,6 +237,19 @@ public interface OutputService {
       OutputMetadataStore outputMetadataStore) {}
 
   /**
+   * Releases the context set up by {@link #updateActionFileSystemContext} once the action has
+   * finished executing.
+   *
+   * <p>An action filesystem can outlive its action: build events reference {@link Path}s in it and
+   * are uploaded asynchronously, and an implementation may have further asynchronous readers. Since
+   * they only ever reference outputs, whatever the filesystem needs to serve the action's inputs
+   * should be dropped here rather than being retained until the last of them is done.
+   *
+   * @param actionFileSystem must be a filesystem returned by {@link #createActionFileSystem}.
+   */
+  default void releaseActionFileSystemContext(FileSystem actionFileSystem) {}
+
+  /**
    * Checks the filesystem returned by {@link #createActionFileSystem} for errors attributable to
    * lost inputs.
    */

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -294,6 +294,28 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
   }
 
   @Test
+  public void releaseActionContext_dropsInputsButKeepsOutputs() throws Exception {
+    ActionInputMap inputs = new ActionInputMap(2);
+    Artifact input = createRemoteArtifact("input", "input contents", inputs);
+    SpecialArtifact inputTree =
+        createRemoteTreeArtifact("input-tree", ImmutableMap.of("subdir/file", ""), inputs);
+    RemoteActionFileSystem actionFs = (RemoteActionFileSystem) createActionFileSystem(inputs);
+    Artifact output = ActionsTestUtil.createArtifact(outputRoot, "output");
+    injectRemoteFile(actionFs, output.getPath().asFragment(), "output contents");
+
+    actionFs.releaseActionContext();
+
+    // Build events reference outputs, so those must remain readable.
+    assertThat(actionFs.exists(output.getPath().asFragment())).isTrue();
+    assertThat(actionFs.getDigest(output.getPath().asFragment()))
+        .isEqualTo(getDigest("output contents"));
+
+    // The inputs are no longer needed and must no longer be retained.
+    assertThat(actionFs.exists(input.getPath().asFragment())).isFalse();
+    assertThat(actionFs.exists(inputTree.getPath().getChild("subdir").asFragment())).isFalse();
+  }
+
+  @Test
   public void statAndExists_notFound() throws Exception {
     RemoteActionFileSystem actionFs = (RemoteActionFileSystem) createActionFileSystem();
     PathFragment path = getOutputPath("does_not_exist");


### PR DESCRIPTION
### Description

An action filesystem outlives its action, and the build event service is not the only reason:

- Build events reference `Path`s in it — `ActionExecutedEvent`'s primary output and stdout/stderr, and the files in `TestAttempt` — and are uploaded asynchronously, so it stays reachable until the transport has drained them.
- With `--remote_cache_async` (on by default), `RemoteExecutionService#doUploadOutputs` runs on a background thread and digests the action's stdout/stderr, which live under the exec root and so resolve through the action filesystem.

Everything a `RemoteActionFileSystem` needs to serve the action's *inputs* is retained for that whole time: the action's `ActionInputMap` and, via the composite metadata provider, everything `SkyframeInputMetadataProvider` saw during input discovery.

None of those readers ever reference inputs. They reference outputs, which are served by the remote output tree and the local filesystem. So this adds an `OutputService` hook symmetric to `updateActionFileSystemContext`, called from `SkyframeActionExecutor#executeAction` at the point where the action execution context is closed — i.e. once the action is done, including postprocessing. `RemoteActionFileSystem` responds by swapping its input view for `StaticInputMetadataProvider.empty()` and clearing the tree artifact directory cache.

### How much does this actually save?

Measured with JOL, subtracting everything reachable from the artifacts and their metadata, since those are retained by Skyframe regardless. What an `ActionInputMap` uniquely retains is just its five parallel arrays, about **22 bytes per entry**, or 7-9% of its reachable size:

| entries | uniquely retained |
| --- | --- |
| 1,500 | 33 kB |
| 10,000 | 226 kB |
| 50,000 | 1.1 MB |

For input-discovering actions, `SkyframeInputMetadataProvider#seen` adds a `ConcurrentHashMap` entry (~40 bytes) per artifact looked up during discovery, which for include scanning can exceed the input map itself.

The multiplier is the number of build events queued but not yet delivered, plus in-flight asynchronous cache uploads — not the size of the build. So in a healthy build this is minor; it matters when the BES backend is slow or backpressured and the event queue grows, which is the failure mode described in #24527 and #20579.

### Notes on safety

- The release happens only once `getResultOrDependOnFuture` has produced a result or an exception, so a Skyframe restart in the middle of action execution does not release early.
- A rewound action gets a fresh filesystem: rewinding invalidates the node's `SkyKeyComputeState`, which is what holds `actionFileSystem`.
- The part of the async cache upload that does read inputs, `checkForConcurrentModifications`, runs synchronously before the background task is submitted; the background task itself only touches outputs and stdout/stderr.
- `inputArtifactData` is volatile so that a thread reading the filesystem while the input view is released observes one of the two providers rather than keeping the released one alive indefinitely. The tree artifact directory cache needs no such treatment: all of its state is already guarded by its own monitor, so it is cleared in place rather than swapped.
- Only `RemoteOutputService` implements the new hook; it is a `default` no-op, so other `OutputService` implementations are unaffected.

### Motivation

Progress towards #24527.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
