### PR TITLE
Refresh the C++ toolchain configuration tutorial.

### DIFF
--- a/docs/tutorials/ccp-toolchain-config.mdx
+++ b/docs/tutorials/ccp-toolchain-config.mdx
@@ -11,15 +11,15 @@ toolchains for a project.
 
 In this tutorial you learn how to:
 
-*   Set up the build environment
-*   Use `--toolchain_resolution_debug` to debug toolchain resolution
-*   Configure the C++ toolchain
+*   Set up the build environment, including the starlark C++ rules.
+*   Use `--toolchain_resolution_debug` to debug toolchain resolution.
+*   Configure the C++ toolchain.
 *   Create a Starlark rule that provides additional configuration for the
-    `cc_toolchain` so that Bazel can build the application with `clang`
+    `cc_toolchain` so that Bazel can build the application with `clang`.
 *   Build the C++ binary by running `bazel build //main:hello-world` on a
-    Linux machine
+    Linux machine.
 *   Cross-compile the binary for android by running `bazel build
-    //main:hello-world --platforms=//:android_x86_64`
+    //main:hello-world --platforms=//:android_x86_64`.
 
 ## Before you begin {#before-you-begin}
 
@@ -31,9 +31,14 @@ uses `clang version 19`, which you can install on your system.
 
 Set up your build environment as follows:
 
