### PR TITLE
Don't turn arbitrary prefetch failures into CacheNotFoundException

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -306,7 +306,6 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:virtual_action_input",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
-        "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/util:digest_util",
         "//src/main/java/com/google/devtools/build/lib/remote/util:tracing_metadata_utils",
         "//src/main/java/com/google/devtools/build/lib/util:temp_path_generator",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -13,13 +13,9 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote;
 
-import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
@@ -29,7 +25,6 @@ import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FileStateType;
 import com.google.devtools.build.lib.actions.VirtualActionInput;
 import com.google.devtools.build.lib.events.Reporter;
-import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
@@ -136,38 +131,20 @@ public class RemoteActionInputFetcher extends AbstractActionInputPrefetcher {
 
     Digest digest = DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());
 
-    // Treat other download error as CacheNotFoundException so that Bazel can
-    // correctly rewind the action/build.
-    // Intentionally, do not transform IOExceptions directly thrown by downloadFile rather than in
-    // the returned future, as those are likely to be caused by local FS issues.
-    return Futures.catchingAsync(
-        combinedCache.downloadFile(
-            context,
+    return combinedCache.downloadFile(
+        context,
+        input.getExecPathString(),
+        input.getExecPath(),
+        tempPath.forHostFileSystem(),
+        digest,
+        new CombinedCache.DownloadProgressReporter(
+            progress -> {
+              if (action != null) {
+                progress.postTo(reporter, action);
+              }
+            },
             input.getExecPathString(),
-            input.getExecPath(),
-            tempPath.forHostFileSystem(),
-            digest,
-            new CombinedCache.DownloadProgressReporter(
-                progress -> {
-                  if (action != null) {
-                    progress.postTo(reporter, action);
-                  }
-                },
-                input.getExecPathString(),
-                digest.getSizeBytes())),
-        IOException.class,
-        e ->
-            immediateFailedFuture(
-                switch (e) {
-                  case CacheNotFoundException cacheNotFoundException -> cacheNotFoundException;
-                  default -> {
-                    var cacheNotFoundException =
-                        new CacheNotFoundException(digest, input.getExecPath());
-                    cacheNotFoundException.addSuppressed(e);
-                    yield cacheNotFoundException;
-                  }
-                }),
-        directExecutor());
+            digest.getSizeBytes()));
   }
 
   public void handleRewoundActionOutputs(Collection<Artifact> outputs) {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCircuitBreakerRecoveryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCircuitBreakerRecoveryIntegrationTest.java
@@ -77,11 +77,8 @@ public class RemoteCircuitBreakerRecoveryIntegrationTest extends BuildIntegratio
     addOptions(
         "--remote_executor=grpc://localhost:" + worker.getPort(),
         "--remote_download_minimal",
-        // Both tests recover a lost input via action rewinding: a failed prefetch (with
-        // --remote_retries=0) is treated as a lost input, and rewinding re-runs the action.
-        "--rewind_lost_inputs",
-        // Disable build-level invocation retries (default 5) so recovery is exercised via action
-        // rewinding within one build, not by retrying the whole build with a fresh breaker.
+        // Disable build-level invocation retries (default 5) so recovery is exercised within a
+        // single build, not by retrying the whole build with a fresh breaker.
         "--experimental_remote_cache_eviction_retries=0");
   }
 
@@ -175,20 +172,20 @@ public class RemoteCircuitBreakerRecoveryIntegrationTest extends BuildIntegratio
   }
 
   @Test
-  public void recovers_whenPrefetchingInput_succeedsWithActionRewinding() throws Exception {
+  public void recovers_whenPrefetchingInput_succeedsWithRetriedDownload() throws Exception {
     setupRemoteOnlyFooOut();
 
     // Act: enable the failure breaker with a short recovery delay, arm a single transient read
     // failure, and force bar to re-prefetch the remote-only foo.out. The prefetch read trips the
-    // breaker; with --remote_retries=0 that becomes a lost input and drives action rewinding, and
-    // the breaker re-closes on a trial probe during the rewind so the build recovers.
+    // breaker, and the retry scheduled for it (~100ms out, well past the recovery delay) is the
+    // caller that picks up the trial probe, so the download succeeds and the build recovers.
     addOptions(
         "--experimental_circuit_breaker_strategy=failure",
         "--experimental_remote_min_fail_count_to_compute_failure_rate=1",
         "--experimental_remote_min_call_count_to_compute_failure_rate=1",
         "--experimental_remote_failure_rate_threshold=1",
         "--experimental_remote_circuit_breaker_recovery_delay=1ms",
-        "--remote_retries=0");
+        "--remote_retries=1");
     write("a/bar.in", "updated bar");
     int stderrLenBefore = worker.getStderr().length();
     worker.armReadFailures();
@@ -206,22 +203,22 @@ public class RemoteCircuitBreakerRecoveryIntegrationTest extends BuildIntegratio
     setupRemoteOnlyFooOut();
 
     // Act: same as the recovery test, but recovery is disabled (the delay defaults to 0), so the
-    // tripped breaker stays open for the rest of the build and the rewound re-execution is
-    // rejected.
+    // tripped breaker stays open for the rest of the build and rejects the retry outright.
     addOptions(
         "--experimental_circuit_breaker_strategy=failure",
         "--experimental_remote_min_fail_count_to_compute_failure_rate=1",
         "--experimental_remote_min_call_count_to_compute_failure_rate=1",
         "--experimental_remote_failure_rate_threshold=1",
-        "--remote_retries=0");
+        "--remote_retries=1");
     write("a/bar.in", "updated bar");
     int stderrLenBefore = worker.getStderr().length();
     worker.armReadFailures();
 
     var error = assertThrows(BuildFailedException.class, () -> buildTarget("//a:bar"));
 
