### PR TITLE
Harden GrpcCacheClient against misbehaving servers

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -57,6 +57,7 @@ import com.google.devtools.build.lib.remote.common.ActionKey;
 import com.google.devtools.build.lib.remote.common.BlobNotSplittableException;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.MissingDigestsFinder;
+import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -85,6 +86,43 @@ import javax.annotation.Nullable;
 @ThreadSafe
 public class GrpcCacheClient extends RemoteCacheClient implements MissingDigestsFinder {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
+  private static final class SizeLimitingOutputStream extends OutputStream {
+    private final CountingOutputStream out;
+    private final Digest digest;
+
+    private SizeLimitingOutputStream(CountingOutputStream out, Digest digest) {
+      this.out = out;
+      this.digest = digest;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      checkSize(1);
+      out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      checkSize(len);
+      out.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+      out.flush();
+    }
+
+    private void checkSize(int bytesToWrite) throws IOException {
+      if (bytesToWrite > digest.getSizeBytes() - out.getCount()) {
+        throw new IOException(
+            String.format(
+                "Received more bytes than expected for digest '%s/%d'. "
+                    + "Server may have ignored read_offset.",
+                digest.getHash(), digest.getSizeBytes()));
+      }
+    }
+  }
 
   private final CallCredentialsProvider callCredentialsProvider;
   private final ReferenceCountedChannel channel;
@@ -482,18 +520,19 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
         getResourceName(
             options.getRemoteInstanceName(), digest, compressed, digestUtil.getDigestFunction());
     SettableFuture<Long> future = SettableFuture.create();
+    // Prevent misbehaving servers from sending more bytes than expected.
+    SizeLimitingOutputStream sizeLimitedOut = new SizeLimitingOutputStream(rawOut, digest);
     OutputStream out;
     try {
-      out = compressed ? new ZstdDecompressingOutputStream(rawOut) : rawOut;
+      out = compressed ? new ZstdDecompressingOutputStream(sizeLimitedOut) : sizeLimitedOut;
     } catch (IOException e) {
       return Futures.immediateFailedFuture(e);
     }
-    long readOffset = rawOut.getCount();
     bsAsyncStub(context, channel)
         .read(
             ReadRequest.newBuilder()
                 .setResourceName(resourceName)
-                .setReadOffset(readOffset)
+                .setReadOffset(rawOut.getCount())
                 .build(),
             new ClientResponseObserver<ReadRequest, ReadResponse>() {
               private volatile ClientCallStreamObserver<ReadRequest> requestStream;
@@ -513,25 +552,14 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
               @Override
               public void onNext(ReadResponse readResponse) {
                 ByteString data = readResponse.getData();
-                if (!compressed && rawOut.getCount() + data.size() > digest.getSizeBytes()) {
-                  String msg =
-                      String.format(
-                          "Received more bytes than expected for digest '%s/%d'. "
-                              + "Server may have ignored read_offset.",
-                          digest.getHash(), digest.getSizeBytes());
-                  if (requestStream != null) {
-                    requestStream.cancel(msg, null);
-                  }
-                  future.setException(new IOException(msg));
-                  return;
-                }
                 try {
                   data.writeTo(out);
                 } catch (IOException e) {
-                  // The output stream was likely closed due to cancellation (e.g. dynamic execution
-                  // choosing the local branch).
+                  // The output stream either refused to accept more bytes than expected for the
+                  // digest or was closed due to cancellation (e.g. dynamic execution choosing the
+                  // local branch).
                   if (requestStream != null) {
-                    requestStream.cancel("output stream closed", e);
+                    requestStream.cancel(e.getMessage(), e);
                   }
                   future.setException(e);
                   return;
@@ -570,6 +598,10 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
                   }
                   if (digestSupplier != null) {
                     Utils.verifyBlobContents(digest, digestSupplier.get());
+                  } else if (rawOut.getCount() != digest.getSizeBytes()) {
+                    // Verifying the digest would also catch an incomplete download; with
+                    // verification disabled, at least verify the size.
+                    throw new OutputDigestMismatchException(digest, rawOut.getCount());
                   }
                 } catch (IOException e) {
                   future.setException(e);

--- a/src/main/java/com/google/devtools/build/lib/remote/common/OutputDigestMismatchException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/OutputDigestMismatchException.java
@@ -16,11 +16,13 @@ package com.google.devtools.build.lib.remote.common;
 import build.bazel.remote.execution.v2.Digest;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
+import javax.annotation.Nullable;
 
 /** An exception to indicate the digest of downloaded output does not match the expected value. */
 public class OutputDigestMismatchException extends IOException {
   private final Digest expected;
-  private final Digest actual;
+  @Nullable private final Digest actual;
+  private final long receivedSizeBytes;
 
   private Path localPath;
   private String outputPath;
@@ -28,6 +30,17 @@ public class OutputDigestMismatchException extends IOException {
   public OutputDigestMismatchException(Digest expected, Digest actual) {
     this.expected = expected;
     this.actual = actual;
+    this.receivedSizeBytes = actual.getSizeBytes();
+  }
+
+  /**
+   * Indicates a download whose digest was not verified, but whose size doesn't match the size of
+   * the expected digest.
+   */
+  public OutputDigestMismatchException(Digest expected, long receivedSizeBytes) {
+    this.expected = expected;
+    this.actual = null;
+    this.receivedSizeBytes = receivedSizeBytes;
   }
 
   public void setOutputPath(String outputPath) {
@@ -48,6 +61,11 @@ public class OutputDigestMismatchException extends IOException {
 
   @Override
   public String getMessage() {
+    if (actual == null) {
+      return String.format(
+          "Output %s download failed: Expected digest '%s/%d', but received %d bytes.",
+          outputPath, expected.getHash(), expected.getSizeBytes(), receivedSizeBytes);
+    }
     return String.format(
         "Output %s download failed: Expected digest '%s/%d' does not match "
             + "received digest '%s/%d'.",

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -79,6 +79,7 @@ import com.google.devtools.build.lib.remote.RemoteRetrier.ExponentialBackoff;
 import com.google.devtools.build.lib.remote.Retrier.Backoff;
 import com.google.devtools.build.lib.remote.common.ActionKey;
 import com.google.devtools.build.lib.remote.common.BlobNotSplittableException;
+import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
@@ -1468,6 +1469,29 @@ public class GrpcCacheClientTest {
   }
 
   @Test
+  public void downloadBlobFailsWhenServerCompletesBeforeExpectedSize() throws IOException {
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.setRemoteVerifyDownloads(false);
+    GrpcCacheClient client = newClient(remoteOptions);
+    Digest digest = DIGEST_UTIL.computeAsUtf8("abcdefg");
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+            responseObserver.onNext(
+                ReadResponse.newBuilder().setData(ByteString.copyFromUtf8("abc")).build());
+            responseObserver.onCompleted();
+          }
+        });
+
+    OutputDigestMismatchException e =
+        assertThrows(
+            OutputDigestMismatchException.class, () -> downloadBlob(context, client, digest));
+    assertThat(e).hasMessageThat().contains(digest.getHash());
+    assertThat(e).hasMessageThat().contains("received 3 bytes");
+  }
+
+  @Test
   public void compressedDownloadBlobIsRetriedWithProgress()
       throws IOException, InterruptedException {
     RemoteOptions options = Options.getDefaults(RemoteOptions.class);
@@ -1508,6 +1532,46 @@ public class GrpcCacheClientTest {
           }
         });
     assertThat(new String(downloadBlob(context, client, digest), UTF_8)).isEqualTo("abcdefg");
+  }
+
+  @Test
+  public void compressedDownloadFailsWhenServerIgnoresReadOffset() throws IOException {
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.setCacheCompression(true);
+    remoteOptions.setCacheCompressionThreshold(0);
+    remoteOptions.setRemoteVerifyDownloads(false);
+    GrpcCacheClient client = newClient(remoteOptions);
+    Digest digest = DIGEST_UTIL.computeAsUtf8("abcdefg");
+    ByteString compressedPrefix = ByteString.copyFrom(Zstd.compress("abcd".getBytes(UTF_8)));
+    ByteString compressedBlob = ByteString.copyFrom(Zstd.compress("abcdefg".getBytes(UTF_8)));
+    AtomicInteger readCalls = new AtomicInteger();
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+            int readCall = readCalls.getAndIncrement();
+            if (readCall == 0) {
+              assertThat(request.getReadOffset()).isEqualTo(0);
+              responseObserver.onNext(ReadResponse.newBuilder().setData(compressedPrefix).build());
+              responseObserver.onError(Status.DEADLINE_EXCEEDED.asException());
+              return;
+            }
+            // Simulate a noncompliant compressed ByteStream server that ignores the uncompressed
+            // read offset and replays the blob from the beginning.
+            assertThat(readCall).isEqualTo(1);
+            assertThat(request.getReadOffset()).isEqualTo(4);
+            responseObserver.onNext(ReadResponse.newBuilder().setData(compressedBlob).build());
+            responseObserver.onCompleted();
+          }
+        });
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    IOException e =
+        assertThrows(
+            IOException.class, () -> getFromFuture(client.downloadBlob(context, digest, out)));
+    assertThat(e).hasMessageThat().contains("Received more bytes than expected");
+    assertThat(out.size()).isAtMost(Math.toIntExact(digest.getSizeBytes()));
+    assertThat(readCalls.get()).isEqualTo(2);
   }
 
   @Test
@@ -1642,6 +1706,7 @@ public class GrpcCacheClientTest {
 
     assertThat(GrpcCacheClient.isRemoteCacheOptions(options)).isFalse();
   }
+
   @Test
   public void splitBlob_serverCannotSplit_failsWithBlobNotSplittable(
       @TestParameter({"NOT_FOUND", "UNIMPLEMENTED"}) Status.Code code) throws Exception {


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
Fail the download early when the server sends more bytes than expected (e.g. because it ignored `read_offset` on a retry) and fail if the received size doesn't match the expected size even with `--noremote_verify_downloads`.

### Motivation
Work towards #30780

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
