### PR TITLE
Document `--build_request_id`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -277,10 +277,15 @@ public abstract class CommonCommandOptions extends OptionsBase {
       name = "build_request_id",
       defaultValue = "",
       converter = PrefixedUUIDConverter.class,
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.BAZEL_MONITORING, OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
-      metadataTags = {OptionMetadataTag.HIDDEN},
-      help = "Unique string identifier for the build being run.")
+      help =
+          """
+          Unique string identifier that groups together a set of invocations that are conceptually
+          part of the same overall build request. The value is sent over the BES transport envelope
+          (as `StreamId.build_id`) and remote execution protocol (as
+          `RequestMetadata.correlated_invocations_id`).
+          """)
   public abstract String getBuildRequestId();
 
   @Option(


### PR DESCRIPTION
### Description

Documents `--build_request_id`, covering it's intended purpose and where the value is used.

`OptionDocumentationCategory.UNCATEGORIZED` used as no other more suitable currently documentation category exists.

### Motivation

To address a documentation gap currently poorly covered by:
- https://github.com/bazelbuild/bazel/issues/15036#issuecomment-1073072405
- https://github.com/buildbarn/bb-remote-execution/blob/13313e6ab05b00769af48cf5d6e4926ce15b1f2b/pkg/proto/configuration/scheduler/scheduler.proto#L144-L149
- https://www.hermetiq.com/docs/configuration#:~:text=build%20%2F%2F%2E%2E%2E-,%2D%2Dbuild%5Frequest%5Fid
- https://github.com/buildfarm/buildfarm/blob/6fdea379a455a579bf582eff1acef001769a769d/_site/docs/execution/observability.md?plain=1#L22

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
