### PR TITLE
Fix hang on `include()` cycles in MODULE.bazel

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -79,6 +79,7 @@ import com.google.devtools.build.skyframe.SkyframeLookupResult;
 import com.google.errorprone.annotations.FormatMethod;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -374,9 +375,14 @@ public class ModuleFileFunction implements SkyFunction {
   }
 
   /**
-   * Reads, parses, and compiles all included module files named by {@code horizon}, stores the
-   * result in {@code includeLabelToCompiledModuleFile}, and finally returns the include statements
-   * of these newly compiled module files as a new "horizon".
+   * Reads, parses, and compiles all module files named by {@code horizon} that haven't been
+   * compiled yet, stores the result in {@code includeLabelToCompiledModuleFile}, and finally
+   * returns the include statements of these newly compiled module files as a new "horizon".
+   *
+   * <p>Skipping files that have already been compiled isn't just an optimization: without it, an
+   * {@code include()} cycle would keep the horizon non-empty forever and a "diamond" include
+   * structure would result in a number of compilations exponential in the include depth. Cycles are
+   * reported as an error when the module file is executed, see {@link ModuleThreadContext#include}.
    */
   @Nullable
   private static ImmutableList<IncludeStatement> advanceHorizon(
@@ -387,13 +393,24 @@ public class ModuleFileFunction implements SkyFunction {
       StarlarkSemantics starlarkSemantics,
       BazelStarlarkEnvironment starlarkEnv)
       throws ModuleFileFunctionException, InterruptedException {
+    var seenIncludeLabels = new HashSet<>(includeLabelToCompiledModuleFile.keySet());
+    var pendingBuilder = ImmutableList.<IncludeStatement>builder();
+    for (var includeStatement : horizon) {
+      if (seenIncludeLabels.add(includeStatement.includeLabel())) {
+        pendingBuilder.add(includeStatement);
+      }
+    }
+    ImmutableList<IncludeStatement> pending = pendingBuilder.build();
+    if (pending.isEmpty()) {
+      return ImmutableList.of();
+    }
     // Includes are only allowed in the root module as well as those with non-registry overrides, so
     // their repo name never contains a version.
     var repoContext =
         Label.RepoContext.of(
             moduleKey.getCanonicalRepoNameWithoutVersion(), RepositoryMapping.EMPTY);
-    var includeLabels = new ArrayList<Label>(horizon.size());
-    for (var includeStatement : horizon) {
+    var includeLabels = new ArrayList<Label>(pending.size());
+    for (var includeStatement : pending) {
       if (!includeStatement.includeLabel().startsWith("//")) {
         throw errorf(
             Code.BAD_MODULE,
@@ -439,8 +456,8 @@ public class ModuleFileFunction implements SkyFunction {
             includeLabels.stream()
                 .map(l -> (SkyKey) PackageLookupValue.key(l.getPackageIdentifier()))
                 .collect(toImmutableSet()));
-    var rootedPaths = new ArrayList<RootedPath>(horizon.size());
-    for (int i = 0; i < horizon.size(); i++) {
+    var rootedPaths = new ArrayList<RootedPath>(pending.size());
+    for (int i = 0; i < pending.size(); i++) {
       Label includeLabel = includeLabels.get(i);
       PackageLookupValue pkgLookupValue =
           (PackageLookupValue)
@@ -458,8 +475,8 @@ public class ModuleFileFunction implements SkyFunction {
         throw errorf(
             Code.BAD_MODULE,
             "unable to load package for '%s' included at %s: %s",
-            horizon.get(i).includeLabel(),
-            horizon.get(i).location(),
+            pending.get(i).includeLabel(),
+            pending.get(i).location(),
             message);
       }
       rootedPaths.add(
@@ -469,7 +486,7 @@ public class ModuleFileFunction implements SkyFunction {
         env.getValuesAndExceptions(
             rootedPaths.stream().map(FileValue::key).collect(toImmutableSet()));
     var newHorizon = ImmutableList.<IncludeStatement>builder();
-    for (int i = 0; i < horizon.size(); i++) {
+    for (int i = 0; i < pending.size(); i++) {
       FileValue fileValue = (FileValue) result.get(FileValue.key(rootedPaths.get(i)));
       if (fileValue == null) {
         return null;
@@ -478,8 +495,8 @@ public class ModuleFileFunction implements SkyFunction {
         throw errorf(
             Code.BAD_MODULE,
             "error reading '%s' included at %s: not a regular file",
-            horizon.get(i).includeLabel(),
-            horizon.get(i).location());
+            pending.get(i).includeLabel(),
+            pending.get(i).location());
       }
       byte[] bytes;
       try {
@@ -488,8 +505,8 @@ public class ModuleFileFunction implements SkyFunction {
         throw errorf(
             Code.BAD_MODULE,
             "error reading '%s' included at %s: %s",
-            horizon.get(i).includeLabel(),
-            horizon.get(i).location(),
+            pending.get(i).includeLabel(),
+            pending.get(i).location(),
             e.getMessage());
       }
       try {
@@ -500,7 +517,7 @@ public class ModuleFileFunction implements SkyFunction {
                 starlarkSemantics,
                 starlarkEnv,
                 env.getListener());
-        includeLabelToCompiledModuleFile.put(horizon.get(i).includeLabel(), compiledModuleFile);
+        includeLabelToCompiledModuleFile.put(pending.get(i).includeLabel(), compiledModuleFile);
         newHorizon.addAll(compiledModuleFile.includeStatements());
       } catch (ExternalDepsException e) {
         throw new ModuleFileFunctionException(e, Transience.PERSISTENT);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
@@ -31,9 +31,11 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.SequencedSet;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Starlark;
@@ -59,6 +61,9 @@ public class ModuleThreadContext extends StarlarkThreadContext {
 
   private final Map<String, RepoOverride> overriddenRepos = new HashMap<>();
   private final Map<String, RepoOverride> overridingRepos = new HashMap<>();
+
+  /** The labels of the module files that are currently being executed via {@link #include}. */
+  private final SequencedSet<String> includeStack = new LinkedHashSet<>();
 
   public static ModuleThreadContext fromOrFail(StarlarkThread thread, String what)
       throws EvalException {
@@ -337,10 +342,23 @@ public class ModuleThreadContext extends StarlarkThreadContext {
       // compiled before evaluation started.
       throw Starlark.errorf("internal error; included file %s not compiled", includeLabel);
     }
+    if (!includeStack.add(includeLabel)) {
+      // include() behaves as if the included file were textually inserted at the location of the
+      // call, so a cycle would result in unbounded recursion.
+      var chain = ImmutableList.copyOf(includeStack);
+      throw Starlark.errorf(
+          "include() cycle detected: %s -> %s",
+          String.join(" -> ", chain.subList(chain.indexOf(includeLabel), chain.size())),
+          includeLabel);
+    }
     PathFragment includer = currentModuleFilePath;
     currentModuleFilePath = Label.parseCanonicalUnchecked(includeLabel).toPathFragment();
-    compiledModuleFile.runOnThread(thread);
-    currentModuleFilePath = includer;
+    try {
+      compiledModuleFile.runOnThread(thread);
+    } finally {
+      currentModuleFilePath = includer;
+      includeStack.remove(includeLabel);
+    }
   }
 
   public PathFragment getCurrentModuleFilePath() {

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -485,6 +485,89 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
   }
 
   @Test
+  public void testRootModule_include_bad_selfCycle() throws Exception {
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa')",
+        "include('//java:java.MODULE.bazel')");
+    scratch.overwriteFile(rootDirectory.getRelative("java/BUILD").getPathString());
+    scratch.overwriteFile(
+        rootDirectory.getRelative("java/java.MODULE.bazel").getPathString(),
+        "include('//java:java.MODULE.bazel')");
+    FakeRegistry registry = registryFactory.newFakeRegistry("/foo");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+
+    reporter.removeHandler(failFastHandler); // expect failures
+    EvaluationResult<RootModuleFileValue> result =
+        evaluator.evaluate(
+            ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
+    assertThat(result.hasError()).isTrue();
+    assertContainsEvent(
+        "include() cycle detected: //java:java.MODULE.bazel -> //java:java.MODULE.bazel");
+  }
+
+  @Test
+  public void testRootModule_include_bad_indirectCycle() throws Exception {
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa')",
+        "include('//java:java.MODULE.bazel')");
+    scratch.overwriteFile(rootDirectory.getRelative("java/BUILD").getPathString());
+    scratch.overwriteFile(
+        rootDirectory.getRelative("java/java.MODULE.bazel").getPathString(),
+        "include('//python:python.MODULE.bazel')");
+    scratch.overwriteFile(rootDirectory.getRelative("python/BUILD").getPathString());
+    scratch.overwriteFile(
+        rootDirectory.getRelative("python/python.MODULE.bazel").getPathString(),
+        "include('//java:java.MODULE.bazel')");
+    FakeRegistry registry = registryFactory.newFakeRegistry("/foo");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+
+    reporter.removeHandler(failFastHandler); // expect failures
+    EvaluationResult<RootModuleFileValue> result =
+        evaluator.evaluate(
+            ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
+    assertThat(result.hasError()).isTrue();
+    assertContainsEvent(
+        "include() cycle detected: //java:java.MODULE.bazel -> //python:python.MODULE.bazel ->"
+            + " //java:java.MODULE.bazel");
+  }
+
+  @Test
+  public void testRootModule_include_sameFileMultipleTimes() throws Exception {
+    // The same file can be reached via multiple include() paths; it is then executed once per path,
+    // just as if its contents had been inlined at each call site.
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa')",
+        "include('//java:java.MODULE.bazel')",
+        "include('//python:python.MODULE.bazel')");
+    scratch.overwriteFile(rootDirectory.getRelative("java/BUILD").getPathString());
+    scratch.overwriteFile(
+        rootDirectory.getRelative("java/java.MODULE.bazel").getPathString(),
+        "include('//common:common.MODULE.bazel')");
+    scratch.overwriteFile(rootDirectory.getRelative("python/BUILD").getPathString());
+    scratch.overwriteFile(
+        rootDirectory.getRelative("python/python.MODULE.bazel").getPathString(),
+        "include('//common:common.MODULE.bazel')");
+    scratch.overwriteFile(rootDirectory.getRelative("common/BUILD").getPathString());
+    scratch.overwriteFile(
+        rootDirectory.getRelative("common/common.MODULE.bazel").getPathString(),
+        "register_toolchains('//:common-toolchain')");
+    FakeRegistry registry = registryFactory.newFakeRegistry("/foo");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+
+    EvaluationResult<RootModuleFileValue> result =
+        evaluator.evaluate(
+            ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
+    if (result.hasError()) {
+      fail(result.getError().toString());
+    }
+    assertThat(result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE).module().getToolchainsToRegister())
+        .containsExactly("//:common-toolchain", "//:common-toolchain");
+  }
+
+  @Test
   public void testRootModule_include_bad_moduleAfterInclude() throws Exception {
     scratch.overwriteFile(
         rootDirectory.getRelative("MODULE.bazel").getPathString(),


### PR DESCRIPTION
### Description

`ModuleFileFunction#advanceHorizon` compiles the module files named by the current horizon of `include()` statements and returns their own `include()` statements as the next horizon, without ever checking whether a file has already been compiled. A cycle among included files thus keeps the horizon non-empty forever, so that `ModuleFileFunction` spins in an endless loop, re-reading and re-compiling the same files until the build is interrupted. For the same reason, a "diamond" include structure results in a number of compilations that is exponential in the include depth.

This PR skips include labels that have already been compiled (or that appear more than once in the same horizon) when advancing the horizon, which makes the loop terminate, and reports actual cycles as an error when the module file is executed, where the chain of `include()` calls is readily available:

```
ERROR: .../MODULE.bazel:1:8: include() cycle detected: //java:java.MODULE.bazel -> //python:python.MODULE.bazel -> //java:java.MODULE.bazel
```

Note that skipping already-compiled files does not change evaluation semantics: `include()` behaves as if the included file were textually inserted at the location of the call, and a file reachable via multiple `include()` paths is still executed once per path. Only the compilation of the file is shared.

### Motivation

A single typo in a `MODULE.bazel` file (e.g. a `foo.MODULE.bazel` that includes itself) currently makes Bazel spin at 100% CPU with no output and no way to make progress. `include()` is only allowed in the root module and in modules with a non-registry override, so this is reachable from user-authored files.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Cycles between `MODULE.bazel` files connected via `include()` are now reported as an error instead of hanging the build.