### PR TITLE
Expand tree artifact inputs from metadata in the compact execution log

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -285,6 +285,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/remote/util:digest_util",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",
         "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/util/io",
         "//src/main/java/com/google/devtools/build/lib/util/io:io-proto",

--- a/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
@@ -49,6 +49,7 @@ import com.google.devtools.build.lib.exec.Protos.Platform;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
 import com.google.devtools.build.lib.util.StringEncoding;
 import com.google.devtools.build.lib.util.io.AsynchronousMessageOutputStream;
 import com.google.devtools.build.lib.util.io.MessageOutputStream;
@@ -549,7 +550,7 @@ public class CompactSpawnLogContext extends SpawnLogContext {
                 .setDirectory(
                     ExecLogEntry.Directory.newBuilder()
                         .setPath(internalToUnicode(input.getExecPathString()))
-                        .addAllFiles(expandDirectory(root, inputMetadataProvider))));
+                        .addAllFiles(expandDirectory(input, root, inputMetadataProvider))));
   }
 
   /**
@@ -620,11 +621,54 @@ public class CompactSpawnLogContext extends SpawnLogContext {
   /**
    * Expands a directory.
    *
+   * @param input the input representing the directory
    * @param root the path to the directory
    * @param inputMetadataProvider provides metadata for inputs; null if logging an output
    * @return the list of files transitively contained in the directory
    */
   private List<ExecLogEntry.File> expandDirectory(
+      ActionInput input, Path root, @Nullable InputMetadataProvider inputMetadataProvider)
+      throws IOException, InterruptedException {
+    if (inputMetadataProvider != null
+        && input instanceof Artifact artifact
+        && artifact.isTreeArtifact()) {
+      TreeArtifactValue treeMetadata = inputMetadataProvider.getTreeMetadata(artifact);
+      if (treeMetadata != null) {
+        // Using the metadata over a filesystem traversal is not just an optimization: an empty tree
+        // artifact may not be materialized on disk.
+        return expandTreeArtifact(treeMetadata, root, inputMetadataProvider);
+      }
+    }
+    return expandDirectoryFromFileSystem(root, inputMetadataProvider);
+  }
+
+  /** Expands a tree artifact into its contents as recorded in its metadata. */
+  private List<ExecLogEntry.File> expandTreeArtifact(
+      TreeArtifactValue treeMetadata, Path root, InputMetadataProvider inputMetadataProvider)
+      throws IOException {
+    var files = new ArrayList<ExecLogEntry.File>(treeMetadata.getChildren().size());
+    for (var child : treeMetadata.getChildren()) {
+      PathFragment parentRelativePath = child.getParentRelativePath();
+      Digest digest =
+          computeDigest(
+              child,
+              root.getRelative(parentRelativePath),
+              inputMetadataProvider,
+              xattrProvider,
+              digestHashFunction,
+              /* includeHashFunctionName= */ false);
+      files.add(
+          ExecLogEntry.File.newBuilder()
+              .setPath(internalToUnicode(parentRelativePath.getPathString()))
+              .setDigest(digest)
+              .build());
+    }
+    files.sort(EXEC_LOG_ENTRY_FILE_COMPARATOR);
+    return files;
+  }
+
+  /** Expands a directory by traversing it on the filesystem. */
+  private List<ExecLogEntry.File> expandDirectoryFromFileSystem(
       Path root, @Nullable InputMetadataProvider inputMetadataProvider)
       throws IOException, InterruptedException {
     ArrayList<ExecLogEntry.File> files = new ArrayList<>();

--- a/src/test/java/com/google/devtools/build/lib/exec/CompactSpawnLogContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/CompactSpawnLogContextTest.java
@@ -21,9 +21,11 @@ import static com.google.devtools.build.lib.testutil.TestConstants.WORKSPACE_NAM
 import com.github.luben.zstd.ZstdInputStream;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.BuildConfigurationEvent;
 import com.google.devtools.build.lib.actions.RunfilesTree;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -35,8 +37,10 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.exec.Protos.File;
 import com.google.devtools.build.lib.exec.Protos.SpawnExec;
+import com.google.devtools.build.lib.exec.util.FakeActionInputFileCache;
 import com.google.devtools.build.lib.exec.util.SpawnBuilder;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
 import com.google.devtools.build.lib.testutil.TestConstants;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.Path;
@@ -236,6 +240,34 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
                     .setDigest(getDigest("ghi"))
                     .setIsTool(false))
             .build());
+  }
+
+  @Test
+  public void testUnmaterializedEmptyTreeInput() throws Exception {
+    SpecialArtifact treeInput =
+        ActionsTestUtil.createTreeArtifactWithGeneratingAction(outputDir, "tree");
+
+    // Deliberately don't create the directory: an empty tree artifact may not be materialized on
+    // disk, so its (empty) contents are only known to in-memory metadata.
+    assertThat(treeInput.getPath().exists()).isFalse();
+
+    TreeArtifactValue treeMetadata = TreeArtifactValue.newBuilder(treeInput).build();
+    FakeActionInputFileCache inputMetadataProvider = new FakeActionInputFileCache();
+    inputMetadataProvider.put(treeInput, treeMetadata.getMetadata());
+    inputMetadataProvider.putTreeArtifact(treeInput, treeMetadata);
+
+    SpawnLogContext context = createSpawnLogContext();
+
+    context.logSpawn(
+        defaultSpawnBuilder().withInputs(treeInput).build(),
+        inputMetadataProvider,
+        // SpawnInputExpander keeps empty tree artifacts in the input map.
+        ImmutableSortedMap.of(treeInput.getExecPath(), treeInput),
+        fs,
+        defaultTimeout(),
+        defaultSpawnResult());
+
+    closeAndAssertLog(context, defaultSpawnExecBuilder().build());
   }
 
   @Test


### PR DESCRIPTION
An empty tree artifact whose generating action template expands into no actions is never materialized on disk when a disk or remote cache is in use: nothing creates the directory and the `RemoteActionFileSystem` has no entries for it either. Logging a spawn that has such a tree artifact as an input then fails the action with

    ERROR: Linking _nativedeps/6a5ccd5.so failed: IOException while logging spawn: .../bin/_objs/biome_proto.upb_minitable/iome (No such file or directory)

since `expandDirectory` readdirs the directory. This happens while logging *inputs*, which isn't covered by the try/catch around output logging added in #30717.

Expand tree artifacts from their `TreeArtifactValue` instead. Their contents are already known, so this avoids the traversal entirely and also keeps the log complete for trees whose files aren't materialized locally. Source directories and filesets keep using the filesystem traversal.

Fixes https://github.com/bazelbuild/bazel/issues/22920#issuecomment-5345473352

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Fixed a build failure with `--execution_log_compact_file` when a C++ action template has no inputs.
