### PR TITLE
[9.3.0] Clone files into the disk cache where the filesystem supports it (htt…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -24,6 +24,7 @@ import build.bazel.remote.execution.v2.Tree;
 import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.ExtensionRegistryLite;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -269,9 +270,7 @@ public class DiskCacheClient {
   public ListenableFuture<Void> uploadFile(Digest digest, Path file) {
     return executorService.submit(
         () -> {
-          try (InputStream in = file.getInputStream()) {
-            saveFile(digest, Store.CAS, in);
-          }
+          saveFile(digest, Store.CAS, file);
           return null;
         });
   }
@@ -312,6 +311,51 @@ public class DiskCacheClient {
   }
 
   public void saveFile(Digest digest, Store store, InputStream in) throws IOException {
+    save(
+        digest,
+        store,
+        temp -> {
+          try (OutputStream out = temp.getOutputStream()) {
+            ByteStreams.copy(in, out);
+            // Fsync temp before we rename it to avoid data loss in the case of machine
+            // crashes (the OS may reorder the writes and the rename).
+            if (out instanceof FileOutputStream fos) {
+              fos.getFD().sync();
+            }
+          }
+        });
+  }
+
+  /**
+   * Saves an existing file into the cache.
+   *
+   * <p>The contents are copied through {@link FileSystemUtils#copyFile}, so a filesystem with
+   * copy-on-write support (clonefile on macOS, copy_file_range on Linux) can serve the copy as a
+   * clone, leaving the entry sharing its blocks with the file it was saved from.
+   */
+  private void saveFile(Digest digest, Store store, Path file) throws IOException {
+    save(
+        digest,
+        store,
+        temp -> {
+          FileSystemUtils.copyFile(file, temp);
+          // copyFile preserves the source's permissions and mtime, neither of which suits a cache
+          // entry: an entry must remain readable by every user of a shared cache, and its mtime
+          // records when it was last stored or retrieved.
+          temp.chmod(0644);
+          temp.setLastModifiedTime(Path.NOW_SENTINEL_TIME);
+          // Fsync temp before we rename it to avoid data loss in the case of machine
+          // crashes (the OS may reorder the writes and the rename).
+          syncFile(temp);
+        });
+  }
+
+  /** Writes the contents of a cache entry into a temporary file. */
+  private interface TempFileWriter {
+    void write(Path temp) throws IOException;
+  }
+
+  private void save(Digest digest, Store store, TempFileWriter writer) throws IOException {
     Path path = toPath(digest, store);
 
     // CAS entries are content-addressed and thus automatically have the correct content if they
@@ -324,14 +368,7 @@ public class DiskCacheClient {
     Path temp = getTempPath();
 
     try {
-      try (OutputStream out = temp.getOutputStream()) {
-        in.transferTo(out);
-        // Fsync temp before we rename it to avoid data loss in the case of machine
-        // crashes (the OS may reorder the writes and the rename).
-        if (out instanceof FileOutputStream fos) {
-          fos.getFD().sync();
-        }
-      }
+      writer.write(temp);
       path.getParentDirectory().createDirectoryAndParents();
       FileSystemUtils.renameToleratingConcurrentCreation(temp, path);
     } catch (IOException e) {
@@ -341,6 +378,15 @@ public class DiskCacheClient {
         e.addSuppressed(deleteErr);
       }
       throw e;
+    }
+  }
+
+  /** Flushes a file's contents to stable storage, where the filesystem supports it. */
+  private static void syncFile(Path path) throws IOException {
+    try (InputStream in = path.getInputStream()) {
+      if (in instanceof FileInputStream fileInputStream) {
+        fileInputStream.getFD().sync();
+      }
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
@@ -155,6 +155,26 @@ public class DiskCacheClientTest {
   }
 
   @Test
+  public void uploadFile_whenMissing_doesNotInheritSourceMtimeOrPermissions() throws Exception {
+    Path file = fs.getPath("/file");
+    FileSystemUtils.writeContent(file, UTF_8, "contents");
+    // A build output is read-only, and may have been written long before it is uploaded. Neither
+    // property may leak into the cache entry: the mtime records when the entry was last stored or
+    // retrieved, and the entry must remain readable by every user of a shared cache.
+    file.chmod(0555);
+    file.setLastModifiedTime(1000);
+    Digest digest = getDigest("contents");
+
+    var unused = getFromFuture(client.uploadFile(digest, file));
+
+    Path path = getCasPath(digest);
+    assertThat(FileSystemUtils.readContent(path, UTF_8)).isEqualTo("contents");
+    assertThat(path.getLastModifiedTime()).isNotEqualTo(1000);
+    assertThat(path.isReadable()).isTrue();
+    assertThat(path.isWritable()).isTrue();
+  }
+
+  @Test
   public void uploadBlob_whenMissing_populatesCas() throws Exception {
     ByteString blob = ByteString.copyFromUtf8("contents");
     Digest digest = getDigest("contents");


### PR DESCRIPTION
…ps://github.com/bazelbuild/bazel/pull/30776)

- `DiskCacheClient.uploadFile` now copies through `FileSystemUtils#copyFile`, which reaches `Files#copy` and lets the filesystem serve the copy as a copy-on-write clone: `clonefile` on macOS, `copy_file_range` on Linux with a supporting filesystem. The cache entry then shares its blocks with the output it came from. The previous code streamed the bytes into the temporary file.
- Where no clone is possible (different filesystem, or no kernel support), `Files#copy` falls back to a byte copy, so this is never slower than the stream it replaces.
- The temporary-file-then-rename scaffolding moved into a private `save()` helper, shared by the stream path and the new file path.
- A clone inherits the source's permissions and mtime, so both are reset: outputs are typically `0555` and can be older than the upload, an entry has to stay readable for every user of a shared cache, and the garbage collector reads the mtime to find the least recently used entries.
- The cloned temporary file is fsynced before the rename, keeping the durability the streamed write had.

Materializing outputs from the disk cache already clones, since ec90e05dee ("Optimize file copies by using NIO methods"). The upload direction still wrote a second physical copy of a file that was already on disk.

Measured on macOS/APFS: one genrule producing a 1 GiB output, fresh disk cache, real disk consumed via `df`.

| | before | after |
|---|---|---|
| 1 GiB output plus its cache entry | 2058 MiB | 1028 MiB |

Physical extent mapping (`fcntl(F_LOG2PHYS_EXT)`) on the same pair agrees: 0/3 sampled extents shared before, 3/3 after. On a large iOS app build, the disk cache held 13.1 GiB duplicating content that was also present in the output tree.

Two consequences worth knowing:

- An entry sharing blocks with an output is no longer freed by deleting either one alone.
- `DiskCacheGarbageCollector` sizes entries by their logical length, so it over-counts what deletion reclaims.

No

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES: Files uploaded to the disk cache are now copied with a copy-on-write clone where the filesystem supports it, so a cache entry can share its blocks with the output it was uploaded from.

Closes #30776.

PiperOrigin-RevId: 968392369
Change-Id: I89bfa402106cd59964045353854336fa36098d8b

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/a341ee59dbdddcb0c3b8257aa025617c9f001702