### PR TITLE
//src/tools/singlejar:options*: Fix multiple mentions of options.h

### DIFF
--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -262,15 +262,9 @@ cc_test(
 
 cc_test(
     name = "options_test",
-    srcs = [
-        "options.h",
-        "options_test.cc",
-    ],
+    srcs = ["options_test.cc"],
     deps = [
         ":options",
-        ":token_stream",
-        "//src/main/cpp/util",
-        "@abseil-cpp//absl/container:flat_hash_set",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -471,10 +465,7 @@ cc_library(
 
 cc_library(
     name = "options",
-    srcs = [
-        "options.cc",
-        "options.h",
-    ],
+    srcs = ["options.cc"],
     hdrs = ["options.h"],
     deps = [
         ":diag",


### PR DESCRIPTION
  * :options had the options.h in both, hdrs, and srcs. It only needs to be in hdrs.
  * :options_test also mentioned the same header again, but it gets it from depending on :options.
  * the libraries already linked in :options don't need to be repeated in :options_test anymore.
