### PR TITLE
Interrupt a command only once when its client goes away

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/server/CommandServer.java
+++ b/src/main/java/com/google/devtools/build/lib/server/CommandServer.java
@@ -479,7 +479,8 @@ public class CommandServer implements GrpcCommandServer.Callback {
       commandId = command.getId();
 
       try {
-        // Send the client the command id as soon as we know it.
+        // Send the client the command id as soon as we know it, also telling BlockingStreamObserver
+        // which thread to interrupt.
         responder.onNext(
             RunResponse.newBuilder()
                 .setCookie(responseCookie)

--- a/src/main/java/com/google/devtools/build/lib/server/GrpcCommandServerImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/server/GrpcCommandServerImpl.java
@@ -48,6 +48,7 @@ import java.net.SocketAddress;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * The {@link GrpcCommandServer} implementation.
@@ -73,11 +74,27 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
    * <p>It does not react to the interrupt flag in order to allow Bazel to complete the current
    * command while printing output as well as sending the final exit code to the client. However, it
    * maintains the interrupt flag if it is already set.
+   *
+   * <p>Once the client is gone, the thread handling the RPC is interrupted a single time, so that
+   * the command it runs unwinds. Interrupting on every {@link #onNext} call instead livelocks a
+   * command that retries an interruptible step, see
+   * https://github.com/bazelbuild/bazel/issues/30435.
    */
   @VisibleForTesting
   static class BlockingStreamObserver<T extends Message> implements GrpcCommandServer.Responder {
     private final ServerCallStreamObserver<T> observer;
     private final Parser<T> parser;
+
+    /**
+     * The thread handling the RPC, taken from the first {@link #onNext} call, which CommandServer
+     * makes before any output can reach this observer.
+     */
+    @GuardedBy("this")
+    @Nullable
+    private Thread rpcThread;
+
+    @GuardedBy("this")
+    private boolean cancelReported;
 
     BlockingStreamObserver(StreamObserver<T> observer, T responseType) {
       this((ServerCallStreamObserver<T>) observer, responseType);
@@ -100,6 +117,9 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
 
     @Override
     public synchronized void onNext(byte[] response) throws IOException {
+      if (rpcThread == null) {
+        rpcThread = Thread.currentThread();
+      }
       boolean interrupted = false;
       while (!observer.isReady() && !observer.isCancelled()) {
         try {
@@ -122,9 +142,12 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
       } catch (StatusRuntimeException e) {
         throw new IOException(e.getMessage(), e);
       } finally {
-        // Restore the interrupt bit.
-        if (interrupted || observer.isCancelled()) {
+        if (interrupted) {
+          // Restore the interrupt bit.
           Thread.currentThread().interrupt();
+        } else if (observer.isCancelled() && !cancelReported) {
+          cancelReported = true;
+          rpcThread.interrupt(); // not the caller: the command is the one that has to unwind
         }
       }
     }

--- a/src/test/java/com/google/devtools/build/lib/server/GrpcCommandServerImplTest.java
+++ b/src/test/java/com/google/devtools/build/lib/server/GrpcCommandServerImplTest.java
@@ -29,6 +29,7 @@ import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -320,6 +321,94 @@ public final class GrpcCommandServerImplTest {
     serverDone.await();
     clientDone.await();
     assertThat(sentCount.get()).isEqualTo(receiveCount.get());
+    server.shutdown();
+    server.awaitTermination();
+  }
+
+  @Test
+  public void testBlockingStreamObserverInterruptsOnceOnClientCancel() throws Exception {
+    // This test attempts to verify that BlockingStreamObserver interrupts the writing thread only
+    // once after the client prematurely closes the connection. Re-interrupting it on every call
+    // livelocks any command that retries an interruptible step, because the retry is interrupted
+    // again as soon as it reports progress: see https://github.com/bazelbuild/bazel/issues/30435.
+    CountDownLatch serverDone = new CountDownLatch(1);
+    CountDownLatch clientDone = new CountDownLatch(1);
+    AtomicInteger receiveCount = new AtomicInteger();
+    AtomicBoolean reinterrupted = new AtomicBoolean();
+    CommandServerGrpc.CommandServerImplBase serverImpl =
+        new CommandServerGrpc.CommandServerImplBase() {
+          @Override
+          public void run(RunRequest request, StreamObserver<RunResponse> observer) {
+            ServerCallStreamObserver<RunResponse> serverCallStreamObserver =
+                (ServerCallStreamObserver<RunResponse>) observer;
+            BlockingStreamObserver<RunResponse> blockingStreamObserver =
+                new BlockingStreamObserver<>(
+                    serverCallStreamObserver, RunResponse.getDefaultInstance());
+            Thread t =
+                new Thread(
+                    () -> {
+                      try {
+                        RunResponse response =
+                            RunResponse.newBuilder()
+                                .setStandardOutput(ByteString.copyFrom(new byte[1024]))
+                                .build();
+                        // Send until the client cancel interrupts us, clearing the interrupt bit.
+                        while (!Thread.interrupted()) {
+                          blockingStreamObserver.onNext(response.toByteArray());
+                        }
+                        // Calls past the cancel must leave the interrupt bit alone, the way the
+                        // command retrying an interruptible step needs it.
+                        for (int i = 0; i < 10; i++) {
+                          blockingStreamObserver.onNext(response.toByteArray());
+                        }
+                        reinterrupted.set(Thread.currentThread().isInterrupted());
+                        serverDone.countDown();
+                      } catch (IOException e) {
+                        throw new IllegalStateException(e);
+                      }
+                    });
+            t.start();
+          }
+        };
+
+    String uniqueName = InProcessServerBuilder.generateName();
+    // Do not use .directExecutor here, as it makes both client and server run in the same thread.
+    Server server =
+        InProcessServerBuilder.forName(uniqueName)
+            .addService(serverImpl)
+            .executor(Executors.newFixedThreadPool(4))
+            .build()
+            .start();
+    ManagedChannel channel =
+        InProcessChannelBuilder.forName(uniqueName)
+            .executor(Executors.newFixedThreadPool(4))
+            .build();
+
+    CommandServerStub stub = CommandServerGrpc.newStub(channel);
+    stub.run(
+        RunRequest.getDefaultInstance(),
+        new StreamObserver<RunResponse>() {
+          @Override
+          public void onNext(RunResponse value) {
+            if (receiveCount.get() > 3) {
+              channel.shutdownNow();
+            }
+            receiveCount.incrementAndGet();
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            clientDone.countDown();
+          }
+
+          @Override
+          public void onCompleted() {
+            clientDone.countDown();
+          }
+        });
+    serverDone.await();
+    clientDone.await();
+    assertThat(reinterrupted.get()).isFalse();
     server.shutdown();
     server.awaitTermination();
   }


### PR DESCRIPTION
### Description
Once the client is gone, interrupt the thread handling the RPC a single time, rather than whichever thread writes, on every write.
That thread is the first to write, which `CommandServer` makes the one it registers as running the command.

### Motivation
Fixes #30435.

A command whose client dies while being canceled can livelock: `SkyframeExecutor.evaluateSkyKeys` retries its evaluation through `Uninterruptibles.callUninterruptibly`, the retry aborts while the interrupt bit is set, and every write to the dead client set it again.

`UiEventHandler` writes on the thread that posts the event, so the command thread re-armed its own bit, spinning without progress and under the threshold that logs anything.

The lock is held throughout, wedging every later invocation and any CI host whose jobs share an output base.

Aiming the interrupt at the writing thread rather than the registered one would starve the command instead, as `cli-update-thread` swallows `InterruptedException` and would consume the only interrupt.

2 behaviors narrow: a command going silent is never told, as before, and `cli-update-thread` keeps refreshing until the command tears it down.

### Build API Changes
No

### Checklist
- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes
RELNOTES: Fixed a livelock when a client disconnects while its command is being canceled, leaving the server to hold the command lock indefinitely and wedge every later invocation.