### PR TITLE
Fix `RepositoryName` interning and codec

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/BUILD
@@ -65,7 +65,6 @@ java_library(
         "//src/main/java/net/starlark/java/syntax",
         "//src/main/protobuf:failure_details_java_proto",
         "//third_party:auto_value",
-        "//third_party:caffeine",
         "//third_party:guava",
         "//third_party:jsr305",
         "@com_google_protobuf//:protobuf_java",

--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
@@ -368,10 +368,13 @@ public final class RepositoryName {
     @Override
     public RepositoryName deserialize(LeafDeserializationContext context, CodedInputStream codedIn)
         throws SerializationException, IOException {
-      return new RepositoryName(
-          context.deserializeLeaf(codedIn, stringCodec()),
-          context.deserializeLeaf(codedIn, this),
-          context.deserializeLeaf(codedIn, stringCodec()));
+      String name = context.deserializeLeaf(codedIn, stringCodec());
+      RepositoryName contextRepoIfNotVisible = context.deserializeLeaf(codedIn, this);
+      String didYouMeanSuffix = context.deserializeLeaf(codedIn, stringCodec());
+      RepositoryName repositoryName = createUnvalidated(name);
+      return contextRepoIfNotVisible == null
+          ? repositoryName
+          : repositoryName.toNonVisible(contextRepoIfNotVisible, didYouMeanSuffix);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
@@ -43,7 +43,6 @@ public final class RepositoryName {
 
   private static final Interner<RepositoryName> interner = BlazeInterners.newWeakInterner();
 
-  // Interned so that creating one of these by name returns the constant itself.
   @SerializationConstant
   public static final RepositoryName BAZEL_TOOLS = createUnvalidated("bazel_tools");
 

--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
@@ -14,14 +14,12 @@
 
 package com.google.devtools.build.lib.cmdline;
 
-import static com.google.common.base.Throwables.throwIfInstanceOf;
-import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.devtools.build.lib.skyframe.serialization.strings.UnsafeStringCodec.stringCodec;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Interner;
+import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.skyframe.serialization.LeafDeserializationContext;
 import com.google.devtools.build.lib.skyframe.serialization.LeafObjectCodec;
 import com.google.devtools.build.lib.skyframe.serialization.LeafSerializationContext;
@@ -35,7 +33,6 @@ import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
 import java.io.IOException;
 import java.util.Objects;
-import java.util.concurrent.CompletionException;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
@@ -44,13 +41,16 @@ import net.starlark.java.eval.Starlark;
 /** The canonical name of an external repository. */
 public final class RepositoryName {
 
-  @SerializationConstant
-  public static final RepositoryName BAZEL_TOOLS = new RepositoryName("bazel_tools");
+  private static final Interner<RepositoryName> interner = BlazeInterners.newWeakInterner();
 
-  @SerializationConstant public static final RepositoryName MAIN = new RepositoryName("");
+  // Interned so that creating one of these by name returns the constant itself.
+  @SerializationConstant
+  public static final RepositoryName BAZEL_TOOLS = createUnvalidated("bazel_tools");
+
+  @SerializationConstant public static final RepositoryName MAIN = createUnvalidated("");
 
   @SerializationConstant
-  public static final RepositoryName BUILTINS = new RepositoryName("_builtins");
+  public static final RepositoryName BUILTINS = createUnvalidated("_builtins");
 
   private static final Pattern VALID_REPO_NAME = Pattern.compile("[\\w\\-.+]*");
 
@@ -63,48 +63,19 @@ public final class RepositoryName {
    */
   public static final Pattern VALID_MODULE_NAME = Pattern.compile("[a-z]([a-z0-9._-]*[a-z0-9])?");
 
-  private static final LoadingCache<String, RepositoryName> repositoryNameCache =
-      Caffeine.newBuilder()
-          .weakValues()
-          .build(
-              name -> {
-                validate(name);
-                return new RepositoryName(name.intern());
-              });
-
   /**
    * Makes sure that name is a valid repository name and creates a new RepositoryName using it.
    *
    * @throws LabelSyntaxException if the name is invalid
    */
   public static RepositoryName create(String name) throws LabelSyntaxException {
-    if (name.isEmpty()) {
-      return MAIN;
-    }
-    if (name.equals(BUILTINS.name)) {
-      return BUILTINS;
-    }
-    try {
-      return repositoryNameCache.get(name);
-    } catch (CompletionException e) {
-      throwIfInstanceOf(e.getCause(), LabelSyntaxException.class);
-      throwIfUnchecked(e.getCause());
-      throw e;
-    }
+    validate(name);
+    return createUnvalidated(name);
   }
 
   /** Creates a RepositoryName from a known-valid string. */
   public static RepositoryName createUnvalidated(String name) {
-    if (name.isEmpty()) {
-      // NOTE(wyv): Without this `if` clause, a lot of Google-internal integration tests would start
-      //   failing. This suggests to me that something is comparing RepositoryName objects using
-      //   reference equality instead of #equals().
-      return MAIN;
-    }
-    if (name.equals(BUILTINS.name)) {
-      return BUILTINS;
-    }
-    return repositoryNameCache.get(name);
+    return interner.intern(new RepositoryName(name));
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryNameTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryNameTest.java
@@ -131,4 +131,24 @@ public class RepositoryNameTest {
             RepositoryName.create("foo").toNonVisible(RepositoryName.create("owner")))
         .runTests();
   }
+
+  @Test
+  public void create_returnsInternedInstance() throws Exception {
+    assertThat(RepositoryName.create("foo")).isSameInstanceAs(RepositoryName.create("foo"));
+    assertThat(RepositoryName.create("foo"))
+        .isSameInstanceAs(RepositoryName.createUnvalidated("foo"));
+  }
+
+  @Test
+  public void create_wellKnownName_returnsConstant() throws Exception {
+    assertThat(RepositoryName.create("")).isSameInstanceAs(RepositoryName.MAIN);
+    assertThat(RepositoryName.create("bazel_tools")).isSameInstanceAs(RepositoryName.BAZEL_TOOLS);
+    assertThat(RepositoryName.create("_builtins")).isSameInstanceAs(RepositoryName.BUILTINS);
+
+    assertThat(RepositoryName.createUnvalidated("")).isSameInstanceAs(RepositoryName.MAIN);
+    assertThat(RepositoryName.createUnvalidated("bazel_tools"))
+        .isSameInstanceAs(RepositoryName.BAZEL_TOOLS);
+    assertThat(RepositoryName.createUnvalidated("_builtins"))
+        .isSameInstanceAs(RepositoryName.BUILTINS);
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryNameTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryNameTest.java
@@ -129,6 +129,15 @@ public class RepositoryNameTest {
     new SerializationTester(
             RepositoryName.create("foo"),
             RepositoryName.create("foo").toNonVisible(RepositoryName.create("owner")))
+        .<RepositoryName>setVerificationFunction(
+            (original, deserialized) -> {
+              assertThat(deserialized).isEqualTo(original);
+              // Instances must stay canonical across separate serialized streams.
+              if (deserialized.isVisible()) {
+                assertThat(deserialized)
+                    .isSameInstanceAs(RepositoryName.createUnvalidated(deserialized.getName()));
+              }
+            })
         .runTests();
   }
 


### PR DESCRIPTION
### Description

Replace `RepositoryName`'s insufficient and wasteful interning with a standard weak interner. It used to mix interning by strongly retained key and string interning, but also didn't intern on the deserialization path. 

### Motivation

Reduces memory usage, fix an existing note and makes (de-)serialization for non-main repositories work as expected.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
