### PR TITLE
Only fall back to a whole-blob download if the blob cannot be split

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloader.java
@@ -23,7 +23,7 @@ import build.bazel.remote.execution.v2.SplitBlobResponse;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.remote.chunking.ChunkingConfig;
-import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
+import com.google.devtools.build.lib.remote.common.BlobNotSplittableException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.util.DigestOutputStream;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
@@ -83,6 +83,12 @@ public class ChunkedBlobDownloader {
     }
   }
 
+  /**
+   * Returns the chunks the blob is composed of.
+   *
+   * @throws BlobNotSplittableException if the server cannot describe the blob as a sequence of
+   *     chunks, in which case the caller may fall back to downloading the whole blob
+   */
   private List<Digest> getChunkDigests(RemoteActionExecutionContext context, Digest blobDigest)
       throws IOException, InterruptedException {
     if (blobDigest.getSizeBytes() == 0) {
@@ -91,11 +97,11 @@ public class ChunkedBlobDownloader {
     ListenableFuture<SplitBlobResponse> splitResponseFuture =
         grpcCacheClient.splitBlob(context, blobDigest, chunkingFunction);
     if (splitResponseFuture == null) {
-      throw new CacheNotFoundException(blobDigest);
+      throw new BlobNotSplittableException(blobDigest);
     }
     List<Digest> chunkDigests = getFromFuture(splitResponseFuture).getChunkDigestsList();
     if (chunkDigests.isEmpty()) {
-      throw new CacheNotFoundException(blobDigest);
+      throw new BlobNotSplittableException(blobDigest);
     }
     validateChunkDigests(blobDigest, chunkDigests);
     return chunkDigests;

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -40,6 +40,7 @@ import com.google.devtools.build.lib.exec.SpawnCheckingCacheEvent;
 import com.google.devtools.build.lib.exec.SpawnProgressEvent;
 import com.google.devtools.build.lib.remote.chunking.ChunkingConfig;
 import com.google.devtools.build.lib.remote.common.ActionKey;
+import com.google.devtools.build.lib.remote.common.BlobNotSplittableException;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.LazyFileOutputStream;
 import com.google.devtools.build.lib.remote.common.MaybePathBacked;
@@ -561,9 +562,14 @@ public class CombinedCache extends AbstractReferenceCounted {
                 chunking.downloader().downloadChunked(context, digest, out);
                 return null;
               });
+      // Only a failure to split the blob is recoverable by downloading it as a whole. Once the
+      // server has described the blob as a sequence of chunks, the download is committed to that
+      // path: chunks are written to `out` as they arrive, so restarting would append the blob to
+      // the chunks already written. A missing chunk is reported as a missing blob instead, letting
+      // the usual lost input handling regenerate it.
       return Futures.catchingAsync(
           chunkedDownloadFuture,
-          CacheNotFoundException.class,
+          BlobNotSplittableException.class,
           (e) -> regularDownloadBlobFromRemote(context, digest, out),
           directExecutor());
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -54,6 +54,7 @@ import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ProgressiveBackoff;
 import com.google.devtools.build.lib.remote.common.ActionKey;
+import com.google.devtools.build.lib.remote.common.BlobNotSplittableException;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.MissingDigestsFinder;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
@@ -212,6 +213,9 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
   /**
    * Queries the server for chunk information about a blob using the SplitBlob RPC.
    *
+   * <p>The returned future fails with a {@link BlobNotSplittableException} if the server does not
+   * implement the RPC or has no chunks for this blob.
+   *
    * @return a future with the split blob response, or null if chunking is not enabled
    */
   @Nullable
@@ -239,9 +243,14 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
             callCredentialsProvider),
         StatusRuntimeException.class,
         (e) ->
-            e.getStatus().getCode() == Code.NOT_FOUND
-                ? Futures.immediateFailedFuture(new CacheNotFoundException(digest))
-                : Futures.immediateFailedFuture(new IOException(e)),
+            switch (e.getStatus().getCode()) {
+              // NOT_FOUND: the server knows how to split blobs, but has no chunks for this one.
+              // UNIMPLEMENTED: the server advertised the parameters of a chunking function in its
+              // capabilities, but does not actually implement SplitBlob.
+              case NOT_FOUND, UNIMPLEMENTED ->
+                  Futures.immediateFailedFuture(new BlobNotSplittableException(digest));
+              default -> Futures.immediateFailedFuture(new IOException(e));
+            },
         directExecutor());
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/common/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/BUILD
@@ -71,6 +71,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_runner",
         "//src/main/java/com/google/devtools/build/lib/remote/util:async_task_cache",
