### PR TITLE
Record materialized top-level outputs in completion values

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -279,7 +279,13 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
     if (digest == null) {
       digest = path.getDigest();
     }
-    return !Arrays.equals(digest, metadata.getDigest());
+    if (!Arrays.equals(digest, metadata.getDigest())) {
+      return true;
+    }
+    // The file contents have been verified to be up to date. Record the contents proxy when
+    // supported, just like after a fresh download, to make future modification checks cheaper.
+    metadata.setContentsProxy(FileContentsProxy.create(stat));
+    return false;
   }
 
   protected abstract boolean canDownloadFile(Path path, FileArtifactValue metadata);

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -176,6 +176,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/runtime:remote_repo_contents_cache",
         "//src/main/java/com/google/devtools/build/lib/runtime:repository_remote_executor",
         "//src/main/java/com/google/devtools/build/lib/runtime:repository_remote_helpers_factory",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:toplevel_output_download_policy",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -158,7 +158,6 @@ public final class RemoteModule extends BlazeModule {
   @Nullable private TempPathGenerator tempPathGenerator;
   @Nullable private BlockWaitingModule blockWaitingModule;
   @Nullable private RemoteOutputChecker remoteOutputChecker;
-  @Nullable private RemoteOutputChecker lastRemoteOutputChecker;
   @Nullable private String lastBuildId;
 
   private ChannelFactory channelFactory =
@@ -589,9 +588,7 @@ public final class RemoteModule extends BlazeModule {
         new RemoteOutputChecker(
             env.getCommandName(),
             remoteOptions.getRemoteOutputsMode(),
-            patternsToDownloadBuilder.build(),
-            lastRemoteOutputChecker);
-    remoteOutputChecker.maybeInvalidateSkyframeValues(env.getSkyframeExecutor().getEvaluator());
+            patternsToDownloadBuilder.build());
 
     // Top-level outputs that are only available as remote metadata are downloaded by the
     // completion functions, whose results are only valid for invocations with the same download
@@ -1130,7 +1127,6 @@ public final class RemoteModule extends BlazeModule {
           () -> afterCommandTask(actionContextProviderRef, tempPathGeneratorRef, rpcLogFileRef));
     }
 
-    lastRemoteOutputChecker = remoteOutputChecker;
     lastBuildId = Preconditions.checkNotNull(env).getCommandId().toString();
 
     buildEventArtifactUploaderFactoryDelegate.reset();

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -98,6 +98,7 @@ import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.RemoteExecution;
 import com.google.devtools.build.lib.server.FailureDetails.RemoteExecution.Code;
 import com.google.devtools.build.lib.skyframe.SkyframeExecutorWrappingWalkableGraph;
+import com.google.devtools.build.lib.skyframe.ToplevelOutputDownloadPolicy;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.util.ExitCode;
@@ -424,6 +425,8 @@ public final class RemoteModule extends BlazeModule {
       knownMissingCasDigests.clear();
     }
 
+    env.getSkyframeExecutor().setToplevelOutputDownloadPolicy(Optional.empty());
+
     var cacheAvailable = setup(env);
     if (!cacheAvailable) {
       if (env.getDirectories().getOutputBase().getFileSystem()
@@ -589,6 +592,14 @@ public final class RemoteModule extends BlazeModule {
             patternsToDownloadBuilder.build(),
             lastRemoteOutputChecker);
     remoteOutputChecker.maybeInvalidateSkyframeValues(env.getSkyframeExecutor().getEvaluator());
+
+    // Top-level outputs that are only available as remote metadata are downloaded by the
+    // completion functions, whose results are only valid for invocations with the same download
+    // policy. Without Skymeld, no important output handler is registered and completion functions
+    // download nothing, but a policy change must still invalidate them.
+    env.getSkyframeExecutor()
+        .setToplevelOutputDownloadPolicy(
+            Optional.of(computeToplevelOutputDownloadPolicy(env.getCommandName(), remoteOptions)));
 
     env.getEventBus().register(this);
     String invocationId = env.getCommandId().toString();
@@ -1207,6 +1218,18 @@ public final class RemoteModule extends BlazeModule {
               actionInputFetcher,
               Preconditions.checkNotNull(outputService).getRewoundActionSynchronizer()));
     }
+  }
+
+  private static ToplevelOutputDownloadPolicy computeToplevelOutputDownloadPolicy(
+      String commandName, RemoteOptions remoteOptions) {
+    ImmutableList.Builder<String> downloadRegexes = ImmutableList.builder();
+    if (remoteOptions.getRemoteOutputsMode() != RemoteOutputsMode.ALL) {
+      for (RegexPatternOption patternOption : remoteOptions.getRemoteDownloadRegex()) {
+        downloadRegexes.add(patternOption.regexPattern().pattern());
+      }
+    }
+    return new ToplevelOutputDownloadPolicy(
+        remoteOptions.getRemoteOutputsMode().name(), commandName, downloadRegexes.build());
   }
 
   private TempPathGenerator getTempPathGenerator(CommandEnvironment env)

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputChecker.java
@@ -38,9 +38,7 @@ import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTa
 import com.google.devtools.build.lib.analysis.test.TestProvider;
 import com.google.devtools.build.lib.clock.Clock;
 import com.google.devtools.build.lib.remote.options.RemoteOutputsMode;
