### PR TITLE
Remote: stop retrying oversized gRPC messages

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -75,15 +75,22 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /** A RemoteActionCache implementation that uses gRPC calls to a remote cache server. */
 @ThreadSafe
 public class GrpcCacheClient extends RemoteCacheClient implements MissingDigestsFinder {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+  private static final Pattern GRPC_GO_MESSAGE_TOO_LARGE =
+      Pattern.compile("grpc: received message larger than max \\((\\d+) vs\\. (\\d+)\\)");
+  private static final Pattern GRPC_JAVA_MESSAGE_TOO_LARGE =
+      Pattern.compile("gRPC message exceeds maximum size (\\d+): (\\d+)");
 
   private final CallCredentialsProvider callCredentialsProvider;
   private final ReferenceCountedChannel channel;
@@ -377,6 +384,13 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
   @Override
   public ListenableFuture<Void> uploadActionResult(
       RemoteActionExecutionContext context, ActionKey actionKey, ActionResult actionResult) {
+    UpdateActionResultRequest request =
+        UpdateActionResultRequest.newBuilder()
+            .setInstanceName(options.getRemoteInstanceName())
+            .setDigestFunction(digestUtil.getDigestFunction())
+            .setActionDigest(actionKey.digest())
+            .setActionResult(actionResult)
+            .build();
     ListenableFuture<ActionResult> upload =
         Utils.refreshIfUnauthenticatedAsync(
             () ->
@@ -386,19 +400,64 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
                             channel.withChannelFuture(
                                 channel ->
                                     acFutureStub(context, channel)
-                                        .updateActionResult(
-                                            UpdateActionResultRequest.newBuilder()
-                                                .setInstanceName(options.getRemoteInstanceName())
-                                                .setDigestFunction(digestUtil.getDigestFunction())
-                                                .setActionDigest(actionKey.digest())
-                                                .setActionResult(actionResult)
-                                                .build())),
+                                        .updateActionResult(request)),
                             StatusRuntimeException.class,
-                            (sre) -> Futures.immediateFailedFuture(new IOException(sre)),
+                            (sre) -> {
+                              OptionalLong maximumSize =
+                                  getMaximumMessageSize(sre);
+                              if (maximumSize.isPresent()) {
+                                Status status =
+                                    sre.getStatus()
+                                        .withDescription(
+                                            ("UpdateActionResult was rejected because its gRPC "
+                                                    + "message exceeds the remote cache's maximum "
+                                                    + "size of %d bytes; increase the server's "
+                                                    + "receive limit or reduce the action result "
+                                                    + "size")
+                                                .formatted(maximumSize.getAsLong()));
+                                return Futures.immediateFailedFuture(
+                                    new RemoteRetrier.NonRetryableCacheException(
+                                        status.asRuntimeException(sre.getTrailers())));
+                              }
+                              return Futures.immediateFailedFuture(new IOException(sre));
+                            },
                             MoreExecutors.directExecutor())),
             callCredentialsProvider);
 
     return Futures.transform(upload, ac -> null, MoreExecutors.directExecutor());
+  }
+
+  @VisibleForTesting
+  static OptionalLong getMaximumMessageSize(StatusRuntimeException exception) {
+    Status status = exception.getStatus();
+    if (status.getCode() != Code.RESOURCE_EXHAUSTED || status.getDescription() == null) {
+      return OptionalLong.empty();
+    }
+
+    Matcher grpcGoMatcher = GRPC_GO_MESSAGE_TOO_LARGE.matcher(status.getDescription());
+    if (grpcGoMatcher.matches()) {
+      return validatedMaximumSize(grpcGoMatcher.group(1), grpcGoMatcher.group(2));
+    }
+
+    Matcher grpcJavaMatcher = GRPC_JAVA_MESSAGE_TOO_LARGE.matcher(status.getDescription());
+    if (grpcJavaMatcher.matches()) {
+      return validatedMaximumSize(grpcJavaMatcher.group(2), grpcJavaMatcher.group(1));
+    }
+
+    return OptionalLong.empty();
+  }
+
+  private static OptionalLong validatedMaximumSize(
+      String actualSizeText, String maximumSizeText) {
+    try {
+      long actualSize = Long.parseLong(actualSizeText);
+      long maximumSize = Long.parseLong(maximumSizeText);
+      return actualSize > maximumSize
+          ? OptionalLong.of(maximumSize)
+          : OptionalLong.empty();
+    } catch (NumberFormatException e) {
+      return OptionalLong.empty();
+    }
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -377,13 +377,6 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
   @Override
   public ListenableFuture<Void> uploadActionResult(
       RemoteActionExecutionContext context, ActionKey actionKey, ActionResult actionResult) {
-    UpdateActionResultRequest request =
-        UpdateActionResultRequest.newBuilder()
-            .setInstanceName(options.getRemoteInstanceName())
-            .setDigestFunction(digestUtil.getDigestFunction())
-            .setActionDigest(actionKey.digest())
-            .setActionResult(actionResult)
-            .build();
     ListenableFuture<ActionResult> upload =
         Utils.refreshIfUnauthenticatedAsync(
             () ->
@@ -393,11 +386,15 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
                             channel.withChannelFuture(
                                 channel ->
                                     acFutureStub(context, channel)
-                                        .updateActionResult(request)),
+                                        .updateActionResult(
+                                            UpdateActionResultRequest.newBuilder()
+                                                .setInstanceName(options.getRemoteInstanceName())
+                                                .setDigestFunction(digestUtil.getDigestFunction())
+                                                .setActionDigest(actionKey.digest())
+                                                .setActionResult(actionResult)
+                                                .build())),
                             StatusRuntimeException.class,
-                            (sre) ->
-                                Futures.immediateFailedFuture(
-                                    new RemoteRetrier.ActionCacheUpdateException(sre)),
+                            (sre) -> Futures.immediateFailedFuture(new IOException(sre)),
                             MoreExecutors.directExecutor())),
             callCredentialsProvider);
 

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -78,17 +78,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /** A RemoteActionCache implementation that uses gRPC calls to a remote cache server. */
 @ThreadSafe
 public class GrpcCacheClient extends RemoteCacheClient implements MissingDigestsFinder {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
-  private static final Pattern GRPC_GO_MESSAGE_TOO_LARGE =
-      Pattern.compile("grpc: received message larger than max \\(\\d+ vs\\. \\d+\\)");
-  private static final Pattern GRPC_JAVA_MESSAGE_TOO_LARGE =
-      Pattern.compile("gRPC message exceeds maximum size \\d+: \\d+");
 
   private final CallCredentialsProvider callCredentialsProvider;
   private final ReferenceCountedChannel channel;
@@ -400,28 +395,13 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
                                     acFutureStub(context, channel)
                                         .updateActionResult(request)),
                             StatusRuntimeException.class,
