### PR TITLE
site: Preserve HTML lists and nested tables in docs2mdx table cells

### DIFF
--- a/scripts/docs/BUILD
+++ b/scripts/docs/BUILD
@@ -97,15 +97,32 @@ py_test(
     ],
 )
 
+py_library(
+    name = "docs2mdx_lib",
+    srcs = ["docs2mdx.py"],
+    deps = [
+        "//third_party/py/abseil",
+        requirement("markdownify"),
+    ],
+)
+
 py_binary(
     name = "docs2mdx",
-    srcs = ["docs2mdx.py"],
+    main = "docs2mdx.py",
     visibility = [
         "//src/main/java/com/google/devtools/build/lib:__pkg__",
     ],
     deps = [
+        ":docs2mdx_lib",
+    ],
+)
+
+py_test(
+    name = "docs2mdx_test",
+    srcs = ["docs2mdx_test.py"],
+    deps = [
+        ":docs2mdx_lib",
         "//third_party/py/abseil",
-        requirement("markdownify"),
     ],
 )
 

--- a/scripts/docs/docs2mdx.py
+++ b/scripts/docs/docs2mdx.py
@@ -55,6 +55,16 @@ _ANGLE_BRACKET_LINK_RE = re.compile(r"<(https?://[^>]+)>")
 _HTML_PRE_PATTERN = re.compile(r"(?:<pre>)(.*?)(?:</pre>)")
 _HTML_STYLE_PATTERN = re.compile(r"^</?style>", re.MULTILINE)
 _MD_FRONT_MATTER_PATTERN = re.compile(r"^---", re.MULTILINE)
+# Flag docs wrap the anchor link inside <code>, which markdownify drops. Move the
+# link outside <code> so it survives conversion to MDX definition lists.
+_CODE_FLAG_LINK_RE = re.compile(
+    r'<code(?:\s[^>]*)?><a href="(#[^"]+)">(.*?)</a>(.*?)</code>',
+    re.DOTALL,
+)
+# Definition-list flag terms that should expose a copyable deep-link anchor.
+_FLAG_TERM_LINK_RE = re.compile(
+    r'^\[`([^`]+)`\]\(#((?:[^)]*-)?flag--[^)]+)\)',
+)
 
 # Across code blocks and similar pre-formatted blocks, these
 # characters must be converted to HTML entities so they don't

--- a/scripts/docs/docs2mdx.py
+++ b/scripts/docs/docs2mdx.py
@@ -89,8 +89,42 @@ def _escape_chars(text, replacements):
   return text
 
 
+# Table cells containing these elements cannot be represented as plain markdown
+# table cell text. Preserve their inner HTML so MDX renders them correctly.
+_COMPLEX_CELL_TAGS = frozenset(["ul", "ol", "table", "pre"])
+
+
+def _cell_has_complex_content(cell):
+  """Returns True if a table cell contains content that needs HTML preservation."""
+  return cell.find(list(_COMPLEX_CELL_TAGS)) is not None
+
+
+def _cell_inner_html(cell):
+  """Returns the raw inner HTML of a table cell."""
+  return "".join(str(child) for child in cell.children).strip()
+
+
+def _format_table_cell(cell, content):
+  """Formats table cell content as a markdown table cell."""
+  colspan = 1
+  if "colspan" in cell.attrs and cell["colspan"].isdigit():
+    colspan = max(1, min(1000, int(cell["colspan"])))
+  # Markdown table rows must be single-line; HTML in cells is fine on one line.
+  return " " + content.replace("\n", " ") + " |" * colspan
+
+
 class AcornSafeMarkdownConverter(markdownify.MarkdownConverter):
   """Custom converter that produces Acorn-parsable MDX output."""
