### PR TITLE
Avoid an extra stat while looking up a cached digest

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -356,7 +356,7 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
     if (digest == null) {
       digest =
           DigestUtils.getDigestWithManualFallback(
-              path, xattrProvider, proxy != null ? proxy.toFileIdentity(size) : null);
+              path, xattrProvider, proxy != null ? proxy.toMetadataOnlyFileStatus(size) : null);
     }
     checkState(digest != null, path);
     return createForNormalFile(digest, proxy, size);

--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -354,7 +354,9 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
       return new DirectoryArtifactValue(path.getLastModifiedTime());
     }
     if (digest == null) {
-      digest = DigestUtils.getDigestWithManualFallback(path, xattrProvider);
+      digest =
+          DigestUtils.getDigestWithManualFallback(
+              path, xattrProvider, proxy != null ? proxy.toFileIdentity(size) : null);
     }
     checkState(digest != null, path);
     return createForNormalFile(digest, proxy, size);

--- a/src/main/java/com/google/devtools/build/lib/actions/FileContentsProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileContentsProxy.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.actions;
 
 import com.google.devtools.build.lib.util.Fingerprint;
-import com.google.devtools.build.lib.vfs.DigestUtils;
 import com.google.devtools.build.lib.vfs.FileStatus;
 import java.io.IOException;
 import java.util.Objects;
@@ -52,13 +51,40 @@ public final class FileContentsProxy {
   }
 
   /**
-   * Returns the identity {@link DigestUtils} keys cached digests on, for a file of the given size.
+   * Returns a partial {@link FileStatus} view of this proxy for a file of the given getSize.
    *
-   * <p>A proxy records exactly the metadata the digest cache is keyed on, so a caller holding one
-   * can look up a cached digest without making {@link DigestUtils} stat the file again.
+   * <p>Only the metadata a proxy records is populated, so the type predicates all throw {@link
+   * UnsupportedOperationException}.
    */