-                            (sre) -> {
-                              if (isMessageTooLarge(sre)) {
-                                return Futures.immediateFailedFuture(
-                                    new RemoteRetrier.NonRetryableCacheException(sre));
-                              }
-                              return Futures.immediateFailedFuture(new IOException(sre));
-                            },
+                            (sre) ->
+                                Futures.immediateFailedFuture(
+                                    new RemoteRetrier.ActionCacheUpdateException(sre)),
                             MoreExecutors.directExecutor())),
             callCredentialsProvider);
 
     return Futures.transform(upload, ac -> null, MoreExecutors.directExecutor());
-  }
-
-  @VisibleForTesting
-  static boolean isMessageTooLarge(StatusRuntimeException exception) {
-    Status status = exception.getStatus();
-    if (status.getCode() != Code.RESOURCE_EXHAUSTED || status.getDescription() == null) {
-      return false;
-    }
-
-    return GRPC_GO_MESSAGE_TOO_LARGE.matcher(status.getDescription()).matches()
-        || GRPC_JAVA_MESSAGE_TOO_LARGE.matcher(status.getDescription()).matches();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -75,11 +75,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
@@ -88,9 +86,9 @@ import javax.annotation.Nullable;
 public class GrpcCacheClient extends RemoteCacheClient implements MissingDigestsFinder {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
   private static final Pattern GRPC_GO_MESSAGE_TOO_LARGE =
-      Pattern.compile("grpc: received message larger than max \\((\\d+) vs\\. (\\d+)\\)");
+      Pattern.compile("grpc: received message larger than max \\(\\d+ vs\\. \\d+\\)");
   private static final Pattern GRPC_JAVA_MESSAGE_TOO_LARGE =
-      Pattern.compile("gRPC message exceeds maximum size (\\d+): (\\d+)");
+      Pattern.compile("gRPC message exceeds maximum size \\d+: \\d+");
 
   private final CallCredentialsProvider callCredentialsProvider;
   private final ReferenceCountedChannel channel;
@@ -403,18 +401,14 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
                                         .updateActionResult(request)),
                             StatusRuntimeException.class,
                             (sre) -> {
-                              OptionalLong maximumSize =
-                                  getMaximumMessageSize(sre);
-                              if (maximumSize.isPresent()) {
+                              if (isMessageTooLarge(sre)) {
                                 Status status =
                                     sre.getStatus()
                                         .withDescription(
                                             ("UpdateActionResult was rejected because its gRPC "
                                                     + "message exceeds the remote cache's maximum "
-                                                    + "size of %d bytes; increase the server's "
-                                                    + "receive limit or reduce the action result "
-                                                    + "size")
-                                                .formatted(maximumSize.getAsLong()));
+                                                    + "size; increase the server's receive limit "
+                                                    + "or reduce the action result size"));
                                 return Futures.immediateFailedFuture(
                                     new RemoteRetrier.NonRetryableCacheException(
                                         status.asRuntimeException(sre.getTrailers())));
@@ -428,36 +422,14 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
   }
 
   @VisibleForTesting
-  static OptionalLong getMaximumMessageSize(StatusRuntimeException exception) {
+  static boolean isMessageTooLarge(StatusRuntimeException exception) {
     Status status = exception.getStatus();
     if (status.getCode() != Code.RESOURCE_EXHAUSTED || status.getDescription() == null) {
-      return OptionalLong.empty();
+      return false;
     }
 
-    Matcher grpcGoMatcher = GRPC_GO_MESSAGE_TOO_LARGE.matcher(status.getDescription());
-    if (grpcGoMatcher.matches()) {
-      return validatedMaximumSize(grpcGoMatcher.group(1), grpcGoMatcher.group(2));
-    }
-
-    Matcher grpcJavaMatcher = GRPC_JAVA_MESSAGE_TOO_LARGE.matcher(status.getDescription());
-    if (grpcJavaMatcher.matches()) {
-      return validatedMaximumSize(grpcJavaMatcher.group(2), grpcJavaMatcher.group(1));
-    }
-
-    return OptionalLong.empty();
-  }
-
-  private static OptionalLong validatedMaximumSize(
-      String actualSizeText, String maximumSizeText) {
-    try {
-      long actualSize = Long.parseLong(actualSizeText);
-      long maximumSize = Long.parseLong(maximumSizeText);
-      return actualSize > maximumSize
-          ? OptionalLong.of(maximumSize)
-          : OptionalLong.empty();
-    } catch (NumberFormatException e) {
-      return OptionalLong.empty();
-    }
+    return GRPC_GO_MESSAGE_TOO_LARGE.matcher(status.getDescription()).matches()
+        || GRPC_JAVA_MESSAGE_TOO_LARGE.matcher(status.getDescription()).matches();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -402,16 +402,8 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
                             StatusRuntimeException.class,
                             (sre) -> {
                               if (isMessageTooLarge(sre)) {
-                                Status status =
-                                    sre.getStatus()
-                                        .withDescription(
-                                            ("UpdateActionResult was rejected because its gRPC "
-                                                    + "message exceeds the remote cache's maximum "
-                                                    + "size; increase the server's receive limit "
-                                                    + "or reduce the action result size"));
                                 return Futures.immediateFailedFuture(
-                                    new RemoteRetrier.NonRetryableCacheException(
-                                        status.asRuntimeException(sre.getTrailers())));
+                                    new RemoteRetrier.NonRetryableCacheException(sre));
                               }
                               return Futures.immediateFailedFuture(new IOException(sre));
                             },

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
@@ -32,12 +32,17 @@ import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /** Specific retry logic for remote execution/caching. */
 public class RemoteRetrier extends Retrier {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+  private static final Pattern GRPC_GO_MESSAGE_TOO_LARGE =
+      Pattern.compile("grpc: received message larger than max \\(\\d+ vs\\. \\d+\\)");
+  private static final Pattern GRPC_JAVA_MESSAGE_TOO_LARGE =
+      Pattern.compile("gRPC message exceeds maximum size \\d+: \\d+");
 
   /**
    * Supplies the gRPC log sink to which a terminal marker is written on retry exhaustion, or {@code
@@ -58,34 +63,46 @@ public class RemoteRetrier extends Retrier {
   }
 
   /**
-   * A deterministic cache request failure that should be propagated without retrying or counting
-   * it as a remote service failure.
+   * Identifies a failure from ActionCache.UpdateActionResult so the result classifier can apply
+   * operation-specific policy without changing the original gRPC status.
    */
-  static final class NonRetryableCacheException extends IOException {
-    NonRetryableCacheException(Throwable cause) {
+  static final class ActionCacheUpdateException extends IOException {
+    ActionCacheUpdateException(Throwable cause) {
       super(cause);
     }
   }
 
-  private static boolean causedByNonRetryableCacheException(Exception e) {
+  private static boolean causedByActionCacheUpdateException(Exception e) {
     for (Throwable cause = e; cause != null; cause = cause.getCause()) {
-      if (cause instanceof NonRetryableCacheException) {
+      if (cause instanceof ActionCacheUpdateException) {
         return true;
       }
     }
     return false;
   }
 
+  private static boolean isMessageTooLarge(Status status) {
+    if (status.getCode() != Status.Code.RESOURCE_EXHAUSTED || status.getDescription() == null) {
+      return false;
+    }
+
+    return GRPC_GO_MESSAGE_TOO_LARGE.matcher(status.getDescription()).matches()
+        || GRPC_JAVA_MESSAGE_TOO_LARGE.matcher(status.getDescription()).matches();
+  }
+
   /** A ResultClassifier suitable to be used by ExperimentalGrpcRemoteExecutor. */
   public static final ResultClassifier EXPERIMENTAL_GRPC_RESULT_CLASSIFIER =
       e -> {
-        if (causedByNonRetryableCacheException(e)) {
-          return Result.SUCCESS;
-        }
         Status s = fromException(e);
         if (s == null) {
           // It's not a gRPC error.
           return Result.PERMANENT_FAILURE;
+        }
+        if (causedByActionCacheUpdateException(e) && isMessageTooLarge(s)) {
+          // Retrying an unchanged request cannot make it fit the server's fixed receive limit. The
+          // failure also doesn't indicate an unhealthy remote service, so don't count it against
+          // the circuit breaker.
+          return Result.SUCCESS;
         }
         return switch (s.getCode()) {
           case CANCELLED ->

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
@@ -57,9 +57,31 @@ public class RemoteRetrier extends Retrier {
     return null;
   }
 
+  /**
+   * A deterministic cache request failure that should be propagated without retrying or counting
+   * it as a remote service failure.
+   */
+  static final class NonRetryableCacheException extends IOException {
+    NonRetryableCacheException(Throwable cause) {
+      super(cause);
+    }
+  }
+
+  private static boolean causedByNonRetryableCacheException(Exception e) {
+    for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+      if (cause instanceof NonRetryableCacheException) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /** A ResultClassifier suitable to be used by ExperimentalGrpcRemoteExecutor. */
   public static final ResultClassifier EXPERIMENTAL_GRPC_RESULT_CLASSIFIER =
       e -> {
+        if (causedByNonRetryableCacheException(e)) {
+          return Result.SUCCESS;
+        }
         Status s = fromException(e);
         if (s == null) {
           // It's not a gRPC error.

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
@@ -39,10 +39,18 @@ import javax.annotation.Nullable;
 public class RemoteRetrier extends Retrier {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
+  // gRPC deliberately maps framework message-size failures to RESOURCE_EXHAUSTED, the same status
+  // applications use for potentially transient failures such as quota exhaustion. The protocol
+  // provides no structured subtype to distinguish them. See https://github.com/grpc/grpc/pull/10612.
   private static final Pattern GRPC_GO_MESSAGE_TOO_LARGE =
-      Pattern.compile("grpc: received message larger than max \\(\\d+ vs\\. \\d+\\)");
+      Pattern.compile("^grpc: received message larger than max \\(\\d+ vs\\. \\d+\\)$");
   private static final Pattern GRPC_JAVA_MESSAGE_TOO_LARGE =
-      Pattern.compile("gRPC message exceeds maximum size \\d+: \\d+");
+      Pattern.compile("^gRPC message exceeds maximum size \\d+: \\d+$");
+  private static final Pattern GRPC_CPP_MESSAGE_TOO_LARGE =
+      Pattern.compile(
+          "^(?:CLIENT|SERVER): (?:Sent|Received) message larger than max"
+              + " \\(\\d+ vs\\. \\d+\\)$");
 
   /**
    * Supplies the gRPC log sink to which a terminal marker is written on retry exhaustion, or {@code
@@ -68,7 +76,8 @@ public class RemoteRetrier extends Retrier {
     }
 
     return GRPC_GO_MESSAGE_TOO_LARGE.matcher(status.getDescription()).matches()
-        || GRPC_JAVA_MESSAGE_TOO_LARGE.matcher(status.getDescription()).matches();
+        || GRPC_JAVA_MESSAGE_TOO_LARGE.matcher(status.getDescription()).matches()
+        || GRPC_CPP_MESSAGE_TOO_LARGE.matcher(status.getDescription()).matches();
   }
 
   /** A ResultClassifier suitable to be used by ExperimentalGrpcRemoteExecutor. */

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
@@ -62,25 +62,6 @@ public class RemoteRetrier extends Retrier {
     return null;
   }
 
-  /**
-   * Identifies a failure from ActionCache.UpdateActionResult so the result classifier can apply
-   * operation-specific policy without changing the original gRPC status.
-   */
-  static final class ActionCacheUpdateException extends IOException {
-    ActionCacheUpdateException(Throwable cause) {
-      super(cause);
-    }
-  }
-
-  private static boolean causedByActionCacheUpdateException(Exception e) {
-    for (Throwable cause = e; cause != null; cause = cause.getCause()) {
-      if (cause instanceof ActionCacheUpdateException) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   private static boolean isMessageTooLarge(Status status) {
     if (status.getCode() != Status.Code.RESOURCE_EXHAUSTED || status.getDescription() == null) {
       return false;
@@ -98,7 +79,7 @@ public class RemoteRetrier extends Retrier {
           // It's not a gRPC error.
           return Result.PERMANENT_FAILURE;
         }
-        if (causedByActionCacheUpdateException(e) && isMessageTooLarge(s)) {
+        if (isMessageTooLarge(s)) {
           // Retrying an unchanged request cannot make it fit the server's fixed receive limit. The
           // failure also doesn't indicate an unhealthy remote service, so don't count it against
           // the circuit breaker.

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -1316,9 +1316,10 @@ public class GrpcCacheClientTest {
     Mockito.verify(mockBackoff, Mockito.never()).nextDelayMillis(any(Exception.class));
     assertThat(Status.fromThrowable(error).getCode()).isEqualTo(Status.Code.RESOURCE_EXHAUSTED);
     assertThat(Status.fromThrowable(error).getDescription())
-        .contains("UpdateActionResult was rejected");
-    assertThat(Status.fromThrowable(error).getDescription())
-        .contains("increase the server's receive limit");
+        .startsWith(
+            grpcJavaFormat
+                ? "gRPC message exceeds maximum size"
+                : "grpc: received message larger than max");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -1272,15 +1272,27 @@ public class GrpcCacheClientTest {
 
   @Test
   public void uploadActionResult_grpcGoMessageTooLargeIsNotRetried() throws Exception {
-    assertMessageTooLargeIsNotRetried(/* grpcJavaFormat= */ false);
+    assertMessageTooLargeIsNotRetried(
+        "grpc: received message larger than max (%d vs. %d)",
+        "grpc: received message larger than max");
   }
 
   @Test
   public void uploadActionResult_grpcJavaMessageTooLargeIsNotRetried() throws Exception {
-    assertMessageTooLargeIsNotRetried(/* grpcJavaFormat= */ true);
+    assertMessageTooLargeIsNotRetried(
+        "gRPC message exceeds maximum size %2$d: %1$d",
+        "gRPC message exceeds maximum size");
   }
 
-  private void assertMessageTooLargeIsNotRetried(boolean grpcJavaFormat) throws Exception {
+  @Test
+  public void uploadActionResult_grpcCppMessageTooLargeIsNotRetried() throws Exception {
+    assertMessageTooLargeIsNotRetried(
+        "SERVER: Received message larger than max (%d vs. %d)",
+        "SERVER: Received message larger than max");
+  }
+
+  private void assertMessageTooLargeIsNotRetried(
+      String descriptionFormat, String descriptionPrefix) throws Exception {
     Backoff mockBackoff = mock(Backoff.class);
     GrpcCacheClient client = newClient(Options.getDefaults(RemoteOptions.class), () -> mockBackoff);
     ActionKey actionKey = DIGEST_UTIL.asActionKey(DIGEST_UTIL.computeAsUtf8("key"));
@@ -1293,12 +1305,7 @@ public class GrpcCacheClientTest {
             calls.incrementAndGet();
             int actualSize = request.getSerializedSize();
             int maximumSize = actualSize - 1;
-            String description =
-                grpcJavaFormat
-                    ? "gRPC message exceeds maximum size %d: %d"
-                        .formatted(maximumSize, actualSize)
-                    : "grpc: received message larger than max (%d vs. %d)"
-                        .formatted(actualSize, maximumSize);
+            String description = descriptionFormat.formatted(actualSize, maximumSize);
             responseObserver.onError(
                 Status.RESOURCE_EXHAUSTED.withDescription(description).asRuntimeException());
           }
@@ -1315,11 +1322,7 @@ public class GrpcCacheClientTest {
     assertThat(calls.get()).isEqualTo(1);
     Mockito.verify(mockBackoff, Mockito.never()).nextDelayMillis(any(Exception.class));
     assertThat(Status.fromThrowable(error).getCode()).isEqualTo(Status.Code.RESOURCE_EXHAUSTED);
-    assertThat(Status.fromThrowable(error).getDescription())
-        .startsWith(
-            grpcJavaFormat
-                ? "gRPC message exceeds maximum size"
-                : "grpc: received message larger than max");
+    assertThat(Status.fromThrowable(error).getDescription()).startsWith(descriptionPrefix);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -1271,6 +1271,106 @@ public class GrpcCacheClientTest {
   }
 
   @Test
+  public void uploadActionResult_grpcGoMessageTooLargeIsNotRetried() throws Exception {
+    assertMessageTooLargeIsNotRetried(/* grpcJavaFormat= */ false);
+  }
+
+  @Test
+  public void uploadActionResult_grpcJavaMessageTooLargeIsNotRetried() throws Exception {
+    assertMessageTooLargeIsNotRetried(/* grpcJavaFormat= */ true);
+  }
+
+  private void assertMessageTooLargeIsNotRetried(boolean grpcJavaFormat) throws Exception {
+    Backoff mockBackoff = mock(Backoff.class);
+    GrpcCacheClient client = newClient(Options.getDefaults(RemoteOptions.class), () -> mockBackoff);
+    ActionKey actionKey = DIGEST_UTIL.asActionKey(DIGEST_UTIL.computeAsUtf8("key"));
+    AtomicInteger calls = new AtomicInteger();
+    serviceRegistry.addService(
+        new ActionCacheImplBase() {
+          @Override
+          public void updateActionResult(
+              UpdateActionResultRequest request, StreamObserver<ActionResult> responseObserver) {
+            calls.incrementAndGet();
+            int actualSize = request.getSerializedSize();
+            int maximumSize = actualSize - 1;
+            String description =
+                grpcJavaFormat
+                    ? "gRPC message exceeds maximum size %d: %d"
+                        .formatted(maximumSize, actualSize)
+                    : "grpc: received message larger than max (%d vs. %d)"
+                        .formatted(actualSize, maximumSize);
+            responseObserver.onError(
+                Status.RESOURCE_EXHAUSTED.withDescription(description).asRuntimeException());
+          }
+        });
+
+    IOException error =
+        assertThrows(
+            IOException.class,
+            () ->
+                getFromFuture(
+                    client.uploadActionResult(
+                        context, actionKey, ActionResult.getDefaultInstance())));
+
+    assertThat(calls.get()).isEqualTo(1);
+    Mockito.verify(mockBackoff, Mockito.never()).nextDelayMillis(any(Exception.class));
+    assertThat(Status.fromThrowable(error).getCode()).isEqualTo(Status.Code.RESOURCE_EXHAUSTED);
+    assertThat(Status.fromThrowable(error).getDescription())
+        .contains("UpdateActionResult was rejected");
+    assertThat(Status.fromThrowable(error).getDescription())
+        .contains("increase the server's receive limit");
+  }
+
+  @Test
+  public void uploadActionResult_ordinaryResourceExhaustedRemainsRetryable() throws Exception {
+    Backoff mockBackoff = mock(Backoff.class);
+    when(mockBackoff.nextDelayMillis(any(Exception.class))).thenReturn(-1L);
+    GrpcCacheClient client = newClient(Options.getDefaults(RemoteOptions.class), () -> mockBackoff);
+    ActionKey actionKey = DIGEST_UTIL.asActionKey(DIGEST_UTIL.computeAsUtf8("key"));
+    serviceRegistry.addService(
+        new ActionCacheImplBase() {
+          @Override
+          public void updateActionResult(
+              UpdateActionResultRequest request, StreamObserver<ActionResult> responseObserver) {
+            responseObserver.onError(
+                Status.RESOURCE_EXHAUSTED
+                    .withDescription("request quota exhausted")
+                    .asRuntimeException());
+          }
+        });
+
+    assertThrows(
+        IOException.class,
+        () ->
+            getFromFuture(
+                client.uploadActionResult(context, actionKey, ActionResult.getDefaultInstance())));
+
+    Mockito.verify(mockBackoff, Mockito.times(1)).nextDelayMillis(any(Exception.class));
+  }
+
+  @Test
+  public void messageTooLargeDetection_rejectsMalformedAndDescriptiveNearMatches() {
+    ImmutableList<String> descriptions =
+        ImmutableList.of(
+            "received message larger than max (5621411 vs. 4194304)",
+            "grpc: received message larger than max (5621411 vs. 5621411)",
+            "grpc: received message larger than max (5621411 vs. 4194304) while decoding",
+            "grpc: received message larger than max (many vs. 4194304)",
+            "gRPC message exceeds maximum size 4194304: 5621411 while decoding",
+            "request quota exhausted");
+
+    for (String description : descriptions) {
+      assertThat(
+              GrpcCacheClient.getMaximumMessageSize(
+                      Status.RESOURCE_EXHAUSTED
+                          .withDescription(description)
+                          .asRuntimeException())
+                  .isPresent())
+          .isFalse();
+    }
+  }
+
+  @Test
   public void downloadBlobIsRetriedWithProgress() throws IOException, InterruptedException {
     Backoff mockBackoff = Mockito.mock(Backoff.class);
     GrpcCacheClient client = newClient(Options.getDefaults(RemoteOptions.class), () -> mockBackoff);

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -1353,7 +1353,6 @@ public class GrpcCacheClientTest {
     ImmutableList<String> descriptions =
         ImmutableList.of(
             "received message larger than max (5621411 vs. 4194304)",
-            "grpc: received message larger than max (5621411 vs. 5621411)",
             "grpc: received message larger than max (5621411 vs. 4194304) while decoding",
             "grpc: received message larger than max (many vs. 4194304)",
             "gRPC message exceeds maximum size 4194304: 5621411 while decoding",
@@ -1361,11 +1360,10 @@ public class GrpcCacheClientTest {
 
     for (String description : descriptions) {
       assertThat(
-              GrpcCacheClient.getMaximumMessageSize(
-                      Status.RESOURCE_EXHAUSTED
-                          .withDescription(description)
-                          .asRuntimeException())
-                  .isPresent())
+              GrpcCacheClient.isMessageTooLarge(
+                  Status.RESOURCE_EXHAUSTED
+                      .withDescription(description)
+                      .asRuntimeException()))
           .isFalse();
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -1350,26 +1350,6 @@ public class GrpcCacheClientTest {
   }
 
   @Test
-  public void messageTooLargeDetection_rejectsMalformedAndDescriptiveNearMatches() {
-    ImmutableList<String> descriptions =
-        ImmutableList.of(
-            "received message larger than max (5621411 vs. 4194304)",
-            "grpc: received message larger than max (5621411 vs. 4194304) while decoding",
-            "grpc: received message larger than max (many vs. 4194304)",
-            "gRPC message exceeds maximum size 4194304: 5621411 while decoding",
-            "request quota exhausted");
-
-    for (String description : descriptions) {
-      assertThat(
-              GrpcCacheClient.isMessageTooLarge(
-                  Status.RESOURCE_EXHAUSTED
-                      .withDescription(description)
-                      .asRuntimeException()))
-          .isFalse();
-    }
-  }
-
-  @Test
   public void downloadBlobIsRetriedWithProgress() throws IOException, InterruptedException {
     Backoff mockBackoff = Mockito.mock(Backoff.class);
     GrpcCacheClient client = newClient(Options.getDefaults(RemoteOptions.class), () -> mockBackoff);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteRetrierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteRetrierTest.java
@@ -138,7 +138,11 @@ public class RemoteRetrierTest {
     List<String> descriptions =
         List.of(
             "grpc: received message larger than max (5621411 vs. 4194304)",
-            "gRPC message exceeds maximum size 4194304: 5621411");
+            "gRPC message exceeds maximum size 4194304: 5621411",
+            "SERVER: Received message larger than max (5621411 vs. 4194304)",
+            "SERVER: Sent message larger than max (5621411 vs. 4194304)",
+            "CLIENT: Received message larger than max (5621411 vs. 4194304)",
+            "CLIENT: Sent message larger than max (5621411 vs. 4194304)");
 
     for (String description : descriptions) {
       Exception error =
@@ -156,6 +160,8 @@ public class RemoteRetrierTest {
             "grpc: received message larger than max (5621411 vs. 4194304) while decoding",
             "grpc: received message larger than max (many vs. 4194304)",
             "gRPC message exceeds maximum size 4194304: 5621411 while decoding",
+            "SERVER: Received message larger than max (5621411 vs. 4194304) while decoding",
+            "server: received message larger than max (5621411 vs. 4194304)",
             "request quota exhausted");
 
     for (String description : descriptions) {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteRetrierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteRetrierTest.java
@@ -134,13 +134,47 @@ public class RemoteRetrierTest {
   }
 
   @Test
-  public void nonRetryableCacheExceptionDoesNotCountAsRemoteFailure() {
+  public void oversizedActionCacheUpdateDoesNotCountAsRemoteFailure() {
     Exception error =
-        new RemoteRetrier.NonRetryableCacheException(
-            Status.RESOURCE_EXHAUSTED.withDescription("request too large").asRuntimeException());
+        new RemoteRetrier.ActionCacheUpdateException(
+            Status.RESOURCE_EXHAUSTED
+                .withDescription("grpc: received message larger than max (5621411 vs. 4194304)")
+                .asRuntimeException());
 
     assertThat(RemoteRetrier.EXPERIMENTAL_GRPC_RESULT_CLASSIFIER.test(error))
         .isEqualTo(Result.SUCCESS);
+  }
+
+  @Test
+  public void oversizedMessageOutsideActionCacheUpdateRemainsTransient() {
+    Exception error =
+        Status.RESOURCE_EXHAUSTED
+            .withDescription("grpc: received message larger than max (5621411 vs. 4194304)")
+            .asRuntimeException();
+
+    assertThat(RemoteRetrier.EXPERIMENTAL_GRPC_RESULT_CLASSIFIER.test(error))
+        .isEqualTo(Result.TRANSIENT_FAILURE);
+  }
+
+  @Test
+  public void actionCacheUpdateNearMatchesRemainTransient() {
+    List<String> descriptions =
+        List.of(
+            "received message larger than max (5621411 vs. 4194304)",
+            "grpc: received message larger than max (5621411 vs. 4194304) while decoding",
+            "grpc: received message larger than max (many vs. 4194304)",
+            "gRPC message exceeds maximum size 4194304: 5621411 while decoding",
+            "request quota exhausted");
+
+    for (String description : descriptions) {
+      Exception error =
+          new RemoteRetrier.ActionCacheUpdateException(
+              Status.RESOURCE_EXHAUSTED
+                  .withDescription(description)
+                  .asRuntimeException());
+      assertThat(RemoteRetrier.EXPERIMENTAL_GRPC_RESULT_CLASSIFIER.test(error))
+          .isEqualTo(Result.TRANSIENT_FAILURE);
+    }
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteRetrierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteRetrierTest.java
@@ -134,6 +134,16 @@ public class RemoteRetrierTest {
   }
 
   @Test
+  public void nonRetryableCacheExceptionDoesNotCountAsRemoteFailure() {
+    Exception error =
+        new RemoteRetrier.NonRetryableCacheException(
+            Status.RESOURCE_EXHAUSTED.withDescription("request too large").asRuntimeException());
+
+    assertThat(RemoteRetrier.EXPERIMENTAL_GRPC_RESULT_CLASSIFIER.test(error))
+        .isEqualTo(Result.SUCCESS);
+  }
+
+  @Test
   public void testRepeatedRetriesReset() throws Exception {
     Supplier<Backoff> s =
         () -> new ExponentialBackoff(Duration.ofSeconds(1), Duration.ofSeconds(10), 2.0, 0.0, 2);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteRetrierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteRetrierTest.java
@@ -134,30 +134,22 @@ public class RemoteRetrierTest {
   }
 
   @Test
-  public void oversizedActionCacheUpdateDoesNotCountAsRemoteFailure() {
-    Exception error =
-        new RemoteRetrier.ActionCacheUpdateException(
-            Status.RESOURCE_EXHAUSTED
-                .withDescription("grpc: received message larger than max (5621411 vs. 4194304)")
-                .asRuntimeException());
+  public void oversizedMessagesDoNotCountAsRemoteFailures() {
+    List<String> descriptions =
+        List.of(
+            "grpc: received message larger than max (5621411 vs. 4194304)",
+            "gRPC message exceeds maximum size 4194304: 5621411");
 
-    assertThat(RemoteRetrier.EXPERIMENTAL_GRPC_RESULT_CLASSIFIER.test(error))
-        .isEqualTo(Result.SUCCESS);
+    for (String description : descriptions) {
+      Exception error =
+          Status.RESOURCE_EXHAUSTED.withDescription(description).asRuntimeException();
+      assertThat(RemoteRetrier.EXPERIMENTAL_GRPC_RESULT_CLASSIFIER.test(error))
+          .isEqualTo(Result.SUCCESS);
+    }
   }
 
   @Test
-  public void oversizedMessageOutsideActionCacheUpdateRemainsTransient() {
-    Exception error =
-        Status.RESOURCE_EXHAUSTED
-            .withDescription("grpc: received message larger than max (5621411 vs. 4194304)")
-            .asRuntimeException();
-
-    assertThat(RemoteRetrier.EXPERIMENTAL_GRPC_RESULT_CLASSIFIER.test(error))
-        .isEqualTo(Result.TRANSIENT_FAILURE);
-  }
-
-  @Test
-  public void actionCacheUpdateNearMatchesRemainTransient() {
+  public void oversizedMessageNearMatchesRemainTransient() {
     List<String> descriptions =
         List.of(
             "received message larger than max (5621411 vs. 4194304)",
@@ -168,13 +160,21 @@ public class RemoteRetrierTest {
 
     for (String description : descriptions) {
       Exception error =
-          new RemoteRetrier.ActionCacheUpdateException(
-              Status.RESOURCE_EXHAUSTED
-                  .withDescription(description)
-                  .asRuntimeException());
+          Status.RESOURCE_EXHAUSTED.withDescription(description).asRuntimeException();
       assertThat(RemoteRetrier.EXPERIMENTAL_GRPC_RESULT_CLASSIFIER.test(error))
           .isEqualTo(Result.TRANSIENT_FAILURE);
     }
+  }
+
+  @Test
+  public void oversizedMessageWithOtherStatusRemainsTransient() {
+    Exception error =
+        Status.UNAVAILABLE
+            .withDescription("grpc: received message larger than max (5621411 vs. 4194304)")
+            .asRuntimeException();
+
+    assertThat(RemoteRetrier.EXPERIMENTAL_GRPC_RESULT_CLASSIFIER.test(error))
+        .isEqualTo(Result.TRANSIENT_FAILURE);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Detect grpc-go, grpc-java, and gRPC C++ message-size rejections in remote gRPC calls.
- Stop retrying only when the error matches an exact, anchored gRPC message-size format.
- Preserve retries for quota, overload, and all other `RESOURCE_EXHAUSTED` failures.
- Preserve the original gRPC failure and exclude the deterministic rejection from remote-cache circuit-breaker failures.

## Motivation

When a gRPC message exceeds the receiver's configured limit, the receiving gRPC implementation may reject it before the application handler runs. Retrying the unchanged message cannot succeed: neither the message bytes nor the receiver's fixed limit changes between attempts. The retries therefore add backoff delay without doing useful work.

gRPC deliberately standardized framework message-size failures as `RESOURCE_EXHAUSTED` in [grpc/grpc#10612](https://github.com/grpc/grpc/pull/10612), the same status applications use for potentially transient failures such as quota exhaustion. The protocol provides no structured subtype that distinguishes these cases; this ambiguity and the lack of a typed alternative were noted in the original discussion.

This keeps the existing general treatment of `RESOURCE_EXHAUSTED` as transient. It recognizes only exact, anchored grpc-go, grpc-java, and gRPC C++ message-size formats, avoiding confusion with quota or descriptive server errors. Rust Tonic reports the corresponding declared-size failure as `OUT_OF_RANGE`, which Bazel already treats as non-retryable.

The classification is centralized in `RemoteRetrier` and preserves the original gRPC status, description, and trailers.

The circuit-breaker treatment follows the precedent discussed in [#18583](https://github.com/bazelbuild/bazel/pull/18583) and implemented in [#18662](https://github.com/bazelbuild/bazel/pull/18662): deterministic request-size failures do not indicate an unhealthy remote-cache service.

This change does not make the RPC succeed; the receiver's limit must be raised or the message reduced. It only avoids retrying a message that cannot succeed under the current limit.

## Tests

- grpc-go, grpc-java, and gRPC C++ message-size formats fail after one attempt.
- malformed and descriptive near-matches are not recognized.
- ordinary `RESOURCE_EXHAUSTED` remains retryable.
- deterministic cache request failures do not count against the circuit breaker.
