### PR TITLE
Turn implicit assumptions in `ActionOutputMetadataStore` into explicit checks

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
@@ -436,23 +436,24 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
           artifactPathResolver.toPath(artifact).getLastModifiedTime());
     }
 
-    byte[] digest = null;
-    if (type.isFile()) {
-      // We don't have an injected digest and there is no digest in the file value (which attempts a
-      // fast digest). Manually compute the digest instead.
-      Path path = statAndValue.pathNoFollow();
-      if (statAndValue.statNoFollow() != null
-          && statAndValue.statNoFollow().isSymbolicLink()
-          && statAndValue.realPath() != null) {
-        // If the file is a symlink, we compute the digest using the target path so that it's
-        // possible to hit the digest cache - we probably already computed the digest for the
-        // target during previous action execution.
-        path = statAndValue.realPath();
-      }
-
-      digest = DigestUtils.manuallyComputeDigest(path);
+    if (type.isSpecialFile()) {
+      return FileArtifactValue.createFromInjectedDigest(value, /* digest= */ null);
     }
-    return FileArtifactValue.createFromInjectedDigest(value, digest);
+
+    checkState(type.isFile());
+    // We don't have an injected digest and there is no digest in the file value (which attempts a
+    // fast digest). Manually compute the digest instead.
+    var path = statAndValue.pathNoFollow();
+    // The file exists and is not an unresolved symlink, so it must have been stat'ed.
+    if (checkNotNull(statAndValue.statNoFollow(), statAndValue).isSymbolicLink()) {
+      // If the file is a symlink, we compute the digest using the target path so that it's
+      // possible to hit the digest cache - we probably already computed the digest for the
+      // target during previous action execution.
+      // The case of an unresolved symlink has been handled above, so realPath() is never null.
+      path = checkNotNull(statAndValue.realPath(), statAndValue);
+    }
+    return FileArtifactValue.createFromInjectedDigest(
+        value, DigestUtils.manuallyComputeDigest(path));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
@@ -440,7 +440,7 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
       return FileArtifactValue.createFromInjectedDigest(value, /* digest= */ null);
     }
 
-    checkState(type.isFile());
+    checkState(type.isFile(), type);
     // We don't have an injected digest and there is no digest in the file value (which attempts a
     // fast digest). Manually compute the digest instead.
     var path = statAndValue.pathNoFollow();


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
When constructing a `FileArtifactValue` from the filesystem, `ActionOutputMetadataStore` relied on `FileStateType#isFile` to also skip special files and on null checks for a stat and a real path that can't be absent at this point. Give special files their own branch and assert the remaining assumptions instead.

This is a pure refactoring: special files already ended up with a null digest as `FileStateType#isFile` only returns true for `REGULAR_FILE`, `statNoFollow` is only null for a non-existent file (handled above) and `realPath` is only null for a non-symlink or an unresolved symlink (both handled above). In particular, special files such as fifos still aren't digested.

### Motivation
Split out of #30774 to make it easier to see that the optimization in that PR doesn't change behavior for special files or symlinks.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
