### PR TITLE
[9.3.0] Await remote repo materialization during teardown (https://github.com/bazelbuild/bazel/pull/30841)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -154,16 +154,19 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
       // unconditionally.
       return;
     }
+
+    // Uninterruptibly await the termination of all ongoing materializations to prevent cleanup
+    // below from interfering with a user's interrupt of the build.
+    materializationExecutor.shutdownNow();
+    materializationExecutor.close();
+
     this.cache = null;
     this.inputPrefetcher = null;
     this.reporter = null;
     this.buildRequestId = null;
     this.commandId = null;
     this.remoteCacheTtl = null;
-    // Materializations happen synchronously and upon request by other repo rules, so there is no
-    // reason to await their orderly completion in afterCommand.
-    materializationExecutor.shutdownNow();
-    materializationExecutor = null;
+    this.materializationExecutor = null;
     // Clean up the in-memory contents of materialized repos to save memory, or those that need to
     // be refetched to recover files that the remote cache has lost. This wouldn't be safe to do
     // eagerly as ongoing repo rule evaluations may still refer to the in-memory content and


### PR DESCRIPTION
### Description

### Motivation
`RemoteExternalOverlayFileSystem#afterCommand` cleared the per-command fields and dropped the in-memory repo contents while `shutdownNow` had merely interrupted the completion of the materialization threads. A user interrupt of the build at this point could lead to NPEs and corruption in the in-memory repo.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #30841.

PiperOrigin-RevId: 970401600
Change-Id: Ief1a04e54a7a6f7cef88844b6b53a4144cca02e2

Commit https://github.com/bazelbuild/bazel/commit/bba8c513e0ecde5edc8f7cf2cca444a5c8e7721d