### PR TITLE
Fail a `ByteStream` read that returns more data than the blob holds

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -508,10 +508,27 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
                 } catch (IOException e) {
                   // The output stream was likely closed due to cancellation (e.g. dynamic execution
                   // choosing the local branch).
-                  if (requestStream != null) {
-                    requestStream.cancel("output stream closed", e);
-                  }
-                  future.setException(e);
+                  failAndCancel(e, "output stream closed");
+                  return;
+                } catch (RuntimeException e) {
+                  // gRPC turns an exception thrown by this listener into a CANCELLED status, which
+                  // the retrier treats as transient and retries while the real cause -- e.g. a
+                  // decompressor rejecting corrupt data -- is reported as "Failed to read message".
+                  // Such a failure is deterministic, so fail with the actual exception instead.
+                  logger.atWarning().withCause(e).log("Unexpected exception while reading blob");
+                  failAndCancel(e, "unexpected exception");
+                  return;
+                }
+                if (rawOut.getCount() > digest.getSizeBytes()) {
+                  // The server sent more data than the blob is long, which typically means that it
+                  // ignored the read offset and restarted the stream from the beginning after a
+                  // retry. Retrying can't fix that and would keep buffering data indefinitely, so
+                  // fail with a non-retriable error instead.
+                  failAndCancel(
+                      new IOException(
+                          "Remote cache sent more than the expected %d bytes for %s"
+                              .formatted(digest.getSizeBytes(), DigestUtil.toString(digest))),
+                      "too many bytes received");
                   return;
                 }
                 // reset the stall backoff because we've made progress or been kept alive
@@ -556,6 +573,20 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
                   future.setException(e);
                 }
                 future.set(rawOut.getCount());
+              }
+
+              /**
+               * Cancels the call and fails the download, making the future terminal even if the
+               * cancellation fails or gRPC never delivers a terminal callback for it.
+               */
+              private void failAndCancel(Throwable t, String cancelMessage) {
+                try {
+                  if (requestStream != null) {
+                    requestStream.cancel(cancelMessage, t);
+                  }
+                } finally {
+                  future.setException(t);
+                }
               }
 
               private void releaseOut() {

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -1300,6 +1300,73 @@ public class GrpcCacheClientTest {
   }
 
   @Test
+  public void downloadBlobFailsWhenServerIgnoresReadOffset() throws IOException {
+    // A server that restarts the stream from the beginning instead of honoring the read offset
+    // would otherwise make the client buffer the blob over and over without ever completing.
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.setRemoteMaxRetryAttempts(2);
+    GrpcCacheClient client = newClient(remoteOptions);
+    Digest digest = DIGEST_UTIL.computeAsUtf8("abcdefg");
+    ByteString data = ByteString.copyFromUtf8("abcdefg");
+    AtomicInteger readCalls = new AtomicInteger();
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+            if (readCalls.getAndIncrement() == 0) {
+              // Deliver a prefix so that the client retries from a non-zero read offset.
+              responseObserver.onNext(
+                  ReadResponse.newBuilder().setData(data.substring(0, 1)).build());
+              responseObserver.onError(Status.UNAVAILABLE.asException());
+              return;
+            }
+            // Restart from the beginning instead of honoring the requested offset.
+            assertThat(request.getReadOffset()).isEqualTo(1);
+            responseObserver.onNext(ReadResponse.newBuilder().setData(data).build());
+            responseObserver.onCompleted();
+          }
+        });
+
+    IOException e = assertThrows(IOException.class, () -> downloadBlob(context, client, digest));
+    assertThat(e).hasMessageThat().contains("more than the expected");
+    // The over-read is a permanent failure, so the client gives up instead of retrying.
+    assertThat(readCalls.get()).isEqualTo(2);
+  }
+
+  @Test
+  public void downloadBlobFailsOnOverlongContentWithoutDownloadVerification() throws IOException {
+    // With --noremote_verify_downloads there is no digest check to fall back on, so an over-read
+    // would otherwise be handed to the caller as if it were the blob's content.
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.setRemoteMaxRetryAttempts(2);
+    remoteOptions.setRemoteVerifyDownloads(false);
+    GrpcCacheClient client = newClient(remoteOptions);
+    Digest digest = DIGEST_UTIL.computeAsUtf8("abcdefg");
+    ByteString data = ByteString.copyFromUtf8("abcdefg");
+    AtomicInteger readCalls = new AtomicInteger();
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+            if (readCalls.getAndIncrement() == 0) {
+              responseObserver.onNext(
+                  ReadResponse.newBuilder().setData(data.substring(0, 1)).build());
+              responseObserver.onError(Status.UNAVAILABLE.asException());
+              return;
+            }
+            responseObserver.onNext(ReadResponse.newBuilder().setData(data).build());
+            responseObserver.onCompleted();
+          }
+        });
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    IOException e =
+        assertThrows(
+            IOException.class, () -> getFromFuture(client.downloadBlob(context, digest, out)));
+    assertThat(e).hasMessageThat().contains("more than the expected");
+  }
+
+  @Test
   public void downloadBlobIdleTimeoutIsRetriedWithProgress()
       throws IOException, InterruptedException {
     // Unexpected failures without progress should stop immediately. The idle-timeout retry below


### PR DESCRIPTION
### Description

A server that ignores `read_offset` and restarts the stream from the beginning on each retry makes `GrpcCacheClient.requestRead` append the blob to what it already buffered. Treat receiving more bytes than the blob is long as a permanent failure instead.

While here, catch unchecked exceptions escaping `onNext`. Both paths go through a new `failAndCancel` helper that sets the exception in a `finally`, so the future is terminal even if cancelling the call throws.

### Motivation

With `--noremote_verify_downloads` there is no digest check to catch the over-read, and the over-long content is handed to the caller as if it were the blob. Verified against master: a 7-byte blob comes back as 8 bytes of `aabcdefg`, with the download reported as successful. `downloadBlobFailsOnOverlongContentWithoutDownloadVerification` covers this.

With verification on, the failure is a digest mismatch that blames the cached content rather than the server's offset handling. In both cases `onError`'s "file was fully received" check can never match, so the read is resumed from an offset the server disregards until the retry budget runs out, buffering another copy of the blob every time -- and if the server errors rather than completing the stream, nothing bounds that at all.

The `onNext` hunk is a smaller matter: gRPC does deliver a terminal callback when the listener throws, but it does so as a CANCELLED status, which the retrier treats as transient and retries even though the failure -- e.g. a decompressor rejecting corrupt data -- is deterministic, and which reports the real cause as "Failed to read message".

This is one of three independent changes for #30780. The other two bound the retry loop for a read that isn't making progress, and stop the remote external file system from holding its monitor across a download.

Progress towards #30780

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
