### PR TITLE
[8.8.0] Don't synchronize `RemoteExternalOverlayFileSystem#getInputStream`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -733,7 +733,7 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
     }
 
     @Override
-    public synchronized InputStream getInputStream(PathFragment path) throws IOException {
+    public InputStream getInputStream(PathFragment path) throws IOException {
       // .bzl and REPO.bazel files are prefetched to the native file system during injection, but
       // only if they are regular files, a symlink with such a name is kept in the in-memory overlay
       // only. We thus need to follow symlinks before attempting to read a supposedly prefetched


### PR DESCRIPTION
### Description

### Motivation

Synchronization is unnecessary as individual methods called by this implementation are already synchronized. It is also harmful since `getInputStream` awaits a network transfer.

Progress towards #30780

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #30791.

PiperOrigin-RevId: 968392939
Change-Id: Ic48cfa823322e67c6cd0344a91333284b496f3b0

(cherry picked from commit 16d479fe66c886e2469f2991e12b5298f030d938)

Closes #30814
