### PR TITLE
site: Fix HTML entities appearing in code blocks after MDX conversion

### DIFF
--- a/scripts/docs/BUILD
+++ b/scripts/docs/BUILD
@@ -97,6 +97,15 @@ py_test(
     ],
 )
 
+py_library(
+    name = "docs2mdx_lib",
+    srcs = ["docs2mdx.py"],
+    deps = [
+        "//third_party/py/abseil",
+        requirement("markdownify"),
+    ],
+)
+
 py_binary(
     name = "docs2mdx",
     srcs = ["docs2mdx.py"],
@@ -104,8 +113,16 @@ py_binary(
         "//src/main/java/com/google/devtools/build/lib:__pkg__",
     ],
     deps = [
+        ":docs2mdx_lib",
+    ],
+)
+
+py_test(
+    name = "docs2mdx_test",
+    srcs = ["docs2mdx_test.py"],
+    deps = [
+        ":docs2mdx_lib",
         "//third_party/py/abseil",
-        requirement("markdownify"),
     ],
 )
 

--- a/scripts/docs/docs2mdx.py
+++ b/scripts/docs/docs2mdx.py
@@ -52,20 +52,16 @@ _METADATA_PATTERN = re.compile(
 _TITLE_RE = re.compile(r"^title: '", re.MULTILINE)
 _HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 _ANGLE_BRACKET_LINK_RE = re.compile(r"<(https?://[^>]+)>")
-_HTML_PRE_PATTERN = re.compile(r"(?:<pre>)(.*?)(?:</pre>)")
 _HTML_STYLE_PATTERN = re.compile(r"^</?style>", re.MULTILINE)
 _MD_FRONT_MATTER_PATTERN = re.compile(r"^---", re.MULTILINE)
 
-# Across code blocks and similar pre-formatted blocks, these
-# characters must be converted to HTML entities so they don't
-# look like JavaScript blocks.
+# In prose (outside code/pre blocks), these characters must be converted to
+# HTML entities so they don't look like JSX or JavaScript blocks to MDX parsers.
 _REPLACED_JS_CHARACTERS = {
     "{": "&lcub;",
     "}": "&rcub;",
 }
 
-# Inside code blocks, these characters need to be converted
-# to HTML entities to prevent parser errors.
 _REPLACED_CODE_CHARACTERS = {
     "<": "&lt;",
     ">": "&gt;",
@@ -119,6 +115,9 @@ class AcornSafeMarkdownConverter(markdownify.MarkdownConverter):
 
     # Unescape underscores that are in the middle of words.
     escaped = re.sub(r"(\w)\\_(\w)", r"\1_\2", escaped)
+    # Fenced and inline code blocks are already safe from MDX parsing.
+    if "pre" in parent_tags or "code" in parent_tags:
+      return escaped
     return _escape_chars(escaped, _REPLACED_CODE_CHARACTERS)
 
 
@@ -178,11 +177,7 @@ def _pre_markdown_transforms(content):
   # Remove Project: and Book: lines
   no_metadata = _METADATA_PATTERN.sub("", no_comments, count=2).lstrip()
   no_templates = _TEMPLATE_RE.sub("", no_metadata)
-  return _HTML_PRE_PATTERN.sub(
-      _escape_chars_in_pre_blocks,
-      no_templates,
-      re.DOTALL,
-  )
+  return no_templates
 
 
 def _post_markdown_transforms(content):
@@ -237,22 +232,6 @@ def _remove_style_sections(content):
 
   parts = _HTML_STYLE_PATTERN.split(content)
   return f"{parts[0]}{parts[2].lstrip()}"
-
-
-def _escape_chars_in_pre_blocks(matches):
-  """Escapes characters in <pre> blocks that cause mdx parse errors.
-
-  Because some <pre> blocks contain valid HTML elements (e.g. links), < and >
-  are not escaped.
-
-  Args:
-    matches: re.Match; an object matching a <pre> block and its content.
-
-  Returns:
-    The <pre> block with properly escaped content.
-  """
-  content = _escape_chars(matches.group(1), _REPLACED_JS_CHARACTERS)
-  return f"<pre>{content}</pre>"
 
 
 def _fix_link(m):

--- a/scripts/docs/docs2mdx_test.py
+++ b/scripts/docs/docs2mdx_test.py
@@ -1,0 +1,67 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+
+from scripts.docs import docs2mdx
+
+
+class Docs2MdxTest(unittest.TestCase):
+
+  def test_code_blocks_keep_literal_characters(self):
+    html = """<html><body>
+<h1>Example</h1>
+<pre><code>values = {"define": "species=excelsior"}
+if x &lt; y { return true; }</code></pre>
+</body></html>"""
+    result = docs2mdx._transform("example.html", html)
+
+    self.assertIn('values = {"define": "species=excelsior"}', result)
+    self.assertNotIn("&lcub;", result)
+    self.assertNotIn("&rcub;", result)
+    code_block = result.split("```")[1]
+    self.assertNotIn("&lt;", code_block)
+
+  def test_prose_still_escapes_mdx_special_characters(self):
+    html = """<html><body>
+<p>Compare x &lt; y and use {braces} in prose.</p>
+</body></html>"""
+    result = docs2mdx._transform("example.html", html)
+
+    self.assertIn("&lt;", result)
+    self.assertIn("&lcub;", result)
+    self.assertIn("&rcub;", result)
+
+  def test_pre_blocks_in_markdown_are_not_entity_escaped(self):
+    md = """# Title
+
+<pre>
+config_setting(
+    values = {"define": "species=excelsior"},
+)
+</pre>
+"""
+    result = docs2mdx._transform("example.md", md)
+
+    self.assertIn('values = {"define": "species=excelsior"}', result)
+    self.assertNotIn("&lcub;", result)
+    self.assertNotIn("&rcub;", result)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
- Skip `_REPLACED_CODE_CHARACTERS` escaping in `AcornSafeMarkdownConverter.escape()` when text is inside `<pre>` or `<code>` elements.
- Remove the pre-markdown `<pre>` block pre-escaping step that converted `{`/`}` to `&lcub;`/`&rcub;`.
- Add `docs2mdx_test` with coverage for fenced code blocks, prose escaping, and raw `<pre>` blocks.

Fixes #30669

## Test plan

### Unit tests
- [x] `bazel test //scripts/docs:docs2mdx_test`
- [x] `bazel test //scripts/docs:rewriter_test`

### Mintlify preview
Preview: https://bazel-pr-30706.mintlify.app/ *(pending — preview workflow triggered)*

| Check | URL | Expected |
|-------|-----|----------|
| [ ] Fenced code | `/remote/output-directories` | `<`, `>` shown literally (not `&lt;` `&gt;`) |
| [ ] Fenced code | `/query/guide` | Shell commands with `<`/`>` render correctly |
| [ ] Prose safety | any reference page | `<`/`{`/`}` in prose still escaped (no MDX parse errors) |

- [ ] Preview deployed
- [ ] Code blocks verified in preview (no visible HTML entities)

### Post-merge
- [ ] Regenerate reference docs; grep generated MDX for `&lt;` inside fenced blocks