### PR TITLE
fix sh_binary launcher on Windows mangling the script path

### DIFF
--- a/src/test/py/bazel/launcher_test.py
+++ b/src/test/py/bazel/launcher_test.py
@@ -662,6 +662,46 @@ class LauncherTest(test_base.TestBase):
     classpath = stdout[stdout.index('-classpath') + 1]
     self.assertRegex(classpath, r'foo-[A-Za-z0-9]+-classpath.(jar|txt)$')
 
+  def testWindowsShBinaryLauncherWithoutRunfilesManifest(self):
+    # Without a runfiles manifest, e.g. in a remotely executed action, the
+    # launcher derives the script's path from its own path, so the script's
+    # path contains backslashes.
+    if not self.IsWindows():
+      return
+    self.AddBazelDep('rules_shell')
+    self.ScratchFile(
+        'bin/BUILD',
+        [
+            'load("@rules_shell//shell:sh_binary.bzl", "sh_binary")',
+            'sh_binary(',
+            '  name = "bin_sh",',
+            '  srcs = ["main.sh"],',
+            ')',
+        ],
+    )
+    self.ScratchFile('bin/main.sh', [
+        'echo "helloworld"',
+    ])
+
+    _, stdout, _ = self.RunBazel(['info', 'bazel-bin'])
+    bazel_bin = stdout[0]
+
+    self.RunBazel(['build', '//bin:bin_sh'])
+
+    launcher = self.CopyFile(
+        os.path.join(bazel_bin, 'bin', 'bin_sh.exe'),
+        'nomanifest/bin_sh.exe',
+        executable=True,
+    )
+    self.CopyFile(
+        os.path.join(bazel_bin, 'bin', 'bin_sh'),
+        'nomanifest/bin_sh.exe.runfiles/_main/bin/bin_sh',
+        executable=True,
+    )
+
+    _, stdout, _ = self.RunProgram([launcher])
+    self.assertEqual('helloworld', ''.join(stdout))
+
   def testWindowsNativeLauncherInNonEnglishPath(self):
     if not self.IsWindows():
       return

--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -61,7 +61,7 @@ ExitCode BashBinaryLauncher::Launch() {
   // + 2.
   args.reserve(origin_args.size() + 2);
   args.push_back(L"-c");
-  args.push_back(BashEscapeArg(bash_file) + L" \"$@\"");
+  args.push_back(L"\"$0\" \"$@\"");
   args.push_back(bash_file);
   for (int i = 1; i < origin_args.size(); i++) {
     args.push_back(origin_args[i]);


### PR DESCRIPTION
aa3eebdee0 dropped BashBinaryLauncher's EscapeArg override, so the arguments passed to bash.exe are now escaped with windows::WindowsEscapeArg instead of BashEscapeArg. The script path is still interpolated into the `-c` command string, which has to survive two rounds of unescaping: the MSYS2/Cygwin command line parsing done by bash.exe, and bash's own parsing of the command string. WindowsEscapeArg only doubles backslashes that precede a quote, so bash drops the backslashes of the script's Windows path and the launcher fails.

The script's path only contains backslashes when the launcher resolves runfiles through the runfiles directory rather than a runfiles manifest, as in a remotely executed action: manifest entries use forward slashes, while the runfiles directory is derived from the launcher's own Windows path.

Instead of restoring the double escaping, reference the script as $0, which the launcher already passes to bash. The command string is now a constant, so no path is subject to bash's expansions.

RELNOTES: None
