### PR TITLE
site: Restore copyable per-flag anchor URLs in MDX docs

### DIFF
--- a/scripts/docs/BUILD
+++ b/scripts/docs/BUILD
@@ -97,15 +97,32 @@ py_test(
     ],
 )
 
+py_library(
+    name = "docs2mdx_lib",
+    srcs = ["docs2mdx.py"],
+    deps = [
+        "//third_party/py/abseil",
+        requirement("markdownify"),
+    ],
+)
+
 py_binary(
     name = "docs2mdx",
-    srcs = ["docs2mdx.py"],
+    main = "docs2mdx.py",
     visibility = [
         "//src/main/java/com/google/devtools/build/lib:__pkg__",
     ],
     deps = [
+        ":docs2mdx_lib",
+    ],
+)
+
+py_test(
+    name = "docs2mdx_test",
+    srcs = ["docs2mdx_test.py"],
+    deps = [
+        ":docs2mdx_lib",
         "//third_party/py/abseil",
-        requirement("markdownify"),
     ],
 )
 

--- a/scripts/docs/docs2mdx.py
+++ b/scripts/docs/docs2mdx.py
@@ -55,6 +55,16 @@ _ANGLE_BRACKET_LINK_RE = re.compile(r"<(https?://[^>]+)>")
 _HTML_PRE_PATTERN = re.compile(r"(?:<pre>)(.*?)(?:</pre>)")
 _HTML_STYLE_PATTERN = re.compile(r"^</?style>", re.MULTILINE)
 _MD_FRONT_MATTER_PATTERN = re.compile(r"^---", re.MULTILINE)
+# Flag docs wrap the anchor link inside <code>, which markdownify drops. Move the
+# link outside <code> so it survives conversion to MDX definition lists.
+_CODE_FLAG_LINK_RE = re.compile(
+    r'<code(?:\s[^>]*)?><a href="(#[^"]+)">(.*?)</a>(.*?)</code>',
+    re.DOTALL,
+)
+# Definition-list flag terms that should expose a copyable deep-link anchor.
+_FLAG_TERM_LINK_RE = re.compile(
+    r'^\[`([^`]+)`\]\(#((?:[^)]*-)?flag--[^)]+)\)',
+)
 
 # Across code blocks and similar pre-formatted blocks, these
 # characters must be converted to HTML entities so they don't
@@ -178,10 +188,30 @@ def _pre_markdown_transforms(content):
   # Remove Project: and Book: lines
   no_metadata = _METADATA_PATTERN.sub("", no_comments, count=2).lstrip()
   no_templates = _TEMPLATE_RE.sub("", no_metadata)
-  return _HTML_PRE_PATTERN.sub(
+  no_pre_escapes = _HTML_PRE_PATTERN.sub(
       _escape_chars_in_pre_blocks,
       no_templates,
       re.DOTALL,
+  )
+  return _move_flag_links_outside_code(no_pre_escapes)
+
+
+def _move_flag_links_outside_code(content):
+  """Moves in-code flag anchor links outside of <code> tags.
+
+  HtmlUtils.getUsageHtml() renders flags as
+  <code><a href="#flag--name">--name</a>...</code>. Markdownify discards links
+  nested inside inline code, so restructure the HTML before conversion.
+
+  Args:
+    content: str; HTML content before markdown conversion.
+
+  Returns:
+    Content with flag links moved outside of <code> tags.
+  """
+  return _CODE_FLAG_LINK_RE.sub(
+      r'<a href="\1"><code>\2\3</code></a>',
+      content,
   )
 
 
@@ -204,7 +234,35 @@ def _post_markdown_transforms(content):
       else _HEADING_RE.sub(_fix_title_heading, no_trailing_whitespaces, count=1)
   )
   front_matter_first = _remove_anything_before_front_matter(fixed_headings)
-  return _remove_style_sections(front_matter_first)
+  no_styles = _remove_style_sections(front_matter_first)
+  return _add_flag_anchor_targets(no_styles)
+
+
+def _add_flag_anchor_targets(content):
+  """Inserts explicit anchor targets for copyable per-flag deep links.
+
+  After markdown conversion, flag terms look like
+  [`--flag_name`](#flag--flag_name). Mintlify needs an element with a matching
+  id attribute for those links (and copied URLs) to resolve.
+
+  Args:
+    content: str; MDX content after markdown conversion.
+
+  Returns:
+    Content with <a id="..."></a> targets inserted before each flag term.
+  """
+  seen_anchor_ids = set()
+  lines = []
+  for line in content.split("\n"):
+    match = _FLAG_TERM_LINK_RE.match(line)
+    if match:
+      anchor_id = match.group(2)
+      if anchor_id not in seen_anchor_ids:
+        seen_anchor_ids.add(anchor_id)
+        lines.append(f'<a id="{anchor_id}"></a>')
+        lines.append("")
+    lines.append(line)
+  return "\n".join(lines)
 
 
 def _remove_trailing_whitespaces(content):