-  public DigestUtils.FileIdentity toFileIdentity(long size) {
-    return new DigestUtils.FileIdentity(nodeId, ctime, mtime, size);
+  public FileStatus toMetadataOnlyFileStatus(long size) {
+    return new MetadataOnlyFileStatus(ctime, mtime, nodeId, size);
+  }
+
+  /**
+   * A {@link FileStatus} populated with the information available in a {@link FileContentsProxy}.
+   */
+  private record MetadataOnlyFileStatus(
+      long getLastChangeTime, long getLastModifiedTime, long getNodeId, long getSize)
+      implements FileStatus {
+    @Override
+    public boolean isFile() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isDirectory() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSymbolicLink() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSpecialFile() {
+      throw new UnsupportedOperationException();
+    }
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/actions/FileContentsProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileContentsProxy.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.actions;
 
 import com.google.devtools.build.lib.util.Fingerprint;
+import com.google.devtools.build.lib.vfs.DigestUtils;
 import com.google.devtools.build.lib.vfs.FileStatus;
 import java.io.IOException;
 import java.util.Objects;
@@ -48,6 +49,16 @@ public final class FileContentsProxy {
         // Note: there are file systems that return mtime for getLastChangeTime() instead of ctime,
         // such as the JavaIoFileSystem.
         stat.getLastChangeTime(), stat.getLastModifiedTime(), stat.getNodeId());
+  }
+
+  /**
+   * Returns the identity {@link DigestUtils} keys cached digests on, for a file of the given size.
+   *
+   * <p>A proxy records exactly the metadata the digest cache is keyed on, so a caller holding one
+   * can look up a cached digest without making {@link DigestUtils} stat the file again.
+   */
+  public DigestUtils.FileIdentity toFileIdentity(long size) {
+    return new DigestUtils.FileIdentity(nodeId, ctime, mtime, size);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/actions/FileContentsProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileContentsProxy.java
@@ -51,7 +51,7 @@ public final class FileContentsProxy {
   }
 
   /**
-   * Returns a partial {@link FileStatus} view of this proxy for a file of the given getSize.
+   * Returns a partial {@link FileStatus} view of this proxy for a file of the given size.
    *
    * <p>Only the metadata a proxy records is populated, so the type predicates all throw {@link
    * UnsupportedOperationException}.

--- a/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
@@ -125,7 +125,7 @@ public class RunfilesTreeUpdater {
       if (tree.getSymlinksMode() == RunfileSymlinksMode.CREATE) {
         // Not following symlinks means that the stat describes the output manifest itself, which is
         // only the file we digest below if it isn't a symbolic link - which is checked first.
-        var outputManifestStat = outputManifest.statNullable(Symlinks.NOFOLLOW);
+        var outputManifestStat = outputManifest.statIfFound(Symlinks.NOFOLLOW);
         if (outputManifestStat != null
             && !outputManifestStat.isSymbolicLink()
             && Arrays.equals(

--- a/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
@@ -106,7 +106,8 @@ public class RunfilesTreeUpdater {
     Path runfilesDir = execRoot.getRelative(tree.getExecPath());
     Path inputManifest =
         execRoot.getRelative(RunfilesSupport.inputManifestExecPath(tree.getExecPath()));
-    if (!inputManifest.exists()) {
+    var inputManifestStat = inputManifest.statNullable();
+    if (inputManifestStat == null) {
       return;
     }
     Path outputManifest =
@@ -121,14 +122,21 @@ public class RunfilesTreeUpdater {
       // which we must not treat as up to date, but we also don't want to unnecessarily rebuild the
       // runfiles directory all the time. Instead, check for the presence of the first runfile in
       // the manifest. If it is present, we can be certain that the previous mode wasn't SKIP.
-      if (tree.getSymlinksMode() == RunfileSymlinksMode.CREATE
-          && !outputManifest.isSymbolicLink()
-          && Arrays.equals(
-              DigestUtils.getDigestWithManualFallback(outputManifest, xattrProvider),
-              DigestUtils.getDigestWithManualFallback(inputManifest, xattrProvider))
-          && (OS.getCurrent() != OS.WINDOWS
-              || isRunfilesDirectoryPopulated(runfilesDir, outputManifest))) {
-        return;
+      if (tree.getSymlinksMode() == RunfileSymlinksMode.CREATE) {
+        // Not following symlinks means that the stat describes the output manifest itself, which is
+        // only the file we digest below if it isn't a symbolic link - which is checked first.
+        var outputManifestStat = outputManifest.statNullable(Symlinks.NOFOLLOW);
+        if (outputManifestStat != null
+            && !outputManifestStat.isSymbolicLink()
+            && Arrays.equals(
+                DigestUtils.getDigestWithManualFallback(
+                    outputManifest, xattrProvider, outputManifestStat),
+                DigestUtils.getDigestWithManualFallback(
+                    inputManifest, xattrProvider, inputManifestStat))
+            && (OS.getCurrent() != OS.WINDOWS
+                || isRunfilesDirectoryPopulated(runfilesDir, outputManifest))) {
+          return;
+        }
       }
     } catch (IOException e) {
       // Ignore it - we will just try to create runfiles directory.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
@@ -444,16 +444,20 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
     // We don't have an injected digest and there is no digest in the file value (which attempts a
     // fast digest). Manually compute the digest instead.
     var path = statAndValue.pathNoFollow();
-    // The file exists and is not an unresolved symlink, so it must have been stat'ed.
-    if (checkNotNull(statAndValue.statNoFollow(), statAndValue).isSymbolicLink()) {
+    // The file exists and is not an unresolved symlink, so it must have been stat'ed. Since the
+    // stat was taken without following symlinks, it only describes the file we are about to digest
+    // as long as the path isn't a symlink.
+    var stat = checkNotNull(statAndValue.statNoFollow(), statAndValue);
+    if (stat.isSymbolicLink()) {
       // If the file is a symlink, we compute the digest using the target path so that it's
       // possible to hit the digest cache - we probably already computed the digest for the
       // target during previous action execution.
       // The case of an unresolved symlink has been handled above, so realPath() is never null.
       path = checkNotNull(statAndValue.realPath(), statAndValue);
+      stat = null;
     }
     return FileArtifactValue.createFromInjectedDigest(
-        value, DigestUtils.manuallyComputeDigest(path));
+        value, DigestUtils.manuallyComputeDigest(path, stat));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/vfs/DigestUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/DigestUtils.java
@@ -34,29 +34,27 @@ public class DigestUtils {
   public static final int ESTIMATED_SIZE = 32;
 
   /**
-   * The file metadata that cached digests are keyed on, in an attempt to detect most file changes.
+   * Keys used to cache the values of the digests for files where we don't have fast digests.
+   *
+   * <p>The cache keys are derived from many properties of the file metadata in an attempt to be
+   * able to detect most file changes.
    */
-  public record FileIdentity(long nodeId, long changeTime, long lastModifiedTime, long size) {
-    /** Returns the identity of the file described by {@code status}. */
-    public static FileIdentity of(FileStatus status) throws IOException {
-      return new FileIdentity(
+  private static record CacheKey(
+      PathFragment path, long nodeId, long changeTime, long lastModifiedTime, long size) {
+    /**
+     * Constructs a new cache key.
+     *
+     * @param path path to the file
+     * @param status file status data from which to obtain the cache key properties
+     * @throws IOException if reading the file status data fails
+     */
+    private CacheKey(Path path, FileStatus status) throws IOException {
+      this(
+          path.asFragment(),
           status.getNodeId(),
           status.getLastChangeTime(),
           status.getLastModifiedTime(),
           status.getSize());
-    }
-  }
-
-  /** Keys used to cache the values of the digests for files where we don't have fast digests. */
-  private record CacheKey(
-      PathFragment path, long nodeId, long changeTime, long lastModifiedTime, long size) {
-    private CacheKey(Path path, FileIdentity identity) {
-      this(
-          path.asFragment(),
-          identity.nodeId(),
-          identity.changeTime(),
-          identity.lastModifiedTime(),
-          identity.size());
     }
   }
 
@@ -128,7 +126,7 @@ public class DigestUtils {
    */
   public static byte[] getDigestWithManualFallback(Path path, XattrProvider xattrProvider)
       throws IOException {
-    return getDigestWithManualFallback(path, xattrProvider, (FileIdentity) null);
+    return getDigestWithManualFallback(path, xattrProvider, null);
   }
 
   /**
@@ -145,19 +143,6 @@ public class DigestUtils {
   }
 
   /**
-   * Same as {@link #getDigestWithManualFallback(Path, XattrProvider, FileStatus)}, for callers that
-   * know the file's {@link FileIdentity} without holding a {@link FileStatus}.
-   *
-   * @param path the file path
-   * @param identity the file's identity, if known
-   */
-  public static byte[] getDigestWithManualFallback(
-      Path path, XattrProvider xattrProvider, @Nullable FileIdentity identity) throws IOException {
-    byte[] digest = xattrProvider.getFastDigest(path);
-    return digest != null ? digest : manuallyComputeDigest(path, identity);
-  }
-
-  /**
    * Calculates a digest manually (i.e., assuming that a fast digest can't obtained).
    *
    * <p>Prefer calling {@link #manuallyComputeDigest(Path, FileStatus)} when a recently obtained
@@ -166,7 +151,7 @@ public class DigestUtils {
    * @param path the file path
    */
   public static byte[] manuallyComputeDigest(Path path) throws IOException {
-    return manuallyComputeDigest(path, (FileIdentity) null);
+    return manuallyComputeDigest(path, null);
   }
 
   /**
@@ -178,28 +163,13 @@ public class DigestUtils {
    */
   public static byte[] manuallyComputeDigest(Path path, @Nullable FileStatus status)
       throws IOException {
-    // Only bother deriving the identity if the cache is enabled; it's unused otherwise.
-    return manuallyComputeDigest(
-        path, status != null && globalCache != null ? FileIdentity.of(status) : null);
-  }
-
-  /**
-   * Same as {@link #manuallyComputeDigest(Path)}, but providing the file's {@link FileIdentity} if
-   * it is already known.
-   *
-   * @param path the file path
-   * @param identity the file's identity, if known. When absent and the digest cache is enabled, the
-   *     file has to be stat'ed to obtain it.
-   */
-  public static byte[] manuallyComputeDigest(Path path, @Nullable FileIdentity identity)
-      throws IOException {
     byte[] digest;
 
     // Attempt a cache lookup if the cache is enabled.
     Cache<CacheKey, byte[]> cache = globalCache;
     CacheKey key = null;
     if (cache != null) {
-      key = new CacheKey(path, identity != null ? identity : FileIdentity.of(path.stat()));
+      key = new CacheKey(path, status != null ? status : path.stat());
       digest = cache.getIfPresent(key);
       if (digest != null) {
         return digest;

--- a/src/main/java/com/google/devtools/build/lib/vfs/DigestUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/DigestUtils.java
@@ -119,22 +119,8 @@ public class DigestUtils {
    * <p>If {@link Path#getFastDigest} has already been attempted and was not available, call {@link
    * #manuallyComputeDigest} to skip an additional attempt to obtain the fast digest.
    *
-   * <p>Prefer calling {@link #manuallyComputeDigest(Path, FileStatus)} when a recently obtained
-   * {@link FileStatus} is available.
-   *
    * @param path the file path
-   */
-  public static byte[] getDigestWithManualFallback(Path path, XattrProvider xattrProvider)
-      throws IOException {
-    return getDigestWithManualFallback(path, xattrProvider, null);
-  }
-
-  /**
-   * Same as {@link #getDigestWithManualFallback(Path, XattrProvider)}, but providing the ability to
-   * reuse a recently obtained {@link FileStatus}.
-   *
-   * @param path the file path
-   * @param status a recently obtained file status, if available
+   * @param status a recently obtained file status, if available. Used to skip a stat.
    */
   public static byte[] getDigestWithManualFallback(
       Path path, XattrProvider xattrProvider, @Nullable FileStatus status) throws IOException {

--- a/src/main/java/com/google/devtools/build/lib/vfs/DigestUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/DigestUtils.java
@@ -34,27 +34,29 @@ public class DigestUtils {
   public static final int ESTIMATED_SIZE = 32;
 
   /**
-   * Keys used to cache the values of the digests for files where we don't have fast digests.
-   *
-   * <p>The cache keys are derived from many properties of the file metadata in an attempt to be
-   * able to detect most file changes.
+   * The file metadata that cached digests are keyed on, in an attempt to detect most file changes.
    */
-  private static record CacheKey(
-      PathFragment path, long nodeId, long changeTime, long lastModifiedTime, long size) {
-    /**
-     * Constructs a new cache key.
-     *
-     * @param path path to the file
-     * @param status file status data from which to obtain the cache key properties
-     * @throws IOException if reading the file status data fails
-     */
-    private CacheKey(Path path, FileStatus status) throws IOException {
-      this(
-          path.asFragment(),
+  public record FileIdentity(long nodeId, long changeTime, long lastModifiedTime, long size) {
+    /** Returns the identity of the file described by {@code status}. */
+    public static FileIdentity of(FileStatus status) throws IOException {
+      return new FileIdentity(
           status.getNodeId(),
           status.getLastChangeTime(),
           status.getLastModifiedTime(),
           status.getSize());
+    }
+  }
+
+  /** Keys used to cache the values of the digests for files where we don't have fast digests. */
+  private record CacheKey(
+      PathFragment path, long nodeId, long changeTime, long lastModifiedTime, long size) {
+    private CacheKey(Path path, FileIdentity identity) {
+      this(
+          path.asFragment(),
+          identity.nodeId(),
+          identity.changeTime(),
+          identity.lastModifiedTime(),
+          identity.size());
     }
   }
 
@@ -126,7 +128,7 @@ public class DigestUtils {
    */
   public static byte[] getDigestWithManualFallback(Path path, XattrProvider xattrProvider)
       throws IOException {
-    return getDigestWithManualFallback(path, xattrProvider, null);
+    return getDigestWithManualFallback(path, xattrProvider, (FileIdentity) null);
   }
 
   /**
@@ -143,6 +145,19 @@ public class DigestUtils {
   }
 
   /**
+   * Same as {@link #getDigestWithManualFallback(Path, XattrProvider, FileStatus)}, for callers that
+   * know the file's {@link FileIdentity} without holding a {@link FileStatus}.
+   *
+   * @param path the file path
+   * @param identity the file's identity, if known
+   */
+  public static byte[] getDigestWithManualFallback(
+      Path path, XattrProvider xattrProvider, @Nullable FileIdentity identity) throws IOException {
+    byte[] digest = xattrProvider.getFastDigest(path);
+    return digest != null ? digest : manuallyComputeDigest(path, identity);
+  }
+
+  /**
    * Calculates a digest manually (i.e., assuming that a fast digest can't obtained).
    *
    * <p>Prefer calling {@link #manuallyComputeDigest(Path, FileStatus)} when a recently obtained
@@ -151,7 +166,7 @@ public class DigestUtils {
    * @param path the file path
    */
   public static byte[] manuallyComputeDigest(Path path) throws IOException {
-    return manuallyComputeDigest(path, null);
+    return manuallyComputeDigest(path, (FileIdentity) null);
   }
 
   /**
@@ -163,13 +178,28 @@ public class DigestUtils {
    */
   public static byte[] manuallyComputeDigest(Path path, @Nullable FileStatus status)
       throws IOException {
+    // Only bother deriving the identity if the cache is enabled; it's unused otherwise.
+    return manuallyComputeDigest(
+        path, status != null && globalCache != null ? FileIdentity.of(status) : null);
+  }
+
+  /**
+   * Same as {@link #manuallyComputeDigest(Path)}, but providing the file's {@link FileIdentity} if
+   * it is already known.
+   *
+   * @param path the file path
+   * @param identity the file's identity, if known. When absent and the digest cache is enabled, the
+   *     file has to be stat'ed to obtain it.
+   */
+  public static byte[] manuallyComputeDigest(Path path, @Nullable FileIdentity identity)
+      throws IOException {
     byte[] digest;
 
     // Attempt a cache lookup if the cache is enabled.
     Cache<CacheKey, byte[]> cache = globalCache;
     CacheKey key = null;
     if (cache != null) {
-      key = new CacheKey(path, status != null ? status : path.stat());
+      key = new CacheKey(path, identity != null ? identity : FileIdentity.of(path.stat()));
       digest = cache.getIfPresent(key);
       if (digest != null) {
         return digest;

--- a/src/test/java/com/google/devtools/build/lib/actions/FileContentsProxyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/FileContentsProxyTest.java
@@ -17,6 +17,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.util.Fingerprint;
+import com.google.devtools.build.lib.vfs.DigestUtils;
 import com.google.devtools.build.lib.vfs.FileStatus;
 import java.io.IOException;
 import org.junit.Test;
@@ -98,6 +99,17 @@ public class FileContentsProxyTest {
         .addEqualityGroup(FileContentsProxy.create(new InjectedStat(3L, 4L)))
         .addEqualityGroup(FileContentsProxy.create(new InjectedStat(-1L, -1L)))
         .testEquals();
+  }
+
+  @Test
+  public void toFileIdentityMatchesTheStatItWasCreatedFrom() throws Exception {
+    // The digest cache is keyed on a FileIdentity, and callers reach it both ways: some hold a
+    // FileStatus, others only the proxy Skyframe recorded earlier. Both have to produce the same
+    // key, or a digest cached by one caller is invisible to the other.
+    FileStatus stat =
+        new InjectedStat(/* mtime= */ 1, /* ctime= */ 2, /* size= */ 3, /* nodeId= */ 4);
+    assertThat(FileContentsProxy.create(stat).toFileIdentity(stat.getSize()))
+        .isEqualTo(DigestUtils.FileIdentity.of(stat));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/actions/FileContentsProxyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/FileContentsProxyTest.java
@@ -17,7 +17,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.util.Fingerprint;
-import com.google.devtools.build.lib.vfs.DigestUtils;
 import com.google.devtools.build.lib.vfs.FileStatus;
 import java.io.IOException;
 import org.junit.Test;
@@ -102,14 +101,15 @@ public class FileContentsProxyTest {
   }
 
   @Test
-  public void toFileIdentityMatchesTheStatItWasCreatedFrom() throws Exception {
-    // The digest cache is keyed on a FileIdentity, and callers reach it both ways: some hold a
-    // FileStatus, others only the proxy Skyframe recorded earlier. Both have to produce the same
-    // key, or a digest cached by one caller is invisible to the other.
+  public void toMetadataOnlyFileStatusRoundTrip() throws Exception {
     FileStatus stat =
         new InjectedStat(/* mtime= */ 1, /* ctime= */ 2, /* size= */ 3, /* nodeId= */ 4);
-    assertThat(FileContentsProxy.create(stat).toFileIdentity(stat.getSize()))
-        .isEqualTo(DigestUtils.FileIdentity.of(stat));
+    FileStatus partial = FileContentsProxy.create(stat).toMetadataOnlyFileStatus(stat.getSize());
+
+    assertThat(partial.getLastModifiedTime()).isEqualTo(stat.getLastModifiedTime());
+    assertThat(partial.getLastChangeTime()).isEqualTo(stat.getLastChangeTime());
+    assertThat(partial.getNodeId()).isEqualTo(stat.getNodeId());
+    assertThat(partial.getSize()).isEqualTo(stat.getSize());
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/unix/UnixDigestHashAttributeNameTest.java
+++ b/src/test/java/com/google/devtools/build/lib/unix/UnixDigestHashAttributeNameTest.java
@@ -42,7 +42,9 @@ public class UnixDigestHashAttributeNameTest extends FileSystemTest {
     // Instead of actually trying to access this file, a call to getxattr() should be made. We
     // intercept this call and return a fake extended attribute value, thereby causing the checksum
     // computation to be skipped entirely.
-    assertThat(DigestUtils.getDigestWithManualFallback(absolutize("myfile"), SyscallCache.NO_CACHE))
+    assertThat(
+            DigestUtils.getDigestWithManualFallback(
+                absolutize("myfile"), SyscallCache.NO_CACHE, /* status= */ null))
         .isEqualTo(FAKE_DIGEST);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/vfs/DigestUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/DigestUtilsTest.java
@@ -75,6 +75,46 @@ public final class DigestUtilsTest {
   }
 
   @Test
+  public void cacheHitRegardlessOfHowTheFileIdentityWasObtained() throws Exception {
+    AtomicInteger getDigestCounter = new AtomicInteger(0);
+    AtomicInteger statCounter = new AtomicInteger(0);
+
+    FileSystem tracingFileSystem =
+        new InMemoryFileSystem(DigestHashFunction.SHA256) {
+          @Override
+          public byte[] getDigest(PathFragment path) throws IOException {
+            getDigestCounter.incrementAndGet();
+            return super.getDigest(path);
+          }
+
+          @Override
+          public FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
+            statCounter.incrementAndGet();
+            return super.stat(path, followSymlinks);
+          }
+        };
+
+    DigestUtils.configureCache(/* maximumSize= */ 100);
+
+    Path file = tracingFileSystem.getPath("/file.txt");
+    FileSystemUtils.writeContentAsLatin1(file, "some contents");
+
+    // Without an identity, DigestUtils has to stat the file itself to build the cache key.
+    byte[] digest = DigestUtils.manuallyComputeDigest(file);
+    assertThat(getDigestCounter.get()).isEqualTo(1);
+    assertThat(statCounter.get()).isEqualTo(1);
+
+    // A caller that already knows the identity gets the cached digest without a further stat,
+    // which only works if both spellings of the key agree.
+    statCounter.set(0);
+    FileStatus stat = file.stat();
+    assertThat(DigestUtils.manuallyComputeDigest(file, DigestUtils.FileIdentity.of(stat)))
+        .isEqualTo(digest);
+    assertThat(getDigestCounter.get()).isEqualTo(1); // Cached.
+    assertThat(statCounter.get()).isEqualTo(1); // Only the caller's own stat.
+  }
+
+  @Test
   public void manuallyComputeDigest() throws Exception {
     byte[] digest = {1, 2, 3};
     FileSystem noDigestFileSystem =

--- a/src/test/java/com/google/devtools/build/lib/vfs/DigestUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/DigestUtilsTest.java
@@ -75,7 +75,7 @@ public final class DigestUtilsTest {
   }
 
   @Test
-  public void cacheHitRegardlessOfHowTheFileIdentityWasObtained() throws Exception {
+  public void cacheHitWithoutRestatingWhenTheCallerSuppliesTheStat() throws Exception {
     AtomicInteger getDigestCounter = new AtomicInteger(0);
     AtomicInteger statCounter = new AtomicInteger(0);
 
@@ -99,19 +99,19 @@ public final class DigestUtilsTest {
     Path file = tracingFileSystem.getPath("/file.txt");
     FileSystemUtils.writeContentAsLatin1(file, "some contents");
 
-    // Without an identity, DigestUtils has to stat the file itself to build the cache key.
+    // Without a stat, DigestUtils has to stat the file itself to build the cache key.
     byte[] digest = DigestUtils.manuallyComputeDigest(file);
     assertThat(getDigestCounter.get()).isEqualTo(1);
     assertThat(statCounter.get()).isEqualTo(1);
 
-    // A caller that already knows the identity gets the cached digest without a further stat,
-    // which only works if both spellings of the key agree.
-    statCounter.set(0);
+    // A caller that already stat'ed the file gets the cached digest without a further stat, which
+    // only works if both spellings of the key agree.
     FileStatus stat = file.stat();
-    assertThat(DigestUtils.manuallyComputeDigest(file, DigestUtils.FileIdentity.of(stat)))
-        .isEqualTo(digest);
-    assertThat(getDigestCounter.get()).isEqualTo(1); // Cached.
-    assertThat(statCounter.get()).isEqualTo(1); // Only the caller's own stat.
+    getDigestCounter.set(0);
+    statCounter.set(0);
+    assertThat(DigestUtils.manuallyComputeDigest(file, stat)).isEqualTo(digest);
+    assertThat(getDigestCounter.get()).isEqualTo(0);
+    assertThat(statCounter.get()).isEqualTo(0);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/vfs/DigestUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/DigestUtilsTest.java
@@ -57,18 +57,23 @@ public final class DigestUtilsTest {
     Path file = tracingFileSystem.getPath("/file.txt");
     FileSystemUtils.writeContentAsLatin1(file, "some contents");
 
-    byte[] digest = DigestUtils.getDigestWithManualFallback(file, SyscallCache.NO_CACHE);
+    byte[] digest =
+        DigestUtils.getDigestWithManualFallback(file, SyscallCache.NO_CACHE, /* status= */ null);
     assertThat(getFastDigestCounter.get()).isEqualTo(1);
     assertThat(getDigestCounter.get()).isEqualTo(1);
 
-    assertThat(DigestUtils.getDigestWithManualFallback(file, SyscallCache.NO_CACHE))
+    assertThat(
+            DigestUtils.getDigestWithManualFallback(
+                file, SyscallCache.NO_CACHE, /* status= */ null))
         .isEqualTo(digest);
     assertThat(getFastDigestCounter.get()).isEqualTo(2);
     assertThat(getDigestCounter.get()).isEqualTo(1); // Cached.
 
     DigestUtils.clearCache();
 
-    assertThat(DigestUtils.getDigestWithManualFallback(file, SyscallCache.NO_CACHE))
+    assertThat(
+            DigestUtils.getDigestWithManualFallback(
+                file, SyscallCache.NO_CACHE, /* status= */ null))
         .isEqualTo(digest);
     assertThat(getFastDigestCounter.get()).isEqualTo(3);
     assertThat(getDigestCounter.get()).isEqualTo(2); // Not cached.


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
`DigestUtils` keys cached digests on a file's node id, ctime, mtime and size, and obtained them by stat-ing the file, but all callers had just stat-ed it for its own metadata. Pass that metadata to the cache to avoid the additional stat.

### Motivation
On a sample (re-)build of Bazel itself, this avoids roughly 5% of all stats issued by Bazel.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
