### PR TITLE
[9.3.0] Optimize retained size of ResourceSet for the common case 

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -487,6 +487,7 @@ java_library(
         ":exec_exception",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
+        "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/worker:worker_key",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceSet.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceSet.java
@@ -16,8 +16,8 @@ package com.google.devtools.build.lib.actions;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.primitives.Doubles;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
+import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.worker.WorkerKey;
 import com.google.devtools.common.options.Converter;
@@ -31,33 +31,22 @@ import javax.annotation.Nullable;
  * Action, or the total available resources. We plan to use this to do smarter scheduling of
  * actions, for example making sure that we don't schedule jobs concurrently if they would use so
  * much memory as to cause the machine to thrash.
+ *
+ * @param resources Map of extra resources (for example: GPUs, embedded boards, ...) mapping name of
+ *     the resource to a value.
+ * @param localTestCount The number of local tests.
+ * @param workerKey The workerKey of used worker. Null if no worker is used.
  */
+@AutoCodec
 @Immutable
-public class ResourceSet implements ResourceSetOrBuilder {
+public record ResourceSet(
+    ImmutableMap<String, Double> resources, int localTestCount, @Nullable WorkerKey workerKey)
+    implements ResourceSetOrBuilder {
   public static final String CPU = "cpu";
   public static final String MEMORY = "memory";
 
   /** For actions that consume negligible resources. */
   public static final ResourceSet ZERO = new ResourceSet(ImmutableMap.of(), 0, null);
-
-  /**
-   * Map of extra resources (for example: GPUs, embedded boards, ...) mapping name of the resource
-   * to a value.
-   */
-  private final ImmutableMap<String, Double> resources;
-
-  /** The number of local tests. */
-  private final int localTestCount;
-
-  /** The workerKey of used worker. Null if no worker is used. */
-  @Nullable private final WorkerKey workerKey;
-
-  private ResourceSet(
-      ImmutableMap<String, Double> resources, int localTestCount, @Nullable WorkerKey workerKey) {
-    this.resources = resources;
-    this.localTestCount = localTestCount;
-    this.workerKey = workerKey;
-  }
 
   public static ResourceSet createWithRamCpu(double memoryMb, double cpu) {
     return create(ImmutableMap.of(MEMORY, memoryMb, CPU, cpu));
@@ -160,29 +149,6 @@ public class ResourceSet implements ResourceSetOrBuilder {
         + "\n";
   }
 
-  @Override
-  public boolean equals(Object that) {
-    if (that == null) {
-      return false;
-    }
-
-    if (!(that instanceof ResourceSet thatResourceSet)) {
-      return false;
-    }
-
-    return thatResourceSet.getMemoryMb() == getMemoryMb()
-        && thatResourceSet.getCpuUsage() == getCpuUsage()
-        && thatResourceSet.localTestCount == getLocalTestCount();
-  }
-
-  @Override
-  public int hashCode() {
-    int p = 239;
-    return Doubles.hashCode(getMemoryMb())
-        + Doubles.hashCode(getCpuUsage()) * p
-        + getLocalTestCount() * p * p;
-  }
-
   /** Converter for {@link ResourceSet}. */
   public static class ResourceSetConverter extends Converter.Contextless<ResourceSet> {
     private static final Splitter SPLITTER = Splitter.on(',');
@@ -217,7 +183,7 @@ public class ResourceSet implements ResourceSetOrBuilder {
   }
 
   @Override
-  public ResourceSet buildResourceSet(OS os, int inputsSize) throws ExecException {
+  public ResourceSet buildResourceSet(OS os, int inputsSize) {
     return this;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -1002,7 +1002,35 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
     }
   }
 
-  private static ResourceSet parseResourceSetFromDict(Object resourceSetUnchecked)
+  /**
+   * A {@link ResourceSetOrBuilder} with only memory and CPU usage optimized for retention by
+   * actions.
+   *
+   * <p>With compact object headers enabled, an instance takes up 16 bytes (8 bytes for the header,
+   * 4 bytes each for the two floats), whereas an equivalent {@link ResourceSet} instance takes up
+   * more than 180 bytes.
+   */
+  private record StarlarkActionResourceSet(float memoryMb, float cpuUsage)
+      implements ResourceSetOrBuilder {
+    private static final Interner<StarlarkActionResourceSet> interner =
+        BlazeInterners.newWeakInterner();
+
+    static StarlarkActionResourceSet create(float memoryMb, float cpuUsage) {
+      var resourceSet = new StarlarkActionResourceSet(memoryMb, cpuUsage);
+      // A very common subcase is that of only an integral CPU limit.
+      if (memoryMb == 0 && cpuUsage == (int) cpuUsage) {
+        resourceSet = interner.intern(resourceSet);
+      }
+      return resourceSet;
+    }
+
+    @Override
+    public ResourceSet buildResourceSet(OS os, int inputsSize) {
+      return ResourceSet.createWithRamCpu(memoryMb, cpuUsage);
+    }
+  }
+
+  private static ResourceSetOrBuilder parseResourceSetFromDict(Object resourceSetUnchecked)
       throws EvalException {
     Map<String, Object> resourceSetMapRaw =
         Dict.cast(resourceSetUnchecked, String.class, Object.class, "resource_set");
@@ -1015,14 +1043,23 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       throw Starlark.errorf("%s", message);
     }
 
-    return ResourceSet.create(
+    double memoryMb =
         StarlarkActionResourceSetBuilder.getNumericOrDefault(
-            resourceSetMapRaw, ResourceSet.MEMORY, DEFAULT_RESOURCE_SET.getMemoryMb()),
+            resourceSetMapRaw, ResourceSet.MEMORY, DEFAULT_RESOURCE_SET.getMemoryMb());
+    double cpuUsage =
         StarlarkActionResourceSetBuilder.getNumericOrDefault(
-            resourceSetMapRaw, ResourceSet.CPU, DEFAULT_RESOURCE_SET.getCpuUsage()),
+            resourceSetMapRaw, ResourceSet.CPU, DEFAULT_RESOURCE_SET.getCpuUsage());
+    int localTestCount =
         (int)
             StarlarkActionResourceSetBuilder.getNumericOrDefault(
-                resourceSetMapRaw, "local_test", DEFAULT_RESOURCE_SET.getLocalTestCount()));
+                resourceSetMapRaw, "local_test", DEFAULT_RESOURCE_SET.getLocalTestCount());
+    // Optimize for low retained memory usage since this resource set is retained by the action.
+    // The loss of precision for memory and CPU usage due to the cast to float is negligible for the
+    // purpose of resource scheduling.
+    if (localTestCount == DEFAULT_RESOURCE_SET.getLocalTestCount()) {
+      return StarlarkActionResourceSet.create((float) memoryMb, (float) cpuUsage);
+    }
+    return ResourceSet.create(memoryMb, cpuUsage, localTestCount);
   }
 
   private static void validateResourceSetBuilder(Object fn) throws EvalException {

--- a/src/test/java/com/google/devtools/build/lib/actions/ResourceSetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ResourceSetTest.java
@@ -17,6 +17,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.actions.ResourceSet.ResourceSetConverter;
 import com.google.devtools.common.options.OptionsParsingException;
 import org.junit.Before;
@@ -31,7 +32,7 @@ public class ResourceSetTest {
   private ResourceSetConverter converter;
 
   @Before
-  public final void createConverter() throws Exception  {
+  public final void createConverter() throws Exception {
     converter = new ResourceSetConverter();
   }
 
@@ -56,6 +57,23 @@ public class ResourceSetTest {
   @Test
   public void testConverterThrowsWhenGivenNegativeInputs() throws Exception {
     assertThrows(OptionsParsingException.class, () -> converter.convert("-1,0,0"));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            ResourceSet.createWithRamCpu(100, 1),
+            ResourceSet.createWithRamCpu(100, 1),
+            ResourceSet.create(ImmutableMap.of("memory", 100.0, "cpu", 1.0)))
+        .addEqualityGroup(ResourceSet.createWithRamCpu(200, 1))
+        .addEqualityGroup(ResourceSet.createWithRamCpu(100, 2))
+        .addEqualityGroup(ResourceSet.create(ImmutableMap.of("memory", 100.0, "cpu", 1.0), 5))
+        .addEqualityGroup(
+            ResourceSet.create(ImmutableMap.of("memory", 100.0, "cpu", 1.0, "my_resource", 1.0), 5))
+        .addEqualityGroup(
+            ResourceSet.create(ImmutableMap.of("memory", 100.0, "cpu", 1.0, "my_resource", 2.0), 5))
+        .testEquals();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
@@ -995,6 +995,35 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
         .isEqualTo(ResourceSet.create(512, 4, 0));
     assertThat(action.getResourceSetOrBuilder().buildResourceSet(OS.DARWIN, 100))
         .isEqualTo(ResourceSet.create(512, 4, 0));
+    // The action retains a compact representation rather than a full ResourceSet.
+    assertThat(action.getResourceSetOrBuilder()).isNotInstanceOf(ResourceSet.class);
+  }
+
+  @Test
+  public void testCreateStarlarkActionArgumentsWithResourceSet_dictInterned() throws Exception {
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+
+    ev.exec(
+        "ruleContext.actions.run(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = [ruleContext.files.srcs[0]],",
+        "  resource_set = {\"cpu\": 3, \"memory\": 0},",
+        "  executable = 'executable')",
+        "ruleContext.actions.run(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = [ruleContext.files.srcs[1]],",
+        "  resource_set = {\"cpu\": 3, \"memory\": 0},",
+        "  executable = 'executable')");
+    ImmutableList<StarlarkAction> actions =
+        ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions().stream()
+            .map(StarlarkAction.class::cast)
+            .collect(toImmutableList());
+    assertThat(actions).hasSize(2);
+
+    // With no memory bound and an integral CPU bound, the compact representation is interned.
+    assertThat(actions.get(0).getResourceSetOrBuilder())
+        .isSameInstanceAs(actions.get(1).getResourceSetOrBuilder());
   }
 
   @Test


### PR DESCRIPTION
### Description
Instances are typically very large (> 180 bytes), so it's worth introducing an optimized version for the common case of CPU and memory usage set only. The common subcase of only an integral CPU limit can be further optimized by interning the instance.

### Motivation
Since https://github.com/bazelbuild/bazel/commit/6ac8c84f8bead2d2d645159aa8f688758be78fcb, `ResourceSet` can be retained by Starlark actions.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes https://github.com/bazelbuild/bazel/pull/30263.

PiperOrigin-RevId: 948482321
Change-Id: I7f6108247e3adb90a9bf41e0f21e5d5af0b93b37

Commit https://github.com/bazelbuild/bazel/commit/6ac8c84f8bead2d2d645159aa8f688758be78fcb