### PR TITLE
Fix builtin action resource set regression introdued by #29284

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -570,6 +570,7 @@ java_library(
     ],
     deps = [
         ":exec_exception",
+        ":execution_requirements",
         ":localhost_compute_resources",
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",

--- a/src/main/java/com/google/devtools/build/lib/actions/BaseSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/BaseSpawn.java
@@ -91,11 +91,11 @@ public class BaseSpawn implements Spawn {
     if (result == null) {
       // Not expected to be called concurrently, and an idempotent computation if it is.
       result =
-          localResources
-              .buildResourceSet(OS.getCurrent(), action.getInputs().memoizedFlattenAndGetSize())
-              .withResourceOverrides(
-                  ExecutionRequirements.parseResources(getExecutionInfo()),
-                  ExecutionRequirements.parseResources(getCombinedExecProperties()));
+          localResources.buildLocalResources(
+              OS.getCurrent(),
+              action.getInputs().memoizedFlattenAndGetSize(),
+              getExecutionInfo(),
+              getCombinedExecProperties());
       localResourcesCached = result;
     }
     return result;

--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceSetOrBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceSetOrBuilder.java
@@ -34,7 +34,7 @@ public interface ResourceSetOrBuilder {
    * executionInfo} and {@code execProperties} applied as overrides.
    *
    * <p>The entries are taken unparsed so that a declaration which ignores them, such as {@link
-   * #fixed}, doesn't pay to parse them.
+   * #ignoringOverrides}, doesn't pay to parse them.
    */
   default ResourceSet buildLocalResources(
       OS os, int inputsSize, Map<String, String> executionInfo, Map<String, String> execProperties)
@@ -47,9 +47,9 @@ public interface ResourceSetOrBuilder {
 
   /**
    * Returns a declaration of {@code resources} that the owning target's "resources:*" entries
-   * must not override.
+   * do not override.
    */
-  static ResourceSetOrBuilder fixed(ResourceSet resources) {
+  static ResourceSetOrBuilder ignoringOverrides(ResourceSet resources) {
     return new ResourceSetOrBuilder() {
       @Override
       public ResourceSet buildResourceSet(OS os, int inputsSize) {

--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceSetOrBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceSetOrBuilder.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.actions;
 
 import com.google.devtools.build.lib.util.OS;
+import java.util.Map;
 
 /** Common interface for ResourceSet and builder. */
 @FunctionalInterface
@@ -26,4 +27,43 @@ public interface ResourceSetOrBuilder {
    */
   public ResourceSet buildResourceSet(OS os, int inputsSize)
       throws ExecException, InterruptedException;
+
+  /**
+   * Returns the resources a spawn with this declaration should book with the {@code
+   * ResourceManager} (the built resource set), with the "resources:*" entries in {@code
+   * executionInfo} and {@code execProperties} applied as overrides.
+   *
+   * <p>The entries are taken unparsed so that a declaration which ignores them, such as {@link
+   * #fixed}, doesn't pay to parse them.
+   */
+  default ResourceSet buildLocalResources(
+      OS os, int inputsSize, Map<String, String> executionInfo, Map<String, String> execProperties)
+      throws ExecException, InterruptedException {
+    return buildResourceSet(os, inputsSize)
+        .withResourceOverrides(
+            ExecutionRequirements.parseResources(executionInfo),
+            ExecutionRequirements.parseResources(execProperties));
+  }
+
+  /**
+   * Returns a declaration of {@code resources} that the owning target's "resources:*" entries
+   * must not override.
+   */
+  static ResourceSetOrBuilder fixed(ResourceSet resources) {
+    return new ResourceSetOrBuilder() {
+      @Override
+      public ResourceSet buildResourceSet(OS os, int inputsSize) {
+        return resources;
+      }
+
+      @Override
+      public ResourceSet buildLocalResources(
+          OS os,
+          int inputsSize,
+          Map<String, String> executionInfo,
+          Map<String, String> execProperties) {
+        return resources;
+      }
+    };
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
@@ -23,7 +23,9 @@ import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
+import com.google.devtools.build.lib.util.OS;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -238,16 +240,13 @@ public final class SimpleSpawn implements Spawn {
   }
 
   @Override
-  public ResourceSet getLocalResources() throws ExecException {
+  public ResourceSet getLocalResources() throws ExecException, InterruptedException {
     ResourceSet result = localResourcesCached;
     if (result == null) {
       // Not expected to be called concurrently, and an idempotent computation if it is.
       result =
-          localResourcesSupplier
-              .get()
-              .withResourceOverrides(
-                  ExecutionRequirements.parseResources(getExecutionInfo()),
-                  ExecutionRequirements.parseResources(getCombinedExecProperties()));
+          localResourcesSupplier.buildLocalResources(
+              getExecutionInfo(), getCombinedExecProperties());
       localResourcesCached = result;
     }
     return result;
@@ -274,8 +273,54 @@ public final class SimpleSpawn implements Spawn {
     return Spawns.prettyPrint(this);
   }
 
-  /** Supplies resources needed for local execution. Result will be cached. */
-  public interface LocalResourcesSupplier {
+  /**
+   * Supplies resources needed for local execution. Result will be cached.
+   * TODO(Silic0nS0ldier): This has significant overlap with ResourceSetOrBuilder. Merge them
+   * while preserving the lazy computation of local resources.
+   */
+  @FunctionalInterface
+  public interface LocalResourcesSupplier extends ResourceSetOrBuilder {
     ResourceSet get() throws ExecException;
+
+    @Override
+    default ResourceSet buildResourceSet(OS os, int inputsSize) throws ExecException {
+      return get();
+    }
+
+    /**
+     * The {@link ResourceSetOrBuilder#buildLocalResources} this interface's callers use, without
+     * the build context a supplier ignores by contract.
+     */
+    default ResourceSet buildLocalResources(
+        Map<String, String> executionInfo, Map<String, String> execProperties)
+        throws ExecException, InterruptedException {
+      // Placeholders, so that the override behaviour stays defined in exactly one place.
+      return buildLocalResources(
+          OS.getCurrent(), /* inputsSize= */ 0, executionInfo, execProperties);
+    }
+  }
+
+  /**
+   * Returns a supplier of fixed {@code resources} that the owning target's {@code resources:}
+   * entries must not override.
+   *
+   * <p>The {@link ResourceSetOrBuilder#fixed} equivalent, in the form {@link SimpleSpawn} accepts.
+   */
+  public static LocalResourcesSupplier fixedLocalResources(ResourceSet resources) {
+    return new LocalResourcesSupplier() {
+      @Override
+      public ResourceSet get() {
+        return resources;
+      }
+
+      @Override
+      public ResourceSet buildLocalResources(
+          OS os,
+          int inputsSize,
+          Map<String, String> executionInfo,
+          Map<String, String> execProperties) {
+        return resources;
+      }
+    };
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
@@ -14,8 +14,6 @@
 
 package com.google.devtools.build.lib.actions;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -25,7 +23,6 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.util.OS;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -43,10 +40,11 @@ public final class SimpleSpawn implements Spawn {
   // If null, all outputs are mandatory.
   @Nullable private final Set<? extends ActionInput> mandatoryOutputs;
   private final PathMapper pathMapper;
-  private final LocalResourcesSupplier localResourcesSupplier;
+  private final ResourceSetOrBuilder localResources;
   @Nullable private ResourceSet localResourcesCached;
 
-  private SimpleSpawn(
+  @SuppressWarnings("TooManyParameters")
+  public SimpleSpawn(
       ActionExecutionMetadata owner,
       ImmutableList<String> arguments,
       ImmutableMap<String, String> environment,
@@ -54,9 +52,8 @@ public final class SimpleSpawn implements Spawn {
       SpawnInputs inputs,
       NestedSet<? extends ActionInput> tools,
       Collection<? extends ActionInput> outputs,
-      @Nullable final Set<? extends ActionInput> mandatoryOutputs,
-      @Nullable ResourceSet localResources,
-      @Nullable LocalResourcesSupplier localResourcesSupplier,
+      @Nullable Set<? extends ActionInput> mandatoryOutputs,
+      ResourceSetOrBuilder localResources,
       PathMapper pathMapper) {
     this.owner = Preconditions.checkNotNull(owner);
     this.arguments = Preconditions.checkNotNull(arguments);
@@ -66,16 +63,7 @@ public final class SimpleSpawn implements Spawn {
     this.tools = Preconditions.checkNotNull(tools);
     this.outputs = ImmutableList.copyOf(outputs);
     this.mandatoryOutputs = mandatoryOutputs;
-    checkState(
-        (localResourcesSupplier == null) != (localResources == null),
-        "Exactly one must be null: %s %s",
-        localResources,
-        localResourcesSupplier);
-    if (localResources != null) {
-      this.localResourcesSupplier = () -> localResources;
-    } else {
-      this.localResourcesSupplier = localResourcesSupplier;
-    }
+    this.localResources = Preconditions.checkNotNull(localResources);
     this.localResourcesCached = null;
     this.pathMapper = pathMapper;
   }
@@ -89,7 +77,7 @@ public final class SimpleSpawn implements Spawn {
       NestedSet<? extends ActionInput> tools,
       Collection<? extends ActionInput> outputs,
       @Nullable Set<? extends ActionInput> mandatoryOutputs,
-      ResourceSet localResources) {
+      ResourceSetOrBuilder localResources) {
     this(
         owner,
         arguments,
@@ -100,83 +88,7 @@ public final class SimpleSpawn implements Spawn {
         outputs,
         mandatoryOutputs,
         localResources,
-        /* localResourcesSupplier= */ null,
         PathMapper.NOOP);
-  }
-
-  @SuppressWarnings("TooManyParameters")
-  public SimpleSpawn(
-      ActionExecutionMetadata owner,
-      ImmutableList<String> arguments,
-      ImmutableMap<String, String> environment,
-      ImmutableMap<String, String> executionInfo,
-      SpawnInputs inputs,
-      NestedSet<? extends ActionInput> tools,
-      Collection<? extends ActionInput> outputs,
-      @Nullable Set<? extends ActionInput> mandatoryOutputs,
-      LocalResourcesSupplier localResourcesSupplier) {
-    this(
-        owner,
-        arguments,
-        environment,
-        executionInfo,
-        inputs,
-        tools,
-        outputs,
-        mandatoryOutputs,
-        /* localResources= */ null,
-        localResourcesSupplier,
-        PathMapper.NOOP);
-  }
-
-  public SimpleSpawn(
-      ActionExecutionMetadata owner,
-      ImmutableList<String> arguments,
-      ImmutableMap<String, String> environment,
-      ImmutableMap<String, String> executionInfo,
-      SpawnInputs inputs,
-      NestedSet<? extends ActionInput> tools,
-      Collection<? extends ActionInput> outputs,
-      @Nullable Set<? extends ActionInput> mandatoryOutputs,
-      LocalResourcesSupplier localResourcesSupplier,
-      PathMapper pathMapper) {
-    this(
-        owner,
-        arguments,
-        environment,
-        executionInfo,
-        inputs,
-        tools,
-        outputs,
-        mandatoryOutputs,
-        null,
-        localResourcesSupplier,
-        pathMapper);
-  }
-
-  public SimpleSpawn(
-      ActionExecutionMetadata owner,
-      ImmutableList<String> arguments,
-      ImmutableMap<String, String> environment,
-      ImmutableMap<String, String> executionInfo,
-      SpawnInputs inputs,
-      NestedSet<? extends ActionInput> tools,
-      Collection<? extends ActionInput> outputs,
-      @Nullable Set<? extends ActionInput> mandatoryOutputs,
-      ResourceSet localResources,
-      PathMapper pathMapper) {
-    this(
-        owner,
-        arguments,
-        environment,
-        executionInfo,
-        inputs,
-        tools,
-        outputs,
-        mandatoryOutputs,
-        localResources,
-        null,
-        pathMapper);
   }
 
   public SimpleSpawn(
@@ -186,7 +98,7 @@ public final class SimpleSpawn implements Spawn {
       ImmutableMap<String, String> executionInfo,
       NestedSet<? extends ActionInput> inputs,
       Collection<? extends ActionInput> outputs,
-      ResourceSet resourceSet) {
+      ResourceSetOrBuilder localResources) {
     this(
         owner,
         arguments,
@@ -196,7 +108,7 @@ public final class SimpleSpawn implements Spawn {
         NestedSetBuilder.emptySet(Order.STABLE_ORDER),
         outputs,
         /* mandatoryOutputs= */ null,
-        resourceSet);
+        localResources);
   }
 
   @Override
@@ -245,8 +157,11 @@ public final class SimpleSpawn implements Spawn {
     if (result == null) {
       // Not expected to be called concurrently, and an idempotent computation if it is.
       result =
-          localResourcesSupplier.buildLocalResources(
-              getExecutionInfo(), getCombinedExecProperties());
+          localResources.buildLocalResources(
+              OS.getCurrent(),
+              inputs.flatten().size(),
+              getExecutionInfo(),
+              getCombinedExecProperties());
       localResourcesCached = result;
     }
     return result;
@@ -271,56 +186,5 @@ public final class SimpleSpawn implements Spawn {
   @Override
   public String toString() {
     return Spawns.prettyPrint(this);
-  }
-
-  /**
-   * Supplies resources needed for local execution. Result will be cached.
-   * TODO(Silic0nS0ldier): This has significant overlap with ResourceSetOrBuilder. Merge them
-   * while preserving the lazy computation of local resources.
-   */
-  @FunctionalInterface
-  public interface LocalResourcesSupplier extends ResourceSetOrBuilder {
-    ResourceSet get() throws ExecException;
-
-    @Override
-    default ResourceSet buildResourceSet(OS os, int inputsSize) throws ExecException {
-      return get();
-    }
-
-    /**
-     * The {@link ResourceSetOrBuilder#buildLocalResources} this interface's callers use, without
-     * the build context a supplier ignores by contract.
-     */
-    default ResourceSet buildLocalResources(
-        Map<String, String> executionInfo, Map<String, String> execProperties)
-        throws ExecException, InterruptedException {
-      // Placeholders, so that the override behaviour stays defined in exactly one place.
-      return buildLocalResources(
-          OS.getCurrent(), /* inputsSize= */ 0, executionInfo, execProperties);
-    }
-  }
-
-  /**
-   * Returns a supplier of fixed {@code resources} that the owning target's {@code resources:}
-   * entries must not override.
-   *
-   * <p>The {@link ResourceSetOrBuilder#fixed} equivalent, in the form {@link SimpleSpawn} accepts.
-   */
-  public static LocalResourcesSupplier fixedLocalResources(ResourceSet resources) {
-    return new LocalResourcesSupplier() {
-      @Override
-      public ResourceSet get() {
-        return resources;
-      }
-
-      @Override
-      public ResourceSet buildLocalResources(
-          OS os,
-          int inputsSize,
-          Map<String, String> executionInfo,
-          Map<String, String> execProperties) {
-        return resources;
-      }
-    };
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
@@ -41,6 +41,7 @@ import com.google.devtools.build.lib.actions.ImportantOutputHandler.ImportantOut
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.NotifyOnActionCacheHit;
 import com.google.devtools.build.lib.actions.ResourceSet;
+import com.google.devtools.build.lib.actions.ResourceSetOrBuilder;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
@@ -128,8 +129,17 @@ public final class CoverageReportActionBuilder {
     @Override
     public ActionResult execute(ActionExecutionContext ctx)
         throws ActionExecutionException, InterruptedException {
+      // The resources are fixed because this action borrows an arbitrary tested target's
+      // ActionOwner (see ACTION_OWNER_COMPARATOR): its exec properties describe that test rather
+      // than this report merge, so charging their `resources:` entries would tie the report's
+      // scheduling to whichever target happened to sort largest.
       Spawn spawn =
-          new BaseSpawn(command, ImmutableMap.of(), ImmutableMap.of(), this, LOCAL_RESOURCES);
+          new BaseSpawn(
+              command,
+              ImmutableMap.of(),
+              ImmutableMap.of(),
+              this,
+              ResourceSetOrBuilder.fixed(LOCAL_RESOURCES));
       try {
         ImmutableList<SpawnResult> spawnResults =
             ctx.getContext(SpawnStrategyResolver.class).exec(spawn, ctx);

--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
@@ -139,7 +139,7 @@ public final class CoverageReportActionBuilder {
               ImmutableMap.of(),
               ImmutableMap.of(),
               this,
-              ResourceSetOrBuilder.fixed(LOCAL_RESOURCES));
+              ResourceSetOrBuilder.ignoringOverrides(LOCAL_RESOURCES));
       try {
         ImmutableList<SpawnResult> spawnResults =
             ctx.getContext(SpawnStrategyResolver.class).exec(spawn, ctx);

--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -439,6 +439,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:action_input",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:execution_requirements",
+        "//src/main/java/com/google/devtools/build/lib/actions:localhost_capacity",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
+import com.google.devtools.build.lib.actions.ResourceSetOrBuilder;
 import com.google.devtools.build.lib.actions.SimpleSpawn;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnInputs;
@@ -125,8 +126,8 @@ public class StandaloneTestStrategy extends TestStrategy {
     executionInfo.put(
         ExecutionRequirements.TIMEOUT, Long.toString(action.getTimeout().toSeconds()));
 
-    SimpleSpawn.LocalResourcesSupplier localResourcesSupplier =
-        () ->
+    ResourceSetOrBuilder localResources =
+        (os, inputsSize) ->
             action
                 .getTestProperties()
                 .getLocalResourceUsage(
@@ -142,7 +143,7 @@ public class StandaloneTestStrategy extends TestStrategy {
             NestedSetBuilder.emptySet(Order.STABLE_ORDER),
             ImmutableSet.copyOf(action.getSpawnOutputs()),
             /* mandatoryOutputs= */ ImmutableSet.of(),
-            localResourcesSupplier);
+            localResources);
     Path execRoot = actionExecutionContext.getExecRoot();
     ArtifactPathResolver pathResolver = actionExecutionContext.getPathResolver();
     Path tmpDir = pathResolver.convertPath(tmpDirRoot.getChild(TestStrategy.getTmpDirName(action)));
@@ -489,7 +490,7 @@ public class StandaloneTestStrategy extends TestStrategy {
         // describe the test process, not this script. Letting them override the default would
         // make a log-to-XML conversion book the whole test's CPU/memory/custom resources and
         // queue behind unrelated actions.
-        SimpleSpawn.fixedLocalResources(SpawnAction.DEFAULT_RESOURCE_SET));
+        ResourceSetOrBuilder.fixed(SpawnAction.DEFAULT_RESOURCE_SET));
   }
 
   private static Spawn createCoveragePostProcessingSpawn(
@@ -530,7 +531,7 @@ public class StandaloneTestStrategy extends TestStrategy {
         /* mandatoryOutputs= */ null,
         // As in createXmlGeneratingSpawn: the test target's `resources:` entries describe the
         // test process, not this post-processing step.
-        SimpleSpawn.fixedLocalResources(SpawnAction.DEFAULT_RESOURCE_SET));
+        ResourceSetOrBuilder.fixed(SpawnAction.DEFAULT_RESOURCE_SET));
   }
 
   private static Map<String, String> createEnvironment(

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -475,8 +475,8 @@ public class StandaloneTestStrategy extends TestStrategy {
         action,
         args,
         envBuilder.buildOrThrow(),
-        // Pass the execution info of the action which is identical to the supported tags set on the
-        // test target. In particular, this does not set the test timeout on the spawn.
+        // Pass the execution info of the action which is identical to the supported tags set on
+        // the test target. In particular, this does not set the test timeout on the spawn.
         action.getExecutionInfo(),
         SpawnInputs.of(
             NestedSetBuilder.create(
@@ -484,7 +484,12 @@ public class StandaloneTestStrategy extends TestStrategy {
         /* tools= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
         /* outputs= */ ImmutableSet.of(action.getTestXml()),
         /* mandatoryOutputs= */ null,
-        SpawnAction.DEFAULT_RESOURCE_SET);
+        // The resources are fixed because the execution info above carries the test target's
+        // `resources:` tags (and, via TestTargetProperties, its exec_properties), which
+        // describe the test process, not this script. Letting them override the default would
+        // make a log-to-XML conversion book the whole test's CPU/memory/custom resources and
+        // queue behind unrelated actions.
+        SimpleSpawn.fixedLocalResources(SpawnAction.DEFAULT_RESOURCE_SET));
   }
 
   private static Spawn createCoveragePostProcessingSpawn(
@@ -523,7 +528,9 @@ public class StandaloneTestStrategy extends TestStrategy {
         /* tools= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
         /* outputs= */ ImmutableSet.of(action.getCoverageData()),
         /* mandatoryOutputs= */ null,
-        SpawnAction.DEFAULT_RESOURCE_SET);
+        // As in createXmlGeneratingSpawn: the test target's `resources:` entries describe the
+        // test process, not this post-processing step.
+        SimpleSpawn.fixedLocalResources(SpawnAction.DEFAULT_RESOURCE_SET));
   }
 
   private static Map<String, String> createEnvironment(

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -490,7 +490,7 @@ public class StandaloneTestStrategy extends TestStrategy {
         // describe the test process, not this script. Letting them override the default would
         // make a log-to-XML conversion book the whole test's CPU/memory/custom resources and
         // queue behind unrelated actions.
-        ResourceSetOrBuilder.fixed(SpawnAction.DEFAULT_RESOURCE_SET));
+        ResourceSetOrBuilder.ignoringOverrides(SpawnAction.DEFAULT_RESOURCE_SET));
   }
 
   private static Spawn createCoveragePostProcessingSpawn(
@@ -531,7 +531,7 @@ public class StandaloneTestStrategy extends TestStrategy {
         /* mandatoryOutputs= */ null,
         // As in createXmlGeneratingSpawn: the test target's `resources:` entries describe the
         // test process, not this post-processing step.
-        ResourceSetOrBuilder.fixed(SpawnAction.DEFAULT_RESOURCE_SET));
+        ResourceSetOrBuilder.ignoringOverrides(SpawnAction.DEFAULT_RESOURCE_SET));
   }
 
   private static Map<String, String> createEnvironment(

--- a/src/main/java/com/google/devtools/build/lib/includescanning/SpawnIncludeScanner.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/SpawnIncludeScanner.java
@@ -475,7 +475,7 @@ public class SpawnIncludeScanner {
           /* environment= */ ImmutableMap.of(),
           executionInfo,
           action,
-          ResourceSetOrBuilder.fixed(LOCAL_RESOURCES));
+          ResourceSetOrBuilder.ignoringOverrides(LOCAL_RESOURCES));
       this.inputs =
           SpawnInputs.of(NestedSetBuilder.create(Order.STABLE_ORDER, grepIncludes, input));
       this.outputs = ImmutableSet.of(output);

--- a/src/main/java/com/google/devtools/build/lib/includescanning/SpawnIncludeScanner.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/SpawnIncludeScanner.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.ResourceSet;
+import com.google.devtools.build.lib.actions.ResourceSetOrBuilder;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnInputs;
 import com.google.devtools.build.lib.actions.SpawnResult;
@@ -466,8 +467,15 @@ public class SpawnIncludeScanner {
         Artifact grepIncludes,
         Artifact input,
         ActionInput output) {
+      // The resources are fixed because the execution info is the compile action's: its
+      // `resources:` entries describe the compiler process rather than this grep, and charging them
+      // here would make include scanning book a full compile's worth of resources.
       super(
-          arguments, /* environment= */ ImmutableMap.of(), executionInfo, action, LOCAL_RESOURCES);
+          arguments,
+          /* environment= */ ImmutableMap.of(),
+          executionInfo,
+          action,
+          ResourceSetOrBuilder.fixed(LOCAL_RESOURCES));
       this.inputs =
           SpawnInputs.of(NestedSetBuilder.create(Order.STABLE_ORDER, grepIncludes, input));
       this.outputs = ImmutableSet.of(output);

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -1792,12 +1792,9 @@ public class CppCompileAction extends AbstractAction
           /* tools= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
           getOutputs(),
           mandatoryOutputs,
-          () ->
+          (os, inputsSize) ->
               estimateResourceConsumptionLocal(
-                  enabledCppCompileResourcesEstimation(),
-                  getMnemonic(),
-                  OS.getCurrent(),
-                  inputs.flatten().size()),
+                  enabledCppCompileResourcesEstimation(), getMnemonic(), os, inputsSize),
           pathMapper);
     } catch (CommandLineExpansionException e) {
       String message =

--- a/src/test/java/com/google/devtools/build/lib/actions/SpawnTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/SpawnTest.java
@@ -16,7 +16,9 @@ package com.google.devtools.build.lib.actions;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.ParameterFile.ParameterFileType;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.exec.util.SpawnBuilder;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import org.junit.Test;
@@ -101,5 +103,65 @@ public final class SpawnTest {
     assertThat(spawn.getArgumentsWithExpandedParamFiles())
         .containsExactly("/bin/gcc", "@some/other/file", "-o", "foo.o")
         .inOrder();
+  }
+
+  private static final ResourceSet DECLARED_RESOURCES =
+      ResourceSet.createWithRamCpu(/* memoryMb= */ 250, /* cpu= */ 1);
+
+  @Test
+  public void getLocalResources_appliesResourceOverrides() throws Exception {
+    Spawn spawn =
+        new SpawnBuilder("/bin/true")
+            .withLocalResources(DECLARED_RESOURCES)
+            .withExecutionInfo("resources:cpu:4", "")
+            .withCombinedExecProperties(ImmutableMap.of("resources:memory", "8000"))
+            .build();
+    ResourceSet resources = spawn.getLocalResources();
+
+    // Execution info and exec properties both override the declared amounts.
+    assertThat(resources.getCpuUsage()).isEqualTo(4.0);
+    assertThat(resources.getMemoryMb()).isEqualTo(8000.0);
+  }
+
+  @Test
+  public void getLocalResources_fixedDeclaration_ignoresResourceOverrides() throws Exception {
+    Spawn spawn =
+        new SpawnBuilder("/bin/true")
+            .withLocalResourcesSupplier(SimpleSpawn.fixedLocalResources(DECLARED_RESOURCES))
+            .withExecutionInfo("resources:cpu:4", "")
+            .withCombinedExecProperties(ImmutableMap.of("resources:memory", "8000"))
+            .build();
+
+    assertThat(spawn.getLocalResources()).isEqualTo(DECLARED_RESOURCES);
+    // The declarations still reach the spawn, so strategy selection is unaffected.
+    assertThat(spawn.getExecutionInfo()).containsKey("resources:cpu:4");
+    assertThat(spawn.getCombinedExecProperties()).containsEntry("resources:memory", "8000");
+  }
+
+  // NullAction's owner has no exec properties, so these only exercise the execution-info route.
+  // Both routes share ResourceSetOrBuilder#applyDeclaredOverrides, which the cases above cover.
+  private static BaseSpawn baseSpawn(ResourceSetOrBuilder localResources) {
+    return new BaseSpawn(
+        ImmutableList.of("/bin/true"),
+        /* environment= */ ImmutableMap.of(),
+        /* executionInfo= */ ImmutableMap.of("resources:cpu:4", ""),
+        new ActionsTestUtil.NullAction(),
+        localResources);
+  }
+
+  @Test
+  public void baseSpawn_getLocalResources_appliesResourceOverrides() throws Exception {
+    ResourceSet resources = baseSpawn(DECLARED_RESOURCES).getLocalResources();
+
+    assertThat(resources.getCpuUsage()).isEqualTo(4.0);
+  }
+
+  @Test
+  public void baseSpawn_getLocalResources_fixedDeclaration_keepsDeclaredResources()
+      throws Exception {
+    BaseSpawn spawn = baseSpawn(ResourceSetOrBuilder.fixed(DECLARED_RESOURCES));
+
+    assertThat(spawn.getLocalResources()).isEqualTo(DECLARED_RESOURCES);
+    assertThat(spawn.getExecutionInfo()).containsKey("resources:cpu:4");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/actions/SpawnTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/SpawnTest.java
@@ -127,7 +127,7 @@ public final class SpawnTest {
   public void getLocalResources_fixedDeclaration_ignoresResourceOverrides() throws Exception {
     Spawn spawn =
         new SpawnBuilder("/bin/true")
-            .withLocalResources(ResourceSetOrBuilder.fixed(DECLARED_RESOURCES))
+            .withLocalResources(ResourceSetOrBuilder.ignoringOverrides(DECLARED_RESOURCES))
             .withExecutionInfo("resources:cpu:4", "")
             .withCombinedExecProperties(ImmutableMap.of("resources:memory", "8000"))
             .build();
@@ -159,7 +159,7 @@ public final class SpawnTest {
   @Test
   public void baseSpawn_getLocalResources_fixedDeclaration_keepsDeclaredResources()
       throws Exception {
-    BaseSpawn spawn = baseSpawn(ResourceSetOrBuilder.fixed(DECLARED_RESOURCES));
+    BaseSpawn spawn = baseSpawn(ResourceSetOrBuilder.ignoringOverrides(DECLARED_RESOURCES));
 
     assertThat(spawn.getLocalResources()).isEqualTo(DECLARED_RESOURCES);
     assertThat(spawn.getExecutionInfo()).containsKey("resources:cpu:4");

--- a/src/test/java/com/google/devtools/build/lib/actions/SpawnTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/SpawnTest.java
@@ -127,7 +127,7 @@ public final class SpawnTest {
   public void getLocalResources_fixedDeclaration_ignoresResourceOverrides() throws Exception {
     Spawn spawn =
         new SpawnBuilder("/bin/true")
-            .withLocalResourcesSupplier(SimpleSpawn.fixedLocalResources(DECLARED_RESOURCES))
+            .withLocalResources(ResourceSetOrBuilder.fixed(DECLARED_RESOURCES))
             .withExecutionInfo("resources:cpu:4", "")
             .withCombinedExecProperties(ImmutableMap.of("resources:memory", "8000"))
             .build();
@@ -139,7 +139,7 @@ public final class SpawnTest {
   }
 
   // NullAction's owner has no exec properties, so these only exercise the execution-info route.
-  // Both routes share ResourceSetOrBuilder#applyDeclaredOverrides, which the cases above cover.
+  // Both routes share ResourceSetOrBuilder#buildLocalResources, which the cases above cover.
   private static BaseSpawn baseSpawn(ResourceSetOrBuilder localResources) {
     return new BaseSpawn(
         ImmutableList.of("/bin/true"),

--- a/src/test/java/com/google/devtools/build/lib/exec/StandaloneTestStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/StandaloneTestStrategyTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.MoreCollectors;
+import com.google.devtools.build.lib.actions.AbstractAction;
 import com.google.devtools.build.lib.actions.ActionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionException;
@@ -710,6 +711,61 @@ public final class StandaloneTestStrategyTest extends BuildViewTestCase {
     assertThat(outErr.getErrorPath().exists()).isFalse();
     assertThat(called).hasSize(2);
     assertThat(called).containsNoDuplicates();
+  }
+
+  @Test
+  public void xmlGeneratingSpawnDoesNotInheritTestResourceDeclarations() throws Exception {
+    ExecutionOptions executionOptions = Options.getDefaults(ExecutionOptions.class);
+    TestSummaryOptions testSummaryOptions = Options.getDefaults(TestSummaryOptions.class);
+    Path tmpDirRoot = TestStrategy.getTmpRoot(rootDirectory, outputBase, executionOptions);
+    TestedStandaloneTestStrategy standaloneTestStrategy =
+        new TestedStandaloneTestStrategy(executionOptions, testSummaryOptions, tmpDirRoot);
+
+    // The test declares a large resource footprint both via tags and via exec_properties; the
+    // test.xml generator must not be charged for either.
+    scratch.file("standalone/simple_test.sh", "this does not get executed, it is mocked out");
+    scratch.file(
+        "standalone/BUILD",
+        """
+        load('//test_defs:foo_test.bzl', 'foo_test')
+        foo_test(
+            name = "simple_test",
+            size = "small",
+            srcs = ["simple_test.sh"],
+            tags = ["resources:cpu:4"],
+            exec_properties = {"resources:memory": "8000"},
+        )
+        """);
+    TestRunnerAction testRunnerAction = getTestAction("//standalone:simple_test");
+
+    List<Spawn> spawns = new ArrayList<>();
+    when(spawnStrategy.exec(any(), any()))
+        .thenAnswer(
+            (invocation) -> {
+              spawns.add(invocation.getArgument(0));
+              return ImmutableList.of(PASSED_TEST_SPAWN);
+            });
+
+    ActionExecutionContext actionExecutionContext =
+        new FakeActionExecutionContext(
+            createTempOutErr(tmpDirRoot), inputMetadataFor(testRunnerAction), spawnStrategy);
+
+    execute(testRunnerAction, actionExecutionContext, standaloneTestStrategy);
+
+    assertThat(spawns).hasSize(2);
+    Spawn testSpawn = spawns.get(0);
+    Spawn xmlGeneratingSpawn = spawns.get(1);
+    assertThat(xmlGeneratingSpawn.getOutputFiles()).containsExactly(testRunnerAction.getTestXml());
+
+    // The test spawn honours the declared resources...
+    assertThat(testSpawn.getLocalResources().getCpuUsage()).isEqualTo(4.0);
+    assertThat(testSpawn.getLocalResources().getMemoryMb()).isEqualTo(8000.0);
+
+    // ...but the injected test.xml generator keeps its own modest, fixed footprint. Both
+    // declarations still reach it as execution info, so strategy selection is unaffected.
+    assertThat(xmlGeneratingSpawn.getLocalResources())
+        .isEqualTo(AbstractAction.DEFAULT_RESOURCE_SET);
+    assertThat(xmlGeneratingSpawn.getExecutionInfo()).containsKey("resources:cpu:4");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.ResourceSet;
+import com.google.devtools.build.lib.actions.ResourceSetOrBuilder;
 import com.google.devtools.build.lib.actions.SimpleSpawn;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnInputs;
@@ -55,8 +56,7 @@ public final class SpawnBuilder {
   @Nullable private Set<? extends ActionInput> mandatoryOutputs;
   private final NestedSetBuilder<ActionInput> tools = NestedSetBuilder.stableOrder();
 
-  private ResourceSet resourceSet = ResourceSet.ZERO;
-  @Nullable private SimpleSpawn.LocalResourcesSupplier localResourcesSupplier;
+  private ResourceSetOrBuilder localResources = ResourceSet.ZERO;
   private PathMapper pathMapper = PathMapper.NOOP;
   private boolean builtForToolConfiguration;
 
@@ -75,19 +75,6 @@ public final class SpawnBuilder {
             platform,
             execProperties,
             builtForToolConfiguration);
-    if (localResourcesSupplier != null) {
-      return new SimpleSpawn(
-          owner,
-          ImmutableList.copyOf(args),
-          ImmutableMap.copyOf(environment),
-          ImmutableMap.copyOf(executionInfo),
-          SpawnInputs.of(inputs.build()),
-          tools.build(),
-          ImmutableSet.copyOf(outputs),
-          mandatoryOutputs,
-          localResourcesSupplier,
-          pathMapper);
-    }
     return new SimpleSpawn(
         owner,
         ImmutableList.copyOf(args),
@@ -97,7 +84,7 @@ public final class SpawnBuilder {
         tools.build(),
         ImmutableSet.copyOf(outputs),
         mandatoryOutputs,
-        resourceSet,
+        localResources,
         pathMapper);
   }
 
@@ -257,15 +244,8 @@ public final class SpawnBuilder {
   }
 
   @CanIgnoreReturnValue
-  public SpawnBuilder withLocalResources(ResourceSet resourceSet) {
-    this.resourceSet = resourceSet;
-    return this;
-  }
-
-  @CanIgnoreReturnValue
-  public SpawnBuilder withLocalResourcesSupplier(
-      SimpleSpawn.LocalResourcesSupplier localResourcesSupplier) {
-    this.localResourcesSupplier = localResourcesSupplier;
+  public SpawnBuilder withLocalResources(ResourceSetOrBuilder localResources) {
+    this.localResources = localResources;
     return this;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
@@ -56,6 +56,7 @@ public final class SpawnBuilder {
   private final NestedSetBuilder<ActionInput> tools = NestedSetBuilder.stableOrder();
 
   private ResourceSet resourceSet = ResourceSet.ZERO;
+  @Nullable private SimpleSpawn.LocalResourcesSupplier localResourcesSupplier;
   private PathMapper pathMapper = PathMapper.NOOP;
   private boolean builtForToolConfiguration;
 
@@ -74,6 +75,19 @@ public final class SpawnBuilder {
             platform,
             execProperties,
             builtForToolConfiguration);
+    if (localResourcesSupplier != null) {
+      return new SimpleSpawn(
+          owner,
+          ImmutableList.copyOf(args),
+          ImmutableMap.copyOf(environment),
+          ImmutableMap.copyOf(executionInfo),
+          SpawnInputs.of(inputs.build()),
+          tools.build(),
+          ImmutableSet.copyOf(outputs),
+          mandatoryOutputs,
+          localResourcesSupplier,
+          pathMapper);
+    }
     return new SimpleSpawn(
         owner,
         ImmutableList.copyOf(args),
@@ -245,6 +259,13 @@ public final class SpawnBuilder {
   @CanIgnoreReturnValue
   public SpawnBuilder withLocalResources(ResourceSet resourceSet) {
     this.resourceSet = resourceSet;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public SpawnBuilder withLocalResourcesSupplier(
+      SimpleSpawn.LocalResourcesSupplier localResourcesSupplier) {
+    this.localResourcesSupplier = localResourcesSupplier;
     return this;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/test/TestTargetPropertiesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/test/TestTargetPropertiesTest.java
@@ -50,7 +50,7 @@ public class TestTargetPropertiesTest extends BuildViewTestCase {
         /* tools= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
         outputs,
         /* mandatoryOutputs= */ null,
-        () ->
+        (os, inputsSize) ->
             action.getTestProperties().getLocalResourceUsage(action.getOwner().getLabel(), false));
   }
 


### PR DESCRIPTION
### Description
Fixes a regression introduced by #29284 where local resource specifications (`resources:*:*`, `cpu:*` and `memory:*`) affected builtin actions such as;
- `test.xml` generator action
- C spawn include scanner

Also moves resource overriding into `ResourceSetOrBuilder` to reduce the risk of drift between `BaseSpawn` and `SimpleSpawn`.

### Motivation
Deriving local resource sets in these builtin spawns causes otherwise lightweight tasks to backup (and temporarily block) other larger spawns due to them taking an unreasonably high number of resource permits. In the case of `test.xml` generation, when resources are exhausted it can cause tests to visibly appear as if they are running for much longer than they really are (exacerbation of an existing issue where `test.xml` generation scheduling is not differentiated from spawn running in UI and potentially elsewhere).

### Build API Changes
No

### Checklist
- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes
RELNOTES: Fix for regression in #29284 that caused select builtin actions to incorrectly inherit resource set overrides.
