### PR TITLE
Avoid retrying refused connections in DownloadManager

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -42,6 +42,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.net.ConnectException;
 import java.net.SocketException;
 import java.net.URI;
 import java.net.UnknownHostException;
@@ -388,8 +389,10 @@ public class DownloadManager {
   }
 
   private boolean isRetryableException(Throwable e) {
+    // HttpConnector already retries connection attempts. Retrying a final ConnectException here
+    // repeats its entire backoff sequence.
     return e instanceof ContentLengthMismatchException
-        || e instanceof SocketException
+        || (e instanceof SocketException && !(e instanceof ConnectException))
         || e instanceof UnknownHostException;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -42,6 +42,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringReader;
+import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -1170,6 +1171,43 @@ public class HttpDownloaderTest {
     assertThat(times.get()).isEqualTo(4);
     String content = new String(result.getInputStream().readAllBytes(), UTF_8);
     assertThat(content).isEqualTo("content");
+  }
+
+  @Test
+  public void download_connectException_doesNotRetry() throws Exception {
+    Downloader downloader = mock(Downloader.class);
+    HttpDownloader httpDownloader = mock(HttpDownloader.class);
+    DownloadManager downloadManager =
+        new DownloadManager(downloadCache, downloader, httpDownloader, eventHandler);
+    downloadManager.setRetries(5);
+    AtomicInteger times = new AtomicInteger(0);
+    doAnswer(
+            (Answer<Void>)
+                invocationOnMock -> {
+                  times.getAndIncrement();
+                  IOException e = new IOException();
+                  e.addSuppressed(new ConnectException("Connection refused"));
+                  throw e;
+                })
+        .when(downloader)
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq("testRepo"));
+
+    assertThrows(
+        IOException.class,
+        () ->
+            download(
+                downloadManager,
+                ImmutableList.of(URI.create("http://localhost")),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                Optional.empty(),
+                "testCanonicalId",
+                Optional.empty(),
+                fs.getPath(workingDir.newFile().getAbsolutePath()),
+                ImmutableMap.of(),
+                "testRepo"));
+
+    assertThat(times.get()).isEqualTo(1);
   }
 
   @Test


### PR DESCRIPTION
### Description

- Do not treat `ConnectException` as retryable in `DownloadManager`.
- Preserve manager-level retries for other socket failures, unknown hosts, and content-length mismatches.
- Add a regression test verifying that a suppressed `ConnectException` invokes the downloader only once, even when manager retries are configured.

### Motivation

`HttpConnector` already retries connection attempts with exponential backoff. When its final `ConnectException` reached `DownloadManager`, the default five manager-level retries replayed that entire sequence, causing downloader rewrites to offline endpoints to take much longer to fail.

In an end-to-end reproduction using an offline rewritten endpoint, the failure time decreased from 83.329 seconds with Bazel 9.2.0 to 13.921 seconds with this change.

Fixes #30746.

### Testing

`bazel test //src/test/java/com/google/devtools/build/lib/bazel/repository/downloader:DownloaderTestSuite`

The complete suite passed: 1/1 test target, with the test process completing in 138.3 seconds.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Downloader rewrites to endpoints that refuse connections no longer repeat the connector's full retry sequence.
