### PR TITLE
Don't crash when a module file's state is dropped mid-computation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -21,6 +21,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.github.difflib.patch.PatchFailedException;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -330,11 +330,7 @@ public class ModuleFileFunction implements SkyFunction {
         env.getListener());
   }
 
-  /**
-   * Executes the module file compiled into {@code state}, which the caller must have obtained from
-   * the environment: looking it up again could return a fresh instance without a compiled module
-   * file if the state was dropped in response to memory pressure in the meantime.
-   */
+  /** env.getState(State::new).compiledModuleFile must be set before calling this method. */
   @Nullable
   private ModuleThreadContext execNonRegistryModuleFile(
       ModuleKey moduleKey,

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -21,7 +21,6 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.github.difflib.patch.PatchFailedException;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -245,7 +244,7 @@ public class ModuleFileFunction implements SkyFunction {
     } else {
       moduleThreadContext =
           execNonRegistryModuleFile(
-              moduleKey, starlarkSemantics, env, SymbolGenerator.create(skyKey));
+              moduleKey, state, starlarkSemantics, env, SymbolGenerator.create(skyKey));
       if (moduleThreadContext == null) {
         return null;
       }
@@ -319,7 +318,8 @@ public class ModuleFileFunction implements SkyFunction {
       }
     }
     var moduleThreadContext =
-        execNonRegistryModuleFile(ModuleKey.ROOT, starlarkSemantics, env, symbolGenerator);
+        execNonRegistryModuleFile(
+            ModuleKey.ROOT, state, starlarkSemantics, env, symbolGenerator);
     if (moduleThreadContext == null) {
       return null;
     }
@@ -330,16 +330,19 @@ public class ModuleFileFunction implements SkyFunction {
         env.getListener());
   }
 
-  /** env.getState(State::new).compiledModuleFile must be set before calling this method. */
+  /**
+   * Executes the module file compiled into {@code state}, which the caller must have obtained from
+   * the environment: looking it up again could return a fresh instance without a compiled module
+   * file if the state was dropped in response to memory pressure in the meantime.
+   */
   @Nullable
   private ModuleThreadContext execNonRegistryModuleFile(
       ModuleKey moduleKey,
+      State state,
       StarlarkSemantics starlarkSemantics,
       Environment env,
       SymbolGenerator<?> symbolGenerator)
       throws ModuleFileFunctionException, InterruptedException {
-    var state = env.getState(State::new);
-    Preconditions.checkNotNull(state.compiledModuleFile);
     if (state.horizon == null) {
       state.horizon = state.compiledModuleFile.includeStatements();
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -339,6 +339,7 @@ public class ModuleFileFunction implements SkyFunction {
       Environment env,
       SymbolGenerator<?> symbolGenerator)
       throws ModuleFileFunctionException, InterruptedException {
+    Preconditions.checkNotNull(state.compiledModuleFile);
     if (state.horizon == null) {
       state.horizon = state.compiledModuleFile.includeStatements();
     }


### PR DESCRIPTION
### Description

`computeForRootModule` and `computeForNonRootModule` compile the module file into the `SkyKeyComputeState` they obtained from the environment and then call `execNonRegistryModuleFile`, which looked the state up a second time and required it to hold a compiled module file. A drop of all compute states in response to memory pressure between the two lookups makes the second one return a fresh state, so the `checkNotNull` fails and Bazel crashes with

```
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.RuntimeException: Unrecoverable error while evaluating node 'Key[moduleKey=]' (requested by nodes 'com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionValue$$Lambda/0x00000000378e5800@43b40961')
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:552)
	...
Caused by: java.lang.NullPointerException
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:902)
	at com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction.execNonRegistryModuleFile(ModuleFileFunction.java:342)
	at com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction.computeForRootModule(ModuleFileFunction.java:322)
	at com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction.compute(ModuleFileFunction.java:171)
```

while computing the main repo mapping.

The state is now passed to `execNonRegistryModuleFile` instead, which keeps the computation on the instance it compiled the module file into. A concurrent drop then only means that this instance is no longer cached, so the next restart recompiles the module file, as it already does whenever the state is dropped between two restarts.

### Motivation

Compute states are dropped by default once the retained heap exceeds `--skyframe_high_water_mark_threshold`, which is 85%, so this crash can hit any sufficiently memory-constrained build. I observed it on Windows CI in a build that ran with `--skyframe_high_water_mark_threshold=0` under allocation pressure.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Fixed a crash while evaluating `MODULE.bazel` files when Skyframe dropped its temporary state in response to memory pressure.