-    // Assert: the breaker tripped and, without recovery, the build failed with a remote error.
+    // Assert: the breaker tripped and, without recovery, it rejected the retry instead of letting
+    // the download recover, failing the build.
     assertReadFailureInjectedSince(stderrLenBefore);
-    assertThat(error.getDetailedExitCode().getExitCode().getNumericExitCode()).isEqualTo(34);
+    assertThat(error).hasMessageThat().contains("Call not executed due to a high failure rate");
   }
 }

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -2397,65 +2397,6 @@ EOF
   fi
 }
 
-function test_retry_build_if_remote_executor_is_unavailable() {
-  mkdir -p a
-
-  cat > a/BUILD <<'EOF'
-genrule(
-  name = 'foo',
-  srcs = ['foo.in'],
-  outs = ['foo.out'],
-  cmd = 'cat $(SRCS) > $@',
-)
-
-genrule(
-  name = 'bar',
-  srcs = ['foo.out', 'bar.in'],
-  outs = ['bar.out'],
-  cmd = 'cat $(SRCS) > $@',
-  tags = ['no-remote-exec'],
-)
-EOF
-
-  echo foo > a/foo.in
-  echo bar > a/bar.in
-
-  # Populate remote cache
-  bazel build \
-      --remote_executor=grpc://localhost:${worker_port} \
-      --remote_download_minimal \
-      //a:bar >& $TEST_log || fail "Failed to build"
-
-  bazel clean
-
-  # Clean build, foo.out isn't downloaded
-  bazel build \
-      --remote_executor=grpc://localhost:${worker_port} \
-      --remote_download_minimal \
-      //a:bar >& $TEST_log || fail "Failed to build"
-
-  if [[ -f bazel-bin/a/foo.out ]]; then
-    fail "Expected intermediate output bazel-bin/a/foo.out to not be downloaded"
-  fi
-
-  # Make the remote worker unavailable
-  stop_worker
-  start_worker --unavailable
-
-  echo "updated bar" > a/bar.in
-
-  # Incremental build triggers remote cache error but Bazel automatically retries the build and reruns the generating
-  # actions locally for missing blobs
-  bazel build \
-      --remote_executor=grpc://localhost:${worker_port} \
-      --remote_local_fallback \
-      --remote_download_minimal \
-      --experimental_remote_cache_eviction_retries=1 \
-      //a:bar >& $TEST_log || fail "Failed to build"
-
-  expect_log "Found transient remote cache error, retrying the build..."
-}
-
 function test_remote_cache_eviction_retries_toplevel_artifacts() {
   mkdir -p a
 

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
@@ -160,19 +160,6 @@ public final class RemoteWorker {
     }
   }
 
