### PR TITLE
Don't terminate the full nested set walk on partially added nodes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/collect/nestedset/ArtifactNestedSetKey.java
+++ b/src/main/java/com/google/devtools/build/lib/collect/nestedset/ArtifactNestedSetKey.java
@@ -111,12 +111,19 @@ public final class ArtifactNestedSetKey implements ExecutionPhaseSkyKey {
    * key}, including all child {@link ArtifactNestedSetKey} nodes and non-source artifacts.
    *
    * <p>This is used in the imprecise/legacy rewinding case where any lost input in a nested set
-   * results in rewinding all artifacts within it. The walk is terminated when a node is already in
-   * the rewind graph.
+   * results in rewinding all artifacts within it. The walk is terminated when a node has already
+   * been fully expanded, as tracked by {@code fullyExpanded}.
+   *
+   * <p>Membership in {@code rewindGraph} must not be used as the termination condition: a node may
+   * already be in the graph because {@link #addNestedSetPathsToRewindGraph} added only the paths
+   * within it that lead to a lost artifact, in which case its remaining children still need to be
+   * added.
    */
   public static void addEntireNestedSetToRewindGraph(
-      MutableGraph<SkyKey> rewindGraph, ArtifactNestedSetKey key) {
-    if (rewindGraph.nodes().contains(key)) {
+      MutableGraph<SkyKey> rewindGraph,
+      ArtifactNestedSetKey key,
+      Set<ArtifactNestedSetKey> fullyExpanded) {
+    if (!fullyExpanded.add(key)) {
       return;
     }
     for (Object child : key.children) {
@@ -126,7 +133,7 @@ public final class ArtifactNestedSetKey implements ExecutionPhaseSkyKey {
         }
       } else {
         ArtifactNestedSetKey nextNode = createInternal((Object[]) child);
-        addEntireNestedSetToRewindGraph(rewindGraph, nextNode);
+        addEntireNestedSetToRewindGraph(rewindGraph, nextNode, fullyExpanded);
         rewindGraph.putEdge(key, nextNode);
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/rewinding/ActionRewindStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/rewinding/ActionRewindStrategy.java
@@ -406,6 +406,7 @@ public final class ActionRewindStrategy {
     // TODO(b/395634488): This should be solved in a more elegant way, but a solution is needed to
     // unblock the simplifications to Fileset (b/394611260)
     Set<ArtifactNestedSetKey> seenNestedSets = precise ? new HashSet<>() : null;
+    Set<ArtifactNestedSetKey> fullyExpandedNestedSets = new HashSet<>();
 
     for (var entry : nestedSetsForPropagatingActions.entries()) {
       ActionAndLookupData root = entry.getKey();
@@ -420,8 +421,11 @@ public final class ActionRewindStrategy {
             rewindGraph, rootKey, nestedSetKey, lostInputsAndTransitiveOwners, seenNestedSets);
       } else {
         // This block isn't expected to execute in practice when precise=true. The exception is a
-        // runfiles SymlinkTreeAction on Windows, which takes all artifacts as inputs.
-        ArtifactNestedSetKey.addEntireNestedSetToRewindGraph(rewindGraph, nestedSetKey);
+        // runfiles SymlinkTreeAction on Windows, which takes all artifacts as inputs. Note that it
+        // shares its input NestedSet with the runfiles RunfilesTreeAction, so this may visit nodes
+        // that the precise walk above has already partially added to the rewind graph.
+        ArtifactNestedSetKey.addEntireNestedSetToRewindGraph(
+            rewindGraph, nestedSetKey, fullyExpandedNestedSets);
         rewindGraph.putEdge(rootKey, nestedSetKey);
       }
     }

--- a/src/test/java/com/google/devtools/build/lib/collect/nestedset/ArtifactNestedSetKeyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/collect/nestedset/ArtifactNestedSetKeyTest.java
@@ -1,0 +1,137 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.collect.nestedset;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.MutableGraph;
+import com.google.devtools.build.lib.actions.ActionLookupData;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
+import com.google.devtools.build.lib.actions.ArtifactRoot;
+import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import com.google.devtools.build.skyframe.SkyKey;
+import java.util.HashSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ArtifactNestedSetKey}'s rewind graph construction. */
+@RunWith(JUnit4.class)
+public final class ArtifactNestedSetKeyTest {
+
+  private static final FileSystem FS = new InMemoryFileSystem(DigestHashFunction.SHA256);
+  private static final ArtifactRoot ROOT =
+      ArtifactRoot.asDerivedRoot(FS.getPath("/execroot"), RootType.OUTPUT, "out");
+
+  /**
+   * Stands in for the {@link ActionLookupData} of an aggregator action such as {@code
+   * RunfilesTreeAction}, for which {@code ActionRewindStrategy} takes the precise branch.
+   */
+  private static final SkyKey AGGREGATOR = actionKey(1000);
+
+  /**
+   * Stands in for the {@link ActionLookupData} of a non-aggregator action that insensitively
+   * propagates inputs, such as a runfiles {@code SymlinkTreeAction} on Windows, for which {@code
+   * ActionRewindStrategy} takes the imprecise branch.
+   */
+  private static final SkyKey PROPAGATOR = actionKey(1001);
+
+  private int nextActionIndex = 0;
+
+  @Test
+  public void entireNestedSetAfterPrecisePartialWalk_addsRemainingLeaves() {
+    DerivedArtifact lost = derivedArtifact("lost");
+    DerivedArtifact untouched = derivedArtifact("untouched");
+    ArtifactNestedSetKey key =
+        keyOf(NestedSetBuilder.<Artifact>stableOrder().add(lost).add(untouched).build());
+
+    MutableGraph<SkyKey> rewindGraph = newRewindGraph();
+    ArtifactNestedSetKey.addNestedSetPathsToRewindGraph(
+        rewindGraph, AGGREGATOR, key, ImmutableSet.of(lost), new HashSet<>());
+    ArtifactNestedSetKey.addEntireNestedSetToRewindGraph(rewindGraph, key, new HashSet<>());
+
+    assertThat(rewindGraph.nodes()).contains(Artifact.key(untouched));
+    assertThat(rewindGraph.successors(key))
+        .containsExactly(Artifact.key(lost), Artifact.key(untouched));
+  }
+
+  @Test
+  public void entireNestedSetAfterPrecisePartialWalk_addsIntermediateNodes() {
+    DerivedArtifact lost = derivedArtifact("lost");
+    DerivedArtifact untouched = derivedArtifact("untouched");
+    DerivedArtifact alsoUntouched = derivedArtifact("also_untouched");
+    NestedSet<Artifact> inner =
+        NestedSetBuilder.<Artifact>stableOrder().add(untouched).add(alsoUntouched).build();
+    NestedSet<Artifact> outer =
+        NestedSetBuilder.<Artifact>stableOrder().add(lost).addTransitive(inner).build();
+    ArtifactNestedSetKey outerKey = keyOf(outer);
+    ArtifactNestedSetKey innerKey = keyOf(inner);
+
+    MutableGraph<SkyKey> rewindGraph = newRewindGraph();
+    ArtifactNestedSetKey.addNestedSetPathsToRewindGraph(
+        rewindGraph, AGGREGATOR, outerKey, ImmutableSet.of(lost), new HashSet<>());
+    ArtifactNestedSetKey.addEntireNestedSetToRewindGraph(rewindGraph, outerKey, new HashSet<>());
+    rewindGraph.putEdge(PROPAGATOR, outerKey);
+
+    // Without the intermediate node, the leaves below it are rewound while a done
+    // ArtifactNestedSetValue still depends on them.
+    assertThat(rewindGraph.nodes()).contains(innerKey);
+    assertThat(rewindGraph.successors(innerKey))
+        .containsExactly(Artifact.key(untouched), Artifact.key(alsoUntouched));
+  }
+
+  @Test
+  public void precisePartialWalkAfterEntireNestedSet_addsRemainingLeaves() {
+    DerivedArtifact lost = derivedArtifact("lost");
+    DerivedArtifact untouched = derivedArtifact("untouched");
+    ArtifactNestedSetKey key =
+        keyOf(NestedSetBuilder.<Artifact>stableOrder().add(lost).add(untouched).build());
+
+    MutableGraph<SkyKey> rewindGraph = newRewindGraph();
+    ArtifactNestedSetKey.addEntireNestedSetToRewindGraph(rewindGraph, key, new HashSet<>());
+    ArtifactNestedSetKey.addNestedSetPathsToRewindGraph(
+        rewindGraph, AGGREGATOR, key, ImmutableSet.of(lost), new HashSet<>());
+
+    assertThat(rewindGraph.successors(key))
+        .containsExactly(Artifact.key(lost), Artifact.key(untouched));
+    assertThat(rewindGraph.successors(AGGREGATOR)).containsExactly(key);
+  }
+
+  private static MutableGraph<SkyKey> newRewindGraph() {
+    return GraphBuilder.directed().allowsSelfLoops(false).build();
+  }
+
+  private static ArtifactNestedSetKey keyOf(NestedSet<Artifact> set) {
+    return ArtifactNestedSetKey.create(set);
+  }
+
+  private DerivedArtifact derivedArtifact(String name) {
+    DerivedArtifact artifact =
+        DerivedArtifact.create(
+            ROOT, ROOT.getExecPath().getRelative(name), ActionsTestUtil.NULL_ARTIFACT_OWNER);
+    artifact.setGeneratingActionKey(actionKey(nextActionIndex++));
+    return artifact;
+  }
+
+  private static ActionLookupData actionKey(int actionIndex) {
+    return ActionLookupData.create(ActionsTestUtil.NULL_ARTIFACT_OWNER, actionIndex);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/collect/nestedset/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/collect/nestedset/BUILD
@@ -14,6 +14,24 @@ filegroup(
 )
 
 java_test(
+    name = "ArtifactNestedSetKeyTest",
+    srcs = ["ArtifactNestedSetKeyTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions:action_lookup_data",
+        "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
+        "//src/main/java/com/google/devtools/build/lib/collect/nestedset:artifact_nested_set_key",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs",
+        "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
+        "//src/test/java/com/google/devtools/build/lib/actions/util",
+        "//third_party:guava",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
+java_test(
     name = "CompileOrderExpanderTest",
     srcs = ["CompileOrderExpanderTest.java"],
     deps = [


### PR DESCRIPTION
### Description

`ArtifactNestedSetKey#addEntireNestedSetToRewindGraph` used membership in the rewind graph as its termination condition. That is only sound if every `ArtifactNestedSetKey` in the graph was put there by a full expansion. With `--experimental_precise_rewinding` that is no longer the case: `addNestedSetPathsToRewindGraph` adds a node to the graph after adding only the paths within it that lead to a lost artifact, so a subsequent full walk that reaches the same node returns immediately and leaves the node's remaining children — and its intermediate `ArtifactNestedSetKey` descendants — out of the rewind graph.

This commit replaces the termination condition with an explicit set of fully expanded nodes, threaded through the walk the same way `addNestedSetPathsToRewindGraph` already threads its `seen` set, and adds `ArtifactNestedSetKeyTest` covering both orderings.

### Motivation

Both branches of the loop over `nestedSetsForPropagatingActions` in `ActionRewindStrategy#prepareRewindPlan` can run in the same rewind plan on Windows.

`SymlinkTreeAction.computeInputs` adds `runfiles.getAllArtifacts()` to its inputs when `runfileSymlinksMode == CREATE && OS.getCurrent() == OS.WINDOWS`, and `RunfilesSupport.createRunfilesTreeArtifactAction` builds `RunfilesTreeAction`'s inputs from the same memoized `NestedSet`. Since `ArtifactNestedSetKey` interns on the identity of the backing `Object[]`, the two actions share a key. `RunfilesTreeAction` is an aggregator and takes the precise branch; `SymlinkTreeAction` is not and takes the full-expansion branch. Which one reaches the shared key first depends on the iteration order of a `HashMultimap`.

When the precise branch wins, the intermediate nested set nodes below the shared key are never dirtied while the artifacts underneath them are, leaving done `ArtifactNestedSetValue`s depending on rewound nodes — the inconsistency that `patchNestedSetGraphToPropagateError` exists to repair after the fact.

The full-expansion branch is unreachable in precise mode on every other platform, so this has no test coverage today; the new unit test exercises the graph construction directly rather than depending on a Windows-only build.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
