### PR TITLE
Reject tar hard link targets that escape the extraction destination

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunction.java
@@ -150,6 +150,20 @@ public abstract class CompressedTarFunction implements Decompressor {
             if (entry.isSymbolicLink()) {
               symlinks.put(filePath, targetName);
             } else {
+              // Hard link targets are re-rooted at the destination above, so
+              // targetName is always absolute for them and the guard before
+              // this branch never fires. Validate the raw linkname for ".."
+              // segments, which is the actual escape vector.
+              String rawLinkName = toRawBytesString(entry.getLinkName());
+              for (String segment : rawLinkName.split("/")) {
+                if (segment.equals("..")) {
+                  throw new IOException(
+                      String.format(
+                          "Failed to extract %s, hard link target %s is escaping the destination"
+                              + " directory",
+                          entryName, rawLinkName));
+                }
+              }
               if (filePath.equals(resolvedTargetPath)) {
                 // The behavior here is semantically different, depending on whether the underlying
                 // filesystem is case-sensitive or case-insensitive. However, it is effectively the

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/CompressedTarFunctionTest.java
@@ -222,6 +222,33 @@ public class CompressedTarFunctionTest {
   }
 
   @Test
+  public void testDecompressTarWithHardlinkEscape() throws Exception {
+    FileSystem fs = FileSystems.getNativeFileSystem();
+    File tarGzFile = folder.newFile("malicious_hardlink.tar.gz");
+    try (FileOutputStream fos = new FileOutputStream(tarGzFile);
+        GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(fos);
+        TarArchiveOutputStream tos = new TarArchiveOutputStream(gzos)) {
+      TarArchiveEntry entry = new TarArchiveEntry("link", TarArchiveEntry.LF_LINK);
+      entry.setLinkName("../foo");
+      entry.setIds(0, 0);
+      entry.setNames("user", "group");
+      tos.putArchiveEntry(entry);
+      tos.closeArchiveEntry();
+    }
+    Path tarGzPath = fs.getPath(tarGzFile.getAbsolutePath());
+
+    DecompressorDescriptor descriptor =
+        DecompressorDescriptor.builder()
+            .setArchivePath(tarGzPath)
+            .setDestinationPath(tarGzPath.getParentDirectory().getRelative("out"))
+            .build();
+    IOException thrown = assertThrows(IOException.class, () -> decompress(descriptor));
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("hard link target ../foo is escaping the destination directory");
+  }
+
+  @Test
   public void testDecompressTarWithChainedSymlinkEscape() throws Exception {
     FileSystem fs = new InMemoryFileSystem(DigestHashFunction.SHA256);
     Path outDir = fs.getPath("/out");


### PR DESCRIPTION
Fixes #30875.

## What

For hard links, `maybeDeprefixSymlink` is called with `forceExtractRootRelative=true`, which always returns an absolute fragment. That means the `!targetName.isAbsolute()` gate on the existing containment check can never fire for hard links, only for symlinks — so a tar member like a hard link to `../foo` slips past the guard and the link gets created outside the extraction destination.

This PR checks the raw linkname (marker-stripped with `toRawBytesString`) for `..` segments before creating the hard link, similar to how GNU tar refuses such members by default. Everything else in the extraction path is untouched.

## Testing

- New `testDecompressTarWithHardlinkEscape` next to the existing symlink/regular-file escape tests: builds a tar.gz with a hard link `link` -> `../foo` and asserts decompression throws.
- Full `//src/test/java/.../decompressor:DecompressorTests` suite passes locally (100/100).