### PR TITLE
Keep an unrelated fetch from using up the memory pressure drop budget in a test

### DIFF
--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -2077,6 +2077,14 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
 
     for attempt in range(5):
       self.RunBazel(['clean', '--expunge'])
+      # The drop budget is shared by all fetches in the build below and is used
+      # up by whichever of them allocates first, so an unrelated repo can
+      # exhaust it before my_repo is even fetched. On Windows, test_base
+      # registers a Python toolchain from rules_python, whose fetch reliably
+      # does so. Fetching it without a remote cache materializes it on disk, so
+      # that the build below finds it up to date instead of having to inject it
+      # from the remote repo contents cache into the memory of its own server.
+      self.RunBazel(['fetch', '--repo=@@rules_python+', '--remote_cache='])
       exit_code, _, stderr = self.RunBazel(
           [
               # A small heap makes minor GC events frequent under allocation


### PR DESCRIPTION
### Description

`testMemoryPressureRestartDuringCachedFetch` relies on a compute state drop landing while the cached fetch of `my_repo` is in flight, but the budget of `--skyframe_high_water_mark_minor_gc_drops_per_invocation` is shared by every fetch in the invocation. On Windows, `test_base` registers a Python toolchain from rules_python, so every attempt starts by fetching that repo, whose contents are large enough to use up all 8 drops within the first few seconds. No full GC happens afterwards, so the fetch under test is never interrupted.

rules_python is now fetched before the poison build, without a remote cache so that it ends up on disk rather than being injected into the memory of the server that runs the fetch: the poison build uses a different server (it sets `--host_jvm_args=-Xmx512m`) and would otherwise have to inject it again.

### Motivation

The test is flaky on Windows:

```
AssertionError: the cached fetch of my_repo was never both interrupted by a memory-pressure compute state drop and served from the cache
```

I instrumented it on Windows CI to log every state drop and every fetch restart to the server log. In a run of 30 attempts, only 2 saw a restart of `my_repo`; every drop in the other 28 was spent on a restart of `@@rules_python+`, all 8 of them within the first ~5 seconds of the build. With this change, all 25 attempts of a run of the same shape were interrupted while still being served from the cache.

The same runs also uncovered a crash that this test can hit on any platform, fixed in #30756.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