-1.  If you have not already done so, [download and install Bazel 7.0.2](https://bazel.build/install) or later.
+1.  If you have not already done so, [download and install Bazel 7.1.2](https://bazel.build/install) or later.
 
-2.  Add an empty `MODULE.bazel` file at the root folder.
+2.  Add a `MODULE.bazel` file at the root folder, pulling in `rules_cc` as
+    follows:
+
+    ```python
+    bazel_dep(name = "rules_cc", version = "0.2.22")
+    ```
 
 3.  Add the following `cc_binary` target to the `main/BUILD` file:
 
@@ -50,7 +55,18 @@ Set up your build environment as follows:
     toolchain of the one created in this tutorial. Hence, the `cc_binary` target
     is also built with the default toolchain.
 
-4.  Run the build with the following command:
+4.  Add the `main/hello-world.cc` source file:
+
+    ```cpp
+    #include <iostream>
+
+    int main() {
+        std::cout << "Hello, world!\n";
+        return 0;
+    }
+    ```
+
+5.  Run the build with the following command:
 
     ```bash
     bazel build //main:hello-world
@@ -75,16 +91,18 @@ Set up your build environment as follows:
 To configure the C++ toolchain, repeatedly build the application and eliminate
 each error one by one as described as following.
 
-Note: This tutorial assumes you're using Bazel 7.0.2 or later. If you're using
+Note: This tutorial assumes you're using Bazel 7.1.2 or later. If you're using
 an older release of Bazel, use `--incompatible_enable_cc_toolchain_resolution`
 flag to enable C++ toolchain resolution.
 
-It also assumes `clang version 9.0.1`, although the details should only change
-slightly between different versions of clang.
+It also uses an arbitrary version of `clang`, although the details should only
+change slightly between different versions.
 
 1.  Add `toolchain/BUILD` with
 
     ```python
+    load("@rules_cc//cc/toolchains:cc_toolchain.bzl", "cc_toolchain")
+
     filegroup(name = "empty")
 
     cc_toolchain(
@@ -115,11 +133,11 @@ slightly between different versions of clang.
     )
     ```
 
-    Then add appropriate dependencies and register the toolchain with
+    Then add appropriate dependencies and register the toolchain in
     `MODULE.bazel` with
 
     ```python
-    bazel_dep(name = "platforms", version = "0.0.10")
+    bazel_dep(name = "platforms", version = "1.1.0")
     register_toolchains(
         "//toolchain:cc_toolchain_for_linux_x86_64"
     )
@@ -132,7 +150,7 @@ slightly between different versions of clang.
     `linux_x86_64_toolchain_config` target, Bazel throws the following error:
 
     ```bash
-    ERROR: toolchain/BUILD:4:13: in toolchain_config attribute of cc_toolchain rule //toolchain:linux_x86_64_toolchain: rule '//toolchain:linux_x86_64_toolchain_config' does not exist.
+    ERROR: toolchain/BUILD:5:13: in toolchain_config attribute of cc_toolchain rule //toolchain:linux_x86_64_toolchain: rule '//toolchain:linux_x86_64_toolchain_config' does not exist.
     ```
 
 3.  In the `toolchain/BUILD` file, define an empty filegroup as follows:
@@ -155,6 +173,9 @@ slightly between different versions of clang.
     `toolchain/cc_toolchain_config.bzl` file with the following content:
 
     ```python
+    load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+    load("@rules_cc//cc/toolchains:cc_toolchain_config_info.bzl", "CcToolchainConfigInfo")
+
     def _impl(ctx):
         return cc_common.create_cc_toolchain_config_info(
             ctx = ctx,
@@ -193,22 +214,22 @@ slightly between different versions of clang.
 5.  Run the build again. Bazel throws the following error:
 
     ```bash
-    .../BUILD:1:1: C++ compilation of rule '//:hello-world' failed (Exit 1)
+    .../BUILD:1:1: C++ compilation of rule '//main:hello-world' failed (Exit 1)
     src/main/tools/linux-sandbox-pid1.cc:421:
     "execvp(toolchain/DUMMY_GCC_TOOL, 0x11f20e0)": No such file or directory
-    Target //:hello-world failed to build`
+    Target //main:hello-world failed to build`
     ```
 
     At this point, Bazel has enough information to attempt building the code but
     it still does not know what tools to use to complete the required build
     actions. You will modify the Starlark rule implementation to tell Bazel what
     tools to use. For that, you need the `tool_path()` constructor from
-    [`@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl`](https://source.bazel.build/bazel/+/4eea5c62a566d21832c93e4c18ec559e75d5c1ce:tools/cpp/cc_toolchain_config_lib.bzl;l=400):
+    [`@rules_cc//cc:cc_toolchain_config_lib.bzl`](https://github.com/bazelbuild/rules_cc/blob/aff544134bc9d29006f27adbe63d824dfe1436f6/cc/cc_toolchain_config_lib.bzl#L445):
 
     ```python
     # toolchain/cc_toolchain_config.bzl:
     # NEW
-    load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl", "tool_path")
+    load("@rules_cc//cc:cc_toolchain_config_lib.bzl", "tool_path")
 
     def _impl(ctx):
         tool_paths = [ # NEW
@@ -322,10 +343,10 @@ slightly between different versions of clang.
 
     ```python
     # NEW
-    load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+    load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
     # NEW
     load(
-        "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+        "@rules_cc//cc:cc_toolchain_config_lib.bzl",
         "feature",    # NEW
         "flag_group", # NEW
         "flag_set",   # NEW


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute.html
-->

### Description

I've updated the C++ toolchain tutorial and completed it as rewritten myself, with both 7.1.2 and 9.2.0.

I changed it to use 7.1.2 because it no longer works with 7.0.2 with the `rules_cc` version I specify; it fails with this error:

<details>

```
❯ bazel build //main:hello-world
Starting local Bazel server and connecting to it...
INFO: Deleting stale sandbox base /private/var/tmp/_bazel_kip/f7c3a206b1f0274a337cc700e93f84bc/sandbox
INFO: Repository rules_python~1.7.0~python~pythons_hub instantiated at:
  <builtin>: in <toplevel>
Repository rule hub_repo defined at:
  /private/var/tmp/_bazel_kip/f7c3a206b1f0274a337cc700e93f84bc/external/rules_python~1.7.0/python/private/pythons_hub.bzl:134:27: in <toplevel>
ERROR: An error occurred during the fetch of repository 'rules_python~1.7.0~python~pythons_hub':
   Traceback (most recent call last):
	File "/private/var/tmp/_bazel_kip/f7c3a206b1f0274a337cc700e93f84bc/external/rules_python~1.7.0/python/private/pythons_hub.bzl", line 101, column 32, in _hub_repo_impl
		_hub_build_file_content(rctx),
	File "/private/var/tmp/_bazel_kip/f7c3a206b1f0274a337cc700e93f84bc/external/rules_python~1.7.0/python/private/pythons_hub.bzl", line 83, column 57, in _hub_build_file_content
		rules_python = rctx.attr._rules_python_workspace.repo_name,
Error: 'Label' value has no field or method 'repo_name'
ERROR: <builtin>: fetching hub_repo rule //:rules_python~1.7.0~python~pythons_hub: Traceback (most recent call last):
	File "/private/var/tmp/_bazel_kip/f7c3a206b1f0274a337cc700e93f84bc/external/rules_python~1.7.0/python/private/pythons_hub.bzl", line 101, column 32, in _hub_repo_impl
		_hub_build_file_content(rctx),
	File "/private/var/tmp/_bazel_kip/f7c3a206b1f0274a337cc700e93f84bc/external/rules_python~1.7.0/python/private/pythons_hub.bzl", line 83, column 57, in _hub_build_file_content
		rules_python = rctx.attr._rules_python_workspace.repo_name,
Error: 'Label' value has no field or method 'repo_name'
INFO: Repository protobuf~29.0-rc3 instantiated at:
  <builtin>: in <toplevel>
Repository rule http_archive defined at:
  /private/var/tmp/_bazel_kip/f7c3a206b1f0274a337cc700e93f84bc/external/bazel_tools/tools/build_defs/repo/http.bzl:381:31: in <toplevel>
INFO: repository @@protobuf~29.0-rc3' used the following cache hits instead of downloading the corresponding file.
 * Hash '537d1c4edb6cbfa96d98a021650e3c455fffcf80dbdcea7fe46cb356e6e9732d' for https://github.com/protocolbuffers/protobuf/releases/download/v29.0-rc3/protobuf-29.0-rc3.zip
If the definition of 'repository @@protobuf~29.0-rc3' was updated, verify that the hashes were also updated.
ERROR: Analysis of target '//main:hello-world' failed; build aborted: 'Label' value has no field or method 'repo_name'
INFO: Elapsed time: 13.019s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
FAILED:
    Fetching /private/var/tmp/_bazel_kip/f7c3a206b1f0274a337cc700e93f84bc/external/protobuf~29.0-rc3; Extracting protobuf-29.0-rc3.zip
```

</details>

### Motivation

There are a number of issues with the tutorial and issues that mean it doesn't work with the newest versions of Bazel. 
Here are some related issues, but I think we can probably close them all already tbh:
* #17500
* #9365
* #12856
* #20616

### Build API Changes

No

### Checklist

- [ ] ~I have added tests for the new use cases (if any).~
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
