### PR TITLE
Report internal output groups in the "nothing to build" message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildResultPrinter.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildResultPrinter.java
@@ -248,8 +248,7 @@ class BuildResultPrinter {
    *
    * <p>Artifacts in output groups prefixed with {@link OutputGroupInfo#HIDDEN_OUTPUT_GROUP_PREFIX}
    * are never shown, but are still built, so the build may well have executed actions on this
-   * target's behalf. Bazel requests these output groups by itself, so report that they were built
-   * without naming them.
+   * target's behalf.
    */
   private static String nothingToBuildMessage(
       ProviderCollection target, TopLevelArtifactContext context) {

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildResultPrinter.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildResultPrinter.java
@@ -27,7 +27,6 @@ import com.google.devtools.build.lib.analysis.OutputGroupInfo;
 import com.google.devtools.build.lib.analysis.ProviderCollection;
 import com.google.devtools.build.lib.analysis.TopLevelArtifactContext;
 import com.google.devtools.build.lib.analysis.TopLevelArtifactHelper;
-import com.google.devtools.build.lib.analysis.TopLevelArtifactHelper.ArtifactsInOutputGroup;
 import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.analysis.configuredtargets.OutputFileConfiguredTarget;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -39,12 +38,9 @@ import com.google.devtools.build.lib.skyframe.ConfiguredTargetKey;
 import com.google.devtools.build.lib.util.io.OutErr;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Objects;
 
-/**
- * Handles --show_result and --experimental_show_artifacts.
- */
+/** Handles --show_result and --experimental_show_artifacts. */
 class BuildResultPrinter {
   private final CommandEnvironment env;
 
@@ -254,7 +250,7 @@ class BuildResultPrinter {
       ProviderCollection target, TopLevelArtifactContext context) {
     boolean ranValidationActions = false;
     boolean builtInternalOutputGroups = false;
-    for (Map.Entry<String, ArtifactsInOutputGroup> outputGroup :
+    for (var outputGroup :
         TopLevelArtifactHelper.getAllArtifactsToBuild(target, context)
             .getAllArtifactsByOutputGroup()
             .entrySet()) {
@@ -329,7 +325,8 @@ class BuildResultPrinter {
       if (artifacts.isEmpty()) {
         if (!omitNothingToBuild) {
           outErr.printErr(
-              "Target " + label + " up-to-date (" + nothingToBuildMessage(target, context) + ")\n");
+              String.format(
+                  "Target %s up-to-date (%s)\n", label, nothingToBuildMessage(target, context)));
         }
         continue;
       }
@@ -372,13 +369,9 @@ class BuildResultPrinter {
       if (artifacts.isEmpty()) {
         if (!omitNothingToBuild) {
           outErr.printErr(
-              "Aspect "
-                  + aspectName
-                  + " of "
-                  + label
-                  + " up-to-date ("
-                  + nothingToBuildMessage(aspects.get(aspect), context)
-                  + ")\n");
+              String.format(
+                  "Aspect %s of %s up-to-date (%s)\n",
+                  aspectName, label, nothingToBuildMessage(aspects.get(aspect), context)));
         }
         continue;
       }

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildResultPrinter.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildResultPrinter.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.analysis.OutputGroupInfo;
 import com.google.devtools.build.lib.analysis.ProviderCollection;
 import com.google.devtools.build.lib.analysis.TopLevelArtifactContext;
 import com.google.devtools.build.lib.analysis.TopLevelArtifactHelper;
+import com.google.devtools.build.lib.analysis.TopLevelArtifactHelper.ArtifactsInOutputGroup;
 import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.analysis.configuredtargets.OutputFileConfiguredTarget;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -38,6 +39,7 @@ import com.google.devtools.build.lib.skyframe.ConfiguredTargetKey;
 import com.google.devtools.build.lib.util.io.OutErr;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -162,6 +164,7 @@ class BuildResultPrinter {
     outputConfiguredTargets(
         outErr,
         prettyPrinter,
+        context,
         succeeded,
         artifactsToPrintPerTarget,
         failed,
@@ -170,6 +173,8 @@ class BuildResultPrinter {
     outputAspects(
         outErr,
         prettyPrinter,
+        context,
+        aspects,
         successfulAspects,
         artifactsToPrintPerAspect,
         failedAspects,
@@ -237,6 +242,46 @@ class BuildResultPrinter {
     return artifacts;
   }
 
+  /**
+   * Returns the message printed in place of the artifacts of a target or aspect that has none to
+   * show.
+   *
+   * <p>Artifacts in output groups prefixed with {@link OutputGroupInfo#HIDDEN_OUTPUT_GROUP_PREFIX}
+   * are never shown, but are still built, so the build may well have executed actions on this
+   * target's behalf. Bazel requests these output groups by itself, so report that they were built
+   * without naming them.
+   */
+  private static String nothingToBuildMessage(
+      ProviderCollection target, TopLevelArtifactContext context) {
+    boolean ranValidationActions = false;
+    boolean builtInternalOutputGroups = false;
+    for (Map.Entry<String, ArtifactsInOutputGroup> outputGroup :
+        TopLevelArtifactHelper.getAllArtifactsToBuild(target, context)
+            .getAllArtifactsByOutputGroup()
+            .entrySet()) {
+      if (outputGroup.getValue().areImportant()) {
+        continue;
+      }
+      if (outputGroup.getKey().equals(OutputGroupInfo.VALIDATION)
+          || outputGroup.getKey().equals(OutputGroupInfo.VALIDATION_TOP_LEVEL)) {
+        ranValidationActions = true;
+      } else {
+        builtInternalOutputGroups = true;
+      }
+    }
+    if (ranValidationActions && builtInternalOutputGroups) {
+      return "nothing to build except validation outputs and other internal output groups, use"
+          + " --norun_validations to skip validations";
+    }
+    if (ranValidationActions) {
+      return "nothing to build except validation outputs, use --norun_validations to skip them";
+    }
+    if (builtInternalOutputGroups) {
+      return "nothing to build except internal output groups";
+    }
+    return "nothing to build";
+  }
+
   private static int splitAspectsByResultReturnRemaining(
       Collection<AspectKey> aspectsToPrint,
       ImmutableMap<AspectKey, ConfiguredAspect> aspects,
@@ -269,6 +314,7 @@ class BuildResultPrinter {
   private static void outputConfiguredTargets(
       OutErr outErr,
       PathPrettyPrinter prettyPrinter,
+      TopLevelArtifactContext context,
       ArrayList<ConfiguredTarget> succeeded,
       ArrayList<ArrayList<Artifact>> artifactsToPrintPerTarget,
       ArrayList<ConfiguredTarget> failed,
@@ -283,7 +329,8 @@ class BuildResultPrinter {
       ArrayList<Artifact> artifacts = artifactsToPrintPerTarget.get(i);
       if (artifacts.isEmpty()) {
         if (!omitNothingToBuild) {
-          outErr.printErr("Target " + label + " up-to-date (nothing to build)\n");
+          outErr.printErr(
+              "Target " + label + " up-to-date (" + nothingToBuildMessage(target, context) + ")\n");
         }
         continue;
       }
@@ -312,6 +359,8 @@ class BuildResultPrinter {
   private static void outputAspects(
       OutErr outErr,
       PathPrettyPrinter prettyPrinter,
+      TopLevelArtifactContext context,
+      ImmutableMap<AspectKey, ConfiguredAspect> aspects,
       ArrayList<AspectKey> succeeded,
       ArrayList<ArrayList<Artifact>> artifactsToPrintPerAspect,
       ArrayList<AspectKey> failed,
@@ -324,7 +373,13 @@ class BuildResultPrinter {
       if (artifacts.isEmpty()) {
         if (!omitNothingToBuild) {
           outErr.printErr(
-              "Aspect " + aspectName + " of " + label + " up-to-date (nothing to build)\n");
+              "Aspect "
+                  + aspectName
+                  + " of "
+                  + label
+                  + " up-to-date ("
+                  + nothingToBuildMessage(aspects.get(aspect), context)
+                  + ")\n");
         }
         continue;
       }

--- a/src/test/java/com/google/devtools/build/lib/buildtool/BuildResultTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/BuildResultTestCase.java
@@ -83,6 +83,37 @@ public abstract class BuildResultTestCase extends BuildIntegrationTestCase {
   }
 
   @Test
+  public void testWithOnlyInternalOutputGroups() throws Exception {
+    write(
+        "foo/BUILD",
+        """
+        load("//test_defs:foo_binary.bzl", "foo_binary")
+
+        genrule(
+            name = "gen",
+            outs = ["gen.out"],
+            cmd = "touch $@",
+        )
+
+        foo_binary(
+            name = "foo",
+            srcs = ["foo.sh"],
+            data = [":gen"],
+        )
+        """);
+    write("foo/foo.sh", "echo foo").setExecutable(true);
+
+    // Subtracting the default output group leaves the internal output group carrying the runfiles,
+    // which are built but never shown.
+    addOptions("--output_groups=-default");
+    build(false, "no-error", "//foo");
+
+    String stderr = recOutErr.errAsLatin1();
+    assertThat(stderr)
+        .contains("Target //foo:foo up-to-date (nothing to build except internal output groups)\n");
+  }
+
+  @Test
   public void testNoKeepGoingResult() throws Exception {
     write("test/BUILD",
         "genrule(name='A', srcs=['A2'], outs=['A.out']," +

--- a/src/test/shell/integration/validation_actions_test.sh
+++ b/src/test/shell/integration/validation_actions_test.sh
@@ -223,6 +223,39 @@ function test_validation_actions() {
   assert_exists bazel-bin/validation_actions/foo0.validation
 }
 
+function test_validation_actions_with_empty_output_group() {
+  setup_test_project
+  setup_passing_validation_action
+
+  # Requesting an output group that has no artifacts leaves nothing to show, but validation actions
+  # are run regardless of --output_groups, so the build is not a no-op.
+  bazel build --run_validations --output_groups=no_such_output_group \
+      //validation_actions:foo0 >& "$TEST_log" || fail "Expected build to succeed"
+
+  expect_log "Target //validation_actions:foo0 up-to-date (nothing to build except validation \
+outputs, use --norun_validations to skip them)"
+  assert_exists bazel-bin/validation_actions/foo0.validation
+
+  bazel build --norun_validations --output_groups=no_such_output_group \
+      //validation_actions:foo0 >& "$TEST_log" || fail "Expected build to succeed"
+
+  expect_log "Target //validation_actions:foo0 up-to-date (nothing to build)"
+}
+
+function test_no_output_group_but_runfiles() {
+  setup_test_project
+  setup_passing_validation_action
+
+  # Subtracting the default output group still leaves the internal output group that carries the
+  # runfiles, so the build is not a no-op here either.
+  bazel build --norun_validations --output_groups=-default \
+      //validation_actions:test_with_rule_with_validation_in_deps \
+      >& "$TEST_log" || fail "Expected build to succeed"
+
+  expect_log "Target //validation_actions:test_with_rule_with_validation_in_deps up-to-date \
+(nothing to build except internal output groups)"
+}
+
 function test_validation_actions_with_validation_aspect() {
   setup_test_project
   setup_passing_validation_action

--- a/src/test/shell/integration/validation_actions_test.sh
+++ b/src/test/shell/integration/validation_actions_test.sh
@@ -242,20 +242,6 @@ outputs, use --norun_validations to skip them)"
   expect_log "Target //validation_actions:foo0 up-to-date (nothing to build)"
 }
 
-function test_no_output_group_but_runfiles() {
-  setup_test_project
-  setup_passing_validation_action
-
-  # Subtracting the default output group still leaves the internal output group that carries the
-  # runfiles, so the build is not a no-op here either.
-  bazel build --norun_validations --output_groups=-default \
-      //validation_actions:test_with_rule_with_validation_in_deps \
-      >& "$TEST_log" || fail "Expected build to succeed"
-
-  expect_log "Target //validation_actions:test_with_rule_with_validation_in_deps up-to-date \
-(nothing to build except internal output groups)"
-}
-
 function test_validation_actions_with_validation_aspect() {
   setup_test_project
   setup_passing_validation_action


### PR DESCRIPTION
### Description

Output groups whose name starts with `_` are deliberately excluded from the artifacts that `--show_result` lists, but they are still built. `--output_groups` also never disables the `_validation` output group, which every rule aggregates transitively from its dependencies.

Together, this means that `bazel build --output_groups=<group that is empty or does not exist> //foo` reports "nothing to build" while executing every action needed to produce `//foo`'s transitive validation outputs. The same happens with `--output_groups=-default`, which keeps building the target's runfiles via `_hidden_top_level_INTERNAL_`.

This PR reports that these output groups were built instead, without naming them since Bazel requests them by itself, and points at `--norun_validations` when validation outputs are among them:

```
Target //foo:bar up-to-date (nothing to build except validation outputs, use --norun_validations to skip them)
Target //foo:bar up-to-date (nothing to build except internal output groups)
Target //foo:bar up-to-date (nothing to build except validation outputs and other internal output groups, use --norun_validations to skip validations)
```

A target that genuinely has nothing to build still reports `(nothing to build)`, and targets with artifacts to show are unaffected.

### Motivation

Reported in #30749: `bazel build --output_groups=thisoutputgroupdoesnotexist //src:bazel` on a clean Bazel checkout says "nothing to build" and then runs 3778 actions.

The work itself is intended. `//src:bazel` transitively aggregates the one-version check of `//src/main/java/com/google/devtools/build/lib/bazel:BazelServer` (enabled by `--experimental_one_version_enforcement=ERROR` in Bazel's own `.bazelrc`) into its `_validation` output group, and that single validation action takes the whole runtime classpath — 1236 generated jars — as its inputs. What is wrong is the report: the console claims nothing happened while the build did almost everything.

Fixes #30749

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
