### PR TITLE
Run ProGuard with the execution-platform Java runtime

### DIFF
--- a/tools/build_defs/proguard/BUILD.bazel
+++ b/tools/build_defs/proguard/BUILD.bazel
@@ -16,14 +16,8 @@ exports_files(
 py_binary(
     name = "wrapper_private",
     srcs = ["wrapper.py"],
-    data = [
-        ":proguard_private",
-    ],
     main = "wrapper.py",
     visibility = ["//visibility:private"],
-    deps = [
-        "@rules_python//python/runfiles",
-    ],
 )
 
 java_binary(

--- a/tools/build_defs/proguard/proguard.bzl
+++ b/tools/build_defs/proguard/proguard.bzl
@@ -20,11 +20,19 @@
 
 """Apply proguard rules to a JAR file."""
 
+load("@rules_java//java:defs.bzl", "java_common")
+
 def _proguard_jar_impl(ctx):
-    inputs = ctx.files.srcs + ctx.files.deps + [ctx.file.proguard_spec]
+    java_runtime = ctx.attr._java_runtime[java_common.JavaRuntimeInfo]
+    inputs = ctx.files.srcs + ctx.files.deps + [
+        ctx.file.proguard_spec,
+        ctx.file._proguard,
+    ]
     output = ctx.outputs.out
 
     args = ctx.actions.args()
+    args.add("--java_executable", java_runtime.java_executable_exec_path)
+    args.add("--proguard_jar", ctx.file._proguard)
     args.add_joined("--srcs", ctx.files.srcs, join_with = ",")
     args.add_joined("--deps", ctx.files.deps, join_with = ",")
     args.add("--proguard_spec", ctx.file.proguard_spec)
@@ -37,6 +45,7 @@ def _proguard_jar_impl(ctx):
         outputs = [output],
         executable = ctx.executable._wrapper,
         arguments = [args],
+        tools = java_runtime.files,
     )
 
     return DefaultInfo(files = depset([output]))
@@ -48,6 +57,16 @@ proguard_jar = rule(
         "deps": attr.label_list(),
         "proguard_spec": attr.label(allow_single_file = True),
         "out": attr.output(),
+        "_java_runtime": attr.label(
+            cfg = "exec",
+            default = "@bazel_tools//tools/jdk:current_java_runtime",
+            providers = [java_common.JavaRuntimeInfo],
+        ),
+        "_proguard": attr.label(
+            allow_single_file = True,
+            cfg = "exec",
+            default = ":proguard_private_deploy.jar",
+        ),
         "_wrapper": attr.label(
             cfg = "exec",
             default = ":wrapper_private",

--- a/tools/build_defs/proguard/wrapper.py
+++ b/tools/build_defs/proguard/wrapper.py
@@ -17,48 +17,19 @@
 import argparse
 import datetime
 import os
-import platform
 import subprocess
 import tempfile
 import zipfile
 
-from python.runfiles import Runfiles
 
-_PROGUARD_PATH = "_main/tools/build_defs/proguard/proguard_private"
-
-
-def lookup_binary(r, path):
-  """Lookup the runfiles-adjusted path to a binary.
-
-  Args:
-    r: The Runfiles object to use for the lookup.
-    path: The path of the binary being found.
-
-  Returns:
-    The full path to the binary.
-
-  Raises:
-    RuntimeError: If the path is not present in the runfiles, or if the adjusted
-    path does not
-    exist on the filesystem.
-  """
-
-  if platform.system() == "Windows":
-    path = path + ".exe"
-  binary = r.Rlocation(path)
-  if not binary:
-    raise RuntimeError(f"Runfiles failed to resolve {path}")
-  elif not os.path.exists(binary):
-    raise RuntimeError(
-        f"Runfiles resolved {path} to {binary} but the file does not exist"
-    )
-  return binary
-
-
-def apply_proguard(srcs, deps, proguard_spec, output_jar):
+def apply_proguard(
+    java_executable, proguard_jar, srcs, deps, proguard_spec, output_jar
+):
   """Call proguard on the given source jars with the spec.
 
   Args:
+    java_executable: The execution-platform Java executable.
+    proguard_jar: The ProGuard deploy JAR.
     srcs: The source jars to be modified.
     deps: Dependency jars needed to resolve the source jars.
     proguard_spec: The path to the proguard spec file describing what
@@ -70,12 +41,11 @@ def apply_proguard(srcs, deps, proguard_spec, output_jar):
     stderr.
   """
 
-  # Set up runfiles and call the proguard binary.
-  r = Runfiles.Create()
-  proguard_path = lookup_binary(r, _PROGUARD_PATH)
-
   command = [
-      proguard_path,
+      java_executable,
+      "-Dlog4j.rootLogger=OFF",
+      "-jar",
+      proguard_jar,
       "-injars",
       srcs,
       "-libraryjars",
@@ -85,10 +55,8 @@ def apply_proguard(srcs, deps, proguard_spec, output_jar):
       "@" + proguard_spec,
   ]
 
-  env = os.environ.copy()
-  env.update(r.EnvVars())
   # print("Running proguard: %s" % " ".join(command))
-  p = subprocess.run(command, capture_output=True, env=env, check=False)
+  p = subprocess.run(command, capture_output=True, check=False)
 
   if p.returncode != 0:
     message = f"Proguard failed ({p.returncode})"
@@ -127,6 +95,12 @@ def main() -> None:
       description="Resets timestamps in ZIP files", fromfile_prefix_chars="@"
   )
   parser.add_argument(
+      "--java_executable", required=True, help="Execution-platform Java."
+  )
+  parser.add_argument(
+      "--proguard_jar", required=True, help="ProGuard deploy JAR."
+  )
+  parser.add_argument(
       "--srcs", required=True, help="Input jar files, mandatory."
   )
   parser.add_argument("--deps", default=[], help="Library jar files, optional.")
@@ -146,7 +120,14 @@ def main() -> None:
 
   with tempfile.TemporaryDirectory() as wdir:
     output_jar = os.path.join(wdir, "stripped.jar")
-    apply_proguard(opts.srcs, opts.deps, opts.proguard_spec, output_jar)
+    apply_proguard(
+        opts.java_executable,
+        opts.proguard_jar,
+        opts.srcs,
+        opts.deps,
+        opts.proguard_spec,
+        output_jar,
+    )
     reset_timestamps(output_jar, opts.output, opts.timestamp)
 
 


### PR DESCRIPTION
### Description
Pass the execution-platform Java runtime and ProGuard deploy JAR to the existing ProGuard wrapper. Avoid generated Java launchers that require a runfiles manifest unavailable to Linux remote execution when Bazel runs on Windows.

Remove the unused Python runfiles dependency while preserving deterministic JAR timestamps and the ProGuard log4j JVM option.

### Motivation
One step closer to bazel (cross-)building hermetically

### Build API Changes
No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
