### PR TITLE
Invalidate symlinks after missing-parent deletes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -360,6 +360,7 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
       path = resolveSymbolicLinksForParent(path);
     } catch (FileNotFoundException ignored) {
       // Failure to delete a nonexistent path is not an error.
+      pathCanonicalizer.clearPrefix(originalPath);
       return false;
     }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -39,9 +39,11 @@ import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInputMap;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Priority;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Reason;
+import com.google.devtools.build.lib.actions.ActionOutputDirectoryHelper;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
+import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
@@ -398,6 +400,29 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
 
     assertThat(actionFs.getPath(linkPath).resolveSymbolicLinks())
         .isEqualTo(actionFs.getPath(linkPath));
+  }
+
+  @Test
+  public void createOutputDirectories_afterMissingParentDelete(
+      @TestParameter({"ns/a", "ns/nested/a"}) String outputPath) throws Exception {
+    FileSystem actionFs = createActionFileSystem();
+    PathFragment namespace = getOutputPath("ns");
+    fs.getPath(namespace).createSymbolicLink(PathFragment.create("missing"));
+
+    // Output preparation caches a dangling parent left by a previous build. Another output's
+    // preparation then replaces it with a directory, as in AbstractActionInputPrefetcher.
+    assertThat(actionFs.delete(getOutputPath(outputPath))).isFalse();
+    ActionOutputDirectoryHelper helper = ActionOutputDirectoryHelper.createForTesting();
+    helper.createOutputDirectories(
+        ImmutableList.of(ActionsTestUtil.createArtifact(outputRoot, "ns/b")));
+    assertThat(fs.getPath(namespace).isDirectory(Symlinks.NOFOLLOW)).isTrue();
+    assertThat(fs.getPath(getOutputPath("missing")).exists()).isFalse();
+    helper.createActionFsOutputDirectories(
+        ImmutableList.of(ActionsTestUtil.createArtifact(outputRoot, outputPath)),
+        ArtifactPathResolver.createPathResolver(actionFs, execRoot));
+
+    assertThat(actionFs.getPath(getOutputPath(outputPath)).getParentDirectory().isDirectory())
+        .isTrue();
   }
 
   @Test


### PR DESCRIPTION
### Description

Incremental builds using the remote action filesystem can fail to create an output directory after a previous build's dangling parent symlink is replaced with a directory. Deleting the new output first caches that symlink, then returns early because its target is missing. Another output's host-side directory preparation repairs the physical path, but the action filesystem continues following its cached missing target.

Invalidate the original path before that early return. The regression interleaves failed output deletion with host directory preparation and covers both immediate and nested parents.

### Motivation

Fixes #30844. This extends the deletion invalidation in 2e29213d00 to the missing-parent case; the cached-resolution mechanism dates to f2512a0718.

### Build API Changes

None.

### Checklist

- [x] Added regression coverage.
- [ ] Documentation update (not applicable).

### Release Notes

RELNOTES: Fix incremental remote builds failing to create output directories beneath stale dangling symlinks.

Prepared with Codex at Tamir Duberstein's request.