### PR TITLE
site: Convert inline CSS style attributes to JSX for MDX compatibility

### DIFF
--- a/docs/configure/attributes.mdx
+++ b/docs/configure/attributes.mdx
@@ -44,7 +44,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/contribute/search.mdx
+++ b/docs/contribute/search.mdx
@@ -210,64 +210,64 @@ You can refine your search using the following filters.
 <table border="1px">
 <thead>
 <tr>
-<th style="padding:5px"><strong>Filter</strong></th>
-<th style="padding:5px"><strong>Other options</strong></th>
-<th style="padding:5px"><strong>Description</strong></th>
-<th style="padding:5px"><strong>Example</strong></th>
+<th style={{padding: "5px"}}><strong>Filter</strong></th>
+<th style={{padding: "5px"}}><strong>Other options</strong></th>
+<th style={{padding: "5px"}}><strong>Description</strong></th>
+<th style={{padding: "5px"}}><strong>Example</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="padding:5px">lang:</td>
-<td style="padding:5px">language:</td>
-<td style="padding:5px">Perform an exact match by file language.</td>
-<td style="padding:5px">lang:java test</td>
+<td style={{padding: "5px"}}>lang:</td>
+<td style={{padding: "5px"}}>language:</td>
+<td style={{padding: "5px"}}>Perform an exact match by file language.</td>
+<td style={{padding: "5px"}}>lang:java test</td>
 </tr>
 <tr>
-<td style="padding:5px">file:</td>
-<td style="padding:5px">
+<td style={{padding: "5px"}}>file:</td>
+<td style={{padding: "5px"}}>
 filepath:<br/>
 path:<br/>
 f:
 </td>
-<td style="padding:5px"></td>
-<td style="padding:5px"></td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}></td>
 </tr>
 <tr>
-<td style="padding:5px">case:yes</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Make the search case sensitive. By default, searches are not case-sensitive.</td>
-<td style="padding:5px">case:yes Hello World</td>
+<td style={{padding: "5px"}}>case:yes</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Make the search case sensitive. By default, searches are not case-sensitive.</td>
+<td style={{padding: "5px"}}>case:yes Hello World</td>
 </tr>
 <tr>
-<td style="padding:5px">class:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Search for a class name.</td>
-<td style="padding:5px">class:MainClass</td>
+<td style={{padding: "5px"}}>class:</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Search for a class name.</td>
+<td style={{padding: "5px"}}>class:MainClass</td>
 </tr>
 <tr>
-<td style="padding:5px">function:</td>
-<td style="padding:5px">func:</td>
-<td style="padding:5px">Search for a function name.</td>
-<td style="padding:5px">function:print</td>
+<td style={{padding: "5px"}}>function:</td>
+<td style={{padding: "5px"}}>func:</td>
+<td style={{padding: "5px"}}>Search for a function name.</td>
+<td style={{padding: "5px"}}>function:print</td>
 </tr>
 <tr>
-<td style="padding:5px">-</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Negates the term from the search.</td>
-<td style="padding:5px">hello -world</td>
+<td style={{padding: "5px"}}>-</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Negates the term from the search.</td>
+<td style={{padding: "5px"}}>hello -world</td>
 </tr>
 <tr>