+        "//src/main/java/com/google/devtools/build/lib/remote/util:digest_util",
         "//src/main/java/com/google/devtools/build/lib/remote/util:rx_futures",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",

--- a/src/main/java/com/google/devtools/build/lib/remote/common/BlobNotSplittableException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/BlobNotSplittableException.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.remote.common;
 
 import build.bazel.remote.execution.v2.Digest;
+import com.google.devtools.build.lib.remote.util.DigestUtil;
 import java.io.IOException;
 
 /**
@@ -38,9 +39,6 @@ public final class BlobNotSplittableException extends IOException {
 
   @Override
   public String getMessage() {
-    return "Not splittable into chunks: "
-        + blobDigest.getHash()
-        + "/"
-        + blobDigest.getSizeBytes();
+    return "Not splittable into chunks: %s".formatted(DigestUtil.toString(blobDigest));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/common/BlobNotSplittableException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/BlobNotSplittableException.java
@@ -1,0 +1,46 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote.common;
+
+import build.bazel.remote.execution.v2.Digest;
+import java.io.IOException;
+
+/**
+ * Indicates that the server cannot describe a blob as a sequence of chunks, either because it does
+ * not implement {@code SplitBlob} or because it has no chunks for this particular blob.
+ *
+ * <p>This says nothing about whether the blob itself is available: the caller is expected to fall
+ * back to downloading it as a whole. It is only thrown before any chunk data has been produced, so
+ * that such a fallback can safely start from the beginning of the blob.
+ */
+public final class BlobNotSplittableException extends IOException {
+  private final Digest blobDigest;
+
+  public BlobNotSplittableException(Digest blobDigest) {
+    this.blobDigest = blobDigest;
+  }
+
+  public Digest getBlobDigest() {
+    return blobDigest;
+  }
+
+  @Override
+  public String getMessage() {
+    return "Not splittable into chunks: "
+        + blobDigest.getHash()
+        + "/"
+        + blobDigest.getSizeBytes();
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloaderTest.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.remote.chunking.ChunkingConfig;
 import com.google.devtools.build.lib.remote.chunking.FastCdcChunkingConfig;
+import com.google.devtools.build.lib.remote.common.BlobNotSplittableException;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
@@ -75,13 +76,51 @@ public class ChunkedBlobDownloaderTest {
   }
 
   @Test
-  public void downloadChunked_splitBlobReturnsNull_throwsCacheNotFound() {
+  public void downloadChunked_splitBlobReturnsNull_throwsBlobNotSplittable() {
     Digest blobDigest = DIGEST_UTIL.compute(new byte[] {1, 2, 3});
     when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any())).thenReturn(null);
 
     assertThrows(
-        CacheNotFoundException.class,
+        BlobNotSplittableException.class,
         () -> downloader.downloadChunked(context, blobDigest, new ByteArrayOutputStream()));
+  }
+
+  @Test
+  public void downloadChunked_serverReturnsNoChunks_throwsBlobNotSplittable() {
+    Digest blobDigest = DIGEST_UTIL.compute(new byte[] {1, 2, 3});
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any()))
+        .thenReturn(Futures.immediateFuture(SplitBlobResponse.getDefaultInstance()));
+
+    assertThrows(
+        BlobNotSplittableException.class,
+        () -> downloader.downloadChunked(context, blobDigest, new ByteArrayOutputStream()));
+  }
+
+  @Test
+  public void downloadChunked_chunkMissing_propagatesCacheNotFound() throws Exception {
+    byte[] chunk1Data = new byte[] {1, 2, 3};
+    byte[] chunk2Data = new byte[] {4, 5, 6};
+    Digest chunk1Digest = DIGEST_UTIL.compute(chunk1Data);
+    Digest chunk2Digest = DIGEST_UTIL.compute(chunk2Data);
+    Digest blobDigest = DIGEST_UTIL.compute(new byte[] {1, 2, 3, 4, 5, 6});
+
+    SplitBlobResponse splitResponse =
+        SplitBlobResponse.newBuilder()
+            .addChunkDigests(chunk1Digest)
+            .addChunkDigests(chunk2Digest)
+            .build();
+    when(grpcCacheClient.splitBlob(any(), eq(blobDigest), any()))
+        .thenReturn(Futures.immediateFuture(splitResponse));
+    when(combinedCache.downloadBlob(any(), eq(chunk1Digest)))
+        .thenReturn(Futures.immediateFuture(chunk1Data));
+    when(combinedCache.downloadBlob(any(), eq(chunk2Digest)))
+        .thenReturn(Futures.immediateFailedFuture(new CacheNotFoundException(chunk2Digest)));
+
+    // A missing chunk is a missing blob, not an invitation to retry the download differently.
+    assertThrows(
+        CacheNotFoundException.class,
+        () ->
+            downloader.downloadChunked(context, blobDigest, new ByteArrayOutputStream()));
   }
 
   @Test
