### PR TITLE
Fix contribute link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!--
 Thank you for contributing to Bazel!
-Please read the contribution guidelines: https://bazel.build/contribute.html
+Please read the contribution guidelines: https://bazel.build/contribute
 -->
 
 ### Description


### PR DESCRIPTION
### Description

Fixes 'contributing' link in PR template. The `.html` causes it to 404.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] ~I have added tests for the new use cases (if any).~
- [ ] ~I have updated the documentation (if applicable).~

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
