### PR TITLE
Expose parent rule executables through DefaultInfo.executable

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/DefaultInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/DefaultInfo.java
@@ -18,6 +18,8 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.configuredtargets.AbstractConfiguredTarget;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.BuiltinProvider;
 import com.google.devtools.build.lib.packages.NativeInfo;
@@ -96,15 +98,20 @@ public abstract class DefaultInfo extends NativeInfo implements DefaultInfoApi {
         Runfiles runfiles,
         Runfiles dataRunfiles,
         Runfiles defaultRunfiles,
-        Artifact executable,
-        @Nullable FilesToRunProvider filesToRunProvider) {
+        Artifact executable) {
       super(loc);
       this.files = files;
       this.runfiles = runfiles;
       this.dataRunfiles = dataRunfiles;
       this.defaultRunfiles = defaultRunfiles;
       this.executable = executable;
-      this.filesToRunProvider = filesToRunProvider;
+      this.filesToRunProvider =
+          executable == null
+              ? null
+              : FilesToRunProvider.create(
+                  NestedSetBuilder.create(Order.STABLE_ORDER, executable),
+                  /* runfilesSupport= */ null,
+                  executable);
     }
 
     @Override
@@ -225,8 +232,7 @@ public abstract class DefaultInfo extends NativeInfo implements DefaultInfoApi {
           statelessRunfiles,
           dataRunfiles,
           defaultRunfiles,
-          castNoneToNull(Artifact.class, executable),
-          null);
+          castNoneToNull(Artifact.class, executable));
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/DefaultInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/DefaultInfo.java
@@ -18,8 +18,6 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.configuredtargets.AbstractConfiguredTarget;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
-import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
-import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.BuiltinProvider;
 import com.google.devtools.build.lib.packages.NativeInfo;
@@ -73,6 +71,8 @@ public abstract class DefaultInfo extends NativeInfo implements DefaultInfoApi {
    * If the rule producing this info object is marked 'executable' or 'test', this is an artifact
    * representing the file that should be executed to run the target. This is null otherwise.
    */
+  @Nullable
+  @Override
   public abstract Artifact getExecutable();
 
   @Override
@@ -98,20 +98,15 @@ public abstract class DefaultInfo extends NativeInfo implements DefaultInfoApi {
         Runfiles runfiles,
         Runfiles dataRunfiles,
         Runfiles defaultRunfiles,
-        Artifact executable) {
+        Artifact executable,
+        @Nullable FilesToRunProvider filesToRunProvider) {
       super(loc);
       this.files = files;
       this.runfiles = runfiles;
       this.dataRunfiles = dataRunfiles;
       this.defaultRunfiles = defaultRunfiles;
       this.executable = executable;
-      this.filesToRunProvider =
-          executable == null
-              ? null
-              : FilesToRunProvider.create(
-                  NestedSetBuilder.create(Order.STABLE_ORDER, executable),
-                  /* runfilesSupport= */ null,
-                  executable);
+      this.filesToRunProvider = filesToRunProvider;
     }
 
     @Override
@@ -191,9 +186,11 @@ public abstract class DefaultInfo extends NativeInfo implements DefaultInfoApi {
       return null;
     }
 
+    @Nullable
     @Override
     public Artifact getExecutable() {
-      return target.getProvider(FilesToRunProvider.class).getExecutable();
+      FilesToRunProvider filesToRun = getFilesToRun();
+      return filesToRun == null ? null : filesToRun.getExecutable();
     }
   }
 
