### PR TITLE
[9.3.0] Turn implicit assumptions in `ActionOutputMetadataStore` into explicit checks (https://github.com/bazelbuild/bazel/pull/30790)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
@@ -433,23 +433,24 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
           artifactPathResolver.toPath(artifact).getLastModifiedTime());
     }
 
-    byte[] digest = null;
-    if (type.isFile()) {
-      // We don't have an injected digest and there is no digest in the file value (which attempts a
-      // fast digest). Manually compute the digest instead.
-      Path path = statAndValue.pathNoFollow();
-      if (statAndValue.statNoFollow() != null
-          && statAndValue.statNoFollow().isSymbolicLink()
-          && statAndValue.realPath() != null) {
-        // If the file is a symlink, we compute the digest using the target path so that it's
-        // possible to hit the digest cache - we probably already computed the digest for the
-        // target during previous action execution.
-        path = statAndValue.realPath();
-      }
-
-      digest = DigestUtils.manuallyComputeDigest(path);
+    if (type.isSpecialFile()) {
+      return FileArtifactValue.createFromInjectedDigest(value, /* digest= */ null);
     }
-    return FileArtifactValue.createFromInjectedDigest(value, digest);
+
+    checkState(type.isFile(), type);
+    // We don't have an injected digest and there is no digest in the file value (which attempts a
+    // fast digest). Manually compute the digest instead.
+    var path = statAndValue.pathNoFollow();
+    // The file exists and is not an unresolved symlink, so it must have been stat'ed.
+    if (checkNotNull(statAndValue.statNoFollow(), statAndValue).isSymbolicLink()) {
+      // If the file is a symlink, we compute the digest using the target path so that it's
+      // possible to hit the digest cache - we probably already computed the digest for the
+      // target during previous action execution.
+      // The case of an unresolved symlink has been handled above, so realPath() is never null.
+      path = checkNotNull(statAndValue.realPath(), statAndValue);
+    }
+    return FileArtifactValue.createFromInjectedDigest(
+        value, DigestUtils.manuallyComputeDigest(path));
   }
 
   /**


### PR DESCRIPTION
### Description
When constructing a `FileArtifactValue` from the filesystem, `ActionOutputMetadataStore` relied on `FileStateType#isFile` to also skip special files and on null checks for a stat and a real path that can't be absent at this point. Give special files their own branch and assert the remaining assumptions instead.

This is a pure refactoring: special files already ended up with a null digest as `FileStateType#isFile` only returns true for `REGULAR_FILE`, `statNoFollow` is only null for a non-existent file (handled above) and `realPath` is only null for a non-symlink or an unresolved symlink (both handled above). In particular, special files such as fifos still aren't digested.

### Motivation
Split out of #30774 to make it easier to see that the optimization in that PR doesn't change behavior for special files or symlinks.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #30790.

PiperOrigin-RevId: 967638009
Change-Id: I361cf9d3b7d680fdfcac1a5f49e4b0131e720f5d

Commit https://github.com/bazelbuild/bazel/commit/216a69c689f5856d937c747a79a4385f92afa0dd