### PR TITLE
Pass -XDaddTypeAnnotationsToSymbol=true to javac on JDK <= 21

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/BlazeJavacMain.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/BlazeJavacMain.java
@@ -124,9 +124,7 @@ public class BlazeJavacMain {
     // Initialize parts of context that the filemanager depends on
     context.put(DiagnosticListener.class, diagnosticsBuilder);
     Log.instance(context).setWriters(errWriter);
-    Options options = Options.instance(context);
-    options.put("-Xlint:path", "path");
-    options.put("expandJarClassPaths", "false");
+    setupDefaultJavacOptions(Options.instance(context), Runtime.version().feature());
 
     try (ClassloaderMaskingFileManager fileManager = new ClassloaderMaskingFileManager(context)) {
 
@@ -189,6 +187,23 @@ public class BlazeJavacMain {
 
     return BlazeJavacResult.createFullResult(
         status, filterDiagnostics(werror, diagnostics), errOutput.toString(), builder.build());
+  }
+
+  @VisibleForTesting
+  static void setupDefaultJavacOptions(Options options, int runtimeFeatureVersion) {
+    options.put("-Xlint:path", "path");
+    options.put("expandJarClassPaths", "false");
+    // JDK-8225377: before JDK 22, javac does not attach type-use annotations
+    // loaded from classpath class files to the corresponding symbols, so
+    // Error Prone's nullness checks emit false positives on nullable-annotated
+    // parameters (e.g. NullArgumentForNonNullParameter on Guava
+    // @ParametricNullness / JSpecify @Nullable). Error Prone's -Xplugin entry
+    // point requires -XDaddTypeAnnotationsToSymbol=true on JDK <= 21; JavaBuilder
+    // wires Error Prone directly, so set the option here. Enabled by default and
+    // a no-op on JDK 22+.
+    if (runtimeFeatureVersion <= 21) {
+      options.put("addTypeAnnotationsToSymbol", "true");
+    }
   }
 
   private static Status fromResult(Result result) {

--- a/src/java_tools/buildjar/javatests/com/google/devtools/build/buildjar/BUILD
+++ b/src/java_tools/buildjar/javatests/com/google/devtools/build/buildjar/BUILD
@@ -12,6 +12,18 @@ filegroup(
 )
 
 java_test(
+    name = "BlazeJavacMainTest",
+    srcs = ["BlazeJavacMainTest.java"],
+    add_exports = ["jdk.compiler/com.sun.tools.javac.util"],
+    test_class = "com.google.devtools.build.buildjar.javac.BlazeJavacMainTest",
+    deps = [
+        "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar:javac",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
+java_test(
     name = "VanillaJavaBuilderTest",
     srcs = ["VanillaJavaBuilderTest.java"],
     deps = [

--- a/src/java_tools/buildjar/javatests/com/google/devtools/build/buildjar/BlazeJavacMainTest.java
+++ b/src/java_tools/buildjar/javatests/com/google/devtools/build/buildjar/BlazeJavacMainTest.java
@@ -1,0 +1,56 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.buildjar.javac;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Options;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests {@link BlazeJavacMain}. */
+@RunWith(JUnit4.class)
+public final class BlazeJavacMainTest {
+
+  @Test
+  public void setupDefaultJavacOptions_jdk21_addsTypeAnnotationsToSymbol() {
+    Options options = Options.instance(new Context());
+
+    BlazeJavacMain.setupDefaultJavacOptions(options, 21);
+
+    assertThat(options.get("addTypeAnnotationsToSymbol")).isEqualTo("true");
+  }
+
+  @Test
+  public void setupDefaultJavacOptions_jdk22_doesNotAddTypeAnnotationsToSymbol() {
+    Options options = Options.instance(new Context());
+
+    BlazeJavacMain.setupDefaultJavacOptions(options, 22);
+
+    assertThat(options.get("addTypeAnnotationsToSymbol")).isNull();
+  }
+
+  @Test
+  public void setupDefaultJavacOptions_keepsExistingDefaults() {
+    Options options = Options.instance(new Context());
+
+    BlazeJavacMain.setupDefaultJavacOptions(options, 21);
+
+    assertThat(options.get("-Xlint:path")).isEqualTo("path");
+    assertThat(options.get("expandJarClassPaths")).isEqualTo("false");
+  }
+}


### PR DESCRIPTION
Before JDK 22 (JDK-8225377), javac does not attach type-use annotations loaded from classpath class files to the corresponding parameter symbols unless -XDaddTypeAnnotationsToSymbol=true is set. Error Prone's nullness analysis then cannot see nullable annotations on a dependency's method parameters (e.g. Guava @ParametricNullness, JSpecify @Nullable) and emits false positives such as NullArgumentForNonNullParameter on idiomatic Iterables.getLast(list, null) or ToStringHelper.add(name, nullable).

Error Prone's own -Xplugin entry point already requires this flag on JDK <= 21 (google/error-prone#5426), so callers that drive Error Prone via -Xplugin (Maven, Gradle) pass it. JavaBuilder instead wires Error Prone directly (ErrorPronePlugin / ErrorProneAnalyzer.createByScanningForPlugins), so nothing supplies the flag and the false positives surface only under Bazel on a JDK <= 21 analyzer runtime.

Set the javac option here, gated on the tool JVM feature version -- matching the existing Runtime.version().feature() checks in this file and the Error-Prone-required javac flags the toolchain already passes (-XDcompilePolicy=simple, --should-stop=ifError=FLOW). Enabled by default and a no-op on JDK 22+.

A toolchain-level workaround exists (add the flag to javacopts, or run the analyzer on JDK >= 22), but the fix belongs here so every Bazel + Error Prone + JDK <= 21 build gets correct behaviour without per-project opt-in, mirroring Error Prone's -Xplugin contract.

Closes #30743

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
