### PR TITLE
Skip the disk cache AC integrity check when action rewinding is enabled

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -237,13 +237,6 @@ public class CombinedCache extends AbstractReferenceCounted {
     ListenableFuture<CachedActionResult> future = immediateFuture(null);
 
     if (diskCacheClient != null && context.getReadCachePolicy().allowDiskCache()) {
-      // If Build without the Bytes is enabled, the future will likely return null
-      // and fallback to remote cache because AC integrity check is enabled and referenced blobs are
-      // probably missing from disk cache due to BwoB.
-      //
-      // TODO(chiwang): With lease service, instead of doing the integrity check against local
-      // filesystem, we can check whether referenced blobs are alive in the lease service to
-      // increase the cache-hit rate for disk cache.
       if (spawnExecutionContext != null) {
         spawnExecutionContext.report(SPAWN_CHECKING_DISK_CACHE_EVENT);
       }

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactory.java
@@ -51,7 +51,8 @@ public final class CombinedCacheClientFactory {
       AuthAndTLSOptions authAndTlsOptions,
       Path workingDirectory,
       DigestUtil digestUtil,
-      RemoteRetrier retrier)
+      RemoteRetrier retrier,
+      boolean checkActionResultIntegrity)
       throws IOException {
     Preconditions.checkNotNull(workingDirectory, "workingDirectory");
     RemoteCacheClient httpCacheClient = null;
@@ -60,7 +61,8 @@ public final class CombinedCacheClientFactory {
       httpCacheClient = createHttp(options, creds, authAndTlsOptions, digestUtil, retrier);
     }
     if (diskCachePath != null) {
-      diskCacheClient = createDiskCache(workingDirectory, diskCachePath, digestUtil);
+      diskCacheClient =
+          createDiskCache(workingDirectory, diskCachePath, digestUtil, checkActionResultIntegrity);
     }
     if (httpCacheClient == null && diskCacheClient == null) {
       throw new IllegalArgumentException(
@@ -122,9 +124,13 @@ public final class CombinedCacheClientFactory {
   }
 
   public static DiskCacheClient createDiskCache(
-      Path workingDirectory, PathFragment diskCachePath, DigestUtil digestUtil) throws IOException {
+      Path workingDirectory,
+      PathFragment diskCachePath,
+      DigestUtil digestUtil,
+      boolean checkActionResultIntegrity)
+      throws IOException {
     Path cacheDir = workingDirectory.getRelative(Preconditions.checkNotNull(diskCachePath));
-    return new DiskCacheClient(cacheDir, digestUtil);
+    return new DiskCacheClient(cacheDir, digestUtil, checkActionResultIntegrity);
   }
 
   public static boolean isHttpCache(RemoteOptions options) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -277,7 +277,8 @@ public final class RemoteModule extends BlazeModule {
       AuthAndTLSOptions authAndTlsOptions,
       RemoteOptions remoteOptions,
       @Nullable PathFragment diskCachePath,
-      DigestUtil digestUtil) {
+      DigestUtil digestUtil,
+      boolean checkDiskCacheActionResultIntegrity) {
     CombinedCacheClient combinedCacheClient;
     Retrier.CircuitBreaker circuitBreaker =
         CircuitBreakerFactory.createCircuitBreaker(remoteOptions);
@@ -291,7 +292,8 @@ public final class RemoteModule extends BlazeModule {
               Preconditions.checkNotNull(env.getWorkingDirectory(), "workingDirectory"),
               digestUtil,
               new RemoteRetrier(
-                  remoteOptions, HTTP_RESULT_CLASSIFIER, retryScheduler, circuitBreaker));
+                  remoteOptions, HTTP_RESULT_CLASSIFIER, retryScheduler, circuitBreaker),
+              checkDiskCacheActionResultIntegrity);
     } catch (IOException e) {
       handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
       return;
@@ -718,9 +720,23 @@ public final class RemoteModule extends BlazeModule {
               buildRequestOptions != null && buildRequestOptions.getRewindLostInputs());
     }
 
+    // Verifying that the blobs referenced by a disk cache action result are present locally turns
+    // most disk cache hits into misses when Build without the Bytes is enabled, as outputs aren't
+    // downloaded and thus never added to the disk cache's CAS. With action rewinding, a blob that
+    // is missing after all is cheap to recover from, so the check can be skipped. This allows disk
+    // cache AC checks to be entirely local, reducing server load and avoiding a network round trip.
+    boolean checkDiskCacheActionResultIntegrity =
+        buildRequestOptions == null || !buildRequestOptions.getRewindLostInputs();
+
     if ((enableHttpCache || enableDiskCache) && !enableGrpcCache) {
       initHttpAndDiskCache(
-          env, credentials, authAndTlsOptions, remoteOptions, diskCachePath, digestUtil);
+          env,
+          credentials,
+          authAndTlsOptions,
+          remoteOptions,
+          diskCachePath,
+          digestUtil,
+          checkDiskCacheActionResultIntegrity);
       initRepoHelpersAndOverlayFs(env, buildRequestId, invocationId, verboseFailures);
       return true;
     }
@@ -844,7 +860,10 @@ public final class RemoteModule extends BlazeModule {
         try {
           diskCacheClient =
               CombinedCacheClientFactory.createDiskCache(
-                  env.getWorkingDirectory(), diskCachePath, digestUtil);
+                  env.getWorkingDirectory(),
+                  diskCachePath,
+                  digestUtil,
+                  checkDiskCacheActionResultIntegrity);
         } catch (Exception e) {
           handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
           return false;
@@ -884,7 +903,10 @@ public final class RemoteModule extends BlazeModule {
         try {
           diskCacheClient =
               CombinedCacheClientFactory.createDiskCache(
-                  env.getWorkingDirectory(), diskCachePath, digestUtil);
+                  env.getWorkingDirectory(),
+                  diskCachePath,
+                  digestUtil,
+                  checkDiskCacheActionResultIntegrity);
         } catch (Exception e) {
           handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
           return false;

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -71,6 +71,7 @@ public class DiskCacheClient {
 
   private final ImmutableMap<Store, Path> storeRootMap;
   private final Path tmpRoot;
+  private final boolean checkActionResultIntegrity;
 
   // Disk cache operations are almost entirely I/O-bound as digests are only computed as part of
   // I/O operations, so using virtual threads is appropriate.
@@ -79,7 +80,15 @@ public class DiskCacheClient {
       MoreExecutors.listeningDecorator(
           Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("disk-cache-", 0).factory()));
 
-  public DiskCacheClient(Path root, DigestUtil digestUtil) throws IOException {
+  /**
+   * Creates a new disk cache client.
+   *
+   * @param checkActionResultIntegrity whether {@link #downloadActionResult} should only return an
+   *     action result whose referenced blobs are all present in the disk cache
+   */
+  public DiskCacheClient(Path root, DigestUtil digestUtil, boolean checkActionResultIntegrity)
+      throws IOException {
+    this.checkActionResultIntegrity = checkActionResultIntegrity;
     Path fnRoot =
         isOldStyleDigestFunction(digestUtil.getDigestFunction())
             ? root
@@ -174,56 +183,90 @@ public class DiskCacheClient {
         directExecutor());
   }
 
-  private void checkDigestExists(Digest digest) throws IOException {
+  /**
+   * If the blob with the given digest exists, marks it as recently used.
+   *
+   * @return whether the blob exists.
+   * @throws IOException if an I/O error other than a missing file occurs.
+   */
+  private boolean refreshDigest(Digest digest) throws IOException {
     if (digest.getSizeBytes() == 0) {
-      return;
+      return true;
     }
 
-    Path path = toPath(digest, Store.CAS);
-    if (!refresh(path)) {
-      throw new CacheNotFoundException(digest);
-    }
+    return refresh(toPath(digest, Store.CAS));
   }
 
-  private void checkOutputDirectory(Directory dir) throws IOException {
+  private boolean refreshOutputDirectory(Directory dir, boolean stopAtFirstMissing)
+      throws IOException {
+    boolean allPresent = true;
     for (var file : dir.getFilesList()) {
-      checkDigestExists(file.getDigest());
+      allPresent &= refreshDigest(file.getDigest());
+      if (!allPresent && stopAtFirstMissing) {
+        return false;
+      }
     }
+    return allPresent;
   }
 
   /**
-   * Checks that all of the blobs referenced by the {@link ActionResult} exist and marks them as
-   * recently used.
+   * Marks all of the blobs referenced by the {@link ActionResult} that exist as recently used.
    *
-   * @throws CacheNotFoundException if at least one of the referenced blobs is missing.
+   * @param stopAtFirstMissing whether to return as soon as a referenced blob is found to be
+   *     missing, leaving the mtime of the remaining blobs untouched.
+   * @return whether all of the referenced blobs exist.
    * @throws IOException if an I/O error other than a missing file occurs.
    */
-  private void checkActionResult(ActionResult actionResult) throws IOException {
+  private boolean refreshActionResult(ActionResult actionResult, boolean stopAtFirstMissing)
+      throws IOException {
+    boolean allPresent = true;
+
     for (var outputFile : actionResult.getOutputFilesList()) {
-      checkDigestExists(outputFile.getDigest());
+      allPresent &= refreshDigest(outputFile.getDigest());
+      if (!allPresent && stopAtFirstMissing) {
+        return false;
+      }
     }
 
     for (var outputDirectory : actionResult.getOutputDirectoriesList()) {
       var treeDigest = outputDirectory.getTreeDigest();
-      checkDigestExists(treeDigest);
+      if (!refreshDigest(treeDigest)) {
+        // Without the Tree, the blobs it references can't be determined.
+        if (stopAtFirstMissing) {
+          return false;
+        }
+        allPresent = false;
+        continue;
+      }
 
       Tree tree;
       try (var in = toPath(treeDigest, Store.CAS).getInputStream()) {
         tree = Tree.parseFrom(in, ExtensionRegistryLite.getEmptyRegistry());
       }
-      checkOutputDirectory(tree.getRoot());
+      allPresent &= refreshOutputDirectory(tree.getRoot(), stopAtFirstMissing);
+      if (!allPresent && stopAtFirstMissing) {
+        return false;
+      }
       for (var dir : tree.getChildrenList()) {
-        checkOutputDirectory(dir);
+        allPresent &= refreshOutputDirectory(dir, stopAtFirstMissing);
+        if (!allPresent && stopAtFirstMissing) {
+          return false;
+        }
       }
     }
 
     if (actionResult.hasStdoutDigest()) {
-      checkDigestExists(actionResult.getStdoutDigest());
+      allPresent &= refreshDigest(actionResult.getStdoutDigest());
+      if (!allPresent && stopAtFirstMissing) {
+        return false;
+      }
     }
 
     if (actionResult.hasStderrDigest()) {
-      checkDigestExists(actionResult.getStderrDigest());
+      allPresent &= refreshDigest(actionResult.getStderrDigest());
     }
+
+    return allPresent;
   }
 
   public ListenableFuture<ActionResult> downloadActionResult(ActionKey actionKey) {
@@ -237,14 +280,13 @@ public class DiskCacheClient {
             return immediateFuture(null);
           }
 
-          try {
-            // Verify that all of the referenced blobs exist and update their mtime.
-            checkActionResult(actionResult);
-          } catch (CacheNotFoundException e) {
+          boolean allBlobsPresent =
+              refreshActionResult(
+                  actionResult, /* stopAtFirstMissing= */ checkActionResultIntegrity);
+
+          if (checkActionResultIntegrity && !allBlobsPresent) {
             // If at least one of the referenced blobs is missing, consider the action result to be
-            // stale. At this point we might have unnecessarily updated the mtime on some of the
-            // referenced blobs, but this should happen infrequently, and doing it this way avoids a
-            // double pass over the blobs.
+            // stale.
             return immediateFuture(null);
           }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheClientFactoryTest.java
@@ -80,7 +80,8 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            retrier);
+            retrier,
+            /* checkActionResultIntegrity= */ true);
 
     assertThat(blobStore.remoteCacheClient()).isInstanceOf(HttpCacheClient.class);
     assertThat(blobStore.diskCacheClient()).isNotNull();
@@ -100,7 +101,8 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            retrier);
+            retrier,
+            /* checkActionResultIntegrity= */ true);
 
     assertThat(blobStore.remoteCacheClient()).isInstanceOf(HttpCacheClient.class);
     assertThat(blobStore.diskCacheClient()).isNotNull();
@@ -125,7 +127,8 @@ public class CombinedCacheClientFactoryTest {
                 authAndTlsOptions,
                 /* workingDirectory= */ null,
                 digestUtil,
-                retrier));
+                retrier,
+                /* checkActionResultIntegrity= */ true));
   }
 
   @Test
@@ -144,7 +147,8 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            retrier);
+            retrier,
+            /* checkActionResultIntegrity= */ true);
 
     assertThat(blobStore.remoteCacheClient()).isInstanceOf(HttpCacheClient.class);
     assertThat(blobStore.diskCacheClient()).isNull();
