### PR TITLE
[9.3.0] Harden GrpcCacheClient against misbehaving servers (https://github.co…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -56,6 +56,7 @@ import com.google.devtools.build.lib.remote.RemoteRetrier.ProgressiveBackoff;
 import com.google.devtools.build.lib.remote.chunking.ChunkingConfig;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.MissingDigestsFinder;
+import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -84,6 +85,43 @@ import javax.annotation.Nullable;
 @ThreadSafe
 public class GrpcCacheClient extends RemoteCacheClient implements MissingDigestsFinder {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
+  private static final class SizeLimitingOutputStream extends OutputStream {
+    private final CountingOutputStream out;
+    private final Digest digest;
+
+    private SizeLimitingOutputStream(CountingOutputStream out, Digest digest) {
+      this.out = out;
+      this.digest = digest;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      checkSize(1);
+      out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      checkSize(len);
+      out.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+      out.flush();
+    }
+
+    private void checkSize(int bytesToWrite) throws IOException {
+      if (bytesToWrite > digest.getSizeBytes() - out.getCount()) {
+        throw new IOException(
+            String.format(
+                "Received more bytes than expected for digest '%s/%d'. "
+                    + "Server may have ignored read_offset.",
+                digest.getHash(), digest.getSizeBytes()));
+      }
+    }
+  }
 
   private final CallCredentialsProvider callCredentialsProvider;
   private final ReferenceCountedChannel channel;
@@ -468,9 +506,11 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
         getResourceName(
             options.remoteInstanceName, digest, compressed, digestUtil.getDigestFunction());
     SettableFuture<Long> future = SettableFuture.create();
+    // Prevent misbehaving servers from sending more bytes than expected.
+    SizeLimitingOutputStream sizeLimitedOut = new SizeLimitingOutputStream(rawOut, digest);
     OutputStream out;
     try {
-      out = compressed ? new ZstdDecompressingOutputStream(rawOut) : rawOut;
+      out = compressed ? new ZstdDecompressingOutputStream(sizeLimitedOut) : sizeLimitedOut;
     } catch (IOException e) {
       return Futures.immediateFailedFuture(e);
     }
@@ -501,10 +541,11 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
                 try {
                   data.writeTo(out);
                 } catch (IOException e) {
-                  // The output stream was likely closed due to cancellation (e.g. dynamic execution
-                  // choosing the local branch).
+                  // The output stream either refused to accept more bytes than expected for the
+                  // digest or was closed due to cancellation (e.g. dynamic execution choosing the
+                  // local branch).
                   if (requestStream != null) {
-                    requestStream.cancel("output stream closed", e);
+                    requestStream.cancel(e.getMessage(), e);
                   }
                   future.setException(e);
                   return;
@@ -543,6 +584,10 @@ public class GrpcCacheClient extends RemoteCacheClient implements MissingDigests
                   }
                   if (digestSupplier != null) {
                     Utils.verifyBlobContents(digest, digestSupplier.get());
+                  } else if (rawOut.getCount() != digest.getSizeBytes()) {
+                    // Verifying the digest would also catch an incomplete download; with
+                    // verification disabled, at least verify the size.
+                    throw new OutputDigestMismatchException(digest, rawOut.getCount());
                   }
                 } catch (IOException e) {
                   future.setException(e);

--- a/src/main/java/com/google/devtools/build/lib/remote/common/OutputDigestMismatchException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/OutputDigestMismatchException.java
@@ -16,11 +16,13 @@ package com.google.devtools.build.lib.remote.common;
 import build.bazel.remote.execution.v2.Digest;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
+import javax.annotation.Nullable;
 
 /** An exception to indicate the digest of downloaded output does not match the expected value. */
 public class OutputDigestMismatchException extends IOException {
   private final Digest expected;
-  private final Digest actual;
+  @Nullable private final Digest actual;
+  private final long receivedSizeBytes;
 
   private Path localPath;
   private String outputPath;
@@ -28,6 +30,17 @@ public class OutputDigestMismatchException extends IOException {
   public OutputDigestMismatchException(Digest expected, Digest actual) {
     this.expected = expected;
     this.actual = actual;
+    this.receivedSizeBytes = actual.getSizeBytes();
+  }
+
+  /**
+   * Indicates a download whose digest was not verified, but whose size doesn't match the size of
+   * the expected digest.
+   */
+  public OutputDigestMismatchException(Digest expected, long receivedSizeBytes) {
+    this.expected = expected;
+    this.actual = null;
+    this.receivedSizeBytes = receivedSizeBytes;
   }
 
   public void setOutputPath(String outputPath) {
@@ -48,6 +61,11 @@ public class OutputDigestMismatchException extends IOException {
 
   @Override
   public String getMessage() {
+    if (actual == null) {
+      return String.format(
+          "Output %s download failed: Expected digest '%s/%d', but received %d bytes.",
+          outputPath, expected.getHash(), expected.getSizeBytes(), receivedSizeBytes);
+    }
     return String.format(
         "Output %s download failed: Expected digest '%s/%d' does not match "
             + "received digest '%s/%d'.",

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -1371,7 +1371,7 @@ public class GrpcCacheClientTest {
   @Test
   public void downloadBlobFailsWhenServerCompletesBeforeExpectedSize() throws IOException {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
-    remoteOptions.setRemoteVerifyDownloads(false);
+    remoteOptions.remoteVerifyDownloads = false;
     GrpcCacheClient client = newClient(remoteOptions);
     Digest digest = DIGEST_UTIL.computeAsUtf8("abcdefg");
     serviceRegistry.addService(
@@ -1439,7 +1439,7 @@ public class GrpcCacheClientTest {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     remoteOptions.setCacheCompression(true);
     remoteOptions.setCacheCompressionThreshold(0);
-    remoteOptions.setRemoteVerifyDownloads(false);
+    remoteOptions.remoteVerifyDownloads = false;
     GrpcCacheClient client = newClient(remoteOptions);
     Digest digest = DIGEST_UTIL.computeAsUtf8("abcdefg");
     ByteString compressedPrefix = ByteString.copyFrom(Zstd.compress("abcd".getBytes(UTF_8)));

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -70,6 +70,7 @@ import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.exec.util.SpawnBuilder;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ExponentialBackoff;
 import com.google.devtools.build.lib.remote.Retrier.Backoff;
+import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
@@ -1368,6 +1369,29 @@ public class GrpcCacheClientTest {
   }
 
   @Test
+  public void downloadBlobFailsWhenServerCompletesBeforeExpectedSize() throws IOException {
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.setRemoteVerifyDownloads(false);
+    GrpcCacheClient client = newClient(remoteOptions);
+    Digest digest = DIGEST_UTIL.computeAsUtf8("abcdefg");
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+            responseObserver.onNext(
+                ReadResponse.newBuilder().setData(ByteString.copyFromUtf8("abc")).build());
+            responseObserver.onCompleted();
+          }
+        });
+
+    OutputDigestMismatchException e =
+        assertThrows(
+            OutputDigestMismatchException.class, () -> downloadBlob(context, client, digest));
+    assertThat(e).hasMessageThat().contains(digest.getHash());
+    assertThat(e).hasMessageThat().contains("received 3 bytes");
+  }
+
+  @Test
   public void compressedDownloadBlobIsRetriedWithProgress()
       throws IOException, InterruptedException {
     RemoteOptions options = Options.getDefaults(RemoteOptions.class);
@@ -1408,6 +1432,46 @@ public class GrpcCacheClientTest {
           }
         });
     assertThat(new String(downloadBlob(context, client, digest), UTF_8)).isEqualTo("abcdefg");
+  }
+
+  @Test
+  public void compressedDownloadFailsWhenServerIgnoresReadOffset() throws IOException {
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.setCacheCompression(true);
+    remoteOptions.setCacheCompressionThreshold(0);
+    remoteOptions.setRemoteVerifyDownloads(false);
+    GrpcCacheClient client = newClient(remoteOptions);
+    Digest digest = DIGEST_UTIL.computeAsUtf8("abcdefg");
+    ByteString compressedPrefix = ByteString.copyFrom(Zstd.compress("abcd".getBytes(UTF_8)));
+    ByteString compressedBlob = ByteString.copyFrom(Zstd.compress("abcdefg".getBytes(UTF_8)));
+    AtomicInteger readCalls = new AtomicInteger();
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+            int readCall = readCalls.getAndIncrement();
+            if (readCall == 0) {
+              assertThat(request.getReadOffset()).isEqualTo(0);
+              responseObserver.onNext(ReadResponse.newBuilder().setData(compressedPrefix).build());
+              responseObserver.onError(Status.DEADLINE_EXCEEDED.asException());
+              return;
+            }
+            // Simulate a noncompliant compressed ByteStream server that ignores the uncompressed
+            // read offset and replays the blob from the beginning.
+            assertThat(readCall).isEqualTo(1);
+            assertThat(request.getReadOffset()).isEqualTo(4);
+            responseObserver.onNext(ReadResponse.newBuilder().setData(compressedBlob).build());
+            responseObserver.onCompleted();
+          }
+        });
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    IOException e =
+        assertThrows(
+            IOException.class, () -> getFromFuture(client.downloadBlob(context, digest, out)));
+    assertThat(e).hasMessageThat().contains("Received more bytes than expected");
+    assertThat(out.size()).isAtMost(Math.toIntExact(digest.getSizeBytes()));
+    assertThat(readCalls.get()).isEqualTo(2);
   }
 
   @Test


### PR DESCRIPTION
…m/bazelbuild/bazel/pull/30819)

Fail the download early when the server sends more bytes than expected (e.g. because it ignored `read_offset` on a retry) and fail if the received size doesn't match the expected size even with `--noremote_verify_downloads`.

Work towards #30780

No

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES: None

Closes #30819.

PiperOrigin-RevId: 971795439
Change-Id: I0e8eb0d2c22b29d234dbc07a6d38aaf9c25a9f13

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/9aae5a6ad69d124762d7913a71f3d12873a58ecd