### PR TITLE
Add documentation for using workspace status output in builds

### DIFF
--- a/docs/docs/user-manual.mdx
+++ b/docs/docs/user-manual.mdx
@@ -1265,7 +1265,7 @@ will include the STABLE lines and the volatile status file will include the rest
 #### Using workspace status in your build
 
 The status key-value pairs can be used in your build through Starlark actions and templates.
-Bazel provides built-in rules like `cc_binary` and `genrule` that support the `stamp` attribute,
+Many binary or 'top-level' rules, and other rules like `genrule`, support the `stamp` attribute,
 which can embed workspace status information into the compiled binaries.
 
 For example, when using `cc_binary` with `stamp = 1`, Bazel will automatically make the workspace

--- a/docs/docs/user-manual.mdx
+++ b/docs/docs/user-manual.mdx
@@ -1262,6 +1262,59 @@ echo "STABLE_USER_NAME $USER"
 Pass this program's path with `--workspace_status_command`, and the stable status file
 will include the STABLE lines and the volatile status file will include the rest of the lines.
 
+#### Using workspace status in your build
+
+The status key-value pairs can be used in your build through Starlark actions and templates.
+Bazel provides built-in rules like `cc_binary` and `genrule` that support the `stamp` attribute,
+which can embed workspace status information into the compiled binaries.
+
+For example, when using `cc_binary` with `stamp = 1`, Bazel will automatically make the workspace
+status available to the build. You can then access these values through template files:
+
+```python
+# In your BUILD file
+cc_binary(
+    name = "my_binary",
+    srcs = ["main.cc"],
+    stamp = 1,  # Enable stamping to include workspace status
+)
+
+# For custom use of workspace status, you can use ctx.actions.declare_file
+# and read the status files from ctx.workspace_status
+```
+
+For Java projects, you can use the `bazel_java_build_info` rule to generate Java source files
+with workspace status information:
+
+```python
+load("@bazel_tools//tools/build_defs/build_info:bazel_java_build_info.bzl", "bazel_java_build_info")
+
+bazel_java_build_info(
+    name = "build_info",
+    stamp = 1,
+)
+
+java_binary(
+    name = "my_app",
+    srcs = ["Main.java", ":build_info"],
+    main_class = "com.example.Main",
+)
+```
+
+This will generate a Java source file containing the workspace status values as string constants,
+which you can then use in your Java code:
+
+```java
+// In your Java code
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Build label: " + BuildInfo.BUILD_LABEL);
+        System.out.println("Build host: " + BuildInfo.BUILD_HOST);
+        System.out.println("Build user: " + BuildInfo.BUILD_USER);
+    }
+}
+```
+
 #### `--[no]stamp` {#stamp}
 
 This option, in conjunction with the `stamp` rule attribute, controls whether to

--- a/site/en/docs/user-manual.md
+++ b/site/en/docs/user-manual.md
@@ -1266,6 +1266,59 @@ echo "STABLE_USER_NAME $USER"
 Pass this program's path with `--workspace_status_command`, and the stable status file
 will include the STABLE lines and the volatile status file will include the rest of the lines.
 
+#### Using workspace status in your build
+
+The status key-value pairs can be used in your build through Starlark actions and templates.
+Bazel provides built-in rules like `cc_binary` and `genrule` that support the `stamp` attribute,
+which can embed workspace status information into the compiled binaries.
+
+For example, when using `cc_binary` with `stamp = 1`, Bazel will automatically make the workspace
+status available to the build. You can then access these values through template files:
+
+```python
+# In your BUILD file
+cc_binary(
+    name = "my_binary",
+    srcs = ["main.cc"],
+    stamp = 1,  # Enable stamping to include workspace status
+)
+
+# For custom use of workspace status, you can use ctx.actions.declare_file
+# and read the status files from ctx.workspace_status
+```
+
+For Java projects, you can use the `bazel_java_build_info` rule to generate Java source files
+with workspace status information:
+
+```python
+load("@bazel_tools//tools/build_defs/build_info:bazel_java_build_info.bzl", "bazel_java_build_info")
+
+bazel_java_build_info(
+    name = "build_info",
+    stamp = 1,
+)
+
+java_binary(
+    name = "my_app",
+    srcs = ["Main.java", ":build_info"],
+    main_class = "com.example.Main",
+)
+```
+
+This will generate a Java source file containing the workspace status values as string constants,
+which you can then use in your Java code:
+
+```java
+// In your Java code
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Build label: " + BuildInfo.BUILD_LABEL);
+        System.out.println("Build host: " + BuildInfo.BUILD_HOST);
+        System.out.println("Build user: " + BuildInfo.BUILD_USER);
+    }
+}
+```
+
 #### `--[no]stamp` {:#stamp}
 
 This option, in conjunction with the `stamp` rule attribute, controls whether to


### PR DESCRIPTION
Fixes #17163

This commit adds comprehensive documentation showing how to use the output of --workspace_status_command in actual build files. Previously, the documentation only explained how to create a workspace status script, but did not show how to consume the resulting stable-status.txt and volatile-status.txt files in BUILD files.

The new documentation includes:
- Explanation of how workspace status integrates with the stamp attribute
- Example for cc_binary with stamp enabled
- Example for Java projects using bazel_java_build_info rule
- Sample Java code showing how to access the generated build info constants

This addresses the feature request for a self-contained example of workspace_status_command usage.

Co-Authored-By: yadavrajkaran854@gmail.com

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
