### PR TITLE
Fix the persistent Merkle subtree cache never hitting for tree artifacts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputer.java
@@ -52,7 +52,6 @@ import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper.BasicActionInput;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
-import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FileStateType;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.LostInputsExecException;
@@ -165,9 +164,12 @@ public final class MerkleTreeComputer {
       Executors.newThreadPerTaskExecutor(
           Thread.ofVirtual().name("merkle-tree-upload-", 0).factory());
 
-  private static final Cache<FileArtifactValue, MerkleTree.RootOnly> persistentToolSubTreeCache =
+  // Keyed on FileArtifactValue-like object describing the contents of the subtree. Since weak keys
+  // imply identity comparison, the key type can't be just FileArtifactValue as not every aggregate
+  // input has a FileArtifactValue that is retained alongside its contents.
+  private static final Cache<Object, MerkleTree.RootOnly> persistentToolSubTreeCache =
       Caffeine.newBuilder().weakKeys().build();
-  private static final Cache<FileArtifactValue, MerkleTree.RootOnly> persistentNonToolSubTreeCache =
+  private static final Cache<Object, MerkleTree.RootOnly> persistentNonToolSubTreeCache =
       Caffeine.newBuilder().weakKeys().build();
 
   // @GuardedBy("MerkleTreeComputer.class") for writes, reads use double-checked locking.
@@ -234,7 +236,8 @@ public final class MerkleTreeComputer {
    * The key type for the cache used to deduplicate ongoing computations and possibly uploading of
    * sub-Merkle trees.
    *
-   * @param metadata the metadata of the aggregate {@link ActionInput} that forms the subtree
+   * @param cacheKey the value describing the contents of the aggregate {@link ActionInput} that
+   *     forms the subtree, compared by value
    * @param isTool whether the subtree consists of tool inputs
    * @param uploadBlobs whether the blobs in this tree will be uploaded
    * @param unmappedExecPath the exec path of the aggregate input, included only when path mapping
@@ -243,7 +246,7 @@ public final class MerkleTreeComputer {
    *     input depends on the unmapped path)
    */
   private record InFlightCacheKey(
-      FileArtifactValue metadata,
+      Object cacheKey,
       boolean isTool,
       boolean uploadBlobs,
       @Nullable PathFragment unmappedExecPath) {}
@@ -837,6 +840,9 @@ public final class MerkleTreeComputer {
     // mappedExecPath and isToolInput must not be used below as they aren't part of the cache key -
     // use isTool instead.
     return computeIfAbsent(
+        // The metadata is a field of the RunfilesArtifactValue and thus just as suitable as a weak
+        // key, but hashes and compares in constant time, whereas RunfilesArtifactValue does so in
+        // time linear in the size of the runfiles tree.
         runfilesArtifactValue.getMetadata(),
         // Runfiles metadata already encodes the exec path of the root.
         /* unmappedExecPath= */ null,
@@ -872,7 +878,9 @@ public final class MerkleTreeComputer {
     // mappedExecPath and isToolInput must not be used below as they aren't part of the cache key -
     // use isTool instead.
     return computeIfAbsent(
-        treeArtifactValue.getMetadata(),
+        // This must not be replaced by treeArtifactValue.getMetadata() as the latter returns a new
+        // instance on every call and is thus unusable as an identity-compared weak key.
+        treeArtifactValue,
         unmappedExecPath,
         () ->
             Lists.transform(
@@ -897,12 +905,17 @@ public final class MerkleTreeComputer {
   /**
    * Performs a cached computation of the sub-Merkle tree for the given aggregate input.
    *
+   * @param cacheKey a value that fully describes the contents of the aggregate input and is
+   *     retained for as long as those contents are current. The persistent caches use it as a weak
+   *     and thus identity-compared key, which only works fi it is a retained instance. The
+   *     in-flight cache compares it by value, so among the eligible values prefer the one with the
+   *     cheapest {@link #hashCode} and {@link #equals}.
    * @param unmappedExecPath the exec path of the aggregate input before path mapping to be added to
    *     the cache key, null if this aggregate input is not subject to path mapping or the metadata
    *     already includes the path
    */
   private ListenableFuture<MerkleTree.RootOnly> computeIfAbsent(
-      FileArtifactValue metadata,
+      Object cacheKey,
       @Nullable PathFragment unmappedExecPath,
       SortedInputsSupplier sortedInputsSupplier,
       boolean isTool,
@@ -913,9 +926,9 @@ public final class MerkleTreeComputer {
       BlobPolicy blobPolicy) {
     var persistentCache = isTool ? persistentToolSubTreeCache : persistentNonToolSubTreeCache;
     if (blobPolicy == BlobPolicy.KEEP_AND_REUPLOAD) {
-      persistentCache.invalidate(metadata);
+      persistentCache.invalidate(cacheKey);
     } else {
-      var cachedRoot = persistentCache.getIfPresent(metadata);
+      var cachedRoot = persistentCache.getIfPresent(cacheKey);
       if (cachedRoot != null
           && (blobPolicy == BlobPolicy.DISCARD
               || cachedRoot instanceof MerkleTree.RootOnly.BlobsUploaded)) {
@@ -931,13 +944,13 @@ public final class MerkleTreeComputer {
     // BulkTransferException.getLostArtifacts has been considered, but is far more complex and only
     // relevant for the uncommon no-DISCARD case.
     var key =
-        new InFlightCacheKey(metadata, isTool, uploadBlobs, uploadBlobs ? unmappedExecPath : null);
+        new InFlightCacheKey(cacheKey, isTool, uploadBlobs, uploadBlobs ? unmappedExecPath : null);
     AsyncCallable<MerkleTree.RootOnly> buildMerkleTreeTask =
         () -> {
           // There is a window in which a concurrent call may have removed the in-flight cache entry
           // while this one had already passed the check above. Recheck the persistent cache to
           // avoid unnecessary work.
-          var cachedRoot = persistentCache.getIfPresent(metadata);
+          var cachedRoot = persistentCache.getIfPresent(cacheKey);
           if (cachedRoot != null
               && (blobPolicy == BlobPolicy.DISCARD
                   || cachedRoot instanceof MerkleTree.RootOnly.BlobsUploaded)) {
@@ -948,7 +961,7 @@ public final class MerkleTreeComputer {
             var inFlightComputation =
                 inFlightComputations.maybeJoinExecution(
                     new InFlightCacheKey(
-                        metadata, isTool, /* uploadBlobs= */ true, unmappedExecPath));
+                        cacheKey, isTool, /* uploadBlobs= */ true, unmappedExecPath));
             if (inFlightComputation != null) {
               return inFlightComputation;
             }
@@ -995,7 +1008,7 @@ public final class MerkleTreeComputer {
                 persistentCache
                     .asMap()
                     .compute(
-                        metadata,
+                        cacheKey,
                         (unused, oldRoot) -> {
                           // Don't downgrade the cached root from one indicating that its blobs have
                           // been uploaded.

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/BUILD
@@ -27,6 +27,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/actions:runfiles_metadata",
         "//src/main/java/com/google/devtools/build/lib/actions:runfiles_tree",
         "//src/main/java/com/google/devtools/build/lib/actions:virtual_action_input",
+        "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/clock",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
@@ -39,8 +40,10 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs",
         "//src/test/java/com/google/devtools/build/lib:test_runner",  # build_cleaner: keep
         "//src/test/java/com/google/devtools/build/lib/actions/util",
+        "//src/test/java/com/google/devtools/build/lib/analysis/util",
         "//src/test/java/com/google/devtools/build/lib/exec/util",
         "//src/test/java/com/google/devtools/build/lib/remote/util",
+        "//src/test/java/com/google/devtools/build/lib/testutil:TestConstants",
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party:junit4",

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeComputerTest.java
@@ -42,6 +42,8 @@ import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnInputs;
 import com.google.devtools.build.lib.actions.VirtualActionInput;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
+import com.google.devtools.build.lib.analysis.Runfiles;
+import com.google.devtools.build.lib.analysis.util.AnalysisTestUtil;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
@@ -53,11 +55,13 @@ import com.google.devtools.build.lib.remote.common.RemotePathResolver;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.FakeSpawnExecutionContext;
 import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
+import com.google.devtools.build.lib.testutil.TestConstants;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import java.io.IOException;
@@ -74,6 +78,8 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class MerkleTreeComputerTest {
+  private static final String WORKSPACE_NAME = "_main";
+
   private Path execRoot;
   private ArtifactRoot artifactRoot;
 
@@ -212,44 +218,8 @@ public class MerkleTreeComputerTest {
         treeFileArtifact, FileArtifactValue.createForTesting(treeFileArtifact));
     fakeFileCache.putTreeArtifact(treeArtifactInput, treeArtifactBuilder.build());
     var spawn = new SpawnBuilder().withInputs(treeArtifactInput).build();
-    var ensureInputsPresentCount = new AtomicInteger();
-    var merkleTreeComputer =
-        createMerkleTreeComputer(
-            new MerkleTreeUploader() {
-              @Override
-              public ListenableFuture<Void> uploadBlob(
-                  RemoteActionExecutionContext context, Digest digest, byte[] data, boolean force) {
-                return immediateVoidFuture();
-              }
-
-              @Override
-              public ListenableFuture<Void> uploadFile(
-                  RemoteActionExecutionContext context,
-                  RemotePathResolver remotePathResolver,
-                  Digest digest,
-                  Path path,
-                  boolean force) {
-                return immediateVoidFuture();
-              }
-
-              @Override
-              public ListenableFuture<Void> uploadVirtualActionInput(
-                  RemoteActionExecutionContext context,
-                  Digest digest,
-                  VirtualActionInput virtualActionInput,
-                  boolean force) {
-                return immediateVoidFuture();
-              }
-
-              @Override
-              public void ensureInputsPresent(
-                  RemoteActionExecutionContext context,
-                  MerkleTree.Uploadable merkleTree,
-                  boolean force,
-                  RemotePathResolver remotePathResolver) {
-                ensureInputsPresentCount.incrementAndGet();
-              }
-            });
+    var uploader = new CountingMerkleTreeUploader();
+    var merkleTreeComputer = createMerkleTreeComputer(uploader);
 
     var treeFileMetadataAccessed = new CountDownLatch(1);
     var treeFileMetadataContinue = new CountDownLatch(1);
@@ -382,7 +352,101 @@ public class MerkleTreeComputerTest {
     }
 
     // All threads share a single upload of the subtree.
-    assertThat(ensureInputsPresentCount.get()).isEqualTo(1);
+    assertThat(uploader.ensureInputsPresentCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void treeArtifactSubtree_reusedByLaterBuild() throws Exception {
+    var fakeFileCache = new FakeActionInputFileCache();
+    var treeArtifactInput =
+        ActionsTestUtil.createTreeArtifactWithGeneratingAction(
+            artifactRoot, "dir/subdir/reused_tree_artifact");
+    treeArtifactInput.getPath().createDirectoryAndParents();
+    var treeArtifactBuilder = TreeArtifactValue.newBuilder(treeArtifactInput);
+    var treeFileArtifact = Artifact.TreeFileArtifact.createTreeOutput(treeArtifactInput, "file");
+    FileSystemUtils.writeContentAsLatin1(treeFileArtifact.getPath(), "reused file content");
+    treeArtifactBuilder.putChild(
+        treeFileArtifact, FileArtifactValue.createForTesting(treeFileArtifact));
+    fakeFileCache.putTreeArtifact(treeArtifactInput, treeArtifactBuilder.build());
+    var spawn = new SpawnBuilder().withInputs(treeArtifactInput).build();
+    var uploader = new CountingMerkleTreeUploader();
+
+    for (int i = 0; i < 2; i++) {
+      var unused =
+          createMerkleTreeComputer(uploader)
+              .buildForSpawn(
+                  spawn,
+                  ImmutableSet.of(),
+                  /* scrubber= */ null,
+                  createSpawnExecutionContext(spawn, fakeFileCache),
+                  RemotePathResolver.createDefault(execRoot),
+                  MerkleTreeComputer.BlobPolicy.KEEP);
+    }
+
+    assertThat(uploader.ensureInputsPresentCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void runfilesTreeSubtree_reusedByLaterBuild() throws Exception {
+    var fakeFileCache = new FakeActionInputFileCache();
+    var runfile = ActionsTestUtil.createArtifact(artifactRoot, "pkg/tool");
+    runfile.getPath().getParentDirectory().createDirectoryAndParents();
+    FileSystemUtils.writeContentAsLatin1(runfile.getPath(), "tool content");
+    fakeFileCache.put(runfile, FileArtifactValue.createForTesting(runfile));
+    var runfilesTreeArtifact =
+        ActionsTestUtil.createRunfilesArtifact(
+            artifactRoot,
+            artifactRoot.getExecPath().getRelative("pkg/tool.runfiles").getPathString());
+    fakeFileCache.putRunfilesTree(
+        runfilesTreeArtifact,
+        AnalysisTestUtil.createRunfilesTree(
+            runfilesTreeArtifact.getExecPath(),
+            new Runfiles.Builder(TestConstants.WORKSPACE_NAME).addArtifact(runfile).build()));
+    var spawn = new SpawnBuilder().withInputs(runfilesTreeArtifact).build();
+    var uploader = new CountingMerkleTreeUploader();
+
+    for (int i = 0; i < 2; i++) {
+      var unused =
+          createMerkleTreeComputer(uploader)
+              .buildForSpawn(
+                  spawn,
+                  ImmutableSet.of(),
+                  /* scrubber= */ null,
+                  createSpawnExecutionContext(spawn, fakeFileCache),
+                  RemotePathResolver.createDefault(execRoot),
+                  MerkleTreeComputer.BlobPolicy.KEEP);
+    }
+
+    assertThat(uploader.ensureInputsPresentCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void sourceDirectorySubtree_reusedByLaterBuild() throws Exception {
+    var sourceRoot = ArtifactRoot.asSourceRoot(Root.fromPath(execRoot));
+    var sourceDirectory =
+        ActionsTestUtil.createArtifactWithExecPath(sourceRoot, PathFragment.create("src_dir"));
+    var sourceDirectoryPath = sourceDirectory.getPath();
+    sourceDirectoryPath.createDirectoryAndParents();
+    FileSystemUtils.writeContentAsLatin1(
+        sourceDirectoryPath.getChild("file"), "source directory file content");
+    var fakeFileCache = new FakeActionInputFileCache();
+    fakeFileCache.put(sourceDirectory, FileArtifactValue.createForTesting(sourceDirectoryPath));
+    var spawn = new SpawnBuilder().withInputs(sourceDirectory).build();
+    var uploader = new CountingMerkleTreeUploader();
+
+    for (int i = 0; i < 2; i++) {
+      var unused =
+          createMerkleTreeComputer(uploader)
+              .buildForSpawn(
+                  spawn,
+                  ImmutableSet.of(),
+                  /* scrubber= */ null,
+                  createSpawnExecutionContext(spawn, fakeFileCache),
+                  RemotePathResolver.createDefault(execRoot),
+                  MerkleTreeComputer.BlobPolicy.KEEP);
+    }
+
+    assertThat(uploader.ensureInputsPresentCount.get()).isEqualTo(1);
   }
 
   @Test
@@ -502,13 +566,52 @@ public class MerkleTreeComputerTest {
     return current;
   }
 
+  /** A {@link MerkleTreeUploader} that only counts calls to {@link #ensureInputsPresent}. */
+  private static final class CountingMerkleTreeUploader implements MerkleTreeUploader {
+    final AtomicInteger ensureInputsPresentCount = new AtomicInteger();
+
+    @Override
+    public ListenableFuture<Void> uploadBlob(
+        RemoteActionExecutionContext context, Digest digest, byte[] data, boolean force) {
+      return immediateVoidFuture();
+    }
+
+    @Override
+    public ListenableFuture<Void> uploadFile(
+        RemoteActionExecutionContext context,
+        RemotePathResolver remotePathResolver,
+        Digest digest,
+        Path path,
+        boolean force) {
+      return immediateVoidFuture();
+    }
+
+    @Override
+    public ListenableFuture<Void> uploadVirtualActionInput(
+        RemoteActionExecutionContext context,
+        Digest digest,
+        VirtualActionInput virtualActionInput,
+        boolean force) {
+      return immediateVoidFuture();
+    }
+
+    @Override
+    public void ensureInputsPresent(
+        RemoteActionExecutionContext context,
+        MerkleTree.Uploadable merkleTree,
+        boolean force,
+        RemotePathResolver remotePathResolver) {
+      ensureInputsPresentCount.incrementAndGet();
+    }
+  }
+
   private MerkleTreeComputer createMerkleTreeComputer(MerkleTreeUploader uploader) {
     return new MerkleTreeComputer(
         new DigestUtil(SyscallCache.NO_CACHE, DigestHashFunction.SHA256),
         uploader,
         "buildRequestId",
         "commandId",
-        "_main");
+        WORKSPACE_NAME);
   }
 
   private FakeSpawnExecutionContext createSpawnExecutionContext(


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
`persistentToolSubTreeCache` and `persistentNonToolSubTreeCache` are built with `Caffeine#weakKeys`, which makes them compare keys by identity. For tree artifacts the key was `TreeArtifactValue#getMetadata`, which constructs a new `TreeArtifactCompositeFileArtifactValue` on every call.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
