### PR TITLE
Don't limit async execution via the remote executor pool

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
@@ -13,6 +13,9 @@
 // limitations under the License.
 package com.google.devtools.build.lib.buildtool;
 
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.flogger.GoogleLogger;
@@ -94,6 +97,23 @@ public abstract class BuildRequestOptions extends OptionsBase {
           less than `--jobs`, it is clamped to `--jobs`.
           """)
   public abstract int getAsyncExecutionMaxConcurrentActions();
+
+  /**
+   * Returns the maximum number of actions that may be in flight at the same time.
+   *
+   * <p>Without async execution, this is {@link #getJobs}. With async execution, actions run on
+   * virtual threads and up to {@link #getAsyncExecutionMaxConcurrentActions} of them may be in
+   * flight, clamped to at least {@link #getJobs} and at most {@link #MAX_JOBS}.
+   *
+   * <p>Platform thread pools that serve in-flight actions must be sized after this value rather
+   * than after {@link #getJobs}, or they starve the extra actions that async execution admits.
+   */
+  public int getMaxConcurrentActions() {
+    if (!getUseAsyncExecution()) {
+      return getJobs();
+    }
+    return max(getJobs(), min(MAX_JOBS, getAsyncExecutionMaxConcurrentActions()));
+  }
 
   @Option(
       name = "bust_action_caches",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -602,17 +602,25 @@ public final class RemoteModule extends BlazeModule {
     BuildRequestOptions buildRequestOptions =
         env.getOptions().getOptions(BuildRequestOptions.class);
 
-    int jobs = 0;
+    // This pool runs the gRPC callbacks of the actions that are in flight, so it is sized after the
+    // maximum number of concurrent actions, which exceeds --jobs under async execution. Threads are
+    // created on demand and time out when idle, so an unused pool costs nothing.
+    int maxConcurrentActions = 0;
     if (buildRequestOptions != null) {
-      jobs = buildRequestOptions.getJobs();
+      maxConcurrentActions = buildRequestOptions.getMaxConcurrentActions();
     }
 
     ThreadFactory threadFactory =
         new ThreadFactoryBuilder().setNameFormat("remote-executor-%d").build();
-    if (jobs != 0) {
+    if (maxConcurrentActions != 0) {
       ThreadPoolExecutor tpe =
           new ThreadPoolExecutor(
-              jobs, jobs, 60L, SECONDS, new LinkedBlockingQueue<>(), threadFactory);
+              maxConcurrentActions,
+              maxConcurrentActions,
+              60L,
+              SECONDS,
+              new LinkedBlockingQueue<>(),
+              threadFactory);
       tpe.allowCoreThreadTimeOut(true);
       executorService = tpe;
     } else {

--- a/src/main/java/com/google/devtools/build/lib/runtime/QuiescingExecutorsImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/QuiescingExecutorsImpl.java
@@ -14,10 +14,7 @@
 package com.google.devtools.build.lib.runtime;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.devtools.build.lib.buildtool.BuildRequestOptions.MAX_JOBS;
 import static com.google.devtools.build.lib.concurrent.NamedForkJoinPool.newNamedPool;
-import static java.lang.Math.max;
-import static java.lang.Math.min;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.devtools.build.lib.analysis.AnalysisOptions;
@@ -102,11 +99,7 @@ public final class QuiescingExecutorsImpl implements QuiescingExecutors {
     this.useAsyncExecution =
         buildRequestOptions != null && buildRequestOptions.getUseAsyncExecution();
     this.asyncExecutionMaxConcurrentActions =
-        max(
-            buildRequestOptions != null
-                ? min(MAX_JOBS, buildRequestOptions.getAsyncExecutionMaxConcurrentActions())
-                : 0,
-            this.executionParallelism);
+        buildRequestOptions != null ? buildRequestOptions.getMaxConcurrentActions() : 0;
     var packageOptions = options.getOptions(PackageOptions.class);
     this.globbingParallelism = packageOptions != null ? packageOptions.getGlobbingThreads() : 0;
     var analysisOptions = options.getOptions(AnalysisOptions.class);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -18,9 +18,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Comparators.max;
 import static com.google.common.collect.Comparators.min;
-import static com.google.devtools.build.lib.buildtool.BuildRequestOptions.MAX_JOBS;
-import static java.lang.Math.max;
-import static java.lang.Math.min;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
@@ -371,13 +368,9 @@ public final class SkyframeActionExecutor {
             ? new Semaphore(Runtime.getRuntime().availableProcessors())
             : null;
 
-    var minActiveAction = buildRequestOptions.getJobs();
-    var maxActiveAction =
-        useAsyncExecution
-            ? min(MAX_JOBS, buildRequestOptions.getAsyncExecutionMaxConcurrentActions())
-            : minActiveAction;
     this.actionConcurrencyMeter =
-        new ActionConcurrencyMeter(minActiveAction, max(minActiveAction, maxActiveAction));
+        new ActionConcurrencyMeter(
+            buildRequestOptions.getJobs(), buildRequestOptions.getMaxConcurrentActions());
   }
 
   public void setActionLogBufferPathGenerator(

--- a/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
@@ -31,6 +31,19 @@ java_test(
 )
 
 java_test(
+    name = "BuildRequestOptionsTest",
+    srcs = [
+        "BuildRequestOptionsTest.java",
+    ],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/buildtool:build_request_options",
+        "//src/main/java/com/google/devtools/common/options",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
+java_test(
     name = "SymlinkForestTest",
     srcs = [
         "SymlinkForestTest.java",
@@ -52,6 +65,7 @@ java_test(
 test_suite(
     name = "BuildtoolTests",
     tests = [
+        ":BuildRequestOptionsTest",
         ":JobsConverterTest",
         ":SymlinkForestTest",
     ],

--- a/src/test/java/com/google/devtools/build/lib/buildtool/BuildRequestOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/BuildRequestOptionsTest.java
@@ -1,0 +1,76 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.buildtool;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.common.options.OptionsParser;
+import com.google.devtools.common.options.OptionsParsingException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests {@link BuildRequestOptions}. */
+@RunWith(JUnit4.class)
+public class BuildRequestOptionsTest {
+
+  private static BuildRequestOptions parse(String... args) throws OptionsParsingException {
+    OptionsParser parser =
+        OptionsParser.builder().optionsClasses(BuildRequestOptions.class).build();
+    parser.parse(args);
+    return parser.getOptions(BuildRequestOptions.class);
+  }
+
+  @Test
+  public void maxConcurrentActions_withoutAsyncExecution_isJobs() throws Exception {
+    assertThat(
+            parse("--jobs=17", "--experimental_async_execution_max_concurrent_actions=100")
+                .getMaxConcurrentActions())
+        .isEqualTo(17);
+  }
+
+  @Test
+  public void maxConcurrentActions_withAsyncExecution_isMaxConcurrentActions() throws Exception {
+    assertThat(
+            parse(
+                    "--jobs=17",
+                    "--experimental_async_execution",
+                    "--experimental_async_execution_max_concurrent_actions=100")
+                .getMaxConcurrentActions())
+        .isEqualTo(100);
+  }
+
+  @Test
+  public void maxConcurrentActions_belowJobs_isClampedToJobs() throws Exception {
+    assertThat(
+            parse(
+                    "--jobs=17",
+                    "--experimental_async_execution",
+                    "--experimental_async_execution_max_concurrent_actions=0")
+                .getMaxConcurrentActions())
+        .isEqualTo(17);
+  }
+
+  @Test
+  public void maxConcurrentActions_aboveMaxJobs_isClampedToMaxJobs() throws Exception {
+    assertThat(
+            parse(
+                    "--jobs=17",
+                    "--experimental_async_execution",
+                    "--experimental_async_execution_max_concurrent_actions="
+                        + (BuildRequestOptions.MAX_JOBS + 1))
+                .getMaxConcurrentActions())
+        .isEqualTo(BuildRequestOptions.MAX_JOBS);
+  }
+}


### PR DESCRIPTION
### Description

The `remote-executor` pool in `RemoteModule` is the gRPC channel executor for the exec, cache, output service and downloader channels, as well as the executor of the BEP artifact uploader. It thus runs the RPC callbacks of every action that is in flight, but was sized after `--jobs`. It is now sized after the maximum number of concurrent actions instead, which can differ with `--experimental_async_execution`.

The clamping of `--experimental_async_execution_max_concurrent_actions` to `[--jobs, MAX_JOBS]` was duplicated in `QuiescingExecutorsImpl` and `SkyframeActionExecutor` and now lives in `BuildRequestOptions#getMaxConcurrentActions`, which is also the accessor the new `RemoteModule` code uses.

### Motivation

With `--experimental_async_execution`, actions run on virtual threads and up to `--experimental_async_execution_max_concurrent_actions` (5000 by default) of them can be in flight. The pools that serve those in-flight actions have to be sized accordingly.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
