### PR TITLE
[9.3.0] Don't report cancelled remote transfers as errors (https://github.com/bazelbuild/bazel/pull/30652)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/util/AsyncTaskCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/AsyncTaskCache.java
@@ -314,7 +314,7 @@ public final class AsyncTaskCache<KeyT, ValueT> {
         emitter -> {
           synchronized (lock) {
             if (state != STATE_ACTIVE) {
-              emitter.onError(new CancellationException("already shutdown"));
+              emitter.tryOnError(new CancellationException("already shutdown"));
               return;
             }
 
@@ -357,9 +357,9 @@ public final class AsyncTaskCache<KeyT, ValueT> {
 
                   @Override
                   public void onError(@NonNull Throwable e) {
-                    if (!emitter.isDisposed()) {
-                      emitter.onError(e);
-                    }
+                    // Don't report via RxJava's global error handler if the emitter has been
+                    // disposed.
+                    emitter.tryOnError(e);
                   }
                 });
           }

--- a/src/main/java/com/google/devtools/build/lib/remote/util/RxFutures.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/RxFutures.java
@@ -92,10 +92,11 @@ public class RxFutures {
                  *   1. The ListenableFuture itself is cancelled.
                  *   2. Completable is disposed by downstream.
                  *
-                 * This check is used to prevent propagating CancellationException to downstream
-                 * when it has already disposed the Completable.
+                 * In the second case, the CancellationException must not be propagated to
+                 * downstream.
                  */
-                if (throwable instanceof CancellationException && emitter.isDisposed()) {
+                if (throwable instanceof CancellationException) {
+                  emitter.tryOnError(throwable);
                   return;
                 }
 
@@ -162,10 +163,11 @@ public class RxFutures {
                  *   1. The ListenableFuture itself is cancelled.
                  *   2. Single is disposed by downstream.
                  *
-                 * This check is used to prevent propagating CancellationException to downstream
-                 * when it has already disposed the Single.
+                 * In the second case, the CancellationException must not be propagated to
+                 * downstream.
                  */
-                if (throwable instanceof CancellationException && emitter.isDisposed()) {
+                if (throwable instanceof CancellationException) {
+                  emitter.tryOnError(throwable);
                   return;
                 }
 
@@ -262,5 +264,4 @@ public class RxFutures {
         });
     return future;
   }
-
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/util/RxUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/RxUtils.java
@@ -20,6 +20,7 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import java.io.IOException;
+import java.util.concurrent.CancellationException;
 import javax.annotation.Nullable;
 
 /** Utility methods for the Rx. * */
@@ -85,7 +86,11 @@ public class RxUtils {
             error -> {
               if (error instanceof IOException ioException) {
                 return Single.just(TransferResult.error(ioException));
-              } else if (error instanceof InterruptedException) {
+              } else if (error instanceof InterruptedException
+                  || error instanceof CancellationException) {
+                // A transfer is only ever canceled as part of tearing down the operation it
+                // belongs to, so this is reported as an interruption rather than propagated
+                // downstream.
                 return Single.just(TransferResult.interrupted());
               } else {
                 return Single.error(error);


### PR DESCRIPTION
### Description

When a bulk transfer to or from the remote cache is cancelled, every one of its in-flight transfers fails with a `CancellationException`. `mergeBulkTransfer` subscribes to all transfers of a bulk operation at once via `flatMapSingle`, which terminates on the first error and hands every subsequent one to RxJava's global error handler.

`RemoteModule` installs a global error handler that reports those as error events, so a single cancelled bulk transfer printed a `java.util.concurrent.CancellationException: Task was cancelled` stack trace for every transfer but the first.

A transfer is only ever cancelled as part of tearing down the operation it belongs to, so `toTransferResult` now maps `CancellationException` to the same result as `InterruptedException` instead of propagating it downstream.

This PR also replaces two `isDisposed()`-then-`onError()` sequences in `RxFutures` and `AsyncTaskCache` with `tryOnError`. Those checks aren't atomic with the delivery: the emitter can be disposed in between, in which case `onError` hands the error to the global error handler as well.

### Motivation

Users see spurious `ERROR: java.util.concurrent.CancellationException: Task was cancelled` stack traces, one per concurrently cancelled transfer, whenever a build that is uploading or downloading blobs is interrupted or an action fails while a bulk transfer is in flight.

This also shows up as a flake in `RemoteExecutionServiceTest.uploadInputsIfNotPresent_interrupted_requestCancelled`, which fails whenever `RxNoGlobalErrorsRule` observes the leaked exception. That test failed in roughly 2-5% of runs before this change and passed 100 out of 100 times after it.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

The existing `uploadInputsIfNotPresent_interrupted_requestCancelled` covers this, but only probabilistically: the number of transfers that are cancelled concurrently determines whether an error is leaked, and the `tryOnError` changes fix races that can't be triggered deterministically.

### Release Notes

RELNOTES: None

Closes #30652.

PiperOrigin-RevId: 965871323
Change-Id: I14b9109bb2e84544cb0a9d573604c8dd891ecce4

Commit https://github.com/bazelbuild/bazel/commit/cec8ee49f731e48b5bb336a27a7f2f1be770da48