+
+  def convert_td(self, el, text, parent_tags):
+    if _cell_has_complex_content(el):
+      return _format_table_cell(el, _cell_inner_html(el))
+    return super().convert_td(el, text, parent_tags)
+
+  def convert_th(self, el, text, parent_tags):
+    if _cell_has_complex_content(el):
+      return _format_table_cell(el, _cell_inner_html(el))
+    return super().convert_th(el, text, parent_tags)
 
   def convert_code(self, node, text, parent_tags):
     """Normalize whitespace in inline code before converting.

--- a/scripts/docs/docs2mdx.py
+++ b/scripts/docs/docs2mdx.py
@@ -55,17 +55,6 @@ _ANGLE_BRACKET_LINK_RE = re.compile(r"<(https?://[^>]+)>")
 _HTML_PRE_PATTERN = re.compile(r"(?:<pre>)(.*?)(?:</pre>)")
 _HTML_STYLE_PATTERN = re.compile(r"^</?style>", re.MULTILINE)
 _MD_FRONT_MATTER_PATTERN = re.compile(r"^---", re.MULTILINE)
-# Flag docs wrap the anchor link inside <code>, which markdownify drops. Move the
-# link outside <code> so it survives conversion to MDX definition lists.
-_CODE_FLAG_LINK_RE = re.compile(
-    r'<code(?:\s[^>]*)?><a href="(#[^"]+)">(.*?)</a>(.*?)</code>',
-    re.DOTALL,
-)
-# Definition-list flag terms that should expose a copyable deep-link anchor.
-_FLAG_TERM_LINK_RE = re.compile(
-    r'^\[`([^`]+)`\]\(#((?:[^)]*-)?flag--[^)]+)\)',
-)
-
 # Across code blocks and similar pre-formatted blocks, these
 # characters must be converted to HTML entities so they don't
 # look like JavaScript blocks.

--- a/scripts/docs/docs2mdx_test.py
+++ b/scripts/docs/docs2mdx_test.py
@@ -17,50 +17,74 @@ from __future__ import division
 from __future__ import print_function
 
 import unittest
-
+from absl.testing import parameterized
 from scripts.docs import docs2mdx
 
 
-class Docs2MdxTest(unittest.TestCase):
+class Docs2MdxTableCellTest(parameterized.TestCase):
 
-  def test_code_blocks_keep_literal_characters(self):
-    html = """<html><body>
-<h1>Example</h1>
-<pre><code>values = {"define": "species=excelsior"}
-if x &lt; y { return true; }</code></pre>
-</body></html>"""
-    result = docs2mdx._transform("example.html", html)
-
-    self.assertIn('values = {"define": "species=excelsior"}', result)
-    self.assertNotIn("&lcub;", result)
-    self.assertNotIn("&rcub;", result)
-    code_block = result.split("```")[1]
-    self.assertNotIn("&lt;", code_block)
-
-  def test_prose_still_escapes_mdx_special_characters(self):
-    html = """<html><body>
-<p>Compare x &lt; y and use {braces} in prose.</p>
-</body></html>"""
-    result = docs2mdx._transform("example.html", html)
-
-    self.assertIn("&lt;", result)
-    self.assertIn("&lcub;", result)
-    self.assertIn("&rcub;", result)
-
-  def test_pre_blocks_in_markdown_are_not_entity_escaped(self):
-    md = """# Title
-
-<pre>
-config_setting(
-    values = {"define": "species=excelsior"},
-)
-</pre>
-"""
-    result = docs2mdx._transform("example.md", md)
-
-    self.assertIn('values = {"define": "species=excelsior"}', result)
-    self.assertNotIn("&lcub;", result)
-    self.assertNotIn("&rcub;", result)
+  @parameterized.named_parameters(
+      (
+          "list_in_table_cell",
+          """
+<table>
+  <tr>
+    <td><code>aspect_hints</code></td>
+    <td>
+      <p>Some text.</p>
+      <p>Best practices:</p>
+      <ul>
+        <li>Targets listed in aspect_hints should be lightweight.</li>
+        <li>Language-specific logic should consider only aspect hints.</li>
+      </ul>
+    </td>
+  </tr>
+</table>
+""",
+          "<ul>",
+          "* Targets listed",
+      ),
+      (
+          "nested_table_in_cell",
+          """
+<table>
+  <tr>
+    <td><code>size</code></td>
+    <td>
+      <p>Test sizes:</p>
+      <table>
+        <tr><th>Size</th><th>RAM (in MB)</th></tr>
+        <tr><td>small</td><td>20</td></tr>
+      </table>
+    </td>
+  </tr>
+</table>
+""",
+          "<table>",
+          "| Size | RAM",
+      ),
+      (
+          "pre_in_table_cell",
+          """
+<table>
+  <tr><th>Attribute</th><th>Description</th></tr>
+  <tr>
+    <td><code>url</code></td>
+    <td>
+      <p>URL of the file.</p>
+      <pre><code>https://example.com/file.tar.gz</code></pre>
+    </td>
+  </tr>
+</table>
+""",
+          "<pre><code>",
+          "```",
+      ),
+  )
+  def testComplexTableCellContent(self, html, expected_substr, unexpected_substr):
+    actual = docs2mdx._html2md(html)
+    self.assertIn(expected_substr, actual)
+    self.assertNotIn(unexpected_substr, actual)
 
 
 if __name__ == "__main__":

--- a/scripts/docs/docs2mdx_test.py
+++ b/scripts/docs/docs2mdx_test.py
@@ -1,0 +1,67 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+
+from scripts.docs import docs2mdx
+
+
+class Docs2MdxTest(unittest.TestCase):
+
+  def test_code_blocks_keep_literal_characters(self):
+    html = """<html><body>
+<h1>Example</h1>
+<pre><code>values = {"define": "species=excelsior"}
+if x &lt; y { return true; }</code></pre>
+</body></html>"""
+    result = docs2mdx._transform("example.html", html)
+
+    self.assertIn('values = {"define": "species=excelsior"}', result)
+    self.assertNotIn("&lcub;", result)
+    self.assertNotIn("&rcub;", result)
+    code_block = result.split("```")[1]
+    self.assertNotIn("&lt;", code_block)
+
+  def test_prose_still_escapes_mdx_special_characters(self):
+    html = """<html><body>
+<p>Compare x &lt; y and use {braces} in prose.</p>
+</body></html>"""
+    result = docs2mdx._transform("example.html", html)
+
+    self.assertIn("&lt;", result)
+    self.assertIn("&lcub;", result)
+    self.assertIn("&rcub;", result)
+
+  def test_pre_blocks_in_markdown_are_not_entity_escaped(self):
+    md = """# Title
+
+<pre>
+config_setting(
+    values = {"define": "species=excelsior"},
+)
+</pre>
+"""
+    result = docs2mdx._transform("example.md", md)
+
+    self.assertIn('values = {"define": "species=excelsior"}', result)
+    self.assertNotIn("&lcub;", result)
+    self.assertNotIn("&rcub;", result)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
- When `docs2mdx.py` converts HTML reference docs to MDX, table cells containing lists, nested tables, or `<pre>` blocks are now preserved as inline HTML instead of being flattened to broken markdown.
- Adds `docs2mdx_test` with coverage for list-in-cell, nested-table-in-cell, and pre-in-cell cases.

Fixes #30614, #30616, and contributes to #30615.

**Note:** Reference docs under `docs/reference/` need to be regenerated after this lands.

## Approach
`markdownify` converts `<ul>/<ol>` inside `<td>` to inline `* item` text, and nested `<table>` elements into broken pipe syntax. The fix overrides `convert_td`/`convert_th` to emit raw inner HTML for complex cells.

## Test plan

### Unit tests
- [x] `bazel test //scripts/docs:docs2mdx_test //scripts/docs:rewriter_test`

### Mintlify preview
Preview: https://bazel-pr-30705.mintlify.app/

| Check | URL | Expected |
|-------|-----|----------|
| [ ] List in cell | `/reference/be/common-definitions#common-attributes` → `aspect_hints` row | Bullet list renders (not inline `* text`) |
| [ ] List in cell | same page → `tags` row | Multi-level bullet list renders |
| [ ] Nested table | `/reference/be/common-definitions#common-attributes-tests` → `size` row | Inner Size/RAM/CPU table renders |
| [ ] Nested table | same page → `timeout` row | Inner timeout table renders |
| [ ] Code in cell | `/rules/lib/repo/http` | Attribute table not squished (#30615) |

- [x] Preview deployed (bazel-docs bot comment)
- [ ] Visual checks above verified in preview

### Post-merge
- [ ] Regenerate reference docs and confirm on bazel.build