### PR TITLE
Track empty inputs in reused sandboxes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -342,7 +342,7 @@ public final class SandboxHelpers {
       throws IOException, InterruptedException {
     Path execroot = workDir.getParentDirectory();
     Preconditions.checkNotNull(stashContents);
-    for (var dirent : stashContents.symlinkMap().entrySet()) {
+    for (var dirent : stashContents.fileMap().entrySet()) {
       if (Thread.interrupted()) {
         throw new InterruptedException();
       }
@@ -350,7 +350,12 @@ public final class SandboxHelpers {
       PathFragment pathRelativeToWorkDir = getPathRelativeToWorkDir(absPath, workDir, execroot);
       Optional<PathFragment> targetPath =
           getExpectedSymlinkTargetPath(pathRelativeToWorkDir, inputs);
-      if (targetPath.isPresent() && dirent.getValue().equals(targetPath.get())) {
+      boolean shouldKeep =
+          dirent.getValue() == null
+              ? inputs.getFiles().containsKey(pathRelativeToWorkDir)
+                  && inputs.getFiles().get(pathRelativeToWorkDir) == null
+              : targetPath.isPresent() && dirent.getValue().equals(targetPath.get());
+      if (shouldKeep) {
         Preconditions.checkState(inputsToCreate.remove(pathRelativeToWorkDir));
       } else {
         absPath.delete();
@@ -780,11 +785,11 @@ public final class SandboxHelpers {
    *
    * <p>The map keys are individual path segments.
    *
-   * @param symlinkMap maps names of known symlinks to their target path
+   * @param fileMap maps names of known symlinks to their target paths and empty files to null
    * @param dirMap maps names of known subdirectories to their contents
    */
   public record SandboxContents(
-      Map<String, PathFragment> symlinkMap, Map<String, SandboxContents> dirMap) {
+      Map<String, PathFragment> fileMap, Map<String, SandboxContents> dirMap) {
     public SandboxContents() {
       this(CompactHashMap.create(), CompactHashMap.create());
     }
@@ -801,15 +806,14 @@ public final class SandboxHelpers {
       Path workDir, SandboxInputs inputs, SandboxOutputs outputs) {
     Map<PathFragment, SandboxContents> contentsMap = CompactHashMap.create();
     for (Map.Entry<PathFragment, Path> entry : inputs.getFiles().entrySet()) {
-      if (entry.getValue() == null) {
-        continue;
-      }
       PathFragment parent = entry.getKey().getParentDirectory();
       boolean parentWasPresent = !addParent(contentsMap, parent);
       contentsMap
           .get(parent)
-          .symlinkMap()
-          .put(entry.getKey().getBaseName(), entry.getValue().asFragment());
+          .fileMap()
+          .put(
+              entry.getKey().getBaseName(),
+              entry.getValue() == null ? null : entry.getValue().asFragment());
       addAllParents(contentsMap, parentWasPresent, parent);
     }
     for (Map.Entry<PathFragment, PathFragment> entry : inputs.getSymlinks().entrySet()) {
@@ -818,7 +822,7 @@ public final class SandboxHelpers {
       }
       PathFragment parent = entry.getKey().getParentDirectory();
       boolean parentWasPresent = !addParent(contentsMap, parent);
-      contentsMap.get(parent).symlinkMap().put(entry.getKey().getBaseName(), entry.getValue());
+      contentsMap.get(parent).fileMap().put(entry.getKey().getBaseName(), entry.getValue());
       addAllParents(contentsMap, parentWasPresent, parent);
     }
 
@@ -858,7 +862,7 @@ public final class SandboxHelpers {
         }
         Path absPath = root.getChild(dirent.getName());
         if (dirent.getType().equals(SYMLINK)) {
-          if (stashContents.symlinkMap().containsKey(dirent.getName())
+          if (stashContents.fileMap().get(dirent.getName()) != null
               && absPath.stat().getLastChangeTime() <= timestamp) {
             filesAndSymlinksToKeep.add(dirent.getName());
           } else {
@@ -877,7 +881,7 @@ public final class SandboxHelpers {
         }
       }
       stashContents.dirMap().keySet().retainAll(dirsToKeep);
-      stashContents.symlinkMap().keySet().retainAll(filesAndSymlinksToKeep);
+      stashContents.fileMap().keySet().retainAll(filesAndSymlinksToKeep);
     } else {
       for (var entry : stashContents.dirMap().entrySet()) {
         Path absPath = root.getChild(entry.getKey());

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.devtools.build.lib.vfs.Dirent.Type.DIRECTORY;
+import static com.google.devtools.build.lib.vfs.Dirent.Type.FILE;
 import static com.google.devtools.build.lib.vfs.Dirent.Type.SYMLINK;
 import static java.util.Objects.requireNonNull;
 
@@ -875,6 +876,14 @@ public final class SandboxHelpers {
           } else {
             absPath.deleteTree();
             stashContents.dirMap().remove(dirent.getName());
+          }
+        } else if (dirent.getType().equals(FILE)) {
+          if (stashContents.fileMap().containsKey(dirent.getName())
+              && stashContents.fileMap().get(dirent.getName()) == null
+              && absPath.stat().getLastChangeTime() <= timestamp) {
+            filesAndSymlinksToKeep.add(dirent.getName());
+          } else {
+            absPath.delete();
           }
         } else {
           absPath.delete();

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.exec.BinTools;
 import com.google.devtools.build.lib.exec.TreeDeleter;
 import com.google.devtools.build.lib.exec.util.SpawnBuilder;
+import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxContents;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
 import com.google.devtools.build.lib.testutil.Scratch;
@@ -50,7 +51,9 @@ import com.google.testing.junit.testparameterinjector.TestParameter;
 import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
@@ -300,6 +303,69 @@ public class SandboxHelpersTest {
     assertThat(execRoot.getRelative("justSomeDir/thatIsDoomed").exists()).isFalse();
     assertThat(execRoot.getRelative("out").exists()).isTrue();
     assertThat(execRoot.getRelative("out/dir").exists()).isFalse();
+  }
+
+  @Test
+  public void createContentMap_withOnlyEmptyInput_tracksContainingDirectories() {
+    PathFragment emptyInput = PathFragment.create("api/__init__.py");
+    Map<PathFragment, Path> files = new HashMap<>();
+    files.put(emptyInput, null);
+    SandboxInputs inputs = new SandboxInputs(files, ImmutableMap.of(), ImmutableMap.of());
+
+    SandboxContents sandboxContents =
+        SandboxHelpers.createContentMap(execRoot, inputs, SandboxOutputs.getEmptyInstance());
+
+    SandboxContents workDirContents = sandboxContents.dirMap().get(execRoot.getBaseName());
+    assertThat(workDirContents).isNotNull();
+    SandboxContents apiContents = workDirContents.dirMap().get("api");
+    assertThat(apiContents).isNotNull();
+    assertThat(apiContents.fileMap()).containsEntry("__init__.py", null);
+  }
+
+  @Test
+  public void cleanExisting_withInMemoryContents_tracksEmptyInputs(
+      @TestParameter boolean keepEmptyInput) throws Exception {
+    PathFragment emptyInput = PathFragment.create("api/__init__.py");
+    PathFragment sharedInput = PathFragment.create("api/shared.py");
+    Path sharedSource = scratch.file("/inputs/shared.py", "shared");
+    Path emptyFile = scratch.file("/execroot/api/__init__.py");
+    execRoot.getRelative(sharedInput).createSymbolicLink(sharedSource.asFragment());
+
+    Map<PathFragment, Path> previousFiles = new HashMap<>();
+    previousFiles.put(emptyInput, null);
+    previousFiles.put(sharedInput, sharedSource);
+    SandboxInputs previousInputs =
+        new SandboxInputs(previousFiles, ImmutableMap.of(), ImmutableMap.of());
+    SandboxContents sandboxContents =
+        SandboxHelpers.createContentMap(
+            execRoot, previousInputs, SandboxOutputs.getEmptyInstance());
+
+    Map<PathFragment, Path> currentFiles = new HashMap<>(previousFiles);
+    if (!keepEmptyInput) {
+      currentFiles.remove(emptyInput);
+    }
+    SandboxInputs currentInputs =
+        new SandboxInputs(currentFiles, ImmutableMap.of(), ImmutableMap.of());
+    Set<PathFragment> inputsToCreate = new LinkedHashSet<>();
+    Set<PathFragment> dirsToCreate = new LinkedHashSet<>();
+    SandboxHelpers.populateInputsAndDirsToCreate(
+        ImmutableSet.of(),
+        inputsToCreate,
+        dirsToCreate,
+        currentFiles.keySet(),
+        SandboxOutputs.getEmptyInstance());
+
+    SandboxHelpers.cleanExisting(
+        execRoot.getParentDirectory(),
+        currentInputs,
+        inputsToCreate,
+        dirsToCreate,
+        execRoot,
+        treeDeleter,
+        sandboxContents);
+
+    assertThat(emptyFile.exists()).isEqualTo(keepEmptyInput);
+    assertThat(inputsToCreate).isEmpty();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.exec.util.SpawnBuilder;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxContents;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
+import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.testutil.Scratch;
 import com.google.devtools.build.lib.testutil.TestUtils;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
@@ -320,6 +321,30 @@ public class SandboxHelpersTest {
     SandboxContents apiContents = workDirContents.dirMap().get("api");
     assertThat(apiContents).isNotNull();
     assertThat(apiContents.fileMap()).containsEntry("__init__.py", null);
+  }
+
+  @Test
+  public void updateContentMap_preservesEmptyInputInUpdatedDirectory() throws Exception {
+    ManualClock clock = new ManualClock();
+    Scratch scratch = new Scratch(new InMemoryFileSystem(clock, DigestHashFunction.SHA256));
+    Path workDir = scratch.dir("/execroot");
+    Path emptyFile = scratch.file("/execroot/api/__init__.py");
+    PathFragment emptyInput = PathFragment.create("api/__init__.py");
+    Map<PathFragment, Path> files = new HashMap<>();
+    files.put(emptyInput, null);
+    SandboxInputs inputs = new SandboxInputs(files, ImmutableMap.of(), ImmutableMap.of());
+    SandboxContents contents =
+        SandboxHelpers.createContentMap(workDir, inputs, SandboxOutputs.getEmptyInstance());
+    long timestamp = clock.currentTimeMillis();
+
+    clock.advanceMillis(1);
+    Path unexpectedFile = scratch.file("/execroot/api/unexpected", "unexpected");
+    SandboxHelpers.updateContentMap(workDir.getParentDirectory(), timestamp, contents);
+
+    assertThat(emptyFile.isFile()).isTrue();
+    assertThat(unexpectedFile.exists()).isFalse();
+    assertThat(contents.dirMap().get("execroot").dirMap().get("api").fileMap())
+        .containsEntry("__init__.py", null);
   }
 
   @Test


### PR DESCRIPTION
### Description
Track empty files alongside symlinks in the existing compact content map, distinguish the two cases during cleanup, and preserve directories containing only empty inputs.

### Motivation

Null-backed sandbox inputs create real empty files, but in-memory sandbox contents omit those files and their parent directories. A reused sandbox can consequently leak empty inputs between actions or fail to recognize empty inputs that should be retained.

### Build API Changes
No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
