### PR TITLE
Add a test for no modifications with `--lockfile_mode=update`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -6,6 +6,7 @@ load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//src:release_archive.bzl", "MINIMUM_JAVA_COMPILATION_RUNTIME_VERSION", "MINIMUM_JAVA_RUNTIME_VERSION")
 load("//src/tools/bzlmod:utils.bzl", "get_canonical_repo_name")
 load("//tools/distributions:distribution_rules.bzl", "distrib_jar_filegroup")
@@ -100,6 +101,22 @@ genrule(
     ]),
     tags = ["requires-network"],
     tools = ["//src:bazel"],
+)
+
+sh_test(
+    name = "verify_module_bazel_lock",
+    timeout = "long",
+    srcs = ["verify_module_bazel_lock.sh"],
+    data = [
+        ".bazelversion",
+        "MODULE.bazel",
+        "MODULE.bazel.lock",
+        "//third_party:patches",
+        "//third_party:remoteapis/MODULE.bazel",
+    ],
+    tags = ["requires-network"],
+    visibility = ["//visibility:private"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 pkg_tar(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -207,8 +207,8 @@
     "https://bcr.bazel.build/modules/prometheus-cpp/1.3.0.bcr.1/MODULE.bazel": "116ad46e97c1d2aeb020fe2899a342a7e703574ce7c0faf7e4810f938c974a9a",
     "https://bcr.bazel.build/modules/prometheus-cpp/1.3.0.bcr.1/source.json": "e813cce2d450708cfcb26e309c5172583a7440776edf354e83e6788c768e5cca",
     "https://bcr.bazel.build/modules/prometheus-cpp/1.3.0/MODULE.bazel": "ce82e086bbc0b60267e970f6a54b2ca6d0f22d3eb6633e00e2cc2899c700f3d8",
-    "https://bcr.bazel.build/modules/protobuf/36.0/MODULE.bazel": "6976c38053e63b19a84ee82d68c82a9c9d0d190469da7fbf32f613d0b7a03ac1",
-    "https://bcr.bazel.build/modules/protobuf/36.0/source.json": "a14d3af196aaede67d2417ff7507814362c4df599ec089e7d9153fdb50843a9b",
+    "https://bcr.bazel.build/modules/protobuf/36.0.bcr.1/MODULE.bazel": "c9f7d8150608ade08bbf871182311021ad5fe08bb3ac13527d5ab341cf2fac2b",
+    "https://bcr.bazel.build/modules/protobuf/36.0.bcr.1/source.json": "31d92819fdd4ef26a324c85eec4f845080155872db5143920b5b1b09837d09c9",
     "https://bcr.bazel.build/modules/protoc-gen-validate/1.0.4.bcr.2/MODULE.bazel": "c4bd2c850211ff5b7dadf9d2d0496c1c922fdedc303c775b01dfd3b3efc907ed",
     "https://bcr.bazel.build/modules/protoc-gen-validate/1.0.4/MODULE.bazel": "b8913c154b16177990f6126d2d2477d187f9ddc568e95ee3e2d50fc65d2c494a",
     "https://bcr.bazel.build/modules/protoc-gen-validate/1.2.1.bcr.1/MODULE.bazel": "4bf09676b62fa587ae07e073420a76ec8766dcce7545e5f8c68cfa8e484b5120",
@@ -537,7 +537,7 @@
     "@@protobuf+//python/dist:system_python.bzl%system_python_extension": {
       "general": {
         "bzlTransitiveDigest": "qh0n9IrXU/xS94wxKQrG1J63zrLkA1Wy2Y3BQxptPcI=",
-        "usagesDigest": "r0v8ejluW9xlYv6K8UBMrSAfXR4CfNX85hawhoVBOAQ=",
+        "usagesDigest": "kVbxR/mYndN3QWrZLS6jdk6e1CL7kQy3QMa3NBMjEpE=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "system_python": {

--- a/verify_module_bazel_lock.sh
+++ b/verify_module_bazel_lock.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+source "$0.runfiles/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+{ echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+function die() {
+  echo "$@" >&2
+  exit 1
+}
+
+# Verifies that Bazel's own MODULE.bazel.lock is up-to-date, i.e., that running
+# `bazel mod deps --lockfile_mode=update` in the workspace would not modify it.
+#
+# `--lockfile_mode=error` on CI only reports lockfile information that is
+# missing or outdated, but tolerates extra information such as entries for
+# registry files, yanked versions or module extensions that are no longer
+# referenced after a change to MODULE.bazel (this tolerance is intentional,
+# e.g. to keep automated git merges of lockfiles working). Such leftovers are
+# only cleaned up by an update, which makes local builds dirty the tree. This
+# test replays module resolution against the checked-in lockfile and fails if
+# an update would modify the file.
+
+# The lockfile is maintained by the Bazel version in .bazelversion, which
+# developers and CI use via bazelisk and which resolves modules slightly
+# differently than a Bazel built at HEAD, e.g. due to the bazel_dep versions in
+# its embedded MODULE.tools. Download and run exactly that version.
+bazel_version="$(tr -d '[:space:]' < "$(rlocation io_bazel/.bazelversion)")"
+case "$(uname -s)" in
+  Linux) os=linux ;;
+  Darwin) os=darwin ;;
+  MSYS*|MINGW*|CYGWIN*) os=windows ;;
+  *) die "Unsupported operating system: $(uname -s)" ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64) arch=x86_64 ;;
+  arm64|aarch64) arch=arm64 ;;
+  *) die "Unsupported architecture: $(uname -m)" ;;
+esac
+suffix=""
+if [[ "$os" == "windows" ]]; then
+  suffix=".exe"
+fi
+url="https://releases.bazel.build/${bazel_version}/release/bazel-${bazel_version}-${os}-${arch}${suffix}"
+bazel="$TEST_TMPDIR/bazel${suffix}"
+echo "Downloading $url"
+curl -fsSL -o "$bazel" "$url" || die "Failed to download Bazel $bazel_version from $url."
+chmod +x "$bazel"
+
+# Set up a workspace that contains everything that module resolution (but not
+# module extension evaluation, which requires fetching repos) needs: the root
+# module file, the current lockfile, and the files referenced by the overrides
+# in MODULE.bazel. This mirrors the workspace set up by the
+# //:generate_dist_lockfile genrule.
+checked_in_lockfile="$(rlocation io_bazel/MODULE.bazel.lock)"
+mkdir -p "$TEST_TMPDIR/workspace"
+cd "$TEST_TMPDIR/workspace"
+touch BUILD.bazel
+cp "$(rlocation io_bazel/MODULE.bazel)" MODULE.bazel
+cp "$checked_in_lockfile" MODULE.bazel.lock
+chmod u+w MODULE.bazel MODULE.bazel.lock
+
+# Patches referenced by overrides in MODULE.bazel are read during module
+# resolution and thus have to exist in the workspace.
+for label in $(grep -o '"//[^"]*\.patch"' MODULE.bazel | tr -d '"' | sort -u); do
+  patch_path="${label#//}"
+  patch_path="${patch_path/://}"
+  mkdir -p "$(dirname "$patch_path")"
+  cp "$(rlocation "io_bazel/$patch_path")" "$patch_path" \
+    || die "Patch file $label referenced by an override in MODULE.bazel is not available to this test. Please add it to the data of //:verify_module_bazel_lock in BUILD."
+  # The package containing a patch has to exist for its label to resolve, but
+  # its BUILD file is never loaded.
+  touch "$(dirname "$patch_path")/BUILD"
+done
+
+# MODULE.bazel files of modules with a local_path_override are read during
+# module resolution. If this list is incomplete, the bazel invocation below
+# fails with a clear error message.
+mkdir -p third_party/remoteapis
+cp "$(rlocation io_bazel/third_party/remoteapis/MODULE.bazel)" \
+  third_party/remoteapis/MODULE.bazel
+
+# `bazel query :all` triggers module resolution, but no extension evaluation,
+# and in update mode rewrites MODULE.bazel.lock if and only if its contents
+# are no longer up-to-date.
+echo "Running: bazel query --lockfile_mode=update to verify the lockfile."
+"$bazel" --batch --ignore_all_rc_files \
+    --output_user_root="$TEST_TMPDIR/output_user_root" \
+    query --check_direct_dependencies=error --lockfile_mode=update :all \
+  || die "Module resolution failed. If the error above mentions a file that does not exist in this test's workspace, please add it to the data of //:verify_module_bazel_lock in BUILD and copy it into place above."
+
+diff -u "$checked_in_lockfile" MODULE.bazel.lock \
+  || die "MODULE.bazel.lock is not up-to-date (see the diff above; '-' lines are checked in, '+' lines are what Bazel would generate). Please run \"bazel mod deps --lockfile_mode=update\" in your workspace and commit the resulting changes. This typically happens when MODULE.bazel is changed without updating the lockfile."
+
+echo "PASS"


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description
`--lockfile_mode=error` intentionally allows certain extra information to not fail on automated merge conflict resolutions. Add a test for Bazel's own lockfile that also runs with `--lockfile_mode=update` and catches this extra information, which would show up as local edits for developers.


### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