@@ -166,7 +170,8 @@ public class CombinedCacheClientFactoryTest {
                         authAndTlsOptions,
                         workingDirectory,
                         digestUtil,
-                        retrier)))
+                        retrier,
+                        /* checkActionResultIntegrity= */ true)))
         .hasMessageThat()
         .contains("Remote cache proxy unsupported: bad-proxy");
   }
@@ -183,7 +188,8 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            retrier);
+            retrier,
+            /* checkActionResultIntegrity= */ true);
 
     assertThat(blobStore.remoteCacheClient()).isInstanceOf(HttpCacheClient.class);
     assertThat(blobStore.diskCacheClient()).isNull();
@@ -201,7 +207,8 @@ public class CombinedCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
-            retrier);
+            retrier,
+            /* checkActionResultIntegrity= */ true);
 
     assertThat(blobStore.remoteCacheClient()).isNull();
     assertThat(blobStore.diskCacheClient()).isNotNull();

--- a/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
@@ -68,7 +68,7 @@ public class DiskCacheClientTest {
 
   @Before
   public void setUp() throws Exception {
-    client = new DiskCacheClient(root, DIGEST_UTIL);
+    client = new DiskCacheClient(root, DIGEST_UTIL, /* checkActionResultIntegrity= */ true);
   }
 
   @After
@@ -107,7 +107,10 @@ public class DiskCacheClientTest {
     assumeNotNull(BazelHashFunctions.BLAKE3); // BLAKE3 not available in Blaze.
 
     DiskCacheClient client =
-        new DiskCacheClient(root, new DigestUtil(SyscallCache.NO_CACHE, BazelHashFunctions.BLAKE3));
+        new DiskCacheClient(
+            root,
+            new DigestUtil(SyscallCache.NO_CACHE, BazelHashFunctions.BLAKE3),
+            /* checkActionResultIntegrity= */ true);
     Digest digest = Digest.newBuilder().setHash("0123456789abcdef").setSizeBytes(42).build();
     Path path = client.toPath(digest, Store.CAS);
 
@@ -119,7 +122,10 @@ public class DiskCacheClientTest {
     assumeNotNull(BazelHashFunctions.BLAKE3); // BLAKE3 not available in Blaze.
 
     DiskCacheClient client =
-        new DiskCacheClient(root, new DigestUtil(SyscallCache.NO_CACHE, BazelHashFunctions.BLAKE3));
+        new DiskCacheClient(
+            root,
+            new DigestUtil(SyscallCache.NO_CACHE, BazelHashFunctions.BLAKE3),
+            /* checkActionResultIntegrity= */ true);
     Digest digest = Digest.newBuilder().setHash("0123456789abcdef").setSizeBytes(42).build();
     Path path = client.toPath(digest, Store.AC);
 
@@ -337,10 +343,87 @@ public class DiskCacheClientTest {
   }
 
   @Test
+  public void downloadActionResult_withoutIntegrityCheck_withReferencedFileMissing_returnsResult()
+      throws Exception {
+    var clientWithoutIntegrityCheck =
+        new DiskCacheClient(root, DIGEST_UTIL, /* checkActionResultIntegrity= */ false);
+    Digest stdoutDigest = getDigest("stdout contents");
+    Digest stderrDigest = getDigest("stderr contents");
+    Digest missingFileDigest = getDigest("missing file contents");
+    Digest treeFileDigest = getDigest("tree file contents");
+    Tree tree = getTreeWithFile(treeFileDigest);
+    Digest treeDigest = getDigest(tree);
+    ActionKey actionKey = new ActionKey(getDigest("key"));
+    ActionResult actionResult =
+        ActionResult.newBuilder()
+            .setStdoutDigest(stdoutDigest)
+            .setStderrDigest(stderrDigest)
+            .addOutputFiles(OutputFile.newBuilder().setDigest(missingFileDigest).build())
+            .addOutputDirectories(OutputDirectory.newBuilder().setTreeDigest(treeDigest))
+            .build();
+
+    Path acPath = populateAc(actionKey, actionResult);
+    Path stdoutCasPath = populateCas(stdoutDigest, "stdout contents");
+    Path stderrCasPath = populateCas(stderrDigest, "stderr contents");
+    Path treeCasPath = populateCas(treeDigest, tree);
+    Path treeFileCasPath = populateCas(treeFileDigest, "tree file contents");
+
+    var result = getFromFuture(clientWithoutIntegrityCheck.downloadActionResult(actionKey));
+
+    assertThat(result).isEqualTo(actionResult);
+    assertThat(getCasPath(missingFileDigest).exists()).isFalse();
+    // The blobs that do exist are marked as recently used, including the ones that follow the
+    // missing blob.
+    assertThat(acPath.getLastModifiedTime()).isNotEqualTo(0);
+    assertThat(stdoutCasPath.getLastModifiedTime()).isNotEqualTo(0);
+    assertThat(stderrCasPath.getLastModifiedTime()).isNotEqualTo(0);
+    assertThat(treeCasPath.getLastModifiedTime()).isNotEqualTo(0);
+    assertThat(treeFileCasPath.getLastModifiedTime()).isNotEqualTo(0);
+  }
+
+  @Test
+  public void downloadActionResult_withoutIntegrityCheck_withReferencedTreeMissing_returnsResult()
+      throws Exception {
+    var clientWithoutIntegrityCheck =
+        new DiskCacheClient(root, DIGEST_UTIL, /* checkActionResultIntegrity= */ false);
+    Digest stdoutDigest = getDigest("stdout contents");
+    Tree tree = getTreeWithFile(getDigest("tree file contents"));
+    Digest treeDigest = getDigest(tree);
+    ActionKey actionKey = new ActionKey(getDigest("key"));
+    ActionResult actionResult =
+        ActionResult.newBuilder()
+            .setStdoutDigest(stdoutDigest)
+            .addOutputDirectories(OutputDirectory.newBuilder().setTreeDigest(treeDigest))
+            .build();
+
+    populateAc(actionKey, actionResult);
+    Path stdoutCasPath = populateCas(stdoutDigest, "stdout contents");
+
+    var result = getFromFuture(clientWithoutIntegrityCheck.downloadActionResult(actionKey));
+
+    assertThat(result).isEqualTo(actionResult);
+    assertThat(stdoutCasPath.getLastModifiedTime()).isNotEqualTo(0);
+  }
+
+  @Test
+  public void downloadActionResult_withoutIntegrityCheck_whenMissing_returnsNull()
+      throws Exception {
+    var clientWithoutIntegrityCheck =
+        new DiskCacheClient(root, DIGEST_UTIL, /* checkActionResultIntegrity= */ false);
+    ActionKey actionKey = new ActionKey(getDigest("key"));
+
+    var result = getFromFuture(clientWithoutIntegrityCheck.downloadActionResult(actionKey));
+
+    assertThat(result).isNull();
+  }
+
+  @Test
   public void concurrentUploadDownload()
       throws IOException, ExecutionException, InterruptedException {
     var nativeDiskCacheDir = TestUtils.createUniqueTmpDir(FileSystems.getNativeFileSystem());
-    var nativeClient = new DiskCacheClient(nativeDiskCacheDir, DIGEST_UTIL);
+    var nativeClient =
+        new DiskCacheClient(
+            nativeDiskCacheDir, DIGEST_UTIL, /* checkActionResultIntegrity= */ true);
     var tasks = new ArrayList<Future<?>>();
     // Use 1 MB blobs to increase the window for concurrent access during write/rename.
     var contentSize = 1024 * 1024;

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
@@ -57,7 +57,7 @@ class OnDiskBlobStoreCache extends CombinedCache {
       throws IOException {
     super(
         /* remoteCacheClient= */ null,
-        new DiskCacheClient(cacheDir, digestUtil),
+        new DiskCacheClient(cacheDir, digestUtil, /* checkActionResultIntegrity= */ true),
         /* symlinkTemplate= */ null,
         digestUtil,
         /* chunkingFunction= */ null);


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
`DiskCacheClient#downloadActionResult` only returned an action result after verifying that every blob it references is present in the disk CAS. With Build without the Bytes, those blobs are usually only available remotely, so the check turns most disk cache hits into misses and forces a fallback to the remote action cache.

Instead, disable the check when `--rewind_lost_inputs` is enabled, so that the disk action cache lookup is a purely local operation. If a referenced blob turns out to be unavailable when it is actually needed, the resulting lost input is recovered from by action rewinding.

The referenced blobs that do exist are still marked as recently used either way, so that trimming the cache in LRU order can't delete a blob that is still referenced by a live action result.

This also gets rid of unnecessary exception-based control flow in DiskCacheClient.


### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Disk cache action results are now always trusted with `--rewind_lost_inputs`, even if Build without the Bytes makes it so that the outputs are not available locally.
