### PR TITLE
Don't synchronize `RemoteExternalOverlayFileSystem#getInputStream`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -848,7 +848,7 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
     }
 
     @Override
-    public synchronized InputStream getInputStream(PathFragment path) throws IOException {
+    public InputStream getInputStream(PathFragment path) throws IOException {
       // Symlinks are never prefetched to the native file system themselves, only the regular file
       // they resolve to, so follow them before reading a prefetched file. Either end of the chain
       // can be what makes the read eligible: a symlink named `helper.bzl` pointing at `helper.txt`


### PR DESCRIPTION
### Description

### Motivation

Synchronization is unnecessary as individual methods called by this implementation are already synchronized. It is also harmful since `getInputStream` awaits a network transfer.

Progress towards #30780

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
