### PR TITLE
Await remote repo materialization during teardown

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -154,16 +154,19 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
       // unconditionally.
       return;
     }
+
+    // Uninterruptibly await the termination of all ongoing materializations to prevent cleanup
+    // below from interfering with a user's interrupt of the build.
+    materializationExecutor.shutdownNow();
+    materializationExecutor.close();
+
     this.cache = null;
     this.inputPrefetcher = null;
     this.reporter = null;
     this.buildRequestId = null;
     this.commandId = null;
     this.remoteCacheTtl = null;
-    // Materializations happen synchronously and upon request by other repo rules, so there is no
-    // reason to await their orderly completion in afterCommand.
-    materializationExecutor.shutdownNow();
-    materializationExecutor = null;
+    this.materializationExecutor = null;
     // Clean up the in-memory contents of materialized repos to save memory, or those that need to
     // be refetched to recover files that the remote cache has lost. This wouldn't be safe to do
     // eagerly as ongoing repo rule evaluations may still refer to the in-memory content and


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
`RemoteExternalOverlayFileSystem#afterCommand` cleared the per-command fields and dropped the in-memory repo contents while `shutdownNow` had merely interrupted the completion of the materialization threads. A user interrupt of the build at this point could lead to NPEs and corruption in the in-memory repo.


### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
