### PR TITLE
Re-enable buildtool integration tests on Windows

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
@@ -692,9 +692,6 @@ java_test(
     srcs = [
         "ConvenienceSymlinkTest.java",
     ],
-    # unsettingSymlinksRemovesSymlinksEvenIfNotPointingInsideExecRoot points a
-    # symlink at a Unix-absolute path, which CreateSymlink rejects on Windows.
-    tags = ["no_windows"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/file_write_action_context",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",

--- a/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
@@ -138,6 +138,8 @@ java_test(
 java_test(
     name = "DanglingSymlinkTest",
     srcs = ["DanglingSymlinkTest.java"],
+    # Test genrule runs `/bin/ln -sf`, which msys2 cannot use to make a symlink.
+    tags = ["no_windows"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
@@ -153,6 +155,9 @@ java_test(
 java_test(
     name = "UnusedInputsFailureIntegrationTest",
     srcs = ["UnusedInputsFailureIntegrationTest.java"],
+    # Asserts on which of two concurrently failing actions is reported first,
+    # which does not hold on Windows.
+    tags = ["no_windows"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
@@ -478,6 +483,9 @@ java_library(
 java_test(
     name = "TargetCompleteEventTest",
     srcs = ["TargetCompleteEventTest.java"],
+    # outputSymlink points a symlink at a Unix-absolute path, which CreateSymlink
+    # rejects on Windows; artifactsNotRetained runs a shell script directly.
+    tags = ["no_windows"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
@@ -608,6 +616,9 @@ java_test(
 java_test(
     name = "SubcommandEventTest",
     srcs = ["SubcommandEventTest.java"],
+    # Re-executes the logged subcommand via a hardcoded /bin/sh, which Windows
+    # resolves to a nonexistent C:\\bin\\sh.
+    tags = ["no_windows"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/shell",
@@ -678,6 +689,9 @@ java_test(
     srcs = [
         "ConvenienceSymlinkTest.java",
     ],
+    # unsettingSymlinksRemovesSymlinksEvenIfNotPointingInsideExecRoot points a
+    # symlink at a Unix-absolute path, which CreateSymlink rejects on Windows.
+    tags = ["no_windows"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/file_write_action_context",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",

--- a/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
@@ -512,6 +512,9 @@ java_test(
     name = "TargetSummaryEventTest",
     srcs = ["TargetSummaryEventTest.java"],
     data = ["//src/test/java/com/google/devtools/build/lib:embedded_scripts"],
+    # Flaky on Windows: getOverallTestStatus() intermittently reports NO_STATUS
+    # instead of the test result. Passed one CI run, failed all 3 attempts the next.
+    tags = ["no_windows"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",

--- a/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
@@ -105,9 +105,6 @@ java_test(
 java_test(
     name = "ContextProviderInitializationTest",
     srcs = ["ContextProviderInitializationTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
@@ -129,9 +126,6 @@ java_test(
 java_test(
     name = "CorruptedActionCacheTest",
     srcs = ["CorruptedActionCacheTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
@@ -144,9 +138,6 @@ java_test(
 java_test(
     name = "DanglingSymlinkTest",
     srcs = ["DanglingSymlinkTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
@@ -162,9 +153,6 @@ java_test(
 java_test(
     name = "UnusedInputsFailureIntegrationTest",
     srcs = ["UnusedInputsFailureIntegrationTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
@@ -187,9 +175,6 @@ java_test(
     name = "DirectoryArtifactWarningTest",
     srcs = ["DirectoryArtifactWarningTest.java"],
     jvm_flags = ["-DBAZEL_TRACK_SOURCE_DIRECTORIES=0"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/test/java/com/google/devtools/build/lib/buildtool/util",
@@ -200,9 +185,6 @@ java_test(
 java_test(
     name = "EditDuringBuildTest",
     srcs = ["EditDuringBuildTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/test/java/com/google/devtools/build/lib/buildtool/util",
@@ -215,9 +197,6 @@ java_test(
 java_test(
     name = "EnvironmentRestrictedBuildTest",
     srcs = ["EnvironmentRestrictedBuildTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
         "//src/main/java/com/google/devtools/build/lib/analysis:view_creation_failed_exception",
@@ -232,9 +211,6 @@ java_test(
 java_test(
     name = "GenQueryIntegrationTest",
     srcs = ["GenQueryIntegrationTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
@@ -267,9 +243,8 @@ java_test(
 java_test(
     name = "InconsistentFilesystemTest",
     srcs = ["InconsistentFilesystemTest.java"],
-    tags = [
-        "no_windows",
-    ],
+    # Overrides createFileSystem() with a UnixFileSystem subclass.
+    tags = ["no_windows"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/unix:native_posix_files_service_impl",
         "//src/main/java/com/google/devtools/build/lib/unix:unix_file_system",
@@ -298,9 +273,6 @@ java_test(
 java_test(
     name = "KeepGoingTest",
     srcs = ["KeepGoingTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
@@ -315,9 +287,6 @@ java_test(
 java_test(
     name = "LabelCrossesPackageBoundaryTest",
     srcs = ["LabelCrossesPackageBoundaryTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/test/java/com/google/devtools/build/lib/buildtool/util",
@@ -328,9 +297,6 @@ java_test(
 java_test(
     name = "MiscAnalysisTest",
     srcs = ["MiscAnalysisTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
@@ -350,9 +316,6 @@ java_test(
 java_test(
     name = "MissingInputActionTest",
     srcs = ["MissingInputActionTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
@@ -371,9 +334,6 @@ java_test(
 java_test(
     name = "NoOutputActionTest",
     srcs = ["NoOutputActionTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/test/java/com/google/devtools/build/lib/buildtool/util",
@@ -386,9 +346,6 @@ java_test(
     name = "OutputArtifactConflictTest",
     srcs = ["OutputArtifactConflictTest.java"],
     shard_count = 3,
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
@@ -411,9 +368,6 @@ java_test(
 java_test(
     name = "PackageGroupIntegrationTest",
     srcs = ["PackageGroupIntegrationTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/analysis:view_creation_failed_exception",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
@@ -438,9 +392,8 @@ java_test(
 java_test(
     name = "ProgressReportingTest",
     srcs = ["ProgressReportingTest.java"],
-    tags = [
-        "no_windows",
-    ],
+    # Overrides createFileSystem() with a UnixFileSystem subclass.
+    tags = ["no_windows"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/unix:native_posix_files_service_impl",
@@ -458,9 +411,8 @@ java_test(
 java_test(
     name = "QueryIntegrationTest",
     srcs = ["QueryIntegrationTest.java"],
-    tags = [
-        "no_windows",
-    ],
+    # Overrides createFileSystem() with a UnixFileSystem subclass.
+    tags = ["no_windows"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/analysis:blaze_directories",
         "//src/main/java/com/google/devtools/build/lib/events",
@@ -495,9 +447,6 @@ java_test(
 java_test(
     name = "SymlinkDependencyAnalysisTest",
     srcs = ["SymlinkDependencyAnalysisTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/test/java/com/google/devtools/build/lib/buildtool/util",
@@ -529,9 +478,6 @@ java_library(
 java_test(
     name = "TargetCompleteEventTest",
     srcs = ["TargetCompleteEventTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
@@ -558,9 +504,6 @@ java_test(
     name = "TargetSummaryEventTest",
     srcs = ["TargetSummaryEventTest.java"],
     data = ["//src/test/java/com/google/devtools/build/lib:embedded_scripts"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
@@ -665,9 +608,6 @@ java_test(
 java_test(
     name = "SubcommandEventTest",
     srcs = ["SubcommandEventTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/shell",
@@ -682,9 +622,6 @@ java_test(
 java_test(
     name = "SkymeldBuildIntegrationTest",
     srcs = ["SkymeldBuildIntegrationTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_phase_complete_event",
@@ -708,9 +645,6 @@ java_test(
 java_test(
     name = "SkymeldOutputServiceBuildIntegrationTest",
     srcs = ["SkymeldOutputServiceBuildIntegrationTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/buildtool:build_result",
@@ -728,9 +662,6 @@ java_test(
 java_test(
     name = "BuildResultListenerIntegrationTest",
     srcs = ["BuildResultListenerIntegrationTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/analysis:view_creation_failed_exception",
@@ -747,7 +678,6 @@ java_test(
     srcs = [
         "ConvenienceSymlinkTest.java",
     ],
-    tags = ["no_windows"],  # Creates symbolic links.
     deps = [
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/file_write_action_context",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
@@ -797,9 +727,6 @@ java_test(
 java_test(
     name = "ProjectResolutionTest",
     srcs = ["ProjectResolutionTest.java"],
-    tags = [
-        "no_windows",
-    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/analysis:project_resolution_exception",
         "//src/main/java/com/google/devtools/build/lib/analysis:projects",

--- a/src/test/java/com/google/devtools/build/lib/buildtool/ConvenienceSymlinkTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/ConvenienceSymlinkTest.java
@@ -876,7 +876,11 @@ public final class ConvenienceSymlinkTest extends BuildIntegrationTestCase {
     Path workspaceLink = getWorkspace().getChild("replaced-" + TestConstants.WORKSPACE_NAME);
     Path outLink = getWorkspace().getChild("replaced-out");
 
-    Path original = getWorkspace().getRelative("/arbitrary/somewhere/else/in/the/filesystem");
+    // Derived from the workspace so that the path is absolute on Windows too, where
+    // CreateSymlink rejects a target without a drive letter. Outside the exec root,
+    // which lives under the output base.
+    Path original =
+        getWorkspace().getParentDirectory().getRelative("arbitrary/somewhere/else");
     binLink.createSymbolicLink(original);
     genfilesLink.createSymbolicLink(original);
     testlogsLink.createSymbolicLink(original);
@@ -1123,7 +1127,11 @@ public final class ConvenienceSymlinkTest extends BuildIntegrationTestCase {
     Path workspaceLink = getWorkspace().getChild("deleted-" + TestConstants.WORKSPACE_NAME);
     Path outLink = getWorkspace().getChild("deleted-out");
 
-    Path original = getWorkspace().getRelative("/arbitrary/somewhere/else/in/the/filesystem");
+    // Derived from the workspace so that the path is absolute on Windows too, where
+    // CreateSymlink rejects a target without a drive letter. Outside the exec root,
+    // which lives under the output base.
+    Path original =
+        getWorkspace().getParentDirectory().getRelative("arbitrary/somewhere/else");
     binLink.createSymbolicLink(original);
     genfilesLink.createSymbolicLink(original);
     testlogsLink.createSymbolicLink(original);

--- a/src/test/java/com/google/devtools/build/lib/buildtool/SkymeldBuildIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/SkymeldBuildIntegrationTest.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -372,8 +373,10 @@ public class SkymeldBuildIntegrationTest extends BuildIntegrationTestCase {
     addOptions("--aspects=//foo:aspect.bzl%execution_err_aspect", "--output_groups=files");
     assertThrows(BuildFailedException.class, () -> buildTarget("//foo:foo"));
     events.assertContainsError(
-        "Action foo/aspect_output (from target //foo:foo) failed: (Exit 1): bash failed: error"
-            + " executing Action command");
+        // The shell binary is "bash" on Unix and "bash.exe" on Windows.
+        Pattern.compile(
+            "\\QAction foo/aspect_output (from target //foo:foo) failed: (Exit 1): bash\\E"
+                + "(\\.exe)?\\Q failed: error executing Action command\\E"));
   }
 
   @Test
@@ -834,8 +837,10 @@ public class SkymeldBuildIntegrationTest extends BuildIntegrationTestCase {
     // Verify that the build did not crash.
     assertThrows(BuildFailedException.class, () -> buildTarget("//foo:foo"));
     events.assertContainsError(
-        "Action foo/aspect_output (from target //foo:foo) failed: (Exit 1): bash failed: error"
-            + " executing Action command");
+        // The shell binary is "bash" on Unix and "bash.exe" on Windows.
+        Pattern.compile(
+            "\\QAction foo/aspect_output (from target //foo:foo) failed: (Exit 1): bash\\E"
+                + "(\\.exe)?\\Q failed: error executing Action command\\E"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/runtime/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BUILD
@@ -195,8 +195,6 @@ java_library(
 java_test(
     name = "ConfigCommandTest",
     srcs = ["commands/ConfigCommandTest.java"],
-    # TODO(bazel-team): Fails on Windows for unclear reasons.
-    tags = ["no_windows"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/analysis/config:fragment_options",
         "//src/main/java/com/google/devtools/build/lib/analysis/config/output:configuration_for_output",


### PR DESCRIPTION
### Description

Removes the `no_windows` tag from 20 tests in `src/test/java/com/google/devtools/build/lib/buildtool` and from `//src/test/java/com/google/devtools/build/lib/runtime:ConfigCommandTest`, and gives every tag that remains a comment explaining why.

### Motivation


### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
