### PR TITLE
Minor cleanups in Bzlmod resolution

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
@@ -107,7 +107,7 @@ public class BazelDepGraphFunction implements SkyFunction {
       LabelConverter labelConverter =
           new LabelConverter(
               PackageIdentifier.create(repoMapping.contextRepo(), PathFragment.EMPTY_FRAGMENT),
-              module.getRepoMappingWithBazelDepsOnly(moduleKeyToRepositoryNames));
+              repoMapping);
       for (ModuleExtensionUsage usage : module.getExtensionUsages()) {
         ModuleExtensionId moduleExtensionId;
         try {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InnateRunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InnateRunnableExtension.java
@@ -189,6 +189,10 @@ final class InnateRunnableExtension implements RunnableExtension {
     RepoRule repoRule = ((StarlarkRepoRule) exported).getRepoRule();
 
     var generatedRepoSpecs = ImmutableMap.<String, RepoSpec>builderWithExpectedSize(tags.size());
+    LabelConverter labelConverter =
+        new LabelConverter(
+            extensionId.bzlFileLabel().getPackageIdentifier(),
+            usagesValue.getRepoMappings().get(moduleKey));
     // Instantiate the repos one by one.
     for (Tag tag : tags) {
       Dict<String, Object> kwargs = tag.getAttributeValues().attributes();
@@ -196,10 +200,6 @@ final class InnateRunnableExtension implements RunnableExtension {
       String name = (String) kwargs.get("name");
       ImmutableList<StarlarkThread.CallStackEntry> fakeCallStack =
           ImmutableList.of(StarlarkThread.callStackEntry("<toplevel>", tag.getLocation()));
-      LabelConverter labelConverter =
-          new LabelConverter(
-              extensionId.bzlFileLabel().getPackageIdentifier(),
-              usagesValue.getRepoMappings().get(moduleKey));
       generatedRepoSpecs.put(
           name,
           repoRule.instantiate(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -288,11 +288,12 @@ public class ModuleFileFunction implements SkyFunction {
     var state = env.getState(State::new);
     if (state.compiledModuleFile == null) {
       RootedPath moduleFilePath = getModuleFilePath(workspaceRoot);
-      if (env.getValue(FileValue.key(moduleFilePath)) == null) {
+      FileValue moduleFileValue = (FileValue) env.getValue(FileValue.key(moduleFilePath));
+      if (moduleFileValue == null) {
         return null;
       }
       byte[] moduleFileContents;
-      if (moduleFilePath.asPath().exists()) {
+      if (moduleFileValue.exists()) {
         moduleFileContents = readModuleFile(moduleFilePath.asPath());
       } else {
         moduleFileContents = BZLMOD_REMINDER.getBytes(UTF_8);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModule.java
@@ -26,7 +26,7 @@ import com.google.devtools.build.lib.packages.LabelConverter;
 import com.google.devtools.build.lib.server.FailureDetails.ExternalDeps.Code;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.StarlarkBuiltin;
@@ -120,7 +120,7 @@ public class StarlarkBazelModule implements StarlarkValue {
             repoMapping,
             repoMappingRecorder);
     ImmutableList<Tag> tags = usage == null ? ImmutableList.of() : usage.getTags();
-    HashMap<String, ArrayList<TypeCheckedTag>> typeCheckedTags = new HashMap<>();
+    LinkedHashMap<String, ArrayList<TypeCheckedTag>> typeCheckedTags = new LinkedHashMap<>();
     for (String tagClassName : extension.tagClasses().keySet()) {
       typeCheckedTags.put(tagClassName, new ArrayList<>());
     }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
@@ -112,7 +112,9 @@ public class StarlarkBazelModuleTest {
 
     assertThat(moduleProxy.getName()).isEqualTo("foo");
     assertThat(moduleProxy.getVersion()).isEqualTo("1.0");
-    assertThat(moduleProxy.getTags().getFieldNames()).containsExactly("dep", "repos", "pom");
+    assertThat(moduleProxy.getTags().getFieldNames())
+        .containsExactly("dep", "repos", "pom")
+        .inOrder();
 
     // We have 2 "dep" tags...
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### Description

Four independent cleanups found while reading through the Bzlmod code:

* `BazelDepGraphFunction#getExtensionUsagesById` computed `Module#getRepoMappingWithBazelDepsOnly` twice per module, once for the context repo and once for the `LabelConverter`.
* `InnateRunnableExtension#run` created a new `LabelConverter` per tag, which defeats its label cache. The other two places that instantiate repo rules in a loop already share one converter.
* `ModuleFileFunction#computeForRootModule` discarded the `FileValue` for the root `MODULE.bazel` and then stat'ed the path again via `Path#exists`.
* `StarlarkBazelModule` collected the type-checked tags into a `HashMap`, so the fields of `bazel_module_tags` ended up in hash order instead of tag class declaration order. Not observable via `dir()`, which sorts, but it does leak into the default `Structure#getStarlarkType`.

### Motivation

Avoids redundant work and ensures that Skyframe state is authoritative.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
