### PR TITLE
[credential-helper] Ignore `null` values in JSON response

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/GetCredentialsResponse.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/GetCredentialsResponse.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import com.google.auto.value.AutoBuilder;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.Immutable;
@@ -131,63 +132,84 @@ public record GetCredentialsResponse(
         String name = reader.nextName();
         switch (name) {
           case "headers" -> {
-            if (reader.peek() != JsonToken.BEGIN_OBJECT) {
-              throw new JsonSyntaxException(
-                  String.format(
-                      Locale.US,
-                      "Expected value of 'headers' to be an object, got %s",
-                      reader.peek()));
-            }
-            reader.beginObject();
+            switch (reader.peek()) {
+              case NULL:
+                // Ignore.
+                reader.skipValue();
+                break;
 
-            while (reader.hasNext()) {
-              String headerName = reader.nextName();
-              ImmutableList.Builder<String> headerValues = ImmutableList.builder();
+              case BEGIN_OBJECT:
+                reader.beginObject();
 
-              if (reader.peek() != JsonToken.BEGIN_ARRAY) {
+                while (reader.hasNext()) {
+                  String headerName = reader.nextName();
+                  ImmutableList.Builder<String> headerValues = ImmutableList.builder();
+
+                  if (reader.peek() != JsonToken.BEGIN_ARRAY) {
+                    throw new JsonSyntaxException(
+                        String.format(
+                            Locale.US,
+                            "Expected value of '%s' header to be an array of strings, got %s",
+                            headerName,
+                            reader.peek()));
+                  }
+                  reader.beginArray();
+                  for (int i = 0; reader.hasNext(); i++) {
+                    if (reader.peek() != JsonToken.STRING) {
+                      throw new JsonSyntaxException(
+                          String.format(
+                              Locale.US,
+                              "Expected value %s of '%s' header to be a string, got %s",
+                              i,
+                              headerName,
+                              reader.peek()));
+                    }
+                    headerValues.add(reader.nextString());
+                  }
+                  reader.endArray();
+
+                  response.headersBuilder().put(headerName, headerValues.build());
+                }
+
+                reader.endObject();
+                break;
+            
+              default:
                 throw new JsonSyntaxException(
                     String.format(
                         Locale.US,
-                        "Expected value of '%s' header to be an array of strings, got %s",
-                        headerName,
+                        "Expected value of 'headers' to be an object, got %s",
                         reader.peek()));
-              }
-              reader.beginArray();
-              for (int i = 0; reader.hasNext(); i++) {
-                if (reader.peek() != JsonToken.STRING) {
+            }
+          }
+          case "expires" -> {
+            switch (reader.peek()) {
+              case NULL:
+                // Ignore.
+                reader.skipValue();
+                break;
+
+              case STRING:
+                try {
+                  var expires = reader.nextString();
+                  if (!Strings.isNullOrEmpty(expires)) {
+                    response.setExpires(Instant.from(RFC_3339_FORMATTER.parse(expires)));
+                  }
+                } catch (DateTimeException e) {
                   throw new JsonSyntaxException(
                       String.format(
                           Locale.US,
-                          "Expected value %s of '%s' header to be a string, got %s",
-                          i,
-                          headerName,
-                          reader.peek()));
+                          "Expected value of 'expires' to be a RFC 3339 formatted timestamp: %s",
+                          e.getMessage()));
                 }
-                headerValues.add(reader.nextString());
-              }
-              reader.endArray();
+                break;
 
-              response.headersBuilder().put(headerName, headerValues.build());
-            }
-
-            reader.endObject();
-          }
-          case "expires" -> {
-            if (reader.peek() != JsonToken.STRING) {
-              throw new JsonSyntaxException(
-                  String.format(
-                      Locale.US,
-                      "Expected value of 'expires' to be a string, got %s",
-                      reader.peek()));
-            }
-            try {
-              response.setExpires(Instant.from(RFC_3339_FORMATTER.parse(reader.nextString())));
-            } catch (DateTimeException e) {
-              throw new JsonSyntaxException(
-                  String.format(
-                      Locale.US,
-                      "Expected value of 'expires' to be a RFC 3339 formatted timestamp: %s",
-                      e.getMessage()));
+              default:
+                throw new JsonSyntaxException(
+                    String.format(
+                        Locale.US,
+                        "Expected value of 'expires' to be a string, got %s",
+                        reader.peek()));
             }
           }
           default ->

--- a/src/test/java/com/google/devtools/build/lib/authandtls/credentialhelper/GetCredentialsResponseTest.java
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/credentialhelper/GetCredentialsResponseTest.java
@@ -35,6 +35,13 @@ public class GetCredentialsResponseTest {
     assertThat(GSON.fromJson("{}", GetCredentialsResponse.class).headers()).isEmpty();
     assertThat(GSON.fromJson("{\"headers\": {}}", GetCredentialsResponse.class).headers())
         .isEmpty();
+    assertThat(GSON.fromJson("{\"headers\": null}", GetCredentialsResponse.class).headers())
+        .isEmpty();
+    assertThat(GSON.fromJson("{\"expires\": null}", GetCredentialsResponse.class).headers()).isEmpty();
+    assertThat(GSON.fromJson("{\"headers\": {}, \"expires\": null}", GetCredentialsResponse.class).headers())
+        .isEmpty();
+    assertThat(GSON.fromJson("{\"headers\": null, \"expires\": null}", GetCredentialsResponse.class).headers())
+        .isEmpty();
 
     GetCredentialsResponse.Builder expectedResponseBuilder = GetCredentialsResponse.newBuilder();
     expectedResponseBuilder.headersBuilder().put("a", ImmutableList.of());
@@ -80,9 +87,6 @@ public class GetCredentialsResponseTest {
 
   @Test
   public void parseInvalidHeadersEnvelope() {
-    assertThrows(
-        JsonSyntaxException.class,
-        () -> GSON.fromJson("{\"headers\": null}", GetCredentialsResponse.class));
     assertThrows(
         JsonSyntaxException.class,
         () -> GSON.fromJson("{\"headers\": \"foo\"}", GetCredentialsResponse.class));
@@ -162,9 +166,6 @@ public class GetCredentialsResponseTest {
 
   @Test
   public void parseInvalidExpires() {
-    assertThrows(
-        JsonSyntaxException.class,
-        () -> GSON.fromJson("{\"expires\": null}", GetCredentialsResponse.class));
     assertThrows(
         JsonSyntaxException.class,
         () -> GSON.fromJson("{\"expires\": \"foo\"}", GetCredentialsResponse.class));


### PR DESCRIPTION
This protects against `GetCredentialsResponse`s of the form `{"expires": null}` or `{"headers": null}`.

Seen in the wild:
```
Caused by: com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelperException: Failed to get credentials for '<redacted>' from helper '<redacted>': error parsing output. stderr:
	at com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelper.getCredentials(CredentialHelper.java:147)
	at com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelperCredentials.getCredentialsFromHelper(CredentialHelperCredentials.java:94)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.lambda$doComputeIfAbsent$14(BoundedLocalCache.java:2688)
	at java.base/java.util.concurrent.ConcurrentHashMap.compute(Unknown Source)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.doComputeIfAbsent(BoundedLocalCache.java:2686)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.computeIfAbsent(BoundedLocalCache.java:2669)
	at com.github.benmanes.caffeine.cache.LocalCache.computeIfAbsent(LocalCache.java:112)
	at com.github.benmanes.caffeine.cache.LocalManualCache.get(LocalManualCache.java:62)
	at com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelperCredentials.getRequestMetadata(CredentialHelperCredentials.java:66)
	at com.google.auth.Credentials.blockingGetToCallback(Credentials.java:128)
	at com.google.auth.Credentials$1.run(Credentials.java:114)
	... 3 more
Caused by: com.google.gson.JsonSyntaxException: Expected value of 'expires' to be a string, got NULL
	at com.google.devtools.build.lib.authandtls.credentialhelper.GetCredentialsResponse$GsonTypeAdapter.read(GetCredentialsResponse.java:178)
	at com.google.devtools.build.lib.authandtls.credentialhelper.GetCredentialsResponse$GsonTypeAdapter.read(GetCredentialsResponse.java:85)
	at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:308)
	at com.google.gson.Gson.fromJson(Gson.java:1361)
	at com.google.gson.Gson.fromJson(Gson.java:1262)
	at com.google.gson.Gson.fromJson(Gson.java:1199)
	at com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelper.getCredentials(CredentialHelper.java:133)
	... 13 more
```

RELNOTES: credential-helper: treat `null` values in response as unset.
