### PR TITLE
handle IOException in rename during CompactPersistentActionCache init

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -482,32 +482,12 @@ public class CompactPersistentActionCache implements ActionCache {
       // This also ensures that the next initialization attempt will create an empty cache.
       // To avoid using too much disk space, only keep the most recent corrupted cache around.
       corruptedCacheRoot.deleteTree();
-
-      boolean renamedCorruptedCacheRoot = false;
-      try {
-        cacheRoot.renameTo(corruptedCacheRoot);
-        renamedCorruptedCacheRoot = true;
-      } catch (IOException ioe) {
-        ioe = new IOException("%s: %s".formatted(message, ioe.getMessage()), ioe);
-
-        logger.atWarning().withCause(ioe).log("Unable to rename %s to %s", cacheRoot, corruptedCacheRoot);
-
-        reporterForInitializationErrors.handle(
-            Event.warn(
-                "Error during action cache initialization: "
-                    + ioe.getMessage()
-                    + ". Data may be incomplete, potentially causing rebuilds"));
-      }
+      cacheRoot.renameTo(corruptedCacheRoot);
 
       e = new IOException("%s: %s".formatted(message, e.getMessage()), e);
 
-      if (renamedCorruptedCacheRoot) {
-        logger.atWarning().withCause(e).log(
-            "Failed to load action cache, preexisting files kept in %s", corruptedCacheRoot);
-      } else {
-        logger.atWarning().withCause(e).log(
-            "Failed to load action cache");
-      }
+      logger.atWarning().withCause(e).log(
+          "Failed to load action cache, preexisting files kept in %s", corruptedCacheRoot);
 
       reporterForInitializationErrors.handle(
           Event.warn(

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -482,12 +482,32 @@ public class CompactPersistentActionCache implements ActionCache {
       // This also ensures that the next initialization attempt will create an empty cache.
       // To avoid using too much disk space, only keep the most recent corrupted cache around.
       corruptedCacheRoot.deleteTree();
-      cacheRoot.renameTo(corruptedCacheRoot);
+
+      boolean renamedCorruptedCacheRoot = false;
+      try {
+        cacheRoot.renameTo(corruptedCacheRoot);
+        renamedCorruptedCacheRoot = true;
+      } catch (IOException ioe) {
+        ioe = new IOException("%s: %s".formatted(message, ioe.getMessage()), ioe);
+
+        logger.atWarning().withCause(ioe).log("Unable to rename %s to %s", cacheRoot, corruptedCacheRoot);
+
+        reporterForInitializationErrors.handle(
+            Event.warn(
+                "Error during action cache initialization: "
+                    + ioe.getMessage()
+                    + ". Data may be incomplete, potentially causing rebuilds"));
+      }
 
       e = new IOException("%s: %s".formatted(message, e.getMessage()), e);
 
-      logger.atWarning().withCause(e).log(
-          "Failed to load action cache, preexisting files kept in %s", corruptedCacheRoot);
+      if (renamedCorruptedCacheRoot) {
+        logger.atWarning().withCause(e).log(
+            "Failed to load action cache, preexisting files kept in %s", corruptedCacheRoot);
+      } else {
+        logger.atWarning().withCause(e).log(
+            "Failed to load action cache");
+      }
 
       reporterForInitializationErrors.handle(
           Event.warn(

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -482,18 +482,43 @@ public class CompactPersistentActionCache implements ActionCache {
       // This also ensures that the next initialization attempt will create an empty cache.
       // To avoid using too much disk space, only keep the most recent corrupted cache around.
       corruptedCacheRoot.deleteTree();
-      cacheRoot.renameTo(corruptedCacheRoot);
+
+      boolean renamedCacheRoot = false;
+      try {
+        cacheRoot.renameTo(corruptedCacheRoot);
+        renamedCacheRoot = true;
+      } catch (IOException ioe) {
+        ioe = new IOException("%s: %s".formatted(message, ioe.getMessage()), ioe);
+
+        logger.atWarning().withCause(ioe).log("Unable to rename %s to %s", cacheRoot, corruptedCacheRoot);
+
+        reporterForInitializationErrors.handle(
+            Event.warn(
+                "Error during action cache initialization: "
+                    + ioe.getMessage()
+                    + ". Data may be incomplete, potentially causing rebuilds"));
+      }
 
       e = new IOException("%s: %s".formatted(message, e.getMessage()), e);
 
-      logger.atWarning().withCause(e).log(
-          "Failed to load action cache, preexisting files kept in %s", corruptedCacheRoot);
+      if (renamedCacheRoot) {
+        logger.atWarning().withCause(e).log(
+            "Failed to load action cache, preexisting files kept in %s", corruptedCacheRoot);
+      } else {
+        logger.atWarning().withCause(e).log(
+            "Failed to load action cache");
+      }
 
       reporterForInitializationErrors.handle(
           Event.warn(
               "Error during action cache initialization: "
                   + e.getMessage()
                   + ". Data may be incomplete, potentially causing rebuilds"));
+
+      // If we failed to rename cacheRoot, then we fall back to deleting it.
+      if (!renamedCacheRoot) {
+        cacheRoot.deleteTree();
+      }
     }
 
     return create(


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

I've observed Bazel 9.2.0 failing as follows:

    ERROR: Couldn't create action cache: [unix_jni.cc:638] /tmp/.cache-bzlmod/bazel/_bazel_jenkins/output-base/action_cache -> /tmp/.cache-bzlmod/bazel/_bazel_jenkins/output-base/action_cache.bad (Invalid cross-device link). If error persists, use 'bazel clean'.

This unhandled `IOException` causes Bazel to fail to print the original cause of the problem that drove it into `logAndThrowOrRecurse()`.

We here attempt to improve the reporting and allow Bazel to survive the problem.

Note that `renameCorruptedFiles()` in Bazel 8 does handle and survive `IOException`.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

Since Bazel 8 was able to survive not being able to rename corrupted action cache files,
it seems like it would be a good idea for Bazel 9 to be able to do the same.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
