### PR TITLE
Depend on :gtest to see the headers.

### DIFF
--- a/src/test/cpp/BUILD
+++ b/src/test/cpp/BUILD
@@ -25,6 +25,7 @@ cc_test(
     deps = [
         "//src/main/cpp:blaze_util",
         "//src/main/cpp/util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -40,6 +41,7 @@ cc_test(
         "//src/main/cpp:option_processor",
         "//src/main/cpp:workspace_layout",
         "//src/main/cpp/util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -56,6 +58,7 @@ cc_test(
         "//src/main/cpp:rc_file",
         "//src/main/cpp:workspace_layout",
         "//src/main/cpp/util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -70,6 +73,7 @@ cc_test(
         "//src/main/cpp:sem_ver",
         "//src/main/cpp:workspace_layout",
         "//src/main/cpp/util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -81,6 +85,7 @@ cc_test(
     deps = [
         "//src/main/cpp:sem_ver",
         "@abseil-cpp//absl/strings:str_format",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -92,6 +97,7 @@ cc_library(
     hdrs = ["test_util.h"],
     deps = [
         "//src/main/cpp:startup_options",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -105,6 +111,7 @@ cc_test(
         "//src/main/cpp:blaze_util",
         "//src/main/cpp:startup_options",
         "//src/main/cpp:workspace_layout",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ] + select({
         "//src/conditions:linux": ["//src/main/cpp/util"],
@@ -121,6 +128,7 @@ cc_test(
         "//src/main/cpp:bazel_startup_options",
         "//src/main/cpp:blaze_util",
         "//src/main/cpp:workspace_layout",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -133,6 +141,7 @@ cc_test(
         "//src/main/cpp:blaze_util",
         "//src/main/cpp:workspace_layout",
         "//src/main/cpp/util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/test/cpp/util/BUILD
+++ b/src/test/cpp/util/BUILD
@@ -17,6 +17,7 @@ cc_test(
     deps = [
         "//src/main/cpp/util",
         "//src/main/cpp/util:md5",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -35,6 +36,7 @@ cc_test(
         ":test_util",
         "//src/main/cpp/util:filesystem",
         "@abseil-cpp//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ] + select({
         "//src/conditions:windows": [
@@ -59,6 +61,7 @@ cc_test(
     deps = [
         ":test_util",
         "//src/main/cpp/util:filesystem",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ] + select({
         "//src/conditions:windows": [
@@ -78,6 +81,7 @@ cc_test(
         "//src/main/cpp/util:bazel_log_handler",
         "//src/main/cpp/util:filesystem",
         "//src/main/cpp/util:logging",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -87,6 +91,7 @@ cc_test(
     srcs = ["numbers_test.cc"],
     deps = [
         "//src/main/cpp/util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -100,6 +105,7 @@ cc_test(
     shard_count = 2,
     deps = [
         "//src/main/cpp/util:strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/test/tools/BUILD
+++ b/src/test/tools/BUILD
@@ -20,6 +20,7 @@ cc_test(
     }),
     deps = [
         "//src/main/tools:process-tools",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/tools/one_version/BUILD
+++ b/src/tools/one_version/BUILD
@@ -45,6 +45,7 @@ cc_test(
     ],
     deps = [
         ":duplicate_class_collector",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -70,6 +71,7 @@ cc_test(
         ":duplicate_class_collector",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/container:flat_hash_set",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -138,6 +138,7 @@ cc_test(
         ":combiners",
         ":input_jar",
         ":test_util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
         "@zlib",
     ],
@@ -156,6 +157,7 @@ cc_test(
         ":combiners",
         ":input_jar",
         ":test_util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
         "@rules_cc//cc/runfiles",
     ],
@@ -172,6 +174,7 @@ cc_test(
         ":combiners",
         ":desugar_checking",
         ":input_jar",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
         "@zlib",
     ],
@@ -189,6 +192,7 @@ cc_test(
         ":input_jar",
         ":test_util",
         "//src/main/cpp/util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -206,6 +210,7 @@ cc_test(
         ":input_jar",
         ":test_util",
         "//src/main/cpp/util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -228,6 +233,7 @@ cc_test(
     deps = [
         ":input_jar",
         ":test_util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -244,6 +250,7 @@ cc_test(
     deps = [
         ":input_jar",
         ":test_util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -256,6 +263,7 @@ cc_test(
     deps = [
         ":input_jar",
         ":test_util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -271,6 +279,7 @@ cc_test(
         ":token_stream",
         "//src/main/cpp/util",
         "@abseil-cpp//absl/container:flat_hash_set",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -315,6 +324,7 @@ cc_test(
         ":test_util",
         "//src/main/cpp/util",
         "@abseil-cpp//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -327,6 +337,7 @@ cc_test(
     deps = [
         ":test_util",
         ":token_stream",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -344,6 +355,7 @@ cc_test(
     deps = [
         ":input_jar",
         ":test_util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
         "@zlib",
     ],
@@ -357,6 +369,7 @@ cc_test(
         ":zip_headers",
     ],
     deps = [
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -368,6 +381,7 @@ cc_test(
         ":zlib_interface",
     ],
     deps = [
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
         "@zlib",
     ],
@@ -513,6 +527,7 @@ cc_library(
     hdrs = ["test_util.h"],
     deps = [
         "//src/main/cpp/util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
         "@rules_cc//cc/runfiles",
     ],


### PR DESCRIPTION
Depending on :gtest_main is not enought: that target only indirectly provides the gtest.h and gmock.h headers. The target to depend on to get the headers is `:gtest`
