### PR TITLE
[9.3.0] Report the JSON profile's start as the origin its events use

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java
@@ -51,6 +51,7 @@ class JsonTraceFileWriter implements Runnable {
 
   private final OutputStream outStream;
   private final long profileStartTimeNanos;
+  private final long profileStartEpochMillis;
   private final ThreadLocal<Boolean> metadataPosted = ThreadLocal.withInitial(() -> Boolean.FALSE);
   private final boolean slimProfile;
   private final UUID buildID;
@@ -64,9 +65,15 @@ class JsonTraceFileWriter implements Runnable {
       new TaskData(
           /* threadId= */ 0, /* startTimeNanos= */ 0, /* eventType= */ null, "poison pill");
 
+  /**
+   * @param profileStartTimeNanos the monotonic clock reading that every event in the profile is
+   *     emitted relative to
+   * @param profileStartEpochMillis the same instant on the wall clock
+   */
   JsonTraceFileWriter(
       OutputStream outStream,
       long profileStartTimeNanos,
+      long profileStartEpochMillis,
       boolean slimProfile,
       String outputBase,
       UUID buildID) {
@@ -74,6 +81,7 @@ class JsonTraceFileWriter implements Runnable {
     this.thread = new Thread(this, "profile-writer-thread");
     this.outStream = outStream;
     this.profileStartTimeNanos = profileStartTimeNanos;
+    this.profileStartEpochMillis = profileStartEpochMillis;
     this.slimProfile = slimProfile;
     this.buildID = buildID;
     this.outputBase = outputBase;
@@ -239,7 +247,7 @@ class JsonTraceFileWriter implements Runnable {
               // Bazel internally stores strings as raw bytes encoded in ISO_8859_1, so we use the
               // same encoding here to also write out raw bytes.
               new OutputStreamWriter(new BufferedOutputStream(outStream, 262144), ISO_8859_1))) {
-        var startDate = Instant.now();
+        var startDate = Instant.ofEpochMilli(profileStartEpochMillis);
         writer.beginObject();
         writer.name("otherData");
         writer.beginObject();

--- a/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.clock.Clock;
 import com.google.devtools.build.lib.collect.Extrema;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadCompatible;
@@ -487,15 +488,24 @@ public final class Profiler {
 
     JsonTraceFileWriter writer = null;
     if (stream != null && format != null) {
+      long profileStartEpochMillis =
+          BlazeClock.createNanosToMillisSinceEpochConverter(clock)
+              .toEpochMillis(execStartTimeNanos);
       writer =
           switch (format) {
             case JSON_TRACE_FILE_FORMAT ->
                 new JsonTraceFileWriter(
-                    stream, execStartTimeNanos, slimProfile, outputBase, buildID);
+                    stream,
+                    execStartTimeNanos,
+                    profileStartEpochMillis,
+                    slimProfile,
+                    outputBase,
+                    buildID);
             case JSON_TRACE_FILE_COMPRESSED_FORMAT ->
                 new JsonTraceFileWriter(
                     new GZIPOutputStream(stream),
                     execStartTimeNanos,
+                    profileStartEpochMillis,
                     slimProfile,
                     outputBase,
                     buildID);


### PR DESCRIPTION
### Description

The JSON profile's time origin is deliberately backdated to when the *client* launched, so that the `LAUNCH` phase and binary extraction appear ahead of the server's own work:

```java
long clientStartTimeNanos = execStartTimeNanos - startupTimeNanos - waitTimeNanos;
Profiler.instance().start(…, clock, clientStartTimeNanos, …);
Profiler.instance().logSimpleTaskDuration(
    clientStartTimeNanos, Duration.ofNanos(startupTimeNanos), ProfilerTask.PHASE,
    ProfilePhase.LAUNCH.description);
```

Every event in the file is emitted as an offset from that reading. The `profile_start_ts` and `date` fields, though, came from an `Instant.now()` evaluated when the profile writer thread starts — one client startup and one command lock wait *later* than the origin the events are measured from.

This PR derives both fields from the profile's own origin rather than sampling the wall clock a second time.

### Motivation

Anything that reconstructs an absolute timeline by adding an event's `ts` to `profile_start_ts` places the entire profile late by `startup_time + command_wait_time`. That is typically tens to hundreds of milliseconds, which is easy to miss — but the command lock wait is unbounded, so it becomes seconds or minutes whenever the invocation had to wait for another command on the same server to finish. Correlating a Bazel profile against any other trace on the machine is off by that much.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #30595.

PiperOrigin-RevId: 966056232
Change-Id: I75f0a910f213cb68495a9084f40098856dedfc35

(cherry picked from commit f67bd6f026bff032a15db3597e5ef93d114ab80c)


9.3.0 adaptation: `TraceProfilerServiceImpl` doesn't exist on this branch, so the epoch-millis computation is performed at the branch's `JsonTraceFileWriter` construction site in `Profiler#start` instead.

Closes #30600
