### PR TITLE
Update protobuf to 36.0.bcr.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,7 +24,7 @@ bazel_dep(name = "googletest", version = "1.17.0.bcr.2", repo_name = "com_google
 bazel_dep(name = "grpc-java", version = "1.71.0")
 bazel_dep(name = "grpc", version = "1.76.0.bcr.1", repo_name = "com_github_grpc_grpc")
 bazel_dep(name = "platforms", version = "1.1.0")
-bazel_dep(name = "protobuf", version = "36.0", repo_name = "com_google_protobuf")
+bazel_dep(name = "protobuf", version = "36.0.bcr.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "re2", version = "2025-11-05.bcr.1")
 bazel_dep(name = "rules_go", version = "0.59.0")
 bazel_dep(name = "rules_graalvm", version = "0.11.1")
@@ -121,7 +121,7 @@ single_version_override(
     patch_strip = 1,
     # Patch is based on 36.0
     patches = ["//third_party:protobuf.patch"],
-    version = "36.0",
+    version = "36.0.bcr.1",
 )
 
 # Remove once the following PRs are available in a grpc-java release.


### PR DESCRIPTION
The old version was yanked, breaking Bazel CI.

See https://github.com/protocolbuffers/protobuf/issues/29313