-<td style="padding:5px">\ </td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Escapes special characters, such as ., \, or (.</td>
-<td style="padding:5px">run\(\)</td>
+<td style={{padding: "5px"}}>\ </td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Escapes special characters, such as ., \, or (.</td>
+<td style={{padding: "5px"}}>run\(\)</td>
 </tr>
 <tr>
-<td style="padding:5px">"[term]"</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Perform a literal search.</td>
-<td style="padding:5px">"class:main"</td>
+<td style={{padding: "5px"}}>"[term]"</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Perform a literal search.</td>
+<td style={{padding: "5px"}}>"class:main"</td>
 </tr>
 </tbody>
 </table>

--- a/docs/docs/configurable-attributes.mdx
+++ b/docs/docs/configurable-attributes.mdx
@@ -44,7 +44,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/external/migration_tool.mdx
+++ b/docs/external/migration_tool.mdx
@@ -70,7 +70,7 @@ Before you begin:
 Once the prerequisites are met, run the following commands to use the migration
 tool:
 
-<pre class="prettyprint lang-shell" style="font-size: 12px;">
+<pre class="prettyprint lang-shell" style={{fontSize: "12px"}}>
 # Clone the Bazel Central Registry repository
 git clone https://github.com/bazelbuild/bazel-central-registry.git
 cd bazel-central-registry
@@ -127,7 +127,7 @@ To see the migration script in action, consider the following scenario when
 Python, Maven and Go dependencies are declared in `WORKSPACE` file.
 
 <details>
-  <summary style="padding: 16px">
+  <summary style={{padding: "16px"}}>
 Click here to see `WORKSPACE` file
   </summary>
 
@@ -267,7 +267,7 @@ Moreover, to demonstrate usage of module extension, custom macro is invoked from
 `WORKSPACE` and it is defined in `my_custom_macro.bzl`.
 
 <details>
-  <summary style="padding: 16px">
+  <summary style={{padding: "16px"}}>
 Click here to see `my_custom_macro.bzl` file
   </summary>
 
@@ -304,27 +304,27 @@ The first step is to follow [How to Use the Migration Tool](#migration-tool-how-
 
 Then, running `migrate2bzlmod -t=//...` outputs:
 
-<pre style="font-size: 12px;">
+<pre style={{fontSize: "12px"}}>
   bazel 7.6.1
 
   Generating ./resolved_deps.py file - It might take a while...
 
-  <span style="color:green;">RESOLVED:</span> <code>rules_java</code> has been introduced as a Bazel module.
-  <span style="color:green;">RESOLVED:</span> <code>bazel_gazelle</code> has been introduced as a Bazel module.
-  <span style="color:green;">RESOLVED:</span> <code>io_bazel_rules_go</code> has been introduced as a Bazel module.
-  <span style="color:green;">RESOLVED:</span> <code>rules_python</code> has been introduced as a Bazel module.
-  <span style="color:orange;">IMPORTANT:</span> 3.11 is used as a default python version. If you need a different version, please change it manually and then rerun the migration tool.
-  <span style="color:green;">RESOLVED:</span> <code>my_python_deps</code> has been introduced as python extension.
-  <span style="color:green;">RESOLVED:</span> <code>org_golang_x_net</code> has been introduced as go extension.
-  <span style="color:green;">RESOLVED:</span> <code>rules_jvm_external</code> has been introduced as a Bazel module.
-  <span style="color:green;">RESOLVED:</span> <code>org.antlr</code> has been introduced as maven extension.
-  <span style="color:green;">RESOLVED:</span> <code>rules_shell</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>rules_java</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>bazel_gazelle</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>io_bazel_rules_go</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>rules_python</code> has been introduced as a Bazel module.
+  <span style={{color: "orange"}}>IMPORTANT:</span> 3.11 is used as a default python version. If you need a different version, please change it manually and then rerun the migration tool.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>my_python_deps</code> has been introduced as python extension.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>org_golang_x_net</code> has been introduced as go extension.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>rules_jvm_external</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>org.antlr</code> has been introduced as maven extension.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>rules_shell</code> has been introduced as a Bazel module.
 
   Congratulations! All external repositories needed for building //... are available with Bzlmod!
-  <span style="color:orange;">IMPORTANT:</span> Fix potential build time issues by running the following command:
-      <span style="font-weight: 700;">bazel build --enable_bzlmod --noenable_workspace //...</span>
+  <span style={{color: "orange"}}>IMPORTANT:</span> Fix potential build time issues by running the following command:
+      <span style={{fontWeight: "700"}}>bazel build --enable_bzlmod --noenable_workspace //...</span>
 
-  <span style="color:orange;">IMPORTANT:</span> <code>For details about the migration process, check `migration_info.md` file.</code>
+  <span style={{color: "orange"}}>IMPORTANT:</span> <code>For details about the migration process, check `migration_info.md` file.</code>
 </pre>
 
 which gives the following important information:
@@ -346,10 +346,10 @@ which gives the following important information:
 This section illustrates the migration of code from the `WORKSPACE` file to
 `MODULE.bazel`.
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Bazel Module</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 http_archive(
     name = "rules_shell",
     sha256 = "3e114424a5c7e4fd43e0133cc6ecdfe54e45ae8affa14fadd839f29901424043",
@@ -358,20 +358,20 @@ http_archive(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Bazel Module</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 bazel_dep(name = "rules_shell", version = "0.6.1")
 </pre>
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;"/>
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}}/>
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Go Extension</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 http_archive(
     name = "io_bazel_rules_go",
     integrity = "sha256-M6zErg9wUC20uJPJ/B3Xqb+ZjCPn/yxFF3QdQEmpdvg=",
@@ -406,9 +406,9 @@ go_repository(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Go Extension</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 
@@ -427,12 +427,12 @@ go_deps.gazelle_override(
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;"/>
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}}/>
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Python Extension</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 http_archive(
     name = "rules_python",
     integrity = "sha256-qDdnnxOC8mlowe5vg5x9r5B5qlMSgGmh8oFd7KpjcwQ=",
@@ -459,9 +459,9 @@ python_register_toolchains(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Python Extension</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "my_python_deps",
@@ -477,12 +477,12 @@ python.toolchain(python_version = "3.11")
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;"/>
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}}/>
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Maven Extension</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 
 RULES_JVM_EXTERNAL_TAG = "4.5"
 RULES_JVM_EXTERNAL_SHA = "b17d7388feb9bfa7f2fa09031b32707df529f26c91ab9e5d909eb1676badd9a6"
@@ -511,9 +511,9 @@ maven_install(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Maven Extension</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 bazel_dep(name = "rules_jvm_external", version = "6.8")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
@@ -529,12 +529,12 @@ maven.artifact(
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;"/>
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}}/>
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Repo rule</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
@@ -545,9 +545,9 @@ http_archive(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Repo rule</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
@@ -560,12 +560,12 @@ http_archive(
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;"/>
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}}/>
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Module extension</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 load(":my_custom_macro.bzl", "my_custom_macro")
 
 my_custom_macro(
@@ -573,14 +573,14 @@ my_custom_macro(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Module extension</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 extension_for_my_custom_macro = use_extension("//:extension_for_my_custom_macro.bzl", "extension_for_my_custom_macro")
 use_repo(extension_for_my_custom_macro, "my_custom_repo")
 </pre>
     <p><strong>extension_for_my_custom_macro.bzl</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 load("//:my_custom_macro.bzl", "my_custom_macro")
 
 def _extension_for_my_custom_macro_impl(ctx):
@@ -593,7 +593,7 @@ extension_for_my_custom_macro = module_extension(implementation = _extension_for
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;"/>
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}}/>
 
 ## Tips with debugging {#migration-tool-tips}
 
@@ -641,7 +641,7 @@ from scratch if it's the first run or if the [`--i` flag](#migration-script-flag
     declared in the `WORKSPACE` file, which is particularly useful for the
     debugging. You can see it as:
 
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
     > Click here to see where and how the repo was declared in the WORKSPACE
     file
     </pre>
@@ -650,7 +650,7 @@ from scratch if it's the first run or if the [`--i` flag](#migration-script-flag
     earlier [Migration Example](#migration-tool-example), that would look as:
     1.  Bazel module Dependency - `Migration of rules_python`
 
-        <pre class="prettyprint lang-java" style="font-size: 12px;">
+        <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
         Found perfect name match in BCR: rules_python
         Found partially name matches in BCR: rules_python_gazelle_plugin
 
@@ -663,7 +663,7 @@ from scratch if it's the first run or if the [`--i` flag](#migration-script-flag
       added.
     2.  Python extension - `Migration of my_python_deps`
 
-        <pre class="prettyprint lang-java" style="font-size: 12px;">
+        <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
         pip.parse(
             hub_name = "my_python_deps",
             requirements_lock = "//:requirements_lock.txt",
@@ -674,7 +674,7 @@ from scratch if it's the first run or if the [`--i` flag](#migration-script-flag
 
     3.  Maven extension - `Migration of org.antlr (px_deps):`
 
-        <pre class="prettyprint lang-java" style="font-size: 12px;">
+        <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
         maven.artifact(
             name = "px_deps",
             group = "org.antlr",
@@ -685,7 +685,7 @@ from scratch if it's the first run or if the [`--i` flag](#migration-script-flag
 
     4.  Go extension - `Migration of org_golang_x_net`
 
-        <pre class="prettyprint lang-java" style="font-size: 12px;">
+        <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
         go_deps.from_file(go_mod = "//:go.mod")
         go_sdk.from_file(go_mod = "//:go.mod")
 

--- a/docs/external/mod-command.mdx
+++ b/docs/external/mod-command.mdx
@@ -207,11 +207,11 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
 ```
 
 <table>
-  <tr style="display: flex; flex-direction: row">
-    <td style="flex: 5; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style="object-fit: cover; max-width: 100%;" />
-        <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph Before Resolution</figcaption>
+  <tr style={{display: "flex", flexDirection: "row"}}>
+    <td style={{flex: "5", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+        <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph Before Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]
@@ -238,10 +238,10 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
   "rules_java@4.0.0" -> "bazel_skylib@1.0.3" [  ]
 } */}
     </td>
-    <td style="flex: 3; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style="object-fit: cover; max-width: 100%;" />
-       <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph After Resolution</figcaption>
+    <td style={{flex: "3", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+       <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph After Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]

--- a/docs/release/rolling.mdx
+++ b/docs/release/rolling.mdx
@@ -11,4 +11,4 @@ these releases.
 
 ## Index {#index}
 
-<iframe src="https://releases.bazel.build/rolling.html" style="height: 3000px; width: 100%" ></iframe>
+<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%", border: "none"}} ></iframe>

--- a/docs/versions/7.6.1/configure/attributes.mdx
+++ b/docs/versions/7.6.1/configure/attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/7.6.1/contribute/search.mdx
+++ b/docs/versions/7.6.1/contribute/search.mdx
@@ -210,62 +210,62 @@ You can refine your search using the following filters.
 <table border="1px">
 <thead>
 <tr>
-<th style="padding:5px"><strong>Filter</strong></th>
-<th style="padding:5px"><strong>Other options</strong></th>
-<th style="padding:5px"><strong>Description</strong></th>
-<th style="padding:5px"><strong>Example</strong></th>
+<th style={{padding: "5px"}}><strong>Filter</strong></th>
+<th style={{padding: "5px"}}><strong>Other options</strong></th>
+<th style={{padding: "5px"}}><strong>Description</strong></th>
+<th style={{padding: "5px"}}><strong>Example</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="padding:5px">lang:</td>
-<td style="padding:5px">language:</td>
-<td style="padding:5px">Perform an exact match by file language.</td>
-<td style="padding:5px">lang:java test</td>
+<td style={{padding: "5px"}}>lang:</td>
+<td style={{padding: "5px"}}>language:</td>
+<td style={{padding: "5px"}}>Perform an exact match by file language.</td>
+<td style={{padding: "5px"}}>lang:java test</td>
 </tr>
 <tr>
-<td style="padding:5px">file:</td>
-<td style="padding:5px">filepath:<br/>
+<td style={{padding: "5px"}}>file:</td>
+<td style={{padding: "5px"}}>filepath:<br/>
 path:<br/>
 f:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px"></td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}></td>
 </tr>
 <tr>
-<td style="padding:5px">case:yes</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Make the search case sensitive. By default, searches are not case-sensitive.</td>
-<td style="padding:5px">case:yes Hello World</td>
+<td style={{padding: "5px"}}>case:yes</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Make the search case sensitive. By default, searches are not case-sensitive.</td>
+<td style={{padding: "5px"}}>case:yes Hello World</td>
 </tr>
 <tr>
-<td style="padding:5px">class:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Search for a class name.</td>
-<td style="padding:5px">class:MainClass</td>
+<td style={{padding: "5px"}}>class:</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Search for a class name.</td>
+<td style={{padding: "5px"}}>class:MainClass</td>
 </tr>
 <tr>
-<td style="padding:5px">function:</td>
-<td style="padding:5px">func:</td>
-<td style="padding:5px">Search for a function name.</td>
-<td style="padding:5px">function:print</td>
+<td style={{padding: "5px"}}>function:</td>
+<td style={{padding: "5px"}}>func:</td>
+<td style={{padding: "5px"}}>Search for a function name.</td>
+<td style={{padding: "5px"}}>function:print</td>
 </tr>
 <tr>
-<td style="padding:5px">-</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Negates the term from the search.</td>
-<td style="padding:5px">hello -world</td>
+<td style={{padding: "5px"}}>-</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Negates the term from the search.</td>
+<td style={{padding: "5px"}}>hello -world</td>
 </tr>
 <tr>
-<td style="padding:5px">\\</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Escapes special characters, such as ., \, or (.</td>
-<td style="padding:5px">run\(\)</td>
+<td style={{padding: "5px"}}>\\</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Escapes special characters, such as ., \, or (.</td>
+<td style={{padding: "5px"}}>run\(\)</td>
 </tr>
 <tr>
-<td style="padding:5px">"[term]"</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Perform a literal search.</td>
-<td style="padding:5px">"class:main"</td>
+<td style={{padding: "5px"}}>"[term]"</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Perform a literal search.</td>
+<td style={{padding: "5px"}}>"class:main"</td>
 </tr>
 </tbody>
 </table>

--- a/docs/versions/7.6.1/docs/configurable-attributes.mdx
+++ b/docs/versions/7.6.1/docs/configurable-attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/7.6.1/external/mod-command.mdx
+++ b/docs/versions/7.6.1/external/mod-command.mdx
@@ -186,11 +186,11 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
 ```
 
 <table>
-  <tr style="display: flex; flex-direction: row">
-    <td style="flex: 5; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style="object-fit: cover; max-width: 100%;" />
-        <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph Before Resolution</figcaption>
+  <tr style={{display: "flex", flexDirection: "row"}}>
+    <td style={{flex: "5", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+        <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph Before Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]
@@ -217,10 +217,10 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
   "rules_java@4.0.0" -> "bazel_skylib@1.0.3" [  ]
 } */}
     </td>
-    <td style="flex: 3; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style="object-fit: cover; max-width: 100%;" />
-       <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph After Resolution</figcaption>
+    <td style={{flex: "3", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+       <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph After Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]

--- a/docs/versions/7.7.1/configure/attributes.mdx
+++ b/docs/versions/7.7.1/configure/attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/7.7.1/contribute/search.mdx
+++ b/docs/versions/7.7.1/contribute/search.mdx
@@ -210,62 +210,62 @@ You can refine your search using the following filters.
 <table border="1px">
 <thead>
 <tr>
-<th style="padding:5px"><strong>Filter</strong></th>
-<th style="padding:5px"><strong>Other options</strong></th>
-<th style="padding:5px"><strong>Description</strong></th>
-<th style="padding:5px"><strong>Example</strong></th>
+<th style={{padding: "5px"}}><strong>Filter</strong></th>
+<th style={{padding: "5px"}}><strong>Other options</strong></th>
+<th style={{padding: "5px"}}><strong>Description</strong></th>
+<th style={{padding: "5px"}}><strong>Example</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="padding:5px">lang:</td>
-<td style="padding:5px">language:</td>
-<td style="padding:5px">Perform an exact match by file language.</td>
-<td style="padding:5px">lang:java test</td>
+<td style={{padding: "5px"}}>lang:</td>
+<td style={{padding: "5px"}}>language:</td>
+<td style={{padding: "5px"}}>Perform an exact match by file language.</td>
+<td style={{padding: "5px"}}>lang:java test</td>
 </tr>
 <tr>
-<td style="padding:5px">file:</td>
-<td style="padding:5px">filepath:<br/>
+<td style={{padding: "5px"}}>file:</td>
+<td style={{padding: "5px"}}>filepath:<br/>
 path:<br/>
 f:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px"></td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}></td>
 </tr>
 <tr>
-<td style="padding:5px">case:yes</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Make the search case sensitive. By default, searches are not case-sensitive.</td>
-<td style="padding:5px">case:yes Hello World</td>
+<td style={{padding: "5px"}}>case:yes</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Make the search case sensitive. By default, searches are not case-sensitive.</td>
+<td style={{padding: "5px"}}>case:yes Hello World</td>
 </tr>
 <tr>
-<td style="padding:5px">class:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Search for a class name.</td>
-<td style="padding:5px">class:MainClass</td>
+<td style={{padding: "5px"}}>class:</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Search for a class name.</td>
+<td style={{padding: "5px"}}>class:MainClass</td>
 </tr>
 <tr>
-<td style="padding:5px">function:</td>
-<td style="padding:5px">func:</td>
-<td style="padding:5px">Search for a function name.</td>
-<td style="padding:5px">function:print</td>
+<td style={{padding: "5px"}}>function:</td>
+<td style={{padding: "5px"}}>func:</td>
+<td style={{padding: "5px"}}>Search for a function name.</td>
+<td style={{padding: "5px"}}>function:print</td>
 </tr>
 <tr>
-<td style="padding:5px">-</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Negates the term from the search.</td>
-<td style="padding:5px">hello -world</td>
+<td style={{padding: "5px"}}>-</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Negates the term from the search.</td>
+<td style={{padding: "5px"}}>hello -world</td>
 </tr>
 <tr>
-<td style="padding:5px">\\</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Escapes special characters, such as ., \, or (.</td>
-<td style="padding:5px">run\(\)</td>
+<td style={{padding: "5px"}}>\\</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Escapes special characters, such as ., \, or (.</td>
+<td style={{padding: "5px"}}>run\(\)</td>
 </tr>
 <tr>
-<td style="padding:5px">"[term]"</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Perform a literal search.</td>
-<td style="padding:5px">"class:main"</td>
+<td style={{padding: "5px"}}>"[term]"</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Perform a literal search.</td>
+<td style={{padding: "5px"}}>"class:main"</td>
 </tr>
 </tbody>
 </table>

--- a/docs/versions/7.7.1/docs/configurable-attributes.mdx
+++ b/docs/versions/7.7.1/docs/configurable-attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/7.7.1/external/mod-command.mdx
+++ b/docs/versions/7.7.1/external/mod-command.mdx
@@ -187,11 +187,11 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
 ```
 
 <table>
-  <tr style="display: flex; flex-direction: row">
-    <td style="flex: 5; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style="object-fit: cover; max-width: 100%;" />
-        <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph Before Resolution</figcaption>
+  <tr style={{display: "flex", flexDirection: "row"}}>
+    <td style={{flex: "5", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+        <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph Before Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]
@@ -218,10 +218,10 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
   "rules_java@4.0.0" -> "bazel_skylib@1.0.3" [  ]
 } */}
     </td>
-    <td style="flex: 3; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style="object-fit: cover; max-width: 100%;" />
-       <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph After Resolution</figcaption>
+    <td style={{flex: "3", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+       <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph After Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]

--- a/docs/versions/8.0.1/configure/attributes.mdx
+++ b/docs/versions/8.0.1/configure/attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.0.1/contribute/search.mdx
+++ b/docs/versions/8.0.1/contribute/search.mdx
@@ -210,62 +210,62 @@ You can refine your search using the following filters.
 <table border="1px">
 <thead>
 <tr>
-<th style="padding:5px"><strong>Filter</strong></th>
-<th style="padding:5px"><strong>Other options</strong></th>
-<th style="padding:5px"><strong>Description</strong></th>
-<th style="padding:5px"><strong>Example</strong></th>
+<th style={{padding: "5px"}}><strong>Filter</strong></th>
+<th style={{padding: "5px"}}><strong>Other options</strong></th>
+<th style={{padding: "5px"}}><strong>Description</strong></th>
+<th style={{padding: "5px"}}><strong>Example</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="padding:5px">lang:</td>
-<td style="padding:5px">language:</td>
-<td style="padding:5px">Perform an exact match by file language.</td>
-<td style="padding:5px">lang:java test</td>
+<td style={{padding: "5px"}}>lang:</td>
+<td style={{padding: "5px"}}>language:</td>
+<td style={{padding: "5px"}}>Perform an exact match by file language.</td>
+<td style={{padding: "5px"}}>lang:java test</td>
 </tr>
 <tr>
-<td style="padding:5px">file:</td>
-<td style="padding:5px">filepath:<br/>
+<td style={{padding: "5px"}}>file:</td>
+<td style={{padding: "5px"}}>filepath:<br/>
 path:<br/>
 f:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px"></td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}></td>
 </tr>
 <tr>
-<td style="padding:5px">case:yes</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Make the search case sensitive. By default, searches are not case-sensitive.</td>
-<td style="padding:5px">case:yes Hello World</td>
+<td style={{padding: "5px"}}>case:yes</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Make the search case sensitive. By default, searches are not case-sensitive.</td>
+<td style={{padding: "5px"}}>case:yes Hello World</td>
 </tr>
 <tr>
-<td style="padding:5px">class:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Search for a class name.</td>
-<td style="padding:5px">class:MainClass</td>
+<td style={{padding: "5px"}}>class:</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Search for a class name.</td>
+<td style={{padding: "5px"}}>class:MainClass</td>
 </tr>
 <tr>
-<td style="padding:5px">function:</td>
-<td style="padding:5px">func:</td>
-<td style="padding:5px">Search for a function name.</td>
-<td style="padding:5px">function:print</td>
+<td style={{padding: "5px"}}>function:</td>
+<td style={{padding: "5px"}}>func:</td>
+<td style={{padding: "5px"}}>Search for a function name.</td>
+<td style={{padding: "5px"}}>function:print</td>
 </tr>
 <tr>
-<td style="padding:5px">-</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Negates the term from the search.</td>
-<td style="padding:5px">hello -world</td>
+<td style={{padding: "5px"}}>-</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Negates the term from the search.</td>
+<td style={{padding: "5px"}}>hello -world</td>
 </tr>
 <tr>
-<td style="padding:5px">&#92;</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Escapes special characters, such as ., \, or (.</td>
-<td style="padding:5px">run\(\)</td>
+<td style={{padding: "5px"}}>&#92;</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Escapes special characters, such as ., \, or (.</td>
+<td style={{padding: "5px"}}>run\(\)</td>
 </tr>
 <tr>
-<td style="padding:5px">"[term]"</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Perform a literal search.</td>
-<td style="padding:5px">"class:main"</td>
+<td style={{padding: "5px"}}>"[term]"</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Perform a literal search.</td>
+<td style={{padding: "5px"}}>"class:main"</td>
 </tr>
 </tbody>
 </table>

--- a/docs/versions/8.0.1/docs/configurable-attributes.mdx
+++ b/docs/versions/8.0.1/docs/configurable-attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.0.1/external/mod-command.mdx
+++ b/docs/versions/8.0.1/external/mod-command.mdx
@@ -186,11 +186,11 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
 ```
 
 <table>
-  <tr style="display: flex; flex-direction: row">
-    <td style="flex: 5; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style="object-fit: cover; max-width: 100%;" />
-        <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph Before Resolution</figcaption>
+  <tr style={{display: "flex", flexDirection: "row"}}>
+    <td style={{flex: "5", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+        <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph Before Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]
@@ -217,10 +217,10 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
   "rules_java@4.0.0" -> "bazel_skylib@1.0.3" [  ]
 } */}
     </td>
-    <td style="flex: 3; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style="object-fit: cover; max-width: 100%;" />
-       <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph After Resolution</figcaption>
+    <td style={{flex: "3", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+       <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph After Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]

--- a/docs/versions/8.0.1/release/rolling.mdx
+++ b/docs/versions/8.0.1/release/rolling.mdx
@@ -9,4 +9,4 @@ these releases.
 
 ## Index {#index}
 
-<iframe src="https://releases.bazel.build/rolling.html" style="height: 3000px; width: 100%" ></iframe>
+<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%", border: "none"}} ></iframe>

--- a/docs/versions/8.1.1/configure/attributes.mdx
+++ b/docs/versions/8.1.1/configure/attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.1.1/contribute/search.mdx
+++ b/docs/versions/8.1.1/contribute/search.mdx
@@ -210,62 +210,62 @@ You can refine your search using the following filters.
 <table border="1px">
 <thead>
 <tr>
-<th style="padding:5px"><strong>Filter</strong></th>
-<th style="padding:5px"><strong>Other options</strong></th>
-<th style="padding:5px"><strong>Description</strong></th>
-<th style="padding:5px"><strong>Example</strong></th>
+<th style={{padding: "5px"}}><strong>Filter</strong></th>
+<th style={{padding: "5px"}}><strong>Other options</strong></th>
+<th style={{padding: "5px"}}><strong>Description</strong></th>
+<th style={{padding: "5px"}}><strong>Example</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="padding:5px">lang:</td>
-<td style="padding:5px">language:</td>
-<td style="padding:5px">Perform an exact match by file language.</td>
-<td style="padding:5px">lang:java test</td>
+<td style={{padding: "5px"}}>lang:</td>
+<td style={{padding: "5px"}}>language:</td>
+<td style={{padding: "5px"}}>Perform an exact match by file language.</td>
+<td style={{padding: "5px"}}>lang:java test</td>
 </tr>
 <tr>
-<td style="padding:5px">file:</td>
-<td style="padding:5px">filepath:<br/>
+<td style={{padding: "5px"}}>file:</td>
+<td style={{padding: "5px"}}>filepath:<br/>
 path:<br/>
 f:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px"></td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}></td>
 </tr>
 <tr>
-<td style="padding:5px">case:yes</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Make the search case sensitive. By default, searches are not case-sensitive.</td>
-<td style="padding:5px">case:yes Hello World</td>
+<td style={{padding: "5px"}}>case:yes</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Make the search case sensitive. By default, searches are not case-sensitive.</td>
+<td style={{padding: "5px"}}>case:yes Hello World</td>
 </tr>
 <tr>
-<td style="padding:5px">class:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Search for a class name.</td>
-<td style="padding:5px">class:MainClass</td>
+<td style={{padding: "5px"}}>class:</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Search for a class name.</td>
+<td style={{padding: "5px"}}>class:MainClass</td>
 </tr>
 <tr>
-<td style="padding:5px">function:</td>
-<td style="padding:5px">func:</td>
-<td style="padding:5px">Search for a function name.</td>
-<td style="padding:5px">function:print</td>
+<td style={{padding: "5px"}}>function:</td>
+<td style={{padding: "5px"}}>func:</td>
+<td style={{padding: "5px"}}>Search for a function name.</td>
+<td style={{padding: "5px"}}>function:print</td>
 </tr>
 <tr>
-<td style="padding:5px">-</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Negates the term from the search.</td>
-<td style="padding:5px">hello -world</td>
+<td style={{padding: "5px"}}>-</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Negates the term from the search.</td>
+<td style={{padding: "5px"}}>hello -world</td>
 </tr>
 <tr>
-<td style="padding:5px">\\</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Escapes special characters, such as ., \, or (.</td>
-<td style="padding:5px">run\(\)</td>
+<td style={{padding: "5px"}}>\\</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Escapes special characters, such as ., \, or (.</td>
+<td style={{padding: "5px"}}>run\(\)</td>
 </tr>
 <tr>
-<td style="padding:5px">"[term]"</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Perform a literal search.</td>
-<td style="padding:5px">"class:main"</td>
+<td style={{padding: "5px"}}>"[term]"</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Perform a literal search.</td>
+<td style={{padding: "5px"}}>"class:main"</td>
 </tr>
 </tbody>
 </table>

--- a/docs/versions/8.1.1/docs/configurable-attributes.mdx
+++ b/docs/versions/8.1.1/docs/configurable-attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.1.1/external/mod-command.mdx
+++ b/docs/versions/8.1.1/external/mod-command.mdx
@@ -186,11 +186,11 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
 ```
 
 <table>
-  <tr style="display: flex; flex-direction: row">
-    <td style="flex: 5; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style="object-fit: cover; max-width: 100%;" />
-        <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph Before Resolution</figcaption>
+  <tr style={{display: "flex", flexDirection: "row"}}>
+    <td style={{flex: "5", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+        <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph Before Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]
@@ -217,10 +217,10 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
   "rules_java@4.0.0" -> "bazel_skylib@1.0.3" [  ]
 } */}
     </td>
-    <td style="flex: 3; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style="object-fit: cover; max-width: 100%;" />
-       <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph After Resolution</figcaption>
+    <td style={{flex: "3", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+       <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph After Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]

--- a/docs/versions/8.1.1/release/rolling.mdx
+++ b/docs/versions/8.1.1/release/rolling.mdx
@@ -9,4 +9,4 @@ these releases.
 
 ## Index {#index}
 
-<iframe src="https://releases.bazel.build/rolling.html" style="height: 3000px; width: 100%" ></iframe>
+<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%", border: "none"}} ></iframe>

--- a/docs/versions/8.2.1/configure/attributes.mdx
+++ b/docs/versions/8.2.1/configure/attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.2.1/contribute/search.mdx
+++ b/docs/versions/8.2.1/contribute/search.mdx
@@ -210,62 +210,62 @@ You can refine your search using the following filters.
 <table border="1px">
 <thead>
 <tr>
-<th style="padding:5px"><strong>Filter</strong></th>
-<th style="padding:5px"><strong>Other options</strong></th>
-<th style="padding:5px"><strong>Description</strong></th>
-<th style="padding:5px"><strong>Example</strong></th>
+<th style={{padding: "5px"}}><strong>Filter</strong></th>
+<th style={{padding: "5px"}}><strong>Other options</strong></th>
+<th style={{padding: "5px"}}><strong>Description</strong></th>
+<th style={{padding: "5px"}}><strong>Example</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-  <td style="padding:5px">lang:</td>
-  <td style="padding:5px">language:</td>
-  <td style="padding:5px">Perform an exact match by file language.</td>
-  <td style="padding:5px">lang:java test</td>
+  <td style={{padding: "5px"}}>lang:</td>
+  <td style={{padding: "5px"}}>language:</td>
+  <td style={{padding: "5px"}}>Perform an exact match by file language.</td>
+  <td style={{padding: "5px"}}>lang:java test</td>
 </tr>
 <tr>
-  <td style="padding:5px">file:</td>
-<td style="padding:5px">filepath:<br/>
+  <td style={{padding: "5px"}}>file:</td>
+<td style={{padding: "5px"}}>filepath:<br/>
 path:<br/>
   f:</td>
-  <td style="padding:5px"></td>
-  <td style="padding:5px"></td>
+  <td style={{padding: "5px"}}></td>
+  <td style={{padding: "5px"}}></td>
 </tr>
 <tr>
-  <td style="padding:5px">case:yes</td>
-  <td style="padding:5px"></td>
-  <td style="padding:5px">Make the search case sensitive. By default, searches are not case-sensitive.</td>
-  <td style="padding:5px">case:yes Hello World</td>
+  <td style={{padding: "5px"}}>case:yes</td>
+  <td style={{padding: "5px"}}></td>
+  <td style={{padding: "5px"}}>Make the search case sensitive. By default, searches are not case-sensitive.</td>
+  <td style={{padding: "5px"}}>case:yes Hello World</td>
 </tr>
 <tr>
-  <td style="padding:5px">class:</td>
-  <td style="padding:5px"></td>
-  <td style="padding:5px">Search for a class name.</td>
-  <td style="padding:5px">class:MainClass</td>
+  <td style={{padding: "5px"}}>class:</td>
+  <td style={{padding: "5px"}}></td>
+  <td style={{padding: "5px"}}>Search for a class name.</td>
+  <td style={{padding: "5px"}}>class:MainClass</td>
 </tr>
 <tr>
-  <td style="padding:5px">function:</td>
-  <td style="padding:5px">func:</td>
-  <td style="padding:5px">Search for a function name.</td>
-  <td style="padding:5px">function:print</td>
+  <td style={{padding: "5px"}}>function:</td>
+  <td style={{padding: "5px"}}>func:</td>
+  <td style={{padding: "5px"}}>Search for a function name.</td>
+  <td style={{padding: "5px"}}>function:print</td>
 </tr>
 <tr>
-  <td style="padding:5px">-</td>
-  <td style="padding:5px"></td>
-  <td style="padding:5px">Negates the term from the search.</td>
-  <td style="padding:5px">hello -world</td>
+  <td style={{padding: "5px"}}>-</td>
+  <td style={{padding: "5px"}}></td>
+  <td style={{padding: "5px"}}>Negates the term from the search.</td>
+  <td style={{padding: "5px"}}>hello -world</td>
 </tr>
 <tr>
-  <td style="padding:5px">`\`</td>
-  <td style="padding:5px"></td>
-  <td style="padding:5px">Escapes special characters, such as ., \, or (.</td>
-  <td style="padding:5px">run\(\)</td>
+  <td style={{padding: "5px"}}>`\`</td>
+  <td style={{padding: "5px"}}></td>
+  <td style={{padding: "5px"}}>Escapes special characters, such as ., \, or (.</td>
+  <td style={{padding: "5px"}}>run\(\)</td>
 </tr>
 <tr>
-  <td style="padding:5px">"[term]"</td>
-  <td style="padding:5px"></td>
-  <td style="padding:5px">Perform a literal search.</td>
-  <td style="padding:5px">"class:main"</td>
+  <td style={{padding: "5px"}}>"[term]"</td>
+  <td style={{padding: "5px"}}></td>
+  <td style={{padding: "5px"}}>Perform a literal search.</td>
+  <td style={{padding: "5px"}}>"class:main"</td>
 </tr>
 </tbody>
 </table>

--- a/docs/versions/8.2.1/docs/configurable-attributes.mdx
+++ b/docs/versions/8.2.1/docs/configurable-attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.2.1/external/mod-command.mdx
+++ b/docs/versions/8.2.1/external/mod-command.mdx
@@ -186,11 +186,11 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
 ```
 
 <table>
-  <tr style="display: flex; flex-direction: row">
-    <td style="flex: 5; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style="object-fit: cover; max-width: 100%;" />
-        <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph Before Resolution</figcaption>
+  <tr style={{display: "flex", flexDirection: "row"}}>
+    <td style={{flex: "5", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+        <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph Before Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]
@@ -217,10 +217,10 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
   "rules_java@4.0.0" -> "bazel_skylib@1.0.3" [  ]
 } */}
     </td>
-    <td style="flex: 3; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style="object-fit: cover; max-width: 100%;" />
-       <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph After Resolution</figcaption>
+    <td style={{flex: "3", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+       <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph After Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]

--- a/docs/versions/8.2.1/release/rolling.mdx
+++ b/docs/versions/8.2.1/release/rolling.mdx
@@ -9,4 +9,4 @@ these releases.
 
 ## Index {#index}
 
-<iframe src="https://releases.bazel.build/rolling.html" style="height: 3000px; width: 100%" ></iframe>
+<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%", border: "none"}} ></iframe>

--- a/docs/versions/8.3.1/configure/attributes.mdx
+++ b/docs/versions/8.3.1/configure/attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.3.1/contribute/search.mdx
+++ b/docs/versions/8.3.1/contribute/search.mdx
@@ -210,62 +210,62 @@ You can refine your search using the following filters.
 <table border="1px">
 <thead>
 <tr>
-<th style="padding:5px"><strong>Filter</strong></th>
-<th style="padding:5px"><strong>Other options</strong></th>
-<th style="padding:5px"><strong>Description</strong></th>
-<th style="padding:5px"><strong>Example</strong></th>
+<th style={{padding: "5px"}}><strong>Filter</strong></th>
+<th style={{padding: "5px"}}><strong>Other options</strong></th>
+<th style={{padding: "5px"}}><strong>Description</strong></th>
+<th style={{padding: "5px"}}><strong>Example</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="padding:5px">lang:</td>
-<td style="padding:5px">language:</td>
-<td style="padding:5px">Perform an exact match by file language.</td>
-<td style="padding:5px">lang:java test</td>
+<td style={{padding: "5px"}}>lang:</td>
+<td style={{padding: "5px"}}>language:</td>
+<td style={{padding: "5px"}}>Perform an exact match by file language.</td>
+<td style={{padding: "5px"}}>lang:java test</td>
 </tr>
 <tr>
-<td style="padding:5px">file:</td>
-<td style="padding:5px">filepath:<br/>
+<td style={{padding: "5px"}}>file:</td>
+<td style={{padding: "5px"}}>filepath:<br/>
 path:<br/>
 f:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px"></td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}></td>
 </tr>
 <tr>
-<td style="padding:5px">case:yes</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Make the search case sensitive. By default, searches are not case-sensitive.</td>
-<td style="padding:5px">case:yes Hello World</td>
+<td style={{padding: "5px"}}>case:yes</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Make the search case sensitive. By default, searches are not case-sensitive.</td>
+<td style={{padding: "5px"}}>case:yes Hello World</td>
 </tr>
 <tr>
-<td style="padding:5px">class:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Search for a class name.</td>
-<td style="padding:5px">class:MainClass</td>
+<td style={{padding: "5px"}}>class:</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Search for a class name.</td>
+<td style={{padding: "5px"}}>class:MainClass</td>
 </tr>
 <tr>
-<td style="padding:5px">function:</td>
-<td style="padding:5px">func:</td>
-<td style="padding:5px">Search for a function name.</td>
-<td style="padding:5px">function:print</td>
+<td style={{padding: "5px"}}>function:</td>
+<td style={{padding: "5px"}}>func:</td>
+<td style={{padding: "5px"}}>Search for a function name.</td>
+<td style={{padding: "5px"}}>function:print</td>
 </tr>
 <tr>
-<td style="padding:5px">-</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Negates the term from the search.</td>
-<td style="padding:5px">hello -world</td>
+<td style={{padding: "5px"}}>-</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Negates the term from the search.</td>
+<td style={{padding: "5px"}}>hello -world</td>
 </tr>
 <tr>
-<td style="padding:5px">\\</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Escapes special characters, such as ., \, or (.</td>
-<td style="padding:5px">run\(\)</td>
+<td style={{padding: "5px"}}>\\</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Escapes special characters, such as ., \, or (.</td>
+<td style={{padding: "5px"}}>run\(\)</td>
 </tr>
 <tr>
-<td style="padding:5px">"[term]"</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Perform a literal search.</td>
-<td style="padding:5px">"class:main"</td>
+<td style={{padding: "5px"}}>"[term]"</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Perform a literal search.</td>
+<td style={{padding: "5px"}}>"class:main"</td>
 </tr>
 </tbody>
 </table>

--- a/docs/versions/8.3.1/docs/configurable-attributes.mdx
+++ b/docs/versions/8.3.1/docs/configurable-attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.3.1/external/mod-command.mdx
+++ b/docs/versions/8.3.1/external/mod-command.mdx
@@ -186,11 +186,11 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
 ```
 
 <table>
-  <tr style="display: flex; flex-direction: row">
-    <td style="flex: 5; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style="object-fit: cover; max-width: 100%;" />
-        <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph Before Resolution</figcaption>
+  <tr style={{display: "flex", flexDirection: "row"}}>
+    <td style={{flex: "5", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+        <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph Before Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]
@@ -217,10 +217,10 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
   "rules_java@4.0.0" -> "bazel_skylib@1.0.3" [  ]
 } */}
     </td>
-    <td style="flex: 3; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style="object-fit: cover; max-width: 100%;" />
-       <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph After Resolution</figcaption>
+    <td style={{flex: "3", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+       <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph After Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]

--- a/docs/versions/8.3.1/release/rolling.mdx
+++ b/docs/versions/8.3.1/release/rolling.mdx
@@ -9,4 +9,4 @@ these releases.
 
 ## Index {#index}
 
-<iframe src="https://releases.bazel.build/rolling.html" style="height: 3000px; width: 100%" ></iframe>
+<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%", border: "none"}} ></iframe>

--- a/docs/versions/8.4.2/configure/attributes.mdx
+++ b/docs/versions/8.4.2/configure/attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.4.2/contribute/search.mdx
+++ b/docs/versions/8.4.2/contribute/search.mdx
@@ -210,62 +210,62 @@ You can refine your search using the following filters.
 <table border="1px">
 <thead>
 <tr>
-<th style="padding:5px"><strong>Filter</strong></th>
-<th style="padding:5px"><strong>Other options</strong></th>
-<th style="padding:5px"><strong>Description</strong></th>
-<th style="padding:5px"><strong>Example</strong></th>
+<th style={{padding: "5px"}}><strong>Filter</strong></th>
+<th style={{padding: "5px"}}><strong>Other options</strong></th>
+<th style={{padding: "5px"}}><strong>Description</strong></th>
+<th style={{padding: "5px"}}><strong>Example</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="padding:5px">lang:</td>
-<td style="padding:5px">language:</td>
-<td style="padding:5px">Perform an exact match by file language.</td>
-<td style="padding:5px">lang:java test</td>
+<td style={{padding: "5px"}}>lang:</td>
+<td style={{padding: "5px"}}>language:</td>
+<td style={{padding: "5px"}}>Perform an exact match by file language.</td>
+<td style={{padding: "5px"}}>lang:java test</td>
 </tr>
 <tr>
-<td style="padding:5px">file:</td>
-<td style="padding:5px">filepath:<br/>
+<td style={{padding: "5px"}}>file:</td>
+<td style={{padding: "5px"}}>filepath:<br/>
 path:<br/>
 f:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px"></td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}></td>
 </tr>
 <tr>
-<td style="padding:5px">case:yes</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Make the search case sensitive. By default, searches are not case-sensitive.</td>
-<td style="padding:5px">case:yes Hello World</td>
+<td style={{padding: "5px"}}>case:yes</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Make the search case sensitive. By default, searches are not case-sensitive.</td>
+<td style={{padding: "5px"}}>case:yes Hello World</td>
 </tr>
 <tr>
-<td style="padding:5px">class:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Search for a class name.</td>
-<td style="padding:5px">class:MainClass</td>
+<td style={{padding: "5px"}}>class:</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Search for a class name.</td>
+<td style={{padding: "5px"}}>class:MainClass</td>
 </tr>
 <tr>
-<td style="padding:5px">function:</td>
-<td style="padding:5px">func:</td>
-<td style="padding:5px">Search for a function name.</td>
-<td style="padding:5px">function:print</td>
+<td style={{padding: "5px"}}>function:</td>
+<td style={{padding: "5px"}}>func:</td>
+<td style={{padding: "5px"}}>Search for a function name.</td>
+<td style={{padding: "5px"}}>function:print</td>
 </tr>
 <tr>
-<td style="padding:5px">-</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Negates the term from the search.</td>
-<td style="padding:5px">hello -world</td>
+<td style={{padding: "5px"}}>-</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Negates the term from the search.</td>
+<td style={{padding: "5px"}}>hello -world</td>
 </tr>
 <tr>
-<td style="padding:5px">\\</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Escapes special characters, such as ., \, or (.</td>
-<td style="padding:5px">run\(\)</td>
+<td style={{padding: "5px"}}>\\</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Escapes special characters, such as ., \, or (.</td>
+<td style={{padding: "5px"}}>run\(\)</td>
 </tr>
 <tr>
-<td style="padding:5px">"[term]"</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Perform a literal search.</td>
-<td style="padding:5px">"class:main"</td>
+<td style={{padding: "5px"}}>"[term]"</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Perform a literal search.</td>
+<td style={{padding: "5px"}}>"class:main"</td>
 </tr>
 </tbody>
 </table>

--- a/docs/versions/8.4.2/docs/configurable-attributes.mdx
+++ b/docs/versions/8.4.2/docs/configurable-attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.4.2/external/mod-command.mdx
+++ b/docs/versions/8.4.2/external/mod-command.mdx
@@ -186,11 +186,11 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
 ```
 
 <table>
-  <tr style="display: flex; flex-direction: row">
-    <td style="flex: 5; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style="object-fit: cover; max-width: 100%;" />
-        <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph Before Resolution</figcaption>
+  <tr style={{display: "flex", flexDirection: "row"}}>
+    <td style={{flex: "5", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+        <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph Before Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]
@@ -217,10 +217,10 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
   "rules_java@4.0.0" -> "bazel_skylib@1.0.3" [  ]
 } */}
     </td>
-    <td style="flex: 3; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style="object-fit: cover; max-width: 100%;" />
-       <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph After Resolution</figcaption>
+    <td style={{flex: "3", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+       <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph After Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]

--- a/docs/versions/8.4.2/release/rolling.mdx
+++ b/docs/versions/8.4.2/release/rolling.mdx
@@ -9,4 +9,4 @@ these releases.
 
 ## Index {#index}
 
-<iframe src="https://releases.bazel.build/rolling.html" style="height: 3000px; width: 100%" ></iframe>
+<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%", border: "none"}} ></iframe>

--- a/docs/versions/8.5.1/configure/attributes.mdx
+++ b/docs/versions/8.5.1/configure/attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.5.1/contribute/search.mdx
+++ b/docs/versions/8.5.1/contribute/search.mdx
@@ -210,62 +210,62 @@ You can refine your search using the following filters.
 <table border="1px">
 <thead>
 <tr>
-<th style="padding:5px"><strong>Filter</strong></th>
-<th style="padding:5px"><strong>Other options</strong></th>
-<th style="padding:5px"><strong>Description</strong></th>
-<th style="padding:5px"><strong>Example</strong></th>
+<th style={{padding: "5px"}}><strong>Filter</strong></th>
+<th style={{padding: "5px"}}><strong>Other options</strong></th>
+<th style={{padding: "5px"}}><strong>Description</strong></th>
+<th style={{padding: "5px"}}><strong>Example</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="padding:5px">lang:</td>
-<td style="padding:5px">language:</td>
-<td style="padding:5px">Perform an exact match by file language.</td>
-<td style="padding:5px">lang:java test</td>
+<td style={{padding: "5px"}}>lang:</td>
+<td style={{padding: "5px"}}>language:</td>
+<td style={{padding: "5px"}}>Perform an exact match by file language.</td>
+<td style={{padding: "5px"}}>lang:java test</td>
 </tr>
 <tr>
-<td style="padding:5px">file:</td>
-<td style="padding:5px">filepath:<br/>
+<td style={{padding: "5px"}}>file:</td>
+<td style={{padding: "5px"}}>filepath:<br/>
 path:<br/>
 f:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px"></td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}></td>
 </tr>
 <tr>
-<td style="padding:5px">case:yes</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Make the search case sensitive. By default, searches are not case-sensitive.</td>
-<td style="padding:5px">case:yes Hello World</td>
+<td style={{padding: "5px"}}>case:yes</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Make the search case sensitive. By default, searches are not case-sensitive.</td>
+<td style={{padding: "5px"}}>case:yes Hello World</td>
 </tr>
 <tr>
-<td style="padding:5px">class:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Search for a class name.</td>
-<td style="padding:5px">class:MainClass</td>
+<td style={{padding: "5px"}}>class:</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Search for a class name.</td>
+<td style={{padding: "5px"}}>class:MainClass</td>
 </tr>
 <tr>
-<td style="padding:5px">function:</td>
-<td style="padding:5px">func:</td>
-<td style="padding:5px">Search for a function name.</td>
-<td style="padding:5px">function:print</td>
+<td style={{padding: "5px"}}>function:</td>
+<td style={{padding: "5px"}}>func:</td>
+<td style={{padding: "5px"}}>Search for a function name.</td>
+<td style={{padding: "5px"}}>function:print</td>
 </tr>
 <tr>
-<td style="padding:5px">-</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Negates the term from the search.</td>
-<td style="padding:5px">hello -world</td>
+<td style={{padding: "5px"}}>-</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Negates the term from the search.</td>
+<td style={{padding: "5px"}}>hello -world</td>
 </tr>
 <tr>
-<td style="padding:5px"><code>\\</code></td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Escapes special characters, such as ., \, or (.</td>
-<td style="padding:5px">run\(\)</td>
+<td style={{padding: "5px"}}><code>\\</code></td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Escapes special characters, such as ., \, or (.</td>
+<td style={{padding: "5px"}}>run\(\)</td>
 </tr>
 <tr>
-<td style="padding:5px">"[term]"</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Perform a literal search.</td>
-<td style="padding:5px">"class:main"</td>
+<td style={{padding: "5px"}}>"[term]"</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Perform a literal search.</td>
+<td style={{padding: "5px"}}>"class:main"</td>
 </tr>
 </tbody>
 </table>

--- a/docs/versions/8.5.1/docs/configurable-attributes.mdx
+++ b/docs/versions/8.5.1/docs/configurable-attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.5.1/external/mod-command.mdx
+++ b/docs/versions/8.5.1/external/mod-command.mdx
@@ -187,11 +187,11 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
 ```
 
 <table>
-  <tr style="display: flex; flex-direction: row">
-    <td style="flex: 5; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style="object-fit: cover; max-width: 100%;" />
-        <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph Before Resolution</figcaption>
+  <tr style={{display: "flex", flexDirection: "row"}}>
+    <td style={{flex: "5", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+        <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph Before Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]
@@ -218,10 +218,10 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
   "rules_java@4.0.0" -> "bazel_skylib@1.0.3" [  ]
 } */}
     </td>
-    <td style="flex: 3; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style="object-fit: cover; max-width: 100%;" />
-       <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph After Resolution</figcaption>
+    <td style={{flex: "3", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+       <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph After Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]

--- a/docs/versions/8.5.1/release/rolling.mdx
+++ b/docs/versions/8.5.1/release/rolling.mdx
@@ -9,4 +9,4 @@ these releases.
 
 ## Index {#index}
 
-<iframe src="https://releases.bazel.build/rolling.html" style="height: 3000px; width: 100%" ></iframe>
+<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%", border: "none"}} ></iframe>

--- a/docs/versions/8.6.0/configure/attributes.mdx
+++ b/docs/versions/8.6.0/configure/attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.6.0/contribute/search.mdx
+++ b/docs/versions/8.6.0/contribute/search.mdx
@@ -210,62 +210,62 @@ You can refine your search using the following filters.
 <table border="1px">
 <thead>
 <tr>
-<th style="padding:5px"><strong>Filter</strong></th>
-<th style="padding:5px"><strong>Other options</strong></th>
-<th style="padding:5px"><strong>Description</strong></th>
-<th style="padding:5px"><strong>Example</strong></th>
+<th style={{padding: "5px"}}><strong>Filter</strong></th>
+<th style={{padding: "5px"}}><strong>Other options</strong></th>
+<th style={{padding: "5px"}}><strong>Description</strong></th>
+<th style={{padding: "5px"}}><strong>Example</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="padding:5px">lang:</td>
-<td style="padding:5px">language:</td>
-<td style="padding:5px">Perform an exact match by file language.</td>
-<td style="padding:5px">lang:java test</td>
+<td style={{padding: "5px"}}>lang:</td>
+<td style={{padding: "5px"}}>language:</td>
+<td style={{padding: "5px"}}>Perform an exact match by file language.</td>
+<td style={{padding: "5px"}}>lang:java test</td>
 </tr>
 <tr>
-<td style="padding:5px">file:</td>
-<td style="padding:5px">filepath:<br />
+<td style={{padding: "5px"}}>file:</td>
+<td style={{padding: "5px"}}>filepath:<br />
 path:<br />
 f:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px"></td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}></td>
 </tr>
 <tr>
-<td style="padding:5px">case:yes</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Make the search case sensitive. By default, searches are not case-sensitive.</td>
-<td style="padding:5px">case:yes Hello World</td>
+<td style={{padding: "5px"}}>case:yes</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Make the search case sensitive. By default, searches are not case-sensitive.</td>
+<td style={{padding: "5px"}}>case:yes Hello World</td>
 </tr>
 <tr>
-<td style="padding:5px">class:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Search for a class name.</td>
-<td style="padding:5px">class:MainClass</td>
+<td style={{padding: "5px"}}>class:</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Search for a class name.</td>
+<td style={{padding: "5px"}}>class:MainClass</td>
 </tr>
 <tr>
-<td style="padding:5px">function:</td>
-<td style="padding:5px">func:</td>
-<td style="padding:5px">Search for a function name.</td>
-<td style="padding:5px">function:print</td>
+<td style={{padding: "5px"}}>function:</td>
+<td style={{padding: "5px"}}>func:</td>
+<td style={{padding: "5px"}}>Search for a function name.</td>
+<td style={{padding: "5px"}}>function:print</td>
 </tr>
 <tr>
-<td style="padding:5px">-</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Negates the term from the search.</td>
-<td style="padding:5px">hello -world</td>
+<td style={{padding: "5px"}}>-</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Negates the term from the search.</td>
+<td style={{padding: "5px"}}>hello -world</td>
 </tr>
 <tr>
-<td style="padding:5px">`\`</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Escapes special characters, such as ., \, or (.</td>
-<td style="padding:5px">run\(\)</td>
+<td style={{padding: "5px"}}>`\`</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Escapes special characters, such as ., \, or (.</td>
+<td style={{padding: "5px"}}>run\(\)</td>
 </tr>
 <tr>
-<td style="padding:5px">"[term]"</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Perform a literal search.</td>
-<td style="padding:5px">"class:main"</td>
+<td style={{padding: "5px"}}>"[term]"</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Perform a literal search.</td>
+<td style={{padding: "5px"}}>"class:main"</td>
 </tr>
 </tbody>
 </table>

--- a/docs/versions/8.6.0/docs/configurable-attributes.mdx
+++ b/docs/versions/8.6.0/docs/configurable-attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.6.0/external/mod-command.mdx
+++ b/docs/versions/8.6.0/external/mod-command.mdx
@@ -213,11 +213,11 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
 ```
 
 <table>
-  <tr style="display: flex; flex-direction: row">
-    <td style="flex: 5; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="images/mod_exampleBefore.svg" alt="Graph Before Resolution" style="object-fit: cover; max-width: 100%;" />
-        <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph Before Resolution</figcaption>
+  <tr style={{display: "flex", flexDirection: "row"}}>
+    <td style={{flex: "5", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="images/mod_exampleBefore.svg" alt="Graph Before Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+        <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph Before Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]
@@ -244,10 +244,10 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
   "rules_java@4.0.0" -> "bazel_skylib@1.0.3" [  ]
 } */}
     </td>
-    <td style="flex: 3; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="images/mod_exampleResolved.svg" alt="Graph After Resolution" style="object-fit: cover; max-width: 100%;" />
-       <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph After Resolution</figcaption>
+    <td style={{flex: "3", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="images/mod_exampleResolved.svg" alt="Graph After Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+       <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph After Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]

--- a/docs/versions/8.6.0/release/rolling.mdx
+++ b/docs/versions/8.6.0/release/rolling.mdx
@@ -9,4 +9,4 @@ these releases.
 
 ## Index
 
-<iframe src="https://releases.bazel.build/rolling.html" style="height: 3000px; width: 100%" ></iframe>
+<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%", border: "none"}} ></iframe>

--- a/docs/versions/8.7.0/configure/attributes.mdx
+++ b/docs/versions/8.7.0/configure/attributes.mdx
@@ -43,7 +43,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.7.0/contribute/search.mdx
+++ b/docs/versions/8.7.0/contribute/search.mdx
@@ -210,62 +210,62 @@ You can refine your search using the following filters.
 <table border="1px">
 <thead>
 <tr>
-<th style="padding:5px"><strong>Filter</strong></th>
-<th style="padding:5px"><strong>Other options</strong></th>
-<th style="padding:5px"><strong>Description</strong></th>
-<th style="padding:5px"><strong>Example</strong></th>
+<th style={{padding: "5px"}}><strong>Filter</strong></th>
+<th style={{padding: "5px"}}><strong>Other options</strong></th>
+<th style={{padding: "5px"}}><strong>Description</strong></th>
+<th style={{padding: "5px"}}><strong>Example</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="padding:5px">lang:</td>
-<td style="padding:5px">language:</td>
-<td style="padding:5px">Perform an exact match by file language.</td>
-<td style="padding:5px">lang:java test</td>
+<td style={{padding: "5px"}}>lang:</td>
+<td style={{padding: "5px"}}>language:</td>
+<td style={{padding: "5px"}}>Perform an exact match by file language.</td>
+<td style={{padding: "5px"}}>lang:java test</td>
 </tr>
 <tr>
-<td style="padding:5px">file:</td>
-<td style="padding:5px">filepath:<br />
+<td style={{padding: "5px"}}>file:</td>
+<td style={{padding: "5px"}}>filepath:<br />
 path:<br />
 f:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px"></td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}></td>
 </tr>
 <tr>
-<td style="padding:5px">case:yes</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Make the search case sensitive. By default, searches are not case-sensitive.</td>
-<td style="padding:5px">case:yes Hello World</td>
+<td style={{padding: "5px"}}>case:yes</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Make the search case sensitive. By default, searches are not case-sensitive.</td>
+<td style={{padding: "5px"}}>case:yes Hello World</td>
 </tr>
 <tr>
-<td style="padding:5px">class:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Search for a class name.</td>
-<td style="padding:5px">class:MainClass</td>
+<td style={{padding: "5px"}}>class:</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Search for a class name.</td>
+<td style={{padding: "5px"}}>class:MainClass</td>
 </tr>
 <tr>
-<td style="padding:5px">function:</td>
-<td style="padding:5px">func:</td>
-<td style="padding:5px">Search for a function name.</td>
-<td style="padding:5px">function:print</td>
+<td style={{padding: "5px"}}>function:</td>
+<td style={{padding: "5px"}}>func:</td>
+<td style={{padding: "5px"}}>Search for a function name.</td>
+<td style={{padding: "5px"}}>function:print</td>
 </tr>
 <tr>
-<td style="padding:5px">-</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Negates the term from the search.</td>
-<td style="padding:5px">hello -world</td>
+<td style={{padding: "5px"}}>-</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Negates the term from the search.</td>
+<td style={{padding: "5px"}}>hello -world</td>
 </tr>
 <tr>
-<td style="padding:5px">\\</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Escapes special characters, such as ., \, or (.</td>
-<td style="padding:5px">run\(\)</td>
+<td style={{padding: "5px"}}>\\</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Escapes special characters, such as ., \, or (.</td>
+<td style={{padding: "5px"}}>run\(\)</td>
 </tr>
 <tr>
-<td style="padding:5px">"[term]"</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Perform a literal search.</td>
-<td style="padding:5px">"class:main"</td>
+<td style={{padding: "5px"}}>"[term]"</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Perform a literal search.</td>
+<td style={{padding: "5px"}}>"class:main"</td>
 </tr>
 </tbody>
 </table>

--- a/docs/versions/8.7.0/docs/configurable-attributes.mdx
+++ b/docs/versions/8.7.0/docs/configurable-attributes.mdx
@@ -43,7 +43,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/8.7.0/external/mod-command.mdx
+++ b/docs/versions/8.7.0/external/mod-command.mdx
@@ -219,18 +219,18 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
 ```
 
 <table>
-  <tr style="display: flex; flex-direction: row">
-    <td style="flex: 5; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="images/mod_exampleBefore.svg" alt="Graph Before Resolution" style="object-fit: cover; max-width: 100%;" />
-        <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph Before Resolution</figcaption>
+  <tr style={{display: "flex", flexDirection: "row"}}>
+    <td style={{flex: "5", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="images/mod_exampleBefore.svg" alt="Graph Before Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+        <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph Before Resolution</figcaption>
       </figure>
 
     </td>
-    <td style="flex: 3; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="images/mod_exampleResolved.svg" alt="Graph After Resolution" style="object-fit: cover; max-width: 100%;" />
-       <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph After Resolution</figcaption>
+    <td style={{flex: "3", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="images/mod_exampleResolved.svg" alt="Graph After Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+       <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph After Resolution</figcaption>
       </figure>
 
     </td>

--- a/docs/versions/8.7.0/release/rolling.mdx
+++ b/docs/versions/8.7.0/release/rolling.mdx
@@ -9,4 +9,4 @@ these releases.
 
 ## Index {#index}
 
-<iframe src="https://releases.bazel.build/rolling.html" style="height: 3000px; width: 100%" ></iframe>
+<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%", border: "none"}} ></iframe>

--- a/docs/versions/9.0.0/configure/attributes.mdx
+++ b/docs/versions/9.0.0/configure/attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/9.0.0/contribute/search.mdx
+++ b/docs/versions/9.0.0/contribute/search.mdx
@@ -210,62 +210,62 @@ You can refine your search using the following filters.
 <table border="1px">
 <thead>
 <tr>
-<th style="padding:5px"><strong>Filter</strong></th>
-<th style="padding:5px"><strong>Other options</strong></th>
-<th style="padding:5px"><strong>Description</strong></th>
-<th style="padding:5px"><strong>Example</strong></th>
+<th style={{padding: "5px"}}><strong>Filter</strong></th>
+<th style={{padding: "5px"}}><strong>Other options</strong></th>
+<th style={{padding: "5px"}}><strong>Description</strong></th>
+<th style={{padding: "5px"}}><strong>Example</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="padding:5px">lang:</td>
-<td style="padding:5px">language:</td>
-<td style="padding:5px">Perform an exact match by file language.</td>
-<td style="padding:5px">lang:java test</td>
+<td style={{padding: "5px"}}>lang:</td>
+<td style={{padding: "5px"}}>language:</td>
+<td style={{padding: "5px"}}>Perform an exact match by file language.</td>
+<td style={{padding: "5px"}}>lang:java test</td>
 </tr>
 <tr>
-<td style="padding:5px">file:</td>
-<td style="padding:5px">filepath:<br/>
+<td style={{padding: "5px"}}>file:</td>
+<td style={{padding: "5px"}}>filepath:<br/>
 path:<br/>
 f:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px"></td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}></td>
 </tr>
 <tr>
-<td style="padding:5px">case:yes</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Make the search case sensitive. By default, searches are not case-sensitive.</td>
-<td style="padding:5px">case:yes Hello World</td>
+<td style={{padding: "5px"}}>case:yes</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Make the search case sensitive. By default, searches are not case-sensitive.</td>
+<td style={{padding: "5px"}}>case:yes Hello World</td>
 </tr>
 <tr>
-<td style="padding:5px">class:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Search for a class name.</td>
-<td style="padding:5px">class:MainClass</td>
+<td style={{padding: "5px"}}>class:</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Search for a class name.</td>
+<td style={{padding: "5px"}}>class:MainClass</td>
 </tr>
 <tr>
-<td style="padding:5px">function:</td>
-<td style="padding:5px">func:</td>
-<td style="padding:5px">Search for a function name.</td>
-<td style="padding:5px">function:print</td>
+<td style={{padding: "5px"}}>function:</td>
+<td style={{padding: "5px"}}>func:</td>
+<td style={{padding: "5px"}}>Search for a function name.</td>
+<td style={{padding: "5px"}}>function:print</td>
 </tr>
 <tr>
-<td style="padding:5px">-</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Negates the term from the search.</td>
-<td style="padding:5px">hello -world</td>
+<td style={{padding: "5px"}}>-</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Negates the term from the search.</td>
+<td style={{padding: "5px"}}>hello -world</td>
 </tr>
 <tr>
-<td style="padding:5px">&#92;</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Escapes special characters, such as ., \, or (.</td>
-<td style="padding:5px">run\(\)</td>
+<td style={{padding: "5px"}}>&#92;</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Escapes special characters, such as ., \, or (.</td>
+<td style={{padding: "5px"}}>run\(\)</td>
 </tr>
 <tr>
-<td style="padding:5px">"[term]"</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Perform a literal search.</td>
-<td style="padding:5px">"class:main"</td>
+<td style={{padding: "5px"}}>"[term]"</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Perform a literal search.</td>
+<td style={{padding: "5px"}}>"class:main"</td>
 </tr>
 </tbody>
 </table>

--- a/docs/versions/9.0.0/docs/configurable-attributes.mdx
+++ b/docs/versions/9.0.0/docs/configurable-attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/9.0.0/external/migration_tool.mdx
+++ b/docs/versions/9.0.0/external/migration_tool.mdx
@@ -68,7 +68,7 @@ Before you begin:
 Once the prerequisites are met, run the following commands to use the migration
 tool:
 
-<pre class="prettyprint lang-shell" style="font-size: 12px;">
+<pre class="prettyprint lang-shell" style={{fontSize: "12px"}}>
 # Clone the Bazel Central Registry repository
 git clone https://github.com/bazelbuild/bazel-central-registry.git
 cd bazel-central-registry
@@ -125,7 +125,7 @@ To see the migration script in action, consider the following scenario when
 Python, Maven and Go dependencies are declared in `WORKSPACE` file.
 
 <details>
-  <summary style="padding: 16px">
+  <summary style={{padding: "16px"}}>
 Click here to see `WORKSPACE` file
   </summary>
 
@@ -265,7 +265,7 @@ Moreover, to demonstrate usage of module extension, custom macro is invoked from
 `WORKSPACE` and it is defined in `my_custom_macro.bzl`.
 
 <details>
-  <summary style="padding: 16px">
+  <summary style={{padding: "16px"}}>
 Click here to see `my_custom_macro.bzl` file
   </summary>
 
@@ -302,27 +302,27 @@ The first step is to follow [How to Use the Migration Tool](#migration-tool-how-
 
 Then, running `migrate2bzlmod -t=//...` outputs:
 
-<pre style="font-size: 12px;">
+<pre style={{fontSize: "12px"}}>
   bazel 7.6.1
 
   Generating ./resolved_deps.py file - It might take a while...
 
-  <span style="color:green;">RESOLVED:</span> <code>rules_java</code> has been introduced as a Bazel module.
-  <span style="color:green;">RESOLVED:</span> <code>bazel_gazelle</code> has been introduced as a Bazel module.
-  <span style="color:green;">RESOLVED:</span> <code>io_bazel_rules_go</code> has been introduced as a Bazel module.
-  <span style="color:green;">RESOLVED:</span> <code>rules_python</code> has been introduced as a Bazel module.
-  <span style="color:orange;">IMPORTANT:</span> 3.11 is used as a default python version. If you need a different version, please change it manually and then rerun the migration tool.
-  <span style="color:green;">RESOLVED:</span> <code>my_python_deps</code> has been introduced as python extension.
-  <span style="color:green;">RESOLVED:</span> <code>org_golang_x_net</code> has been introduced as go extension.
-  <span style="color:green;">RESOLVED:</span> <code>rules_jvm_external</code> has been introduced as a Bazel module.
-  <span style="color:green;">RESOLVED:</span> <code>org.antlr</code> has been introduced as maven extension.
-  <span style="color:green;">RESOLVED:</span> <code>rules_shell</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>rules_java</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>bazel_gazelle</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>io_bazel_rules_go</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>rules_python</code> has been introduced as a Bazel module.
+  <span style={{color: "orange"}}>IMPORTANT:</span> 3.11 is used as a default python version. If you need a different version, please change it manually and then rerun the migration tool.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>my_python_deps</code> has been introduced as python extension.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>org_golang_x_net</code> has been introduced as go extension.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>rules_jvm_external</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>org.antlr</code> has been introduced as maven extension.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>rules_shell</code> has been introduced as a Bazel module.
 
   Congratulations! All external repositories needed for building //... are available with Bzlmod!
-  <span style="color:orange;">IMPORTANT:</span> Fix potential build time issues by running the following command:
-      <span style="font-weight: 700;">bazel build --enable_bzlmod --noenable_workspace //...</span>
+  <span style={{color: "orange"}}>IMPORTANT:</span> Fix potential build time issues by running the following command:
+      <span style={{fontWeight: "700"}}>bazel build --enable_bzlmod --noenable_workspace //...</span>
 
-  <span style="color:orange;">IMPORTANT:</span> <code>For details about the migration process, check `migration_info.md` file.</code>
+  <span style={{color: "orange"}}>IMPORTANT:</span> <code>For details about the migration process, check `migration_info.md` file.</code>
 </pre>
 
 which gives the following important information:
@@ -344,10 +344,10 @@ which gives the following important information:
 This section illustrates the migration of code from the `WORKSPACE` file to
 `MODULE.bazel`.
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Bazel Module</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 http_archive(
     name = "rules_shell",
     sha256 = "3e114424a5c7e4fd43e0133cc6ecdfe54e45ae8affa14fadd839f29901424043",
@@ -356,20 +356,20 @@ http_archive(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Bazel Module</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 bazel_dep(name = "rules_shell", version = "0.6.1")
 </pre>
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;"/>
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}}/>
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Go Extension</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 http_archive(
     name = "io_bazel_rules_go",
     integrity = "sha256-M6zErg9wUC20uJPJ/B3Xqb+ZjCPn/yxFF3QdQEmpdvg=",
@@ -404,9 +404,9 @@ go_repository(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Go Extension</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 
@@ -425,12 +425,12 @@ go_deps.gazelle_override(
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;"/>
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}}/>
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Python Extension</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 http_archive(
     name = "rules_python",
     integrity = "sha256-qDdnnxOC8mlowe5vg5x9r5B5qlMSgGmh8oFd7KpjcwQ=",
@@ -457,9 +457,9 @@ python_register_toolchains(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Python Extension</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "my_python_deps",
@@ -475,12 +475,12 @@ python.toolchain(python_version = "3.11")
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;"/>
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}}/>
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Maven Extension</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 
 RULES_JVM_EXTERNAL_TAG = "4.5"
 RULES_JVM_EXTERNAL_SHA = "b17d7388feb9bfa7f2fa09031b32707df529f26c91ab9e5d909eb1676badd9a6"
@@ -509,9 +509,9 @@ maven_install(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Maven Extension</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 bazel_dep(name = "rules_jvm_external", version = "6.8")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
@@ -527,12 +527,12 @@ maven.artifact(
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;"/>
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}}/>
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Repo rule</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
@@ -543,9 +543,9 @@ http_archive(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Repo rule</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
@@ -558,12 +558,12 @@ http_archive(
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;"/>
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}}/>
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Module extension</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 load(":my_custom_macro.bzl", "my_custom_macro")
 
 my_custom_macro(
@@ -571,14 +571,14 @@ my_custom_macro(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Module extension</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 extension_for_my_custom_macro = use_extension("//:extension_for_my_custom_macro.bzl", "extension_for_my_custom_macro")
 use_repo(extension_for_my_custom_macro, "my_custom_repo")
 </pre>
     <p><strong>extension_for_my_custom_macro.bzl</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 load("//:my_custom_macro.bzl", "my_custom_macro")
 
 def _extension_for_my_custom_macro_impl(ctx):
@@ -591,7 +591,7 @@ extension_for_my_custom_macro = module_extension(implementation = _extension_for
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;"/>
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}}/>
 
 ## Tips with debugging {#migration-tool-tips}
 
@@ -639,7 +639,7 @@ from scratch if it's the first run or if the [`--i` flag](#migration-script-flag
     declared in the `WORKSPACE` file, which is particularly useful for the
     debugging. You can see it as:
 
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
     > Click here to see where and how the repo was declared in the WORKSPACE
     file
     </pre>
@@ -648,7 +648,7 @@ from scratch if it's the first run or if the [`--i` flag](#migration-script-flag
     earlier [Migration Example](#migration-tool-example), that would look as:
     1.  Bazel module Dependency - `Migration of rules_python`
 
-        <pre class="prettyprint lang-java" style="font-size: 12px;">
+        <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
         Found perfect name match in BCR: rules_python
         Found partially name matches in BCR: rules_python_gazelle_plugin
 
@@ -661,7 +661,7 @@ from scratch if it's the first run or if the [`--i` flag](#migration-script-flag
       added.
     2.  Python extension - `Migration of my_python_deps`
 
-        <pre class="prettyprint lang-java" style="font-size: 12px;">
+        <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
         pip.parse(
             hub_name = "my_python_deps",
             requirements_lock = "//:requirements_lock.txt",
@@ -672,7 +672,7 @@ from scratch if it's the first run or if the [`--i` flag](#migration-script-flag
 
     3.  Maven extension - `Migration of org.antlr (px_deps):`
 
-        <pre class="prettyprint lang-java" style="font-size: 12px;">
+        <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
         maven.artifact(
             name = "px_deps",
             group = "org.antlr",
@@ -683,7 +683,7 @@ from scratch if it's the first run or if the [`--i` flag](#migration-script-flag
 
     4.  Go extension - `Migration of org_golang_x_net`
 
-        <pre class="prettyprint lang-java" style="font-size: 12px;">
+        <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
         go_deps.from_file(go_mod = "//:go.mod")
         go_sdk.from_file(go_mod = "//:go.mod")
 

--- a/docs/versions/9.0.0/external/mod-command.mdx
+++ b/docs/versions/9.0.0/external/mod-command.mdx
@@ -204,11 +204,11 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
 ```
 
 <table>
-  <tr style="display: flex; flex-direction: row">
-    <td style="flex: 5; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style="object-fit: cover; max-width: 100%;" />
-        <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph Before Resolution</figcaption>
+  <tr style={{display: "flex", flexDirection: "row"}}>
+    <td style={{flex: "5", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleBefore.svg" alt="Graph Before Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+        <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph Before Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]
@@ -235,10 +235,10 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
   "rules_java@4.0.0" -> "bazel_skylib@1.0.3" [  ]
 } */}
     </td>
-    <td style="flex: 3; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style="object-fit: cover; max-width: 100%;" />
-       <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph After Resolution</figcaption>
+    <td style={{flex: "3", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="/external/images/mod_exampleResolved.svg" alt="Graph After Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+       <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph After Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]

--- a/docs/versions/9.0.0/release/rolling.mdx
+++ b/docs/versions/9.0.0/release/rolling.mdx
@@ -9,4 +9,4 @@ these releases.
 
 ## Index {#index}
 
-<iframe src="https://releases.bazel.build/rolling.html" style="height: 3000px; width: 100%" ></iframe>
+<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%", border: "none"}} ></iframe>

--- a/docs/versions/9.1.0/configure/attributes.mdx
+++ b/docs/versions/9.1.0/configure/attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/9.1.0/contribute/search.mdx
+++ b/docs/versions/9.1.0/contribute/search.mdx
@@ -210,62 +210,62 @@ You can refine your search using the following filters.
 <table border="1px">
 <thead>
 <tr>
-<th style="padding:5px"><strong>Filter</strong></th>
-<th style="padding:5px"><strong>Other options</strong></th>
-<th style="padding:5px"><strong>Description</strong></th>
-<th style="padding:5px"><strong>Example</strong></th>
+<th style={{padding: "5px"}}><strong>Filter</strong></th>
+<th style={{padding: "5px"}}><strong>Other options</strong></th>
+<th style={{padding: "5px"}}><strong>Description</strong></th>
+<th style={{padding: "5px"}}><strong>Example</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="padding:5px">lang:</td>
-<td style="padding:5px">language:</td>
-<td style="padding:5px">Perform an exact match by file language.</td>
-<td style="padding:5px">lang:java test</td>
+<td style={{padding: "5px"}}>lang:</td>
+<td style={{padding: "5px"}}>language:</td>
+<td style={{padding: "5px"}}>Perform an exact match by file language.</td>
+<td style={{padding: "5px"}}>lang:java test</td>
 </tr>
 <tr>
-<td style="padding:5px">file:</td>
-<td style="padding:5px">filepath:<br/>
+<td style={{padding: "5px"}}>file:</td>
+<td style={{padding: "5px"}}>filepath:<br/>
 path:<br/>
 f:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px"></td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}></td>
 </tr>
 <tr>
-<td style="padding:5px">case:yes</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Make the search case sensitive. By default, searches are not case-sensitive.</td>
-<td style="padding:5px">case:yes Hello World</td>
+<td style={{padding: "5px"}}>case:yes</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Make the search case sensitive. By default, searches are not case-sensitive.</td>
+<td style={{padding: "5px"}}>case:yes Hello World</td>
 </tr>
 <tr>
-<td style="padding:5px">class:</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Search for a class name.</td>
-<td style="padding:5px">class:MainClass</td>
+<td style={{padding: "5px"}}>class:</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Search for a class name.</td>
+<td style={{padding: "5px"}}>class:MainClass</td>
 </tr>
 <tr>
-<td style="padding:5px">function:</td>
-<td style="padding:5px">func:</td>
-<td style="padding:5px">Search for a function name.</td>
-<td style="padding:5px">function:print</td>
+<td style={{padding: "5px"}}>function:</td>
+<td style={{padding: "5px"}}>func:</td>
+<td style={{padding: "5px"}}>Search for a function name.</td>
+<td style={{padding: "5px"}}>function:print</td>
 </tr>
 <tr>
-<td style="padding:5px">-</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Negates the term from the search.</td>
-<td style="padding:5px">hello -world</td>
+<td style={{padding: "5px"}}>-</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Negates the term from the search.</td>
+<td style={{padding: "5px"}}>hello -world</td>
 </tr>
 <tr>
-<td style="padding:5px">`\`</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Escapes special characters, such as ., \, or (.</td>
-<td style="padding:5px">`run\(\)`</td>
+<td style={{padding: "5px"}}>`\`</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Escapes special characters, such as ., \, or (.</td>
+<td style={{padding: "5px"}}>`run\(\)`</td>
 </tr>
 <tr>
-<td style="padding:5px">"[term]"</td>
-<td style="padding:5px"></td>
-<td style="padding:5px">Perform a literal search.</td>
-<td style="padding:5px">"class:main"</td>
+<td style={{padding: "5px"}}>"[term]"</td>
+<td style={{padding: "5px"}}></td>
+<td style={{padding: "5px"}}>Perform a literal search.</td>
+<td style={{padding: "5px"}}>"class:main"</td>
 </tr>
 </tbody>
 </table>

--- a/docs/versions/9.1.0/docs/configurable-attributes.mdx
+++ b/docs/versions/9.1.0/docs/configurable-attributes.mdx
@@ -42,7 +42,7 @@ This declares a `cc_binary` that "chooses" its deps based on the flags at the
 command line. Specifically, `deps` becomes:
 
 <table>
-  <tr style="background: #E9E9E9; font-weight: bold">
+  <tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
     <td>Command</td>
     <td>deps =</td>
   </tr>

--- a/docs/versions/9.1.0/external/migration_tool.mdx
+++ b/docs/versions/9.1.0/external/migration_tool.mdx
@@ -68,7 +68,7 @@ Before you begin:
 Once the prerequisites are met, run the following commands to use the migration
 tool:
 
-<pre class="prettyprint lang-shell" style="font-size: 12px;">
+<pre class="prettyprint lang-shell" style={{fontSize: "12px"}}>
 # Clone the Bazel Central Registry repository
 git clone https://github.com/bazelbuild/bazel-central-registry.git
 cd bazel-central-registry
@@ -126,7 +126,7 @@ To see the migration script in action, consider the following scenario when
 Python, Maven and Go dependencies are declared in `WORKSPACE` file.
 
 <details>
-  <summary style="padding: 16px">
+  <summary style={{padding: "16px"}}>
 Click here to see `WORKSPACE` file
   </summary>
 
@@ -266,7 +266,7 @@ Moreover, to demonstrate usage of module extension, custom macro is invoked from
 `WORKSPACE` and it is defined in `my_custom_macro.bzl`.
 
 <details>
-  <summary style="padding: 16px">
+  <summary style={{padding: "16px"}}>
 Click here to see `my_custom_macro.bzl` file
   </summary>
 
@@ -304,27 +304,27 @@ Tool](#migration-tool-how-to-use), which mostly is checking the bazel version
 
 Then, running `migrate2bzlmod -t=//...` outputs:
 
-<pre style="font-size: 12px;">
+<pre style={{fontSize: "12px"}}>
   bazel 7.6.1
 
   Generating ./resolved_deps.py file - It might take a while...
 
-  <span style="color:green;">RESOLVED:</span> <code>rules_java</code> has been introduced as a Bazel module.
-  <span style="color:green;">RESOLVED:</span> <code>bazel_gazelle</code> has been introduced as a Bazel module.
-  <span style="color:green;">RESOLVED:</span> <code>io_bazel_rules_go</code> has been introduced as a Bazel module.
-  <span style="color:green;">RESOLVED:</span> <code>rules_python</code> has been introduced as a Bazel module.
-  <span style="color:orange;">IMPORTANT:</span> 3.11 is used as a default python version. If you need a different version, please change it manually and then rerun the migration tool.
-  <span style="color:green;">RESOLVED:</span> <code>my_python_deps</code> has been introduced as python extension.
-  <span style="color:green;">RESOLVED:</span> <code>org_golang_x_net</code> has been introduced as go extension.
-  <span style="color:green;">RESOLVED:</span> <code>rules_jvm_external</code> has been introduced as a Bazel module.
-  <span style="color:green;">RESOLVED:</span> <code>org.antlr</code> has been introduced as maven extension.
-  <span style="color:green;">RESOLVED:</span> <code>rules_shell</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>rules_java</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>bazel_gazelle</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>io_bazel_rules_go</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>rules_python</code> has been introduced as a Bazel module.
+  <span style={{color: "orange"}}>IMPORTANT:</span> 3.11 is used as a default python version. If you need a different version, please change it manually and then rerun the migration tool.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>my_python_deps</code> has been introduced as python extension.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>org_golang_x_net</code> has been introduced as go extension.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>rules_jvm_external</code> has been introduced as a Bazel module.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>org.antlr</code> has been introduced as maven extension.
+  <span style={{color: "green"}}>RESOLVED:</span> <code>rules_shell</code> has been introduced as a Bazel module.
 
   Congratulations! All external repositories needed for building //... are available with Bzlmod!
-  <span style="color:orange;">IMPORTANT:</span> Fix potential build time issues by running the following command:
-      <span style="font-weight: 700;">bazel build --enable_bzlmod --noenable_workspace //...</span>
+  <span style={{color: "orange"}}>IMPORTANT:</span> Fix potential build time issues by running the following command:
+      <span style={{fontWeight: "700"}}>bazel build --enable_bzlmod --noenable_workspace //...</span>
 
-  <span style="color:orange;">IMPORTANT:</span> <code>For details about the migration process, check `migration_info.md` file.</code>
+  <span style={{color: "orange"}}>IMPORTANT:</span> <code>For details about the migration process, check `migration_info.md` file.</code>
 </pre>
 
 which gives the following important information:
@@ -346,10 +346,10 @@ which gives the following important information:
 This section illustrates the migration of code from the `WORKSPACE` file to
 `MODULE.bazel`.
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Bazel Module</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 http_archive(
     name = "rules_shell",
     sha256 = "3e114424a5c7e4fd43e0133cc6ecdfe54e45ae8affa14fadd839f29901424043",
@@ -358,20 +358,20 @@ http_archive(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Bazel Module</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 bazel_dep(name = "rules_shell", version = "0.6.1")
 </pre>
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;" />
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}} />
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Go Extension</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 http_archive(
     name = "io_bazel_rules_go",
     integrity = "sha256-M6zErg9wUC20uJPJ/B3Xqb+ZjCPn/yxFF3QdQEmpdvg=",
@@ -406,9 +406,9 @@ go_repository(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Go Extension</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 
@@ -427,12 +427,12 @@ go_deps.gazelle_override(
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;" />
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}} />
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Python Extension</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 http_archive(
     name = "rules_python",
     integrity = "sha256-qDdnnxOC8mlowe5vg5x9r5B5qlMSgGmh8oFd7KpjcwQ=",
@@ -459,9 +459,9 @@ python_register_toolchains(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Python Extension</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "my_python_deps",
@@ -477,12 +477,12 @@ python.toolchain(python_version = "3.11")
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;" />
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}} />
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Maven Extension</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 
 RULES_JVM_EXTERNAL_TAG = "4.5"
 RULES_JVM_EXTERNAL_SHA = "b17d7388feb9bfa7f2fa09031b32707df529f26c91ab9e5d909eb1676badd9a6"
@@ -511,9 +511,9 @@ maven_install(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Maven Extension</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 bazel_dep(name = "rules_jvm_external", version = "6.8")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
@@ -529,12 +529,12 @@ maven.artifact(
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;" />
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}} />
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Repo rule</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
@@ -545,9 +545,9 @@ http_archive(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Repo rule</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
@@ -560,12 +560,12 @@ http_archive(
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;" />
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}} />
 
-<div style="display: flex; flex-wrap: wrap; gap: 16px;">
-  <div style="flex: 1; min-width: 300px;">
+<div style={{display: "flex", flexWrap: "wrap", gap: "16px"}}>
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>WORKSPACE - Module extension</strong></p>
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
 load(":my_custom_macro.bzl", "my_custom_macro")
 
 my_custom_macro(
@@ -573,14 +573,14 @@ my_custom_macro(
 )
 </pre>
   </div>
-  <div style="flex: 1; min-width: 300px;">
+  <div style={{flex: "1", minWidth: "300px"}}>
     <p><strong>MODULE.bazel - Module extension</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 extension_for_my_custom_macro = use_extension("//:extension_for_my_custom_macro.bzl", "extension_for_my_custom_macro")
 use_repo(extension_for_my_custom_macro, "my_custom_repo")
 </pre>
     <p><strong>extension_for_my_custom_macro.bzl</strong></p>
-    <pre class="prettyprint lang-py" style="font-size: 12px;">
+    <pre class="prettyprint lang-py" style={{fontSize: "12px"}}>
 load("//:my_custom_macro.bzl", "my_custom_macro")
 
 def _extension_for_my_custom_macro_impl(ctx):
@@ -593,7 +593,7 @@ extension_for_my_custom_macro = module_extension(implementation = _extension_for
   </div>
 </div>
 
-<hr style="height: 1px; background-color: black; border: none;" />
+<hr style={{height: "1px", backgroundColor: "black", border: "none"}} />
 
 ## Tips with debugging {#migration-tool-tips}
 
@@ -642,7 +642,7 @@ flag](#migration-script-flags) is used. The report contains:
     declared in the `WORKSPACE` file, which is particularly useful for the
     debugging. You can see it as:
 
-    <pre class="prettyprint lang-java" style="font-size: 12px;">
+    <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
     > Click here to see where and how the repo was declared in the WORKSPACE
     file
     </pre>
@@ -651,7 +651,7 @@ flag](#migration-script-flags) is used. The report contains:
     earlier [Migration Example](#migration-tool-example), that would look as:
     1.  Bazel module Dependency - `Migration of rules_python`
 
-        <pre class="prettyprint lang-java" style="font-size: 12px;">
+        <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
         Found perfect name match in BCR: rules_python
         Found partially name matches in BCR: rules_python_gazelle_plugin
 
@@ -664,7 +664,7 @@ flag](#migration-script-flags) is used. The report contains:
       added.
     2.  Python extension - `Migration of my_python_deps`
 
-        <pre class="prettyprint lang-java" style="font-size: 12px;">
+        <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
         pip.parse(
             hub_name = "my_python_deps",
             requirements_lock = "//:requirements_lock.txt",
@@ -675,7 +675,7 @@ flag](#migration-script-flags) is used. The report contains:
 
     3.  Maven extension - `Migration of org.antlr (px_deps):`
 
-        <pre class="prettyprint lang-java" style="font-size: 12px;">
+        <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
         maven.artifact(
             name = "px_deps",
             group = "org.antlr",
@@ -686,7 +686,7 @@ flag](#migration-script-flags) is used. The report contains:
 
     4.  Go extension - `Migration of org_golang_x_net`
 
-        <pre class="prettyprint lang-java" style="font-size: 12px;">
+        <pre class="prettyprint lang-java" style={{fontSize: "12px"}}>
         go_deps.from_file(go_mod = "//:go.mod")
         go_sdk.from_file(go_mod = "//:go.mod")
 

--- a/docs/versions/9.1.0/external/mod-command.mdx
+++ b/docs/versions/9.1.0/external/mod-command.mdx
@@ -207,11 +207,11 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
 ```
 
 <table>
-  <tr style="display: flex; flex-direction: row">
-    <td style="flex: 5; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="images/mod_exampleBefore.svg" alt="Graph Before Resolution" style="object-fit: cover; max-width: 100%;" />
-        <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph Before Resolution</figcaption>
+  <tr style={{display: "flex", flexDirection: "row"}}>
+    <td style={{flex: "5", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="images/mod_exampleBefore.svg" alt="Graph Before Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+        <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph Before Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]
@@ -238,10 +238,10 @@ use_repo(toolchains, my_jdk="remotejdk17_linux")
   "rules_java@4.0.0" -> "bazel_skylib@1.0.3" [  ]
 } */}
     </td>
-    <td style="flex: 3; display: flex; flex-direction: column">
-      <figure style="height: 100%; display: flex; flex-direction: column;">
-        <img src="images/mod_exampleResolved.svg" alt="Graph After Resolution" style="object-fit: cover; max-width: 100%;" />
-       <figcaption style="margin-top: auto; margin-left: auto; margin-right: auto ">Graph After Resolution</figcaption>
+    <td style={{flex: "3", display: "flex", flexDirection: "column"}}>
+      <figure style={{height: "100%", display: "flex", flexDirection: "column"}}>
+        <img src="images/mod_exampleResolved.svg" alt="Graph After Resolution" style={{objectFit: "cover", maxWidth: "100%"}} />
+       <figcaption style={{marginTop: "auto", marginLeft: "auto", marginRight: "auto"}}>Graph After Resolution</figcaption>
       </figure>
 {/* digraph mygraph {
   node [ shape=box ]

--- a/docs/versions/9.1.0/release/rolling.mdx
+++ b/docs/versions/9.1.0/release/rolling.mdx
@@ -9,4 +9,4 @@ these releases.
 
 ## Index {#index}
 
-<iframe src="https://releases.bazel.build/rolling.html" style="height: 3000px; width: 100%" ></iframe>
+<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%", border: "none"}} ></iframe>


### PR DESCRIPTION
## Summary

Mintlify renders hand-authored MDX as JSX. HTML-style `style="property: value"` attributes are not valid in MDX and cause pages to fail with HTTP 500 errors or be silently excluded from the site build.

This change converts all inline `style="..."` attributes to JSX object form `style={{...}}`, with CSS property names in camelCase and values as strings—matching the approach in #30657.

**Root cause:** MDX expects JSX-style objects for inline styles, not HTML string attributes.

**Example (from `docs/release/rolling.mdx`):**

Before:
```html
<iframe src="..." style="height: 3000px; width: 100%" />
```

After:
```jsx
<iframe src="..." style={{height: "3000px", width: "100%", border: "none"}} />
```

## Affected pages (unversioned + all `docs/versions/*/` copies)

- `docs/configure/attributes.mdx`
- `docs/docs/configurable-attributes.mdx`
- `docs/release/rolling.mdx`
- `docs/external/mod-command.mdx`
- `docs/external/migration_tool.mdx`
- `docs/contribute/search.mdx`

**66 files** updated (6 top-level pages + versioned mirrors where those paths exist).

## Proof (post-fix excerpts)

`docs/release/rolling.mdx`:
```jsx
<iframe src="https://releases.bazel.build/rolling.html" style={{height: "3000px", width: "100%", border: "none"}} ></iframe>
```

`docs/configure/attributes.mdx`:
```jsx
<tr style={{background: "#E9E9E9", fontWeight: "bold"}}>
```

Fixes #30658
Fixes #30668

## Test plan

### Unit / build
- [x] No remaining `style="` in targeted `.mdx` paths (verified by conversion script)

### Mintlify preview
Preview: https://bazel-pr-30702.mintlify.app/

| Page | Before (production) | Preview check |
|------|---------------------|---------------|
| `/configure/attributes` | HTTP 500 (#30668) | [ ] HTTP 200, styled table renders |
| `/release/rolling` | excluded from build (#30658) | [ ] iframe loads rolling releases index |
| `/external/mod-command` | excluded | [ ] side-by-side SVG layout renders |
| `/external/migration_tool` | excluded | [ ] flex-wrap diagram layout renders |
| `/contribute/search` | excluded | [ ] filter reference table renders |
| `/docs/configurable-attributes` | excluded | [ ] styled table renders |

- [x] Preview deployed (bazel-docs bot comment)
- [x] `/configure/attributes` — HTTP 200, Playwright screenshot captured
- [x] `/release/rolling` — HTTP 200, Playwright screenshot captured
- [ ] Remaining pages spot-checked in preview