### PR TITLE
Fix default --shell_executable on openbsd

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1544,6 +1544,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util:os",
         "//third_party/java/guava:annotations",
         "//third_party/java/guava:collect",
+        "//third_party/java/jsr305_annotations",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/ShToolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ShToolchain.java
@@ -19,7 +19,6 @@ import com.google.devtools.build.lib.analysis.constraints.ConstraintConstants;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import java.util.Optional;
 import javax.annotation.Nullable;
 
 /** Class to work with the shell toolchain, e.g. get the shell interpreter's path. */
@@ -49,9 +48,8 @@ public final class ShToolchain {
       return shellConfiguration.getOptionsBasedDefault();
     }
 
-    return Optional.ofNullable(platformInfo)
-        .map(ConstraintConstants::getOsFromConstraintsOrHost)
-        .flatMap(ShellConfiguration::getShellExecutable)
+    return ShellConfiguration.getShellExecutable(
+            ConstraintConstants.getOsFromConstraintsOrHost(platformInfo))
         .or(() -> ShellConfiguration.getShellExecutable(OS.UNKNOWN))
         .orElseThrow();
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/ShellConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ShellConfiguration.java
@@ -84,7 +84,7 @@ public class ShellConfiguration extends Fragment {
             up a Bazel server), Bazel uses that. If neither is set, Bazel uses a hard-coded
             default path depending on the operating system it runs on;
             - Windows: `c:/msys64/usr/bin/bash.exe`
-            - FreeBSD: `/usr/local/bin/bash`
+            - FreeBSD and OpenBSD: `/usr/local/bin/bash`
             - All others: `/bin/bash`.
 
             Note that using a shell that is not compatible with `bash` may lead

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/ConstraintConstants.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/ConstraintConstants.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.util.OS;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /** Constants needed for use of the constraints system. */
 public final class ConstraintConstants {
@@ -77,9 +78,13 @@ public final class ConstraintConstants {
 
   /**
    * Returns the OS corresponding to the given platform's constraint collection based on the
-   * contained platform constraint, falling back to the host platform if none is found.
+   * contained platform constraint, falling back to the host platform if the platform is null or
+   * has no OS constraint.
    */
-  public static OS getOsFromConstraintsOrHost(PlatformInfo platformInfo) {
+  public static OS getOsFromConstraintsOrHost(@Nullable PlatformInfo platformInfo) {
+    if (platformInfo == null) {
+      return OS.getCurrent();
+    }
     var osConstraintValue = platformInfo.constraints().get(OS_CONSTRAINT_SETTING);
     if (osConstraintValue == null) {
       // The platform doesn't specify any OS constraint, which makes it difficult to say how the

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/GenRuleConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/GenRuleConfiguredTargetTest.java
@@ -180,7 +180,10 @@ public final class GenRuleConfiguredTargetTest extends BuildViewTestCase {
 
     String expected = "echo \"Hello, world.\" >" + messageArtifact.getExecPathString();
     assertThat(shellAction.getArguments().get(0))
-        .isEqualTo(ShToolchain.getPathForHost(targetConfig).getPathString());
+        .isEqualTo(
+            ShToolchain.getPathForPlatform(
+                    targetConfig, shellAction.getOwner().getExecutionPlatform())
+                .getPathString());
     assertThat(shellAction.getArguments().get(1)).isEqualTo("-c");
     assertCommandEquals(expected, shellAction.getArguments().get(2));
   }


### PR DESCRIPTION
Previously the default didn't actually work here unless you had platform
info, which you don't in the `bazel run` codepath, therefore it ignored
the switch statement that hands using a valid bash path on bsd.

Fixes https://github.com/bazelbuild/bazel/issues/30924
