### PR TITLE
Add an opt-in native POSIX test wrapper

### DIFF
--- a/docs/docs/user-manual.mdx
+++ b/docs/docs/user-manual.mdx
@@ -1496,6 +1496,15 @@ speed gains.
 
 ### Options for `bazel test` {#bazel-test-options}
 
+#### `--[no]incompatible_use_native_posix_test_wrapper` {#incompatible-use-native-posix-test-wrapper}
+
+This option is disabled by default. Enable it to run Linux and macOS tests with
+a native test wrapper instead of `test-setup.sh`. Windows continues to use its
+existing native test wrapper. A C++ toolchain for the execution platform may be
+needed when that platform differs from the host. On Linux and macOS, tests using
+a nondefault test execution group or an execution platform without an
+operating-system constraint continue to use `test-setup.sh`.
+
 #### `--cache_test_results=(yes|no|auto)` (`-t`) {#cache-test-results}
 
 If this option is set to 'auto' (the default) then Bazel will only rerun a test if any of the

--- a/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
@@ -130,6 +130,25 @@ public class BaseRuleClasses {
         TestConfiguration.class, defaultValue, COVERAGE_SUPPORT_CONFIGURATION_RESOLVER);
   }
 
+  @SerializationConstant @VisibleForSerialization
+  static final Resolver<TestConfiguration, Label>
+      NATIVE_POSIX_TEST_WRAPPER_CONFIGURATION_RESOLVER =
+          (rule, attributes, configuration) -> {
+            if (!configuration.incompatibleUseNativePosixTestWrapper()) {
+              return null;
+            }
+            Label existingWrapper = attributes.get("$test_wrapper", BuildType.LABEL);
+            return Label.createUnvalidated(
+                existingWrapper.getPackageIdentifier(), "native_posix_test_wrapper");
+          };
+
+  public static LabelLateBoundDefault<TestConfiguration> nativePosixTestWrapperAttribute() {
+    return LabelLateBoundDefault.fromTargetConfiguration(
+        TestConfiguration.class,
+        /* defaultValue= */ null,
+        NATIVE_POSIX_TEST_WRAPPER_CONFIGURATION_RESOLVER);
+  }
+
   public static final String DEFAULT_COVERAGE_REPORT_GENERATOR_VALUE =
       "//tools/test:coverage_report_generator";
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -297,6 +297,13 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
                     .singleArtifact()
                     .value(labelCache.get(toolsRepository + "//tools/test:test_wrapper")))
             .add(
+                attr(":native_posix_test_wrapper", LABEL)
+                    .cfg(
+                        ExecutionTransitionFactory.createFactory(
+                            DEFAULT_TEST_RUNNER_EXEC_GROUP_NAME))
+                    .singleArtifact()
+                    .value(BaseRuleClasses.nativePosixTestWrapperAttribute()))
+            .add(
                 attr("$xml_writer", LABEL)
                     .cfg(
                         ExecutionTransitionFactory.createFactory(

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -239,14 +239,24 @@ public final class TestActionBuilder {
     ArtifactRoot root = ruleContext.getTestLogsDirectory();
     ActionOwner actionOwner = getTestActionOwner();
     String unrunnableReason = getUnrunnableReason();
-    boolean isExecutedOnWindows =
-        getOsFromConstraintsOrHost(actionOwner.getExecutionPlatform()) == OS.WINDOWS;
+    OS executionOs = getOsFromConstraintsOrHost(actionOwner.getExecutionPlatform());
+    boolean isExecutedOnWindows = executionOs == OS.WINDOWS;
+    Artifact testWrapper = ruleContext.getPrerequisiteArtifact("$test_wrapper");
+    Artifact nativePosixTestWrapper =
+        ruleContext.getPrerequisiteArtifact(":native_posix_test_wrapper");
+    boolean usesNativePosixTestWrapper =
+        testConfiguration.incompatibleUseNativePosixTestWrapper()
+            && (executionOs == OS.LINUX || executionOs == OS.DARWIN)
+            && DEFAULT_TEST_RUNNER_EXEC_GROUP_NAME.equals(getTestExecGroupName())
+            && nativePosixTestWrapper != null
+            && !nativePosixTestWrapper.equals(testWrapper);
+    boolean usesNativeTestWrapper = isExecutedOnWindows || usesNativePosixTestWrapper;
 
     NestedSetBuilder<Artifact> inputsBuilder = NestedSetBuilder.stableOrder();
     inputsBuilder.addTransitive(
         NestedSetBuilder.create(Order.STABLE_ORDER, runfilesSupport.getRunfilesTreeArtifact()));
 
-    if (!isExecutedOnWindows) {
+    if (!usesNativeTestWrapper) {
       NestedSet<Artifact> testRuntime =
           PrerequisiteArtifacts.nestedSet(
               ruleContext.getRulePrerequisitesCollection(), "$test_runtime");
@@ -262,8 +272,10 @@ public final class TestActionBuilder {
 
     Artifact testActionExecutable =
         isExecutedOnWindows
-            ? ruleContext.getPrerequisiteArtifact("$test_wrapper")
-            : ruleContext.getPrerequisiteArtifact("$test_setup_script");
+            ? testWrapper
+            : usesNativePosixTestWrapper
+                ? nativePosixTestWrapper
+                : ruleContext.getPrerequisiteArtifact("$test_setup_script");
 
     inputsBuilder.add(testActionExecutable);
     Artifact testXmlGeneratorExecutable =
@@ -460,7 +472,7 @@ public final class TestActionBuilder {
                 run,
                 config,
                 ruleContext.getWorkspaceName(),
-                (!isExecutedOnWindows || executionSettings.needsShell())
+                (!usesNativeTestWrapper || executionSettings.needsShell())
                     ? ShToolchain.getPathForPlatform(
                         ruleContext.getConfiguration(), actionOwner.getExecutionPlatform())
                     : null,

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -359,6 +359,21 @@ public class TestConfiguration extends Fragment {
     public abstract boolean getIncompatibleExclusiveTestSandboxed();
 
     @Option(
+        name = "incompatible_use_native_posix_test_wrapper",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.TESTING,
+        effectTags = {
+          OptionEffectTag.CHANGES_INPUTS,
+          OptionEffectTag.LOADING_AND_ANALYSIS,
+          OptionEffectTag.TEST_RUNNER
+        },
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+        help =
+            "Use the native C++ test wrapper on Linux and macOS instead of test-setup.sh. "
+                + "See https://github.com/bazelbuild/bazel/issues/15838.")
+    public abstract boolean getIncompatibleUseNativePosixTestWrapper();
+
+    @Option(
         name = "experimental_split_coverage_postprocessing",
         defaultValue = FlagConstants.DEFAULT_EXPERIMENTAL_SPLIT_COVERAGE_POSTPROCESSING,
         documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
@@ -484,6 +499,10 @@ public class TestConfiguration extends Fragment {
 
   public boolean incompatibleExclusiveTestSandboxed() {
     return options.getIncompatibleExclusiveTestSandboxed();
+  }
+
+  public boolean incompatibleUseNativePosixTestWrapper() {
+    return options.getIncompatibleUseNativePosixTestWrapper();
   }
 
   public boolean splitCoveragePostProcessing() {

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -378,6 +378,17 @@ launcher_flag_alias(
         )
 
         filegroup(
+            name = "native_posix_test_wrapper",
+            srcs = select({
+                "@platforms//os:linux": ["native_posix_test_wrapper_bin"],
+                "@platforms//os:macos": ["native_posix_test_wrapper_bin"],
+                "@platforms//os:osx": ["native_posix_test_wrapper_bin"],
+                "//conditions:default": [":test_wrapper"],
+            }),
+            visibility = ["//visibility:public"],
+        )
+
+        filegroup(
             name = "xml_writer",
             srcs = ["xml_writer_bin"],
         )

--- a/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
@@ -892,6 +892,105 @@ public class TestActionBuilderTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testNativePosixTestWrapperDisabledByDefault() throws Exception {
+    useNativePosixTestWrapperExecutionPlatform("linux");
+
+    ConfiguredTarget testTarget = getConfiguredTarget("//tests:small_test_2");
+    TestRunnerAction testAction =
+        (TestRunnerAction)
+            getGeneratingAction(Iterables.getOnlyElement(getTestStatusArtifacts(testTarget)));
+
+    assertThat(getPrerequisites(testTarget, ":native_posix_test_wrapper")).isEmpty();
+    assertThat(testAction.getTestSetupScript().getFilename()).isEqualTo("test-setup.sh");
+    assertThat(testAction.getShExecutableMaybe()).isNotNull();
+  }
+
+  @Test
+  public void testNativePosixTestWrapperEnabled(
+      @TestParameter({"linux", "macos"}) String executionOs,
+      @TestParameter boolean trimTestConfiguration)
+      throws Exception {
+    useNativePosixTestWrapperExecutionPlatform(
+        executionOs,
+        "--incompatible_use_native_posix_test_wrapper",
+        "--trim_test_configuration=" + trimTestConfiguration);
+
+    ConfiguredTarget testTarget = getConfiguredTarget("//tests:small_test_2");
+    TestRunnerAction testAction =
+        (TestRunnerAction)
+            getGeneratingAction(Iterables.getOnlyElement(getTestStatusArtifacts(testTarget)));
+
+    assertThat(getPrerequisites(testTarget, ":native_posix_test_wrapper")).hasSize(1);
+    assertThat(testAction.getTestSetupScript().getFilename())
+        .isEqualTo("native_posix_test_wrapper_bin");
+    assertThat(testAction.getTestXmlGeneratorScript().getFilename())
+        .isEqualTo("test-xml-generator.sh");
+    assertThat(testAction.getShExecutableMaybe()).isNull();
+    assertThat(
+            testAction.getInputs().toList().stream()
+                .map(Artifact::getFilename)
+                .collect(toImmutableList()))
+        .doesNotContain("test-setup.sh");
+  }
+
+  @Test
+  public void testNativePosixTestWrapperDoesNotReplaceWindowsWrapper(
+      @TestParameter boolean useNativePosixTestWrapper) throws Exception {
+    useNativePosixTestWrapperExecutionPlatform(
+        "windows", "--incompatible_use_native_posix_test_wrapper=" + useNativePosixTestWrapper);
+
+    ConfiguredTarget testTarget = getConfiguredTarget("//tests:small_test_2");
+    TestRunnerAction testAction =
+        (TestRunnerAction)
+            getGeneratingAction(Iterables.getOnlyElement(getTestStatusArtifacts(testTarget)));
+
+    assertThat(testAction.getTestSetupScript().getFilename()).isEqualTo("test_wrapper_bin");
+    assertThat(testAction.getTestXmlGeneratorScript().getFilename()).isEqualTo("xml_writer_bin");
+    assertThat(testAction.getShExecutableMaybe()).isNull();
+  }
+
+  @Test
+  public void testNativePosixTestWrapperFallsBackWithoutOsConstraint() throws Exception {
+    useNativePosixTestWrapperExecutionPlatform(
+        "", "--incompatible_use_native_posix_test_wrapper");
+
+    ConfiguredTarget testTarget = getConfiguredTarget("//tests:small_test_2");
+    TestRunnerAction testAction =
+        (TestRunnerAction)
+            getGeneratingAction(Iterables.getOnlyElement(getTestStatusArtifacts(testTarget)));
+
+    assertThat(getPrerequisiteArtifacts(testTarget, ":native_posix_test_wrapper"))
+        .containsExactly(
+            Iterables.getOnlyElement(getPrerequisiteArtifacts(testTarget, "$test_wrapper")));
+    assertThat(testAction.getTestSetupScript().getFilename())
+        .isEqualTo(OS.getCurrent() == OS.WINDOWS ? "test_wrapper_bin" : "test-setup.sh");
+  }
+
+  private void useNativePosixTestWrapperExecutionPlatform(
+      String executionOs, String... additionalOptions) throws Exception {
+    scratch.file(
+        "test_platform/BUILD",
+        """
+        platform(
+            name = "execution_platform",
+            constraint_values = [%s],
+        )
+        """
+            .formatted(
+                executionOs.isEmpty()
+                    ? ""
+                    : "\"" + TestConstants.CONSTRAINTS_PACKAGE_ROOT + "os:" + executionOs + "\""));
+    ImmutableList<String> options =
+        ImmutableList.<String>builder()
+            .add("--platforms=//test_platform:execution_platform")
+            .add("--host_platform=//test_platform:execution_platform")
+            .add("--extra_execution_platforms=//test_platform:execution_platform")
+            .add(additionalOptions)
+            .build();
+    useConfiguration(options.toArray(new String[0]));
+  }
+
+  @Test
   public void testRunUnderConfiguredForTestExecPlatform() throws Exception {
     scratch.file(
         "some_test.bzl",
@@ -1067,7 +1166,8 @@ public class TestActionBuilderTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testCommandLineBuiltForTestExecutionOS_withExecutionInfo() throws Exception {
+  public void testCommandLineBuiltForTestExecutionOS_withExecutionInfo(
+      @TestParameter boolean useNativePosixTestWrapper) throws Exception {
     scratch.file(
         "some_test.bzl",
         """
@@ -1130,13 +1230,16 @@ public class TestActionBuilderTest extends BuildViewTestCase {
         """
             .formatted(TestConstants.CONSTRAINTS_PACKAGE_ROOT));
     useConfiguration(
+        "--incompatible_use_native_posix_test_wrapper=" + useNativePosixTestWrapper,
         "--platforms=//:windows",
         "--host_platform=//:windows",
         "--extra_execution_platforms=//:windows,//:linux,//:macos");
 
-    Action testAction = getGeneratingAction(getTestStatusArtifacts("//:some_test").get(0));
-    assertThat(((TestRunnerAction) testAction).getExecutionSettings().getExecutionOs())
-        .isEqualTo(OS.LINUX);
+    TestRunnerAction testAction =
+        (TestRunnerAction) getGeneratingAction(getTestStatusArtifacts("//:some_test").get(0));
+    assertThat(testAction.getExecutionSettings().getExecutionOs()).isEqualTo(OS.LINUX);
+    assertThat(testAction.getTestSetupScript().getFilename()).isEqualTo("test-setup.sh");
+    assertThat(testAction.getShExecutableMaybe()).isNotNull();
   }
 
   private ImmutableList<Artifact.DerivedArtifact> getTestStatusArtifacts(

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -1046,6 +1046,31 @@ EOF
   assert_equals "$(cat "$outputs_manifest")" "$(cat expected_manifest)"
 }
 
+function test_native_posix_test_wrapper_processes_undeclared_outputs() {
+  setup_undeclared_outputs_test
+
+  bazel test \
+      --incompatible_use_native_posix_test_wrapper \
+      --zip_undeclared_test_outputs \
+      //dir:test > "$TEST_log" 2>&1 \
+      || fail "native POSIX test wrapper failed"
+
+  local -r outputs_zip=bazel-testlogs/dir/test/test.outputs/outputs.zip
+  local -r outputs_manifest=bazel-testlogs/dir/test/test.outputs_manifest/MANIFEST
+  assert_exists "$outputs_zip"
+  assert_exists "$outputs_manifest"
+  assert_contains $'deeply/nested/index.html\t16\ttext/html' "$outputs_manifest"
+  assert_contains $'text.txt\t10\ttext/plain' "$outputs_manifest"
+
+  bazel aquery \
+      --incompatible_use_native_posix_test_wrapper \
+      --output=text \
+      'mnemonic(TestRunner, //dir:test)' > "$TEST_log" 2>&1 \
+      || fail "failed to inspect native POSIX test wrapper"
+  expect_log 'Command Line: .*posix_tw'
+  expect_not_log 'test-setup\.sh'
+}
+
 function test_undeclared_outputs_are_zipped_multiple_attempts() {
   setup_undeclared_outputs_test
 
@@ -1381,6 +1406,44 @@ EOF
   bazel build --test_env=FOO=bar "${pkg}:my_rule" >$TEST_log 2>&1 \
    || fail "expected build to pass"
   expect_not_log "my_rule is being analyzed"
+}
+
+function test_failing_test_runs_without_execution_os_constraint() {
+  mkdir -p osless
+  cat > osless/defs.bzl <<'EOF'
+def _failing_test_impl(ctx):
+    executable = ctx.actions.declare_file(ctx.label.name + ".sh")
+    ctx.actions.write(
+        output = executable,
+        content = "#!/bin/sh\necho OSLESS_TEST_EXECUTED\nexit 42\n",
+        is_executable = True,
+    )
+    return [DefaultInfo(executable = executable)]
+
+failing_test = rule(implementation = _failing_test_impl, test = True)
+EOF
+  cat > osless/BUILD <<'EOF'
+load(":defs.bzl", "failing_test")
+
+constraint_setting(name = "test_runner")
+constraint_value(name = "osless_runner", constraint_setting = ":test_runner")
+platform(name = "execution_platform", constraint_values = [":osless_runner"])
+failing_test(
+    name = "failing_test",
+    exec_compatible_with = [":osless_runner"],
+    exec_group_compatible_with = {"test": [":osless_runner"]},
+)
+EOF
+
+  if bazel test \
+      --incompatible_use_native_posix_test_wrapper \
+      --platforms=//osless:execution_platform \
+      --extra_execution_platforms=//osless:execution_platform \
+      --test_output=all \
+      //osless:failing_test > "$TEST_log" 2>&1; then
+    fail "failing test passed without executing on its OS-less platform"
+  fi
+  expect_log "OSLESS_TEST_EXECUTED"
 }
 
 run_suite "bazel test tests"

--- a/src/test/shell/bazel/testdata/embedded_tools_srcs_deps
+++ b/src/test/shell/bazel/testdata/embedded_tools_srcs_deps
@@ -1,3 +1,4 @@
+//tools/test:posix_tw
 //tools/test:tw
 //tools/test:tw_lib
 //tools/test:xml

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -76,15 +76,36 @@ cc_binary(
     deps = [":tw_lib"],
 )
 
-# Test wrapper binary to run tests on Windows.
-# See https://github.com/bazelbuild/bazel/issues/5508
+cc_binary(
+    name = "posix_tw",
+    srcs = ["posix/tw_main.cc"],
+    target_compatible_with = select({
+        "@bazel_tools//src/conditions:darwin": [],
+        "@bazel_tools//src/conditions:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["//visibility:private"],
+    deps = [":tw_lib"],
+)
+
+# Shared test wrapper implementation for Windows, Linux, and macOS.
 cc_library(
     name = "tw_lib",
-    srcs = select({
+    srcs = ["test_wrapper_common.cc"] + select({
+        "@bazel_tools//src/conditions:darwin": [
+            "posix/tw.cc",
+            "posix/tw_outputs.cc",
+        ],
+        "@bazel_tools//src/conditions:linux": [
+            "posix/tw.cc",
+            "posix/tw_outputs.cc",
+        ],
         "@bazel_tools//src/conditions:windows": ["windows/tw.cc"],
         "//conditions:default": ["empty_test_wrapper.cc"],
     }),
-    hdrs = select({
+    hdrs = ["test_wrapper_common.h"] + select({
+        "@bazel_tools//src/conditions:darwin": ["posix/tw_outputs.h"],
+        "@bazel_tools//src/conditions:linux": ["posix/tw_outputs.h"],
         "@bazel_tools//src/conditions:windows": ["windows/tw.h"],
         "//conditions:default": [],
     }),
@@ -95,13 +116,14 @@ cc_library(
         "//conditions:default": [],
     }),
     visibility = ["//visibility:private"],
-    deps = select({
+    deps = [
+        "//src/main/cpp/util:filesystem",
+        "//third_party/ijar:zip",
+    ] + select({
         "@bazel_tools//src/conditions:windows": [
-            "//src/main/cpp/util:filesystem",
             "//src/main/cpp/util:strings",
             "//src/main/native/windows:lib-file",
             "//src/main/native/windows:lib-process",
-            "//third_party/ijar:zip",
             "@rules_cc//cc/runfiles",
         ],
         "//conditions:default": [],
@@ -111,18 +133,20 @@ cc_library(
 cc_test(
     name = "tw_test",
     srcs = select({
+        "@bazel_tools//src/conditions:darwin": ["posix/tw_test.cc"],
+        "@bazel_tools//src/conditions:linux": ["posix/tw_test.cc"],
         "@bazel_tools//src/conditions:windows": ["windows/tw_test.cc"],
         "//conditions:default": ["empty_test.cc"],
     }),
     deps = [
         ":tw_lib",
         "//src/main/cpp/util:filesystem",
-        "//src/test/cpp/util:windows_test_util",
+        "//third_party/ijar:zip",
         "@com_google_googletest//:gtest_main",
     ] + select({
         "@bazel_tools//src/conditions:windows": [
             "//src/main/native/windows:lib-file",
-            "//third_party/ijar:zip",
+            "//src/test/cpp/util:windows_test_util",
         ],
         "//conditions:default": [],
     }),
@@ -142,8 +166,22 @@ filegroup(
         "default_test_toolchain.bzl",
         "extensions.bzl",
         "generate-xml.sh",
+        "posix/tw.cc",
+        "posix/tw_main.cc",
+        "posix/tw_outputs.cc",
+        "posix/tw_outputs.h",
         "test-setup.sh",
+        "test_wrapper_common.cc",
+        "test_wrapper_common.h",
     ] + select({
+        "@bazel_tools//src/conditions:darwin": [
+            "dummy.sh",
+            "posix_tw",
+        ],
+        "@bazel_tools//src/conditions:linux": [
+            "dummy.sh",
+            "posix_tw",
+        ],
         "@bazel_tools//src/conditions:windows": [
             "tw",
             "xml",

--- a/tools/test/BUILD.tools
+++ b/tools/test/BUILD.tools
@@ -1,3 +1,5 @@
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load(":default_test_toolchain.bzl", "bool_flag", "empty_toolchain")
 
@@ -123,6 +125,59 @@ filegroup(
     srcs = select({
         "@bazel_tools//src/conditions:windows": ["tw.exe"],
         "//conditions:default": ["dummy.sh"],
+    }),
+)
+
+config_setting(
+    name = "matches_host_constraints",
+    constraint_values = HOST_CONSTRAINTS,
+    visibility = ["//visibility:private"],
+)
+
+cc_binary(
+    name = "compiled_posix_test_wrapper",
+    srcs = [
+        "posix/tw.cc",
+        "posix/tw_main.cc",
+        "posix/tw_outputs.cc",
+        "posix/tw_outputs.h",
+        "test_wrapper_common.cc",
+        "test_wrapper_common.h",
+    ],
+    target_compatible_with = select({
+        "@bazel_tools//src/conditions:darwin": [],
+        "@bazel_tools//src/conditions:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/main/cpp/util:filesystem",
+        "//third_party/ijar:zip",
+    ],
+)
+
+filegroup(
+    name = "native_posix_test_wrapper_binary",
+    srcs = select({
+        ":matches_host_constraints": glob(
+            ["posix_tw*"],
+            allow_empty = True,
+        ),
+        "//conditions:default": [":compiled_posix_test_wrapper"],
+    }),
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "native_posix_test_wrapper",
+    srcs = select({
+        "@bazel_tools//src/conditions:darwin": [
+            ":native_posix_test_wrapper_binary",
+        ],
+        "@bazel_tools//src/conditions:linux": [
+            ":native_posix_test_wrapper_binary",
+        ],
+        "//conditions:default": [":test_wrapper"],
     }),
 )
 

--- a/tools/test/posix/tw.cc
+++ b/tools/test/posix/tw.cc
@@ -1,0 +1,847 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pwd.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "tools/test/posix/tw_outputs.h"
+
+namespace bazel {
+namespace tools {
+namespace test_wrapper {
+namespace {
+
+constexpr char kPagerHeader[] =
+    "exec ${PAGER:-/usr/bin/less} \"$0\" || exit 1\n";
+constexpr char kTestLogDelimiter[] =
+    "--------------------------------------------------------------------------"
+    "---\n";
+constexpr char kMissingRunfilesDirectory[] =
+    "ERROR: RUNFILES_DIR does not exist. This can happen when using "
+    "--nobuild_runfile_manifests with local execution. Use a different "
+    "execution strategy, or build with runfile manifests.";
+constexpr char kRlocationFunctionName[] = "BASH_FUNC_rlocation%%";
+constexpr char kRlocationFunction[] =
+    "() {  caller 0 | { read LINE SUB FILE; "
+    "echo >&2 \"ERROR: rlocation is no longer implicitly provided by Bazel's "
+    "test setup, but called from $SUB in line $LINE of $FILE. Please use "
+    "https://github.com/bazelbuild/rules_shell/blob/main/shell/runfiles/"
+    "runfiles.bash instead.\"; exit 1; }; }";
+
+constexpr std::array<int, 17> kForwardedSignals = {
+    SIGHUP,   SIGINT,  SIGQUIT, SIGTERM,   SIGALRM, SIGUSR1,
+    SIGUSR2,  SIGPIPE, SIGPROF, SIGVTALRM, SIGXCPU, SIGXFSZ,
+    SIGWINCH, SIGTSTP, SIGTTIN, SIGTTOU,   SIGCONT,
+};
+
+volatile sig_atomic_t g_child_process_group = 0;
+volatile sig_atomic_t g_received_sigterm = 0;
+
+std::string GetEnv(const char* name) {
+  const char* value = getenv(name);
+  return value == nullptr ? std::string() : std::string(value);
+}
+
+bool SetEnv(const char* name, const std::string& value) {
+  if (setenv(name, value.c_str(), 1) == 0) {
+    return true;
+  }
+  fprintf(stderr, "ERROR: could not set %s: %s\n", name, strerror(errno));
+  return false;
+}
+
+bool UnsetEnv(const char* name) {
+  if (unsetenv(name) == 0) {
+    return true;
+  }
+  fprintf(stderr, "ERROR: could not unset %s: %s\n", name, strerror(errno));
+  return false;
+}
+
+bool IsAbsolute(const std::string& path) {
+  if (path.empty()) {
+    return false;
+  }
+  if (path[0] == '/') {
+    return true;
+  }
+  return path.size() >= 3 &&
+         ((path[0] >= 'a' && path[0] <= 'z') ||
+          (path[0] >= 'A' && path[0] <= 'Z')) &&
+         path[1] == ':' && (path[2] == '/' || path[2] == '\\');
+}
+
+std::string JoinPath(const std::string& parent, const std::string& child) {
+  if (parent.empty() || IsAbsolute(child)) {
+    return child;
+  }
+  if (parent.back() == '/') {
+    return parent + child;
+  }
+  return parent + "/" + child;
+}
+
+std::string Dirname(std::string path) {
+  while (path.size() > 1 && path.back() == '/') {
+    path.pop_back();
+  }
+  const std::string::size_type separator = path.find_last_of('/');
+  if (separator == std::string::npos) {
+    return ".";
+  }
+  return separator == 0 ? "/" : path.substr(0, separator);
+}
+
+bool GetCurrentDirectory(std::string* result) {
+  const std::string logical_directory = GetEnv("PWD");
+  struct stat logical_info;
+  struct stat current_info;
+  if (IsAbsolute(logical_directory) &&
+      stat(logical_directory.c_str(), &logical_info) == 0 &&
+      stat(".", &current_info) == 0 &&
+      logical_info.st_dev == current_info.st_dev &&
+      logical_info.st_ino == current_info.st_ino) {
+    *result = logical_directory;
+    return true;
+  }
+
+  size_t buffer_size = 256;
+  while (buffer_size <= 1024 * 1024) {
+    std::vector<char> buffer(buffer_size);
+    if (getcwd(buffer.data(), buffer.size()) != nullptr) {
+      *result = buffer.data();
+      return true;
+    }
+    if (errno != ERANGE) {
+      break;
+    }
+    buffer_size *= 2;
+  }
+  fprintf(stderr, "ERROR: could not determine current directory: %s\n",
+          strerror(errno));
+  return false;
+}
+
+bool IsDirectory(const std::string& path) {
+  struct stat info;
+  return stat(path.c_str(), &info) == 0 && S_ISDIR(info.st_mode);
+}
+
+bool PathExists(const std::string& path) {
+  struct stat info;
+  return stat(path.c_str(), &info) == 0;
+}
+
+bool PathOrSymlinkExists(const std::string& path) {
+  struct stat info;
+  return lstat(path.c_str(), &info) == 0;
+}
+
+bool MakeDirectories(const std::string& path) {
+  if (path.empty()) {
+    return true;
+  }
+  std::string current;
+  if (path[0] == '/') {
+    current = "/";
+  }
+  size_t position = current.size();
+  while (position < path.size()) {
+    const size_t separator = path.find('/', position);
+    const size_t length = separator == std::string::npos
+                              ? path.size() - position
+                              : separator - position;
+    if (length != 0) {
+      current = JoinPath(current, path.substr(position, length));
+      if (mkdir(current.c_str(), 0777) != 0 &&
+          (errno != EEXIST || !IsDirectory(current))) {
+        fprintf(stderr, "ERROR: could not create directory %s: %s\n",
+                current.c_str(), strerror(errno));
+        return false;
+      }
+    }
+    if (separator == std::string::npos) {
+      break;
+    }
+    position = separator + 1;
+  }
+  return true;
+}
+
+bool AbsolutizeEnv(const char* name, const std::string& exec_root,
+                   bool preserve_empty, std::string* result = nullptr) {
+  std::string value = GetEnv(name);
+  if (!(preserve_empty && value.empty()) && !IsAbsolute(value)) {
+    value = JoinPath(exec_root, value);
+  }
+  if (result != nullptr) {
+    *result = value;
+  }
+  return SetEnv(name, value);
+}
+
+bool ExportUserName() {
+  if (!GetEnv("USER").empty()) {
+    return true;
+  }
+  long suggested_size = sysconf(_SC_GETPW_R_SIZE_MAX);
+  size_t buffer_size =
+      suggested_size <= 0 ? 16384 : static_cast<size_t>(suggested_size);
+  buffer_size = std::min<size_t>(buffer_size, 1024 * 1024);
+
+  while (buffer_size <= 1024 * 1024) {
+    std::vector<char> buffer(buffer_size);
+    struct passwd account;
+    struct passwd* result = nullptr;
+    const int status =
+        getpwuid_r(getuid(), &account, buffer.data(), buffer.size(), &result);
+    if (status == 0 && result != nullptr) {
+      return SetEnv("USER", account.pw_name);
+    }
+    if (status != ERANGE) {
+      break;
+    }
+    buffer_size *= 2;
+  }
+
+  const std::string login = GetEnv("LOGNAME");
+  if (!login.empty()) {
+    return SetEnv("USER", login);
+  }
+  return SetEnv("USER", std::to_string(static_cast<unsigned long>(getuid())));
+}
+
+bool ExportGtestVariables(const std::string& test_tmpdir) {
+  const char* total_shards = getenv("TEST_TOTAL_SHARDS");
+  if (total_shards != nullptr && total_shards[0] != '\0' &&
+      strcmp(total_shards, "0") != 0) {
+    if (!SetEnv("GTEST_SHARD_INDEX", GetEnv("TEST_SHARD_INDEX")) ||
+        !SetEnv("GTEST_TOTAL_SHARDS", total_shards) ||
+        !SetEnv("GTEST_SHARD_STATUS_FILE", GetEnv("TEST_SHARD_STATUS_FILE"))) {
+      return false;
+    }
+  }
+  return SetEnv("GTEST_TMP_DIR", test_tmpdir);
+}
+
+bool PrepareEnvironment(const std::string& exec_root,
+                        UndeclaredOutputs* undeclared_outputs,
+                        std::string* test_srcdir) {
+  if (!SetEnv("BAZEL_TEST", "1")) {
+    return false;
+  }
+
+  for (const char* name :
+       {"TEST_PREMATURE_EXIT_FILE", "TEST_WARNINGS_OUTPUT_FILE",
+        "TEST_LOGSPLITTER_OUTPUT_FILE", "TEST_INFRASTRUCTURE_FAILURE_FILE",
+        "TEST_UNUSED_RUNFILES_LOG_FILE"}) {
+    if (!AbsolutizeEnv(name, exec_root, false)) {
+      return false;
+    }
+  }
+
+  if (!AbsolutizeEnv("TEST_UNDECLARED_OUTPUTS_DIR", exec_root, false,
+                     &undeclared_outputs->root) ||
+      !AbsolutizeEnv("TEST_UNDECLARED_OUTPUTS_MANIFEST", exec_root, false,
+                     &undeclared_outputs->manifest) ||
+      !AbsolutizeEnv("TEST_UNDECLARED_OUTPUTS_ZIP", exec_root, true,
+                     &undeclared_outputs->zip) ||
+      !AbsolutizeEnv("TEST_UNDECLARED_OUTPUTS_ANNOTATIONS", exec_root, false,
+                     &undeclared_outputs->annotations) ||
+      !AbsolutizeEnv("TEST_UNDECLARED_OUTPUTS_ANNOTATIONS_DIR", exec_root,
+                     false, &undeclared_outputs->annotations_dir) ||
+      !AbsolutizeEnv("TEST_SRCDIR", exec_root, false, test_srcdir)) {
+    return false;
+  }
+
+  std::string test_tmpdir;
+  if (!AbsolutizeEnv("TEST_TMPDIR", exec_root, false, &test_tmpdir)) {
+    return false;
+  }
+  if (!IsAbsolute(GetEnv("HOME")) && !SetEnv("HOME", test_tmpdir)) {
+    return false;
+  }
+
+  std::string xml_output;
+  if (!AbsolutizeEnv("XML_OUTPUT_FILE", exec_root, false, &xml_output) ||
+      !SetEnv("GUNIT_OUTPUT", "xml:" + xml_output) || !ExportUserName()) {
+    return false;
+  }
+
+  const std::string shard_status = GetEnv("TEST_SHARD_STATUS_FILE");
+  if (!shard_status.empty()) {
+    std::string absolute_shard_status;
+    if (!AbsolutizeEnv("TEST_SHARD_STATUS_FILE", exec_root, false,
+                       &absolute_shard_status) ||
+        !MakeDirectories(Dirname(absolute_shard_status))) {
+      return false;
+    }
+  }
+
+  std::string runfiles_dir;
+  if (!AbsolutizeEnv("RUNFILES_DIR", exec_root, false, &runfiles_dir)) {
+    return false;
+  }
+  if (!IsDirectory(runfiles_dir)) {
+    fprintf(stderr, "%s\n", kMissingRunfilesDirectory);
+    return false;
+  }
+  if (!AbsolutizeEnv("JAVA_RUNFILES", exec_root, false) ||
+      !AbsolutizeEnv("PYTHON_RUNFILES", exec_root, false) ||
+      !MakeDirectories(Dirname(xml_output)) ||
+      !MakeDirectories(undeclared_outputs->root) ||
+      !MakeDirectories(undeclared_outputs->annotations_dir) ||
+      !MakeDirectories(test_tmpdir) ||
+      !UnsetEnv("TEST_UNDECLARED_OUTPUTS_MANIFEST") ||
+      !UnsetEnv("TEST_UNDECLARED_OUTPUTS_ZIP") ||
+      !UnsetEnv("TEST_UNDECLARED_OUTPUTS_ANNOTATIONS") ||
+      !ExportGtestVariables(test_tmpdir)) {
+    return false;
+  }
+
+  const std::string runfiles_manifest = JoinPath(*test_srcdir, "MANIFEST");
+  const bool manifest_was_exported =
+      getenv("RUNFILES_MANIFEST_FILE") != nullptr;
+  if ((manifest_was_exported || (GetEnv("RUNFILES_MANIFEST_ONLY") == "1" &&
+                                 PathExists(runfiles_manifest))) &&
+      !SetEnv("RUNFILES_MANIFEST_FILE", runfiles_manifest)) {
+    return false;
+  }
+  return true;
+}
+
+bool ChangeToRunfiles(const std::string& exec_root,
+                      const std::string& test_srcdir, bool coverage_mode) {
+  if (coverage_mode) {
+    return true;
+  }
+
+  std::string directory = test_srcdir;
+  const std::string test_workspace = GetEnv("TEST_WORKSPACE");
+  if (!test_workspace.empty()) {
+    directory = JoinPath(directory, test_workspace);
+  }
+  if (!GetEnv("RUNTEST_PRESERVE_CWD").empty()) {
+    directory = exec_root;
+  }
+  if (chdir(directory.c_str()) != 0) {
+    fprintf(stderr, "Could not chdir %s: %s\n", directory.c_str(),
+            strerror(errno));
+    return false;
+  }
+  return SetEnv("PWD", directory);
+}
+
+bool ResolveRunfile(const std::string& test_srcdir, const std::string& runfile,
+                    std::string* result) {
+  if (IsAbsolute(runfile)) {
+    *result = runfile;
+    return true;
+  }
+
+  const std::string direct_path = JoinPath(test_srcdir, runfile);
+  if (PathExists(direct_path)) {
+    *result = direct_path;
+    return true;
+  }
+
+  std::ifstream manifest(JoinPath(test_srcdir, "MANIFEST"));
+  std::string line;
+  const std::string prefix = runfile + " ";
+  while (std::getline(manifest, line)) {
+    if (line.compare(0, prefix.size(), prefix) == 0) {
+      *result = line.substr(prefix.size());
+      return true;
+    }
+  }
+
+  fprintf(stderr, "ERROR: could not resolve test executable %s\n",
+          runfile.c_str());
+  return false;
+}
+
+bool ResolveTestPath(const std::string& test_srcdir, std::string executable,
+                     std::string* result) {
+  if (executable.compare(0, 2, "./") == 0) {
+    executable.erase(0, 2);
+  }
+  if (IsAbsolute(executable)) {
+    *result = std::move(executable);
+    return true;
+  }
+  if (executable.compare(0, 3, "../") == 0) {
+    executable.erase(0, 3);
+  } else {
+    executable = JoinPath(GetEnv("TEST_WORKSPACE"), executable);
+  }
+  return ResolveRunfile(test_srcdir, executable, result);
+}
+
+bool ShortenTestPath(const std::string& exec_root, std::string* test_path) {
+  if (GetEnv("TEST_SHORT_EXEC_PATH").empty()) {
+    return true;
+  }
+
+  unsigned int qualifier = 0;
+  std::string base;
+  do {
+    base = JoinPath(exec_root, "t" + std::to_string(qualifier++));
+  } while (PathOrSymlinkExists(base) || PathOrSymlinkExists(base + ".exe") ||
+           PathOrSymlinkExists(base + ".zip"));
+
+  std::string extensionless = *test_path;
+  const size_t dot = extensionless.find_last_of('.');
+  if (dot != std::string::npos) {
+    extensionless.erase(dot);
+  }
+  (void)symlink(extensionless.c_str(), base.c_str());
+  (void)symlink((extensionless + ".zip").c_str(), (base + ".zip").c_str());
+  if (symlink(test_path->c_str(), (base + ".exe").c_str()) != 0) {
+    fprintf(stderr, "ERROR: could not shorten test executable %s: %s\n",
+            test_path->c_str(), strerror(errno));
+    return false;
+  }
+  *test_path = base + ".exe";
+  return true;
+}
+
+bool PrepareCommand(int argc, char** argv, const std::string& exec_root,
+                    const std::string& test_srcdir, bool coverage_mode,
+                    std::vector<std::string>* command) {
+  const int executable_index = coverage_mode ? 2 : 1;
+  if (argc <= executable_index) {
+    fprintf(stderr,
+            coverage_mode
+                ? "Usage: %s <coverage_wrapper> <test_path> [test_args...]\n"
+                : "Usage: %s <test_path> [test_args...]\n",
+            argv[0]);
+    return false;
+  }
+
+  std::string test_path;
+  if (!ResolveTestPath(test_srcdir, argv[executable_index], &test_path) ||
+      !ShortenTestPath(exec_root, &test_path)) {
+    return false;
+  }
+
+  if (coverage_mode) {
+    command->emplace_back(argv[1]);
+  }
+  command->push_back(std::move(test_path));
+  for (int i = executable_index + 1; i < argc; ++i) {
+    command->emplace_back(argv[i]);
+  }
+  return true;
+}
+
+std::vector<char*> CommandPointers(std::vector<std::string>* command) {
+  std::vector<char*> arguments;
+  arguments.reserve(command->size() + 1);
+  for (std::string& argument : *command) {
+    arguments.push_back(&argument[0]);
+  }
+  arguments.push_back(nullptr);
+  return arguments;
+}
+
+void ForwardSignal(int signal_number) {
+  const int saved_errno = errno;
+  if (signal_number == SIGTERM) {
+    g_received_sigterm = 1;
+  }
+  const sig_atomic_t process_group = g_child_process_group;
+  if (process_group > 0) {
+    (void)kill(-static_cast<pid_t>(process_group), signal_number);
+  }
+  errno = saved_errno;
+}
+
+class SignalHandlers {
+ public:
+  bool Install() {
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = ForwardSignal;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = 0;
+
+    for (size_t i = 0; i < kForwardedSignals.size(); ++i) {
+      if (sigaction(kForwardedSignals[i], &action, &previous_[i]) != 0) {
+        fprintf(stderr, "ERROR: could not handle signal %d: %s\n",
+                kForwardedSignals[i], strerror(errno));
+        Restore();
+        return false;
+      }
+      ++installed_;
+    }
+    return true;
+  }
+
+  void Restore() {
+    while (installed_ != 0) {
+      --installed_;
+      (void)sigaction(kForwardedSignals[installed_], &previous_[installed_],
+                      nullptr);
+    }
+  }
+
+  ~SignalHandlers() { Restore(); }
+
+ private:
+  std::array<struct sigaction, kForwardedSignals.size()> previous_;
+  size_t installed_ = 0;
+};
+
+class ForwardedSignalMask {
+ public:
+  bool Block() {
+    sigset_t blocked_signals;
+    if (sigemptyset(&blocked_signals) != 0) {
+      fprintf(stderr, "ERROR: could not initialize signal mask: %s\n",
+              strerror(errno));
+      return false;
+    }
+    for (int signal_number : kForwardedSignals) {
+      if (sigaddset(&blocked_signals, signal_number) != 0) {
+        fprintf(stderr, "ERROR: could not block signal %d: %s\n", signal_number,
+                strerror(errno));
+        return false;
+      }
+    }
+    if (sigprocmask(SIG_BLOCK, &blocked_signals, &previous_) != 0) {
+      fprintf(stderr, "ERROR: could not block forwarded signals: %s\n",
+              strerror(errno));
+      return false;
+    }
+    blocked_ = true;
+    return true;
+  }
+
+  bool Restore() {
+    if (!blocked_) {
+      return true;
+    }
+    if (sigprocmask(SIG_SETMASK, &previous_, nullptr) != 0) {
+      fprintf(stderr, "ERROR: could not restore signal mask: %s\n",
+              strerror(errno));
+      return false;
+    }
+    blocked_ = false;
+    return true;
+  }
+
+  ~ForwardedSignalMask() { (void)Restore(); }
+
+ private:
+  sigset_t previous_;
+  bool blocked_ = false;
+};
+
+bool CloseOnExec(int descriptor) {
+  const int flags = fcntl(descriptor, F_GETFD);
+  return flags != -1 && fcntl(descriptor, F_SETFD, flags | FD_CLOEXEC) != -1;
+}
+
+void PrintTimeoutMessage() {
+  time_t now = time(nullptr);
+  struct tm local_time;
+  char formatted[128];
+  if (localtime_r(&now, &local_time) != nullptr &&
+      strftime(formatted, sizeof(formatted), "%Y-%m-%d %H:%M:%S %Z",
+               &local_time) != 0) {
+    fprintf(stdout, "-- Test timed out at %s --\n", formatted);
+  } else {
+    fprintf(stdout, "-- Test timed out --\n");
+  }
+  fflush(stdout);
+}
+
+void ResetChildSignals() {
+  struct sigaction action;
+  memset(&action, 0, sizeof(action));
+  action.sa_handler = SIG_DFL;
+  sigemptyset(&action.sa_mask);
+  for (int signal_number : kForwardedSignals) {
+    (void)sigaction(signal_number, &action, nullptr);
+  }
+  sigset_t unblocked;
+  sigemptyset(&unblocked);
+  (void)sigprocmask(SIG_SETMASK, &unblocked, nullptr);
+}
+
+void ExecuteTest(std::vector<std::string>* command, bool null_stdin) {
+  if (null_stdin) {
+    const int null_descriptor = open("/dev/null", O_RDONLY);
+    if (null_descriptor == -1 || dup2(null_descriptor, STDIN_FILENO) == -1) {
+      fprintf(stderr, "ERROR: could not configure test stdin: %s\n",
+              strerror(errno));
+      _exit(1);
+    }
+    if (null_descriptor != STDIN_FILENO) {
+      close(null_descriptor);
+    }
+  }
+
+  std::vector<char*> arguments = CommandPointers(command);
+  execv(arguments[0], arguments.data());
+  if (errno == ENOEXEC) {
+    command->insert(command->begin(), "bash");
+    arguments = CommandPointers(command);
+    execvp(arguments[0], arguments.data());
+  }
+  const int execution_error = errno;
+  fprintf(stderr, "ERROR: could not execute %s: %s\n", arguments[0],
+          strerror(execution_error));
+  _exit(execution_error == ENOENT ? 127 : 126);
+}
+
+void WatchParent(int descriptor, pid_t child_process_group) {
+  (void)setpgid(0, 0);
+  char byte = 0;
+  ssize_t result;
+  do {
+    result = read(descriptor, &byte, 1);
+  } while (result == -1 && errno == EINTR);
+  if (result <= 0) {
+    (void)kill(-child_process_group, SIGKILL);
+  }
+  close(descriptor);
+  _exit(0);
+}
+
+bool WaitForProcess(pid_t process, int* status) {
+  while (waitpid(process, status, 0) == -1) {
+    if (errno != EINTR) {
+      fprintf(stderr, "ERROR: could not wait for test process: %s\n",
+              strerror(errno));
+      return false;
+    }
+    if (g_received_sigterm != 0) {
+      g_received_sigterm = 0;
+      PrintTimeoutMessage();
+    }
+  }
+  if (g_received_sigterm != 0) {
+    g_received_sigterm = 0;
+    PrintTimeoutMessage();
+  }
+  return true;
+}
+
+bool RunTest(std::vector<std::string>* command, int* exit_code) {
+  int watchdog_pipe[2] = {-1, -1};
+  if (pipe(watchdog_pipe) != 0 || !CloseOnExec(watchdog_pipe[0]) ||
+      !CloseOnExec(watchdog_pipe[1])) {
+    fprintf(stderr, "ERROR: could not create process cleanup pipe: %s\n",
+            strerror(errno));
+    if (watchdog_pipe[0] != -1) {
+      close(watchdog_pipe[0]);
+    }
+    if (watchdog_pipe[1] != -1) {
+      close(watchdog_pipe[1]);
+    }
+    return false;
+  }
+
+  ForwardedSignalMask signal_mask;
+  if (!signal_mask.Block()) {
+    close(watchdog_pipe[0]);
+    close(watchdog_pipe[1]);
+    return false;
+  }
+
+  SignalHandlers handlers;
+  if (!handlers.Install()) {
+    close(watchdog_pipe[0]);
+    close(watchdog_pipe[1]);
+    return false;
+  }
+
+  const pid_t child = fork();
+  if (child < 0) {
+    fprintf(stderr, "ERROR: could not start test process: %s\n",
+            strerror(errno));
+    close(watchdog_pipe[0]);
+    close(watchdog_pipe[1]);
+    return false;
+  }
+  if (child == 0) {
+    close(watchdog_pipe[0]);
+    close(watchdog_pipe[1]);
+    if (setpgid(0, 0) != 0) {
+      fprintf(stderr, "ERROR: could not create test process group: %s\n",
+              strerror(errno));
+      _exit(1);
+    }
+    ResetChildSignals();
+    ExecuteTest(command, true);
+  }
+
+  g_child_process_group = static_cast<sig_atomic_t>(child);
+  if (setpgid(child, child) != 0 && errno != EACCES && errno != ESRCH) {
+    fprintf(stderr, "ERROR: could not configure test process group: %s\n",
+            strerror(errno));
+    (void)kill(child, SIGKILL);
+    int ignored;
+    (void)waitpid(child, &ignored, 0);
+    close(watchdog_pipe[0]);
+    close(watchdog_pipe[1]);
+    g_child_process_group = 0;
+    return false;
+  }
+  if (!signal_mask.Restore()) {
+    (void)kill(-child, SIGKILL);
+    int ignored;
+    (void)waitpid(child, &ignored, 0);
+    close(watchdog_pipe[0]);
+    close(watchdog_pipe[1]);
+    g_child_process_group = 0;
+    return false;
+  }
+
+  const pid_t watchdog = fork();
+  if (watchdog == 0) {
+    close(watchdog_pipe[1]);
+    ResetChildSignals();
+    WatchParent(watchdog_pipe[0], child);
+  }
+  close(watchdog_pipe[0]);
+  if (watchdog < 0) {
+    fprintf(stderr, "ERROR: could not start process cleanup: %s\n",
+            strerror(errno));
+    (void)kill(-child, SIGKILL);
+    int ignored;
+    (void)waitpid(child, &ignored, 0);
+    close(watchdog_pipe[1]);
+    g_child_process_group = 0;
+    return false;
+  }
+
+  int status = 0;
+  const bool waited = WaitForProcess(child, &status);
+  (void)kill(-child, SIGKILL);
+  g_child_process_group = 0;
+
+  const char normal_exit = 1;
+  ssize_t written;
+  do {
+    written = write(watchdog_pipe[1], &normal_exit, sizeof(normal_exit));
+  } while (written == -1 && errno == EINTR);
+  close(watchdog_pipe[1]);
+
+  int watchdog_status;
+  while (waitpid(watchdog, &watchdog_status, 0) == -1 && errno == EINTR) {
+  }
+  handlers.Restore();
+  if (!waited) {
+    return false;
+  }
+
+  if (WIFEXITED(status)) {
+    *exit_code = WEXITSTATUS(status);
+  } else if (WIFSIGNALED(status)) {
+    *exit_code = 128 + WTERMSIG(status);
+  } else {
+    fprintf(stderr, "ERROR: unexpected test process status %d\n", status);
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+int TestWrapperMain(int argc, char** argv) {
+  if (dup2(STDOUT_FILENO, STDERR_FILENO) == -1) {
+    return 1;
+  }
+  setvbuf(stdout, nullptr, _IONBF, 0);
+
+  fputs(kPagerHeader, stdout);
+  fprintf(stdout, "Executing tests from %s\n", GetEnv("TEST_TARGET").c_str());
+
+  std::string exec_root;
+  std::string test_srcdir;
+  UndeclaredOutputs undeclared_outputs;
+  if (!GetCurrentDirectory(&exec_root) ||
+      !PrepareEnvironment(exec_root, &undeclared_outputs, &test_srcdir)) {
+    return 1;
+  }
+
+  const bool coverage_mode = !GetEnv("COVERAGE_DIR").empty();
+  if (!ChangeToRunfiles(exec_root, test_srcdir, coverage_mode)) {
+    return 1;
+  }
+
+  fputs(kTestLogDelimiter, stdout);
+  if (!SetEnv("PATH", ".:" + GetEnv("PATH")) ||
+      !SetEnv(kRlocationFunctionName, kRlocationFunction)) {
+    return 1;
+  }
+
+  std::vector<std::string> command;
+  if (!PrepareCommand(argc, argv, exec_root, test_srcdir, coverage_mode,
+                      &command)) {
+    return 1;
+  }
+
+  if (!GetEnv("BUILD_EXECROOT").empty()) {
+    ExecuteTest(&command, false);
+  }
+
+  int exit_code = 1;
+  if (!RunTest(&command, &exit_code)) {
+    return 1;
+  }
+
+  std::string error;
+  if (!ProcessUndeclaredOutputs(undeclared_outputs, &error)) {
+    fprintf(stderr, "ERROR: could not process undeclared test outputs: %s\n",
+            error.c_str());
+    return 1;
+  }
+
+  if (exit_code > 128 && exit_code - 128 < NSIG) {
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = SIG_DFL;
+    sigemptyset(&action.sa_mask);
+    const int signal_number = exit_code - 128;
+    if (signal_number == SIGKILL || signal_number == SIGSTOP ||
+        sigaction(signal_number, &action, nullptr) == 0) {
+      raise(signal_number);
+    }
+  }
+  return exit_code;
+}
+
+}  // namespace test_wrapper
+}  // namespace tools
+}  // namespace bazel

--- a/tools/test/posix/tw_main.cc
+++ b/tools/test/posix/tw_main.cc
@@ -1,0 +1,27 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace bazel {
+namespace tools {
+namespace test_wrapper {
+
+int TestWrapperMain(int argc, char** argv);
+
+}  // namespace test_wrapper
+}  // namespace tools
+}  // namespace bazel
+
+int main(int argc, char** argv) {
+  return bazel::tools::test_wrapper::TestWrapperMain(argc, argv);
+}

--- a/tools/test/posix/tw_outputs.cc
+++ b/tools/test/posix/tw_outputs.cc
@@ -1,0 +1,724 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tools/test/posix/tw_outputs.h"
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <initializer_list>
+#include <limits>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "src/main/cpp/util/file_platform.h"
+#include "src/main/cpp/util/path_platform.h"
+#include "third_party/ijar/platform_utils.h"
+#include "third_party/ijar/zip.h"
+#include "tools/test/test_wrapper_common.h"
+
+namespace bazel {
+namespace tools {
+namespace test_wrapper {
+namespace {
+
+constexpr size_t kMimeSampleSize = 8192;
+
+struct OutputEntry {
+  std::string relative_path;
+  uint64_t size;
+  mode_t mode;
+  bool is_directory;
+};
+
+using DirectoryIdentity = std::pair<dev_t, ino_t>;
+
+bool Fail(const std::string& message, std::string* error) {
+  if (error != nullptr) {
+    *error = message;
+  }
+  return false;
+}
+
+bool FailWithErrno(const std::string& operation, const std::string& path,
+                   int error_number, std::string* error) {
+  return Fail(operation + " '" + path +
+                  "': " + std::string(std::strerror(error_number)),
+              error);
+}
+
+std::string JoinPath(const std::string& directory, const std::string& name) {
+  if (directory.empty() || directory.back() == '/') {
+    return directory + name;
+  }
+  return directory + "/" + name;
+}
+
+std::string ParentDirectory(const std::string& path) {
+  const std::string::size_type separator = path.find_last_of('/');
+  if (separator == std::string::npos) {
+    return ".";
+  }
+  return separator == 0 ? "/" : path.substr(0, separator);
+}
+
+bool EnsureParentDirectory(const std::string& path, std::string* error) {
+  const std::string parent = ParentDirectory(path);
+  std::string current = !parent.empty() && parent[0] == '/' ? "/" : "";
+  size_t position = current.size();
+  while (position < parent.size()) {
+    const size_t separator = parent.find('/', position);
+    const size_t length = separator == std::string::npos
+                              ? parent.size() - position
+                              : separator - position;
+    if (length != 0) {
+      current = JoinPath(current, parent.substr(position, length));
+      struct stat existing;
+      if (stat(current.c_str(), &existing) == 0) {
+        if (!S_ISDIR(existing.st_mode)) {
+          return FailWithErrno("Parent directory is not a directory", current,
+                               ENOTDIR, error);
+        }
+      } else if (errno != ENOENT) {
+        return FailWithErrno("Cannot stat parent directory", current, errno,
+                             error);
+      } else if (mkdir(current.c_str(), 0777) != 0) {
+        const int mkdir_error = errno;
+        if (mkdir_error != EEXIST || stat(current.c_str(), &existing) != 0 ||
+            !S_ISDIR(existing.st_mode)) {
+          return FailWithErrno("Cannot create parent directory", current,
+                               mkdir_error, error);
+        }
+      }
+    }
+    if (separator == std::string::npos) {
+      break;
+    }
+    position = separator + 1;
+  }
+  return true;
+}
+
+bool ListOutputs(const std::string& root, const std::string& relative_dir,
+                 std::set<DirectoryIdentity>* ancestors,
+                 std::vector<OutputEntry>* entries,
+                 std::vector<std::string>* root_children, std::string* error) {
+  const std::string directory =
+      relative_dir.empty() ? root : JoinPath(root, relative_dir);
+  std::unique_ptr<DIR, decltype(&closedir)> stream(opendir(directory.c_str()),
+                                                   &closedir);
+  if (stream == nullptr) {
+    return FailWithErrno("Cannot open undeclared-output directory", directory,
+                         errno, error);
+  }
+
+  std::vector<std::pair<std::string, DirectoryIdentity>> subdirectories;
+  for (;;) {
+    errno = 0;
+    dirent* const entry = readdir(stream.get());
+    if (entry == nullptr) {
+      if (errno != 0) {
+        return FailWithErrno("Cannot read undeclared-output directory",
+                             directory, errno, error);
+      }
+      break;
+    }
+
+    const std::string name(entry->d_name);
+    if (name == "." || name == "..") {
+      continue;
+    }
+
+    if (relative_dir.empty()) {
+      root_children->push_back(name);
+    }
+
+    const std::string relative_path =
+        relative_dir.empty() ? name : JoinPath(relative_dir, name);
+    const std::string absolute_path = JoinPath(root, relative_path);
+    struct stat file_stat;
+    if (stat(absolute_path.c_str(), &file_stat) != 0) {
+      const int stat_error = errno;
+      if (stat_error == ENOENT || stat_error == ENOTDIR) {
+        continue;
+      }
+      return FailWithErrno("Cannot stat undeclared output", absolute_path,
+                           stat_error, error);
+    }
+
+    if (S_ISDIR(file_stat.st_mode)) {
+      entries->push_back(
+          OutputEntry{relative_path, 0, file_stat.st_mode, true});
+      const DirectoryIdentity identity(file_stat.st_dev, file_stat.st_ino);
+      if (ancestors->find(identity) == ancestors->end()) {
+        subdirectories.emplace_back(relative_path, identity);
+      }
+    } else if (S_ISREG(file_stat.st_mode)) {
+      if (file_stat.st_size < 0) {
+        return Fail(
+            "Undeclared output has an invalid size: '" + absolute_path + "'",
+            error);
+      }
+      entries->push_back(OutputEntry{relative_path,
+                                     static_cast<uint64_t>(file_stat.st_size),
+                                     file_stat.st_mode, false});
+    }
+  }
+
+  DIR* const opened_directory = stream.release();
+  if (closedir(opened_directory) != 0) {
+    return FailWithErrno("Cannot close undeclared-output directory", directory,
+                         errno, error);
+  }
+
+  for (const auto& subdirectory : subdirectories) {
+    ancestors->insert(subdirectory.second);
+    if (!ListOutputs(root, subdirectory.first, ancestors, entries,
+                     root_children, error)) {
+      return false;
+    }
+    ancestors->erase(subdirectory.second);
+  }
+  return true;
+}
+
+bool ReadPrefix(const std::string& path, std::string* content,
+                std::string* error) {
+  const int descriptor = open(path.c_str(), O_RDONLY);
+  if (descriptor < 0) {
+    return FailWithErrno("Cannot read undeclared output", path, errno, error);
+  }
+
+  std::array<char, kMimeSampleSize> buffer;
+  ssize_t bytes_read;
+  do {
+    bytes_read = read(descriptor, buffer.data(), buffer.size());
+  } while (bytes_read < 0 && errno == EINTR);
+  const int read_error = errno;
+  if (close(descriptor) != 0 && bytes_read >= 0) {
+    return FailWithErrno("Cannot close undeclared output", path, errno, error);
+  }
+  if (bytes_read < 0) {
+    return FailWithErrno("Cannot read undeclared output", path, read_error,
+                         error);
+  }
+  content->assign(buffer.data(), static_cast<size_t>(bytes_read));
+  return true;
+}
+
+bool StartsWithBytes(const std::string& content,
+                     std::initializer_list<unsigned char> signature) {
+  if (content.size() < signature.size()) {
+    return false;
+  }
+  size_t position = 0;
+  for (const unsigned char byte : signature) {
+    if (static_cast<unsigned char>(content[position++]) != byte) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool IsUtf8Text(const std::string& content) {
+  for (size_t position = 0; position < content.size();) {
+    const unsigned char first = static_cast<unsigned char>(content[position++]);
+    if (first < 0x80) {
+      if ((first < 0x20 && first != '\t' && first != '\n' && first != '\r' &&
+           first != '\f') ||
+          first == 0x7f) {
+        return false;
+      }
+      continue;
+    }
+
+    size_t remaining;
+    uint32_t code_point;
+    uint32_t minimum;
+    if (first >= 0xc2 && first <= 0xdf) {
+      remaining = 1;
+      code_point = first & 0x1f;
+      minimum = 0x80;
+    } else if (first >= 0xe0 && first <= 0xef) {
+      remaining = 2;
+      code_point = first & 0x0f;
+      minimum = 0x800;
+    } else if (first >= 0xf0 && first <= 0xf4) {
+      remaining = 3;
+      code_point = first & 0x07;
+      minimum = 0x10000;
+    } else {
+      return false;
+    }
+
+    if (remaining > content.size() - position) {
+      return content.size() == kMimeSampleSize;
+    }
+    for (size_t index = 0; index < remaining; ++index) {
+      const unsigned char continuation =
+          static_cast<unsigned char>(content[position++]);
+      if ((continuation & 0xc0) != 0x80) {
+        return false;
+      }
+      code_point = (code_point << 6) | (continuation & 0x3f);
+    }
+    if (code_point < minimum || code_point > 0x10ffff ||
+        (code_point >= 0xd800 && code_point <= 0xdfff)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string LowercaseTextPrefix(const std::string& content) {
+  size_t position = StartsWithBytes(content, {0xef, 0xbb, 0xbf}) ? 3 : 0;
+  while (position < content.size() &&
+         (content[position] == ' ' || content[position] == '\t' ||
+          content[position] == '\n' || content[position] == '\r')) {
+    ++position;
+  }
+
+  std::string prefix = content.substr(position, 128);
+  std::transform(prefix.begin(), prefix.end(), prefix.begin(),
+                 [](unsigned char value) {
+                   return value >= 'A' && value <= 'Z'
+                              ? static_cast<char>(value + ('a' - 'A'))
+                              : static_cast<char>(value);
+                 });
+  return prefix;
+}
+
+std::string ClassifyContent(const std::string& content) {
+  if (content.empty()) {
+    return "inode/x-empty";
+  }
+  if (StartsWithBytes(content, {0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'})) {
+    return "image/png";
+  }
+  if (StartsWithBytes(content, {0xff, 0xd8, 0xff})) {
+    return "image/jpeg";
+  }
+  if (content.compare(0, 6, "GIF87a") == 0 ||
+      content.compare(0, 6, "GIF89a") == 0) {
+    return "image/gif";
+  }
+  if (StartsWithBytes(content, {0x00, 0x00, 0x01, 0x00}) ||
+      StartsWithBytes(content, {0x00, 0x00, 0x02, 0x00})) {
+    return "image/vnd.microsoft.icon";
+  }
+  if (content.compare(0, 5, "%PDF-") == 0) {
+    return "application/pdf";
+  }
+  if (StartsWithBytes(content, {'P', 'K', 0x03, 0x04}) ||
+      StartsWithBytes(content, {'P', 'K', 0x05, 0x06}) ||
+      StartsWithBytes(content, {'P', 'K', 0x07, 0x08})) {
+    return "application/zip";
+  }
+  if (StartsWithBytes(content, {0x1f, 0x8b})) {
+    return "application/gzip";
+  }
+  if (!IsUtf8Text(content)) {
+    return "application/octet-stream";
+  }
+
+  const std::string prefix = LowercaseTextPrefix(content);
+  if (prefix.compare(0, 14, "<!doctype html") == 0 ||
+      prefix.compare(0, 5, "<html") == 0 ||
+      prefix.compare(0, 5, "<head") == 0 ||
+      prefix.compare(0, 6, "<title") == 0 ||
+      prefix.compare(0, 5, "<body") == 0) {
+    return "text/html";
+  }
+  if (prefix.compare(0, 4, "<svg") == 0 ||
+      (prefix.compare(0, 5, "<?xml") == 0 &&
+       prefix.find("<svg") != std::string::npos)) {
+    return "image/svg+xml";
+  }
+  if (prefix.compare(0, 5, "<?xml") == 0) {
+    return "text/xml";
+  }
+  if (!prefix.empty() && (prefix.front() == '{' || prefix.front() == '[')) {
+    return "application/json";
+  }
+  if (prefix.compare(0, 2, "#!") == 0) {
+    return "text/x-shellscript";
+  }
+  return "text/plain";
+}
+
+bool WriteManifest(const std::string& root, const std::string& manifest,
+                   const std::vector<OutputEntry>& entries,
+                   std::string* error) {
+  if (manifest.empty()) {
+    return true;
+  }
+
+  std::string content;
+  for (const OutputEntry& entry : entries) {
+    if (entry.is_directory) {
+      continue;
+    }
+    std::string sample;
+    if (!ReadPrefix(JoinPath(root, entry.relative_path), &sample, error)) {
+      return false;
+    }
+    content += FormatUndeclaredOutputManifestEntry(
+        entry.relative_path, entry.size, ClassifyContent(sample));
+  }
+  if (content.empty()) {
+    return true;
+  }
+  if (!EnsureParentDirectory(manifest, error)) {
+    return false;
+  }
+  std::ofstream output(manifest,
+                       std::ios::out | std::ios::binary | std::ios::trunc);
+  if (!output.is_open()) {
+    return FailWithErrno("Cannot open undeclared-output manifest", manifest,
+                         errno, error);
+  }
+  output.write(content.data(), static_cast<std::streamsize>(content.size()));
+  output.close();
+  if (output.fail()) {
+    return Fail("Cannot write undeclared-output manifest '" + manifest + "'",
+                error);
+  }
+  return true;
+}
+
+bool AppendFile(const std::string& input, std::ofstream* output,
+                std::string* error) {
+  std::ifstream stream(input, std::ios::in | std::ios::binary);
+  if (!stream.is_open()) {
+    return FailWithErrno("Cannot open undeclared-output annotation", input,
+                         errno, error);
+  }
+
+  std::array<char, 65536> buffer;
+  while (stream.good()) {
+    stream.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+    const std::streamsize bytes_read = stream.gcount();
+    if (bytes_read > 0) {
+      output->write(buffer.data(), bytes_read);
+      if (output->fail()) {
+        return Fail(
+            "Cannot append undeclared-output annotation '" + input + "'",
+            error);
+      }
+    }
+  }
+  if (!stream.eof()) {
+    return Fail("Cannot read undeclared-output annotation '" + input + "'",
+                error);
+  }
+  return true;
+}
+
+bool HasSuffix(const std::string& value, const std::string& suffix) {
+  return value.size() >= suffix.size() &&
+         value.compare(value.size() - suffix.size(), suffix.size(), suffix) ==
+             0;
+}
+
+bool ConcatenateAnnotations(const std::string& directory,
+                            const std::vector<std::string>& entries,
+                            const std::string& suffix,
+                            const std::string& destination,
+                            std::string* error) {
+  std::vector<std::string> matching;
+  for (const std::string& entry : entries) {
+    if (!entry.empty() && entry.front() != '.' && HasSuffix(entry, suffix)) {
+      const std::string path = JoinPath(directory, entry);
+      struct stat file_stat;
+      if (stat(path.c_str(), &file_stat) == 0 && S_ISREG(file_stat.st_mode)) {
+        matching.push_back(entry);
+      }
+    }
+  }
+  if (matching.empty()) {
+    return true;
+  }
+  if (!EnsureParentDirectory(destination, error)) {
+    return false;
+  }
+
+  std::ofstream output(destination,
+                       std::ios::out | std::ios::binary | std::ios::trunc);
+  if (!output.is_open()) {
+    return FailWithErrno("Cannot open undeclared-output annotations",
+                         destination, errno, error);
+  }
+  for (const std::string& entry : matching) {
+    if (!AppendFile(JoinPath(directory, entry), &output, error)) {
+      return false;
+    }
+  }
+  output.close();
+  if (output.fail()) {
+    return Fail(
+        "Cannot write undeclared-output annotations '" + destination + "'",
+        error);
+  }
+  return true;
+}
+
+bool ProcessAnnotations(const UndeclaredOutputs& outputs, std::string* error) {
+  if (outputs.annotations.empty() || outputs.annotations_dir.empty()) {
+    return true;
+  }
+
+  std::unique_ptr<DIR, decltype(&closedir)> directory(
+      opendir(outputs.annotations_dir.c_str()), &closedir);
+  if (directory == nullptr) {
+    if (errno == ENOENT || errno == ENOTDIR) {
+      return true;
+    }
+    return FailWithErrno("Cannot open undeclared-output annotations directory",
+                         outputs.annotations_dir, errno, error);
+  }
+
+  std::vector<std::string> entries;
+  for (;;) {
+    errno = 0;
+    dirent* const entry = readdir(directory.get());
+    if (entry == nullptr) {
+      if (errno != 0) {
+        return FailWithErrno(
+            "Cannot read undeclared-output annotations directory",
+            outputs.annotations_dir, errno, error);
+      }
+      break;
+    }
+    if (std::strcmp(entry->d_name, ".") != 0 &&
+        std::strcmp(entry->d_name, "..") != 0) {
+      entries.emplace_back(entry->d_name);
+    }
+  }
+  std::sort(entries.begin(), entries.end());
+  return ConcatenateAnnotations(outputs.annotations_dir, entries, ".part",
+                                outputs.annotations, error) &&
+         ConcatenateAnnotations(outputs.annotations_dir, entries, ".pb",
+                                outputs.annotations + ".pb", error);
+}
+
+bool ReadZipEntry(const std::string& path, uint64_t size,
+                  devtools_ijar::u1* destination, std::string* error) {
+  const int descriptor = open(path.c_str(), O_RDONLY);
+  if (descriptor < 0) {
+    return FailWithErrno("Cannot open undeclared output for ZIP", path, errno,
+                         error);
+  }
+
+  size_t remaining = static_cast<size_t>(size);
+  while (remaining > 0) {
+    const ssize_t bytes_read = read(descriptor, destination, remaining);
+    if (bytes_read < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      const int read_error = errno;
+      close(descriptor);
+      return FailWithErrno("Cannot read undeclared output for ZIP", path,
+                           read_error, error);
+    }
+    if (bytes_read == 0) {
+      close(descriptor);
+      return Fail(
+          "Undeclared output changed while creating ZIP: '" + path + "'",
+          error);
+    }
+    destination += bytes_read;
+    remaining -= static_cast<size_t>(bytes_read);
+  }
+  if (close(descriptor) != 0) {
+    return FailWithErrno("Cannot close undeclared output for ZIP", path, errno,
+                         error);
+  }
+  return true;
+}
+
+std::string ZipError(devtools_ijar::ZipBuilder* builder) {
+  const char* const message = builder->GetError();
+  return message == nullptr ? "unknown ZIP error" : std::string(message);
+}
+
+bool CreateZip(const UndeclaredOutputs& outputs,
+               const std::vector<OutputEntry>& entries, std::string* error) {
+  if (outputs.zip.empty() || entries.empty()) {
+    return true;
+  }
+  if (entries.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    return Fail("Too many undeclared outputs to archive", error);
+  }
+  if (!EnsureParentDirectory(outputs.zip, error)) {
+    return false;
+  }
+
+  std::vector<std::string> relative_paths;
+  relative_paths.reserve(entries.size());
+  for (const OutputEntry& entry : entries) {
+    if (entry.size >
+        static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())) {
+      return Fail("Undeclared output exceeds the ZIP file-size limit: '" +
+                      JoinPath(outputs.root, entry.relative_path) + "'",
+                  error);
+    }
+    relative_paths.push_back(entry.relative_path +
+                             (entry.is_directory ? "/" : ""));
+  }
+
+  ZipEntryPaths paths;
+  paths.Create(outputs.root, relative_paths);
+  const devtools_ijar::u8 estimated_size =
+      devtools_ijar::ZipBuilder::EstimateSize(paths.AbsPathPtrs(),
+                                              paths.EntryPathPtrs(),
+                                              static_cast<int>(paths.Size()));
+  if (estimated_size == 0) {
+    return Fail(
+        "Cannot estimate undeclared-output ZIP size for '" + outputs.zip + "'",
+        error);
+  }
+  if (estimated_size > std::numeric_limits<uint32_t>::max()) {
+    return Fail("Undeclared outputs exceed the maximum ZIP archive size: '" +
+                    outputs.zip + "'",
+                error);
+  }
+
+  std::unique_ptr<devtools_ijar::ZipBuilder> builder(
+      devtools_ijar::ZipBuilder::Create(outputs.zip.c_str(), estimated_size));
+  if (builder == nullptr) {
+    return FailWithErrno("Cannot create undeclared-output ZIP", outputs.zip,
+                         errno, error);
+  }
+
+  for (size_t index = 0; index < entries.size(); ++index) {
+    const OutputEntry& entry = entries[index];
+    const devtools_ijar::Stat file_stat = {entry.size, entry.mode,
+                                           entry.is_directory};
+    devtools_ijar::u1* const destination =
+        builder->NewFile(paths.EntryPathPtrs()[index],
+                         devtools_ijar::stat_to_zipattr(file_stat));
+    if (destination == nullptr) {
+      return Fail("Cannot add undeclared output '" + entry.relative_path +
+                      "' to ZIP: " + ZipError(builder.get()),
+                  error);
+    }
+    if (!entry.is_directory &&
+        !ReadZipEntry(JoinPath(outputs.root, entry.relative_path), entry.size,
+                      destination, error)) {
+      return false;
+    }
+    if (builder->FinishFile(static_cast<size_t>(entry.size),
+                            /*compress=*/true, /*compute_crc=*/true) == -1) {
+      return Fail("Cannot finish undeclared-output ZIP entry '" +
+                      entry.relative_path + "': " + ZipError(builder.get()),
+                  error);
+    }
+  }
+  if (builder->Finish() == -1) {
+    return Fail("Cannot finish undeclared-output ZIP '" + outputs.zip +
+                    "': " + ZipError(builder.get()),
+                error);
+  }
+  return true;
+}
+
+bool DeleteArchivedOutputs(const UndeclaredOutputs& outputs,
+                           const std::vector<std::string>& root_children,
+                           std::string* error) {
+  if (outputs.zip.empty()) {
+    return true;
+  }
+  for (const std::string& child : root_children) {
+    const std::string path = JoinPath(outputs.root, child);
+    if (path == outputs.zip) {
+      continue;
+    }
+    if (!blaze_util::RemoveRecursively(blaze_util::Path(path))) {
+      return FailWithErrno("Cannot remove archived undeclared output", path,
+                           errno, error);
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+bool ProcessUndeclaredOutputs(const UndeclaredOutputs& outputs,
+                              std::string* error) {
+  if (error != nullptr) {
+    error->clear();
+  }
+
+  std::vector<OutputEntry> entries;
+  std::vector<std::string> root_children;
+  if (!outputs.root.empty() &&
+      (!outputs.manifest.empty() || !outputs.zip.empty())) {
+    struct stat root_stat;
+    if (stat(outputs.root.c_str(), &root_stat) != 0) {
+      const int stat_error = errno;
+      if (stat_error != ENOENT && stat_error != ENOTDIR) {
+        return FailWithErrno("Cannot stat undeclared-output directory",
+                             outputs.root, stat_error, error);
+      }
+    } else if (!S_ISDIR(root_stat.st_mode)) {
+      return Fail(
+          "Undeclared-output root is not a directory: '" + outputs.root + "'",
+          error);
+    } else {
+      std::set<DirectoryIdentity> ancestors;
+      ancestors.emplace(root_stat.st_dev, root_stat.st_ino);
+      if (!ListOutputs(outputs.root, "", &ancestors, &entries, &root_children,
+                       error)) {
+        return false;
+      }
+      std::sort(entries.begin(), entries.end(),
+                [](const OutputEntry& first, const OutputEntry& second) {
+                  return first.relative_path < second.relative_path;
+                });
+      std::sort(root_children.begin(), root_children.end());
+      if (!WriteManifest(outputs.root, outputs.manifest, entries, error)) {
+        return false;
+      }
+    }
+  }
+
+  if (!ProcessAnnotations(outputs, error)) {
+    return false;
+  }
+  if (!CreateZip(outputs, entries, error)) {
+    return false;
+  }
+  if (!entries.empty() &&
+      !DeleteArchivedOutputs(outputs, root_children, error)) {
+    return false;
+  }
+  return true;
+}
+
+}  // namespace test_wrapper
+}  // namespace tools
+}  // namespace bazel

--- a/tools/test/posix/tw_outputs.h
+++ b/tools/test/posix/tw_outputs.h
@@ -1,0 +1,39 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BAZEL_TOOLS_TEST_POSIX_TW_OUTPUTS_H_
+#define BAZEL_TOOLS_TEST_POSIX_TW_OUTPUTS_H_
+
+#include <string>
+
+namespace bazel {
+namespace tools {
+namespace test_wrapper {
+
+struct UndeclaredOutputs {
+  std::string root;
+  std::string zip;
+  std::string manifest;
+  std::string annotations;
+  std::string annotations_dir;
+};
+
+bool ProcessUndeclaredOutputs(const UndeclaredOutputs& outputs,
+                              std::string* error);
+
+}  // namespace test_wrapper
+}  // namespace tools
+}  // namespace bazel
+
+#endif  // BAZEL_TOOLS_TEST_POSIX_TW_OUTPUTS_H_

--- a/tools/test/posix/tw_test.cc
+++ b/tools/test/posix/tw_test.cc
@@ -1,0 +1,455 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "src/main/cpp/util/file_platform.h"
+#include "src/main/cpp/util/path_platform.h"
+#include "third_party/ijar/common.h"
+#include "third_party/ijar/zip.h"
+#include "tools/test/posix/tw_outputs.h"
+#include "tools/test/test_wrapper_common.h"
+
+namespace bazel {
+namespace tools {
+namespace test_wrapper {
+namespace {
+
+struct ExtractedEntry {
+  std::string content;
+  bool is_directory;
+};
+
+class InMemoryZipExtractor : public devtools_ijar::ZipExtractorProcessor {
+ public:
+  bool Accept(const char* filename, devtools_ijar::u4 attr) override {
+    return true;
+  }
+
+  void Process(const char* filename, devtools_ijar::u4 attr,
+               const devtools_ijar::u1* data, size_t size) override {
+    ExtractedEntry entry;
+    if (size != 0) {
+      entry.content.assign(reinterpret_cast<const char*>(data), size);
+    }
+    entry.is_directory = devtools_ijar::zipattr_is_dir(attr);
+    entries_[filename] = entry;
+  }
+
+  const std::map<std::string, ExtractedEntry>& entries() const {
+    return entries_;
+  }
+
+ private:
+  std::map<std::string, ExtractedEntry> entries_;
+};
+
+class TestWrapperPosixTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const char* test_tmpdir = std::getenv("TEST_TMPDIR");
+    ASSERT_NE(test_tmpdir, nullptr);
+
+    std::string pattern =
+        std::string(test_tmpdir) + "/posix-test-wrapper.XXXXXX";
+    std::vector<char> writable_pattern(pattern.begin(), pattern.end());
+    writable_pattern.push_back('\0');
+    char* directory = mkdtemp(writable_pattern.data());
+    ASSERT_NE(directory, nullptr) << std::strerror(errno);
+    directory_ = directory;
+    root_ = directory_ + "/outputs";
+    MakeDirectory(root_);
+  }
+
+  void TearDown() override {
+    if (!directory_.empty()) {
+      EXPECT_TRUE(blaze_util::RemoveRecursively(blaze_util::Path(directory_)))
+          << directory_ << ": " << std::strerror(errno);
+    }
+  }
+
+  void MakeDirectory(const std::string& path) {
+    ASSERT_EQ(mkdir(path.c_str(), 0755), 0)
+        << path << ": " << std::strerror(errno);
+  }
+
+  void WriteFile(const std::string& path, const std::string& content) {
+    std::ofstream stream(path,
+                         std::ios::out | std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(stream.is_open()) << path << ": " << std::strerror(errno);
+    stream.write(content.data(), static_cast<std::streamsize>(content.size()));
+    stream.close();
+    ASSERT_FALSE(stream.fail()) << path;
+  }
+
+  std::string ReadFile(const std::string& path) {
+    std::ifstream stream(path, std::ios::in | std::ios::binary);
+    if (!stream.is_open()) {
+      ADD_FAILURE() << path << ": " << std::strerror(errno);
+      return "";
+    }
+    std::ostringstream result;
+    result << stream.rdbuf();
+    if (stream.bad()) {
+      ADD_FAILURE() << "Failed to read " << path;
+      return "";
+    }
+    return result.str();
+  }
+
+  bool Exists(const std::string& path) const {
+    struct stat file_stat;
+    return lstat(path.c_str(), &file_stat) == 0;
+  }
+
+  void ExtractZip(const std::string& path,
+                  InMemoryZipExtractor* extracted_entries) {
+    std::unique_ptr<devtools_ijar::ZipExtractor> extractor(
+        devtools_ijar::ZipExtractor::Create(path.c_str(), extracted_entries));
+    ASSERT_NE(extractor, nullptr) << path << ": " << std::strerror(errno);
+    ASSERT_EQ(extractor->ProcessAll(), 0)
+        << (extractor->GetError() == nullptr ? "Unknown ZIP error"
+                                             : extractor->GetError());
+  }
+
+  std::string directory_;
+  std::string root_;
+};
+
+TEST(TestWrapperCommonTest, EmptyZipEntryPathsAreNullTerminated) {
+  ZipEntryPaths paths;
+  paths.Create("/execution/root", {});
+
+  EXPECT_EQ(paths.Size(), 0);
+  ASSERT_NE(paths.AbsPathPtrs(), nullptr);
+  ASSERT_NE(paths.EntryPathPtrs(), nullptr);
+  EXPECT_EQ(paths.AbsPathPtrs()[0], nullptr);
+  EXPECT_EQ(paths.EntryPathPtrs()[0], nullptr);
+}
+
+TEST(TestWrapperCommonTest, ZipEntryPathsPreserveDirectoriesAndSpaces) {
+  ZipEntryPaths paths;
+  paths.Create("/execution/root", {"directory/", "directory/a file.txt"});
+
+  ASSERT_EQ(paths.Size(), 2);
+  EXPECT_STREQ(paths.AbsPathPtrs()[0], "/execution/root/directory/");
+  EXPECT_STREQ(paths.AbsPathPtrs()[1], "/execution/root/directory/a file.txt");
+  EXPECT_EQ(paths.AbsPathPtrs()[2], nullptr);
+  EXPECT_STREQ(paths.EntryPathPtrs()[0], "directory/");
+  EXPECT_STREQ(paths.EntryPathPtrs()[1], "directory/a file.txt");
+  EXPECT_EQ(paths.EntryPathPtrs()[2], nullptr);
+
+  paths.Create("/other", {"replacement"});
+  ASSERT_EQ(paths.Size(), 1);
+  EXPECT_STREQ(paths.AbsPathPtrs()[0], "/other/replacement");
+  EXPECT_STREQ(paths.EntryPathPtrs()[0], "replacement");
+  EXPECT_EQ(paths.AbsPathPtrs()[1], nullptr);
+  EXPECT_EQ(paths.EntryPathPtrs()[1], nullptr);
+}
+
+TEST(TestWrapperCommonTest, ManifestFormattingSupportsFullUint64Range) {
+  EXPECT_EQ(
+      FormatUndeclaredOutputManifestEntry("nested/file.txt", 10, "text/plain"),
+      "nested/file.txt\t10\ttext/plain\n");
+  EXPECT_EQ(FormatUndeclaredOutputManifestEntry(
+                "large.bin", std::numeric_limits<uint64_t>::max(),
+                "application/octet-stream"),
+            "large.bin\t18446744073709551615\tapplication/octet-stream\n");
+}
+
+TEST_F(TestWrapperPosixTest, ManifestIsSortedAndPreservesUnarchivedOutputs) {
+  MakeDirectory(root_ + "/nested");
+  WriteFile(root_ + "/zeta", "last\n");
+  WriteFile(root_ + "/nested/index.html", "<!DOCTYPE html>\n");
+  WriteFile(root_ + "/alpha.txt", "some text\n");
+  WriteFile(root_ + "/.hidden", std::string("\0\1\xff", 3));
+
+  UndeclaredOutputs outputs;
+  outputs.root = root_;
+  outputs.manifest = directory_ + "/metadata/nested/MANIFEST";
+  std::string error;
+  ASSERT_TRUE(ProcessUndeclaredOutputs(outputs, &error)) << error;
+
+  EXPECT_EQ(ReadFile(outputs.manifest),
+            ".hidden\t3\tapplication/octet-stream\n"
+            "alpha.txt\t10\ttext/plain\n"
+            "nested/index.html\t16\ttext/html\n"
+            "zeta\t5\ttext/plain\n");
+  EXPECT_TRUE(Exists(root_ + "/.hidden"));
+  EXPECT_TRUE(Exists(root_ + "/alpha.txt"));
+  EXPECT_TRUE(Exists(root_ + "/nested/index.html"));
+  EXPECT_TRUE(Exists(root_ + "/zeta"));
+}
+
+TEST_F(TestWrapperPosixTest, MimeTypeUsesContentInsteadOfFilename) {
+  WriteFile(root_ + "/binary.txt", std::string("\0\1\2", 3));
+  WriteFile(root_ + "/document.bin", "<HTML><body>content</body></HTML>\n");
+  WriteFile(root_ + "/empty.txt", "");
+  WriteFile(root_ + "/text.dat", "ordinary text\n");
+
+  UndeclaredOutputs outputs;
+  outputs.root = root_;
+  outputs.manifest = directory_ + "/MANIFEST";
+  std::string error;
+  ASSERT_TRUE(ProcessUndeclaredOutputs(outputs, &error)) << error;
+
+  EXPECT_EQ(ReadFile(outputs.manifest),
+            "binary.txt\t3\tapplication/octet-stream\n"
+            "document.bin\t34\ttext/html\n"
+            "empty.txt\t0\tinode/x-empty\n"
+            "text.dat\t14\ttext/plain\n");
+}
+
+TEST_F(TestWrapperPosixTest,
+       ZipContainsDirectoriesHiddenFilesAndSortedManifest) {
+  MakeDirectory(root_ + "/.secrets");
+  MakeDirectory(root_ + "/empty");
+  MakeDirectory(root_ + "/nested");
+  MakeDirectory(root_ + "/nested/deeper");
+  WriteFile(root_ + "/.hidden", "hidden\n");
+  WriteFile(root_ + "/.secrets/inside.txt", "secret\n");
+  WriteFile(root_ + "/nested/deeper/leaf.txt", "leaf\n");
+  WriteFile(root_ + "/zeta.html", "<!DOCTYPE html>\n");
+
+  UndeclaredOutputs outputs;
+  outputs.root = root_;
+  outputs.zip = root_ + "/outputs.zip";
+  outputs.manifest = directory_ + "/manifest/MANIFEST";
+  std::string error;
+  ASSERT_TRUE(ProcessUndeclaredOutputs(outputs, &error)) << error;
+
+  EXPECT_EQ(ReadFile(outputs.manifest),
+            ".hidden\t7\ttext/plain\n"
+            ".secrets/inside.txt\t7\ttext/plain\n"
+            "nested/deeper/leaf.txt\t5\ttext/plain\n"
+            "zeta.html\t16\ttext/html\n");
+  EXPECT_TRUE(Exists(outputs.zip));
+  EXPECT_FALSE(Exists(root_ + "/.hidden"));
+  EXPECT_FALSE(Exists(root_ + "/.secrets"));
+  EXPECT_FALSE(Exists(root_ + "/empty"));
+  EXPECT_FALSE(Exists(root_ + "/nested"));
+  EXPECT_FALSE(Exists(root_ + "/zeta.html"));
+
+  InMemoryZipExtractor archive;
+  ExtractZip(outputs.zip, &archive);
+  const std::map<std::string, ExtractedEntry>& entries = archive.entries();
+  ASSERT_EQ(entries.size(), 8);
+  ASSERT_EQ(entries.count(".hidden"), 1);
+  ASSERT_EQ(entries.count(".secrets/"), 1);
+  ASSERT_EQ(entries.count(".secrets/inside.txt"), 1);
+  ASSERT_EQ(entries.count("empty/"), 1);
+  ASSERT_EQ(entries.count("nested/"), 1);
+  ASSERT_EQ(entries.count("nested/deeper/"), 1);
+  ASSERT_EQ(entries.count("nested/deeper/leaf.txt"), 1);
+  ASSERT_EQ(entries.count("zeta.html"), 1);
+  EXPECT_EQ(entries.at(".hidden").content, "hidden\n");
+  EXPECT_EQ(entries.at(".secrets/inside.txt").content, "secret\n");
+  EXPECT_EQ(entries.at("nested/deeper/leaf.txt").content, "leaf\n");
+  EXPECT_EQ(entries.at("zeta.html").content, "<!DOCTYPE html>\n");
+  EXPECT_TRUE(entries.at(".secrets/").is_directory);
+  EXPECT_TRUE(entries.at("empty/").is_directory);
+  EXPECT_TRUE(entries.at("nested/").is_directory);
+  EXPECT_TRUE(entries.at("nested/deeper/").is_directory);
+  EXPECT_FALSE(entries.at(".hidden").is_directory);
+}
+
+TEST_F(TestWrapperPosixTest, ArchiveCanBeOutsideUndeclaredOutputDirectory) {
+  WriteFile(root_ + "/output.txt", "content\n");
+
+  UndeclaredOutputs outputs;
+  outputs.root = root_;
+  outputs.zip = directory_ + "/archive/nested/outputs.zip";
+  std::string error;
+  ASSERT_TRUE(ProcessUndeclaredOutputs(outputs, &error)) << error;
+
+  EXPECT_TRUE(Exists(outputs.zip));
+  EXPECT_FALSE(Exists(root_ + "/output.txt"));
+  InMemoryZipExtractor archive;
+  ExtractZip(outputs.zip, &archive);
+  ASSERT_EQ(archive.entries().size(), 1);
+  EXPECT_EQ(archive.entries().at("output.txt").content, "content\n");
+}
+
+TEST_F(TestWrapperPosixTest,
+       AnnotationsConcatenateSortedTopLevelPartAndProtoFiles) {
+  const std::string annotation_directory = directory_ + "/annotation_parts";
+  MakeDirectory(annotation_directory);
+  MakeDirectory(annotation_directory + "/nested");
+  MakeDirectory(annotation_directory + "/directory.part");
+  WriteFile(annotation_directory + "/z.part", "last");
+  WriteFile(annotation_directory + "/a.part", "first");
+  WriteFile(annotation_directory + "/.hidden.part", "hidden");
+  WriteFile(annotation_directory + "/ignored.txt", "ignored");
+  WriteFile(annotation_directory + "/nested/nested.part", "nested");
+  WriteFile(annotation_directory + "/z.pb", std::string("\0z", 2));
+  WriteFile(annotation_directory + "/a.pb", std::string("\1a", 2));
+  WriteFile(annotation_directory + "/.hidden.pb", "hidden");
+
+  UndeclaredOutputs outputs;
+  outputs.annotations_dir = annotation_directory;
+  outputs.annotations = directory_ + "/metadata/nested/ANNOTATIONS";
+  std::string error;
+  ASSERT_TRUE(ProcessUndeclaredOutputs(outputs, &error)) << error;
+
+  EXPECT_EQ(ReadFile(outputs.annotations), "firstlast");
+  EXPECT_EQ(ReadFile(outputs.annotations + ".pb"), std::string("\1a\0z", 4));
+  EXPECT_TRUE(Exists(annotation_directory + "/a.part"));
+  EXPECT_TRUE(Exists(annotation_directory + "/z.pb"));
+}
+
+TEST_F(TestWrapperPosixTest, HiddenAnnotationFragmentsDoNotCreateOutputs) {
+  const std::string annotation_directory = directory_ + "/annotation_parts";
+  MakeDirectory(annotation_directory);
+  WriteFile(annotation_directory + "/.hidden.part", "hidden");
+  WriteFile(annotation_directory + "/.hidden.pb", "hidden");
+  WriteFile(annotation_directory + "/ignored.txt", "ignored");
+
+  UndeclaredOutputs outputs;
+  outputs.annotations_dir = annotation_directory;
+  outputs.annotations = directory_ + "/ANNOTATIONS";
+  std::string error;
+  ASSERT_TRUE(ProcessUndeclaredOutputs(outputs, &error)) << error;
+
+  EXPECT_FALSE(Exists(outputs.annotations));
+  EXPECT_FALSE(Exists(outputs.annotations + ".pb"));
+}
+
+TEST_F(TestWrapperPosixTest, EmptyDirectoriesDoNotCreateOutputArtifacts) {
+  const std::string annotation_directory = directory_ + "/annotation_parts";
+  MakeDirectory(annotation_directory);
+
+  UndeclaredOutputs outputs;
+  outputs.root = root_;
+  outputs.zip = root_ + "/outputs.zip";
+  outputs.manifest = directory_ + "/MANIFEST";
+  outputs.annotations_dir = annotation_directory;
+  outputs.annotations = directory_ + "/ANNOTATIONS";
+  std::string error = "previous error";
+  ASSERT_TRUE(ProcessUndeclaredOutputs(outputs, &error)) << error;
+
+  EXPECT_TRUE(error.empty());
+  EXPECT_FALSE(Exists(outputs.zip));
+  EXPECT_FALSE(Exists(outputs.manifest));
+  EXPECT_FALSE(Exists(outputs.annotations));
+  EXPECT_FALSE(Exists(outputs.annotations + ".pb"));
+}
+
+TEST_F(TestWrapperPosixTest, MissingDirectoriesDoNotCreateOutputArtifacts) {
+  UndeclaredOutputs outputs;
+  outputs.root = directory_ + "/missing_outputs";
+  outputs.zip = directory_ + "/outputs.zip";
+  outputs.manifest = directory_ + "/MANIFEST";
+  outputs.annotations_dir = directory_ + "/missing_annotations";
+  outputs.annotations = directory_ + "/ANNOTATIONS";
+  std::string error;
+  ASSERT_TRUE(ProcessUndeclaredOutputs(outputs, &error)) << error;
+
+  EXPECT_FALSE(Exists(outputs.zip));
+  EXPECT_FALSE(Exists(outputs.manifest));
+  EXPECT_FALSE(Exists(outputs.annotations));
+  EXPECT_FALSE(Exists(outputs.annotations + ".pb"));
+}
+
+TEST_F(TestWrapperPosixTest, SymlinkTargetsAreArchivedButNotDeleted) {
+  const std::string external_directory = directory_ + "/external";
+  MakeDirectory(external_directory);
+  WriteFile(external_directory + "/file.txt", "outside\n");
+  MakeDirectory(external_directory + "/directory");
+  WriteFile(external_directory + "/directory/child.txt", "nested\n");
+
+  ASSERT_EQ(symlink((external_directory + "/file.txt").c_str(),
+                    (root_ + "/file-link.txt").c_str()),
+            0)
+      << std::strerror(errno);
+  ASSERT_EQ(symlink((external_directory + "/directory").c_str(),
+                    (root_ + "/directory-link").c_str()),
+            0)
+      << std::strerror(errno);
+
+  UndeclaredOutputs outputs;
+  outputs.root = root_;
+  outputs.zip = root_ + "/outputs.zip";
+  outputs.manifest = directory_ + "/MANIFEST";
+  std::string error;
+  ASSERT_TRUE(ProcessUndeclaredOutputs(outputs, &error)) << error;
+
+  EXPECT_EQ(ReadFile(outputs.manifest),
+            "directory-link/child.txt\t7\ttext/plain\n"
+            "file-link.txt\t8\ttext/plain\n");
+  EXPECT_FALSE(Exists(root_ + "/file-link.txt"));
+  EXPECT_FALSE(Exists(root_ + "/directory-link"));
+  EXPECT_EQ(ReadFile(external_directory + "/file.txt"), "outside\n");
+  EXPECT_EQ(ReadFile(external_directory + "/directory/child.txt"), "nested\n");
+
+  InMemoryZipExtractor archive;
+  ExtractZip(outputs.zip, &archive);
+  ASSERT_EQ(archive.entries().size(), 3);
+  EXPECT_TRUE(archive.entries().at("directory-link/").is_directory);
+  EXPECT_EQ(archive.entries().at("directory-link/child.txt").content,
+            "nested\n");
+  EXPECT_EQ(archive.entries().at("file-link.txt").content, "outside\n");
+}
+
+TEST_F(TestWrapperPosixTest, SymlinkCyclesDoNotRecurseIndefinitely) {
+  WriteFile(root_ + "/file.txt", "content\n");
+  ASSERT_EQ(symlink(".", (root_ + "/cycle").c_str()), 0)
+      << std::strerror(errno);
+
+  UndeclaredOutputs outputs;
+  outputs.root = root_;
+  outputs.zip = root_ + "/outputs.zip";
+  outputs.manifest = directory_ + "/MANIFEST";
+  std::string error;
+  ASSERT_TRUE(ProcessUndeclaredOutputs(outputs, &error)) << error;
+
+  EXPECT_EQ(ReadFile(outputs.manifest), "file.txt\t8\ttext/plain\n");
+  InMemoryZipExtractor archive;
+  ExtractZip(outputs.zip, &archive);
+  ASSERT_EQ(archive.entries().size(), 2);
+  EXPECT_TRUE(archive.entries().at("cycle/").is_directory);
+  EXPECT_EQ(archive.entries().at("file.txt").content, "content\n");
+}
+
+TEST_F(TestWrapperPosixTest, NondirectoryRootReturnsUsefulError) {
+  const std::string invalid_root = directory_ + "/not_a_directory";
+  WriteFile(invalid_root, "content");
+
+  UndeclaredOutputs outputs;
+  outputs.root = invalid_root;
+  outputs.manifest = directory_ + "/MANIFEST";
+  std::string error;
+  EXPECT_FALSE(ProcessUndeclaredOutputs(outputs, &error));
+  EXPECT_NE(error.find("not a directory"), std::string::npos) << error;
+  EXPECT_NE(error.find(invalid_root), std::string::npos) << error;
+  EXPECT_FALSE(Exists(outputs.manifest));
+}
+
+}  // namespace
+}  // namespace test_wrapper
+}  // namespace tools
+}  // namespace bazel

--- a/tools/test/test_wrapper_common.cc
+++ b/tools/test/test_wrapper_common.cc
@@ -1,0 +1,60 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tools/test/test_wrapper_common.h"
+
+#include <cstring>
+
+namespace bazel {
+namespace tools {
+namespace test_wrapper {
+
+void ZipEntryPaths::Create(const std::string& root,
+                           const std::vector<std::string>& relative_paths) {
+  size_ = relative_paths.size();
+
+  size_t total_size = 0;
+  for (const std::string& relative_path : relative_paths) {
+    total_size += root.size() + 1 + relative_path.size() + 1;
+  }
+
+  abs_paths_.reset(new char[total_size]);
+  abs_path_ptrs_.reset(new char*[size_ + 1]);
+  entry_path_ptrs_.reset(new char*[size_ + 1]);
+
+  char* next = abs_paths_.get();
+  for (size_t i = 0; i < size_; ++i) {
+    abs_path_ptrs_[i] = next;
+    std::memcpy(next, root.data(), root.size());
+    next += root.size();
+    *next++ = '/';
+
+    entry_path_ptrs_[i] = next;
+    std::memcpy(next, relative_paths[i].c_str(), relative_paths[i].size() + 1);
+    next += relative_paths[i].size() + 1;
+  }
+
+  abs_path_ptrs_[size_] = nullptr;
+  entry_path_ptrs_[size_] = nullptr;
+}
+
+std::string FormatUndeclaredOutputManifestEntry(
+    const std::string& relative_path, uint64_t size,
+    const std::string& mime_type) {
+  return relative_path + '\t' + std::to_string(size) + '\t' + mime_type + '\n';
+}
+
+}  // namespace test_wrapper
+}  // namespace tools
+}  // namespace bazel

--- a/tools/test/test_wrapper_common.h
+++ b/tools/test/test_wrapper_common.h
@@ -1,0 +1,59 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BAZEL_TOOLS_TEST_TEST_WRAPPER_COMMON_H_
+#define BAZEL_TOOLS_TEST_TEST_WRAPPER_COMMON_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace bazel {
+namespace tools {
+namespace test_wrapper {
+
+// Owns the absolute file paths and relative ZIP entry paths passed to
+// devtools_ijar::ZipBuilder.
+class ZipEntryPaths {
+ public:
+  // `root` is an absolute path using forward slashes. `files` contains relative
+  // ZIP entry paths using forward slashes.
+  void Create(const std::string& root, const std::vector<std::string>& files);
+
+  size_t Size() const { return size_; }
+
+  // Both arrays are null-terminated and remain valid until this object is
+  // destroyed or Create is called again.
+  char const* const* AbsPathPtrs() const { return abs_path_ptrs_.get(); }
+  char const* const* EntryPathPtrs() const { return entry_path_ptrs_.get(); }
+
+ private:
+  size_t size_ = 0;
+  std::unique_ptr<char[]> abs_paths_;
+  std::unique_ptr<char*[]> abs_path_ptrs_;
+  std::unique_ptr<char*[]> entry_path_ptrs_;
+};
+
+// Returns one line for TEST_UNDECLARED_OUTPUTS_MANIFEST.
+std::string FormatUndeclaredOutputManifestEntry(
+    const std::string& relative_path, uint64_t size,
+    const std::string& mime_type);
+
+}  // namespace test_wrapper
+}  // namespace tools
+}  // namespace bazel
+
+#endif  // BAZEL_TOOLS_TEST_TEST_WRAPPER_COMMON_H_

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -952,8 +952,8 @@ bool CreateUndeclaredOutputsManifestContent(const std::vector<FileInfo>& files,
         return false;
       }
 
-      stm << acp_path << "\t" << e.Size() << "\t" << GetMimeType(acp_path)
-          << "\n";
+      stm << FormatUndeclaredOutputManifestEntry(acp_path, e.Size(),
+                                                 GetMimeType(acp_path));
     }
   }
   *result = stm.str();
@@ -1876,64 +1876,6 @@ DWORD IFStreamImpl::Peek(DWORD n, uint8_t* out) const {
 }
 
 }  // namespace
-
-void ZipEntryPaths::Create(const std::string& root,
-                           const std::vector<std::string>& relative_paths) {
-  size_ = relative_paths.size();
-
-  size_t total_size = 0;
-  for (const auto& e : relative_paths) {
-    // Increase total size for absolute paths by <root> + "/" + <path> +
-    // null-terminator.
-    total_size += root.size() + 1 + e.size() + 1;
-  }
-
-  // Store all absolute paths in one continuous char array.
-  abs_paths_.reset(new char[total_size]);
-
-  // Store pointers in two arrays. The pointers point into `abs_path`.
-  // We'll pass these paths to devtools_ijar::ZipBuilder::EstimateSize that
-  // expects an array of char pointers. The last element must be NULL, so
-  // allocate one extra pointer.
-  abs_path_ptrs_.reset(new char*[relative_paths.size() + 1]);
-  entry_path_ptrs_.reset(new char*[relative_paths.size() + 1]);
-
-  char* p = abs_paths_.get();
-  // Create all full paths (root + '/' + relative_paths[i] + '\0').
-  //
-  // If `root` is "c:/foo", then store the following:
-  //
-  // - Store each absolute path consecutively in `abs_paths_` (via `p`).
-  //   Store paths with forward slashes and not backslashes, because we use them
-  //   as zip entry paths, as well as paths we open with CreateFileA (which can
-  //   convert these paths internally to Windows-style).
-  //   Example: "c:/foo/bar.txt\0c:/foo/sub/baz.txt\0"
-  //
-  // - Store pointers in `abs_path_ptrs_`, pointing to the start of each
-  //   string inside `abs_paths_`.
-  //   Example: "c:/foo/bar.txt\0c:/foo/sub/baz.txt\0"
-  //             ^ here          ^ here
-  //
-  // - Store pointers in `entry_path_ptrs_`, pointing to the start of each
-  //   zip entry path inside `abs_paths_`, which is the part of each path
-  //   that's relative to `root`.
-  //   Example: "c:/foo/bar.txt\0c:/foo/sub/baz.txt\0"
-  //                    ^ here          ^ here
-  //
-  // - Because the ZipBuilder requires that the file paths and zip entry paths
-  //   are null-terminated arrays, we insert an extra null at their ends.
-  for (size_t i = 0; i < relative_paths.size(); ++i) {
-    abs_path_ptrs_.get()[i] = p;
-    strncpy(p, root.c_str(), root.size());
-    p += root.size();
-    *p++ = '/';
-    entry_path_ptrs_.get()[i] = p;
-    strncpy(p, relative_paths[i].c_str(), relative_paths[i].size() + 1);
-    p += relative_paths[i].size() + 1;
-  }
-  abs_path_ptrs_.get()[relative_paths.size()] = nullptr;
-  entry_path_ptrs_.get()[relative_paths.size()] = nullptr;
-}
 
 int TestWrapperMain(int argc, wchar_t** argv) {
   Path executable, exec_root, srcdir, tmpdir, test_outerr, xml_log;

--- a/tools/test/windows/tw.h
+++ b/tools/test/windows/tw.h
@@ -23,6 +23,8 @@
 #include <string>
 #include <vector>
 
+#include "tools/test/test_wrapper_common.h"
+
 namespace bazel {
 
 namespace windows {
@@ -64,40 +66,6 @@ class FileInfo {
 
   // Whether this is a directory (true) or a regular file (false).
   bool is_dir_;
-};
-
-// Zip entry paths for devtools_ijar::ZipBuilder.
-// The function signatures mirror the signatures of ZipBuilder's functions.
-class ZipEntryPaths {
- public:
-  // Initialize the strings in this object.
-  // `root` must be an absolute mixed-style path (Windows path with "/"
-  // separators).
-  // `files` must be relative, Unix-style paths.
-  void Create(const std::string& root, const std::vector<std::string>& files);
-
-  // Returns the number of paths in `AbsPathPtrs` and `EntryPathPtrs`.
-  size_t Size() const { return size_; }
-
-  // Returns a mutable array of const pointers to const char data.
-  // Each pointer points to an absolute path: the file to archive.
-  // The pointers are owned by this object and become invalid when the object is
-  // destroyed.
-  // Each entry corresponds to the entry at the same index in `EntryPathPtrs`.
-  char const* const* AbsPathPtrs() const { return abs_path_ptrs_.get(); }
-
-  // Returns a mutable array of const pointers to const char data.
-  // Each pointer points to a relative path: an entry in the zip file.
-  // The pointers are owned by this object and become invalid when the object is
-  // destroyed.
-  // Each entry corresponds to the entry at the same index in `AbsPathPtrs`.
-  char const* const* EntryPathPtrs() const { return entry_path_ptrs_.get(); }
-
- private:
-  size_t size_;
-  std::unique_ptr<char[]> abs_paths_;
-  std::unique_ptr<char*[]> abs_path_ptrs_;
-  std::unique_ptr<char*[]> entry_path_ptrs_;
 };
 
 // Streams data from an input to two outputs.


### PR DESCRIPTION
Add --incompatible_use_native_posix_test_wrapper, disabled by default. Share ZIP and manifest support with the Windows test wrapper, preserve Windows behavior, and fall back to test-setup.sh for unsupported execution platforms and custom test execution groups.

RELNOTES: --incompatible_use_native_posix_test_wrapper has been added. See #15838 for details.

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
