### PR TITLE
fix(http_file): Improve error message when referencing repository root directly

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
@@ -127,6 +127,7 @@ public class PackageLookupFunction implements SkyFunction {
    * PackageLookupValue.key(packageKey)} returned {@code NO_BUILD_FILE_VALUE}, provide a
    * human-readable error message with more details on where we searched for the package.
    */
+  
   public static String explainNoBuildFileValue(PackageIdentifier packageKey, Environment env)
       throws InterruptedException {
     String educationalMessage = "Add a BUILD file to a directory to mark it as a package.";
@@ -145,14 +146,31 @@ public class PackageLookupFunction implements SkyFunction {
       }
       return message.toString();
     } else {
-      return "BUILD file not found in directory '"
+      String baseMessage = "BUILD file not found in directory '"
           + packageKey.getPackageFragment()
           + "' of external repository "
           + packageKey.getRepository()
           + ". "
           + educationalMessage;
+
+      // Fix: Check if this is the root directory of an external http_file repo layout
+      if (packageKey.getPackageFragment().isEmpty()) {
+        SkyKey repositoryKey = RepositoryDirectoryValue.key(packageKey.getRepository());
+        RepositoryDirectoryValue repositoryValue = (RepositoryDirectoryValue) env.getValue(repositoryKey);
+        
+        if (repositoryValue instanceof RepositoryDirectoryValue.Success) {
+          Root root = ((RepositoryDirectoryValue.Success) repositoryValue).root();
+          
+          if (root.getRelative(PathFragment.create("file")).isDirectory()) {
+            return baseMessage + " Did you mean to reference '" + packageKey.getRepository() + "//file' instead?";
+          }
+        }
+      }
+
+      return baseMessage;
     }
   }
+
 
   @Nullable
   private PackageLookupValue findPackageByBuildFile(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PackageLookupFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PackageLookupFunctionTest.java
@@ -369,6 +369,22 @@ public abstract class PackageLookupFunctionTest extends FoundationTestCase {
         .testEquals();
   }
 
+  @Test
+  public void testHttpFileRepositoryRootSuggestsFilePackage() throws Exception {
+    RepositoryName repoName = RepositoryName.create("available_port_finder");
+    
+    scratch.dir("/external/available_port_finder/file");
+    Root repoRoot = Root.fromPath(scratch.dir("/external/available_port_finder"));
+    
+    PackageIdentifier packageId = PackageIdentifier.create(repoName, PathFragment.EMPTY_FRAGMENT);
+
+    String message = PackageLookupFunction.explainNoBuildFileValue(packageId, this.env);
+    
+    assertThat(message).contains("Did you mean to reference '@available_port_finder//file' instead?");
+  }
+
+
+
   /**
    * Runs all tests in the base {@link PackageLookupFunctionTest} class with the {@link
    * CrossRepositoryLabelViolationStrategy#IGNORE} enum set, and also additional tests specific to


### PR DESCRIPTION
### Description
Improves the package lookup error message when referencing an external http_file repository root directly (e.g., @available_port_finder//:AvailablePortFinder.java). Instead of a cryptic missing BUILD file error, it now suggests using @available_port_finder//file instead.

### Motivation
Fixes #16375 to help users easily understand how to correctly reference files downloaded via http_file.

### Build API Changes
No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
