### PR TITLE
Batch TreeArtifact metadata through BazelOutputService

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
@@ -759,6 +759,7 @@ public class ActionExecutionFunction implements SkyFunction {
             skyframeActionExecutor.getOutputPermissions(),
             ImmutableSet.copyOf(action.getOutputs()),
             skyframeActionExecutor.getXattrProvider(),
+            skyframeActionExecutor.getOutputService().getBatchStatter(),
             tsgm.get(),
             pathResolver);
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.actions.FileStateValue;
 import com.google.devtools.build.lib.actions.FileStatusWithMetadata;
 import com.google.devtools.build.lib.actions.cache.OutputMetadataStore;
 import com.google.devtools.build.lib.util.io.TimestampGranularityMonitor;
+import com.google.devtools.build.lib.vfs.BatchStat;
 import com.google.devtools.build.lib.vfs.DigestUtils;
 import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.FileStatus;
@@ -53,6 +54,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
@@ -84,6 +86,7 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
       OutputPermissions outputPermissions,
       ImmutableSet<Artifact> outputs,
       XattrProvider xattrProvider,
+      @Nullable BatchStat batchStatter,
       TimestampGranularityMonitor tsgm,
       ArtifactPathResolver artifactPathResolver) {
     return new ActionOutputMetadataStore(
@@ -91,6 +94,7 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
         outputPermissions,
         outputs,
         xattrProvider,
+        batchStatter,
         tsgm,
         artifactPathResolver);
   }
@@ -99,6 +103,7 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
   private final OutputPermissions outputPermissions;
 
   private final XattrProvider xattrProvider;
+  @Nullable private final BatchStat batchStatter;
   private final TimestampGranularityMonitor tsgm;
   private final ArtifactPathResolver artifactPathResolver;
 
@@ -115,12 +120,14 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
       OutputPermissions outputPermissions,
       ImmutableSet<Artifact> outputs,
       XattrProvider xattrProvider,
+      @Nullable BatchStat batchStatter,
       TimestampGranularityMonitor tsgm,
       ArtifactPathResolver artifactPathResolver) {
     this.archivedTreeArtifactsEnabled = archivedTreeArtifactsEnabled;
     this.outputPermissions = outputPermissions;
     this.outputs = checkNotNull(outputs);
     this.xattrProvider = xattrProvider;
+    this.batchStatter = batchStatter;
     this.tsgm = checkNotNull(tsgm);
     this.artifactPathResolver = checkNotNull(artifactPathResolver);
   }
@@ -262,6 +269,7 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
     }
 
     TreeArtifactValue.Builder tree = TreeArtifactValue.newBuilder(parent);
+    ConcurrentLinkedQueue<TreeFileArtifact> childrenToBatchStat = new ConcurrentLinkedQueue<>();
 
     TreeArtifactValue.visitTree(
         treeDir,
@@ -277,12 +285,30 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
             return; // The final TreeArtifactValue does not contain child directories.
           }
           TreeFileArtifact child = TreeFileArtifact.createTreeOutput(parent, parentRelativePath);
+          if (batchStatter != null) {
+            childrenToBatchStat.add(child);
+            return;
+          }
           FileArtifactValue metadata = constructFileArtifactValueFromFilesystem(child);
           // visitTree() uses multiple threads and putChild() is not thread-safe
           synchronized (tree) {
             tree.putChild(child, metadata);
           }
         });
