### PR TITLE
Register a FileValue dep on bzlCompileCache hits in BzlLoadFunction

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -885,6 +885,7 @@ java_library(
     name = "bzl_compile_value",
     srcs = ["BzlCompileValue.java"],
     deps = [
+        ":filesystem_keys",
         ":sky_functions",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization:visible-for-serialization",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlCompileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlCompileFunction.java
@@ -296,32 +296,6 @@ public class BzlCompileFunction implements SkyFunction {
   }
 
   /**
-   * Requests the {@link FileValue} for the .bzl file denoted by {@code key} so that the requesting
-   * Skyframe node depends on it, without using the result.
-   *
-   * <p>Used by {@code BzlLoadFunction.InliningAndCachingGetter} on a {@code bzlCompileCache} hit:
-   * the cached value may have been computed on behalf of a different {@code BzlLoadValue} node that
-   * shares the same compile key (e.g. the {@code KeyForBuild} and {@code KeyForBzlmod} variants of
-   * the same label), in which case the node consuming the cache hit doesn't yet depend on the file
-   * and would miss invalidation when it changes.
-   *
-   * @return false if the {@link FileValue} is not yet available
-   */
-  static boolean requestFileDepOnCacheHit(BzlCompileValue.Key key, Environment env)
-      throws FailedIOException, InterruptedException {
-    if (key.kind == BzlCompileValue.Kind.EMPTY_PRELUDE) {
-      // Does not correspond to a file.
-      return true;
-    }
-    RootedPath rootedPath = RootedPath.toRootedPath(key.root, key.label.toPathFragment());
-    try {
-      return env.getValueOrThrow(FileValue.key(rootedPath), IOException.class) != null;
-    } catch (IOException e) {
-      throw new FailedIOException(e, Transience.PERSISTENT);
-    }
-  }
-
-  /**
    * Replays the syntax errors from a file onto an event handler, adding more context if necessary.
    */
   private static void addSyntaxErrorsToListener(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlCompileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlCompileFunction.java
@@ -296,6 +296,32 @@ public class BzlCompileFunction implements SkyFunction {
   }
 
   /**
+   * Requests the {@link FileValue} for the .bzl file denoted by {@code key} so that the requesting
+   * Skyframe node depends on it, without using the result.
+   *
+   * <p>Used by {@code BzlLoadFunction.InliningAndCachingGetter} on a {@code bzlCompileCache} hit:
+   * the cached value may have been computed on behalf of a different {@code BzlLoadValue} node that
+   * shares the same compile key (e.g. the {@code KeyForBuild} and {@code KeyForBzlmod} variants of
+   * the same label), in which case the node consuming the cache hit doesn't yet depend on the file
+   * and would miss invalidation when it changes.
+   *
+   * @return false if the {@link FileValue} is not yet available
+   */
+  static boolean requestFileDepOnCacheHit(BzlCompileValue.Key key, Environment env)
+      throws FailedIOException, InterruptedException {
+    if (key.kind == BzlCompileValue.Kind.EMPTY_PRELUDE) {
+      // Does not correspond to a file.
+      return true;
+    }
+    RootedPath rootedPath = RootedPath.toRootedPath(key.root, key.label.toPathFragment());
+    try {
+      return env.getValueOrThrow(FileValue.key(rootedPath), IOException.class) != null;
+    } catch (IOException e) {
+      throw new FailedIOException(e, Transience.PERSISTENT);
+    }
+  }
+
+  /**
    * Replays the syntax errors from a file onto an event handler, adding more context if necessary.
    */
   private static void addSyntaxErrorsToListener(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlCompileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlCompileValue.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerializat
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.SerializationConstant;
 import com.google.devtools.build.lib.vfs.Root;
+import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.skyframe.NotComparableSkyValue;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyKey;
@@ -231,6 +232,16 @@ public abstract class BzlCompileValue implements NotComparableSkyValue {
 
     public Label getLabel() {
       return label;
+    }
+
+    /** Returns the dep to register for the underlying .bzl file (if any). */
+    @Nullable
+    public FileKey getBzlFileKey() {
+      if (label == null) {
+        // Implies kind == Kind.EMPTY_PRELUDE.
+        return null;
+      }
+      return FileKey.create(RootedPath.toRootedPath(root, label.toPathFragment()));
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
@@ -1519,6 +1519,12 @@ public class BzlLoadFunction implements SkyFunction {
         if (value != null) {
           bzlCompileCache.put(key, value);
         }
+      } else {
+        // The cache hit may have been populated on behalf of a different BzlLoadValue node with
+        // the same compile key; make sure this node depends on the .bzl file too.
+        if (!BzlCompileFunction.requestFileDepOnCacheHit(key, env)) {
+          return null;
+        }
       }
       return value;
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
@@ -1522,8 +1522,9 @@ public class BzlLoadFunction implements SkyFunction {
       } else {
         // The cache hit may have been populated on behalf of a different BzlLoadValue node with
         // the same compile key; make sure this node depends on the .bzl file too.
-        if (!BzlCompileFunction.requestFileDepOnCacheHit(key, env)) {
-          return null;
+        var bzlFileKey = key.getBzlFileKey();
+        if (bzlFileKey != null) {
+          env.registerDependencies(ImmutableList.of(bzlFileKey));
         }
       }
       return value;

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -2194,6 +2194,7 @@ java_test(
         "//src/test/java/com/google/devtools/build/lib/bazel/bzlmod:util",
         "//src/test/java/com/google/devtools/build/lib/skyframe/util:SkyframeExecutorTestUtils",
         "//src/test/java/com/google/devtools/build/lib/testutil:TestConstants",
+        "//src/test/java/com/google/devtools/build/lib/testutil:TestUtils",
         "//src/test/java/com/google/devtools/build/skyframe:testutil",
         "//third_party/java/guava:collect",
         "//third_party/java/jsr305_annotations",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadFunctionTest.java
@@ -34,10 +34,12 @@ import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
 import com.google.devtools.build.lib.runtime.QuiescingExecutorsImpl;
 import com.google.devtools.build.lib.skyframe.util.SkyframeExecutorTestUtils;
 import com.google.devtools.build.lib.testutil.TestConstants;
+import com.google.devtools.build.lib.testutil.TestUtils;
 import com.google.devtools.build.lib.util.io.TimestampGranularityMonitor;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.ModifiedFileSet;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
@@ -49,7 +51,11 @@ import com.google.devtools.common.options.Options;
 import com.google.devtools.common.options.OptionsParser;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.syntax.Types;
@@ -1270,9 +1276,86 @@ public class BzlLoadFunctionTest extends BuildViewTestCase {
         "in call to requires_int(), parameter 'x' got value of type 'str', want 'int'");
   }
 
+  @Test
+  public void bzlCompileCacheHitFromNodeWithOtherKeyKind_registersFileDep() throws Exception {
+    // Regression test for https://github.com/bazelbuild/bazel/issues/30900: the KeyForBuild and
+    // KeyForBzlmod variants of the same .bzl share a single entry in BzlLoadFunction's
+    // bzlCompileCache. A node that gets a cache hit for an entry computed on behalf of the other
+    // variant must still register a dependency on the .bzl's FileValue; otherwise it isn't
+    // invalidated when the file changes and keeps serving stale contents.
+    CustomInMemoryFs fs = (CustomInMemoryFs) fileSystem;
+    scratch.file("pkg/BUILD");
+    scratch.file(
+        "pkg/foo.bzl",
+        """
+        load(":bar.bzl", "x")
+
+        y = x
+        """);
+    Path barBzl = scratch.file("pkg/bar.bzl", "x = 1");
+
+    // Evaluate the KeyForBuild node on another thread and interrupt the evaluation while it is
+    // blocked statting bar.bzl. At that point foo.bzl has already been compiled and cached in the
+    // bzlCompileCache (a .bzl is compiled before its load() deps are requested), and the interrupt
+    // strands the entry there since it is only released when the owning BzlLoadValue node
+    // completes. This simulates a .bzl file compiled on behalf of one BzlLoadValue node while a
+    // node for the other key variant of the same file is in flight.
+    SkyKey keyForBuild = key("//pkg:foo.bzl");
+    fs.pathToBlockOnStat = barBzl;
+    AtomicBoolean evaluationInterrupted = new AtomicBoolean(false);
+    Thread evalThread =
+        new Thread(
+            () -> {
+              try {
+                SkyframeExecutorTestUtils.evaluate(
+                    getSkyframeExecutor(), keyForBuild, /* keepGoing= */ false, reporter);
+              } catch (InterruptedException e) {
+                evaluationInterrupted.set(true);
+              }
+            });
+    evalThread.start();
+    assertThat(fs.blockedStatReached.await(TestUtils.WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+        .isTrue();
+    evalThread.interrupt();
+    evalThread.join();
+    assertThat(evaluationInterrupted.get()).isTrue();
+    fs.pathToBlockOnStat = null;
+    fs.blockedStatMayProceed.countDown();
+
+    // The interrupted evaluation may have committed an error for bar.bzl's FileStateValue (the
+    // blocked stat throws InterruptedIOException when the evaluation shuts down). Invalidate it so
+    // that the next evaluation stats the file afresh.
+    getSkyframeExecutor()
+        .invalidateFilesUnderPathForTesting(
+            reporter,
+            ModifiedFileSet.builder().modify(PathFragment.create("pkg/bar.bzl")).build(),
+            Root.fromPath(rootDirectory));
+
+    // The KeyForBzlmod node gets a bzlCompileCache hit for the entry compiled on behalf of the
+    // KeyForBuild node above.
+    SkyKey keyForBzlmod = BzlLoadValue.keyForBzlmod(Label.parseCanonical("//pkg:foo.bzl"));
+    EvaluationResult<BzlLoadValue> result = get(keyForBzlmod);
+    assertThat(result.get(keyForBzlmod).getModule().getGlobals())
+        .containsEntry("y", StarlarkInt.of(1));
+
+    // Change foo.bzl. The KeyForBzlmod node must pick up the new file contents.
+    scratch.overwriteFile("pkg/foo.bzl", "y = 2");
+    getSkyframeExecutor()
+        .invalidateFilesUnderPathForTesting(
+            reporter,
+            ModifiedFileSet.builder().modify(PathFragment.create("pkg/foo.bzl")).build(),
+            Root.fromPath(rootDirectory));
+    result = get(keyForBzlmod);
+    assertThat(result.get(keyForBzlmod).getModule().getGlobals())
+        .containsEntry("y", StarlarkInt.of(2));
+  }
+
   private static class CustomInMemoryFs extends InMemoryFileSystem {
     @Nullable private Path badPathForStat;
     @Nullable private Path badPathForRead;
+    @Nullable private volatile Path pathToBlockOnStat;
+    private final CountDownLatch blockedStatReached = new CountDownLatch(1);
+    private final CountDownLatch blockedStatMayProceed = new CountDownLatch(1);
 
     CustomInMemoryFs() {
       super(DigestHashFunction.SHA256);
@@ -1282,6 +1365,16 @@ public class BzlLoadFunctionTest extends BuildViewTestCase {
     public FileStatus statIfFound(PathFragment path, boolean followSymlinks) throws IOException {
       if (badPathForStat != null && badPathForStat.asFragment().equals(path)) {
         throw new IOException("bad");
+      }
+      Path blockedPath = pathToBlockOnStat;
+      if (blockedPath != null && blockedPath.asFragment().equals(path)) {
+        blockedStatReached.countDown();
+        try {
+          blockedStatMayProceed.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new InterruptedIOException();
+        }
       }
       return super.statIfFound(path, followSymlinks);
     }


### PR DESCRIPTION



<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description
The KeyForBuild and KeyForBzlmod variants of a BzlLoadValue key for the same .bzl file share a single BzlCompileValue.Key, and thus a single entry in the bzlCompileCache used when BzlCompileFunction is inlined. When a BzlLoadValue node got a cache hit for an entry that was computed on behalf of a node of the other key variant, it never requested the FileValue for the .bzl file, so it was missing the Skyframe edge that would invalidate it when the file changes and kept serving stale file contents on subsequent builds.

Fix this by (re-)requesting the FileValue for the .bzl file on a cache hit. 

### Motivation
Fixes https://github.com/bazelbuild/bazel/issues/30900


### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