--- a/scripts/docs/docs2mdx_test.py
+++ b/scripts/docs/docs2mdx_test.py
@@ -1,0 +1,77 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+from absl.testing import parameterized
+from scripts.docs import docs2mdx
+
+
+class Docs2MdxFlagAnchorTest(parameterized.TestCase):
+
+  @parameterized.named_parameters(
+      (
+          "command_specific_flag",
+          """
+<dl>
+<dt id="build-flag--define"><code id="define"><a href="#build-flag--define">--define</a>=&lt;a 'name=value' assignment&gt;</code> multiple uses are accumulated</dt>
+<dd><p>Each --define option specifies an assignment for a build variable.</p></dd>
+</dl>
+""",
+          "build-flag--define",
+      ),
+      (
+          "global_flag",
+          """
+<dl>
+<dt id="flag--test_string"><code><a href="#flag--test_string">--test_string</a>=&lt;a string&gt;</code> default: "test string default"</dt>
+<dd><p>a string-valued option to test simple option operations</p></dd>
+</dl>
+""",
+          "flag--test_string",
+      ),
+      (
+          "boolean_flag",
+          """
+<dl>
+<dt id="flag--expanded_a"><code><a href="#flag--expanded_a">--[no]expanded_a</a></code> default: "true"</dt>
+<dd><p>boolean option</p></dd>
+</dl>
+""",
+          "flag--expanded_a",
+      ),
+  )
+  def test_flag_anchor_preserved(self, html, anchor_id):
+    result = docs2mdx._transform("test.html", html)
+    self.assertIn(f'<a id="{anchor_id}"></a>', result)
+    self.assertIn(f"](#{anchor_id})", result)
+
+  def test_duplicate_anchor_id_inserted_once(self):
+    html = """
+<dl>
+<dt id="build-flag--define"><code><a href="#build-flag--define">--define</a>=&lt;value&gt;</code></dt>
+<dd><p>First definition.</p></dd>
+<dt id="build-flag--define"><code><a href="#build-flag--define">--define</a>=&lt;value&gt;</code></dt>
+<dd><p>Duplicate id should not add a second anchor.</p></dd>
+</dl>
+"""
+    result = docs2mdx._transform("test.html", html)
+    self.assertEqual(result.count('<a id="build-flag--define"></a>'), 1)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
- Restore per-flag deep links in the command-line reference by moving flag anchor links outside `<code>` tags before markdownify conversion.
- Insert explicit `<a id="..."></a>` anchor targets in generated MDX for Mintlify deep links.
- Add `docs2mdx_test` coverage for flag anchor preservation.

Fixes #30670

## Root cause
`HtmlUtils.getUsageHtml()` generates:
```html
<dt id="build-flag--define">
  <code><a href="#build-flag--define">--define</a>=...</code>
</dt>
```
markdownify discards links nested inside inline `<code>`, producing plain backtick text with no copyable URL.

## Test plan

### Unit tests
- [x] `bazel test //scripts/docs:docs2mdx_test` — command-specific, global, boolean, duplicate-id cases

### Mintlify preview
Preview: https://bazel-pr-30708.mintlify.app/ *(pending — preview workflow triggered)*

| Check | URL | Expected |
|-------|-----|----------|
| [ ] Flag is a link | `/reference/command-line-reference` → any `--flag` | Clickable, not plain backtick text |
| [ ] Copyable URL | Click `--output_base`, copy browser URL | Contains `#flag--output_base` or `#build-flag--output_base` |
| [ ] Deep link works | Paste `#build-flag--define` URL directly | Scrolls to `--define` entry |
| [ ] Per-command flags | `/reference/command-line-reference#build-flag--jobs` | Resolves to build command flags section |

- [ ] Preview deployed
- [ ] Flag links and anchor URLs verified in preview

### Post-merge
- [ ] Regenerate docs; confirm on bazel.build