### PR TITLE
Restore deleted top-level outputs materialized by earlier invocations

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -127,6 +127,24 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
   public void setContentsProxy(FileContentsProxy proxy) {}
 
   /**
+   * Returns whether the remote file this metadata refers to was materialized in the local
+   * filesystem as a requested top-level output without its generating action being reexecuted.
+   *
+   * <p>Such a file requires special handling in incremental builds: since the metadata tracked for
+   * it remains remote, a local deletion of the file can only be detected by consulting this flag.
+   */
+  public boolean wasMaterializedAsToplevelOutput() {
+    return false;
+  }
+
+  /**
+   * Records whether the remote file this metadata refers to was materialized in the local
+   * filesystem as a requested top-level output without its generating action being reexecuted. If
+   * this metadata does not support recording this, does nothing.
+   */
+  public void setMaterializedAsToplevelOutput(boolean materializedAsToplevelOutput) {}
+
+  /**
    * Returns whether this metadata describes an in-memory output (e.g. a file kept in memory by
    * {@code --experimental_inmemory_dotd_files} or {@code --experimental_inmemory_jdeps_files}) that
    * is never written to the local filesystem.
@@ -807,6 +825,7 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
       extends RemoteFileArtifactValue {
     private long expirationTime;
     @Nullable private FileContentsProxy proxy;
+    private boolean materializedAsToplevelOutput;
     private final boolean inMemoryOutput;
 
     private RemoteFileArtifactValueWithMaterializationData(
@@ -862,6 +881,16 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
     }
 
     @Override
+    public boolean wasMaterializedAsToplevelOutput() {
+      return materializedAsToplevelOutput;
+    }
+
+    @Override
+    public void setMaterializedAsToplevelOutput(boolean materializedAsToplevelOutput) {
+      this.materializedAsToplevelOutput = materializedAsToplevelOutput;
+    }
+
+    @Override
     public boolean isInMemoryOutput() {
       return inMemoryOutput;
     }
@@ -893,6 +922,7 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
           .add("locationIndex", getLocationIndex())
           .add("expirationTime", fromEpochMilli(expirationTime))
           .add("proxy", proxy)
+          .add("materializedAsToplevelOutput", materializedAsToplevelOutput)
           .add("inMemoryOutput", inMemoryOutput)
           .toString();
     }
@@ -952,6 +982,16 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
     @Override
     public void setContentsProxy(FileContentsProxy proxy) {
       delegate.setContentsProxy(proxy);
+    }
+
+    @Override
+    public boolean wasMaterializedAsToplevelOutput() {
+      return delegate.wasMaterializedAsToplevelOutput();
+    }
+
+    @Override
+    public void setMaterializedAsToplevelOutput(boolean materializedAsToplevelOutput) {
+      delegate.setMaterializedAsToplevelOutput(materializedAsToplevelOutput);
     }
 
     @Override
@@ -1321,6 +1361,16 @@ public abstract class FileArtifactValue implements SkyValue, FileArtifactMetadat
     @Override
     public void setContentsProxy(FileContentsProxy proxy) {
       delegate.setContentsProxy(proxy);
+    }
+
+    @Override
+    public boolean wasMaterializedAsToplevelOutput() {
+      return delegate.wasMaterializedAsToplevelOutput();
+    }
+
+    @Override
+    public void setMaterializedAsToplevelOutput(boolean materializedAsToplevelOutput) {
+      delegate.setMaterializedAsToplevelOutput(materializedAsToplevelOutput);
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteImportantOutputHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteImportantOutputHandler.java
@@ -135,14 +135,15 @@ public final class RemoteImportantOutputHandler implements ImportantOutputHandle
       Iterable<Artifact> importantArtifacts, InputMetadataProvider metadataProvider)
       throws IOException, InterruptedException {
     var futures = new ArrayList<ListenableFuture<Void>>();
+    var ensuredOutputMetadata = new ArrayList<FileArtifactValue>();
 
     for (var artifact : importantArtifacts) {
-      downloadArtifact(metadataProvider, artifact, futures);
+      downloadArtifact(metadataProvider, artifact, futures, ensuredOutputMetadata);
     }
 
     for (var runfileTree : metadataProvider.getRunfilesTrees()) {
       for (var artifact : runfileTree.getArtifacts().toList()) {
-        downloadArtifact(metadataProvider, artifact, futures);
+        downloadArtifact(metadataProvider, artifact, futures, ensuredOutputMetadata);
       }
     }
 
@@ -156,12 +157,21 @@ public final class RemoteImportantOutputHandler implements ImportantOutputHandle
       Throwables.throwIfUnchecked(e.getCause());
       throw new IllegalStateException(e.getCause());
     }
+
+    // These outputs are now present in the local filesystem, but their generating actions were not
+    // reexecuted, so the metadata tracked for them in Skyframe remains remote. Record the
+    // materialization on the metadata so that if such a file is deleted locally, a later
+    // invocation reruns the generating action to restore it.
+    for (var metadata : ensuredOutputMetadata) {
+      metadata.setMaterializedAsToplevelOutput(true);
+    }
   }
 
   private void downloadArtifact(
       InputMetadataProvider metadataProvider,
       Artifact artifact,
-      List<ListenableFuture<Void>> futures)
+      List<ListenableFuture<Void>> futures,
+      List<FileArtifactValue> ensuredOutputMetadata)
       throws IOException, InterruptedException {
     if (!RemoteOutputChecker.mayBeRemote(artifact)) {
       return;
@@ -200,6 +210,7 @@ public final class RemoteImportantOutputHandler implements ImportantOutputHandle
       }
 
       if (remoteOutputChecker.shouldDownloadOutput(artifact, metadata)) {
+        ensuredOutputMetadata.add(metadata);
         futures.add(
             actionInputPrefetcher.prefetchFiles(
                 artifact instanceof DerivedArtifact derivedArtifact

--- a/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
@@ -531,11 +531,26 @@ public class FilesystemValueChecker {
       FileArtifactValue fileMetadata =
           ActionOutputMetadataStore.fileArtifactValueFromArtifact(
               file, null, xattrProviderOverrider.getXattrProvider(syscallCache), tsgm);
-      boolean isTrustedRemoteValue =
+      // Remote metadata may record that the file has been materialized in the local filesystem as
+      // a requested top-level output without its generating action having been reexecuted (e.g. by
+      // the completion function after an action cache hit). If the file is missing now, the action
+      // has to be invalidated so that its reevaluation can restore the file in case the current
+      // invocation wants it locally.
+      boolean deletedAfterMaterialization =
           fileMetadata.getType() == FileStateType.NONEXISTENT
+              && lastKnownData.isRemote()
+              && lastKnownData.wasMaterializedAsToplevelOutput();
+      boolean isTrustedRemoteValue =
+          !deletedAfterMaterialization
+              && fileMetadata.getType() == FileStateType.NONEXISTENT
               && lastKnownData.isRemote()
               && outputChecker.shouldTrustMetadata(file, lastKnownData);
       if (!isTrustedRemoteValue && fileMetadata.couldBeModifiedSince(lastKnownData)) {
+        if (deletedAfterMaterialization) {
+          // Clear the record so that a reevaluation that chooses not to rematerialize the file
+          // doesn't invalidate the action again on every subsequent invocation.
+          lastKnownData.setMaterializedAsToplevelOutput(false);
+        }
         modifiedOutputsReceiver.reportModifiedOutputFile(
             fileMetadata.getType() != FileStateType.NONEXISTENT
                 ? file.getPath().getLastModifiedTime(Symlinks.FOLLOW)

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -213,6 +213,133 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
   }
 
   @Test
+  public void downloadToplevel_outputDeletedAfterUnrelatedBuild_toplevelOutputIsRestored()
+      throws Exception {
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'foo',",
+        "  outs = ['out/foo.txt'],",
+        "  cmd = 'echo foo > $@',",
+        ")",
+        "genrule(",
+        "  name = 'bar',",
+        "  outs = ['out/bar.txt'],",
+        "  cmd = 'echo bar > $@',",
+        ")");
+
+    // The default minimal build leaves out/foo.txt represented only by remote metadata. The
+    // subsequent toplevel build materializes it via the completion function without reexecuting
+    // the generating action, so the metadata tracked for it in Skyframe remains remote.
+    buildTarget("//:foo");
+    assertOutputsDoNotExist("//:foo");
+    setDownloadToplevel();
+    buildTarget("//:foo");
+    waitDownloads();
+    assertValidOutputFile("out/foo.txt", "foo\n");
+
+    // An intervening build of an unrelated target discards the previous invocation's record of
+    // which outputs it wanted locally.
+    buildTarget("//:bar");
+    waitDownloads();
+    assertValidOutputFile("out/bar.txt", "bar\n");
+
+    // Delete the top-level output of the earlier build and request it again.
+    getOutputPath("out/foo.txt").delete();
+    buildTarget("//:foo");
+    waitDownloads();
+
+    assertValidOutputFile("out/foo.txt", "foo\n");
+  }
+
+  @Test
+  public void downloadToplevel_formerToplevelOutputDeleted_restoreAttemptedOnlyOnce()
+      throws Exception {
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'foo',",
+        "  outs = ['out/foo.txt'],",
+        "  cmd = 'echo foo > $@',",
+        ")",
+        "genrule(",
+        "  name = 'foobar',",
+        "  srcs = [':foo'],",
+        "  outs = ['out/foobar.txt'],",
+        "  cmd = 'cat $(location :foo) > $@ && echo bar >> $@',",
+        ")");
+
+    // Materialize out/foo.txt via the completion function so that the metadata tracked for it in
+    // Skyframe remains remote, then build a target for which it is merely an intermediate output.
+    buildTarget("//:foo");
+    assertOutputsDoNotExist("//:foo");
+    setDownloadToplevel();
+    buildTarget("//:foo");
+    waitDownloads();
+    assertValidOutputFile("out/foo.txt", "foo\n");
+    buildTarget("//:foobar");
+    waitDownloads();
+    assertValidOutputFile("out/foobar.txt", "foo\nbar\n");
+
+    getOutputPath("out/foo.txt").delete();
+
+    // The first incremental build reevaluates the generating action so that the current download
+    // policy can decide whether to restore the file, but doesn't materialize it as it is no
+    // longer a top-level output.
+    ActionEventCollector actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+    buildTarget("//:foobar");
+    waitDownloads();
+    assertOutputDoesNotExist("out/foo.txt");
+    assertValidOutputFile("out/foobar.txt", "foo\nbar\n");
+    assertThat(actionEventCollector.getNumActionNodesEvaluated()).isEqualTo(1);
+
+    // Subsequent incremental builds trust the still-missing output and evaluate nothing.
+    actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+    buildTarget("//:foobar");
+    waitDownloads();
+    assertOutputDoesNotExist("out/foo.txt");
+    assertThat(actionEventCollector.getNumActionNodesEvaluated()).isEqualTo(0);
+  }
+
+  @Test
+  public void downloadToplevel_afterDownloadAllBuild_deletedToplevelOutputIsRestored()
+      throws Exception {
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'foo',",
+        "  outs = ['out/foo.txt'],",
+        "  cmd = 'echo foo > $@',",
+        ")",
+        "genrule(",
+        "  name = 'foobar',",
+        "  srcs = [':foo'],",
+        "  outs = ['out/foobar.txt'],",
+        "  cmd = 'cat $(location :foo) > $@ && echo bar >> $@',",
+        ")");
+
+    setDownloadAll();
+    buildTarget("//:foobar");
+    assertValidOutputFile("out/foo.txt", "foo\n");
+    assertValidOutputFile("out/foobar.txt", "foo\nbar\n");
+
+    // Delete both a top-level and an intermediate output, then build with a narrower download
+    // policy.
+    getOutputPath("out/foo.txt").delete();
+    getOutputPath("out/foobar.txt").delete();
+
+    setDownloadToplevel();
+    buildTarget("//:foobar");
+    waitDownloads();
+
+    // The top-level output must be restored; the intermediate output is not needed locally.
+    assertValidOutputFile("out/foobar.txt", "foo\nbar\n");
+    assertOutputDoesNotExist("out/foo.txt");
+  }
+
+  @Test
   public void downloadOutputsWithRegex_changeRegex_downloadNewMatches() throws Exception {
     // Arrange: Do a clean build
     write(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
@@ -1568,6 +1568,63 @@ public final class FilesystemValueCheckerTest {
   }
 
   @Test
+  public void testRemoteArtifactMaterializedAsToplevelOutputThenDeleted() throws Exception {
+    // Test that a remote artifact recorded as materialized in the local filesystem as a top-level
+    // output invalidates the generating action when the local file is deleted, even if remote
+    // metadata is otherwise trusted - but only once: the record is cleared so that a reevaluation
+    // that doesn't rematerialize the file isn't invalidated again.
+    SkyKey actionKey = ActionLookupData.create(ACTION_LOOKUP_KEY, 0);
+
+    Artifact out = createDerivedArtifact("foo");
+    var outMetadata = createRemoteMetadata("foo-content");
+    differencer.inject(ImmutableMap.of(actionKey, actionValueWithMetadata(out, outMetadata)));
+
+    EvaluationContext evaluationContext =
+        EvaluationContext.newBuilder()
+            .setKeepGoing(false)
+            .setParallelism(1)
+            .setEventHandler(NullEventHandler.INSTANCE)
+            .build();
+    assertThat(evaluator.evaluate(ImmutableList.of(actionKey), evaluationContext).hasError())
+        .isFalse();
+
+    // Materialize the file without reexecuting the action, then delete it.
+    FileSystemUtils.writeContentAsLatin1(out.getPath(), "foo-content");
+    outMetadata.setContentsProxy(FileContentsProxy.create(out.getPath().stat()));
+    outMetadata.setMaterializedAsToplevelOutput(true);
+    out.getPath().delete();
+
+    assertThat(
+            new FilesystemValueChecker(
+                    /* tsgm= */ null,
+                    SyscallCache.NO_CACHE,
+                    XattrProviderOverrider.NO_OVERRIDE,
+                    FSVC_THREADS_FOR_TEST)
+                .getDirtyActionValues(
+                    evaluator.getValues(),
+                    /* batchStatter= */ null,
+                    ModifiedFileSet.EVERYTHING_MODIFIED,
+                    OutputChecker.TRUST_ALL,
+                    (ignored, ignored2) -> {}))
+        .containsExactly(actionKey);
+
+    // The materialization record has been cleared, so the still-missing file is trusted again.
+    assertThat(
+            new FilesystemValueChecker(
+                    /* tsgm= */ null,
+                    SyscallCache.NO_CACHE,
+                    XattrProviderOverrider.NO_OVERRIDE,
+                    FSVC_THREADS_FOR_TEST)
+                .getDirtyActionValues(
+                    evaluator.getValues(),
+                    /* batchStatter= */ null,
+                    ModifiedFileSet.EVERYTHING_MODIFIED,
+                    OutputChecker.TRUST_ALL,
+                    (ignored, ignored2) -> {}))
+        .isEmpty();
+  }
+
+  @Test
   public void testRemoteArtifactsExpired() throws Exception {
     // Test that if injected remote artifacts expired, they are considered as dirty.
     SkyKey actionKey1 = ActionLookupData.create(ACTION_LOOKUP_KEY, 0);


### PR DESCRIPTION
### Description

When the completion function downloads a top-level output of an action with an action cache hit, the file is materialized in the local filesystem while the metadata tracked for it in Skyframe remains remote: local metadata can only be recorded when the generating action itself is (re)executed. If the file is later deleted locally, the modified output check doesn't detect the deletion, and the only signal that reruns the generating action to restore the file is `RemoteOutputChecker#shouldTrustMetadata` consulting the immediately preceding invocation's checker. Any intervening invocation that doesn't request the output (e.g. a build of an unrelated target) discards that record, after which an incremental build reports success without restoring the deleted top-level output.

Fix this by recording the materialization on the (mutable) remote metadata itself, following the existing example of its contents proxy: `RemoteImportantOutputHandler` flags the metadata of the outputs it ensured and `FilesystemValueChecker` invalidates the generating action of a flagged output that is missing locally, so that its reevaluation can restore the file if the current invocation's download policy wants it locally. The flag is cleared upon invalidation so that a reevaluation that chooses not to rematerialize the file doesn't invalidate the action again on every subsequent invocation.

The contents proxy itself is deliberately not used as the signal: it is also set when a remote output is materialized as an input to a locally executing action, and deleting such a file must not invalidate anything, as covered by the existing test `incrementalBuild_intermediateOutputDeleted_nothingIsReEvaluated`.

Also adds a test documenting that a top-level output deleted after a `--remote_download_outputs=all` build is already restored by a subsequent build with `--remote_download_outputs=toplevel`: outputs downloaded during action execution are tracked with local metadata, so their deletion invalidates the generating action through the ordinary modified output check.

### Motivation

Without this change, the new `downloadToplevel_outputDeletedAfterUnrelatedBuild_toplevelOutputIsRestored` test fails: after a minimal build of `//:foo`, a toplevel build of `//:foo` (which materializes `out/foo.txt` via the completion function), a toplevel build of an unrelated `//:bar` and a local deletion of `out/foo.txt`, another toplevel build of `//:foo` reports success without restoring `out/foo.txt`. The scenario came up while discussing #30852.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: With Build without the Bytes, a requested top-level output that was deleted locally is now reliably redownloaded in the next build that requests it, even if other invocations ran in between.