@@ -232,7 +229,8 @@ public abstract class DefaultInfo extends NativeInfo implements DefaultInfoApi {
           statelessRunfiles,
           dataRunfiles,
           defaultRunfiles,
-          castNoneToNull(Artifact.class, executable));
+          castNoneToNull(Artifact.class, executable),
+          null);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/DefaultInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/DefaultInfoApi.java
@@ -65,7 +65,11 @@ public interface DefaultInfoApi extends StructApi {
       name = "files_to_run",
       doc =
           "A <a href='../providers/FilesToRunProvider.html'><code>FilesToRunProvider</code></a>"
-              + " object containing information about the executable and runfiles of the target.",
+              + " object containing information about the executable and runfiles of the target."
+              + " On a directly constructed <code>DefaultInfo</code>, including one returned by"
+              + " <code>ctx.super()</code>, this provider contains only the executable. Runfiles"
+              + " and manifests are populated only after configured-target finalization. Do not"
+              + " rely on automatic action runfiles before finalization.",
       structField = true,
       allowReturnNones = true)
   @Nullable

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/DefaultInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/DefaultInfoApi.java
@@ -62,14 +62,22 @@ public interface DefaultInfoApi extends StructApi {
   Depset getFiles();
 
   @StarlarkMethod(
+      name = "executable",
+      doc =
+          "The executable <a href='../builtins/File.html'><code>File</code></a> associated with"
+              + " this provider, or <code>None</code> if no executable is available. This field is"
+              + " available on a <code>DefaultInfo</code> returned directly by a rule"
+              + " implementation, including through <code>ctx.super()</code>.",
+      structField = true,
+      allowReturnNones = true)
+  @Nullable
+  FileApi getExecutable();
+
+  @StarlarkMethod(
       name = "files_to_run",
       doc =
           "A <a href='../providers/FilesToRunProvider.html'><code>FilesToRunProvider</code></a>"
-              + " object containing information about the executable and runfiles of the target."
-              + " On a directly constructed <code>DefaultInfo</code>, including one returned by"
-              + " <code>ctx.super()</code>, this provider contains only the executable. Runfiles"
-              + " and manifests are populated only after configured-target finalization. Do not"
-              + " rely on automatic action runfiles before finalization.",
+              + " object containing information about the executable and runfiles of the target.",
       structField = true,
       allowReturnNones = true)
   @Nullable

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/DefaultInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/DefaultInfoApi.java
@@ -64,10 +64,11 @@ public interface DefaultInfoApi extends StructApi {
   @StarlarkMethod(
       name = "executable",
       doc =
-          "The executable <a href='../builtins/File.html'><code>File</code></a> associated with"
-              + " this provider, or <code>None</code> if no executable is available. This field is"
-              + " available on a <code>DefaultInfo</code> returned directly by a rule"
-              + " implementation, including through <code>ctx.super()</code>.",
+          "A <a href='../builtins/File.html'><code>File</code></a> object representing the"
+              + " executable that should be executed to run the target, or <code>None</code> if"
+              + " unset. Should be set only for <a"
+              + " href='../globals/bzl.html#rule.executable'><code>executable</code></a> and <a"
+              + " href='../globals/bzl.html#rule.test'><code>test</code></a> targets.",
       structField = true,
       allowReturnNones = true)
   @Nullable

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -31,6 +31,7 @@ import com.google.common.truth.Correspondence;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.FilesToRunProvider;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
@@ -6151,6 +6152,89 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
     assertNoEvents();
     assertThat(rule.getRuleClassObject().isExecutableStarlark()).isTrue();
     assertThat(rule.getRuleClassObject().getRuleClassType()).isEqualTo(RuleClassType.TEST);
+  }
+
+  @Test
+  public void extendRule_parentDefaultInfoExposesExecutable() throws Exception {
+    scratch.file("extend_rule_testing/parent/BUILD");
+    scratch.file(
+        "extend_rule_testing/parent/parent.bzl",
+        """
+        def _parent_impl(ctx):
+            executable = ctx.actions.declare_file(
+                ctx.label.name + "_/unrelated_launcher.bat",
+            )
+            ctx.actions.write(executable, "", is_executable = True)
+            return DefaultInfo(
+                executable = executable,
+                runfiles = ctx.runfiles(files = [ctx.file.runtime_data]),
+            )
+
+        parent_test = rule(
+            implementation = _parent_impl,
+            attrs = {"runtime_data": attr.label(allow_single_file = True)},
+            test = True,
+            extendable = True,
+        )
+        """);
+    scratch.file(
+        "extend_rule_testing/child.bzl",
+        """
+        load("//extend_rule_testing/parent:parent.bzl", "parent_test")
+
+        def _child_impl(ctx):
+            parent_default = ctx.super()[0]
+            if parent_default.files != None:
+                fail("parent DefaultInfo.files should be unset")
+
+            files_to_run = parent_default.files_to_run
+            if files_to_run == None:
+                fail("parent DefaultInfo.files_to_run should contain its executable")
+            if files_to_run != parent_default.files_to_run:
+                fail("parent DefaultInfo.files_to_run changed between reads")
+            if files_to_run.executable.basename != "unrelated_launcher.bat":
+                fail("parent executable was not preserved")
+            if files_to_run.runfiles_manifest != None:
+                fail("parent runfiles manifest should not exist before finalization")
+            if files_to_run.repo_mapping_manifest != None:
+                fail("parent repo mapping manifest should not exist before finalization")
+            if files_to_run.executable in parent_default.default_runfiles.files.to_list():
+                fail("parent executable should not be present in its raw runfiles")
+            if DefaultInfo().files_to_run != None:
+                fail("DefaultInfo without an executable should not have files_to_run")
+
+            executable = ctx.actions.declare_file(ctx.label.name + ".wrapped")
+            ctx.actions.symlink(
+                output = executable,
+                target_file = files_to_run.executable,
+                is_executable = True,
+            )
+            return DefaultInfo(
+                executable = executable,
+                runfiles = parent_default.default_runfiles,
+            )
+
+        child_test = rule(implementation = _child_impl, parent = parent_test)
+        """);
+    scratch.file("extend_rule_testing/runtime.data", "runtime data");
+    scratch.file(
+        "extend_rule_testing/BUILD",
+        """
+        load(":child.bzl", "child_test")
+
+        child_test(name = "my_target", runtime_data = "runtime.data")
+        """);
+
+    ConfiguredTarget configuredTarget = getConfiguredTarget("//extend_rule_testing:my_target");
+    FilesToRunProvider filesToRun = configuredTarget.getProvider(FilesToRunProvider.class);
+
+    assertNoEvents();
+    assertThat(filesToRun.getExecutable().getFilename()).isEqualTo("my_target.wrapped");
+    assertThat(filesToRun.getRunfilesSupport()).isNotNull();
+    assertThat(
+            filesToRun.getRunfilesSupport().getRunfiles().getAllArtifacts().toList().stream()
+                .map(Artifact::getFilename))
+        .containsAtLeast("my_target.wrapped", "runtime.data");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -6186,27 +6186,21 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
             parent_default = ctx.super()[0]
             if parent_default.files != None:
                 fail("parent DefaultInfo.files should be unset")
+            if parent_default.files_to_run != None:
+                fail("parent DefaultInfo.files_to_run should not exist before finalization")
 
-            files_to_run = parent_default.files_to_run
-            if files_to_run == None:
-                fail("parent DefaultInfo.files_to_run should contain its executable")
-            if files_to_run != parent_default.files_to_run:
-                fail("parent DefaultInfo.files_to_run changed between reads")
-            if files_to_run.executable.basename != "unrelated_launcher.bat":
+            parent_executable = parent_default.executable
+            if parent_executable.basename != "unrelated_launcher.bat":
                 fail("parent executable was not preserved")
-            if files_to_run.runfiles_manifest != None:
-                fail("parent runfiles manifest should not exist before finalization")
-            if files_to_run.repo_mapping_manifest != None:
-                fail("parent repo mapping manifest should not exist before finalization")
-            if files_to_run.executable in parent_default.default_runfiles.files.to_list():
+            if parent_executable in parent_default.default_runfiles.files.to_list():
                 fail("parent executable should not be present in its raw runfiles")
-            if DefaultInfo().files_to_run != None:
-                fail("DefaultInfo without an executable should not have files_to_run")
+            if DefaultInfo().executable != None:
+                fail("DefaultInfo without an executable should return None")
 
             executable = ctx.actions.declare_file(ctx.label.name + ".wrapped")
             ctx.actions.symlink(
                 output = executable,
-                target_file = files_to_run.executable,
+                target_file = parent_executable,
                 is_executable = True,
             )
             return DefaultInfo(

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
@@ -1287,6 +1287,7 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
                 dir = str(sorted(dir(provider))),
                 rule_data_runfiles = provider.data_runfiles,
                 rule_default_runfiles = provider.default_runfiles,
+                rule_executable = provider.executable,
                 rule_files = provider.files,
                 rule_files_to_run = provider.files_to_run,
                 rule_file_executable = provider.files_to_run.executable
@@ -1316,7 +1317,8 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
         .isEqualTo(DefaultInfo.PROVIDER.getKey());
 
     assertThat(myInfo.getValue("dir"))
-        .isEqualTo("[\"data_runfiles\", \"default_runfiles\", \"files\", \"files_to_run\"]");
+        .isEqualTo(
+            "[\"data_runfiles\", \"default_runfiles\", \"executable\", \"files\", \"files_to_run\"]");
 
     assertThat(myInfo.getValue("rule_data_runfiles")).isInstanceOf(Runfiles.class);
     assertThat(
@@ -1336,6 +1338,7 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
 
     assertThat(myInfo.getValue("rule_files")).isInstanceOf(Depset.class);
     assertThat(myInfo.getValue("rule_files_to_run")).isInstanceOf(FilesToRunProvider.class);
+    assertThat(myInfo.getValue("rule_executable")).isEqualTo(Starlark.NONE);
     assertThat(myInfo.getValue("rule_file_executable")).isEqualTo(Starlark.NONE);
   }
 
@@ -1400,7 +1403,8 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
         .isEqualTo(DefaultInfo.PROVIDER.getKey());
 
     assertThat(myInfo.getValue("dir"))
-        .isEqualTo("[\"data_runfiles\", \"default_runfiles\", \"files\", \"files_to_run\"]");
+        .isEqualTo(
+            "[\"data_runfiles\", \"default_runfiles\", \"executable\", \"files\", \"files_to_run\"]");
 
     assertThat(myInfo.getValue("rule_data_runfiles")).isInstanceOf(Runfiles.class);
     assertThat(
@@ -1436,6 +1440,7 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
                 dir = str(sorted(dir(provider))),
                 file_data_runfiles = provider.data_runfiles,
                 file_default_runfiles = provider.default_runfiles,
+                file_executable = provider.executable,
                 file_files = provider.files,
                 file_files_to_run = provider.files_to_run,
             )]
@@ -1463,7 +1468,8 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
         .isEqualTo(DefaultInfo.PROVIDER.getKey());
 
     assertThat(myInfo.getValue("dir"))
-        .isEqualTo("[\"data_runfiles\", \"default_runfiles\", \"files\", \"files_to_run\"]");
+        .isEqualTo(
+            "[\"data_runfiles\", \"default_runfiles\", \"executable\", \"files\", \"files_to_run\"]");
 
     assertThat(myInfo.getValue("file_data_runfiles")).isInstanceOf(Runfiles.class);
     assertThat(
@@ -1481,6 +1487,20 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
 
     assertThat(myInfo.getValue("file_files")).isInstanceOf(Depset.class);
     assertThat(myInfo.getValue("file_files_to_run")).isInstanceOf(FilesToRunProvider.class);
+    assertThat(myInfo.getValue("file_executable"))
+        .isEqualTo(((FilesToRunProvider) myInfo.getValue("file_files_to_run")).getExecutable());
+  }
+
+  @Test
+  public void testDefaultProviderOnPackageGroup() throws Exception {
+    scratch.file("test/BUILD", "package_group(name = 'group', packages = ['//...'])");
+
+    DefaultInfo provider =
+        (DefaultInfo) getConfiguredTarget("//test:group").get(DefaultInfo.PROVIDER.getKey());
+    ev.update("provider", provider);
+
+    assertThat(ev.eval("provider.executable")).isEqualTo(Starlark.NONE);
+    assertThat((String) ev.eval("str(provider)")).contains("executable = None");
   }
 
   @Test


### PR DESCRIPTION
### Description

Expose the existing `DefaultInfo` executable as the nullable Starlark field `DefaultInfo.executable`. Preserve the existing `DefaultInfo.files_to_run` behavior and handle configured targets without a `FilesToRunProvider`.

### Motivation

`ctx.super()` returns the parent rule implementation's unfinalized `DefaultInfo`. Its executable can be absent from both `DefaultInfo.files` and `DefaultInfo.default_runfiles`, while `DefaultInfo.files_to_run` is not populated until configured-target finalization. `parent_default.executable` exposes the executable that `DefaultInfo` already stores without constructing an incomplete `FilesToRunProvider`.

### Build API Changes

Yes. Adds the nullable Starlark field `DefaultInfo.executable`. Existing `DefaultInfo.files_to_run` behavior remains unchanged. `DefaultInfo.executable` is `None` for non-executable configured targets and package groups, and matches `DefaultInfo.files_to_run.executable` for source-file targets. Existing provider introspection, representation, and equality include the new field.

### Checklist

- [x] I have added tests for the new use cases.
- [x] I have updated the documentation.

### Testing

`bazel test --test_sharding_strategy=disabled //src/test/java/com/google/devtools/build/lib/starlark:StarlarkRuleClassFunctionsTest //src/test/java/com/google/devtools/build/lib/starlark:StarlarkRuleImplementationFunctionsTest`

Both test classes passed: 462 tests total.

### Release Notes

RELNOTES[NEW]: `DefaultInfo.executable` exposes the executable of configured targets and directly constructed providers, including providers returned by `ctx.super()`.
