### PR TITLE
Resolve string-type `toolchain` parameter of `ctx.actions.run{,_shell}` relative to the caller's `.bzl` file

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -67,6 +67,7 @@ import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.packages.BuiltinRestriction;
 import com.google.devtools.build.lib.packages.DeclaredExecGroup;
+import com.google.devtools.build.lib.packages.LabelConverter;
 import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.server.FailureDetails;
@@ -880,9 +881,9 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       toolchainLabel = label;
     } else if (toolchainUnchecked instanceof String) {
       try {
-        toolchainLabel =
-            Label.parseWithPackageContext(
-                (String) toolchainUnchecked, ruleContext.getPackageContext());
+        LabelConverter converter =
+            LabelConverter.forBzlEvaluatingThread(ruleContext.getStarlarkThread());
+        toolchainLabel = converter.convert((String) toolchainUnchecked);
       } catch (LabelSyntaxException e) {
         throw Starlark.errorf("%s", e.getMessage());
       }

--- a/src/test/java/com/google/devtools/build/lib/analysis/AutoExecGroupsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/AutoExecGroupsTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.analysis;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.createModuleKey;
 import static com.google.devtools.build.lib.rules.cpp.CppRuleClasses.CPP_LINK_EXEC_GROUP;
 
 import com.google.common.collect.ImmutableList;
@@ -51,6 +52,12 @@ import org.junit.runner.RunWith;
 /** Test for automatic exec groups. */
 @RunWith(TestParameterInjector.class)
 public class AutoExecGroupsTest extends BuildViewTestCase {
+
+  @Override
+  protected boolean allowExternalRepositories() {
+    return true;
+  }
+
   /**
    * Sets up two toolchains types, each with a single toolchain implementation and a single
    * exec_compatible_with platform.
@@ -911,6 +918,80 @@ public class AutoExecGroupsTest extends BuildViewTestCase {
 
     assertContainsEvent(
         "invalid label 'rule:toolchain_type_1': absolute label must begin with '@'" + " or '//'");
+  }
+
+  @Test
+  @TestParameters({
+    "{action: ctx.actions.run}",
+    "{action: ctx.actions.run_shell}",
+  })
+  public void toolchainParameterAsString_stringLabelResolvedRelativeToBzlFile(String action)
+      throws Exception {
+    // create a rule + a toolchain type in an external repository; use a
+    // repo-relative (`//...`) string label to refer to the toolchain type
+    //
+    // then instantiate this rule in the main repository — the toolchain type
+    // specified by the rule should be resolved to be within the external
+    // repository
+    registry.addModule(
+        createModuleKey("ext", "1.0"), "module(name = 'ext', version = '1.0')");
+    scratch.overwriteFile(moduleRoot.getRelative("ext+1.0/REPO.bazel").getPathString());
+    scratch.overwriteFile(
+        moduleRoot.getRelative("ext+1.0/BUILD.bazel").getPathString(),
+        """
+        load(":defs.bzl", "mk_toolchain")
+        toolchain_type(name = "toolchain_type")
+        mk_toolchain(name = "toolchain_inner")
+        toolchain(
+            name = "toolchain",
+            toolchain_type = ":toolchain_type",
+            toolchain = ":toolchain_inner",
+        )
+        """);
+    scratch.overwriteFile(
+        moduleRoot.getRelative("ext+1.0/defs.bzl").getPathString(),
+        """
+        mk_toolchain = rule(lambda _: platform_common.ToolchainInfo())
+
+        def _impl(ctx):
+            out = ctx.actions.declare_file(ctx.label.name)
+        """,
+        "    " + action + "(",
+        action.equals("ctx.actions.run")
+            ? "        executable = '/...',"
+            : "        command = '...',",
+        """
+                outputs = [out],
+                toolchain = '//:toolchain_type',
+            )
+            return [DefaultInfo(files = depset([out]))]
+        custom_rule = rule(
+            implementation = _impl,
+            toolchains = ["//:toolchain_type"],
+        )
+        """);
+
+    scratch.overwriteFile(
+        "MODULE.bazel",
+        """
+        module(name = 'top', version = '1.0')
+        bazel_dep(name = 'ext', version = '1.0')
+        """);
+    scratch.overwriteFile(
+        "BUILD.bazel",
+        """
+        load("@ext//:defs.bzl", "custom_rule")
+        custom_rule(name = "test")
+        """
+    );
+
+    invalidatePackages();
+
+    useConfiguration("--extra_toolchains=@ext//:all", "--incompatible_auto_exec_groups");
+
+    getConfiguredTarget("//:test");
+
+    assertNoEvents();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/BUILD
@@ -319,6 +319,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/rules/cpp",
         "//src/main/java/com/google/devtools/build/lib/rules/java:java-compilation",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
+        "//src/test/java/com/google/devtools/build/lib/bazel/bzlmod:util",
         "//src/test/java/com/google/devtools/build/lib/packages:testutil",
         "//src/test/java/com/google/devtools/build/lib/rules/java:java-info",
         "//src/test/java/com/google/devtools/build/lib/testutil:TestConstants",


### PR DESCRIPTION
### Description

For this example:
```starlark
# @ext//:MODULE.bazel
module(name = "ext", version = "1.0")

# @ext//:defs.bzl
def _impl(ctx):
    ctx.actions.run(
        toolchain = "//:toolchain_type", # (1)
        ...
    )
custom_rule = rule(
    implementation = _impl,
    toolchains = ["//:toolchain_type"], # (2)
)
...

# @ext//:BUILD.bazel
toolchain_type(name = "toolchain_type")
...
```
```starlark
# //:MODULE.bazel
module(name = "top", version = "1.0")
bazel_dep(name = "ext", version = "1.0")

# //:BUILD.bazel
load("@ext//:defs.bzl", "custom_rule")
custom_rule(name = "test")
```

Prior to this change, (2) (i.e. `toolchains` parameter on `rule`) would be resolved relative to the caller's `.bzl` file, but (1) (i.e. `toolchain` parameter on `ctx.actions.run`/`ctx.actions.run_shell`) was resolved relative to the package of the current rule instantiation.

For the example above, this results in:
  - (2) being resolved to `@ext//:toolchain_type` (as expected)
  - (1) being resolved to `@//:toolchain_type` (results in an error)

This PR changes strings passed to the `toolchain` parameter of `ctx.actions.run{,_shell}` to be resolved the same way as strings passed to `rule(toolchains = [...])`/`ctx.toolchains[...]`, i.e. relative to the caller's `.bzl` file.

cc: https://github.com/hermeticbuild/hermetic-launcher/pull/75

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

Changes how `ctx.actions.run{,_shell}(toolchain = "<string>")` is resolved. Strictly speaking this is not a backwards compatible change but it seems unlikely any users are relying on the existing behavior.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
