### PR TITLE
Rerun extensions when the root module's dev-ness changes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionUsage.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionUsage.java
@@ -167,17 +167,43 @@ public abstract class ModuleExtensionUsage {
     // preserves correctness in case new fields are added without updating this code.
     return toBuilder()
         .setTags(getTags().stream().map(Tag::trimForEvaluation).collect(toImmutableList()))
-        // Clear out all proxies as information contained therein isn't useful for evaluation.
+        // Reduce the proxies to the only piece of information about them that the extension can
+        // observe: whether there are any dev and/or non-dev usages, which is exposed to the root
+        // module's extensions as module_ctx.root_module_has_non_dev_dependency.
         // Locations are only used for error reporting and thus don't influence whether the
         // evaluation of the extension is successful and what its result is in case of success.
         // Extension implementation functions do not see the imports, they are only validated
         // against the set of generated repos in a validation step that comes afterward.
-        .setProxies(ImmutableList.of())
+        .setProxies(trimProxiesForEvaluation())
         // Tracked in SingleExtensionUsagesValue instead, using canonical instead of apparent names.
         // Whether this override must apply to an existing repo as well as its source location also
         // don't influence the evaluation of the extension as they are checked in
         // SingleExtensionFunction.
         .setRepoOverrides(ImmutableMap.of())
+        .build();
+  }
+
+  /**
+   * Returns at most two content-free proxies, one for each of {@link #getHasNonDevUseExtension} and
+   * {@link #getHasDevUseExtension} that holds.
+   */
+  private ImmutableList<Proxy> trimProxiesForEvaluation() {
+    var proxies = ImmutableList.<Proxy>builder();
+    if (getHasNonDevUseExtension()) {
+      proxies.add(trimmedProxy(/* devDependency= */ false));
+    }
+    if (getHasDevUseExtension()) {
+      proxies.add(trimmedProxy(/* devDependency= */ true));
+    }
+    return proxies.build();
+  }
+
+  private static Proxy trimmedProxy(boolean devDependency) {
+    return Proxy.builder()
+        .setDevDependency(devDependency)
+        .setLocation(Location.BUILTIN)
+        .setContainingModuleFilePath(PathFragment.EMPTY_FRAGMENT)
+        .setImports(ImmutableBiMap.of())
         .build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionUsage.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionUsage.java
@@ -169,7 +169,9 @@ public abstract class ModuleExtensionUsage {
         .setTags(getTags().stream().map(Tag::trimForEvaluation).collect(toImmutableList()))
         // Reduce the proxies to the only piece of information about them that the extension can
         // observe: whether there are any dev and/or non-dev usages, which is exposed to the root
-        // module's extensions as module_ctx.root_module_has_non_dev_dependency.
+        // module's extensions as module_ctx.root_module_has_non_dev_dependency. Note that this only
+        // encodes new information if the proxy doesn't carry any tags as each of those has its
+        // dev-ness tracked (see #30738).
         // Locations are only used for error reporting and thus don't influence whether the
         // evaluation of the extension is successful and what its result is in case of success.
         // Extension implementation functions do not see the imports, they are only validated

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -2622,6 +2622,65 @@ class BazelLockfileTest(test_base.TestBase):
     stderr = ''.join(stderr)
     self.assertIn('I am running the extension: 4.5.6', stderr)
 
+  def testModuleExtensionRerunsOnDevDependencyChange(self):
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            (
+                'lockfile_ext = use_extension("//:extension.bzl",'
+                ' "lockfile_ext", dev_dependency = True)'
+            ),
+            'use_repo(lockfile_ext, "hello")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def impl(ctx):',
+            '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
+            '',
+            'repo_rule = repository_rule(implementation=impl)',
+            '',
+            'def _module_ext_impl(ctx):',
+            (
+                '    print("I am running the extension: " +'
+                ' str(ctx.root_module_has_non_dev_dependency))'
+            ),
+            '    repo_rule(name="hello")',
+            '',
+            'lockfile_ext = module_extension(',
+            '    implementation=_module_ext_impl',
+            ')',
+        ],
+    )
+
+    _, _, stderr = self.RunBazel(['build', '@hello//:all'])
+    stderr = ''.join(stderr)
+    self.assertIn('I am running the extension: False', stderr)
+
+    # Shutdown bazel to empty cache and run with no changes
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(['build', '@hello//:all'])
+    stderr = ''.join(stderr)
+    self.assertNotIn('I am running the extension:', stderr)
+
+    # Turn the usage into a non-dev dependency and rerun
+    self.RunBazel(['shutdown'])
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            (
+                'lockfile_ext = use_extension("//:extension.bzl",'
+                ' "lockfile_ext")'
+            ),
+            'use_repo(lockfile_ext, "hello")',
+        ],
+    )
+    _, _, stderr = self.RunBazel(['build', '@hello//:all'])
+    stderr = ''.join(stderr)
+    self.assertIn('I am running the extension: True', stderr)
+
   def testModuleExtensionRerunsOnGetenvChanges(self):
     self.ScratchFile(
         'MODULE.bazel',

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -200,7 +200,7 @@
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "i/i90DMdIifmbl+U6MMrM7QayQUvoNf2GsYd738TxxY=",
-        "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
+        "usagesDigest": "ZQiGVXrj8yl+WvAOGWZCipKxak7/2zZWT+1/qI4Ac4U=",
         "recordedInputs": [
           "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
         ],
@@ -257,7 +257,7 @@
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
         "bzlTransitiveDigest": "K2CtbBVV3aCFwN1jN9HinfYTSjqp8rV4DuXb3kXzyDM=",
-        "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
+        "usagesDigest": "cwDr/pxIBBufM3ypvgH7wsGwkQH2zIyIbFPGTAtKXhw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
           "REPO_MAPPING:rules_python+,pypi__build rules_python++config+pypi__build",
@@ -425,7 +425,7 @@
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
         "bzlTransitiveDigest": "ijW9KS7qsIY+yBVvJ+Nr1mzwQox09j13DnE3iIwaeTM=",
-        "usagesDigest": "H8dQoNZcoqP+Mu0tHZTi4KHATzvNkM5ePuEqoQdklIU=",
+        "usagesDigest": "T2gL2j7jWAaLy4VVKveM57Xr5plhW5gICghTUpDs6dM=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
           "REPO_MAPPING:rules_python+,platforms platforms"


### PR DESCRIPTION
### Description

`module_ctx.root_module_has_non_dev_dependency` is derived from the `dev_dependency` values of the root module's `use_extension` proxies (`ModuleExtensionUsage#getHasNonDevUseExtension`), but `ModuleExtensionUsage#trimForEvaluation` clears out all proxies before the usages digest that guards the extension's lockfile entry is computed. Toggling `dev_dependency` on a root module `use_extension` call therefore doesn't invalidate that entry, so the extension keeps seeing the previous value of `root_module_has_non_dev_dependency` and the repos derived from it until something else forces it to rerun.

For example, starting from

```python
lockfile_ext = use_extension("//:extension.bzl", "lockfile_ext", dev_dependency = True)
use_repo(lockfile_ext, "hello")
```

and dropping `dev_dependency = True` does not rerun the extension, which keeps reporting `root_module_has_non_dev_dependency = False`.

Up to commit 40ec2cd1a15d73473945475552ad1d0cb6d77927, `hasDevUseExtension` and `hasNonDevUseExtension` were properties of `ModuleExtensionUsage` and thus survived trimming. That commit turned them into functions of the newly introduced proxies, which `trimForEvaluation` drops entirely. This PR restores the previous behavior by replacing the proxies with up to two content-free proxies, one for each dev-ness that occurs. Everything else about a proxy (locations, names, imports, containing module file path) stays out of the digest, so the existing guarantee that extensions are not rerun when only imports or locations change is preserved.

Note that this changes the usages digest of every extension, so extensions are rerun once after this change. Users of `--lockfile_mode=error` have to regenerate their lockfile with `bazel mod deps --lockfile_mode=update`.

### Motivation

The staleness makes a documented `module_ctx` field observably wrong, and there is no way for the user to tell: the build succeeds with repos generated from the previous value. Extensions use this field to decide whether repos that don't correspond to a tag (e.g. hub repos) are dev or non-dev dependencies.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Module extensions are now correctly rerun when the root module changes the `dev_dependency` value of a `use_extension` call, which is visible to extensions as `module_ctx.root_module_has_non_dev_dependency`.