### PR TITLE
Resolve remote inputs without parent metadata

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/PathCanonicalizer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/PathCanonicalizer.java
@@ -14,14 +14,16 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.devtools.build.lib.vfs.FileSymlinkLoopException;
+import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.annotation.Nullable;
 
 /**
  * Canonicalizes paths like {@link FileSystem#resolveSymbolicLinks}, while storing the intermediate
@@ -45,13 +47,15 @@ final class PathCanonicalizer {
 
   interface Resolver {
     /**
-     * Returns the result of {@link FileSystem#readSymbolicLink} if the path is a symlink, otherwise
-     * null. All but the last path segment must be canonical.
+     * Returns the status of a component without following its symlink. All but the last path
+     * segment must be canonical.
      *
-     * @throws IOException if the file type or symlink target path could not be determined
+     * @throws IOException if the component's status could not be determined
      */
-    @Nullable
-    PathFragment resolveOneLink(PathFragment path) throws IOException;
+    FileStatus statNoFollow(PathFragment path) throws IOException;
+
+    /** Returns the raw target of a symlink whose parent path is canonical. */
+    PathFragment readSymlink(PathFragment path) throws IOException;
   }
 
   /** A trie node. */
@@ -60,28 +64,32 @@ final class PathCanonicalizer {
   /** A trie node corresponding to a symlink. */
   private record SymlinkNode(PathFragment targetPath) implements Node {}
 
-  /** A trie node not corresponding to a symlink. */
-  private static final class NonSymlinkNode extends ConcurrentHashMap<String, Node>
-      implements Node {
-    NonSymlinkNode() {
+  /** A trie node for a directory and its cached children. */
+  private static final class DirectoryNode extends ConcurrentHashMap<String, Node> implements Node {
+    DirectoryNode() {
       super(/* initialCapacity= */ 1);
     }
   }
 
+  /** A regular file cannot be traversed as a directory. */
+  private enum NonDirectoryNode implements Node {
+    INSTANCE
+  }
+
   private final Resolver resolver;
-  private final NonSymlinkNode root = new NonSymlinkNode();
+  private final DirectoryNode root = new DirectoryNode();
 
   PathCanonicalizer(Resolver resolver) {
     this.resolver = resolver;
   }
 
   /** Returns the root node for an absolute path. */
-  private NonSymlinkNode getRootNode(PathFragment path) {
+  private DirectoryNode getRootNode(PathFragment path) {
     checkArgument(path.isAbsolute());
     // Unix has a single root. Windows has one root per drive.
     if (path.getDriveStrLength() > 1) {
-      return (NonSymlinkNode)
-          root.computeIfAbsent(path.getDriveStr(), unused -> new NonSymlinkNode());
+      return (DirectoryNode)
+          root.computeIfAbsent(path.getDriveStr(), unused -> new DirectoryNode());
     }
     return root;
   }
@@ -92,16 +100,24 @@ final class PathCanonicalizer {
    * @param path the path to canonicalize.
    * @param maxLinks the maximum number of symlinks that can be followed in the process of
    *     canonicalizing the path.
+   * @param allowMissingFinalComponent whether the final component may be missing, as when
+   *     canonicalizing an input's parent path.
+   * @param requireDirectory whether the final component must be a directory.
    * @throws FileSymlinkLoopException if too many symlinks had to be followed.
    * @throws IOException if an I/O error occurs
    * @return the canonical path.
    */
-  private PathFragment resolveSymbolicLinks(PathFragment path, int maxLinks) throws IOException {
+  private PathFragment resolveSymbolicLinks(
+      PathFragment path,
+      int maxLinks,
+      boolean allowMissingFinalComponent,
+      boolean requireDirectory)
+      throws IOException {
     // This code is carefully written to be as fast as possible when the path is already canonical
     // and has been previously cached. Avoid making changes without benchmarking. A tree artifact
     // with hundreds of thousands of files makes for a good benchmark.
 
-    NonSymlinkNode node = getRootNode(path);
+    DirectoryNode node = getRootNode(path);
     Iterable<String> segments = path.segments();
     int segmentIndex = 0;
 
@@ -116,11 +132,24 @@ final class PathCanonicalizer {
       Node nextNode = node.get(segment);
       if (nextNode == null) {
         PathFragment naivePath = path.subFragment(0, segmentIndex + 1);
-        PathFragment targetPath = resolver.resolveOneLink(naivePath);
-        nextNode =
-            node.computeIfAbsent(
-                segment,
-                unused -> targetPath != null ? new SymlinkNode(targetPath) : new NonSymlinkNode());
+        Node resolvedNode;
+        try {
+          FileStatus stat = resolver.statNoFollow(naivePath);
+          resolvedNode =
+              stat.isSymbolicLink()
+                  ? new SymlinkNode(checkNotNull(resolver.readSymlink(naivePath)))
+                  : stat.isDirectory() ? new DirectoryNode() : NonDirectoryNode.INSTANCE;
+        } catch (FileNotFoundException e) {
+          if (segmentIndex + 1 == path.segmentCount() && !allowMissingFinalComponent) {
+            throw e;
+          }
+          // Input metadata can exist without its parent directories. Continue in a detached trie
+          // so this missing prefix and its descendants are rechecked on the next resolution.
+          node = new DirectoryNode();
+          segmentIndex++;
+          continue;
+        }
+        nextNode = node.computeIfAbsent(segment, unused -> resolvedNode);
       }
 
       switch (nextNode) {
@@ -146,10 +175,17 @@ final class PathCanonicalizer {
           // For absolute symlinks, we must start over.
           // For relative symlinks, it would have been possible to restart after the already
           // canonicalized prefix, but they're too rare to be worth optimizing for.
-          return resolveSymbolicLinks(newPath, maxLinks);
+          return resolveSymbolicLinks(
+              newPath, maxLinks, allowMissingFinalComponent, requireDirectory);
         }
-        case NonSymlinkNode nonSymlinkNode -> {
-          node = nonSymlinkNode;
+        case DirectoryNode directoryNode -> {
+          node = directoryNode;
+          segmentIndex++;
+        }
+        case NonDirectoryNode ignored -> {
+          if (segmentIndex + 1 < path.segmentCount() || requireDirectory) {
+            throw new FileNotFoundException(path.getPathString() + " (Not a directory)");
+          }
           segmentIndex++;
         }
       }
@@ -161,7 +197,9 @@ final class PathCanonicalizer {
   /**
    * Canonicalizes a path, reusing cached information if possible.
    *
-   * <p>See {@link FileSystem#resolveSymbolicLinks} for the full specification.
+   * <p>Like {@link FileSystem#resolveSymbolicLinks}, except that missing intermediate directories
+   * are allowed: input metadata may describe a file without describing its parents. The final
+   * component must exist.
    *
    * @param path the path to canonicalize.
    * @throws FileSymlinkLoopException if too many symlinks had to be followed.
@@ -169,13 +207,34 @@ final class PathCanonicalizer {
    * @return the canonical path.
    */
   PathFragment resolveSymbolicLinks(PathFragment path) throws IOException {
-    return resolveSymbolicLinks(path, FileSystem.MAX_SYMLINKS);
+    return resolveSymbolicLinks(
+        path,
+        FileSystem.MAX_SYMLINKS,
+        /* allowMissingFinalComponent= */ false,
+        /* requireDirectory= */ false);
+  }
+
+  /**
+   * Canonicalizes only the parent path, allowing missing parent directories. The caller must look
+   * up or operate on the final path to determine whether it exists.
+   */
+  PathFragment resolveSymbolicLinksForParent(PathFragment path) throws IOException {
+    checkArgument(path.isAbsolute());
+    PathFragment parent = path.getParentDirectory();
+    return parent == null
+        ? path
+        : resolveSymbolicLinks(
+                parent,
+                FileSystem.MAX_SYMLINKS,
+                /* allowMissingFinalComponent= */ true,
+                /* requireDirectory= */ true)
+            .getChild(path.getBaseName());
   }
 
   /** Removes cached information for a path prefix. */
   void clearPrefix(PathFragment pathPrefix) {
     Node node = getRootNode(pathPrefix);
-    NonSymlinkNode parent = null;
+    DirectoryNode parent = null;
     String parentSegment = null;
     Iterator<String> segments = pathPrefix.segments().iterator();
     boolean hasNext = segments.hasNext();
@@ -192,14 +251,20 @@ final class PathCanonicalizer {
           }
           return;
         }
-        case NonSymlinkNode nonSymlinkNode -> {
+        case NonDirectoryNode ignored -> {
+          if (parent != null) {
+            parent.remove(parentSegment);
+          }
+          return;
+        }
+        case DirectoryNode directoryNode -> {
           if (!hasNext) {
             // Found the path prefix.
-            nonSymlinkNode.remove(segment);
+            directoryNode.remove(segment);
           } else {
-            parent = nonSymlinkNode;
+            parent = directoryNode;
             parentSegment = segment;
-            node = nonSymlinkNode.get(segment);
+            node = directoryNode.get(segment);
           }
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -104,7 +104,7 @@ import javax.annotation.Nullable;
  * sources, such as the same path existing in multiple underlying sources with different type or
  * contents.
  */
-public class RemoteActionFileSystem extends FileSystem implements PathCanonicalizer.Resolver {
+public class RemoteActionFileSystem extends FileSystem {
   private final PathFragment execRoot;
   private final PathFragment outputBase;
   private final InputMetadataProvider inputArtifactData;
@@ -248,10 +248,22 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
     this.outputBase = execRoot.getRelative(checkNotNull(relativeOutputPath, "relativeOutputPath"));
     this.inputArtifactData = checkNotNull(inputArtifactData, "inputArtifactData");
     this.inputTreeArtifactDirectoryCache = new TreeArtifactDirectoryCache();
-    this.pathCanonicalizer = new PathCanonicalizer(this);
     this.inputFetcher = checkNotNull(inputFetcher, "inputFetcher");
     this.localFs = checkNotNull(localFs, "localFs");
     this.remoteOutputTree = new RemoteInMemoryFileSystem(getDigestFunction());
+    this.pathCanonicalizer =
+        new PathCanonicalizer(
+            new PathCanonicalizer.Resolver() {
+              @Override
+              public FileStatus statNoFollow(PathFragment path) throws IOException {
+                return statComponentNoFollow(path);
+              }
+
+              @Override
+              public PathFragment readSymlink(PathFragment path) throws IOException {
+                return readSymbolicLinkInternal(path);
+              }
+            });
   }
 
   @Override
@@ -331,6 +343,10 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
   @Override
   @Nullable
   public PathFragment resolveOneLink(PathFragment path) throws IOException {
+    return statComponentNoFollow(path).isSymbolicLink() ? readSymbolicLinkInternal(path) : null;
+  }
+
+  private FileStatus statComponentNoFollow(PathFragment path) throws IOException {
     // The base implementation attempts to readSymbolicLink first and falls back to stat, but that
     // unnecessarily allocates a NotASymlinkException in the overwhelmingly likely non-symlink case.
     // It's more efficient to stat unconditionally.
@@ -342,23 +358,14 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
     if (stat == null) {
       throw new FileNotFoundException(path.getPathString() + " (No such file or directory)");
     }
-    return stat.isSymbolicLink() ? readSymbolicLinkInternal(path) : null;
-  }
-
-  // Like resolveSymbolicLinks(), except that only the parent path is canonicalized.
-  private PathFragment resolveSymbolicLinksForParent(PathFragment path) throws IOException {
-    PathFragment parentPath = path.getParentDirectory();
-    if (parentPath != null) {
-      return resolveSymbolicLinks(parentPath).asFragment().getChild(path.getBaseName());
-    }
-    return path;
+    return stat;
   }
 
   @Override
   public boolean delete(PathFragment path) throws IOException {
     PathFragment originalPath = path;
     try {
-      path = resolveSymbolicLinksForParent(path);
+      path = pathCanonicalizer.resolveSymbolicLinksForParent(path);
     } catch (FileNotFoundException ignored) {
       // Failure to delete a nonexistent path is not an error.
       pathCanonicalizer.clearPrefix(originalPath);
@@ -566,7 +573,7 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
 
   @Override
   public PathFragment readSymbolicLink(PathFragment path) throws IOException {
-    return readSymbolicLinkInternal(resolveSymbolicLinksForParent(path));
+    return readSymbolicLinkInternal(pathCanonicalizer.resolveSymbolicLinksForParent(path));
   }
 
   // Like readSymbolicLink(), except that the parent path is assumed to be already canonical.
@@ -603,7 +610,7 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
   public void createSymbolicLink(
       PathFragment linkPath, PathFragment targetFragment, SymlinkTargetType type)
       throws IOException {
-    linkPath = resolveSymbolicLinksForParent(linkPath);
+    linkPath = pathCanonicalizer.resolveSymbolicLinksForParent(linkPath);
 
     if (isOutput(linkPath)) {
       remoteOutputTree.getPath(linkPath).createSymbolicLink(targetFragment, type);
@@ -659,10 +666,7 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
       if (followMode == FollowMode.FOLLOW_ALL) {
         path = resolveSymbolicLinks(path).asFragment();
       } else if (followMode == FollowMode.FOLLOW_PARENT) {
-        PathFragment parent = path.getParentDirectory();
-        if (parent != null) {
-          path = resolveSymbolicLinks(parent).asFragment().getChild(path.getBaseName());
-        }
+        path = pathCanonicalizer.resolveSymbolicLinksForParent(path);
       }
     } catch (FileNotFoundException e) {
       return null;
@@ -759,8 +763,8 @@ public class RemoteActionFileSystem extends FileSystem implements PathCanonicali
 
   @Override
   public void renameTo(PathFragment srcPath, PathFragment dstPath) throws IOException {
-    srcPath = resolveSymbolicLinksForParent(srcPath);
-    dstPath = resolveSymbolicLinksForParent(dstPath);
+    srcPath = pathCanonicalizer.resolveSymbolicLinksForParent(srcPath);
+    dstPath = pathCanonicalizer.resolveSymbolicLinksForParent(dstPath);
 
     checkArgument(isOutput(srcPath), "srcPath must be an output path");
     checkArgument(isOutput(dstPath), "dstPath must be an output path");

--- a/src/test/java/com/google/devtools/build/lib/remote/PathCanonicalizerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/PathCanonicalizerTest.java
@@ -20,16 +20,16 @@ import static org.junit.Assume.assumeTrue;
 
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileSymlinkLoopException;
 import com.google.devtools.build.lib.vfs.FileSystem;
-import com.google.devtools.build.lib.vfs.FileSystem.NotASymlinkException;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -48,16 +48,20 @@ public final class PathCanonicalizerTest {
 
   private final FileSystem fs = new InMemoryFileSystem(DigestHashFunction.SHA256);
 
-  private final PathCanonicalizer canonicalizer = new PathCanonicalizer(this::resolve);
+  private final PathCanonicalizer.Resolver resolver =
+      new PathCanonicalizer.Resolver() {
+        @Override
+        public FileStatus statNoFollow(PathFragment path) throws IOException {
+          return fs.getPath(path).stat(Symlinks.NOFOLLOW);
+        }
 
-  private @Nullable PathFragment resolve(PathFragment pathFragment) throws IOException {
-    Path path = fs.getPath(pathFragment);
-    try {
-      return path.readSymbolicLink();
-    } catch (NotASymlinkException e) {
-      return null;
-    }
-  }
+        @Override
+        public PathFragment readSymlink(PathFragment path) throws IOException {
+          return fs.getPath(path).readSymbolicLink();
+        }
+      };
+
+  private final PathCanonicalizer canonicalizer = new PathCanonicalizer(resolver);
 
   @Test
   public void testRoot() throws Exception {
@@ -158,6 +162,16 @@ public final class PathCanonicalizerTest {
     createNonSymlink("/a/e");
     assertSuccess("/a/b/c", "/d/c");
     assertSuccess("/a/e", "/a/e");
+  }
+
+  @Test
+  public void testDirectoryNodesDoNotShareChildren() throws Exception {
+    createSymlink("/a/link", "/target");
+    createNonSymlink("/target");
+    createNonSymlink("/b/link");
+
+    assertSuccess("/a/link", "/target");
+    assertSuccess("/b/link", "/b/link");
   }
 
   @Test
@@ -263,6 +277,50 @@ public final class PathCanonicalizerTest {
     assertFailure(FileNotFoundException.class, "/a/b");
     createNonSymlink("/a/b");
     assertSuccess("/a/b", "/a/b");
+  }
+
+  @Test
+  public void testSymlinksAfterMissingParent() throws Exception {
+    createNonSymlink("/target/file");
+    createSymlink("/missing/link", "../target");
+    createSymlink("/missing/loop", "loop");
+    PathCanonicalizer sparseCanonicalizer =
+        new PathCanonicalizer(
+            new PathCanonicalizer.Resolver() {
+              @Override
+              public FileStatus statNoFollow(PathFragment path) throws IOException {
+                // Model a union filesystem that knows the children but has no parent metadata.
+                if (path.equals(pathFragment("/missing"))) {
+                  throw new FileNotFoundException(path.getPathString());
+                }
+                return resolver.statNoFollow(path);
+              }
+
+              @Override
+              public PathFragment readSymlink(PathFragment path) throws IOException {
+                return resolver.readSymlink(path);
+              }
+            });
+
+    assertThat(sparseCanonicalizer.resolveSymbolicLinks(pathFragment("/missing/link/file")))
+        .isEqualTo(pathFragment("/target/file"));
+    assertThrows(
+        FileSymlinkLoopException.class,
+        () -> sparseCanonicalizer.resolveSymbolicLinks(pathFragment("/missing/loop")));
+  }
+
+  @Test
+  public void testNonDirectoryCannotContainChildren() throws Exception {
+    createNonSymlink("/a/file");
+    assertSuccess("/a/file", "/a/file");
+    assertFailure(FileNotFoundException.class, "/a/file/child");
+    assertThrows(
+        FileNotFoundException.class,
+        () -> canonicalizer.resolveSymbolicLinksForParent(pathFragment("/a/file/child")));
+
+    deleteTree("/a/file");
+    createNonSymlink("/a/file/child");
+    assertSuccess("/a/file/child", "/a/file/child");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -222,6 +222,84 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
   }
 
   @Test
+  public void stat_fromInputArtifactData_missingParents(
+      @TestParameter boolean followSymlinks) throws Exception {
+    ActionInputMap inputs = new ActionInputMap(1);
+    Artifact artifact = createRemoteArtifact("missing/dir/file", "contents", inputs);
+    PathFragment path = artifact.getPath().asFragment();
+    RemoteActionFileSystem actionFs = (RemoteActionFileSystem) createActionFileSystem(inputs);
+
+    FileStatus st = actionFs.stat(path, followSymlinks);
+    assertThat(st.isFile()).isTrue();
+    assertThat(((FileStatusWithDigest) st).getDigest()).isEqualTo(getDigest("contents"));
+    assertThat(actionFs.isExecutable(path)).isTrue();
+
+    // Resolving remote metadata must not materialize its missing parent directories.
+    assertThat(fs.getPath(path.getParentDirectory()).exists()).isFalse();
+    assertThat(actionFs.getRemoteOutputTree().getPath(path.getParentDirectory()).exists()).isFalse();
+
+    PathFragment missing = path.replaceName("unknown");
+    assertThat(actionFs.statIfFound(missing, followSymlinks)).isNull();
+    assertThrows(FileNotFoundException.class, () -> actionFs.isExecutable(missing));
+  }
+
+  @Test
+  public void stat_missingParentsAreNotCached(
+      @TestParameter boolean knownInput, @TestParameter boolean followSymlinks) throws Exception {
+    ActionInputMap inputs = new ActionInputMap(2);
+    createRemoteArtifact("target/dir/file", "target contents", inputs);
+    if (knownInput) {
+      createRemoteArtifact("link/dir/file", "original contents", inputs);
+    }
+    RemoteActionFileSystem actionFs = (RemoteActionFileSystem) createActionFileSystem(inputs);
+    PathFragment path = getOutputPath("link/dir/file");
+
+    if (knownInput) {
+      FileStatusWithDigest before = (FileStatusWithDigest) actionFs.stat(path, followSymlinks);
+      assertThat(before.getDigest()).isEqualTo(getDigest("original contents"));
+    } else {
+      assertThat(actionFs.statIfFound(path, followSymlinks)).isNull();
+    }
+    // The local symlink must take precedence over any inference from the input's naive path.
+    fs.getPath(getOutputPath("link")).createSymbolicLink(getOutputPath("target"));
+
+    FileStatusWithDigest after = (FileStatusWithDigest) actionFs.stat(path, followSymlinks);
+    assertThat(after.getDigest()).isEqualTo(getDigest("target contents"));
+  }
+
+  @Test
+  public void stat_regularFileBlocksRemoteInput(
+      @TestParameter boolean followSymlinks, @TestParameter boolean cacheParent) throws Exception {
+    ActionInputMap inputs = new ActionInputMap(1);
+    createRemoteArtifact("link/dir/file", "contents", inputs);
+    RemoteActionFileSystem actionFs = (RemoteActionFileSystem) createActionFileSystem(inputs);
+    PathFragment link = getOutputPath("link");
+    FileSystemUtils.writeContent(fs.getPath(link), UTF_8, "local file");
+
+    if (cacheParent) {
+      assertThat(actionFs.stat(link, /* followSymlinks= */ true).isFile()).isTrue();
+    }
+
+    PathFragment path = getOutputPath("link/dir/file");
+    assertThat(actionFs.statIfFound(path, followSymlinks)).isNull();
+    assertThrows(FileNotFoundException.class, () -> actionFs.stat(path, followSymlinks));
+  }
+
+  @Test
+  public void stat_missingParentLaterBecomesFile(@TestParameter boolean followSymlinks)
+      throws Exception {
+    ActionInputMap inputs = new ActionInputMap(1);
+    createRemoteArtifact("link/dir/file", "contents", inputs);
+    RemoteActionFileSystem actionFs = (RemoteActionFileSystem) createActionFileSystem(inputs);
+    PathFragment path = getOutputPath("link/dir/file");
+    assertThat(actionFs.stat(path, followSymlinks).isFile()).isTrue();
+
+    FileSystemUtils.writeContent(fs.getPath(getOutputPath("link")), UTF_8, "local file");
+
+    assertThat(actionFs.statIfFound(path, followSymlinks)).isNull();
+  }
+
+  @Test
   public void statAndExists_fromInputArtifactData_treeSubDir() throws Exception {
     ActionInputMap inputs = new ActionInputMap(1);
     SpecialArtifact tree =
@@ -473,7 +551,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
   @Test
   public void getDigest_fromInputArtifactData_forLocalArtifact() throws Exception {
     ActionInputMap inputs = new ActionInputMap(1);
-    Artifact artifact = createRemoteArtifact("file", "local contents", inputs);
+    Artifact artifact = createLocalArtifact("file", "local contents", inputs);
     PathFragment path = artifact.getPath().asFragment();
     RemoteActionFileSystem actionFs = (RemoteActionFileSystem) createActionFileSystem(inputs);
 
@@ -488,7 +566,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
   @Test
   public void getDigest_fromInputArtifactData_forRemoteArtifact() throws Exception {
     ActionInputMap inputs = new ActionInputMap(1);
-    Artifact artifact = createRemoteArtifact("file", "remote contents", inputs);
+    Artifact artifact = createRemoteArtifact("missing/dir/file", "remote contents", inputs);
     PathFragment path = artifact.getPath().asFragment();
     RemoteActionFileSystem actionFs = (RemoteActionFileSystem) createActionFileSystem(inputs);
 
@@ -846,7 +924,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
   @Test
   public void readSymbolicLink_fromInputArtifactData_regularFile() throws Exception {
     ActionInputMap inputs = new ActionInputMap(1);
-    Artifact artifact = createRemoteArtifact("file", "contents", inputs);
+    Artifact artifact = createRemoteArtifact("missing/dir/file", "contents", inputs);
     RemoteActionFileSystem actionFs = (RemoteActionFileSystem) createActionFileSystem(inputs);
 
     assertThrows(
@@ -922,7 +1000,8 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
   public void createSymbolicLink_remoteFileArtifact() throws Exception {
     // arrange
     ActionInputMap inputs = new ActionInputMap(1);
-    Artifact remoteArtifact = createRemoteArtifact("remote-file", "remote contents", inputs);
+    Artifact remoteArtifact =
+        createRemoteArtifact("missing/dir/remote-file", "remote contents", inputs);
     Artifact outputArtifact = ActionsTestUtil.createArtifact(outputRoot, "out");
     FileSystem actionFs = createActionFileSystem(inputs);
 
@@ -940,6 +1019,9 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
         .isEqualTo(targetPath);
     assertThat(getLocalFileSystem(actionFs).getPath(linkPath).readSymbolicLink())
         .isEqualTo(targetPath);
+    assertThat(((FileStatusWithDigest) symlinkActionFs.stat()).getDigest())
+        .isEqualTo(getDigest("remote contents"));
+    assertThat(fs.getPath(targetPath.getParentDirectory()).exists()).isFalse();
   }
 
   @Test

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -386,6 +386,46 @@ EOF
   || fail "Expected runfile bazel-bin/a/create_bar.sh to be downloaded"
 }
 
+function test_remote_executable_symlink_after_bazel_bin_deletion() {
+  # Regression test for https://github.com/bazelbuild/bazel/issues/26877.
+  add_rules_shell "MODULE.bazel"
+  cat > BUILD <<'EOF'
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+genrule(
+    name = "a",
+    outs = ["subdir/a"],
+    cmd = "printf '#!/bin/sh\\nexit 0\\n' > \"$@\" && chmod +x \"$@\"",
+)
+
+sh_test(
+    name = "b",
+    srcs = [":a"],
+)
+
+sh_test(
+    name = "c",
+    srcs = [":a"],
+)
+EOF
+
+  bazel test \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_download_minimal \
+      -- //:b >& "$TEST_log" || fail "Failed to test //:b"
+
+  local bazel_bin
+  bazel_bin="$(bazel info bazel-bin)"
+  [[ -n "$bazel_bin" && "$bazel_bin" != "/" ]] || fail "Invalid bazel-bin: '$bazel_bin'"
+  bazel shutdown
+  rm -rf -- "$bazel_bin"
+
+  bazel test \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_download_minimal \
+      -- //:c >& "$TEST_log" || fail "Failed to test //:c"
+}
+
 # Test that --remote_download_toplevel fetches inputs to symlink actions. In
 # particular, cc_binary links against a symlinked imported .so file, and only
 # the symlink is in the runfiles.


### PR DESCRIPTION
With `--remote_download_minimal`, deleting `bazel-bin` and restarting Bazel can make an executable symlink action report that its declared input `subdir/a` "is not a file", although metadata for the input is available (#26877).

`RemoteActionFileSystem` combines exact-path metadata for the action's inputs, an output tree private to that action, and local disk. The input map may describe `subdir/a` without describing `subdir/`, and the producer's output-tree directories do not carry over to the symlink action. The old path walk queried `subdir/` first and stopped at its absence before it could inspect the known file. A real regular file at `subdir/` is different: its child must remain inaccessible even if the input map names `subdir/a`.

Known components already have three trie node types: a symlink redirects the walk, a directory can contain children, and a non-directory blocks traversal. The canonicalizer constructs these private nodes from a no-follow status lookup and, for symlinks, a raw target read. A missing intermediate component is not treated as a known directory; the walk continues in a detached trie to reach descendant input metadata without creating or caching that missing prefix. The next lookup rechecks it, so a local symlink or file created there takes effect. Full path resolution still requires a known final component; operations that resolve only the parent check the final path themselves. Directory nodes have distinct child maps, and deletion invalidates the original path even when parent resolution fails.

The shell regression uses the same nested generated executable in a second test after shutdown and `bazel-bin` deletion. Unit tests cover missing ancestors, subsequent changes to them, regular-file obstructions, and an output symlink targeting a nested remote input.

Fixes #26877.

— Codex, on behalf of @tamird.

RELNOTES: None
