### PR TITLE
[9.3.0] Intern `execution_info` computations.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -17,6 +17,9 @@ package com.google.devtools.build.lib.analysis.config;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -55,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.StarlarkAnnotations;
 import net.starlark.java.annot.StarlarkBuiltin;
@@ -891,6 +895,30 @@ public class BuildConfigurationValue
     return options.remotableSourceManifestActions;
   }
 
+  private static record ExecutionInfoInternerKey(
+      ImmutableMap<String, String> executionInfo,
+      String mnemonic,
+      List<ExecutionInfoModifier> executionInfoModifiers,
+      boolean additive) {}
+
+  private static final LoadingCache<ExecutionInfoInternerKey, ImmutableMap<String, String>>
+      modifiedExecutionInfoInterner =
+          CacheBuilder.newBuilder()
+              .weakValues()
+              .build(
+                  new CacheLoader<ExecutionInfoInternerKey, ImmutableMap<String, String>>() {
+                    @Override
+                    public ImmutableMap<String, String> load(ExecutionInfoInternerKey key) {
+                      Map<String, String> mutableCopy = new HashMap<>(key.executionInfo());
+                      ExecutionInfoModifier.apply(
+                          key.executionInfoModifiers(),
+                          key.additive(),
+                          key.mnemonic(),
+                          mutableCopy);
+                      return ImmutableSortedMap.copyOf(mutableCopy);
+                    }
+                  });
+
   /**
    * Returns a modified copy of {@code executionInfo} if any {@code executionInfoModifiers} apply to
    * the given {@code mnemonic}. Otherwise returns {@code executionInfo} unchanged.
@@ -901,9 +929,23 @@ public class BuildConfigurationValue
         options.executionInfoModifier, options.additiveModifyExecutionInfo, mnemonic)) {
       return executionInfo;
     }
-    Map<String, String> mutableCopy = new HashMap<>(executionInfo);
-    modifyExecutionInfo(mutableCopy, mnemonic);
-    return ImmutableSortedMap.copyOf(mutableCopy);
+    if (!ExecutionInfoModifier.wouldChange(
+        options.executionInfoModifier,
+        options.additiveModifyExecutionInfo,
+        mnemonic,
+        executionInfo)) {
+      return executionInfo;
+    }
+    try {
+      return modifiedExecutionInfoInterner.get(
+          new ExecutionInfoInternerKey(
+              executionInfo,
+              mnemonic,
+              options.executionInfoModifier,
+              options.additiveModifyExecutionInfo));
+    } catch (ExecutionException e) {
+      throw new IllegalStateException(e);
+    }
   }
 
   /** Applies {@code executionInfoModifiers} to the given {@code executionInfo}. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/ExecutionInfoModifier.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/ExecutionInfoModifier.java
@@ -122,6 +122,45 @@ public abstract class ExecutionInfoModifier {
     }
   }
 
+  /** Checks whether applying this modifier would actually change the given map. */
+  // When --modify_execution_info is non-empty, this method helps reduce CPU/memory overhead from
+  // modifying every action's execution info map.
+  boolean wouldChange(String mnemonic, Map<String, String> executionInfo) {
+    for (Expression expr : expressions()) {
+      if (!expr.pattern().matcher(internalToUnicode(mnemonic)).matches()) {
+        continue;
+      }
+      if (expr.remove()) {
+        if (executionInfo.containsKey(expr.key())) {
+          return true;
+        }
+      } else {
+        String val = executionInfo.get(expr.key());
+        if (val == null || !val.isEmpty()) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /** Checks whether any modifier in the list would actually change the given map. */
+  public static boolean wouldChange(
+      List<ExecutionInfoModifier> executionInfoList,
+      boolean isAdditive,
+      String mnemonic,
+      Map<String, String> executionInfo) {
+    if (executionInfoList.isEmpty()) {
+      return false;
+    }
+
+    if (isAdditive) {
+      return executionInfoList.stream().anyMatch(eim -> eim.wouldChange(mnemonic, executionInfo));
+    } else {
+      return executionInfoList.getLast().wouldChange(mnemonic, executionInfo);
+    }
+  }
+
   /** Applies {@code executionInfoList} to the given {@code executionInfo}. */
   public static void apply(
       List<ExecutionInfoModifier> executionInfoList,

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/ExecutionInfoModifierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/ExecutionInfoModifierTest.java
@@ -166,6 +166,44 @@ public class ExecutionInfoModifierTest {
         .testEquals();
   }
 
+  @Test
+  public void wouldChange_remove_keyNotPresent_returnsFalse() throws Exception {
+    ExecutionInfoModifier modifier = converter.convert("Genrule=-x");
+    Map<String, String> info = new HashMap<>();
+    assertThat(modifier.wouldChange("Genrule", info)).isFalse();
+  }
+
+  @Test
+  public void wouldChange_remove_keyPresent_returnsTrue() throws Exception {
+    ExecutionInfoModifier modifier = converter.convert("Genrule=-x");
+    Map<String, String> info = new HashMap<>();
+    info.put("x", "");
+    assertThat(modifier.wouldChange("Genrule", info)).isTrue();
+  }
+
+  @Test
+  public void wouldChange_add_keyNotPresent_returnsTrue() throws Exception {
+    ExecutionInfoModifier modifier = converter.convert("Genrule=+x");
+    Map<String, String> info = new HashMap<>();
+    assertThat(modifier.wouldChange("Genrule", info)).isTrue();
+  }
+
+  @Test
+  public void wouldChange_add_keyPresentWithEmptyValue_returnsFalse() throws Exception {
+    ExecutionInfoModifier modifier = converter.convert("Genrule=+x");
+    Map<String, String> info = new HashMap<>();
+    info.put("x", "");
+    assertThat(modifier.wouldChange("Genrule", info)).isFalse();
+  }
+
+  @Test
+  public void wouldChange_add_keyPresentWithNonEmptyValue_returnsTrue() throws Exception {
+    ExecutionInfoModifier modifier = converter.convert("Genrule=+x");
+    Map<String, String> info = new HashMap<>();
+    info.put("x", "val");
+    assertThat(modifier.wouldChange("Genrule", info)).isTrue();
+  }
+
   private void assertModifierMatchesAndResults(
       ExecutionInfoModifier modifier, String mnemonic, Set<String> expectedKeys) {
     assertModifierMatchesAndResults(


### PR DESCRIPTION
When `--modify_exeution_info` is set at the command line, this triggers [many new](https://github.com/bazelbuild/bazel/blob/a37a8a50132f3885d037c1774325b3ed4f02e973/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java#L898) `ImmutableSortedMap.copyOf` calls which shows up on benchmark memory reports.

PiperOrigin-RevId: 959750542
Change-Id: I600899f5f5c7dccc3398fde91aabdbc63ce4dabb

(cherry picked from commit fa230017c6679a05338171f0c88cd2192a0940ca)

9.3.0 adaptation: `--experimental_additive_modify_execution_info` still exists on the release branch, so `ExecutionInfoModifier.matches`/`apply` take an `isAdditive` flag there. The new `wouldChange` overload takes the same flag and mirrors `matches` (only the last modifier applies in non-additive mode), and `ExecutionInfoInternerKey` carries `additive` so configurations that differ only in that option don't share interned maps. The two master-only tests in the conflicting hunk (`starlarkConvertible_returnsTrue`, `reverseForStarlark_returnsOriginalString`) were dropped since neither method exists on 9.3.0.

Replaces #30723, whose branch ended up empty.
