### PR TITLE
[9.3.0] Don't synchronize `RemoteExternalOverlayFileSystem#getInputStream` (h…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -764,7 +764,7 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
     }
 
     @Override
-    public synchronized InputStream getInputStream(PathFragment path) throws IOException {
+    public InputStream getInputStream(PathFragment path) throws IOException {
       // .bzl and REPO.bazel files are prefetched to the native file system during injection, but
       // only if they are regular files, a symlink with such a name is kept in the in-memory overlay
       // only. We thus need to follow symlinks before attempting to read a supposedly prefetched


### PR DESCRIPTION
…ttps://github.com/bazelbuild/bazel/pull/30791)

Synchronization is unnecessary as individual methods called by this implementation are already synchronized. It is also harmful since `getInputStream` awaits a network transfer.

Progress towards #30780

No

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

RELNOTES: None

Closes #30791.

PiperOrigin-RevId: 968392939
Change-Id: Ic48cfa823322e67c6cd0344a91333284b496f3b0

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/16d479fe66c886e2469f2991e12b5298f030d938