### PR TITLE
[9.3.0] Prevent NPE crash when updating `MODULE.bazel.lock` with `null` `RepoRuleId`.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileFunction.java
@@ -120,7 +120,21 @@ public class BazelLockFileFunction implements SkyFunction {
       Matcher matcher = LOCKFILE_VERSION_PATTERN.matcher(json);
       int version = matcher.find() ? Integer.parseInt(matcher.group(1)) : -1;
       if (version == BazelLockFileValue.LOCK_FILE_VERSION) {
-        return GsonTypeAdapterUtil.LOCKFILE_GSON.fromJson(json, BazelLockFileValue.class);
+        BazelLockFileValue lockFileValue =
+            GsonTypeAdapterUtil.LOCKFILE_GSON.fromJson(json, BazelLockFileValue.class);
+        if (!isValidLockfile(lockFileValue)) {
+          if (lockfileMode == LockfileMode.ERROR) {
+            throw new BazelLockfileFunctionException(
+                ExternalDepsException.withMessage(
+                    Code.BAD_LOCKFILE,
+                    "The version of MODULE.bazel.lock is not supported by this version of Bazel."
+                        + " Please run `bazel mod deps --lockfile_mode=update` to update your"
+                        + " lockfile."),
+                Transience.PERSISTENT);
+          }
+          return BazelLockFileValue.EMPTY_LOCKFILE;
+        }
+        return lockFileValue;
       } else {
         // This is an old version, its information can't be used.
         if (lockfileMode == LockfileMode.ERROR) {
@@ -137,6 +151,28 @@ public class BazelLockFileFunction implements SkyFunction {
     } catch (FileNotFoundException e) {
       return BazelLockFileValue.EMPTY_LOCKFILE;
     }
+  }
+
+  private static boolean isValidLockfile(@Nullable BazelLockFileValue lockFileValue) {
+    if (lockFileValue == null || lockFileValue.getModuleExtensions() == null) {
+      return false;
+    }
+    for (var extensionMap : lockFileValue.getModuleExtensions().values()) {
+      if (extensionMap == null) {
+        return false;
+      }
+      for (LockFileModuleExtension extension : extensionMap.values()) {
+        if (extension == null || extension.getGeneratedRepoSpecs() == null) {
+          return false;
+        }
+        for (RepoSpec repoSpec : extension.getGeneratedRepoSpecs().values()) {
+          if (repoSpec == null || repoSpec.repoRuleId() == null) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
   }
 
   static final class BazelLockfileFunctionException extends SkyFunctionException {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
@@ -95,6 +95,10 @@ public final class GsonTypeAdapterUtil {
       new TypeAdapter<>() {
         @Override
         public void write(JsonWriter jsonWriter, ModuleKey moduleKey) throws IOException {
+          if (moduleKey == null) {
+            jsonWriter.nullValue();
+            return;
+          }
           jsonWriter.value(internalToUnicode(moduleKey.toString()));
         }
 
@@ -115,6 +119,10 @@ public final class GsonTypeAdapterUtil {
       new TypeAdapter<>() {
         @Override
         public void write(JsonWriter jsonWriter, Label label) throws IOException {
+          if (label == null) {
+            jsonWriter.nullValue();
+            return;
+          }
           jsonWriter.value(internalToUnicode(label.getUnambiguousCanonicalForm()));
         }
 
@@ -128,6 +136,10 @@ public final class GsonTypeAdapterUtil {
       new TypeAdapter<>() {
         @Override
         public void write(JsonWriter jsonWriter, RepoRuleId repoRuleId) throws IOException {
+          if (repoRuleId == null) {
+            jsonWriter.nullValue();
+            return;
+          }
           jsonWriter.value(internalToUnicode(repoRuleId.toString()));
         }
 
@@ -148,6 +160,10 @@ public final class GsonTypeAdapterUtil {
       new TypeAdapter<>() {
         @Override
         public void write(JsonWriter jsonWriter, RepositoryName repoName) throws IOException {
+          if (repoName == null) {
+            jsonWriter.nullValue();
+            return;
+          }
           jsonWriter.value(repoName.getName());
         }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModuleTest.java
@@ -126,4 +126,26 @@ public class BazelLockFileModuleTest {
         .isEqualTo(
             GsonTypeAdapterUtil.LOCKFILE_GSON.toJson(BazelLockFileValue.EMPTY_LOCKFILE) + "\n");
   }
+
+  @Test
+  public void updateLockfileWithNullRepoRuleIdDoesNotThrow() throws Exception {
+    Path workspaceRoot = new Scratch().dir("/workspace");
+    RepoSpec repoSpecWithNullRuleId = new RepoSpec(null, AttributeValues.create(Dict.empty()));
+    LockFileModuleExtension extensionWithNullRuleId =
+        LockFileModuleExtension.builder()
+            .setBzlTransitiveDigest(new byte[] {1, 2, 3})
+            .setUsagesDigest(new byte[] {4, 5, 6})
+            .setRecordedInputs(ImmutableList.of())
+            .setGeneratedRepoSpecs(ImmutableMap.of("repo", repoSpecWithNullRuleId))
+            .build();
+    BazelLockFileValue lockfile =
+        BazelLockFileValue.builder()
+            .setModuleExtensions(
+                ImmutableMap.of(extensionId, ImmutableMap.of(evalFactors, extensionWithNullRuleId)))
+            .build();
+
+    BazelLockFileModule.updateLockfile(workspaceRoot, lockfile);
+
+    assertThat(workspaceRoot.getRelative("MODULE.bazel.lock").exists()).isTrue();
+  }
 }


### PR DESCRIPTION
When a lockfile contains an entry from before commit 3d60f1c or from a merge conflict resolution that lacks `repoRuleId`, GSON deserializes `RepoSpec` with `repoRuleId = null`. Later, when Bazel updates and writes the lockfile in `BazelLockFileModule.updateLockfile`, serializing `RepoSpec` invokes `repoRuleId.toString()`, which throws an NPE resulting in a Bazel crash.

Now we have proper `null`-safety checks in GSON TypeAdapters so that malformed lockfile entries with `null` repoRuleId are cleanly reported.

Fixes https://github.com/bazelbuild/bazel/issues/24716

PiperOrigin-RevId: 971891689
Change-Id: I405c61d5c6f4d20b9908083099a1e64d7f571350

Commit https://github.com/bazelbuild/bazel/commit/a671c5e78f4a78196341cf3a487f62ff4101be4f