### PR TITLE
Bump protobuf to 36.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,7 +24,7 @@ bazel_dep(name = "googletest", version = "1.17.0.bcr.2", repo_name = "com_google
 bazel_dep(name = "grpc-java", version = "1.71.0")
 bazel_dep(name = "grpc", version = "1.76.0.bcr.1", repo_name = "com_github_grpc_grpc")
 bazel_dep(name = "platforms", version = "1.1.0")
-bazel_dep(name = "protobuf", version = "35.1", repo_name = "com_google_protobuf")
+bazel_dep(name = "protobuf", version = "36.0", repo_name = "com_google_protobuf")
 bazel_dep(name = "re2", version = "2025-11-05.bcr.1")
 bazel_dep(name = "rules_go", version = "0.59.0")
 bazel_dep(name = "rules_graalvm", version = "0.11.1")
@@ -116,13 +116,12 @@ single_version_override(
 # 3. Pull in the removal of the memoizedIsInitialized field for messages with no
 # required fields early. This reduces the memory usage of Bazel and avoids
 # spread in memory usage between Bazel and Blaze.
-# https://github.com/protocolbuffers/protobuf/blob/adf9e8b80fd10398b82e16c4ea72f2d2cffb0e9b/src/google/protobuf/compiler/java/full/message.cc#L884C1-L899C6
 single_version_override(
     module_name = "protobuf",
     patch_strip = 1,
-    # Patch is based on 35.1
+    # Patch is based on 36.0
     patches = ["//third_party:protobuf.patch"],
-    version = "35.1",
+    version = "36.0",
 )
 
 # Remove once the following PRs are available in a grpc-java release.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -53,6 +53,7 @@
     "https://bcr.bazel.build/modules/bazel_features/1.39.0/MODULE.bazel": "28739425c1fc283c91931619749c832b555e60bcd1010b40d8441ce0a5cf726d",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.42.1/MODULE.bazel": "275a59b5406ff18c01739860aa70ad7ccb3cfb474579411decca11c93b951080",
+    "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.47.0/MODULE.bazel": "e34df3cb35b1684cfa69923a61ae3803595babd3942cd306a488d51400886b30",
     "https://bcr.bazel.build/modules/bazel_features/1.47.0/source.json": "4ba0b5138327f2d73352a51547a4e49a0a828ef400e046b15334d8905bf6b7ff",
     "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
@@ -206,8 +207,8 @@
     "https://bcr.bazel.build/modules/prometheus-cpp/1.3.0.bcr.1/MODULE.bazel": "116ad46e97c1d2aeb020fe2899a342a7e703574ce7c0faf7e4810f938c974a9a",
     "https://bcr.bazel.build/modules/prometheus-cpp/1.3.0.bcr.1/source.json": "e813cce2d450708cfcb26e309c5172583a7440776edf354e83e6788c768e5cca",
     "https://bcr.bazel.build/modules/prometheus-cpp/1.3.0/MODULE.bazel": "ce82e086bbc0b60267e970f6a54b2ca6d0f22d3eb6633e00e2cc2899c700f3d8",
-    "https://bcr.bazel.build/modules/protobuf/35.1/MODULE.bazel": "9f25044d646c9c1b1e03b25aa3818bf5250078eabadbd213ea940262dba99471",
-    "https://bcr.bazel.build/modules/protobuf/35.1/source.json": "5e256f85483431bd96fc9a6ae468e420326673e9d9f250d313725875597bf1ba",
+    "https://bcr.bazel.build/modules/protobuf/36.0/MODULE.bazel": "6976c38053e63b19a84ee82d68c82a9c9d0d190469da7fbf32f613d0b7a03ac1",
+    "https://bcr.bazel.build/modules/protobuf/36.0/source.json": "a14d3af196aaede67d2417ff7507814362c4df599ec089e7d9153fdb50843a9b",
     "https://bcr.bazel.build/modules/protoc-gen-validate/1.0.4.bcr.2/MODULE.bazel": "c4bd2c850211ff5b7dadf9d2d0496c1c922fdedc303c775b01dfd3b3efc907ed",
     "https://bcr.bazel.build/modules/protoc-gen-validate/1.0.4/MODULE.bazel": "b8913c154b16177990f6126d2d2477d187f9ddc568e95ee3e2d50fc65d2c494a",
     "https://bcr.bazel.build/modules/protoc-gen-validate/1.2.1.bcr.1/MODULE.bazel": "4bf09676b62fa587ae07e073420a76ec8766dcce7545e5f8c68cfa8e484b5120",
@@ -259,6 +260,7 @@
     "https://bcr.bazel.build/modules/rules_cc/0.2.14/MODULE.bazel": "353c99ed148887ee89c54a17d4100ae7e7e436593d104b668476019023b58df8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.15/MODULE.bazel": "6a0a4a75a57aa6dc888300d848053a58c6b12a29f89d4304e1c41448514ec6e8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.18/MODULE.bazel": "4460ec36adc8f722a6a2a4ac9374cb91f2acebadaa93fc37966129afb3dece87",
     "https://bcr.bazel.build/modules/rules_cc/0.2.19/MODULE.bazel": "d5e0f05b63273281a16654eb6b1a8742a75ec153ac8b4f0419949d6e401e46f0",
     "https://bcr.bazel.build/modules/rules_cc/0.2.19/source.json": "1ef48cdbd7aa6238015189b582d3d74ef0cbea3cb3e2cb259d782463f570c14a",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
@@ -535,7 +537,7 @@
     "@@protobuf+//python/dist:system_python.bzl%system_python_extension": {
       "general": {
         "bzlTransitiveDigest": "qh0n9IrXU/xS94wxKQrG1J63zrLkA1Wy2Y3BQxptPcI=",
-        "usagesDigest": "gM2v8KEcm9rpUrlYSngytVomDKFCsh+Qb9pL3rcZurY=",
+        "usagesDigest": "r0v8ejluW9xlYv6K8UBMrSAfXR4CfNX85hawhoVBOAQ=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "system_python": {

--- a/third_party/protobuf.patch
+++ b/third_party/protobuf.patch
@@ -1,5 +1,5 @@
 diff --git a/MODULE.bazel b/MODULE.bazel
-index a490e51b27..d5b3e174b7 100644
+index 8c224dbb35..6ecff93efa 100644
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
 @@ -40,7 +40,7 @@ bazel_dep(name = "rules_kotlin", version = "2.3.20")
@@ -11,7 +11,7 @@ index a490e51b27..d5b3e174b7 100644
  
  bazel_dep(name = "rules_ruby", version = "0.20.1", dev_dependency = True)
  
-@@ -194,7 +194,7 @@ rust.toolchain(
+@@ -193,7 +193,7 @@ rust.toolchain(
      versions = ["1.85.0"],
  )
  
@@ -34,10 +34,10 @@ index 393fab95d6..9012b01649 100644
      scope = "universal",  # propagate from host to exec configuration
      visibility = ["//bazel/toolchains:__pkg__"],
 diff --git a/java/core/BUILD.bazel b/java/core/BUILD.bazel
-index 4cbd4732c1..2e789054c8 100644
+index 0502c5489f..e777afd309 100644
 --- a/java/core/BUILD.bazel
 +++ b/java/core/BUILD.bazel
-@@ -183,10 +183,7 @@ protobuf_java_export(
+@@ -178,10 +178,7 @@ protobuf_java_export(
  protobuf_java_library(
      name = "lite_runtime_only",
      srcs = LITE_SRCS,
@@ -50,7 +50,7 @@ index 4cbd4732c1..2e789054c8 100644
  
  proto_library(
 diff --git a/src/google/protobuf/compiler/java/full/message.cc b/src/google/protobuf/compiler/java/full/message.cc
-index 819f20a44b..e3f7b82701 100644
+index 1b73773a0c..9a78eee880 100644
 --- a/src/google/protobuf/compiler/java/full/message.cc
 +++ b/src/google/protobuf/compiler/java/full/message.cc
 @@ -875,32 +875,26 @@ void ImmutableMessageGenerator::GenerateIsInitialized(io::Printer* printer) {
@@ -104,10 +104,10 @@ index 819f20a44b..e3f7b82701 100644
        "@java.lang.Override\n"
        "public final boolean isInitialized() {\n");
 diff --git a/upb/BUILD b/upb/BUILD
-index 4ce905cbbf..d8e701c131 100644
+index b33477efda..b93fb2c9be 100644
 --- a/upb/BUILD
 +++ b/upb/BUILD
-@@ -125,6 +125,26 @@ cc_library(
+@@ -149,6 +149,26 @@ cc_library(
      visibility = ["//hpb/bazel:__pkg__"],
  )
  
@@ -168,7 +168,7 @@ index 61f70a8561..b625db3eea 100644
          files = _generate_upb_protos(
              ctx,
 diff --git a/upb/bazel/private/upb_proto_library_internal/cc_library_func.bzl b/upb/bazel/private/upb_proto_library_internal/cc_library_func.bzl
-index 47fc5a1cc2..90db085061 100644
+index 39cfb1e3f5..9e45276e38 100644
 --- a/upb/bazel/private/upb_proto_library_internal/cc_library_func.bzl
 +++ b/upb/bazel/private/upb_proto_library_internal/cc_library_func.bzl
 @@ -1,11 +1,11 @@
@@ -183,9 +183,9 @@ index 47fc5a1cc2..90db085061 100644
 -    return use_cpp_toolchain()
 +    return use_cc_toolchain()
  
- def cc_library_func(ctx, name, hdrs, srcs, copts, dep_ccinfos, includes = [], alwayslink = False):
+ def cc_library_func(ctx, name, hdrs, srcs, copts, dep_ccinfos, includes = [], alwayslink = False, **kwargs):
      """Like cc_library(), but callable from rules.
-@@ -25,7 +25,7 @@ def cc_library_func(ctx, name, hdrs, srcs, copts, dep_ccinfos, includes = [], al
+@@ -27,7 +27,7 @@ def cc_library_func(ctx, name, hdrs, srcs, copts, dep_ccinfos, includes = [], al
  
      compilation_contexts = [info.compilation_context for info in dep_ccinfos]
      linking_contexts = [info.linking_context for info in dep_ccinfos]
@@ -234,7 +234,7 @@ index 77f168ef28..0a3e159807 100644
      },
      implementation = _upb_proto_reflection_library_aspect_impl,
 diff --git a/upb_generator/minitable/generator.cc b/upb_generator/minitable/generator.cc
-index 54f8490ce4..801c58a8b2 100644
+index c074e724e1..f0cc162127 100644
 --- a/upb_generator/minitable/generator.cc
 +++ b/upb_generator/minitable/generator.cc
 @@ -297,7 +297,7 @@ void WriteExtension(const DefPoolPair& pools, upb::FieldDefPtr ext,


### PR DESCRIPTION
protobuf 36.0's standard generated Java no longer uses sun.misc.Unsafe. This silences the terminal-deprecation warnings that TurbineDirect emits on JDK 24+ during header compilation, since it bundles protobuf-java (protocolbuffers/protobuf#20760, JEP 498). It also lets rules_java drop the header_compiler_direct_opts workaround once a java_tools release picks up the new turbine (bazelbuild/rules_java#374).

Rebase third_party/protobuf.patch onto 36.0 (all hunks still apply unchanged) and re-pin MODULE.bazel.lock.

RELNOTES: None

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