@@ -429,6 +468,10 @@ public class ChunkedBlobDownloaderTest {
 
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     assertThrows(IOException.class, () -> downloader.downloadChunked(context, blobDigest, out));
+
+    // Chunks are written as they arrive, so a failed download leaves a prefix of the blob behind.
+    // Callers must not restart the download into the same stream.
+    assertThat(out.toByteArray()).isEqualTo(chunk1Data);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
@@ -20,8 +20,10 @@ import static com.google.devtools.build.lib.remote.util.Utils.waitForBulkTransfe
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -31,6 +33,7 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.FastCdc2020Params;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.bazel.remote.execution.v2.ServerCapabilities;
+import build.bazel.remote.execution.v2.SplitBlobResponse;
 import com.google.common.collect.ImmutableClassToInstanceMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -57,7 +60,9 @@ import com.google.devtools.build.lib.exec.SpawnCheckingCacheEvent;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.exec.util.FakeOwner;
 import com.google.devtools.build.lib.exec.util.SpawnBuilder;
+import com.google.devtools.build.lib.remote.common.BlobNotSplittableException;
 import com.google.devtools.build.lib.remote.common.BulkTransferException;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.Blob;
@@ -83,8 +88,10 @@ import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.common.options.Options;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Arrays;
 import java.util.Deque;
 import java.util.Map;
 import java.util.SortedMap;
@@ -943,6 +950,180 @@ public class CombinedCacheTest {
     } finally {
       combinedCache.release();
     }
+  }
+
+  @Test
+  public void downloadBlob_chunkMissingAfterPartialWrite_doesNotRestartIntoSameStream()
+      throws Exception {
+    // Larger than the chunking threshold (4 * 1024, derived from the advertised average chunk size
+    // of 1024) so that the download is chunked, with chunks small enough not to be chunked again.
+    byte[] chunk1Data = new byte[4096];
+    Arrays.fill(chunk1Data, (byte) 1);
+    byte[] chunk2Data = new byte[4096];
+    Arrays.fill(chunk2Data, (byte) 2);
+    byte[] blobData = new byte[8192];
+    System.arraycopy(chunk1Data, 0, blobData, 0, chunk1Data.length);
+    System.arraycopy(chunk2Data, 0, blobData, chunk1Data.length, chunk2Data.length);
+    Digest blobDigest = digestUtil.compute(blobData);
+    Digest chunk1Digest = digestUtil.compute(chunk1Data);
+    Digest chunk2Digest = digestUtil.compute(chunk2Data);
+
+    GrpcCacheClient grpcCacheClient = newChunkingGrpcCacheClient();
+    doAnswer(
+            unused ->
+                immediateFuture(
+                    SplitBlobResponse.newBuilder()
+                        .addChunkDigests(chunk1Digest)
+                        .addChunkDigests(chunk2Digest)
+                        .build()))
+        .when(grpcCacheClient)
+        .splitBlob(any(), eq(blobDigest), any());
+    doAnswer(
+            invocation -> {
+              OutputStream chunkOut = invocation.getArgument(2);
+              chunkOut.write(chunk1Data);
+              return Futures.immediateVoidFuture();
+            })
+        .when(grpcCacheClient)
+        .downloadBlob(any(), eq(chunk1Digest), any());
+    // The second chunk was evicted between SplitBlob and the read of the chunk itself.
+    doAnswer(unused -> Futures.immediateFailedFuture(new CacheNotFoundException(chunk2Digest)))
+        .when(grpcCacheClient)
+        .downloadBlob(any(), eq(chunk2Digest), any());
+    // Only reached if the whole-blob fallback is (incorrectly) attempted, in which case `out` ends
+    // up holding the first chunk followed by the entire blob.
+    doAnswer(
+            invocation -> {
+              OutputStream blobOut = invocation.getArgument(2);
+              blobOut.write(blobData);
+              return Futures.immediateVoidFuture();
+            })
+        .when(grpcCacheClient)
+        .downloadBlob(any(), eq(blobDigest), any());
+
+    CombinedCache combinedCache = newChunkingCombinedCache(grpcCacheClient);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try {
+      assertThrows(
+          CacheNotFoundException.class,
+          () ->
+              getFromFuture(
+                  combinedCache.downloadBlob(remoteActionExecutionContext, blobDigest, out)));
+
+      // Falling back to a whole-blob download here would append the blob to the chunks already
+      // written, silently producing a blob longer than its digest claims.
+      verify(grpcCacheClient, never()).downloadBlob(any(), eq(blobDigest), any());
+      assertThat(out.toByteArray()).isEqualTo(chunk1Data);
+    } finally {
+      combinedCache.release();
+    }
+  }
+
+  @Test
+  public void downloadBlob_firstChunkMissing_doesNotFallBackToWholeBlobDownload() throws Exception {
+    byte[] chunk1Data = new byte[4096];
+    Arrays.fill(chunk1Data, (byte) 1);
+    byte[] chunk2Data = new byte[4096];
+    Arrays.fill(chunk2Data, (byte) 2);
+    byte[] blobData = new byte[8192];
+    System.arraycopy(chunk1Data, 0, blobData, 0, chunk1Data.length);
+    System.arraycopy(chunk2Data, 0, blobData, chunk1Data.length, chunk2Data.length);
+    Digest blobDigest = digestUtil.compute(blobData);
+    Digest chunk1Digest = digestUtil.compute(chunk1Data);
+    Digest chunk2Digest = digestUtil.compute(chunk2Data);
+
+    GrpcCacheClient grpcCacheClient = newChunkingGrpcCacheClient();
+    doAnswer(
+            unused ->
+                immediateFuture(
+                    SplitBlobResponse.newBuilder()
+                        .addChunkDigests(chunk1Digest)
+                        .addChunkDigests(chunk2Digest)
+                        .build()))
+        .when(grpcCacheClient)
+        .splitBlob(any(), eq(blobDigest), any());
+    doAnswer(unused -> Futures.immediateFailedFuture(new CacheNotFoundException(chunk1Digest)))
+        .when(grpcCacheClient)
+        .downloadBlob(any(), eq(chunk1Digest), any());
+    doAnswer(
+            invocation -> {
+              OutputStream blobOut = invocation.getArgument(2);
+              blobOut.write(blobData);
+              return Futures.immediateVoidFuture();
+            })
+        .when(grpcCacheClient)
+        .downloadBlob(any(), eq(blobDigest), any());
+
+    CombinedCache combinedCache = newChunkingCombinedCache(grpcCacheClient);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try {
+      // Nothing has been written yet, so restarting would be safe, but the blob is genuinely
+      // incomplete in the CAS. Report it as missing and let lost input handling regenerate it
+      // rather than papering over it, which also keeps the behavior independent of which chunk
+      // happens to be missing.
+      assertThrows(
+          CacheNotFoundException.class,
+          () ->
+              getFromFuture(
+                  combinedCache.downloadBlob(remoteActionExecutionContext, blobDigest, out)));
+
+      verify(grpcCacheClient, never()).downloadBlob(any(), eq(blobDigest), any());
+    } finally {
+      combinedCache.release();
+    }
+  }
+
+  @Test
+  public void downloadBlob_blobNotSplittable_fallsBackToWholeBlobDownload() throws Exception {
+    byte[] blobData = new byte[8192];
+    Arrays.fill(blobData, (byte) 1);
+    Digest blobDigest = digestUtil.compute(blobData);
+
+    GrpcCacheClient grpcCacheClient = newChunkingGrpcCacheClient();
+    // What GrpcCacheClient#splitBlob reports when the server answers NOT_FOUND or UNIMPLEMENTED.
+    doAnswer(unused -> Futures.immediateFailedFuture(new BlobNotSplittableException(blobDigest)))
+        .when(grpcCacheClient)
+        .splitBlob(any(), eq(blobDigest), any());
+    doAnswer(
+            invocation -> {
+              OutputStream blobOut = invocation.getArgument(2);
+              blobOut.write(blobData);
+              return Futures.immediateVoidFuture();
+            })
+        .when(grpcCacheClient)
+        .downloadBlob(any(), eq(blobDigest), any());
+
+    CombinedCache combinedCache = newChunkingCombinedCache(grpcCacheClient);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try {
+      getFromFuture(combinedCache.downloadBlob(remoteActionExecutionContext, blobDigest, out));
+
+      assertThat(out.toByteArray()).isEqualTo(blobData);
+    } finally {
+      combinedCache.release();
+    }
+  }
+
+  private GrpcCacheClient newChunkingGrpcCacheClient() throws IOException {
+    GrpcCacheClient grpcCacheClient =
+        spy(
+            new GrpcCacheClient(
+                mock(ReferenceCountedChannel.class),
+                mock(CallCredentialsProvider.class),
+                Options.getDefaults(RemoteOptions.class),
+                mock(RemoteRetrier.class),
+                digestUtil));
+    doAnswer(unused -> chunkingCapabilities()).when(grpcCacheClient).getServerCapabilities();
+    return grpcCacheClient;
+  }
+
+  private CombinedCache newChunkingCombinedCache(GrpcCacheClient grpcCacheClient) {
+    return new CombinedCache(
+        grpcCacheClient,
+        /* diskCacheClient= */ null,
+        /* symlinkTemplate= */ null,
+        digestUtil,
+        RemoteOptions.ChunkingFunctionValue.FAST_CDC_2020);
   }
 
   private InMemoryCombinedCache newCombinedCache() {

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -33,6 +33,7 @@ import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionCacheGrpc.ActionCacheImplBase;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Command;
+import build.bazel.remote.execution.v2.ChunkingFunction;
 import build.bazel.remote.execution.v2.ContentAddressableStorageGrpc.ContentAddressableStorageImplBase;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.DigestFunction;
@@ -44,6 +45,8 @@ import build.bazel.remote.execution.v2.FindMissingBlobsResponse;
 import build.bazel.remote.execution.v2.GetActionResultRequest;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.bazel.remote.execution.v2.ServerCapabilities;
+import build.bazel.remote.execution.v2.SplitBlobRequest;
+import build.bazel.remote.execution.v2.SplitBlobResponse;
 import build.bazel.remote.execution.v2.Tree;
 import build.bazel.remote.execution.v2.UpdateActionResultRequest;
 import com.github.luben.zstd.Zstd;
@@ -75,6 +78,7 @@ import com.google.devtools.build.lib.exec.util.SpawnBuilder;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ExponentialBackoff;
 import com.google.devtools.build.lib.remote.Retrier.Backoff;
 import com.google.devtools.build.lib.remote.common.ActionKey;
+import com.google.devtools.build.lib.remote.common.BlobNotSplittableException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
@@ -1628,5 +1632,28 @@ public class GrpcCacheClientTest {
     RemoteOptions options = Options.getDefaults(RemoteOptions.class);
 
     assertThat(GrpcCacheClient.isRemoteCacheOptions(options)).isFalse();
+  }
+
+  @Test
+  public void splitBlob_serverCannotSplit_failsWithBlobNotSplittable(
+      @TestParameter({"NOT_FOUND", "UNIMPLEMENTED"}) Status.Code code) throws Exception {
+    RemoteOptions options =
+        Options.parse(RemoteOptions.class, "--experimental_remote_cache_chunking").getOptions();
+    GrpcCacheClient client = newClient(options);
+    Digest digest = DIGEST_UTIL.computeAsUtf8("abcdefg");
+    serviceRegistry.addService(
+        new ContentAddressableStorageImplBase() {
+          @Override
+          public void splitBlob(
+              SplitBlobRequest request, StreamObserver<SplitBlobResponse> responseObserver) {
+            responseObserver.onError(code.toStatus().asRuntimeException());
+          }
+        });
+
+    assertThrows(
+        BlobNotSplittableException.class,
+        () ->
+            getFromFuture(
+                client.splitBlob(context, digest, ChunkingFunction.Value.FAST_CDC_2020)));
   }
 }


