### PR TITLE
Retry upgrading bazel_ci_rules

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -467,7 +467,7 @@ use_repo(
 # Other Bazel testing dependencies
 # =========================================
 
-bazel_dep(name = "bazel_ci_rules", version = "2.0.0")
+bazel_dep(name = "bazel_ci_rules", version = "2.1.0")
 bazel_dep(name = "rules_fuzzing", version = "0.6.0")
 bazel_dep(name = "wabt", version = "1.0.37")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -32,8 +32,8 @@
     "https://bcr.bazel.build/modules/apple_support/2.3.0/MODULE.bazel": "d48f824ae8eeea5f837eb3038cef3615075d996d3e82eb9187192c2820605a81",
     "https://bcr.bazel.build/modules/apple_support/2.5.2/MODULE.bazel": "bb1b7081e390a8d3885f642cb0073dfcf8e7a36525e079fa8f5835af7079c0fe",
     "https://bcr.bazel.build/modules/apple_support/2.5.2/source.json": "dd51ee925a550e92b55eb41c4c809a967da311a2d2520241252a238a48b39c4c",
-    "https://bcr.bazel.build/modules/bazel_ci_rules/2.0.0/MODULE.bazel": "96dc6d2eac255b530a645cbf9102064ea997cae7b22acbe34fcc976f3dd53cbf",
-    "https://bcr.bazel.build/modules/bazel_ci_rules/2.0.0/source.json": "b6948e739190180af80dd91ceb9e3fb2b0c0160ecbf81177de2130475b54b516",
+    "https://bcr.bazel.build/modules/bazel_ci_rules/2.1.0/MODULE.bazel": "16d9e7837764f4beb1ceedc90d293e0a6160e85982432bca70ec5386f406aa33",
+    "https://bcr.bazel.build/modules/bazel_ci_rules/2.1.0/source.json": "9c5211b2a580ee50d421afd4243efb3ecb1da8504c96f4b2a94fb2919dddffd0",
     "https://bcr.bazel.build/modules/bazel_features/1.0.0/MODULE.bazel": "d7f022dc887efb96e1ee51cec7b2e48d41e36ff59a6e4f216c40e4029e1585bf",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
@@ -488,7 +488,7 @@
     },
     "@@bazel_ci_rules+//:rbe_config.bzl%rbe_config_extension": {
       "general": {
-        "bzlTransitiveDigest": "9+l/EBrynYwo8/gokt6U/+ZoE2tIACzH5rOoPfI01wE=",
+        "bzlTransitiveDigest": "htl6UC0UDRDiPZb/ZY16HZk5k1FvZxBHkRLK6J8T/cE=",
         "usagesDigest": "HujAq5EGA+Tlz7DHoDf3wQuuXcobfsrLb9WdkQry/+A=",
         "recordedInputs": [],
         "generatedRepoSpecs": {


### PR DESCRIPTION
This reverts commit 909985a3b9a1f71106e7cba31eb862078e5bdebe (CL 958603112).

We can try upgrading this module again, since we've deployed the correct multi-platform Docker images.