### PR TITLE
Extend .gitignore to better ignore directories generated by IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 .project
 eclipse-*bin/
 /bazel.iml
+.gradle/
 # Ignore all bazel-* symlinks. There is no full list since this can change
 # based on the name of the directory bazel is cloned into.
 /bazel-*
@@ -34,3 +35,5 @@ eclipse-*bin/
 .bazelversion
 # User-specific .bazelrc
 user.bazelrc
+# Generated directories from 3p deps that may be triggered by IDEs.
+/third_party/java/proguard/**/build


### PR DESCRIPTION
IDEs may silently trigger the generation of these directories when working from the Bazel git repo, dirtying the git repo state. Ignore for convenience.

RELNOTES: None