### PR DESCRIPTION
### Description

`CombinedCache#downloadBlobFromRemote` falls back to downloading a blob as a whole when its chunked download fails with a `CacheNotFoundException`. That exception covers two very different situations:

* the server cannot describe the blob as a sequence of chunks, which is raised by `getChunkDigests` before any data has been produced, and
* one of the chunks is missing from the CAS, which is only discovered after the preceding chunks have already been written to the output stream.

`ChunkedBlobDownloader` writes each chunk to the output stream as soon as it arrives and the stream cannot be rewound, so in the second case the fallback appended the entire blob to the chunks already written. Nothing catches this afterwards: there is no size or digest check over the final artifact, and `--remote_verify_downloads` doesn't help because the fallback wraps the stream in a fresh `DigestOutputStream` that only digests what the fallback itself writes. The result is a build artifact that is silently longer than its digest claims. The same applies to the other consumers of this code path, including `Tree` protos, in-memory outputs and stdout/stderr.

The fallback is now keyed off a dedicated `BlobNotSplittableException`, which is only thrown before any chunk data has been produced. A missing chunk keeps propagating as a `CacheNotFoundException` and is handled like any other missing blob, so the outcome no longer depends on which chunk happens to be missing.

`SplitBlob` returning `UNIMPLEMENTED` is now treated as "not splittable" as well. It previously turned into a plain `IOException`, so a server that advertises the parameters of a chunking function in its capabilities without implementing `SplitBlob` failed the build instead of falling back.

### Motivation

Chunks have independent CAS lifetimes from the blob they belong to, so a chunk being evicted between `SplitBlob` and the read of that chunk is exactly the situation this fallback exists to handle. Recovering from it by restarting the download is only safe before any chunk has been handed to the caller.

Found by inspection; requires `--experimental_remote_cache_chunking`.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

