### PR TITLE
Bound the retries of a `ByteStream` read that isn't making progress

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -479,11 +479,14 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
     } catch (IOException e) {
       return Futures.immediateFailedFuture(e);
     }
+    // The offset this attempt resumes the read at. Bytes written past it are forward progress that
+    // no earlier attempt made, which is what earns this attempt a fresh deck of retries.
+    long readOffset = rawOut.getCount();
     bsAsyncStub(context, channel)
         .read(
             ReadRequest.newBuilder()
                 .setResourceName(resourceName)
-                .setReadOffset(rawOut.getCount())
+                .setReadOffset(readOffset)
                 .build(),
             new ClientResponseObserver<ReadRequest, ReadResponse>() {
               private volatile ClientCallStreamObserver<ReadRequest> requestStream;
@@ -514,8 +517,6 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
                   future.setException(e);
                   return;
                 }
-                // reset the stall backoff because we've made progress or been kept alive
-                progressiveBackoff.reset();
               }
 
               @Override
@@ -530,6 +531,16 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
                   return;
                 }
                 releaseOut();
+                if (rawOut.getCount() > readOffset) {
+                  // This attempt advanced the read past where it resumed, so the next one starts
+                  // from further along and deserves a full deck of retries. An attempt that
+                  // received no data at all deliberately does not reset the backoff: otherwise a
+                  // server that keeps accepting the read but never delivers any of the blob --
+                  // e.g. one that only ever sends headers or keepalives before the deadline or the
+                  // idle timeout kicks in -- would be retried forever and this future would never
+                  // become terminal, hanging every thread waiting on the download.
+                  progressiveBackoff.reset();
+                }
                 Status status = Status.fromThrowable(t);
                 if (status.getCode() == Status.Code.NOT_FOUND) {
                   future.setException(new CacheNotFoundException(digest));

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -1300,6 +1300,33 @@ public class GrpcCacheClientTest {
   }
 
   @Test
+  public void downloadBlobIsNotRetriedForeverWithoutProgress() throws IOException {
+    // A server that keeps accepting the read and answering with keepalive-style responses that
+    // carry no data, then failing with a retriable error, must not be retried indefinitely: the
+    // backoff may only be reset when the read actually advanced. Otherwise the download future
+    // never becomes terminal and every thread waiting on it hangs for the rest of the build.
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.setRemoteMaxRetryAttempts(2);
+    GrpcCacheClient client = newClient(remoteOptions);
+    Digest digest = DIGEST_UTIL.computeAsUtf8("abcdefg");
+    AtomicInteger readCalls = new AtomicInteger();
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+            assertThat(request.getReadOffset()).isEqualTo(0);
+            readCalls.incrementAndGet();
+            responseObserver.onNext(ReadResponse.getDefaultInstance());
+            responseObserver.onError(Status.UNAVAILABLE.asException());
+          }
+        });
+
+    assertThrows(IOException.class, () -> downloadBlob(context, client, digest));
+    // The initial attempt plus exactly --remote_max_retry_attempts retries.
+    assertThat(readCalls.get()).isEqualTo(3);
+  }
+
+  @Test
   public void downloadBlobIdleTimeoutIsRetriedWithProgress()
       throws IOException, InterruptedException {
     // Unexpected failures without progress should stop immediately. The idle-timeout retry below


### PR DESCRIPTION
### Description

`ProgressiveBackoff.reset()` discards the current backoff, so the next failure gets a brand new `ExponentialBackoff` with a full `--remote_max_retry_attempts` budget and an immediate retry. `GrpcCacheClient.requestRead` called it from `onNext`, i.e. on every single response received.

Reset the backoff once per attempt instead, and only when the read actually advanced past the offset it resumed at.

### Motivation

The gRPC service config Bazel derives from `--remote_timeout` puts a deadline on `ByteStream.Read`, and `RemoteDownloadIdleTimeoutInterceptor` cancels stalled reads, so every attempt against an unhealthy server ends in a retriable `DEADLINE_EXCEEDED` or `CANCELLED`. As long as each attempt received at least one response, the retry budget was wiped before it could be consumed -- and a response that carries no data at all, i.e. a keepalive, counts. The read is then retried without bound and its future never becomes terminal, so every thread waiting on it in `waitForBulkTransfer` blocks for the rest of the build.

`downloadBlobIsNotRetriedForeverWithoutProgress` reproduces that against master: the test hangs until the timeout kills it, with the main thread parked in `Utils.getFromFuture` -> `Future.get`, which is the stack from the thread dump on #30780.

Resetting only on actual forward progress is what `ByteStreamUploader` already does with the committed size, and it keeps the property the reset exists for: a large blob whose download outlives the deadline still resumes with a full deck of retries, as long as it makes progress. The two existing tests covering that, `downloadBlobIsRetriedWithProgress` and `downloadBlobIdleTimeoutIsRetriedWithProgress`, are unchanged and still pass.

The behavior change is confined to attempts that receive nothing but data-free responses. A server that keepalives its way through, say, a cold-storage fetch now gives up after `--remote_max_retry_attempts` instead of retrying forever; the per-attempt deadline applies either way, so what the keepalives were buying was only the unlimited retries.

This is one of three independent changes for #30780. The other two fail a read that returns more data than the blob holds, and stop the remote external file system from holding its monitor across a download.

Progress towards #30780

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
