### PR TITLE
[9.3.0] Allow building test targets without a matching execution platform

### DIFF
--- a/docs/reference/test-encyclopedia.mdx
+++ b/docs/reference/test-encyclopedia.mdx
@@ -701,7 +701,7 @@ The [execution platform](/extending/platforms) for a test action is determined
 via [toolchain resolution](/extending/toolchains#toolchain-resolution), just
 like for any other action. Each test rule has an implicitly defined [
 `test` exec group](/extending/exec-groups#exec-groups-for-native-rules) that,
-unless overridden, has a mandatory toolchain requirement on
+unless overridden, has an optional toolchain requirement on
 `@bazel_tools//tools/test:default_test_toolchain_type`.
 
 Toolchains of this type do not carry any data in the form of providers, but can
@@ -718,7 +718,9 @@ define their own::
 
   In particular, the target platform is compatible with this toolchain
   if it is also registered as an execution platform. If no such platform is
-  found, the test rule fails with a toolchain resolution error
+  found, the test can still be built, for example to cross-compile it for a
+  platform that isn't available for execution, but running it fails with an
+  error.
 * If `--@bazel_tools//tools/test:incompatible_use_default_test_toolchain` is
   disabled, the active test toolchain is
   `@bazel_tools//tools/test:legacy_test_toolchain`. This toolchain does not

--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -250,6 +250,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis/config/transitions:starlark_exposed_rule_transition_factory",
         "//src/main/java/com/google/devtools/build/lib/analysis/config/transitions:transition_factory",
         "//src/main/java/com/google/devtools/build/lib/analysis/platform",
+        "//src/main/java/com/google/devtools/build/lib/analysis/platform:constants",
         "//src/main/java/com/google/devtools/build/lib/analysis/stringtemplate",
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:resolution",
         "//src/main/java/com/google/devtools/build/lib/bugreport",

--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformConfiguration.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.starlarkbuildapi.platform.PlatformConfigurationApi;
 import com.google.devtools.build.lib.util.RegexFilter;
 import java.util.Collection;
+import java.util.regex.Pattern;
 
 /** A configuration fragment describing the current platform configuration. */
 @ThreadSafety.Immutable
@@ -117,5 +118,26 @@ public class PlatformConfiguration extends Fragment implements PlatformConfigura
     return labels.stream()
         .map(Label::getCanonicalForm)
         .anyMatch(this.toolchainResolutionDebugRegexFilter);
+  }
+
+  // All characters with special meaning anywhere in a regex (':' for example is only special
+  // within brackets).
+  private static final char[] REGEX_SPECIAL_CHARS = "+.|([{^$?\\*".toCharArray();
+
+  /**
+   * Returns a value for {@code --toolchain_resolution_debug} that matches exactly the given label,
+   * for use in error messages.
+   *
+   * <p>The filter is matched against {@link Label#getCanonicalForm}, so the canonical form is used
+   * even if the label has a shorter display form.
+   */
+  public static String toolchainResolutionDebugFilter(Label label) {
+    String canonicalForm = label.getCanonicalForm();
+    for (char c : REGEX_SPECIAL_CHARS) {
+      if (canonicalForm.indexOf(c) >= 0) {
+        return Pattern.quote(canonicalForm);
+      }
+    }
+    return canonicalForm;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -32,7 +32,9 @@ import com.google.devtools.build.lib.analysis.Allowlist;
 import com.google.devtools.build.lib.analysis.AnalysisEnvironment;
 import com.google.devtools.build.lib.analysis.FilesToRunProvider;
 import com.google.devtools.build.lib.analysis.PackageSpecificationProvider;
+import com.google.devtools.build.lib.analysis.PlatformConfiguration;
 import com.google.devtools.build.lib.analysis.PrerequisiteArtifacts;
+import com.google.devtools.build.lib.analysis.ResolvedToolchainContext;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.RunfilesProvider;
 import com.google.devtools.build.lib.analysis.RunfilesSupport;
@@ -41,9 +43,12 @@ import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.analysis.actions.LazyWriteNestedSetOfTupleAction;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
+import com.google.devtools.build.lib.analysis.platform.PlatformConstants;
+import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
 import com.google.devtools.build.lib.analysis.test.TestConfiguration.TestOptions.CancelConcurrentTests;
 import com.google.devtools.build.lib.analysis.test.TestProvider.TestParams;
 import com.google.devtools.build.lib.analysis.test.TestProvider.TestParams.CoverageParams;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
@@ -143,21 +148,63 @@ public final class TestActionBuilder {
     return this;
   }
 
+  private String getTestExecGroupName() {
+    return this.executionRequirements != null
+        ? this.executionRequirements.getExecGroup()
+        : DEFAULT_TEST_RUNNER_EXEC_GROUP_NAME;
+  }
+
   private ActionOwner getTestActionOwner(boolean useTargetPlatformForTests) {
     if (useTargetPlatformForTests && this.executionRequirements == null) {
       return ruleContext.getTestActionOwner();
     }
-    var execGroup =
-        this.executionRequirements != null
-            ? this.executionRequirements.getExecGroup()
-            : DEFAULT_TEST_RUNNER_EXEC_GROUP_NAME;
-    var owner = ruleContext.getActionOwner(execGroup);
+    var owner = ruleContext.getActionOwner(getTestExecGroupName());
     if (owner != null) {
       return owner;
     }
     return useTargetPlatformForTests
         ? ruleContext.getTestActionOwner()
         : ruleContext.getActionOwner();
+  }
+
+  /**
+   * Returns the reason why the test can't be run in this build, or {@code null} if it can be run.
+   *
+   * <p>The toolchain type of the default test exec group is optional so that test targets can be
+   * built even if no execution platform matches all constraints of the target platform, e.g. when
+   * cross-compiling a test for a platform that isn't available for execution. Since the test can't
+   * be run in that situation, the test action is created, but fails when executed.
+   */
+  @Nullable
+  private String getUnrunnableReason() {
+    var toolchainContexts = ruleContext.getToolchainContexts();
+    if (toolchainContexts == null
+        || !toolchainContexts.hasToolchainContext(getTestExecGroupName())) {
+      return null;
+    }
+    ResolvedToolchainContext toolchainContext =
+        toolchainContexts.getToolchainContext(getTestExecGroupName());
+    ToolchainTypeInfo testToolchainType =
+        toolchainContext
+            .requestedToolchainTypeLabels()
+            .get(PlatformConstants.DEFAULT_TEST_TOOLCHAIN_TYPE);
+    if (testToolchainType == null || toolchainContext.forToolchainType(testToolchainType) != null) {
+      return null;
+    }
+    RepositoryMapping mainRepoMapping =
+        ruleContext.getLabel().getRepository().isMain()
+            ? ruleContext.getRule().getPackageMetadata().repositoryMapping()
+            : null;
+    return String.format(
+        """
+        No matching toolchain found for type %s, which is required to run tests for target \
+        platform %s.%s
+        To debug, rerun with --toolchain_resolution_debug='%s'\
+        """,
+        testToolchainType.typeLabel().getDisplayForm(mainRepoMapping),
+        toolchainContext.targetPlatform().label().getDisplayForm(mainRepoMapping),
+        testToolchainType.noneFoundError() != null ? " " + testToolchainType.noneFoundError() : "",
+        PlatformConfiguration.toolchainResolutionDebugFilter(testToolchainType.typeLabel()));
   }
 
   public static int getShardCount(RuleContext ruleContext) {
@@ -201,6 +248,7 @@ public final class TestActionBuilder {
     ArtifactRoot root = ruleContext.getTestLogsDirectory();
     ActionOwner actionOwner =
         getTestActionOwner(config.getOptions().get(CoreOptions.class).useTargetPlatformForTests);
+    String unrunnableReason = getUnrunnableReason();
     boolean isExecutedOnWindows =
         getOsFromConstraintsOrHost(actionOwner.getExecutionPlatform()) == OS.WINDOWS;
 
@@ -432,7 +480,8 @@ public final class TestActionBuilder {
                 MoreObjects.firstNonNull(
                     Allowlist.fetchPackageSpecificationProviderOrNull(
                         ruleContext, "external_network"),
-                    PackageSpecificationProvider.EMPTY));
+                    PackageSpecificationProvider.EMPTY),
+                unrunnableReason);
 
         testOutputs.addAll(testRunnerAction.getSpawnOutputs());
         testOutputs.addAll(testRunnerAction.getOutputs());

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
@@ -64,6 +64,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.server.FailureDetails.Execution.Code;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.TestAction;
+import com.google.devtools.build.lib.server.FailureDetails.Toolchain;
 import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.Dirent;
@@ -175,6 +176,12 @@ public class TestRunnerAction extends AbstractAction
   // TODO(b/192694287): Remove once we migrate all tests from the allowlist.
   private final PackageSpecificationProvider networkAllowlist;
 
+  /**
+   * If not null, the reason why this test can't be run in the current build, to be reported when
+   * the action is executed. The action is still created so that the test target can be built.
+   */
+  @Nullable private final String unrunnableReason;
+
   private static ImmutableSet<Artifact> nonNullAsSet(Artifact... artifacts) {
     ImmutableSet.Builder<Artifact> builder = ImmutableSet.builder();
     for (Artifact artifact : artifacts) {
@@ -219,7 +226,8 @@ public class TestRunnerAction extends AbstractAction
       CancelConcurrentTests cancelConcurrentTests,
       boolean splitCoveragePostProcessing,
       NestedSet<Artifact> lcovMergerFilesToRun,
-      PackageSpecificationProvider networkAllowlist) {
+      PackageSpecificationProvider networkAllowlist,
+      @Nullable String unrunnableReason) {
     super(
         owner,
         inputs,
@@ -284,6 +292,7 @@ public class TestRunnerAction extends AbstractAction
     this.splitCoveragePostProcessing = splitCoveragePostProcessing;
     this.lcovMergerFilesToRun = lcovMergerFilesToRun;
     this.networkAllowlist = networkAllowlist;
+    this.unrunnableReason = unrunnableReason;
 
     // Mark all possible test outputs for deletion before test execution.
     // TestRunnerAction potentially can create many more non-declared outputs - xml output, coverage
@@ -322,6 +331,16 @@ public class TestRunnerAction extends AbstractAction
 
   public boolean allowLocalTests() {
     return testConfiguration.allowLocalTests();
+  }
+
+  /**
+   * Returns the reason why this test can't be run in the current build, or {@code null} if it can
+   * be run.
+   */
+  @VisibleForTesting
+  @Nullable
+  public String getUnrunnableReason() {
+    return unrunnableReason;
   }
 
   @Override
@@ -535,6 +554,7 @@ public class TestRunnerAction extends AbstractAction
     fp.addBoolean(configuration.isCodeCoverageEnabled());
     fp.addBoolean(testConfiguration.getZipUndeclaredTestOutputs());
     fp.addStringMap(getExecutionInfo());
+    fp.addNullableString(unrunnableReason);
   }
 
   /**
@@ -1002,6 +1022,7 @@ public class TestRunnerAction extends AbstractAction
     return networkAllowlist;
   }
 
+
   @Override
   public ActionResult execute(ActionExecutionContext actionExecutionContext)
       throws ActionExecutionException, InterruptedException {
@@ -1013,6 +1034,15 @@ public class TestRunnerAction extends AbstractAction
   public ActionResult execute(
       ActionExecutionContext actionExecutionContext, TestActionContext testActionContext)
       throws ActionExecutionException, InterruptedException {
+    if (unrunnableReason != null) {
+      FailureDetail failureDetail =
+          FailureDetail.newBuilder()
+              .setMessage(unrunnableReason)
+              .setToolchain(Toolchain.newBuilder().setCode(Toolchain.Code.NO_MATCHING_TOOLCHAIN))
+              .build();
+      throw new ActionExecutionException(
+          unrunnableReason, this, /* catastrophe= */ false, DetailedExitCode.of(failureDetail));
+    }
 
     List<SpawnResult> spawnResults = new ArrayList<>();
     List<ProcessedAttemptResult> failedAttempts = new ArrayList<>();

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -151,10 +151,19 @@ public class RuleClass implements RuleClassData {
   public static final String APPLICABLE_METADATA_ATTR_ALT = "applicable_licenses";
 
   public static final String DEFAULT_TEST_RUNNER_EXEC_GROUP_NAME = "test";
+
+  // The toolchain type is optional so that test targets can still be built (but not run) when no
+  // execution platform matches the constraints of the target platform, e.g. when cross-compiling a
+  // test for a platform that isn't available as an execution platform. Since toolchain resolution
+  // prefers execution platforms that provide the most toolchains, an execution platform matching
+  // the target platform is still selected whenever one exists. If none does, the test action is
+  // created, but fails when executed.
   public static final DeclaredExecGroup DEFAULT_TEST_RUNNER_EXEC_GROUP =
       DeclaredExecGroup.builder()
           .addToolchainType(
-              ToolchainTypeRequirement.create(PlatformConstants.DEFAULT_TEST_TOOLCHAIN_TYPE))
+              ToolchainTypeRequirement.builder(PlatformConstants.DEFAULT_TEST_TOOLCHAIN_TYPE)
+                  .mandatory(false)
+                  .build())
           .build();
 
   /** Interface for determining whether a rule needs toolchain resolution or not. */

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunction.java
@@ -50,7 +50,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.SequencedSet;
 import java.util.Set;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /**
@@ -393,25 +392,10 @@ public class ToolchainResolutionFunction implements SkyFunction {
 
     private static String getMessage(
         PlatformInfo targetPlatformInfo, SequencedSet<ToolchainTypeInfo> missingToolchainTypes) {
-      // All characters with special meaning anywhere in a regex (':' for example is only special
-      // within brackets).
-      List<Character> regexSpecialChars =
-          "+.|([{^$?\\*".codePoints().mapToObj(c -> (char) c).toList();
       ImmutableList<String> labelStrings =
           missingToolchainTypes.stream()
               .map(ToolchainTypeInfo::typeLabel)
-              .map(Label::toString)
-              .map(
-                  label -> {
-                    // Regex-quote if label contains special characters.
-                    for (char c : regexSpecialChars) {
-                      if (label.indexOf(c) >= 0) {
-                        return Pattern.quote(label);
-                      }
-                    }
-
-                    return label;
-                  })
+              .map(PlatformConfiguration::toolchainResolutionDebugFilter)
               .collect(toImmutableList());
       ImmutableList<String> missingToolchainRows =
           missingToolchainTypes.stream()

--- a/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
@@ -49,7 +49,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -751,8 +750,8 @@ public class TestActionBuilderTest extends BuildViewTestCase {
   }
 
   /**
-   * With the default test toolchain, a failure to find a suitable execution platform will result in
-   * a toolchain resolution error.
+   * With the default test toolchain, a failure to find a suitable execution platform doesn't fail
+   * analysis: the test target can still be built, but its test action fails when executed.
    */
   @Test
   public void testNoMatchingExecPlatformWithDefaultTestToolchain() throws Exception {
@@ -808,12 +807,26 @@ public class TestActionBuilderTest extends BuildViewTestCase {
         "--platforms=//:linux_x86_64_target",
         "--host_platform=//:macos_aarch64_exec",
         "--extra_execution_platforms=//:macos_aarch64_exec");
-    reporter.removeHandler(failFastHandler);
-    assertThat(getConfiguredTarget("//:some_test")).isNull();
-    assertContainsEvent(
-        Pattern.compile(
-            "While resolving toolchains for target //:some_test: No matching toolchains found for"
-                + " types:.*?//tools/test:default_test_toolchain_type"));
+    ImmutableList<Artifact.DerivedArtifact> testStatusList = getTestStatusArtifacts("//:some_test");
+    TestRunnerAction testAction = (TestRunnerAction) getGeneratingAction(testStatusList.get(0));
+    // The test action is created so that the test target can be built, but falls back to the first
+    // execution platform and fails when executed.
+    assertThat(testAction.getExecutionPlatform().label())
+        .isEqualTo(Label.parseCanonicalUnchecked("//:macos_aarch64_exec"));
+    // Labels are rendered in display form, except for the value of --toolchain_resolution_debug,
+    // which is matched against the canonical form.
+    assertThat(testAction.getUnrunnableReason())
+        .isEqualTo(
+            """
+            No matching toolchain found for type %s//tools/test:default_test_toolchain_type, which \
+            is required to run tests for target platform //:linux_x86_64_target.
+            To debug, rerun with --toolchain_resolution_debug='%s//tools/test:default_test_toolchain_type'\
+            """
+                .formatted(
+                    TestConstants.TOOLS_REPOSITORY.isMain()
+                        ? ""
+                        : "@" + TestConstants.TOOLS_REPOSITORY.getName(),
+                    TestConstants.TOOLS_REPOSITORY.getCanonicalForm()));
   }
 
   /**

--- a/src/test/shell/integration/toolchain_test.sh
+++ b/src/test/shell/integration/toolchain_test.sh
@@ -3060,5 +3060,53 @@ EOF
   expect_log "Misconfigured execution platforms: //${pkg}/platforms:platform_cycle is declared as a platform but has inappropriate dependencies"
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/29159
+function test_cross_compile_test_without_matching_exec_platform {
+  local -r pkg="${FUNCNAME[0]}"
+
+  add_rules_shell "MODULE.bazel"
+
+  # A target platform whose constraints aren't satisfied by any execution platform.
+  mkdir -p "${pkg}/platforms"
+  cat > "${pkg}/platforms/BUILD" <<EOF
+package(default_visibility = ['//visibility:public'])
+
+constraint_setting(name = 'setting')
+constraint_value(name = 'value', constraint_setting = ':setting')
+
+platform(
+    name = 'target_platform',
+    constraint_values = [':value'],
+)
+EOF
+
+  mkdir -p "${pkg}/demo"
+  cat > "${pkg}/demo/hello.sh" <<EOF
+echo hello
+EOF
+  chmod +x "${pkg}/demo/hello.sh"
+  cat > "${pkg}/demo/BUILD" <<EOF
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+sh_test(
+  name = 'sample_test',
+  srcs = ["hello.sh"],
+)
+EOF
+
+  # The test can be built even though it can't be run.
+  bazel build \
+    --platforms="//${pkg}/platforms:target_platform" \
+    "//${pkg}/demo:sample_test" &> $TEST_log || fail "Build failed"
+
+  # Running the test fails with an actionable error message.
+  bazel test \
+    --platforms="//${pkg}/platforms:target_platform" \
+    "//${pkg}/demo:sample_test" &> $TEST_log && fail "Unexpected success"
+  # The toolchain type is rendered in display form, except for the value of
+  # --toolchain_resolution_debug, which is matched against the canonical form.
+  expect_log "No matching toolchain found for type .*//tools/test:default_test_toolchain_type, which is required to run tests for target platform //${pkg}/platforms:target_platform"
+  expect_log "rerun with --toolchain_resolution_debug='.*//tools/test:default_test_toolchain_type'"
+}
 
 run_suite "toolchain tests"


### PR DESCRIPTION
### Description

The toolchain type requirement of the implicitly defined `test` exec group is now optional instead of mandatory.

Toolchain resolution picks the candidate execution platform that provides the most toolchains, so an execution platform that matches all constraints of the target platform is still selected whenever one exists, meaning that selection is unchanged for every build that works today. If no such platform exists, analysis no longer fails: the test target can be built, but `TestRunnerAction` fails when executed, with the same message that the toolchain resolution error used to carry (including the toolchain type's `no_match_error`).

```
$ bazel build --platforms=//platforms:target_platform //demo:sample_test
Target //demo:sample_test up-to-date:
  bazel-bin/demo/sample_test
INFO: Build completed successfully

$ bazel test --platforms=//platforms:target_platform //demo:sample_test
ERROR: demo/BUILD:2:8: Testing //demo:sample_test failed: No matching toolchain found for type @@bazel_tools//tools/test:default_test_toolchain_type, which is required to run tests for target platform //platforms:target_platform. By default, tests are executed on the first execution platform that matches all constraints specified by the target platform. Either register the target platform (or a platform with at least the same constraints) as an execution platform, or override the default behavior by registering a custom toolchain for @bazel_tools//tools/test:default_test_toolchain_type.
To debug, rerun with --toolchain_resolution_debug='@@bazel_tools//tools/test:default_test_toolchain_type'
//demo:sample_test                                              FAILED TO BUILD
```

### Motivation

Building a test binary for a platform that isn't available as an execution platform — for example to cross-compile a Windows test on Linux and copy it over to a Windows machine — currently fails during analysis, even though nothing about the build requires the test to be runnable. The only workaround left is registering a fake execution platform, since `--use_target_platform_for_tests` is a no-op at HEAD.

Fixes #29159

### Build API Changes

This relaxes the behavior of the implicitly defined `test` exec group, which is documented in the test encyclopedia.

1. Discussed in #29159; the underlying design is tracked in #25160.
2. Yes, it is backward compatible: every build that succeeds today keeps selecting the exact same execution platform, because a platform providing the default test toolchain still wins over one that doesn't. Only builds that fail today change behavior.
3. Not a breaking change, so no migration is needed.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Test targets can now be built for a target platform that no execution platform is compatible with, e.g. to cross-compile them. Running such a test fails with an error at execution time instead of failing analysis.

Closes #30493.

PiperOrigin-RevId: 967226631
Change-Id: I183c6bf68bffbe15ccb16d17f77cb1c07545aadb

(cherry picked from commit 28bb4097c20f69713b6b9e9d4e9884747ce842a4)


9.3.0 adaptation: master had already removed `--use_target_platform_for_tests` support and the `networkAllowlist` parameter of `TestRunnerAction` before this commit; both still exist on this branch and are preserved, with the `getTestExecGroupName()` extraction and `unrunnableReason` threading applied on top.

Closes #30495
