### PR TITLE
[9.3.0] Attempt to fix a race condition in ArtifactFactory.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
@@ -134,12 +134,13 @@ public class ArtifactFactory implements ArtifactResolver {
                         new Entry[] {entry, computeFunction.apply(execPath, null)});
             case CopyOnWriteArrayList<?> rawEntries -> {
               var entries = (CopyOnWriteArrayList<Entry>) rawEntries;
-              for (Entry entry : entries) {
+              for (int i = 0; i < entries.size(); i++) {
                 // Update the existing entry for this exact casing if it exists.
+                Entry entry = entries.get(i);
                 if (entry.artifact().getExecPath().equals(execPath)) {
                   Entry newEntry = computeFunction.apply(execPath, entry);
                   if (newEntry != entry) {
-                    entries.set(entries.indexOf(entry), newEntry);
+                    entries.set(i, newEntry);
                   }
                   yield entries;
                 }


### PR DESCRIPTION
My theory is that the loop here used Entry.equals(), which checks both the path and the build ID. So if the build ID is different but the path is the same including case, the check on exec path will match but the Entry.equals() one will not.

RELNOTES: None.
PiperOrigin-RevId: 902622211
Change-Id: Ic5fdc982ae0b424c559286827b899c8573025f7d

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/0833e3f253e0c4e583505925b9039e91e36ad829