### PR TITLE
Fail git_repository when submodule update fails

### DIFF
--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -806,6 +806,39 @@ EOF
   expect_log "Only one of sparse_checkout_patterns and sparse_checkout_file can be provided."
 }
 
+function test_git_repository_failed_submodule_update_fails_the_rule() {
+  local parent=$TEST_TMPDIR/broken-submodule-parent
+  rm -rf "$parent"
+  mkdir -p "$parent"
+  git -C "$parent" init
+  git -C "$parent" config user.email 'me@example.com'
+  git -C "$parent" config user.name 'repro'
+  git -C "$parent" commit --allow-empty -m empty
+  git -C "$parent" update-index --add --cacheinfo \
+    160000,$(git -C "$parent" rev-parse HEAD),vendor/sub
+  printf '%s\n' \
+    '[submodule "vendor/sub"]' \
+    '	path = vendor/sub' \
+    '	url = https://127.0.0.1:1/does-not-exist.git' > "$parent/.gitmodules"
+  git -C "$parent" add .gitmodules
+  git -C "$parent" commit -m 'unreachable submodule'
+  local commit_hash
+  commit_hash=$(git -C "$parent" rev-parse HEAD)
+
+  cat >> MODULE.bazel <<EOF
+git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+git_repository(
+    name = "broken_submodules",
+    remote = "$parent",
+    commit = "$commit_hash",
+    init_submodules = True,
+)
+EOF
+
+  bazel fetch --repo=@broken_submodules >& $TEST_log && fail "Fetch succeeded"
+  expect_log "error running 'git .*submodule update"
+}
+
 function test_git_repository_invalid_commit() {
   local sentinel=$TEST_TMPDIR/sentinel_validation
   cat >> MODULE.bazel <<EOF

--- a/tools/build_defs/repo/git_worker.bzl
+++ b/tools/build_defs/repo/git_worker.bzl
@@ -208,13 +208,26 @@ def clean(ctx, git_repo):
     _git(ctx, git_repo, "clean", "-xdf")
 
 def update_submodules(ctx, git_repo, recursive = False):
+    # "protocol.file.allow=always" allows cloning a submodule from a local
+    # directory. Needed for Git 2.38.1 and associated backports.
+    # See https://github.com/bazelbuild/bazel/issues/17040
+    start = ["-c", "protocol.file.allow=always", "submodule", "update"]
+    flags = ["--init", "--checkout", "--force"]
     if recursive:
-        # "protocol.file.allow=always" allows the submodule command clone from a local directory.
-        # It's necessary for Git 2.38.1 and assoicated backport versions.
-        # See https://github.com/bazelbuild/bazel/issues/17040
-        _git_maybe_shallow(ctx, git_repo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--checkout", "--force")
-    else:
-        _git_maybe_shallow(ctx, git_repo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--checkout", "--force")
+        flags = ["--init", "--recursive", "--checkout", "--force"]
+
+    # `--depth=1` / `--shallow-since` are flags of `submodule update`, not of
+    # `git submodule`. `_git_maybe_shallow` inserts the shallow arg after its
+    # first token, which is correct for `fetch` but produced `git -c --depth=1
+    # ...` or `git submodule --depth=1 update` here. It also ignored nonzero
+    # exits, so a failed submodule update was still cached as a successful repo.
+    if git_repo.shallow:
+        st = _execute(ctx, git_repo, start + [git_repo.shallow] + flags)
+        if st.return_code == 0:
+            return
+    st = _execute(ctx, git_repo, start + flags)
+    if st.return_code != 0:
+        _error(ctx.name, ["git"] + start + flags, st.stderr)
 
 def _get_head_commit(ctx, git_repo):
     return _git(ctx, git_repo, "log", "-n", "1", "--pretty=format:%H")

--- a/tools/build_defs/repo/git_worker.bzl
+++ b/tools/build_defs/repo/git_worker.bzl
@@ -214,13 +214,8 @@ def update_submodules(ctx, git_repo, recursive = False):
     start = ["-c", "protocol.file.allow=always", "submodule", "update"]
     flags = ["--init", "--checkout", "--force"]
     if recursive:
-        flags = ["--init", "--recursive", "--checkout", "--force"]
+        flags.append("--recursive")
 
-    # `--depth=1` / `--shallow-since` are flags of `submodule update`, not of
-    # `git submodule`. `_git_maybe_shallow` inserts the shallow arg after its
-    # first token, which is correct for `fetch` but produced `git -c --depth=1
-    # ...` or `git submodule --depth=1 update` here. It also ignored nonzero
-    # exits, so a failed submodule update was still cached as a successful repo.
     if git_repo.shallow:
         st = _execute(ctx, git_repo, start + [git_repo.shallow] + flags)
         if st.return_code == 0:


### PR DESCRIPTION
Fixes #30919

`git_repository(init_submodules=True)` (and `recursive_init_submodules`) called `_git_maybe_shallow` for `git submodule update`. That helper:

1. Inserts `--depth=1` after its first token, which is correct for `git fetch` but produced `git -c --depth=1 protocol.file.allow=always submodule update ...` here.
2. Returns a failed `execute` status without calling `fail()`, so a timeout or unreachable submodule URL still published the incomplete tree. The cache key is the parent commit, so a later fetch does not retry.

This runs `git submodule update` with shallow flags on the `update` command, then fails the repository rule if both the shallow and full attempts fail.

Test: parent repo with a gitlink whose URL is `https://127.0.0.1:1/...`; `bazel fetch --repo=@broken_submodules` must fail.