+
+    if (!childrenToBatchStat.isEmpty()) {
+      ImmutableList<TreeFileArtifact> children = ImmutableList.copyOf(childrenToBatchStat);
+      var stats = checkNotNull(batchStatter).batchStat(Artifact.asPathFragments(children));
+      checkState(
+          stats.size() == children.size(),
+          "BatchStat returned %s statuses for %s tree artifact children",
+          stats.size(),
+          children.size());
+      for (int index = 0; index < children.size(); index++) {
+        tree.putChild(
+            children.get(index), constructFileArtifactValue(children.get(index), stats.get(index)));
+      }
+    }
 
     if (archivedTreeArtifactsEnabled) {
       ArchivedTreeArtifact archivedTreeArtifact = ArchivedTreeArtifact.createForTree(parent);

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStoreTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStoreTest.java
@@ -40,14 +40,18 @@ import com.google.devtools.build.lib.remote.RemoteActionInputFetcher;
 import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.testutil.Scratch;
 import com.google.devtools.build.lib.util.io.TimestampGranularityMonitor;
+import com.google.devtools.build.lib.vfs.BatchStat;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.DigestUtils;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import com.google.devtools.build.lib.vfs.FileStatusWithDigest;
+import com.google.devtools.build.lib.vfs.FileStatusWithDigestAdapter;
 import com.google.devtools.build.lib.vfs.OutputPermissions;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
+import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.testing.junit.testparameterinjector.TestParameter;
@@ -111,11 +115,19 @@ public final class ActionOutputMetadataStoreTest {
 
   private ActionOutputMetadataStore createStore(
       ImmutableSet<Artifact> outputs, @Nullable FileSystem actionFs) {
+    return createStore(outputs, actionFs, /* batchStatter= */ null);
+  }
+
+  private ActionOutputMetadataStore createStore(
+      ImmutableSet<Artifact> outputs,
+      @Nullable FileSystem actionFs,
+      @Nullable BatchStat batchStatter) {
     return ActionOutputMetadataStore.create(
         /* archivedTreeArtifactsEnabled= */ false,
         OutputPermissions.READONLY,
         outputs,
         SyscallCache.NO_CACHE,
+        batchStatter,
         tsgm,
         ArtifactPathResolver.createPathResolver(actionFs, execRoot));
   }
@@ -243,6 +255,48 @@ public final class ActionOutputMetadataStoreTest {
     assertThat(store.getTreeArtifactValue(treeArtifact)).isEqualTo(tree);
     assertThat(store.getAllArtifactData()).isEmpty();
     assertThat(chmodCalls).isEmpty();
+  }
+
+  @Test
+  public void createsTreeArtifactValueUsingOneBatchStatOfFinalFilesystemState() throws Exception {
+    SpecialArtifact treeArtifact =
+        ActionsTestUtil.createTreeArtifactWithGeneratingAction(outputRoot, "foo/bar");
+    TreeFileArtifact child1 = TreeFileArtifact.createTreeOutput(treeArtifact, "child1");
+    TreeFileArtifact child2 = TreeFileArtifact.createTreeOutput(treeArtifact, "nested/child2");
+    scratch.file(child1.getPath().getPathString(), "staged child1");
+    scratch.file(child2.getPath().getPathString(), "child2");
+    ImmutableList.Builder<ImmutableList<PathFragment>> batches = ImmutableList.builder();
+    BatchStat batchStatter =
+        paths -> {
+          ImmutableList<PathFragment> batch = ImmutableList.copyOf(paths);
+          batches.add(batch);
+          ImmutableList.Builder<FileStatusWithDigest> stats = ImmutableList.builder();
+          for (PathFragment path : batch) {
+            stats.add(
+                FileStatusWithDigestAdapter.maybeAdapt(
+                    execRoot.getRelative(path).statIfFound(Symlinks.NOFOLLOW)));
+          }
+          return stats.build();
+        };
+    ActionOutputMetadataStore store =
+        createStore(
+            /* outputs= */ ImmutableSet.of(treeArtifact),
+            /* actionFs= */ null,
+            batchStatter);
+    scratch.overwriteFile(child1.getPath().getPathString(), "locally modified child1");
+    byte[] finalChild1Digest = child1.getPath().getDigest();
+
+    TreeArtifactValue tree = store.getTreeArtifactValue(treeArtifact);
+
+    ImmutableList<ImmutableList<PathFragment>> calls = batches.build();
+    assertThat(calls).hasSize(1);
+    assertThat(calls.get(0))
+        .containsExactly(child1.getExecPath(), child2.getExecPath());
+    assertThat(tree.getChildren()).containsExactly(child1, child2);
+    assertThat(tree.getChildValues().get(child1).getDigest())
+        .isEqualTo(finalChild1Digest);
+    assertThat(tree.getChildValues().get(child2).getDigest())
+        .isEqualTo(child2.getPath().getDigest());
   }
 
   @Test
@@ -625,6 +679,7 @@ public final class ActionOutputMetadataStoreTest {
             OutputPermissions.WRITABLE,
             /* outputs= */ ImmutableSet.of(output),
             SyscallCache.NO_CACHE,
+            /* batchStatter= */ null,
             tsgm,
             ArtifactPathResolver.IDENTITY);
     store.prepareForActionExecution();


### PR DESCRIPTION
### Description

Keep Skyframe as the central place that discovers and constructs final output
metadata, while allowing `ActionOutputMetadataStore` to query an
`OutputService` for all `TreeArtifact` child statuses in one `BatchStat` call.

When no batch statter is available, the existing per-child filesystem path is
unchanged. There is no metadata injection from `SpawnRunner` or
`RemoteExecutionService`.

### Motivation

`BazelOutputService` already exposes a multi-path `BatchStat`, but
`TreeArtifact` construction requested every child's fast digest separately.
For a lazy output filesystem, every request can cross the output-service RPC
boundary even though the service already owns the staged file and directory
metadata.

In a representative remote-output benchmark producing 4,098 files and 528 MiB
of logical output, the profile contained approximately 4,100 one-path
`BazelOutputService.BatchStat` calls. An equivalent batching patch on Bazel
8.5.1 produced:

| Configuration | Elapsed time |
| --- | ---: |
| Eager output download | 4.100 s |
| Lazy output service before batching | 1.484 s |
| Lazy output service with batched metadata | 0.896 s |
| Inaccessible minimal-download roofline | 0.549 s |

This removes the RPC fanout while deliberately retaining Skyframe's final
filesystem traversal. That distinction is important for actions containing
multiple spawns or a mix of remote and local outputs: metadata is collected
from the final output-service state, rather than copied from an earlier remote
`ActionResult`.

### Build API Changes

No.

### Checklist

- [x] I have added tests for the new use case.
- [x] Documentation is not applicable because this is an internal remote
      execution optimization without user-facing configuration changes.

### Validation

- `bazel test //src/test/java/com/google/devtools/build/lib/skyframe:ActionOutputMetadataStoreTest --test_timeout=60`
- `bazel test //src/test/java/com/google/devtools/build/lib/remote:RemoteTests --test_timeout=60`
- `bazel build //src:bazel-dev`

The regression test stages a nested `TreeArtifact`, modifies one child before
Skyframe collects metadata, and verifies both the final digest and exactly one
batch request containing all children.

### Release Notes

RELNOTES: None
