### PR TITLE
compile-source.mdx: link to releases/latest to skip prereleases

### DIFF
--- a/docs/install/compile-source.mdx
+++ b/docs/install/compile-source.mdx
@@ -173,7 +173,7 @@ You can also build Bazel from scratch, without using an existing Bazel binary.
 (This step is the same for all platforms.)
 
 1.  Download `bazel-<version>-dist.zip` from
-    [GitHub](https://github.com/bazelbuild/bazel/releases), for example
+    [GitHub](https://github.com/bazelbuild/bazel/releases/latest), for example
     `bazel-0.28.1-dist.zip`.
 
     **Attention**:


### PR DESCRIPTION
Linking to <https://github.com/bazelbuild/bazel/releases> has a substantial chance of showing the reader a prerelease before any final releases.

Changing it to <https://github.com/bazelbuild/bazel/releases/latest> will show *just* the latest release.