-  private static class UnavailableInterceptor implements ServerInterceptor {
-
-    @Override
-    public <ReqT, RespT> Listener<ReqT> interceptCall(
-        ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
-      if (!call.getMethodDescriptor().getServiceName().contains("Capabilities")) {
-        call.close(Status.UNAVAILABLE, new Metadata());
-        return new ServerCall.Listener<ReqT>() {};
-      }
-      return Contexts.interceptCall(Context.current(), call, headers, next);
-    }
-  }
-
   /**
    * Fails the first N calls to a single gRPC method with {@link Status#UNAVAILABLE}, optionally
    * gated on a marker file. The failure budget re-arms whenever the marker transitions from absent
@@ -272,9 +259,6 @@ public final class RemoteWorker {
       interceptors.add(
           new FailFirstNInterceptor(
               workerOptions.getFailureCount(), workerOptions.getFailureMethod(), markerFile));
-    }
-    if (workerOptions.getUnavailable()) {
-      interceptors.add(new UnavailableInterceptor());
     }
     interceptors.add(new TracingMetadataUtils.ServerHeadersInterceptor());
     if (workerOptions.getExpectedAuthorizationToken() != null) {

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorkerOptions.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorkerOptions.java
@@ -215,16 +215,6 @@ public abstract class RemoteWorkerOptions extends OptionsBase {
   public abstract String getExpectedAuthorizationToken();
 
   @Option(
-      name = "unavailable",
-      defaultValue = "false",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      help =
-          "If true, all gRPC services, except Capabilities, return UNAVAILABLE. This is useful for"
-              + " testing only.")
-  public abstract boolean getUnavailable();
-
-  @Option(
       name = "error_on_duplicate_downloads",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,


### PR DESCRIPTION
### Description

`RemoteActionInputFetcher#doDownloadFile` turned every `IOException` surfacing from the future returned by `CombinedCache#downloadFile` into a `CacheNotFoundException`. Bazel treats that exception as evidence that an input has been lost and tries to recover by rewinding the generating action, so any download failure was reported to the user as a missing blob.

`CombinedCache` already fails with a `CacheNotFoundException` (carrying the exec path and file name) when a blob is genuinely absent from the disk or remote cache. The conversion therefore only ever fired for errors that are *not* "blob missing": gRPC `UNAVAILABLE` and `DEADLINE_EXCEEDED`, authentication failures, corrupted responses, local I/O errors while writing the temp file, and `Retrier.CircuitBreakerException`, which means the remote calls were never even attempted.

This reverts the behavior introduced in 70c410ea9707f65fc7c76f06e08c86e021bc9bd8 and narrowed in dfc910329e6463d1984f4b1c4ca8dddc7fbe545f, along with the integration test added with it and the reference worker's `--unavailable` option, whose last user that test was. Download failures now propagate with their original cause.

`SpawnRunner#prefetchInputsAndWait` still maps a `BulkTransferException` to `Spawn.Code.REMOTE_CACHE_EVICTED` regardless of its causes, so `--experimental_remote_cache_eviction_retries` continues to restart the build. The restarted build no longer re-runs the generating action locally, which is why the deleted shell test can no longer pass: its retried attempt failed identically to the first.

#### Circuit breaker recovery

`RemoteCircuitBreakerRecoveryIntegrationTest` (added in #30420 for the recovery added in #30260) was the only other test relying on the conversion. It set `--remote_retries=0` so an injected `UNAVAILABLE` on a prefetch read failed the download outright, then leaned on that failure being reported as a lost input and let the rewind keep the build alive until the breaker handed out its trial probe.

A transient `UNAVAILABLE` on a blob read needs none of that. `RemoteRetrier.EXPERIMENTAL_GRPC_RESULT_CLASSIFIER` classifies it as a transient failure and `GrpcCacheClient#downloadBlob` runs the read under `retrier.executeAsync`, so the natural recovery is retrying the download rather than re-executing the action that produced the blob. The retry is also what the breaker's recovery is built for: it re-enters `Retrier#executeAsync`, which re-reads `CircuitBreaker#state()`, so it is the caller that picks up the `TRIAL_CALL` probe once the recovery delay has elapsed.

Both cases now run with `--remote_retries=1` and no `--rewind_lost_inputs`. The first attempt trips the breaker and its retry is scheduled roughly 100ms out, well past the 1ms recovery delay, so it takes the trial probe and closes the breaker. With recovery disabled the breaker never leaves `OPEN` and rejects that retry up front with a `CircuitBreakerException`; that case now asserts on its "Call not executed due to a high failure rate" message, which pins the failure to the breaker rather than to whichever failure detail the prefetch path happens to produce.

The revert and the test rework are one commit because they cannot be split in either order: dropping `--rewind_lost_inputs` alone changes the recovery-disabled case's outcome to "Unexpected lost inputs (pass --rewind_lost_inputs to enable recovery): a/foo.out", and the breaker's own message only surfaces once the conversion is gone.

### Motivation

Reporting an unreachable cache as a lost input hides the actual cause behind a "no longer available in the remote cache" message and sends the build into a rewinding attempt that cannot fix it. To recover one unreachable blob it discards and re-executes the action that produced it, even though the blob is fine on the server and the request simply failed; and it only works at all when there is something to rewind to, which is not the case for a top-level artifact or a source input from the repo cache.

A persistent fault such as an authentication failure, a wrong endpoint or a TLS error therefore turns into a storm of futile re-executions that finally reports itself as cache eviction. Genuine eviction is already covered without any conversion, since `GrpcCacheClient` raises a real `CacheNotFoundException` on `NOT_FOUND`.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

`RemoteCircuitBreakerRecoveryIntegrationTest` keeps covering the circuit breaker recovery, now through the download retry. Both cases were mutation-tested: taking away either the recovery delay or the retry makes the recovery case fail, and the pair passed 25 consecutive runs.

### Release Notes

RELNOTES: A remote cache error while prefetching an input is no longer reported as a lost input. Transient errors are retried by `--remote_retries` as before; errors that survive the retries now fail with their original cause instead of triggering action rewinding.
