### PR TITLE
Populate TestResult.ExecutionInfo.resource_usage with measured peak memory

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -785,6 +785,13 @@ message TestResult {
     }
     TimingBreakdown timing_breakdown = 4;
 
+    // A named resource consumed by the test action, keyed by `name`. The set of
+    // names is not fixed; consumers should ignore names they do not recognize.
+    //
+    // Names currently emitted by Bazel:
+    //   * `memory_bytes`: peak memory usage of the test process, in bytes. Only
+    //     present when the test spawn ran under the process-wrapper or a sandbox
+    //     that reports rusage; absent for remotely executed and cached spawns.
     message ResourceUsage {
       string name = 1;
       int64 value = 2;

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -437,6 +437,17 @@ public class StandaloneTestStrategy extends TestStrategy {
                     .build())
             .build());
 
+    // Peak memory usage is only measured for spawns that ran under the process-wrapper or a
+    // sandbox that reports rusage; it is unavailable for remotely executed or cached spawns.
+    long measuredMemoryPeakBytes = sm.measuredMemoryPeak();
+    if (measuredMemoryPeakBytes > 0) {
+      executionInfo.addResourceUsage(
+          BuildEventStreamProtos.TestResult.ExecutionInfo.ResourceUsage.newBuilder()
+              .setName("memory_bytes")
+              .setValue(measuredMemoryPeakBytes)
+              .build());
+    }
+
     return executionInfo.build();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/exec/StandaloneTestStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/StandaloneTestStrategyTest.java
@@ -340,6 +340,58 @@ public final class StandaloneTestStrategyTest extends BuildViewTestCase {
             .collect(MoreCollectors.onlyElement());
     assertThat(attempt.getExecutionInfo().getStrategy()).isEqualTo("test");
     assertThat(attempt.getExecutionInfo().getHostname()).isEqualTo("");
+    assertThat(attempt.getExecutionInfo().getResourceUsageList()).isEmpty();
+  }
+
+  @Test
+  public void testRunTestOnceReportsMeasuredPeakMemory() throws Exception {
+    ExecutionOptions executionOptions = Options.getDefaults(ExecutionOptions.class);
+    TestSummaryOptions testSummaryOptions = TestSummaryOptions.DEFAULTS;
+    Path tmpDirRoot = TestStrategy.getTmpRoot(rootDirectory, outputBase, executionOptions);
+    TestedStandaloneTestStrategy standaloneTestStrategy =
+        new TestedStandaloneTestStrategy(executionOptions, testSummaryOptions, tmpDirRoot);
+
+    // setup a test action
+    scratch.file("standalone/simple_test.sh", "this does not get executed, it is mocked out");
+    scratch.file(
+        "standalone/BUILD",
+        """
+        load('//test_defs:foo_test.bzl', 'foo_test')
+        foo_test(
+            name = "simple_test",
+            size = "small",
+            srcs = ["simple_test.sh"],
+        )
+        """);
+    TestRunnerAction testRunnerAction = getTestAction("//standalone:simple_test");
+
+    SpawnResult expectedSpawnResult =
+        new SpawnResult.Builder()
+            .setStatus(Status.SUCCESS)
+            .setWallTimeInMs(10)
+            .setMemoryInKb(2048)
+            .setRunnerName("test")
+            .build();
+    when(spawnStrategy.exec(any(), any())).thenReturn(ImmutableList.of(expectedSpawnResult));
+
+    ActionExecutionContext actionExecutionContext =
+        new FakeActionExecutionContext(
+            createTempOutErr(tmpDirRoot), inputMetadataFor(testRunnerAction), spawnStrategy);
+
+    // actual StandaloneTestStrategy execution
+    execute(testRunnerAction, actionExecutionContext, standaloneTestStrategy);
+
+    TestAttempt attempt =
+        storedEvents.getPosts().stream()
+            .filter(TestAttempt.class::isInstance)
+            .map(TestAttempt.class::cast)
+            .collect(MoreCollectors.onlyElement());
+    assertThat(attempt.getExecutionInfo().getResourceUsageList())
+        .containsExactly(
+            ExecutionInfo.ResourceUsage.newBuilder()
+                .setName("memory_bytes")
+                .setValue(2048L * 1024)
+                .build());
   }
 
   @Test


### PR DESCRIPTION
Fixes #30953

Draft, because the design questions in that issue should be settled before this is worth
polishing — in particular the choice of `ResourceUsage.name`, since nothing in the Bazel
tree populates this field today and I may be diverging from an existing convention.

### What this does

Bazel already measures peak memory usage (`maxrss`) for spawns that run under the
process-wrapper or a sandbox that reports rusage, and surfaces it through
`SpawnMetrics.measuredMemoryPeak()`. Until now the only way to consume it was the execution
log, as `SpawnExec.metrics.measured_memory_peak_bytes`.

`build_event_stream.proto` already declares a field for exactly this —
`TestResult.ExecutionInfo.ResourceUsage` (`name`/`value`) — but `addResourceUsage` is never
called anywhere in the tree. This populates it from
`StandaloneTestStrategy#extractExecutionInfo`, next to the `timing_breakdown` that is
already derived from the same `SpawnResult`, so BEP/BES consumers can attribute memory usage
to a test target without post-processing an execution log.

The entry is only added when a measurement is actually available, so remotely executed and
cached test spawns are unaffected — see the coverage table in #30953.

No proto schema change; the rest of the plumbing (`StandaloneTestResult` → `TestAttempt` →
`TestResult.execution_info`) already exists. The proto change here is a comment documenting
the key name, since this establishes the first one Bazel emits.

### Testing

Added `StandaloneTestStrategyTest#testRunTestOnceReportsMeasuredPeakMemory`, and extended
`testRunTestOnce` to assert the list stays empty when no measurement is available.

```
bazel test //src/test/java/com/google/devtools/build/lib/exec:ExecTests \
  --test_filter='StandaloneTestStrategyTest.*'
```