-import com.google.devtools.build.lib.skyframe.SkyFunctions;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.skyframe.MemoizingEvaluator;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
@@ -62,7 +60,6 @@ public class RemoteOutputChecker implements OutputChecker {
 
   private final CommandMode commandMode;
   private final RemoteOutputsMode outputsMode;
-  @Nullable private final RemoteOutputChecker lastRemoteOutputChecker;
 
   @Nullable private Clock clock;
 
@@ -74,14 +71,6 @@ public class RemoteOutputChecker implements OutputChecker {
       String commandName,
       RemoteOutputsMode outputsMode,
       ImmutableList<Predicate<String>> patternsToDownload) {
-    this(commandName, outputsMode, patternsToDownload, /* lastRemoteOutputChecker= */ null);
-  }
-
-  public RemoteOutputChecker(
-      String commandName,
-      RemoteOutputsMode outputsMode,
-      ImmutableList<Predicate<String>> patternsToDownload,
-      RemoteOutputChecker lastRemoteOutputChecker) {
     this.commandMode =
         switch (commandName) {
           case "build" -> CommandMode.BUILD;
@@ -92,7 +81,6 @@ public class RemoteOutputChecker implements OutputChecker {
         };
     this.outputsMode = outputsMode;
     this.patternsToDownload = patternsToDownload;
-    this.lastRemoteOutputChecker = lastRemoteOutputChecker;
   }
 
   /** Sets this checker to check the TTL of remote metadata when deciding whether to trust it. */
@@ -350,14 +338,6 @@ public class RemoteOutputChecker implements OutputChecker {
       // If Bazel should download this file, but it does not exist locally, returns false to rerun
       // the generating action to trigger the download (just like in the normal build, when local
       // outputs are missing).
-      if (lastRemoteOutputChecker != null) {
-        // This is an incremental build. If the file was downloaded by previous build and is now
-        // missing, invalidate the action.
-        if (lastRemoteOutputChecker.shouldDownloadOutput(file, metadata)) {
-          return false;
-        }
-      }
-
       if (shouldDownloadOutput(file, metadata)) {
         return false;
       }
@@ -379,21 +359,4 @@ public class RemoteOutputChecker implements OutputChecker {
     return expirationTime == null || expirationTime.isAfter(clock.now());
   }
 
-  public void maybeInvalidateSkyframeValues(MemoizingEvaluator memoizingEvaluator) {
-    if (lastRemoteOutputChecker == null) {
-      return;
-    }
-
-    // If the outputsMode or commandMode is changed, we invalidate completion functions. Otherwise,
-    // some requested outputs might not be correctly downloaded.
-    if (lastRemoteOutputChecker.outputsMode != outputsMode
-        || lastRemoteOutputChecker.commandMode != commandMode) {
-      memoizingEvaluator.delete(
-          k -> {
-            var functionName = k.functionName();
-            return functionName.equals(SkyFunctions.TARGET_COMPLETION)
-                || functionName.equals(SkyFunctions.ASPECT_COMPLETION);
-          });
-    }
-  }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/AspectCompletionValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/AspectCompletionValue.java
@@ -14,7 +14,10 @@
 package com.google.devtools.build.lib.skyframe;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.FileContentsProxy;
 import com.google.devtools.build.lib.analysis.TopLevelArtifactContext;
 import com.google.devtools.build.lib.skyframe.AspectKeyCreator.AspectKey;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.SerializationConstant;
@@ -23,14 +26,49 @@ import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.build.skyframe.StallableSkykey;
 import java.util.Collection;
+import java.util.Objects;
+import javax.annotation.Nullable;
 
-/**
- * The value of an AspectCompletion. Currently this just stores an Aspect.
- */
+/** The value of an AspectCompletion. */
 public class AspectCompletionValue implements SkyValue {
-  @SerializationConstant static final AspectCompletionValue INSTANCE = new AspectCompletionValue();
+  @SerializationConstant
+  static final AspectCompletionValue INSTANCE = new AspectCompletionValue(null);
 
-  private AspectCompletionValue() {}
+  @Nullable private final ImmutableMap<Artifact, FileContentsProxy> materializedOutputs;
+
+  private AspectCompletionValue(
+      @Nullable ImmutableMap<Artifact, FileContentsProxy> materializedOutputs) {
+    this.materializedOutputs = materializedOutputs;
+  }
+
+  public static AspectCompletionValue create(
+      @Nullable ImmutableMap<Artifact, FileContentsProxy> materializedOutputs) {
+    return materializedOutputs == null || materializedOutputs.isEmpty()
+        ? INSTANCE
+        : new AspectCompletionValue(materializedOutputs);
+  }
+
+  /** See {@link TargetCompletionValue#getMaterializedOutputs}. */
+  @Nullable
+  public ImmutableMap<Artifact, FileContentsProxy> getMaterializedOutputs() {
+    return materializedOutputs;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AspectCompletionValue that)) {
+      return false;
+    }
+    return Objects.equals(materializedOutputs, that.materializedOutputs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(materializedOutputs);
+  }
 
   public static Iterable<SkyKey> keys(Collection<AspectKey> keys, TopLevelArtifactContext ctx) {
     return Iterables.transform(keys, k -> AspectCompletionKey.create(k, ctx));

--- a/src/main/java/com/google/devtools/build/lib/skyframe/AspectCompletor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/AspectCompletor.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.skyframe;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.actions.FileContentsProxy;
 import com.google.devtools.build.lib.actions.CompletionContext;
 import com.google.devtools.build.lib.actions.CompletionContext.PathResolverFactory;
 import com.google.devtools.build.lib.analysis.AspectCompleteEvent;
@@ -34,6 +35,8 @@ import com.google.devtools.build.lib.skyframe.CompletionFunction.Completor;
 import com.google.devtools.build.lib.skyframe.rewinding.ActionRewindStrategy;
 import com.google.devtools.build.skyframe.SkyFunction;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
+import javax.annotation.Nullable;
+import com.google.devtools.build.lib.actions.Artifact;
 
 /** Manages completing builds for aspects. */
 final class AspectCompletor
@@ -82,8 +85,9 @@ final class AspectCompletor
   }
 
   @Override
-  public AspectCompletionValue getResult() {
-    return AspectCompletionValue.INSTANCE;
+  public AspectCompletionValue getResult(
+      @Nullable ImmutableMap<Artifact, FileContentsProxy> materializedOutputs) {
+    return AspectCompletionValue.create(materializedOutputs);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1620,6 +1620,8 @@ java_library(
         "FilesystemValueChecker.java",
     ],
     deps = [
+        ":target_completion_value",
+        ":aspect_completion_value",
         ":action_execution_value",
         ":action_output_metadata_store",
         ":directory_listing_state_value",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -210,6 +210,7 @@ java_library(
         ":test_expansion_function",
         ":tests_for_target_pattern_function",
         ":tests_for_target_pattern_value",
+        ":toplevel_output_download_policy",
         ":top_level_action_lookup_key_wrapper",
         ":top_level_aspects_details_build_failed_exception",
         ":top_level_aspects_identified_event",
@@ -2133,6 +2134,7 @@ java_library(
         "PrecomputedValue.java",
     ],
     deps = [
+        ":toplevel_output_download_policy",
         ":sky_functions",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/packages:rule_visibility",
@@ -3174,6 +3176,14 @@ java_library(
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//src/main/java/com/google/devtools/build/skyframe:stallable_skykey",
         "//third_party/java/auto:auto_value",
+        "//third_party/java/guava:collect",
+    ],
+)
+
+java_library(
+    name = "toplevel_output_download_policy",
+    srcs = ["ToplevelOutputDownloadPolicy.java"],
+    deps = [
         "//third_party/java/guava:collect",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -686,6 +686,9 @@ java_library(
     name = "aspect_completion_value",
     srcs = ["AspectCompletionValue.java"],
     deps = [
+        "//third_party/java/jsr305_annotations",
+        "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
+        "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         ":aspect_key_creator",
         ":sky_functions",
         ":top_level_action_lookup_key_wrapper",
@@ -3167,6 +3170,9 @@ java_library(
     name = "target_completion_value",
     srcs = ["TargetCompletionValue.java"],
     deps = [
+        "//third_party/java/jsr305_annotations",
+        "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
+        "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         ":configured_target_key",
         ":sky_functions",
         ":top_level_action_lookup_key_wrapper",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/CompletionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/CompletionFunction.java
@@ -65,6 +65,7 @@ import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.build.skyframe.SkyframeLookupResult;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 import net.starlark.java.syntax.Location;
@@ -152,6 +153,11 @@ public final class CompletionFunction<
   public SkyValue compute(SkyKey skyKey, Environment env)
       throws CompletionFunctionException, InterruptedException {
     KeyT key = (KeyT) skyKey;
+    // The downloads performed below depend on the invocation's download policy, so completion
+    // functions must be reevaluated when it changes (e.g. on a different download mode or a switch
+    // between build and run).
+    Optional<ToplevelOutputDownloadPolicy> unusedToplevelOutputDownloadPolicy =
+        PrecomputedValue.TOPLEVEL_OUTPUT_DOWNLOAD_POLICY.get(env);
     Pair<ValueT, ArtifactsToBuild> valueAndArtifactsToBuild = getValueAndArtifactsToBuild(key, env);
     if (env.valuesMissing()) {
       return null;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/CompletionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/CompletionFunction.java
@@ -27,6 +27,8 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.CompletionContext;
 import com.google.devtools.build.lib.actions.CompletionContext.PathResolverFactory;
 import com.google.devtools.build.lib.actions.EventReportingArtifacts;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.FileContentsProxy;
 import com.google.devtools.build.lib.actions.ImportantOutputHandler;
 import com.google.devtools.build.lib.actions.ImportantOutputHandler.ImportantOutputException;
 import com.google.devtools.build.lib.actions.ImportantOutputHandler.LostArtifacts;
@@ -64,7 +66,10 @@ import com.google.devtools.build.skyframe.SkyFunctionException;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.build.skyframe.SkyframeLookupResult;
+import java.io.IOException;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -95,7 +100,7 @@ public final class CompletionFunction<
         throws InterruptedException;
 
     /** Provides a successful completion value. */
-    ResultT getResult();
+    ResultT getResult(@Nullable ImmutableMap<Artifact, FileContentsProxy> materializedOutputs);
 
     /**
      * Creates a failed completion event.
@@ -330,7 +335,82 @@ public final class CompletionFunction<
     env.getListener().post(event);
     topLevelArtifactsMetric.mergeIn(currentConsumer);
 
-    return completor.getResult();
+    return completor.getResult(collectMaterializedOutputs(importantArtifacts, inputMap));
+  }
+
+  /**
+   * Collects the output files that are present in the local filesystem while the metadata tracked
+   * for them in Skyframe is remote, i.e., the files the important output handler downloaded (in
+   * this or a previous evaluation) without their generating action being reexecuted.
+   *
+   * <p>{@link FilesystemValueChecker} compares this record against the local filesystem so that
+   * the deletion of such a file invalidates this node, whose reevaluation restores the file.
+   */
+  @Nullable
+  private ImmutableMap<Artifact, FileContentsProxy> collectMaterializedOutputs(
+      ImmutableCollection<Artifact> importantArtifacts, ActionInputMap inputMap) {
+    if (skyframeActionExecutor.getActionContextRegistry().getContext(ImportantOutputHandler.class)
+        == null) {
+      return null;
+    }
+    InputMetadataProvider metadataProvider = new ActionInputMetadataProvider(inputMap);
+    Map<Artifact, FileContentsProxy> materializedOutputs = new LinkedHashMap<>();
+    for (Artifact artifact : importantArtifacts) {
+      collectMaterializedOutputs(metadataProvider, artifact, materializedOutputs);
+    }
+    for (var runfilesTree : metadataProvider.getRunfilesTrees()) {
+      for (var artifact : runfilesTree.getArtifacts().toList()) {
+        collectMaterializedOutputs(metadataProvider, artifact, materializedOutputs);
+      }
+    }
+    return ImmutableMap.copyOf(materializedOutputs);
+  }
+
+  private static void collectMaterializedOutputs(
+      InputMetadataProvider metadataProvider,
+      Artifact artifact,
+      Map<Artifact, FileContentsProxy> materializedOutputs) {
+    if (artifact.isFileset() || artifact.isRunfilesTree()) {
+      return;
+    }
+    try {
+      if (artifact.isTreeArtifact()) {
+        var treeArtifactValue = metadataProvider.getTreeMetadata(artifact);
+        if (treeArtifactValue == null) {
+          return;
+        }
+        for (var entry : treeArtifactValue.getChildValues().entrySet()) {
+          addIfMaterialized(entry.getKey(), entry.getValue(), materializedOutputs);
+        }
+      } else {
+        FileArtifactValue metadata = metadataProvider.getInputMetadata(artifact);
+        if (metadata == null) {
+          return;
+        }
+        addIfMaterialized(artifact, metadata, materializedOutputs);
+      }
+    } catch (IOException e) {
+      // An output whose metadata can't be read isn't recorded; a deletion of its local copy then
+      // doesn't invalidate this node, which errs on the side of not redoing work.
+    }
+  }
+
+  private static void addIfMaterialized(
+      Artifact artifact,
+      FileArtifactValue metadata,
+      Map<Artifact, FileContentsProxy> materializedOutputs) {
+    if (!metadata.isRemote() || metadata.isInMemoryOutput()) {
+      return;
+    }
+    // A contents proxy on remote metadata is recorded when the file is materialized in the local
+    // filesystem. It may be stale if the file has been deleted since a previous invocation
+    // materialized it and the current invocation's download policy doesn't want it locally, so
+    // only record files that are actually present.
+    FileContentsProxy contentsProxy = metadata.getContentsProxy();
+    if (contentsProxy == null || !artifact.getPath().exists()) {
+      return;
+    }
+    materializedOutputs.put(artifact, contentsProxy);
   }
 
   private void postFailedEvent(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
@@ -32,6 +33,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.FileContentsProxy;
 import com.google.devtools.build.lib.actions.FileStateType;
 import com.google.devtools.build.lib.actions.OutputChecker;
 import com.google.devtools.build.lib.concurrent.ExecutorUtil;
@@ -45,6 +47,7 @@ import com.google.devtools.build.lib.skyframe.TreeArtifactValue.ArchivedRepresen
 import com.google.devtools.build.lib.util.io.TimestampGranularityMonitor;
 import com.google.devtools.build.lib.vfs.BatchStat;
 import com.google.devtools.build.lib.vfs.Dirent;
+import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileStatusWithDigest;
 import com.google.devtools.build.lib.vfs.ModifiedFileSet;
 import com.google.devtools.build.lib.vfs.Path;
@@ -259,6 +262,21 @@ public class FilesystemValueChecker {
                 }
               }
             });
+
+    try (SilentCloseable c =
+        Profiler.instance().profile("getDirtyActionValues/materializedOutputs")) {
+      valuesMap.entrySet().parallelStream()
+          .forEach(
+              e -> {
+                ImmutableMap<Artifact, FileContentsProxy> materializedOutputs =
+                    getMaterializedOutputs(e.getValue());
+                if (materializedOutputs != null
+                    && materializedOutputsAreDirty(
+                        materializedOutputs, knownModifiedOutputFiles, modifiedOutputsReceiver)) {
+                  dirtyKeys.add(e.getKey());
+                }
+              });
+    }
 
     boolean interrupted;
     try (SilentCloseable c = Profiler.instance().profile("getDirtyActionValues/statFiles")) {
@@ -612,6 +630,51 @@ public class FilesystemValueChecker {
           "Failed to get modified time for output at: %s", path);
       return -1;
     }
+  }
+
+  @Nullable
+  private static ImmutableMap<Artifact, FileContentsProxy> getMaterializedOutputs(SkyValue value) {
+    if (value instanceof TargetCompletionValue targetCompletionValue) {
+      return targetCompletionValue.getMaterializedOutputs();
+    }
+    if (value instanceof AspectCompletionValue aspectCompletionValue) {
+      return aspectCompletionValue.getMaterializedOutputs();
+    }
+    return null;
+  }
+
+  /**
+   * Checks whether the outputs recorded as locally materialized by a completion value still match
+   * the local filesystem. If a file is missing or modified, the completion node is invalidated so
+   * that its reevaluation can restore the file in case the current invocation wants it locally -
+   * without invalidating the generating action, whose outputs didn't change.
+   */
+  private static boolean materializedOutputsAreDirty(
+      ImmutableMap<Artifact, FileContentsProxy> materializedOutputs,
+      @Nullable ImmutableSet<PathFragment> knownModifiedOutputFiles,
+      ModifiedOutputsReceiver modifiedOutputsReceiver) {
+    boolean isDirty = false;
+    for (Map.Entry<Artifact, FileContentsProxy> entry : materializedOutputs.entrySet()) {
+      Artifact artifact = entry.getKey();
+      if (!shouldCheckFile(knownModifiedOutputFiles, artifact)) {
+        continue;
+      }
+      long maybeModifiedTime = -1;
+      try {
+        FileStatus stat = artifact.getPath().statIfFound(Symlinks.FOLLOW);
+        if (stat != null) {
+          if (FileContentsProxy.create(stat).equals(entry.getValue())) {
+            continue;
+          }
+          maybeModifiedTime = stat.getLastModifiedTime();
+        }
+      } catch (IOException e) {
+        // Treat an unexpected stat failure like a modification.
+      }
+      modifiedOutputsReceiver.reportModifiedOutputFile(maybeModifiedTime, artifact);
+      isDirty = true;
+    }
+    return isDirty;
   }
 
   private static boolean shouldCheckFile(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PrecomputedValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PrecomputedValue.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.StarlarkSemantics;
@@ -97,6 +98,13 @@ public final class PrecomputedValue implements SkyValue {
 
   public static final Precomputed<Boolean> REMOTE_EXECUTION_ENABLED =
       new Precomputed<>("remote_execution_enabled");
+
+  /**
+   * The current invocation's policy for downloading top-level outputs that are only available as
+   * remote metadata, or {@link Optional#empty()} if no such downloads happen in this invocation.
+   */
+  public static final Precomputed<Optional<ToplevelOutputDownloadPolicy>>
+      TOPLEVEL_OUTPUT_DOWNLOAD_POLICY = new Precomputed<>("toplevel_output_download_policy");
 
   public static final Precomputed<LazyMacroExpansionPackages> LAZY_MACRO_EXPANSION_PACKAGES =
       new Precomputed<>("lazy_macro_expansion_packages");

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyFunctions.java
@@ -102,10 +102,12 @@ public final class SkyFunctions {
   static final SkyFunctionName TOP_LEVEL_ASPECTS =
       SkyFunctionName.createHermetic("TOP_LEVEL_ASPECTS");
   static final SkyFunctionName LOAD_ASPECTS = SkyFunctionName.createHermetic("LOAD_ASPECTS");
+  // Non-hermetic because completion values record the local materialization state of top-level
+  // outputs, which the FilesystemValueChecker invalidates when it diverges from the filesystem.
   public static final SkyFunctionName TARGET_COMPLETION =
-      SkyFunctionName.createHermetic("TARGET_COMPLETION");
+      SkyFunctionName.createNonHermetic("TARGET_COMPLETION");
   public static final SkyFunctionName ASPECT_COMPLETION =
-      SkyFunctionName.createHermetic("ASPECT_COMPLETION");
+      SkyFunctionName.createNonHermetic("ASPECT_COMPLETION");
   static final SkyFunctionName TEST_COMPLETION = SkyFunctionName.createHermetic("TEST_COMPLETION");
   public static final SkyFunctionName BUILD_CONFIGURATION =
       SkyFunctionName.createHermetic("BUILD_CONFIGURATION");

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -523,6 +523,12 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
 
   @Nullable private PlatformMappingKey platformMappingKey;
 
+  // The policy under which completion functions download top-level outputs, injected as a
+  // precomputed value on each sync. Empty unless set for the current invocation via
+  // setToplevelOutputDownloadPolicy.
+  private volatile Optional<ToplevelOutputDownloadPolicy> toplevelOutputDownloadPolicy =
+      Optional.empty();
+
   /**
    * Determines the type of hybrid globbing strategy to use when {@link
    * #tracksStateForIncrementality()} is {@code true}. See {@link #getGlobbingStrategy()} for more
@@ -1900,6 +1906,16 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     PrecomputedValue.REMOTE_EXECUTION_ENABLED.set(injectable(), enabled);
   }
 
+  /**
+   * Sets the policy under which completion functions download top-level outputs in this
+   * invocation, or {@link Optional#empty()} if no such downloads happen. The value is injected
+   * into the graph on the next {@link #sync}.
+   */
+  public void setToplevelOutputDownloadPolicy(
+      Optional<ToplevelOutputDownloadPolicy> toplevelOutputDownloadPolicy) {
+    this.toplevelOutputDownloadPolicy = checkNotNull(toplevelOutputDownloadPolicy);
+  }
+
   /** Called when a top-level configuration is determined. */
   protected void setTopLevelConfiguration(BuildConfigurationValue topLevelConfiguration) {}
 
@@ -3061,6 +3077,8 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     platformMappingKey = platformOptions != null ? platformOptions.getPlatformMappingKey() : null;
     RemoteOptions remoteOptions = options.getOptions(RemoteOptions.class);
     setRemoteExecutionEnabled(remoteOptions != null && remoteOptions.isRemoteExecutionEnabled());
+    PrecomputedValue.TOPLEVEL_OUTPUT_DOWNLOAD_POLICY.set(
+        injectable(), toplevelOutputDownloadPolicy);
     cpuBoundSemaphore.set(getUpdatedSkyFunctionsSemaphore(options));
     syncPackageLoading(
         pathPackageLocator,

--- a/src/main/java/com/google/devtools/build/lib/skyframe/TargetCompletionValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/TargetCompletionValue.java
@@ -14,7 +14,10 @@
 package com.google.devtools.build.lib.skyframe;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.FileContentsProxy;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.TopLevelArtifactContext;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.SerializationConstant;
@@ -22,13 +25,59 @@ import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.build.skyframe.StallableSkykey;
 import java.util.Collection;
+import java.util.Objects;
+import javax.annotation.Nullable;
 import java.util.Set;
 
-/** The value of a TargetCompletion. Just a sentinel. */
+/** The value of a TargetCompletion. */
 public class TargetCompletionValue implements SkyValue {
-  @SerializationConstant static final TargetCompletionValue INSTANCE = new TargetCompletionValue();
+  @SerializationConstant
+  static final TargetCompletionValue INSTANCE = new TargetCompletionValue(null);
 
-  private TargetCompletionValue() {}
+  @Nullable private final ImmutableMap<Artifact, FileContentsProxy> materializedOutputs;
+
+  private TargetCompletionValue(
+      @Nullable ImmutableMap<Artifact, FileContentsProxy> materializedOutputs) {
+    this.materializedOutputs = materializedOutputs;
+  }
+
+  public static TargetCompletionValue create(
+      @Nullable ImmutableMap<Artifact, FileContentsProxy> materializedOutputs) {
+    return materializedOutputs == null || materializedOutputs.isEmpty()
+        ? INSTANCE
+        : new TargetCompletionValue(materializedOutputs);
+  }
+
+  /**
+   * The output files that are present in the local filesystem while the metadata tracked for them
+   * in Skyframe is remote (i.e., they were downloaded without their generating action being
+   * reexecuted), together with the contents proxy they were last observed with, or {@code null} if
+   * no such files were recorded.
+   *
+   * <p>{@link FilesystemValueChecker} compares this record against the local filesystem so that
+   * e.g. the deletion of such a file invalidates this node, whose reevaluation restores the file -
+   * without invalidating the generating action.
+   */
+  @Nullable
+  public ImmutableMap<Artifact, FileContentsProxy> getMaterializedOutputs() {
+    return materializedOutputs;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TargetCompletionValue that)) {
+      return false;
+    }
+    return Objects.equals(materializedOutputs, that.materializedOutputs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(materializedOutputs);
+  }
 
   public static TargetCompletionKey key(
       ConfiguredTargetKey configuredTargetKey,

--- a/src/main/java/com/google/devtools/build/lib/skyframe/TargetCompletor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/TargetCompletor.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.skyframe;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.actions.FileContentsProxy;
 import com.google.devtools.build.lib.actions.CompletionContext;
 import com.google.devtools.build.lib.actions.CompletionContext.PathResolverFactory;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
@@ -34,6 +35,7 @@ import com.google.devtools.build.skyframe.SkyFunction;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import javax.annotation.Nullable;
 import net.starlark.java.syntax.Location;
+import com.google.devtools.build.lib.actions.Artifact;
 
 /** Manages completing builds for configured targets. */
 final class TargetCompletor
@@ -78,8 +80,9 @@ final class TargetCompletor
   }
 
   @Override
-  public TargetCompletionValue getResult() {
-    return TargetCompletionValue.INSTANCE;
+  public TargetCompletionValue getResult(
+      @Nullable ImmutableMap<Artifact, FileContentsProxy> materializedOutputs) {
+    return TargetCompletionValue.create(materializedOutputs);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ToplevelOutputDownloadPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ToplevelOutputDownloadPolicy.java
@@ -1,0 +1,28 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.skyframe;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * An invocation's policy for downloading top-level outputs that are only available as remote
+ * metadata.
+ *
+ * <p>Since the policy determines which outputs the completion functions materialize in the local
+ * filesystem, a change to it (e.g. a different download mode or a switch between {@code bazel
+ * build} and {@code bazel run}) must invalidate completion functions, which happens by injecting
+ * it as {@link PrecomputedValue#TOPLEVEL_OUTPUT_DOWNLOAD_POLICY}.
+ */
+public record ToplevelOutputDownloadPolicy(
+    String outputsMode, String commandName, ImmutableList<String> downloadRegexes) {}

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -53,6 +53,7 @@ import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.FileContentsProxy;
 import com.google.devtools.build.lib.actions.StaticInputMetadataProvider;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.remote.AbstractActionInputPrefetcher.MetadataSupplier;
@@ -309,6 +310,26 @@ public abstract class ActionInputPrefetcherTestBase {
         .doDownloadFile(eq(action), any(), eq(a), any(), any(), any(), any(), any());
     assertThat(prefetcher.downloadedFiles()).containsExactly(a.getPath());
     assertThat(prefetcher.downloadsInProgress()).isEmpty();
+  }
+
+  @Test
+  public void prefetchFiles_fileExists_recordsContentsProxy()
+      throws IOException, ExecException, InterruptedException {
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+    Map<HashCode, byte[]> cas = new HashMap<>();
+    Artifact a = createRemoteArtifact("file", "hello world", metadata, cas);
+    FileSystemUtils.writeContent(a.getPath(), "hello world".getBytes(UTF_8));
+    AbstractActionInputPrefetcher prefetcher = createPrefetcher(cas);
+    assertThat(metadata.get(a).getContentsProxy()).isNull();
+
+    wait(
+        prefetcher.prefetchFilesInterruptibly(
+            action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
+
+    // The already present file was verified to be up to date by digest and its contents proxy was
+    // recorded to make future modification checks cheaper.
+    assertThat(metadata.get(a).getContentsProxy())
+        .isEqualTo(FileContentsProxy.create(a.getPath().stat()));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -320,6 +320,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
+        "//src/main/java/com/google/devtools/build/lib/runtime/commands",
         "//src/main/java/com/google/devtools/build/lib/skyframe:action_execution_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe/rewinding:action_rewound_event",

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -213,6 +213,131 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
   }
 
   @Test
+  public void downloadToplevel_outputDeletedAfterUnrelatedBuild_toplevelOutputIsRestored()
+      throws Exception {
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'foo',",
+        "  outs = ['out/foo.txt'],",
+        "  cmd = 'echo foo > $@',",
+        ")",
+        "genrule(",
+        "  name = 'bar',",
+        "  outs = ['out/bar.txt'],",
+        "  cmd = 'echo bar > $@',",
+        ")");
+
+    // The default minimal build leaves out/foo.txt represented only by remote metadata. The
+    // subsequent toplevel build materializes it via the completion function without reexecuting
+    // the generating action, so the metadata tracked for it in Skyframe remains remote.
+    buildTarget("//:foo");
+    assertOutputsDoNotExist("//:foo");
+    setDownloadToplevel();
+    buildTarget("//:foo");
+    waitDownloads();
+    assertValidOutputFile("out/foo.txt", "foo\n");
+
+    // An intervening build of an unrelated target discards the previous invocation's record of
+    // which outputs it wanted locally.
+    buildTarget("//:bar");
+    waitDownloads();
+    assertValidOutputFile("out/bar.txt", "bar\n");
+
+    // Delete the top-level output of the earlier build and request it again.
+    getOutputPath("out/foo.txt").delete();
+    buildTarget("//:foo");
+    waitDownloads();
+
+    assertValidOutputFile("out/foo.txt", "foo\n");
+  }
+
+  @Test
+  public void downloadToplevel_formerToplevelOutputDeleted_nothingIsReevaluated()
+      throws Exception {
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'foo',",
+        "  outs = ['out/foo.txt'],",
+        "  cmd = 'echo foo > $@',",
+        ")",
+        "genrule(",
+        "  name = 'foobar',",
+        "  srcs = [':foo'],",
+        "  outs = ['out/foobar.txt'],",
+        "  cmd = 'cat $(location :foo) > $@ && echo bar >> $@',",
+        ")");
+
+    // Materialize out/foo.txt via the completion function so that the metadata tracked for it in
+    // Skyframe remains remote, then build a target for which it is merely an intermediate output.
+    buildTarget("//:foo");
+    assertOutputsDoNotExist("//:foo");
+    setDownloadToplevel();
+    buildTarget("//:foo");
+    waitDownloads();
+    assertValidOutputFile("out/foo.txt", "foo\n");
+    buildTarget("//:foobar");
+    waitDownloads();
+    assertValidOutputFile("out/foobar.txt", "foo\nbar\n");
+
+    getOutputPath("out/foo.txt").delete();
+
+    // The output is no longer wanted locally by the invocations that follow, so its deletion
+    // neither reexecutes the generating action nor rematerializes the file.
+    ActionEventCollector actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+    buildTarget("//:foobar");
+    waitDownloads();
+    assertOutputDoesNotExist("out/foo.txt");
+    assertValidOutputFile("out/foobar.txt", "foo\nbar\n");
+    assertThat(actionEventCollector.getNumActionNodesEvaluated()).isEqualTo(0);
+
+    actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+    buildTarget("//:foobar");
+    waitDownloads();
+    assertOutputDoesNotExist("out/foo.txt");
+    assertThat(actionEventCollector.getNumActionNodesEvaluated()).isEqualTo(0);
+  }
+
+  @Test
+  public void downloadToplevel_afterDownloadAllBuild_deletedToplevelOutputIsRestored()
+      throws Exception {
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'foo',",
+        "  outs = ['out/foo.txt'],",
+        "  cmd = 'echo foo > $@',",
+        ")",
+        "genrule(",
+        "  name = 'foobar',",
+        "  srcs = [':foo'],",
+        "  outs = ['out/foobar.txt'],",
+        "  cmd = 'cat $(location :foo) > $@ && echo bar >> $@',",
+        ")");
+
+    setDownloadAll();
+    buildTarget("//:foobar");
+    assertValidOutputFile("out/foo.txt", "foo\n");
+    assertValidOutputFile("out/foobar.txt", "foo\nbar\n");
+
+    // Delete both a top-level and an intermediate output, then build with a narrower download
+    // policy.
+    getOutputPath("out/foo.txt").delete();
+    getOutputPath("out/foobar.txt").delete();
+
+    setDownloadToplevel();
+    buildTarget("//:foobar");
+    waitDownloads();
+
+    // The top-level output must be restored; the intermediate output is not needed locally.
+    assertValidOutputFile("out/foobar.txt", "foo\nbar\n");
+    assertOutputDoesNotExist("out/foo.txt");
+  }
+
+  @Test
   public void downloadOutputsWithRegex_changeRegex_downloadNewMatches() throws Exception {
     // Arrange: Do a clean build
     write(

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.actions.CachedActionEvent;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.analysis.TargetCompleteEvent;
 import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
+import com.google.devtools.build.lib.runtime.commands.HelpCommand;
 import com.google.devtools.build.lib.skyframe.ActionExecutionValue;
 import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
 import com.google.devtools.build.lib.skyframe.rewinding.ActionRewoundEvent;
@@ -210,6 +211,117 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     // Assert: out/foo.txt is re-downloaded
     assertThat(actionEventCollector.getActionExecutedEvents()).hasSize(1);
     assertValidOutputFile("out/foo.txt", "foo\n");
+  }
+
+  @Test
+  public void downloadToplevel_afterHelpWithDownloadAll_doesNotReevaluateRemoteOutputs()
+      throws Exception {
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'foo',",
+        "  outs = ['out/foo.txt'],",
+        "  cmd = 'echo foo > $@',",
+        ")",
+        "genrule(",
+        "  name = 'foobar',",
+        "  srcs = [':foo'],",
+        "  outs = ['out/foobar.txt'],",
+        "  cmd = 'cat $(location :foo) > $@ && echo bar >> $@',",
+        ")");
+
+    // Leave both outputs represented only by remote metadata.
+    buildTarget("//:foobar");
+    assertOutputsDoNotExist("//:foo");
+    assertOutputsDoNotExist("//:foobar");
+
+    // Install a previous checker with download-all, without running a build or materializing any
+    // outputs.
+    setDownloadAll();
+    runtimeWrapper.newCommand(HelpCommand.class);
+    runtimeWrapper.executeCustomCommand();
+
+    setDownloadToplevel();
+    ActionEventCollector actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+    buildTarget("//:foobar");
+
+    assertOutputDoesNotExist("out/foo.txt");
+    assertValidOutputFile("out/foobar.txt", "foo\nbar\n");
+    assertThat(actionEventCollector.getNumActionNodesEvaluated()).isEqualTo(0);
+  }
+
+  @Test
+  public void downloadToplevel_afterDownloadAllBuildOfAnotherTarget_doesNotReexecuteActions()
+      throws Exception {
+    writeAppWithLibs();
+    setDownloadToplevel();
+    buildTarget("//:app");
+    assertValidOutputFile("out/app.txt", "lib0\nlib1\nlib2\n");
+    assertOutputsDoNotExist("//:lib0");
+    assertOutputsDoNotExist("//:lib1");
+    assertOutputsDoNotExist("//:lib2");
+
+    // Build an unrelated target with a broader download policy, as e.g. an IDE project generator
+    // does, then run an incremental build without changes.
+    setDownloadAll();
+    buildTarget("//:tool");
+    setDownloadToplevel();
+    ActionEventCollector actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+    buildTarget("//:app");
+
+    // The intermediate outputs are still trusted, so their actions hit the action cache instead of
+    // being re-executed remotely.
+    assertOutputsDoNotExist("//:lib0");
+    assertValidOutputFile("out/app.txt", "lib0\nlib1\nlib2\n");
+    assertThat(actionEventCollector.getActionExecutedEvents()).isEmpty();
+  }
+
+  @Test
+  public void downloadToplevel_afterDownloadAllBuildOfAnotherTarget_onlyModifiedActionsRerun()
+      throws Exception {
+    writeAppWithLibs();
+    setDownloadToplevel();
+    buildTarget("//:app");
+    assertValidOutputFile("out/app.txt", "lib0\nlib1\nlib2\n");
+    setDownloadAll();
+    buildTarget("//:tool");
+
+    setDownloadToplevel();
+    write("lib0.in", "modified");
+    ActionEventCollector actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+    buildTarget("//:app");
+
+    // Only the actions depending on the modified source are re-executed.
+    assertOutputsDoNotExist("//:lib1");
+    assertOutputsDoNotExist("//:lib2");
+    assertValidOutputFile("out/app.txt", "modified\nlib1\nlib2\n");
+    assertThat(actionEventCollector.getActionExecutedEvents()).hasSize(2);
+  }
+
+  @Test
+  public void downloadMinimal_afterDownloadAllBuildOfAnotherTarget_doesNotReexecuteActions()
+      throws Exception {
+    writeAppWithLibs();
+    buildTarget("//:app");
+    assertOutputsDoNotExist("//:app");
+    assertOutputsDoNotExist("//:lib0");
+
+    // Build an unrelated target with a broader download policy, then run an incremental build
+    // without changes.
+    setDownloadAll();
+    buildTarget("//:tool");
+    addOptions("--remote_download_outputs=minimal");
+    ActionEventCollector actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+    buildTarget("//:app");
+
+    // Nothing is downloaded and no action is re-executed.
+    assertOutputsDoNotExist("//:app");
+    assertOutputsDoNotExist("//:lib0");
+    assertThat(actionEventCollector.getActionExecutedEvents()).isEmpty();
   }
 
   @Test
@@ -2104,6 +2216,43 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
             },
         )
         """);
+  }
+
+  protected void writeAppWithLibs() throws IOException {
+    write("lib0.in", "lib0");
+    write("lib1.in", "lib1");
+    write("lib2.in", "lib2");
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'lib0',",
+        "  srcs = ['lib0.in'],",
+        "  outs = ['out/lib0.txt'],",
+        "  cmd = 'cat $(SRCS) > $@',",
+        ")",
+        "genrule(",
+        "  name = 'lib1',",
+        "  srcs = ['lib1.in'],",
+        "  outs = ['out/lib1.txt'],",
+        "  cmd = 'cat $(SRCS) > $@',",
+        ")",
+        "genrule(",
+        "  name = 'lib2',",
+        "  srcs = ['lib2.in'],",
+        "  outs = ['out/lib2.txt'],",
+        "  cmd = 'cat $(SRCS) > $@',",
+        ")",
+        "genrule(",
+        "  name = 'app',",
+        "  srcs = [':lib0', ':lib1', ':lib2'],",
+        "  outs = ['out/app.txt'],",
+        "  cmd = 'cat $(SRCS) > $@',",
+        ")",
+        "genrule(",
+        "  name = 'tool',",
+        "  outs = ['out/tool.txt'],",
+        "  cmd = 'echo tool > $@',",
+        ")");
   }
 
   protected void writeCopyAspectRule(boolean aggregate) throws IOException {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1011,6 +1011,9 @@ java_test(
     timeout = "short",
     srcs = ["FilesystemValueCheckerTest.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/skyframe:configured_target_key",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:target_completion_value",
+        "//src/main/java/com/google/devtools/build/lib/analysis:top_level_artifact_context",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:action_lookup_data",
         "//src/main/java/com/google/devtools/build/lib/actions:action_lookup_key",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
@@ -25,6 +25,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.hash.HashCode;
 import com.google.common.util.concurrent.Runnables;
 import com.google.devtools.build.lib.actions.Action;
@@ -44,6 +45,7 @@ import com.google.devtools.build.lib.actions.OutputChecker;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.actions.util.TestAction;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
+import com.google.devtools.build.lib.analysis.TopLevelArtifactContext;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -1565,6 +1567,79 @@ public final class FilesystemValueCheckerTest {
     } else {
       assertThat(dirtyActionKeys).containsExactly(actionKey1);
     }
+  }
+
+  @Test
+  public void testCompletionValueWithMaterializedOutputs() throws Exception {
+    // Test that a completion value recording materialized outputs is invalidated iff one of those
+    // files is deleted or modified.
+    Artifact out = createDerivedArtifact("foo");
+    FileSystemUtils.writeContentAsLatin1(out.getPath(), "foo-content");
+    SkyKey completionKey =
+        TargetCompletionValue.key(
+            ConfiguredTargetKey.builder().setLabel(Label.parseCanonical("//foo:bar")).build(),
+            new TopLevelArtifactContext(
+                /* runTestsExclusively= */ false,
+                /* expandFilesets= */ false,
+                ImmutableSortedSet.of()),
+            /* willTest= */ false);
+    var completionValue =
+        TargetCompletionValue.create(
+            ImmutableMap.of(out, FileContentsProxy.create(out.getPath().stat())));
+    differencer.inject(ImmutableMap.of(completionKey, Delta.justNew(completionValue)));
+
+    EvaluationContext evaluationContext =
+        EvaluationContext.newBuilder()
+            .setKeepGoing(false)
+            .setParallelism(1)
+            .setEventHandler(NullEventHandler.INSTANCE)
+            .build();
+    assertThat(evaluator.evaluate(ImmutableList.of(completionKey), evaluationContext).hasError())
+        .isFalse();
+
+    assertThat(
+            new FilesystemValueChecker(
+                    /* tsgm= */ null,
+                    SyscallCache.NO_CACHE,
+                    XattrProviderOverrider.NO_OVERRIDE,
+                    FSVC_THREADS_FOR_TEST)
+                .getDirtyActionValues(
+                    evaluator.getValues(),
+                    /* batchStatter= */ null,
+                    ModifiedFileSet.EVERYTHING_MODIFIED,
+                    OutputChecker.TRUST_ALL,
+                    (ignored, ignored2) -> {}))
+        .isEmpty();
+
+    out.getPath().delete();
+    assertThat(
+            new FilesystemValueChecker(
+                    /* tsgm= */ null,
+                    SyscallCache.NO_CACHE,
+                    XattrProviderOverrider.NO_OVERRIDE,
+                    FSVC_THREADS_FOR_TEST)
+                .getDirtyActionValues(
+                    evaluator.getValues(),
+                    /* batchStatter= */ null,
+                    ModifiedFileSet.EVERYTHING_MODIFIED,
+                    OutputChecker.TRUST_ALL,
+                    (ignored, ignored2) -> {}))
+        .containsExactly(completionKey);
+
+    FileSystemUtils.writeContentAsLatin1(out.getPath(), "modified-content");
+    assertThat(
+            new FilesystemValueChecker(
+                    /* tsgm= */ null,
+                    SyscallCache.NO_CACHE,
+                    XattrProviderOverrider.NO_OVERRIDE,
+                    FSVC_THREADS_FOR_TEST)
+                .getDirtyActionValues(
+                    evaluator.getValues(),
+                    /* batchStatter= */ null,
+                    ModifiedFileSet.EVERYTHING_MODIFIED,
+                    OutputChecker.TRUST_ALL,
+                    (ignored, ignored2) -> {}))
+        .containsExactly(completionKey);
   }
 
   @Test


### PR DESCRIPTION
### Description

This PR implements the consolidated design from @coeuvre's [design document](https://github.com/user-attachments/files/31513218/consolidated_skyframe_materialization.md), replacing the dedicated download SkyFunction from earlier revisions of this PR: the materialization state of top-level outputs is recorded directly in the existing completion values instead of a child node, adding no Skyframe nodes or edges.

The commits are meant to be reviewed individually:

1. The invocation's download policy (mode, `--remote_download_regex` patterns, command) is injected as a precomputed value that completion functions depend on, so a policy change reevaluates them. This is a correction to the design document, which doesn't specify how completions are invalidated on policy changes after `maybeInvalidateSkyframeValues` is deleted; without it, e.g. a `minimal` build followed by a `toplevel` build of the same target would never download the top-level outputs. The policy must not be gated on Skymeld (non-Skymeld invocations also need policy-change invalidation, and `SkymeldModule.beforeCommand` runs after `RemoteModule`'s).
2. `TargetCompletionValue` and `AspectCompletionValue`, previously empty singletons, record the outputs that are present in the local filesystem while their metadata tracked in Skyframe remains remote, together with their contents proxy. Invocations that materialize nothing keep sharing the empty singleton.
3. `FilesystemValueChecker` compares each completion value's record against the local filesystem and invalidates the completion node if a file is missing or modified; its reevaluation rematerializes the file if the policy wants it locally, without reexecuting or even revalidating the generating action. The completion functions become non-hermetic to permit this invalidation, matching action execution nodes. Lost-output rewinding stays in `CompletionFunction`, unchanged.
4. The previous-invocation state in `RemoteOutputChecker` (the `lastRemoteOutputChecker` chain and `maybeInvalidateSkyframeValues`) is deleted. The current invocation's policy check in `shouldTrustMetadata` stays for the non-Skymeld path.
5. The incremental build tests from #30852 are carried over; they fail on master and pass here. Fixes #26924.

The base commit is #30871, whose contents-proxy recording keeps the completion values' record precise for files that were verified by digest rather than freshly downloaded.

Two caveats relative to the design document, to be addressed separately: completion values are only produced on success, so partially materialized outputs of failed targets are still not tracked (the failed event path keeps its inline important output handler call); and the FSVC-notification-to-prefetcher-submission mechanism for `--remote_download_regex`-matched intermediate outputs (the document's second pillar) is left to a follow-up, including a story for lost remote blobs on that path.

### Motivation

With Build without the Bytes, the completion functions download top-level outputs that only exist as remote metadata as an unmodeled side effect of their evaluation, and correctness across invocations was maintained by point mechanisms whose gaps surfaced as bugs: a top-level output deleted locally was silently not restored if any intervening invocation didn't request it (the new `downloadToplevel_outputDeletedAfterUnrelatedBuild_toplevelOutputIsRestored` test fails on master), and an invocation with a broader download policy caused the next incremental build to reevaluate and reexecute actions wholesale (#26924).

Full test runs: `BuildWithoutTheBytesIntegrationTest` (Java and shell), `RemoteTests`, `FilesystemValueCheckerTest`, `RewindingTest`, `SkymeldBuildIntegrationTest`, `TargetCompleteEventTest`.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: With Build without the Bytes, locally materialized top-level outputs are now tracked in Skyframe. A requested top-level output that was deleted locally is reliably redownloaded in the next build that requests it, and changes to the download policy no longer cause unnecessary reevaluation or reexecution of actions.
