### PR TITLE
ensureInputsPresent should chunk inputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloader.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.remote.chunking.ChunkingConfig;
 import com.google.devtools.build.lib.remote.common.BlobNotSplittableException;
 import com.google.devtools.build.lib.remote.common.MaybePathBacked;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
+import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.util.DigestOutputStream;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.Utils;
@@ -47,22 +48,19 @@ public class ChunkedBlobDownloader {
   // stack below it, which is what bounds active remote RPC concurrency across blobs.
   private static final int MAX_IN_FLIGHT_CHUNK_DOWNLOADS = 16;
 
-  private final GrpcCacheClient grpcCacheClient;
+  private final RemoteCacheClient remoteCacheClient;
   private final CombinedCache combinedCache;
-  private final DigestUtil digestUtil;
   private final ChunkLocationMap chunkLocationMap;
   private final ChunkingFunction.Value chunkingFunction;
   private final long maxChunkSize;
 
-  ChunkedBlobDownloader(
-      GrpcCacheClient grpcCacheClient,
+  public ChunkedBlobDownloader(
+      RemoteCacheClient remoteCacheClient,
       CombinedCache combinedCache,
       ChunkingConfig chunkingConfig,
-      DigestUtil digestUtil,
       ChunkLocationMap chunkLocationMap) {
-    this.grpcCacheClient = grpcCacheClient;
+    this.remoteCacheClient = remoteCacheClient;
     this.combinedCache = combinedCache;
-    this.digestUtil = digestUtil;
     this.chunkLocationMap = chunkLocationMap;
     this.chunkingFunction = chunkingConfig.chunkingFunction();
     this.maxChunkSize = chunkingConfig.maxChunkSize();
@@ -85,8 +83,8 @@ public class ChunkedBlobDownloader {
       finalDestination = pathBacked.maybeGetFinalPath();
     }
     @Nullable DigestOutputStream digestOut = null;
-    if (grpcCacheClient.shouldVerifyDownloads()) {
-      digestOut = digestUtil.newDigestOutputStream(out);
+    if (remoteCacheClient.shouldVerifyDownloads()) {
+      digestOut = combinedCache.digestUtil().newDigestOutputStream(out);
       out = digestOut;
     }
 
@@ -115,7 +113,7 @@ public class ChunkedBlobDownloader {
       return ImmutableList.of();
     }
     ListenableFuture<SplitBlobResponse> splitResponseFuture =
-        grpcCacheClient.splitBlob(context, blobDigest, chunkingFunction);
+        remoteCacheClient.splitBlob(context, blobDigest, chunkingFunction);
     if (splitResponseFuture == null) {
       throw new BlobNotSplittableException(blobDigest);
     }
@@ -255,7 +253,7 @@ public class ChunkedBlobDownloader {
 
     /** Returns the contents of a chunk, preferring a copy already on local disk over a download. */
     private ListenableFuture<byte[]> fetchChunk(Digest chunkDigest) {
-      byte[] local = chunkLocationMap.read(chunkDigest, destination, digestUtil);
+      byte[] local = chunkLocationMap.read(chunkDigest, destination, combinedCache.digestUtil());
       return local != null
           ? immediateFuture(local)
           : combinedCache.downloadBlob(context, chunkDigest);

--- a/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobUploader.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.remote;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 
@@ -86,12 +87,17 @@ public class ChunkedBlobUploader {
     return chunkingThreshold;
   }
 
+  public void uploadChunked(RemoteActionExecutionContext context, Digest blobDigest, Path file)
+      throws IOException, InterruptedException {
+    uploadChunked(context, blobDigest, file, /* force= */ false);
+  }
+
   /**
    * Uploads a blob in content-defined chunks. The file is chunked with the configured chunking
    * function, missing chunks are uploaded, and {@code SpliceBlob} is called to register the blob as
    * the concatenation of its chunks.
    */
-  public void uploadChunked(RemoteActionExecutionContext context, Digest blobDigest, Path file)
+  public void uploadChunked(RemoteActionExecutionContext context, Digest blobDigest, Path file, boolean force)
       throws IOException, InterruptedException {
     List<Digest> chunkDigests;
     try (InputStream input = file.getInputStream()) {
@@ -103,7 +109,7 @@ public class ChunkedBlobUploader {
 
     ImmutableSet<Digest> missingDigests =
         getFromFuture(remoteCacheClient.findMissingDigests(context, chunkDigests));
-    uploadMissingChunks(context, missingDigests, chunkDigests, file);
+    uploadMissingChunks(context, missingDigests, chunkDigests, file, force);
     getFromFuture(remoteCacheClient.spliceBlob(context, blobDigest, chunkDigests, chunkingFunction));
   }
 
@@ -111,12 +117,13 @@ public class ChunkedBlobUploader {
       RemoteActionExecutionContext context,
       ImmutableSet<Digest> missingDigests,
       List<Digest> chunkDigests,
-      Path file)
+      Path file,
+      boolean force)
       throws IOException, InterruptedException {
     if (missingDigests.isEmpty()) {
       return;
     }
-    new UploadSession(context, missingDigests, chunkDigests).run(file);
+    new UploadSession(context, missingDigests, chunkDigests, force).run(file);
   }
 
   private final class UploadSession {
@@ -128,14 +135,17 @@ public class ChunkedBlobUploader {
     private final RemoteActionExecutionContext context;
     private final ImmutableSet<Digest> missingDigests;
     private final List<Digest> chunkDigests;
+    private final boolean force;
 
     UploadSession(
         RemoteActionExecutionContext context,
         ImmutableSet<Digest> missingDigests,
-        List<Digest> chunkDigests) {
+        List<Digest> chunkDigests,
+        boolean force) {
       this.context = context;
       this.missingDigests = missingDigests;
       this.chunkDigests = chunkDigests;
+      this.force = force;
     }
 
     void run(Path file) throws IOException, InterruptedException {
@@ -151,7 +161,7 @@ public class ChunkedBlobUploader {
           if (inFlightUploads.size() >= MAX_IN_FLIGHT_CHUNK_UPLOADS) {
             awaitCompletedUpload();
           }
-          startUpload(file, chunkOffset, chunkDigest);
+          startUpload(file, chunkOffset, chunkDigest, force);
         }
         while (!inFlightUploads.isEmpty()) {
           awaitCompletedUpload();
@@ -165,10 +175,10 @@ public class ChunkedBlobUploader {
       return missingDigests.contains(chunkDigest) && scheduledDigests.add(chunkDigest);
     }
 
-    private void startUpload(Path file, long chunkOffset, Digest chunkDigest) {
+    private void startUpload(Path file, long chunkOffset, Digest chunkDigest, boolean force) {
       ListenableFuture<Void> upload =
           combinedCache.uploadBlob(
-              context, chunkDigest, new ChunkBlob(file, chunkOffset, chunkDigest));
+              context, chunkDigest, new ChunkBlob(file, chunkOffset, chunkDigest), force);
       inFlightUploads.add(upload);
       upload.addListener(() -> completedUploads.add(upload), directExecutor());
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobUploader.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.remote.chunking.ChunkingConfig;
 import com.google.devtools.build.lib.remote.chunking.ContentDefinedChunker;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
+import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.Blob;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.vfs.Path;
@@ -56,7 +57,7 @@ public class ChunkedBlobUploader {
   // stack below it, which is what bounds active remote RPC concurrency across blobs.
   private static final int MAX_IN_FLIGHT_CHUNK_UPLOADS = 16;
 
-  private final GrpcCacheClient grpcCacheClient;
+  private final RemoteCacheClient remoteCacheClient;
   private final CombinedCache combinedCache;
   private final ContentDefinedChunker chunker;
   private final ChunkingFunction.Value chunkingFunction;
@@ -65,19 +66,17 @@ public class ChunkedBlobUploader {
   /**
    * Creates a new uploader with the given chunking configuration.
    *
-   * @param grpcCacheClient client used for {@code FindMissingDigests} and {@code SpliceBlob} RPCs
+   * @param remoteCacheClient client used for {@code FindMissingDigests} and {@code SpliceBlob} RPCs
    * @param combinedCache cache used to upload individual chunks
    * @param config chunking parameters negotiated from server capabilities
-   * @param digestUtil utility for computing chunk digests
    */
   public ChunkedBlobUploader(
-      GrpcCacheClient grpcCacheClient,
+      RemoteCacheClient remoteCacheClient,
       CombinedCache combinedCache,
-      ChunkingConfig config,
-      DigestUtil digestUtil) {
-    this.grpcCacheClient = grpcCacheClient;
+      ChunkingConfig config) {
+    this.remoteCacheClient = remoteCacheClient;
     this.combinedCache = combinedCache;
-    this.chunker = config.newChunker(digestUtil);
+    this.chunker = config.newChunker(combinedCache.digestUtil());
     this.chunkingFunction = config.chunkingFunction();
     this.chunkingThreshold = config.chunkingThreshold();
   }
@@ -103,9 +102,9 @@ public class ChunkedBlobUploader {
     }
 
     ImmutableSet<Digest> missingDigests =
-        getFromFuture(grpcCacheClient.findMissingDigests(context, chunkDigests));
+        getFromFuture(remoteCacheClient.findMissingDigests(context, chunkDigests));
     uploadMissingChunks(context, missingDigests, chunkDigests, file);
-    getFromFuture(grpcCacheClient.spliceBlob(context, blobDigest, chunkDigests, chunkingFunction));
+    getFromFuture(remoteCacheClient.spliceBlob(context, blobDigest, chunkDigests, chunkingFunction));
   }
 
   private void uploadMissingChunks(

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -108,46 +108,47 @@ public class CombinedCache extends AbstractReferenceCounted {
   @Nullable protected final RemoteCacheClient remoteCacheClient;
   @Nullable protected final DiskCacheClient diskCacheClient;
   @Nullable protected final String symlinkTemplate;
-  protected final DigestUtil digestUtil;
-  @Nullable private final ChunkingFunctionValue chunkingFunction;
-  private final ChunkLocationMap chunkLocationMap;
+  private final DigestUtil digestUtil;
 
   // Delays the initialization of the chunking support logic until first use to avoid blocking on
   // a server capabilities check at construction time.
-  private final class Chunking {
-    private ChunkingConfig config = null;
-    private ChunkedBlobDownloader downloader = null;
-    private ChunkedBlobUploader uploader = null;
-    private volatile boolean initialized = false;
+  private static final class Chunking {
+    private final ChunkingConfig config;
+    private final ChunkedBlobDownloader downloader;
+    private final ChunkedBlobUploader uploader;
 
-    boolean supported() throws IOException {
-      if (chunkingFunction == null) {
-        return false;
+    Chunking() {
+      this.config = null;
+      this.downloader = null;
+      this.uploader = null;
+    }
+
+    Chunking(
+        ServerCapabilities serverCapabilities,
+        RemoteCacheClient remoteCacheClient,
+        ChunkingFunctionValue chunkingFunction,
+        ChunkLocationMap chunkLocationMap,
+        CombinedCache combinedCache) {
+      config =
+          switch (chunkingFunction) {
+            case AUTO -> ChunkingConfig.fromServerCapabilities(serverCapabilities);
+            case FAST_CDC_2020 ->
+                ChunkingConfig.fromServerCapabilities(
+                    serverCapabilities, ChunkingFunction.Value.FAST_CDC_2020);
+            case REP_MAX_CDC ->
+                ChunkingConfig.fromServerCapabilities(
+                    serverCapabilities, ChunkingFunction.Value.REP_MAX_CDC);
+          };
+      if (config != null) {
+        downloader = new ChunkedBlobDownloader(remoteCacheClient, combinedCache, config, chunkLocationMap);
+        uploader = new ChunkedBlobUploader(remoteCacheClient, combinedCache, config);
+      } else {
+        downloader = null;
+        uploader = null;
       }
-      if (!(remoteCacheClient instanceof GrpcCacheClient grpcClient)) {
-        return false;
-      }
-      if (!initialized) {
-        synchronized (this) {
-          config =
-              switch (chunkingFunction) {
-                case AUTO -> ChunkingConfig.fromServerCapabilities(getRemoteServerCapabilities());
-                case FAST_CDC_2020 ->
-                    ChunkingConfig.fromServerCapabilities(
-                        getRemoteServerCapabilities(), ChunkingFunction.Value.FAST_CDC_2020);
-                case REP_MAX_CDC ->
-                    ChunkingConfig.fromServerCapabilities(
-                        getRemoteServerCapabilities(), ChunkingFunction.Value.REP_MAX_CDC);
-              };
-          if (config != null) {
-            downloader =
-                new ChunkedBlobDownloader(
-                    grpcClient, CombinedCache.this, config, digestUtil, chunkLocationMap);
-            uploader = new ChunkedBlobUploader(grpcClient, CombinedCache.this, config, digestUtil);
-          }
-          initialized = true;
-        }
-      }
+    }
+
+    boolean supported() {
       return config != null;
     }
 
@@ -164,7 +165,21 @@ public class CombinedCache extends AbstractReferenceCounted {
     }
   }
 
-  private final Chunking chunking = new Chunking();
+  private final ListenableFuture<Chunking> chunking;
+
+  private static ListenableFuture<Chunking> createChunking(
+      @Nullable RemoteCacheClient remoteCacheClient,
+      @Nullable ChunkingFunctionValue chunkingFunction,
+      ChunkLocationMap chunkLocationMap,
+      CombinedCache combinedCache) {
+    if (remoteCacheClient == null || chunkingFunction == null) {
+      return immediateFuture(new Chunking());
+    }
+    return Futures.transform(
+        remoteCacheClient.serverCapabilities(),
+        serverCapabilities -> new Chunking(serverCapabilities, remoteCacheClient, chunkingFunction, chunkLocationMap, combinedCache),
+        directExecutor());
+  }
 
   public CombinedCache(
       @Nullable RemoteCacheClient remoteCacheClient,
@@ -180,8 +195,11 @@ public class CombinedCache extends AbstractReferenceCounted {
     this.diskCacheClient = diskCacheClient;
     this.symlinkTemplate = symlinkTemplate;
     this.digestUtil = digestUtil;
-    this.chunkingFunction = chunkingFunction;
-    this.chunkLocationMap = chunkLocationMap;
+    this.chunking = createChunking(remoteCacheClient, chunkingFunction, chunkLocationMap, this);
+  }
+
+  public DigestUtil digestUtil() {
+    return digestUtil;
   }
 
   public CacheCapabilities getRemoteCacheCapabilities() throws IOException {
@@ -389,22 +407,18 @@ public class CombinedCache extends AbstractReferenceCounted {
       diskCacheFuture = diskCacheClient.uploadFile(digest, file);
     }
 
-    boolean chunkingSupported;
-    try {
-      chunkingSupported = chunking.supported();
-    } catch (IOException e) {
-      return immediateFailedFuture(e);
-    }
-
     ListenableFuture<Void> remoteCacheFuture = Futures.immediateVoidFuture();
     if (remoteCacheClient != null && context.getWriteCachePolicy().allowRemoteCache()) {
-      if (chunkingSupported && digest.getSizeBytes() > chunking.config().chunkingThreshold()) {
-        remoteCacheFuture =
-            remoteCacheClient.dedupUpload(
-                digest, () -> uploadChunked(context, digest, file), /* force= */ false);
-      } else {
-        remoteCacheFuture = remoteCacheClient.uploadFile(context, digest, file, /* force= */ false);
-      }
+      remoteCacheFuture = Futures.transformAsync(
+          chunking,
+          chunking -> {
+            if (chunking.supported() && digest.getSizeBytes() > chunking.config().chunkingThreshold()) {
+              return remoteCacheClient.dedupUpload(
+                  digest, () -> uploadChunked(chunking, context, digest, file), /* force= */ false);
+            }
+            return remoteCacheClient.uploadFile(context, digest, file, /* force= */ false);
+          },
+          directExecutor());
     }
 
     return Futures.whenAllSucceed(diskCacheFuture, remoteCacheFuture)
@@ -412,7 +426,7 @@ public class CombinedCache extends AbstractReferenceCounted {
   }
 
   private ListenableFuture<Void> uploadChunked(
-      RemoteActionExecutionContext context, Digest digest, Path file) {
+      Chunking chunking, RemoteActionExecutionContext context, Digest digest, Path file) {
     return virtualThreadExecutor.submit(
         () -> {
           chunking.uploader().uploadChunked(context, digest, file);
@@ -536,35 +550,31 @@ public class CombinedCache extends AbstractReferenceCounted {
 
   private ListenableFuture<Void> downloadBlobFromRemote(
       RemoteActionExecutionContext context, Digest digest, OutputStream out) {
-    checkState(remoteCacheClient != null && context.getReadCachePolicy().allowRemoteCache());
+    return Futures.transformAsync(
+        chunking,
+        chunking -> {
+          if (chunking.supported() && digest.getSizeBytes() > chunking.config().chunkingThreshold()) {
+            ListenableFuture<Void> chunkedDownloadFuture =
+                virtualThreadExecutor.submit(
+                    () -> {
+                      chunking.downloader().downloadChunked(context, digest, out);
+                      return null;
+                    });
+            // Only a failure to split the blob is recoverable by downloading it as a whole. Once the
+            // server has described the blob as a sequence of chunks, the download is committed to that
+            // path: chunks are written to `out` as they arrive, so restarting would append the blob to
+            // the chunks already written. A missing chunk is reported as a missing blob instead, letting
+            // the usual lost input handling regenerate it.
+            return Futures.catchingAsync(
+                chunkedDownloadFuture,
+                BlobNotSplittableException.class,
+                (e) -> regularDownloadBlobFromRemote(context, digest, out),
+                directExecutor());
+          }
 
-    boolean chunkingSupported;
-    try {
-      chunkingSupported = chunking.supported();
-    } catch (IOException e) {
-      return immediateFailedFuture(e);
-    }
-
-    if (chunkingSupported && digest.getSizeBytes() > chunking.config().chunkingThreshold()) {
-      ListenableFuture<Void> chunkedDownloadFuture =
-          virtualThreadExecutor.submit(
-              () -> {
-                chunking.downloader().downloadChunked(context, digest, out);
-                return null;
-              });
-      // Only a failure to split the blob is recoverable by downloading it as a whole. Once the
-      // server has described the blob as a sequence of chunks, the download is committed to that
-      // path: chunks are written to `out` as they arrive, so restarting would append the blob to
-      // the chunks already written. A missing chunk is reported as a missing blob instead, letting
-      // the usual lost input handling regenerate it.
-      return Futures.catchingAsync(
-          chunkedDownloadFuture,
-          BlobNotSplittableException.class,
-          (e) -> regularDownloadBlobFromRemote(context, digest, out),
-          directExecutor());
-    }
-
-    return regularDownloadBlobFromRemote(context, digest, out);
+          return regularDownloadBlobFromRemote(context, digest, out);
+        },
+        directExecutor());
   }
 
   private ListenableFuture<Void> regularDownloadBlobFromRemote(

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -386,6 +386,20 @@ public class CombinedCache extends AbstractReferenceCounted {
         .call(() -> null, directExecutor());
   }
 
+  /* must not interact with casUploadCache */
+  protected ListenableFuture<Void> uploadOrChunkFile(
+      RemoteActionExecutionContext context, Digest digest, Path file, boolean force) {
+    return Futures.transformAsync(
+        chunking,
+        chunking -> {
+          if (chunking.supported() && digest.getSizeBytes() > chunking.config().chunkingThreshold()) {
+            return uploadChunked(chunking, context, digest, file, force);
+          }
+          return remoteCacheClient.uploadFile(context, digest, file, force);
+        },
+        directExecutor());
+  }
+
   /**
    * Upload a local file to the remote cache.
    *
@@ -414,7 +428,7 @@ public class CombinedCache extends AbstractReferenceCounted {
           chunking -> {
             if (chunking.supported() && digest.getSizeBytes() > chunking.config().chunkingThreshold()) {
               return remoteCacheClient.dedupUpload(
-                  digest, () -> uploadChunked(chunking, context, digest, file), /* force= */ false);
+                  digest, () -> uploadChunked(chunking, context, digest, file, /* force= */ false), /* force= */ false);
             }
             return remoteCacheClient.uploadFile(context, digest, file, /* force= */ false);
           },
@@ -426,10 +440,10 @@ public class CombinedCache extends AbstractReferenceCounted {
   }
 
   private ListenableFuture<Void> uploadChunked(
-      Chunking chunking, RemoteActionExecutionContext context, Digest digest, Path file) {
+      Chunking chunking, RemoteActionExecutionContext context, Digest digest, Path file, boolean force) {
     return virtualThreadExecutor.submit(
         () -> {
-          chunking.uploader().uploadChunked(context, digest, file);
+          chunking.uploader().uploadChunked(context, digest, file, force);
           return null;
         });
   }
@@ -441,7 +455,7 @@ public class CombinedCache extends AbstractReferenceCounted {
    * cache writes are enabled.
    */
   public ListenableFuture<Void> uploadBlob(
-      RemoteActionExecutionContext context, Digest digest, Blob blob) {
+      RemoteActionExecutionContext context, Digest digest, Blob blob, boolean force) {
     if (digest.getSizeBytes() == 0) {
       return COMPLETED_SUCCESS;
     }
@@ -453,7 +467,7 @@ public class CombinedCache extends AbstractReferenceCounted {
 
     ListenableFuture<Void> remoteCacheFuture = Futures.immediateVoidFuture();
     if (remoteCacheClient != null && context.getWriteCachePolicy().allowRemoteCache()) {
-      remoteCacheFuture = remoteCacheClient.uploadBlob(context, digest, blob, /* force= */ false);
+      remoteCacheFuture = remoteCacheClient.uploadBlob(context, digest, blob, force);
     }
 
     return Futures.whenAllSucceed(diskCacheFuture, remoteCacheFuture)

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -421,21 +421,6 @@ public class CombinedCache extends AbstractReferenceCounted {
   }
 
   /**
-   * Uploads a sequence of bytes to the cache.
-   *
-   * <p>Trying to upload the same BLOB multiple times concurrently, results in only one upload being
-   * performed.
-   *
-   * @param context the context for the action.
-   * @param digest the digest of the BLOB.
-   * @param data the BLOB to upload.
-   */
-  public ListenableFuture<Void> uploadBlob(
-      RemoteActionExecutionContext context, Digest digest, ByteString data) {
-    return uploadBlob(context, digest, (Blob) data::newInput);
-  }
-
-  /**
    * Uploads a blob to the cache from a repeatable stream supplier.
    *
    * <p>The supplier may be opened more than once, including concurrently when both disk and remote

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -110,9 +110,7 @@ public class CombinedCache extends AbstractReferenceCounted {
   @Nullable protected final String symlinkTemplate;
   private final DigestUtil digestUtil;
 
-  // Delays the initialization of the chunking support logic until first use to avoid blocking on
-  // a server capabilities check at construction time.
-  private static final class Chunking {
+  static final class Chunking {
     private final ChunkingConfig config;
     private final ChunkedBlobDownloader downloader;
     private final ChunkedBlobUploader uploader;
@@ -196,6 +194,22 @@ public class CombinedCache extends AbstractReferenceCounted {
     this.symlinkTemplate = symlinkTemplate;
     this.digestUtil = digestUtil;
     this.chunking = createChunking(remoteCacheClient, chunkingFunction, chunkLocationMap, this);
+  }
+
+  public CombinedCache(
+      @Nullable RemoteCacheClient remoteCacheClient,
+      @Nullable DiskCacheClient diskCacheClient,
+      @Nullable String symlinkTemplate,
+      DigestUtil digestUtil,
+      ListenableFuture<Chunking> chunking) {
+    checkArgument(
+        remoteCacheClient != null || diskCacheClient != null,
+        "remoteCacheClient and diskCacheClient cannot be null at the same time");
+    this.remoteCacheClient = remoteCacheClient;
+    this.diskCacheClient = diskCacheClient;
+    this.symlinkTemplate = symlinkTemplate;
+    this.digestUtil = digestUtil;
+    this.chunking = chunking;
   }
 
   public DigestUtil digestUtil() {

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -96,7 +96,8 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
 
   private final AtomicBoolean closed = new AtomicBoolean();
 
-  boolean shouldVerifyDownloads() {
+  @Override
+  public boolean shouldVerifyDownloads() {
     return options.getRemoteVerifyDownloads();
   }
 
@@ -351,6 +352,11 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
   @Override
   public ServerCapabilities getServerCapabilities() throws IOException {
     return channel.getServerCapabilities();
+  }
+
+  @Override
+  public ListenableFuture<ServerCapabilities> serverCapabilities() {
+    return channel.serverCapabilities();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -108,19 +108,35 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
       RemoteOptions options,
       RemoteRetrier retrier,
       DigestUtil digestUtil) {
-    this.callCredentialsProvider = callCredentialsProvider;
-    this.channel = channel;
-    this.options = options;
-    this.digestUtil = digestUtil;
-    this.retrier = retrier;
-    this.uploader =
+    this(
+        channel,
+        callCredentialsProvider,
+        options,
+        retrier,
+        digestUtil,
         new ByteStreamUploader(
             options.getRemoteInstanceName(),
             channel,
             callCredentialsProvider,
             retrier,
             options.getMaximumOpenFiles(),
-            digestUtil.getDigestFunction());
+            digestUtil.getDigestFunction()));
+  }
+
+  @VisibleForTesting
+  public GrpcCacheClient(
+      ReferenceCountedChannel channel,
+      CallCredentialsProvider callCredentialsProvider,
+      RemoteOptions options,
+      RemoteRetrier retrier,
+      DigestUtil digestUtil,
+      ByteStreamUploader uploader) {
+    this.callCredentialsProvider = callCredentialsProvider;
+    this.channel = channel;
+    this.options = options;
+    this.digestUtil = digestUtil;
+    this.retrier = retrier;
+    this.uploader = uploader;
     maxMissingBlobsDigestsPerMessage = computeMaxMissingBlobsDigestsPerMessage();
     Preconditions.checkState(
         maxMissingBlobsDigestsPerMessage > 0, "Error: gRPC message size too small.");

--- a/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannel.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannel.java
@@ -114,6 +114,11 @@ public class ReferenceCountedChannel implements ReferenceCounted {
     return caps;
   }
 
+  public ListenableFuture<ServerCapabilities> serverCapabilities() {
+    return RxFutures.toListenableFuture(
+          withChannelConnection(ChannelConnectionWithServerCapabilities::getServerCapabilities));
+  }
+
   public boolean isShutdown() {
     return dynamicConnectionPool.isClosed();
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
@@ -230,7 +230,7 @@ public class RemoteExecutionCache extends CombinedCache implements MerkleTreeUpl
               throw new CacheNotFoundException(digest, path.getPathString());
             }
           }
-          return remoteCacheClient.uploadFile(context, digest, path, force);
+          return uploadOrChunkFile(context, digest, path, force);
         },
         directExecutor());
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
@@ -142,6 +142,20 @@ public class RemoteExecutionCache extends CombinedCache implements MerkleTreeUpl
         chunkLocationMap);
   }
 
+  RemoteExecutionCache(
+      RemoteCacheClient remoteCacheClient,
+      @Nullable DiskCacheClient diskCacheClient,
+      @Nullable String symlinkTemplate,
+      DigestUtil digestUtil,
+      ListenableFuture<Chunking> chunking) {
+    super(
+        checkNotNull(remoteCacheClient),
+        diskCacheClient,
+        symlinkTemplate,
+        digestUtil,
+        chunking);
+  }
+
   @VisibleForTesting
   void setRemotePathChecker(RemotePathChecker remotePathChecker) {
     this.remotePathChecker = remotePathChecker;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -214,7 +214,7 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
     var childMap =
         remoteContents.getChildrenList().stream()
             .collect(
-                toImmutableMap(cache.digestUtil::compute, directory -> directory, (a, b) -> a));
+                toImmutableMap(cache.digestUtil()::compute, directory -> directory, (a, b) -> a));
     var filesToPrefetch = new LinkedHashSet<PathFragment>();
     var symlinksToPrefetch = new ArrayList<PathFragment>();
     externalFs.createDirectoryAndParents(repoDir.getParentDirectory());

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
@@ -344,7 +344,7 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
     // The command is shared by all action results and small enough that FindMissingBlobs is not
     // worthwhile. The REAPI spec requires the command to be uploaded before an action result that
     // references it.
-    waitForBulkTransfer(ImmutableSet.of(cache.uploadBlob(context, commandDigest, (Blob) COMMAND_BYTES::newInput)));
+    waitForBulkTransfer(ImmutableSet.of(cache.uploadBlob(context, commandDigest, (Blob) COMMAND_BYTES::newInput, /* force= */ false)));
 
     String rollingHash = predeclaredInputHash;
     var batches = RepoRecordedInput.WithValue.splitIntoBatches(recordedInputValues);
@@ -415,8 +415,8 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
           var actionResult =
               ActionResult.newBuilder().setExitCode(0).setStdoutDigest(stdoutDigest).build();
           return whenAllSucceed(
-                  cache.uploadBlob(context, actionKey.digest(), (Blob) action.toByteString()::newInput),
-                  cache.uploadBlob(context, stdoutDigest, (Blob) ByteString.copyFrom(stdoutBytes)::newInput))
+                  cache.uploadBlob(context, actionKey.digest(), (Blob) action.toByteString()::newInput, /* force= */ false),
+                  cache.uploadBlob(context, stdoutDigest, (Blob) ByteString.copyFrom(stdoutBytes)::newInput, /* force= */ false))
               .callAsync(
                   () -> cache.uploadActionResult(context, actionKey, actionResult),
                   directExecutor());

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
@@ -51,6 +51,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.exec.SpawnRunner;
 import com.google.devtools.build.lib.remote.common.ActionKey;
+import com.google.devtools.build.lib.remote.common.RemoteCacheClient.Blob;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext.CachePolicy;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
@@ -345,7 +346,7 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
     // The command is shared by all action results and small enough that FindMissingBlobs is not
     // worthwhile. The REAPI spec requires the command to be uploaded before an action result that
     // references it.
-    waitForBulkTransfer(ImmutableSet.of(cache.uploadBlob(context, commandDigest, COMMAND_BYTES)));
+    waitForBulkTransfer(ImmutableSet.of(cache.uploadBlob(context, commandDigest, (Blob) COMMAND_BYTES::newInput, /* force= */ false)));
 
     String rollingHash = predeclaredInputHash;
     var batches = RepoRecordedInput.WithValue.splitIntoBatches(recordedInputValues);
@@ -416,8 +417,8 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
           var actionResult =
               ActionResult.newBuilder().setExitCode(0).setStdoutDigest(stdoutDigest).build();
           return whenAllSucceed(
-                  cache.uploadBlob(context, actionKey.digest(), action.toByteString()),
-                  cache.uploadBlob(context, stdoutDigest, ByteString.copyFrom(stdoutBytes)))
+                  cache.uploadBlob(context, actionKey.digest(), (Blob) action.toByteString()::newInput, /* force= */ false),
+                  cache.uploadBlob(context, stdoutDigest, (Blob) ByteString.copyFrom(stdoutBytes)::newInput, /* force= */ false))
               .callAsync(
                   () -> cache.uploadActionResult(context, actionKey, actionResult),
                   directExecutor());

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
@@ -138,7 +138,6 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
   private final boolean acceptCached;
   private final boolean uploadLocalResults;
   private final boolean verboseFailures;
-  private final DigestUtil digestUtil;
   private final Action baseAction;
   private final Digest commandDigest;
 
@@ -157,14 +156,13 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
     this.acceptCached = acceptCached;
     this.uploadLocalResults = uploadLocalResults;
     this.verboseFailures = verboseFailures;
-    this.digestUtil = cache.digestUtil;
     this.baseAction =
         Action.newBuilder()
-            .setCommandDigest(digestUtil.compute(COMMAND))
-            .setInputRootDigest(digestUtil.compute(INPUT_ROOT))
+            .setCommandDigest(cache.digestUtil().compute(COMMAND))
+            .setInputRootDigest(cache.digestUtil().compute(INPUT_ROOT))
             .setPlatform(Platform.getDefaultInstance())
             .build();
-    this.commandDigest = digestUtil.compute(COMMAND);
+    this.commandDigest = cache.digestUtil().compute(COMMAND);
   }
 
   @Override
@@ -203,12 +201,12 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
       var finalHash =
           uploadIntermediateActionResults(context, predeclaredInputHash, recordedInputValues);
       var action = buildAction(finalHash);
-      var actionKey = new ActionKey(digestUtil.compute(action));
+      var actionKey = new ActionKey(cache.digestUtil().compute(action));
       var remotePathResolver = new RepoRemotePathResolver(fetchedRepoMarkerFile, fetchedRepoDir);
       var unused =
           UploadManifest.create(
                   cache.getRemoteCacheCapabilities(),
-                  digestUtil,
+                  cache.digestUtil(),
                   remotePathResolver,
                   actionKey,
                   action,
@@ -346,7 +344,7 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
     // The command is shared by all action results and small enough that FindMissingBlobs is not
     // worthwhile. The REAPI spec requires the command to be uploaded before an action result that
     // references it.
-    waitForBulkTransfer(ImmutableSet.of(cache.uploadBlob(context, commandDigest, (Blob) COMMAND_BYTES::newInput, /* force= */ false)));
+    waitForBulkTransfer(ImmutableSet.of(cache.uploadBlob(context, commandDigest, (Blob) COMMAND_BYTES::newInput)));
 
     String rollingHash = predeclaredInputHash;
     var batches = RepoRecordedInput.WithValue.splitIntoBatches(recordedInputValues);
@@ -377,7 +375,7 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
       RemoteActionExecutionContext context,
       Action action,
       Collection<RepoRecordedInput> newInputs) {
-    var actionKey = digestUtil.computeActionKey(action);
+    var actionKey = cache.digestUtil().computeActionKey(action);
     var currentInputsFuture =
         Futures.transformAsync(
             cache.downloadActionResultAsync(
@@ -413,12 +411,12 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
           // cache entry is an acceptable trade-off for simplicity.
           var newInputsString = newInputString + '\n' + currentInputsString;
           var stdoutBytes = getInternalStringBytes(newInputsString);
-          var stdoutDigest = digestUtil.compute(stdoutBytes);
+          var stdoutDigest = cache.digestUtil().compute(stdoutBytes);
           var actionResult =
               ActionResult.newBuilder().setExitCode(0).setStdoutDigest(stdoutDigest).build();
           return whenAllSucceed(
-                  cache.uploadBlob(context, actionKey.digest(), (Blob) action.toByteString()::newInput, /* force= */ false),
-                  cache.uploadBlob(context, stdoutDigest, (Blob) ByteString.copyFrom(stdoutBytes)::newInput, /* force= */ false))
+                  cache.uploadBlob(context, actionKey.digest(), (Blob) action.toByteString()::newInput),
+                  cache.uploadBlob(context, stdoutDigest, (Blob) ByteString.copyFrom(stdoutBytes)::newInput))
               .callAsync(
                   () -> cache.uploadActionResult(context, actionKey, actionResult),
                   directExecutor());
@@ -495,7 +493,7 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
   private CacheEntry fetchCacheEntry(
       SkyFunction.Environment env, RemoteActionExecutionContext context, String inputHash)
       throws IOException, InterruptedException {
-    var actionKey = new ActionKey(digestUtil.compute(buildAction(inputHash)));
+    var actionKey = new ActionKey(cache.digestUtil().compute(buildAction(inputHash)));
     // The marker file is read right after and thus requested to be inlined. If the action result
     // is an intermediate node, the full result will be contained in the stdout, which should thus
     // also be inlined.

--- a/src/main/java/com/google/devtools/build/lib/remote/RepositoryRemoteHelpersFactoryImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RepositoryRemoteHelpersFactoryImpl.java
@@ -67,7 +67,7 @@ class RepositoryRemoteHelpersFactoryImpl implements RepositoryRemoteHelpersFacto
     return new RemoteRepositoryRemoteExecutor(
         (RemoteExecutionCache) cache,
         remoteExecutor,
-        cache.digestUtil,
+        cache.digestUtil(),
         buildRequestId,
         commandId,
         workspaceName,

--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -661,7 +661,7 @@ public class UploadManifest {
           new IOException("FindMissingBlobs call returned an unknown digest: " + digest));
     }
 
-    return combinedCache.uploadBlob(context, digest, (Blob) blob::newInput);
+    return combinedCache.uploadBlob(context, digest, (Blob) blob::newInput, /* force= */ false);
   }
 
   @CanIgnoreReturnValue

--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -661,7 +661,7 @@ public class UploadManifest {
           new IOException("FindMissingBlobs call returned an unknown digest: " + digest));
     }
 
-    return combinedCache.uploadBlob(context, digest, (Blob) blob::newInput, /* force= */ false);
+    return combinedCache.uploadBlob(context, digest, (Blob) blob::newInput);
   }
 
   @CanIgnoreReturnValue

--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -57,6 +57,7 @@ import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.remote.common.ActionKey;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
+import com.google.devtools.build.lib.remote.common.RemoteCacheClient.Blob;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
@@ -660,7 +661,7 @@ public class UploadManifest {
           new IOException("FindMissingBlobs call returned an unknown digest: " + digest));
     }
 
-    return combinedCache.uploadBlob(context, digest, blob);
+    return combinedCache.uploadBlob(context, digest, (Blob) blob::newInput, /* force= */ false);
   }
 
   @CanIgnoreReturnValue

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
@@ -21,6 +21,7 @@ import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.ChunkingFunction;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.ServerCapabilities;
+import build.bazel.remote.execution.v2.SplitBlobResponse;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -50,6 +51,8 @@ public abstract class RemoteCacheClient implements MissingDigestsFinder {
   private final AsyncTaskCache.NoResult<Digest> casUploadCache = AsyncTaskCache.NoResult.create();
 
   public abstract ServerCapabilities getServerCapabilities() throws IOException;
+
+  public abstract ListenableFuture<ServerCapabilities> serverCapabilities();
 
   public abstract ListenableFuture<String> getAuthority();
 
@@ -209,6 +212,22 @@ public abstract class RemoteCacheClient implements MissingDigestsFinder {
   }
 
   /**
+   * Queries the cache client for chunk information about a blob using the SplitBlob RPC.
+   *
+   * <p>This is used for CDC (Content-Defined Chunking) downloads.
+   *
+   * @return A future representing pending completion of the split operation, or null if SplitBlob
+   *     is not supported by this cache client.
+   */
+  @Nullable
+  public ListenableFuture<SplitBlobResponse> splitBlob(
+      RemoteActionExecutionContext context,
+      Digest digest,
+      ChunkingFunction.Value chunkingFunction) {
+    return null;
+  }
+
+  /**
    * Deduplicates an upload by digest using the same cache as {@link #uploadFile} and {@link
    * #uploadBlob}. For use by callers that perform their own upload logic but want to share the
    * dedup state with the regular upload paths (e.g. chunked uploads).
@@ -251,4 +270,8 @@ public abstract class RemoteCacheClient implements MissingDigestsFinder {
 
   /** Close resources associated with the remote cache. */
   public abstract void close();
+
+  public boolean shouldVerifyDownloads() {
+    return false;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -616,6 +616,11 @@ public final class HttpCacheClient extends RemoteCacheClient {
   }
 
   @Override
+  public ListenableFuture<ServerCapabilities> serverCapabilities() {
+    return Futures.immediateFuture(getServerCapabilities());
+  }
+
+  @Override
   public ListenableFuture<String> getAuthority() {
     return Futures.immediateFuture("");
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.ServerCapabilities;
@@ -460,7 +461,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
                 + "/"
                 + digest.getSizeBytes());
     verify(combinedCache, never()).uploadFile(any(), any(), any());
-    verify(combinedCache, never()).uploadBlob(any(), any(), any(Blob.class));
+    verify(combinedCache, never()).uploadBlob(any(), any(), any(Blob.class), any(Boolean.class));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -458,9 +459,8 @@ public class ByteStreamBuildEventArtifactUploaderTest {
                 + digest.getHash()
                 + "/"
                 + digest.getSizeBytes());
-    verify(combinedCache, times(0)).uploadFile(any(), any(), any());
-    verify(combinedCache, times(0)).uploadBlob(any(), any(), any(ByteString.class));
-    verify(combinedCache, times(0)).uploadBlob(any(), any(), any(Blob.class));
+    verify(combinedCache, never()).uploadFile(any(), any(), any());
+    verify(combinedCache, never()).uploadBlob(any(), any(), any(Blob.class));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloaderTest.java
@@ -78,10 +78,10 @@ public class ChunkedBlobDownloaderTest {
 
   @Before
   public void setUp() throws Exception {
+    when(combinedCache.digestUtil()).thenReturn(DIGEST_UTIL);
     when(grpcCacheClient.shouldVerifyDownloads()).thenReturn(true);
     downloader =
-        new ChunkedBlobDownloader(
-            grpcCacheClient, combinedCache, CHUNKING_CONFIG, DIGEST_UTIL, new ChunkLocationMap());
+        new ChunkedBlobDownloader(grpcCacheClient, combinedCache, CHUNKING_CONFIG, new ChunkLocationMap());
     tmpDir = TestUtils.createUniqueTmpDir(null);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobUploaderTest.java
@@ -84,19 +84,21 @@ public class ChunkedBlobUploaderTest {
 
   @Before
   public void setUp() throws Exception {
+    when(combinedCache.digestUtil()).thenReturn(DIGEST_UTIL);
+
     fs = new InMemoryFileSystem(new JavaClock(), DigestHashFunction.SHA256);
     execRoot = fs.getPath("/execroot");
     execRoot.createDirectoryAndParents();
 
     FastCdcChunkingConfig config = new FastCdcChunkingConfig(1024, 2, 0);
-    uploader = new ChunkedBlobUploader(grpcCacheClient, combinedCache, config, DIGEST_UTIL);
+    uploader = new ChunkedBlobUploader(grpcCacheClient, combinedCache, config);
   }
 
   @Test
   public void getChunkingThreshold_returnsConfiguredValue() {
     FastCdcChunkingConfig config = new FastCdcChunkingConfig(512, 2, 0);
     ChunkedBlobUploader uploader =
-        new ChunkedBlobUploader(grpcCacheClient, combinedCache, config, DIGEST_UTIL);
+        new ChunkedBlobUploader(grpcCacheClient, combinedCache, config);
 
     assertThat(uploader.getChunkingThreshold()).isEqualTo(512 * 4);
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobUploaderTest.java
@@ -119,7 +119,7 @@ public class ChunkedBlobUploaderTest {
               List<Digest> digests = invocation.getArgument(1);
               return immediateFuture(ImmutableSet.copyOf(digests));
             });
-    when(combinedCache.uploadBlob(any(), any(Digest.class), any(Blob.class)))
+    when(combinedCache.uploadBlob(any(), any(Digest.class), any(Blob.class), any(Boolean.class)))
         .thenReturn(immediateVoidFuture());
     when(grpcCacheClient.spliceBlob(any(), any(), any(), any())).thenReturn(immediateVoidFuture());
 
@@ -146,7 +146,7 @@ public class ChunkedBlobUploaderTest {
 
     uploader.uploadChunked(context, blobDigest, file);
 
-    verify(combinedCache, never()).uploadBlob(any(), any(Digest.class), any(Blob.class));
+    verify(combinedCache, never()).uploadBlob(any(), any(Digest.class), any(Blob.class), any(Boolean.class));
     verify(grpcCacheClient).spliceBlob(any(), eq(blobDigest), any(), any());
   }
 
@@ -190,7 +190,7 @@ public class ChunkedBlobUploaderTest {
     when(grpcCacheClient.findMissingDigests(any(), any()))
         .thenReturn(immediateFuture(ImmutableSet.copyOf(digestsToReportMissing)));
     Map<Digest, ByteString> actualUploads = new HashMap<>();
-    when(combinedCache.uploadBlob(any(), any(Digest.class), any(Blob.class)))
+    when(combinedCache.uploadBlob(any(), any(Digest.class), any(Blob.class), any(Boolean.class)))
         .thenAnswer(
             invocation -> {
               Digest d = invocation.getArgument(1);
@@ -250,7 +250,7 @@ public class ChunkedBlobUploaderTest {
     CountDownLatch firstWindowRequested = new CountDownLatch(MAX_IN_FLIGHT_CHUNK_UPLOADS);
     CountDownLatch overflowUploadRequested = new CountDownLatch(1);
 
-    when(combinedCache.uploadBlob(any(), any(Digest.class), any(Blob.class)))
+    when(combinedCache.uploadBlob(any(), any(Digest.class), any(Blob.class), any(Boolean.class)))
         .thenAnswer(
             invocation -> {
               Digest digest = invocation.getArgument(1);
@@ -326,7 +326,7 @@ public class ChunkedBlobUploaderTest {
     SettableFuture<Void> failedUpload = SettableFuture.create();
     SettableFuture<Void> cancelledUpload = SettableFuture.create();
     CountDownLatch uploadsStarted = new CountDownLatch(2);
-    when(combinedCache.uploadBlob(any(), any(Digest.class), any(Blob.class)))
+    when(combinedCache.uploadBlob(any(), any(Digest.class), any(Blob.class), any(Boolean.class)))
         .thenAnswer(
             invocation -> {
               Digest digest = invocation.getArgument(1);
@@ -384,7 +384,7 @@ public class ChunkedBlobUploaderTest {
 
     SettableFuture<Void> cancelledUpload = SettableFuture.create();
     cancelledUpload.cancel(/* mayInterruptIfRunning= */ true);
-    when(combinedCache.uploadBlob(any(), eq(firstChunkDigest), any(Blob.class)))
+    when(combinedCache.uploadBlob(any(), eq(firstChunkDigest), any(Blob.class), any(Boolean.class)))
         .thenReturn(cancelledUpload);
 
     assertThrows(
@@ -416,7 +416,7 @@ public class ChunkedBlobUploaderTest {
 
     SettableFuture<Void> failedUpload = SettableFuture.create();
     failedUpload.setException(new IOException("upload failed"));
-    when(combinedCache.uploadBlob(any(), eq(chunkDigests.get(0)), any(Blob.class)))
+    when(combinedCache.uploadBlob(any(), eq(chunkDigests.get(0)), any(Blob.class), any(Boolean.class)))
         .thenReturn(failedUpload);
 
     Thread uploadThread =
@@ -459,7 +459,7 @@ public class ChunkedBlobUploaderTest {
         .thenReturn(new ByteArrayInputStream(data), new ByteArrayInputStream(new byte[0]));
     when(grpcCacheClient.findMissingDigests(any(), any()))
         .thenReturn(immediateFuture(ImmutableSet.of(secondChunkDigest)));
-    when(combinedCache.uploadBlob(any(), eq(secondChunkDigest), any(Blob.class)))
+    when(combinedCache.uploadBlob(any(), eq(secondChunkDigest), any(Blob.class), any(Boolean.class)))
         .thenAnswer(
             invocation -> {
               Blob blob = invocation.getArgument(2);

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedTransferBenchmark.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedTransferBenchmark.java
@@ -212,7 +212,7 @@ public class ChunkedTransferBenchmark {
           .thenReturn(Futures.immediateFuture(ImmutableSet.copyOf(chunkDigests)));
       when(grpcCacheClient.spliceBlob(any(), any(Digest.class), any(), any()))
           .thenReturn(Futures.immediateVoidFuture());
-      when(combinedCache.uploadBlob(any(), any(Digest.class), any(Blob.class)))
+      when(combinedCache.uploadBlob(any(), any(Digest.class), any(Blob.class), /* force= */ false))
           .thenAnswer(
               invocation ->
                   delayedFuture(null, delayMillis, jitterMillis, latencyJitter, scheduler));

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedTransferBenchmark.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedTransferBenchmark.java
@@ -123,6 +123,7 @@ public class ChunkedTransferBenchmark {
         totalBytes += chunkData.length;
       }
 
+      when(combinedCache.digestUtil()).thenReturn(DIGEST_UTIL);
       when(combinedCache.downloadBlob(any(), any(Digest.class)))
           .thenAnswer(
               invocation ->
@@ -146,8 +147,7 @@ public class ChunkedTransferBenchmark {
 
       FastCdcChunkingConfig chunkingConfig = new FastCdcChunkingConfig(chunkSizeBytes, 2, 0);
       downloader =
-          new ChunkedBlobDownloader(
-              grpcCacheClient, combinedCache, chunkingConfig, DIGEST_UTIL, new ChunkLocationMap());
+          new ChunkedBlobDownloader(grpcCacheClient, combinedCache, chunkingConfig, new ChunkLocationMap());
     }
 
     @TearDown(Level.Trial)
@@ -186,6 +186,7 @@ public class ChunkedTransferBenchmark {
 
       GrpcCacheClient grpcCacheClient = mock(GrpcCacheClient.class);
       CombinedCache combinedCache = mock(CombinedCache.class);
+      when(combinedCache.digestUtil()).thenReturn(DIGEST_UTIL);
 
       byte[] data = new byte[fileSizeBytes];
       new Random(42).nextBytes(data);
@@ -200,7 +201,7 @@ public class ChunkedTransferBenchmark {
 
       FastCdcChunkingConfig chunkingConfig = new FastCdcChunkingConfig(avgChunkSizeBytes, 2, 0);
       uploader =
-          new ChunkedBlobUploader(grpcCacheClient, combinedCache, chunkingConfig, DIGEST_UTIL);
+          new ChunkedBlobUploader(grpcCacheClient, combinedCache, chunkingConfig);
 
       List<Digest> chunkDigests;
       try (var input = file.getInputStream()) {

--- a/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -61,6 +62,7 @@ import com.google.devtools.build.lib.exec.SpawnCheckingCacheEvent;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.exec.util.FakeOwner;
 import com.google.devtools.build.lib.exec.util.SpawnBuilder;
+import com.google.devtools.build.lib.remote.chunking.ChunkingConfig;
 import com.google.devtools.build.lib.remote.common.BlobNotSplittableException;
 import com.google.devtools.build.lib.remote.common.BulkTransferException;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
@@ -95,6 +97,7 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.Map;
+import java.util.Random;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -113,6 +116,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 /** Tests for {@link CombinedCache}. */
@@ -137,6 +141,7 @@ public class CombinedCacheTest {
   private FakeActionInputFileCache fakeFileCache;
 
   private ListeningScheduledExecutorService retryService;
+  @Mock private ByteStreamUploader uploader;
 
   @Before
   public void setUp() throws Exception {
@@ -873,6 +878,47 @@ public class CombinedCacheTest {
   }
 
   @Test
+  public void ensureInputsPresent_chunksInputsOverThreshold() throws Exception {
+    when(uploader.uploadBlobAsync(any(), any(), any())).thenReturn(immediateFuture(null));
+    GrpcCacheClient grpcCacheClient = newChunkingGrpcCacheClient();
+    CombinedCache.Chunking chunking = mock(CombinedCache.Chunking.class);
+    when(chunking.supported()).thenReturn(true);
+    ChunkingConfig config = ChunkingConfig.fromServerCapabilities(grpcCacheClient.serverCapabilities().get());
+    when(chunking.config()).thenReturn(config);
+    ChunkedBlobUploader uploader = mock(ChunkedBlobUploader.class);
+    when(chunking.uploader()).thenReturn(uploader);
+    RemoteExecutionCache remoteCache = spy(new RemoteExecutionCache(
+        grpcCacheClient,
+        /* diskCacheClient= */ null,
+        /* symlinkTemplate= */ null,
+        digestUtil,
+        immediateFuture(chunking)));
+    remoteActionExecutionContext = RemoteActionExecutionContext.create(metadata);
+
+    Path path = execRoot.getRelative("foo");
+    // exceed chunking threshold
+    byte[] blob = new byte[2 * (int) config.chunkingThreshold()];
+    new Random().nextBytes(blob);
+    FileSystemUtils.writeContent(path, blob);
+    SortedMap<PathFragment, Path> inputs = new TreeMap<>();
+    inputs.put(PathFragment.create("foo"), path);
+    doAnswer(unused -> immediateFuture(ImmutableSet.of(digestUtil.compute(path))))
+        .when(grpcCacheClient)
+        .findMissingDigests(any(), any());
+    var merkleTree = merkleTreeComputer.buildForFiles(inputs);
+
+    remoteCache.ensureInputsPresent(
+        remoteActionExecutionContext,
+        merkleTree,
+        ImmutableMap.of(),
+        /* force= */ false,
+        /* remotePathResolver= */ null);
+
+    // could verify individual chunks, or the call itself
+    verify(uploader, times(1)).uploadChunked(eq(remoteActionExecutionContext), any(), any(), any(Boolean.class));
+  }
+
+  @Test
   public void shutdownNow_cancelInProgressUploads() throws Exception {
     RemoteCacheClient remoteCacheClient = spy(new InMemoryCacheClient());
     // Return a future that never completes
@@ -1105,7 +1151,8 @@ public class CombinedCacheTest {
             mock(CallCredentialsProvider.class),
             Options.getDefaults(RemoteOptions.class),
             mock(RemoteRetrier.class),
-            digestUtil));
+            digestUtil,
+            uploader));
   }
 
   private CombinedCache newChunkingCombinedCache(GrpcCacheClient grpcCacheClient) {

--- a/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
@@ -281,7 +281,7 @@ public class CombinedCacheTest {
     Path file = execRoot.getRelative("file");
 
     getFromFuture(
-        combinedCache.uploadBlob(remoteActionExecutionContext, emptyDigest, (Blob) ByteString.EMPTY::newInput));
+        combinedCache.uploadBlob(remoteActionExecutionContext, emptyDigest, (Blob) ByteString.EMPTY::newInput, /* force= */ false));
     assertThat(
             getFromFuture(
                 combinedCache.findMissingDigests(

--- a/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.CacheCapabilities;
@@ -280,7 +281,7 @@ public class CombinedCacheTest {
     Path file = execRoot.getRelative("file");
 
     getFromFuture(
-        combinedCache.uploadBlob(remoteActionExecutionContext, emptyDigest, ByteString.EMPTY));
+        combinedCache.uploadBlob(remoteActionExecutionContext, emptyDigest, (Blob) ByteString.EMPTY::newInput));
     assertThat(
             getFromFuture(
                 combinedCache.findMissingDigests(
@@ -892,17 +893,7 @@ public class CombinedCacheTest {
 
   @Test
   public void uploadFile_chunkedUpload_deduplicatesRemoteUpload() throws Exception {
-    // Spy on a real GrpcCacheClient so that final methods on the RemoteCacheClient base class
-    // (e.g. dedupUpload, uploadFile) execute their real implementations against a properly
-    // initialized casUploadCache.
-    GrpcCacheClient grpcCacheClient =
-        spy(
-            new GrpcCacheClient(
-                mock(ReferenceCountedChannel.class),
-                mock(CallCredentialsProvider.class),
-                Options.getDefaults(RemoteOptions.class),
-                mock(RemoteRetrier.class),
-                digestUtil));
+    GrpcCacheClient grpcCacheClient = newChunkingGrpcCacheClient();
     doAnswer(unused -> chunkingCapabilities()).when(grpcCacheClient).getServerCapabilities();
     doAnswer(unused -> immediateFuture(ImmutableSet.of()))
         .when(grpcCacheClient)
@@ -1106,16 +1097,15 @@ public class CombinedCacheTest {
   }
 
   private GrpcCacheClient newChunkingGrpcCacheClient() throws IOException {
-    GrpcCacheClient grpcCacheClient =
-        spy(
-            new GrpcCacheClient(
-                mock(ReferenceCountedChannel.class),
-                mock(CallCredentialsProvider.class),
-                Options.getDefaults(RemoteOptions.class),
-                mock(RemoteRetrier.class),
-                digestUtil));
-    doAnswer(unused -> chunkingCapabilities()).when(grpcCacheClient).getServerCapabilities();
-    return grpcCacheClient;
+    ReferenceCountedChannel channel = mock(ReferenceCountedChannel.class);
+    when(channel.serverCapabilities()).thenReturn(Futures.immediateFuture(chunkingCapabilities()));
+    return spy(
+        new GrpcCacheClient(
+            channel,
+            mock(CallCredentialsProvider.class),
+            Options.getDefaults(RemoteOptions.class),
+            mock(RemoteRetrier.class),
+            digestUtil));
   }
 
   private CombinedCache newChunkingCombinedCache(GrpcCacheClient grpcCacheClient) {

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -840,7 +840,7 @@ public class GrpcCacheClientTest {
     UploadManifest uploadManifest =
         UploadManifest.create(
             combinedCache.getRemoteCacheCapabilities(),
-            combinedCache.digestUtil,
+            combinedCache.digestUtil(),
             remotePathResolver,
             actionKey,
             action,

--- a/src/test/java/com/google/devtools/build/lib/remote/InMemoryCombinedCache.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/InMemoryCombinedCache.java
@@ -77,7 +77,7 @@ class InMemoryCombinedCache extends RemoteExecutionCache {
 
   Digest addContents(RemoteActionExecutionContext context, byte[] bytes)
       throws IOException, InterruptedException {
-    Digest digest = digestUtil.compute(bytes);
+    Digest digest = digestUtil().compute(bytes);
     Utils.getFromFuture(
         remoteCacheClient.uploadBlob(
             context, digest, ByteString.copyFrom(bytes), /* force= */ false));
@@ -90,13 +90,13 @@ class InMemoryCombinedCache extends RemoteExecutionCache {
   }
 
   Digest addException(String txt, Exception e) {
-    Digest digest = digestUtil.compute(txt.getBytes(UTF_8));
+    Digest digest = digestUtil().compute(txt.getBytes(UTF_8));
     ((InMemoryCacheClient) remoteCacheClient).addDownloadFailure(digest, e);
     return digest;
   }
 
   Digest addException(Message m, Exception e) {
-    Digest digest = digestUtil.compute(m);
+    Digest digest = digestUtil().compute(m);
     ((InMemoryCacheClient) remoteCacheClient).addDownloadFailure(digest, e);
     return digest;
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
@@ -124,6 +124,11 @@ public class InMemoryCacheClient extends RemoteCacheClient {
   }
 
   @Override
+  public ListenableFuture<ServerCapabilities> serverCapabilities() {
+    return Futures.immediateFuture(getServerCapabilities());
+  }
+
+  @Override
   public ListenableFuture<String> getAuthority() {
     return Futures.immediateFuture("");
   }

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CasServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CasServer.java
@@ -103,7 +103,7 @@ final class CasServer extends ContentAddressableStorageImplBase {
       BatchUpdateBlobsResponse.Response.Builder resp = batchResponse.addResponsesBuilder();
       try {
         Digest digest = cache.digestUtil().compute(r.getData().toByteArray());
-        getFromFuture(cache.uploadBlob(context, digest, (Blob) r.getData()::newInput));
+        getFromFuture(cache.uploadBlob(context, digest, (Blob) r.getData()::newInput, /* force= */ false));
         if (!r.getDigest().equals(digest)) {
           String err =
               "Upload digest " + r.getDigest() + " did not match data digest: " + digest;

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CasServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CasServer.java
@@ -36,6 +36,7 @@ import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.remote.Store;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
+import com.google.devtools.build.lib.remote.common.RemoteCacheClient.Blob;
 import com.google.devtools.build.lib.remote.disk.DiskCacheClient;
 import com.google.devtools.build.lib.remote.util.DigestOutputStream;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
@@ -101,8 +102,8 @@ final class CasServer extends ContentAddressableStorageImplBase {
     for (BatchUpdateBlobsRequest.Request r : request.getRequestsList()) {
       BatchUpdateBlobsResponse.Response.Builder resp = batchResponse.addResponsesBuilder();
       try {
-        Digest digest = cache.getDigestUtil().compute(r.getData().toByteArray());
-        getFromFuture(cache.uploadBlob(context, digest, r.getData()));
+        Digest digest = cache.digestUtil().compute(r.getData().toByteArray());
+        getFromFuture(cache.uploadBlob(context, digest, (Blob) r.getData()::newInput));
         if (!r.getDigest().equals(digest)) {
           String err =
               "Upload digest " + r.getDigest() + " did not match data digest: " + digest;
@@ -251,7 +252,7 @@ final class CasServer extends ContentAddressableStorageImplBase {
     try {
       Digest computedDigest;
       OutputStream rawOut = tempPath.getOutputStream();
-      try (DigestOutputStream digestOut = cache.getDigestUtil().newDigestOutputStream(rawOut)) {
+      try (DigestOutputStream digestOut = cache.digestUtil().newDigestOutputStream(rawOut)) {
         for (Digest chunkDigest : chunkDigests) {
           digestOut.write(getFromFuture(cache.downloadBlob(context, chunkDigest)));
         }

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
@@ -162,10 +162,6 @@ class OnDiskBlobStoreCache extends CombinedCache {
     return super.downloadBlob(context, digest);
   }
 
-  public DigestUtil getDigestUtil() {
-    return digestUtil;
-  }
-
   public DiskCacheClient getDiskCacheClient() {
     return checkNotNull(diskCacheClient);
   }


### PR DESCRIPTION
With the RemoteExecutionCache bypassing behavior from CombinedCache's uploadFile, it fails to use chunking behavior when inputs are found missing. Simply calling the uploadFile would attempt to dedup the upload when in the UploadTask context, keyed by its digest, of RemoteExecutionCache, so this change adds a method that ignores the dedup for the digest itself to submit writes through to the remoteCacheClient.

### Motivation
Without this change, inputs are not composed with splicing, a large part of the benefit of CDC

### Build API Changes
None. This corrects an oversight

### Checklist

- [ ] I have added tests for the new use cases (if any).
Sadly, no. The chunking code is unbelievably difficult to test for verification of remote behaviors - instance checks for Grpc cache types, local construction, non-static classes bleeding through to cache assets, interaction with the dedup task set, and more prevent the establishment of clear behavior expression of this component. The modules require a rewrite to be more injectable to resolve this.
- [ ] I have updated the documentation (if applicable).
If there is documentation backing the 'expected behavior of CDC', I'm happy to update it, but I doubt there is.

RELNOTES: None