### PR TITLE
[9.3.0] Permit C++ build variables to be `Label`-valued (https://github.com/bazelbuild/bazel/pull/30682)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Sets.SetView;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.PathMapper;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.concurrent.BlazeInterners;
@@ -827,6 +828,7 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
       case NoneType ignored -> null; // null has the same behavior as omitted field
       case Boolean b -> BooleanValue.of(b);
       case String s -> new StringValue(s);
+      case Label label -> new StringValue(label.expandToCommandLine());
       case Artifact artifact -> new ArtifactValue(artifact);
       case PathFragment pathFragment -> new PathFragmentValue(pathFragment);
       case Iterable<?> iterable -> new Sequence(ImmutableList.copyOf(iterable));


### PR DESCRIPTION
### Description

### Motivation
This enables further memory savings for module maps (see https://github.com/bazelbuild/rules_cc/pull/789).

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #30682.

PiperOrigin-RevId: 966523652
Change-Id: Id0a9b3963f854bc2db199a4dd650e8b62d830b35

Commit https://github.com/bazelbuild/bazel/commit/f0dbc0e8e52700f0d66b8ae65961f1b792b3e63c