### PR TITLE
Update zstd-jni to 1.5.6-9.bcr.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,7 +38,7 @@ bazel_dep(name = "rules_testing", version = "0.9.0")
 bazel_dep(name = "stardoc", version = "0.8.0", repo_name = "io_bazel_skydoc")
 bazel_dep(name = "with_cfg.bzl", version = "0.13.0")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.7")
-bazel_dep(name = "zstd-jni", version = "1.5.6-9.bcr.1")
+bazel_dep(name = "zstd-jni", version = "1.5.6-9.bcr.2")
 
 # Depend on apple_support first and then rules_cc so that the Xcode toolchain
 # from apple_support wins over the generic Unix toolchain from rules_cc.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -396,8 +396,8 @@
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.7/source.json": "086122bc43f9108094fed21aaace4c0affd5abd8364af0520dbacdb76cc0546d",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198",
     "https://bcr.bazel.build/modules/zlib/1.3/MODULE.bazel": "6a9c02f19a24dcedb05572b2381446e27c272cd383aed11d41d99da9e3167a72",
-    "https://bcr.bazel.build/modules/zstd-jni/1.5.6-9.bcr.1/MODULE.bazel": "c6696745628cdc909b39adc10d79548815b32d4504bf225be98cad6bfabd4def",
-    "https://bcr.bazel.build/modules/zstd-jni/1.5.6-9.bcr.1/source.json": "889fe50d0f7cf72ef35b692ad32a6b0873732463a396a47ec917023da353bc81"
+    "https://bcr.bazel.build/modules/zstd-jni/1.5.6-9.bcr.2/MODULE.bazel": "867ee1f4864de7f29545db4c5ea7675723a704f941e47c129ed89c782f462eff",
+    "https://bcr.bazel.build/modules/zstd-jni/1.5.6-9.bcr.2/source.json": "ff6e5c953dc3a44a59c38a9eb361540276dc72e8032b7746decd406a6a99c0e7"
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {


### PR DESCRIPTION
Update `zstd-jni` to `1.5.6-9.bcr.2` and refresh the `MODULE.bazel.lock` registry hashes.

`zstd-jni@1.5.6-9.bcr.2` replaces the shell- and PowerShell-based `ZstdVersion.java` generation with Skylib's `write_file` rule: https://github.com/bazelbuild/bazel-central-registry/pull/10048.
