### PR TITLE
Check previous build's toplevel outputs in shouldTrustMetadata

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputChecker.java
@@ -350,12 +350,12 @@ public class RemoteOutputChecker implements OutputChecker {
       // If Bazel should download this file, but it does not exist locally, returns false to rerun
       // the generating action to trigger the download (just like in the normal build, when local
       // outputs are missing).
-      if (lastRemoteOutputChecker != null) {
-        // This is an incremental build. If the file was downloaded by previous build and is now
-        // missing, invalidate the action.
-        if (lastRemoteOutputChecker.shouldDownloadOutput(file, metadata)) {
-          return false;
-        }
+      //
+      // Under Skymeld, this check may run before analysis has registered the current build's
+      // toplevel targets. Checks the toplevel outputs tracked by the previous build's checker.
+      if (lastRemoteOutputChecker != null
+          && lastRemoteOutputChecker.pathsToDownload.contains(file.getExecPath())) {
+        return false;
       }
 
       if (shouldDownloadOutput(file, metadata)) {

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -319,6 +319,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
+        "//src/main/java/com/google/devtools/build/lib/runtime/commands",
         "//src/main/java/com/google/devtools/build/lib/skyframe:action_execution_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",
         "//src/main/java/com/google/devtools/build/lib/util:command",

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.actions.CachedActionEvent;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.analysis.TargetCompleteEvent;
 import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
+import com.google.devtools.build.lib.runtime.commands.HelpCommand;
 import com.google.devtools.build.lib.skyframe.ActionExecutionValue;
 import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
 import com.google.devtools.build.lib.testutil.TestUtils;
@@ -1382,6 +1383,117 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
   }
 
   @Test
+  public void downloadToplevel_afterHelpWithDownloadAll_doesNotReevaluateRemoteOutputs()
+      throws Exception {
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'foo',",
+        "  outs = ['out/foo.txt'],",
+        "  cmd = 'echo foo > $@',",
+        ")",
+        "genrule(",
+        "  name = 'foobar',",
+        "  srcs = [':foo'],",
+        "  outs = ['out/foobar.txt'],",
+        "  cmd = 'cat $(location :foo) > $@ && echo bar >> $@',",
+        ")");
+
+    // Leave both outputs represented only by remote metadata.
+    buildTarget("//:foobar");
+    assertOutputsDoNotExist("//:foo");
+    assertOutputsDoNotExist("//:foobar");
+
+    // Install a previous checker with download-all, without running a build or materializing any
+    // outputs.
+    setDownloadAll();
+    runtimeWrapper.newCommand(HelpCommand.class);
+    runtimeWrapper.executeCustomCommand();
+
+    setDownloadToplevel();
+    ActionEventCollector actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+    buildTarget("//:foobar");
+
+    assertOutputDoesNotExist("out/foo.txt");
+    assertValidOutputFile("out/foobar.txt", "foo\nbar\n");
+    assertThat(actionEventCollector.getNumActionNodesEvaluated()).isEqualTo(0);
+  }
+
+  @Test
+  public void downloadToplevel_afterDownloadAllBuildOfAnotherTarget_doesNotReexecuteActions()
+      throws Exception {
+    writeAppWithLibs();
+    setDownloadToplevel();
+    buildTarget("//:app");
+    assertValidOutputFile("out/app.txt", "lib0\nlib1\nlib2\n");
+    assertOutputsDoNotExist("//:lib0");
+    assertOutputsDoNotExist("//:lib1");
+    assertOutputsDoNotExist("//:lib2");
+
+    // Build an unrelated target with a broader download policy, as e.g. an IDE project generator
+    // does, then run an incremental build without changes.
+    setDownloadAll();
+    buildTarget("//:tool");
+    setDownloadToplevel();
+    ActionEventCollector actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+    buildTarget("//:app");
+
+    // The intermediate outputs are still trusted, so their actions hit the action cache instead of
+    // being re-executed remotely.
+    assertOutputsDoNotExist("//:lib0");
+    assertValidOutputFile("out/app.txt", "lib0\nlib1\nlib2\n");
+    assertThat(actionEventCollector.getActionExecutedEvents()).isEmpty();
+  }
+
+  @Test
+  public void downloadToplevel_afterDownloadAllBuildOfAnotherTarget_onlyModifiedActionsRerun()
+      throws Exception {
+    writeAppWithLibs();
+    setDownloadToplevel();
+    buildTarget("//:app");
+    assertValidOutputFile("out/app.txt", "lib0\nlib1\nlib2\n");
+    setDownloadAll();
+    buildTarget("//:tool");
+
+    setDownloadToplevel();
+    write("lib0.in", "modified");
+    ActionEventCollector actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+    buildTarget("//:app");
+
+    // Only the actions depending on the modified source are re-executed.
+    assertOutputsDoNotExist("//:lib1");
+    assertOutputsDoNotExist("//:lib2");
+    assertValidOutputFile("out/app.txt", "modified\nlib1\nlib2\n");
+    assertThat(actionEventCollector.getActionExecutedEvents()).hasSize(2);
+  }
+
+  @Test
+  public void downloadMinimal_afterDownloadAllBuildOfAnotherTarget_doesNotReexecuteActions()
+      throws Exception {
+    writeAppWithLibs();
+    buildTarget("//:app");
+    assertOutputsDoNotExist("//:app");
+    assertOutputsDoNotExist("//:lib0");
+
+    // Build an unrelated target with a broader download policy, then run an incremental build
+    // without changes.
+    setDownloadAll();
+    buildTarget("//:tool");
+    addOptions("--remote_download_outputs=minimal");
+    ActionEventCollector actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+    buildTarget("//:app");
+
+    // Nothing is downloaded and no action is re-executed.
+    assertOutputsDoNotExist("//:app");
+    assertOutputsDoNotExist("//:lib0");
+    assertThat(actionEventCollector.getActionExecutedEvents()).isEmpty();
+  }
+
+  @Test
   public void incrementalBuild_fileOutputIsPrefetched_noRuns() throws Exception {
     // We need to download the intermediate output
     if (!hasAccessToRemoteOutputs()) {
@@ -1974,6 +2086,43 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
             },
         )
         """);
+  }
+
+  protected void writeAppWithLibs() throws IOException {
+    write("lib0.in", "lib0");
+    write("lib1.in", "lib1");
+    write("lib2.in", "lib2");
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'lib0',",
+        "  srcs = ['lib0.in'],",
+        "  outs = ['out/lib0.txt'],",
+        "  cmd = 'cat $(SRCS) > $@',",
+        ")",
+        "genrule(",
+        "  name = 'lib1',",
+        "  srcs = ['lib1.in'],",
+        "  outs = ['out/lib1.txt'],",
+        "  cmd = 'cat $(SRCS) > $@',",
+        ")",
+        "genrule(",
+        "  name = 'lib2',",
+        "  srcs = ['lib2.in'],",
+        "  outs = ['out/lib2.txt'],",
+        "  cmd = 'cat $(SRCS) > $@',",
+        ")",
+        "genrule(",
+        "  name = 'app',",
+        "  srcs = [':lib0', ':lib1', ':lib2'],",
+        "  outs = ['out/app.txt'],",
+        "  cmd = 'cat $(SRCS) > $@',",
+        ")",
+        "genrule(",
+        "  name = 'tool',",
+        "  outs = ['out/tool.txt'],",
+        "  cmd = 'echo tool > $@',",
+        ")");
   }
 
   protected void writeCopyAspectRule(boolean aggregate) throws IOException {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteOutputCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteOutputCheckerTest.java
@@ -16,7 +16,9 @@ package com.google.devtools.build.lib.remote;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.remote.options.RemoteOutputsMode;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
@@ -54,5 +56,77 @@ public class RemoteOutputCheckerTest {
     assertThat(
             remoteOutputChecker.shouldDownloadOutput(PathFragment.create("out/foo/bar-baz"), null))
         .isTrue();
+  }
+
+  @Test
+  public void shouldTrustMetadata_previousBuildDownloadedAll_trusted() {
+    // Outputs that the current build does not want downloaded must not be distrusted
+    // due to a previous invocation using a broader download policy.
+    Artifact artifact = ActionsTestUtil.createArtifact(execRoot, "foo/bar");
+    FileArtifactValue metadata =
+        FileArtifactValue.createForRemoteFile(
+            new byte[] {1, 2, 3}, /* size= */ 3, /* locationIndex= */ 1);
+
+    var previousBuildChecker =
+        new RemoteOutputChecker("build", RemoteOutputsMode.ALL, ImmutableList.of());
+    var currentBuildChecker =
+        new RemoteOutputChecker(
+            "build", RemoteOutputsMode.TOPLEVEL, ImmutableList.of(), previousBuildChecker);
+
+    assertThat(currentBuildChecker.shouldTrustMetadata(artifact, metadata)).isTrue();
+  }
+
+  @Test
+  public void shouldTrustMetadata_previousBuildRegexMatch_trusted() {
+    Artifact artifact = ActionsTestUtil.createArtifact(execRoot, "foo/bar");
+    FileArtifactValue metadata =
+        FileArtifactValue.createForRemoteFile(
+            new byte[] {1, 2, 3}, /* size= */ 3, /* locationIndex= */ 1);
+
+    var previousBuildChecker =
+        new RemoteOutputChecker(
+            "build", RemoteOutputsMode.TOPLEVEL, ImmutableList.of(unused -> true));
+    var currentBuildChecker =
+        new RemoteOutputChecker(
+            "build", RemoteOutputsMode.TOPLEVEL, ImmutableList.of(), previousBuildChecker);
+
+    assertThat(currentBuildChecker.shouldTrustMetadata(artifact, metadata)).isTrue();
+  }
+
+  @Test
+  public void shouldTrustMetadata_toplevelOutputOfPreviousBuild_distrusted() {
+    // A toplevel output downloaded by the previous build must be distrusted if missing locally, so
+    // that the generating action reruns to restore it. Under Skymeld, the current build's toplevel
+    // outputs are not yet registered when this check runs.
+    Artifact artifact = ActionsTestUtil.createArtifact(execRoot, "foo/bar");
+    FileArtifactValue metadata =
+        FileArtifactValue.createForRemoteFile(
+            new byte[] {1, 2, 3}, /* size= */ 3, /* locationIndex= */ 1);
+
+    var previousBuildChecker =
+        new RemoteOutputChecker("build", RemoteOutputsMode.TOPLEVEL, ImmutableList.of());
+    previousBuildChecker.addOutputToDownload(artifact);
+    var currentBuildChecker =
+        new RemoteOutputChecker(
+            "build", RemoteOutputsMode.TOPLEVEL, ImmutableList.of(), previousBuildChecker);
+
+    assertThat(currentBuildChecker.shouldTrustMetadata(artifact, metadata)).isFalse();
+  }
+
+  @Test
+  public void shouldTrustMetadata_downloadedByCurrentBuild_distrusted() {
+    Artifact artifact = ActionsTestUtil.createArtifact(execRoot, "foo/bar");
+    FileArtifactValue metadata =
+        FileArtifactValue.createForRemoteFile(
+            new byte[] {1, 2, 3}, /* size= */ 3, /* locationIndex= */ 1);
+
+    var previousBuildChecker =
+        new RemoteOutputChecker("build", RemoteOutputsMode.TOPLEVEL, ImmutableList.of());
+    var currentBuildChecker =
+        new RemoteOutputChecker(
+            "build", RemoteOutputsMode.TOPLEVEL, ImmutableList.of(), previousBuildChecker);
+    currentBuildChecker.addOutputToDownload(artifact);
+
+    assertThat(currentBuildChecker.shouldTrustMetadata(artifact, metadata)).isFalse();
   }
 }


### PR DESCRIPTION
### Description

`RemoteOutputChecker.shouldTrustMetadata` now references only the previous build's tracked toplevel outputs rather than its full download policy. Since the policy itself is already known to the current checker at construction time.

### Motivation

Fixes #26924 

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Fixed unnecessary remote-cache hits in incremental BwoB builds after a previous invocation used a broader remote output download policy.