### PR TITLE
Interrupt a command once when its client goes away

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/server/CommandServer.java
+++ b/src/main/java/com/google/devtools/build/lib/server/CommandServer.java
@@ -81,7 +81,8 @@ import javax.annotation.Nullable;
  *
  * <p>Each running RPC has a UUID associated with it that is used to identify it when a client wants
  * to cancel it. Cancellation is done by the client sending the server a Cancel RPC, which results
- * in the main thread of the command being interrupted.
+ * in the main thread of the command being interrupted. A client going away without sending one has
+ * the same effect, see {@link GrpcCommandServerImpl.BlockingStreamObserver}.
  */
 public class CommandServer implements GrpcCommandServer.Callback {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
@@ -479,7 +480,8 @@ public class CommandServer implements GrpcCommandServer.Callback {
       commandId = command.getId();
 
       try {
-        // Send the client the command id as soon as we know it.
+        // Send the client the command id as soon as we know it, letting the responder capture the
+        // current thread as the one to interrupt if the client goes away.
         responder.onNext(
             RunResponse.newBuilder()
                 .setCookie(responseCookie)

--- a/src/main/java/com/google/devtools/build/lib/server/GrpcCommandServerImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/server/GrpcCommandServerImpl.java
@@ -48,6 +48,7 @@ import java.net.SocketAddress;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * The {@link GrpcCommandServer} implementation.
@@ -73,11 +74,28 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
    * <p>It does not react to the interrupt flag in order to allow Bazel to complete the current
    * command while printing output as well as sending the final exit code to the client. However, it
    * maintains the interrupt flag if it is already set.
+   *
+   * <p>Once the client prematurely closed the connection, the main thread of the command is
+   * interrupted once, so that the command terminates even when it writes nothing more. Interrupting
+   * the calling thread instead loses that interrupt whenever cli-update-thread writes first, as it
+   * ignores interrupts, and interrupting on every call keeps a command retrying an interruptible
+   * step from ever converging, see https://github.com/bazelbuild/bazel/issues/30435.
    */
   @VisibleForTesting
   static class BlockingStreamObserver<T extends Message> implements GrpcCommandServer.Responder {
     private final ServerCallStreamObserver<T> observer;
     private final Parser<T> parser;
+
+    /**
+     * Taken from the first {@link #onNext} call, which {@link CommandServer} performs before any
+     * output can reach this observer.
+     */
+    @GuardedBy("this")
+    @Nullable
+    private Thread commandThread;
+
+    @GuardedBy("this")
+    private boolean commandInterrupted;
 
     BlockingStreamObserver(StreamObserver<T> observer, T responseType) {
       this((ServerCallStreamObserver<T>) observer, responseType);
@@ -87,7 +105,7 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
     BlockingStreamObserver(ServerCallStreamObserver<T> observer, T responseType) {
       this.observer = observer;
       this.observer.setOnReadyHandler(this::notifyWaiters);
-      this.observer.setOnCancelHandler(this::notifyWaiters);
+      this.observer.setOnCancelHandler(this::notifyWaitersAndInterruptCommand);
       this.parser = (Parser<T>) responseType.getParserForType();
     }
 
@@ -98,8 +116,19 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
       notifyAll();
     }
 
+    private synchronized void notifyWaitersAndInterruptCommand() {
+      notifyAll(); // for the reason given in notifyWaiters
+      if (commandThread != null && !commandInterrupted) {
+        commandThread.interrupt(); // the client went away after the first write
+        commandInterrupted = true;
+      }
+    }
+
     @Override
     public synchronized void onNext(byte[] response) throws IOException {
+      if (commandThread == null) {
+        commandThread = Thread.currentThread();
+      }
       boolean interrupted = false;
       while (!observer.isReady() && !observer.isCancelled()) {
         try {
@@ -123,8 +152,11 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
         throw new IOException(e.getMessage(), e);
       } finally {
         // Restore the interrupt bit.
-        if (interrupted || observer.isCancelled()) {
+        if (interrupted) {
           Thread.currentThread().interrupt();
+        } else if (observer.isCancelled() && !commandInterrupted) {
+          commandThread.interrupt(); // the client was already gone at the first write
+          commandInterrupted = true;
         }
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/server/GrpcCommandServerImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/server/GrpcCommandServerImpl.java
@@ -88,7 +88,7 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
 
     /**
      * Taken from the first {@link #onNext} call, which {@link CommandServer} performs before any
-     * output can reach this observer.
+     * output can reach this observer, and cleared in {@link #onCompleted} when done.
      */
     @GuardedBy("this")
     @Nullable
@@ -154,7 +154,8 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
         // Restore the interrupt bit.
         if (interrupted) {
           Thread.currentThread().interrupt();
-        } else if (observer.isCancelled() && !commandInterrupted) {
+        }
+        if (observer.isCancelled() && !commandInterrupted) {
           commandThread.interrupt(); // the client was already gone at the first write
           commandInterrupted = true;
         }
@@ -162,7 +163,8 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
     }
 
     @Override
-    public void onCompleted() throws IOException {
+    public synchronized void onCompleted() throws IOException {
+      commandThread = null; // a thread pool may already run another command on it
       try {
         observer.onCompleted();
       } catch (StatusRuntimeException e) {

--- a/src/main/java/com/google/devtools/build/lib/server/GrpcCommandServerImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/server/GrpcCommandServerImpl.java
@@ -75,11 +75,12 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
    * command while printing output as well as sending the final exit code to the client. However, it
    * maintains the interrupt flag if it is already set.
    *
-   * <p>Once the client prematurely closed the connection, the main thread of the command is
-   * interrupted once, so that the command terminates even when it writes nothing more. Interrupting
-   * the calling thread instead loses that interrupt whenever cli-update-thread writes first, as it
-   * ignores interrupts, and interrupting on every call keeps a command retrying an interruptible
-   * step from ever converging, see https://github.com/bazelbuild/bazel/issues/30435.
+   * <p>When the client connection closes prematurely, the command thread is interrupted exactly
+   * once, allowing it to terminate even if it produces no further output. Interrupting the thread
+   * calling {@link #onNext} instead may lose the signal when {@code cli-update-thread} writes
+   * first because that thread ignores interrupts. Also, interrupting on every write may repeatedly
+   * re-arm the interrupt and prevent a retry of an interruptible step from ever converging, see
+   * https://github.com/bazelbuild/bazel/issues/30435.
    */
   @VisibleForTesting
   static class BlockingStreamObserver<T extends Message> implements GrpcCommandServer.Responder {
@@ -88,14 +89,14 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
 
     /**
      * Taken from the first {@link #onNext} call, which {@link CommandServer} performs before any
-     * output can reach this observer, and cleared in {@link #onCompleted} when done.
+     * output can reach this observer.
      */
     @GuardedBy("this")
     @Nullable
     private Thread commandThread;
 
     @GuardedBy("this")
-    private boolean commandInterrupted;
+    private boolean commandInterruptible = true;
 
     BlockingStreamObserver(StreamObserver<T> observer, T responseType) {
       this((ServerCallStreamObserver<T>) observer, responseType);
@@ -118,9 +119,9 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
 
     private synchronized void notifyWaitersAndInterruptCommand() {
       notifyAll(); // for the reason given in notifyWaiters
-      if (commandThread != null && !commandInterrupted) {
+      if (commandInterruptible && commandThread != null) {
         commandThread.interrupt(); // the client went away after the first write
-        commandInterrupted = true;
+        commandInterruptible = false;
       }
     }
 
@@ -155,16 +156,16 @@ public class GrpcCommandServerImpl extends CommandServerGrpc.CommandServerImplBa
         if (interrupted) {
           Thread.currentThread().interrupt();
         }
-        if (observer.isCancelled() && !commandInterrupted) {
+        if (commandInterruptible && observer.isCancelled()) {
           commandThread.interrupt(); // the client was already gone at the first write
-          commandInterrupted = true;
+          commandInterruptible = false;
         }
       }
     }
 
     @Override
     public synchronized void onCompleted() throws IOException {
-      commandThread = null; // a thread pool may already run another command on it
+      commandInterruptible = false; // a late event may otherwise interrupt the pooled commandThread
       try {
         observer.onCompleted();
       } catch (StatusRuntimeException e) {

--- a/src/test/java/com/google/devtools/build/lib/server/CommandServerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/server/CommandServerTest.java
@@ -321,6 +321,75 @@ public final class CommandServerTest {
   }
 
   @Test
+  public void testCommandCanFinishAfterClosingClient() throws Exception {
+    // A command whose client went away retries interruptible steps as it terminates, reporting
+    // progress as it goes. Interrupting it again on every report keeps such a retry from ever
+    // converging, holding the command lock: https://github.com/bazelbuild/bazel/issues/30435
+    int maxAttempts = 100;
+    CountDownLatch done = new CountDownLatch(1);
+    AtomicInteger attempts = new AtomicInteger();
+    CommandDispatcher dispatcher =
+        new CommandDispatcher() {
+          @Override
+          public BlazeCommandResult exec(
+              InvocationPolicy invocationPolicy,
+              List<String> args,
+              OutErr outErr,
+              LockingMode lockingMode,
+              UiVerbosity uiVerbosity,
+              String clientDescription,
+              long firstContactTimeMillis,
+              Optional<List<Pair<String, String>>> startupOptionsTaggedWithBazelRc,
+              Supplier<ImmutableList<IdleTask.Result>> idleTaskResultsSupplier,
+              List<Any> commandExtensions,
+              CommandExtensionReporter commandExtensionReporter) {
+            synchronized (this) {
+              // The client is gone, hence the interrupt telling this command to terminate.
+              assertThrows(InterruptedException.class, this::wait);
+            }
+            OutputStream out = outErr.getOutputStream();
+            try {
+              while (attempts.incrementAndGet() < maxAttempts) {
+                out.write(new byte[1024]);
+                if (!Thread.interrupted()) {
+                  break; // the step went through, this command can return
+                }
+              }
+            } catch (IOException e) {
+              throw new IllegalStateException(e);
+            }
+            done.countDown();
+            return BlazeCommandResult.failureDetail(
+                FailureDetail.newBuilder()
+                    .setInterrupted(Interrupted.newBuilder().setCode(Code.INTERRUPTED_UNKNOWN))
+                    .build());
+          }
+        };
+
+    ServerAndStub serverAndStub = createServerAndStub(dispatcher);
+    CommandServer server = serverAndStub.server();
+    CommandServerStub stub = serverAndStub.stub();
+
+    stub.run(
+        createRequest("Foo"),
+        new StreamObserver<RunResponse>() {
+          @Override
+          public void onNext(RunResponse value) {
+            server.shutdownNow();
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+    server.awaitTermination();
+    done.await();
+    assertThat(attempts.get()).isLessThan(maxAttempts);
+  }
+
+  @Test
   public void testStream() throws Exception {
     CommandDispatcher dispatcher =
         new CommandDispatcher() {

--- a/src/test/java/com/google/devtools/build/lib/server/GrpcCommandServerImplTest.java
+++ b/src/test/java/com/google/devtools/build/lib/server/GrpcCommandServerImplTest.java
@@ -14,6 +14,9 @@
 package com.google.devtools.build.lib.server;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.devtools.build.lib.server.CommandProtos.RunRequest;
 import com.google.devtools.build.lib.server.CommandProtos.RunResponse;
@@ -33,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
 
 /** Unit tests for {@link GrpcCommandServerImpl}. */
 @RunWith(JUnit4.class)
@@ -322,5 +326,45 @@ public final class GrpcCommandServerImplTest {
     assertThat(sentCount.get()).isEqualTo(receiveCount.get());
     server.shutdown();
     server.awaitTermination();
+  }
+
+  @Test
+  public void testBlockingStreamObserverInterruptsOnceOnClientCancel() throws Exception {
+    // This test attempts to verify that BlockingStreamObserver interrupts only once after the
+    // client prematurely closes the connection. Re-interrupting on every call keeps any command
+    // retrying an interruptible step from ever converging, because the retry is interrupted again
+    // as soon as it reports progress: see https://github.com/bazelbuild/bazel/issues/30435.
+    ServerCallStreamObserver<RunResponse> observer = mock(ServerCallStreamObserver.class);
+    when(observer.isReady()).thenReturn(true);
+    ArgumentCaptor<Runnable> onCancelHandler = ArgumentCaptor.forClass(Runnable.class);
+    BlockingStreamObserver<RunResponse> blockingStreamObserver =
+        new BlockingStreamObserver<>(observer, RunResponse.getDefaultInstance());
+    verify(observer).setOnCancelHandler(onCancelHandler.capture());
+
+    byte[] response = RunResponse.getDefaultInstance().toByteArray();
+    blockingStreamObserver.onNext(response); // the call this thread gets remembered by
+    when(observer.isCancelled()).thenReturn(true);
+    onCancelHandler.getValue().run();
+    assertThat(Thread.interrupted()).isTrue(); // clears the interrupt bit for the call below
+    blockingStreamObserver.onNext(response);
+    assertThat(Thread.interrupted()).isFalse();
+  }
+
+  @Test
+  public void testBlockingStreamObserverInterruptsOnFirstWriteAfterCancel() throws Exception {
+    // This test attempts to verify that BlockingStreamObserver interrupts the command when the
+    // client is already gone by the time of the first write: the cancellation has no thread to
+    // interrupt yet, leaving that write the only occasion to do so.
+    ServerCallStreamObserver<RunResponse> observer = mock(ServerCallStreamObserver.class);
+    when(observer.isReady()).thenReturn(true);
+    when(observer.isCancelled()).thenReturn(true);
+    BlockingStreamObserver<RunResponse> blockingStreamObserver =
+        new BlockingStreamObserver<>(observer, RunResponse.getDefaultInstance());
+
+    byte[] response = RunResponse.getDefaultInstance().toByteArray();
+    blockingStreamObserver.onNext(response);
+    assertThat(Thread.interrupted()).isTrue(); // clears the interrupt bit for the call below
+    blockingStreamObserver.onNext(response);
+    assertThat(Thread.interrupted()).isFalse();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/server/GrpcCommandServerImplTest.java
+++ b/src/test/java/com/google/devtools/build/lib/server/GrpcCommandServerImplTest.java
@@ -367,4 +367,44 @@ public final class GrpcCommandServerImplTest {
     blockingStreamObserver.onNext(response);
     assertThat(Thread.interrupted()).isFalse();
   }
+
+  @Test
+  public void testBlockingStreamObserverInterruptsOnceEvenIfOwnWaitWasInterrupted()
+      throws Exception {
+    // This test attempts to verify that a call whose own wait is interrupted for an unrelated
+    // reason still records this site's interrupt when the client is also gone, so that a later
+    // write does not repeat it.
+    ServerCallStreamObserver<RunResponse> observer = mock(ServerCallStreamObserver.class);
+    when(observer.isReady()).thenReturn(false);
+    when(observer.isCancelled()).thenReturn(false, true);
+    BlockingStreamObserver<RunResponse> blockingStreamObserver =
+        new BlockingStreamObserver<>(observer, RunResponse.getDefaultInstance());
+
+    byte[] response = RunResponse.getDefaultInstance().toByteArray();
+    Thread.currentThread().interrupt(); // an interrupt unrelated to the client leaving
+    blockingStreamObserver.onNext(response);
+    assertThat(Thread.interrupted()).isTrue(); // clears the interrupt bit for the call below
+    blockingStreamObserver.onNext(response);
+    assertThat(Thread.interrupted()).isFalse();
+  }
+
+  @Test
+  public void testBlockingStreamObserverIgnoresCancelAfterCompletion() throws Exception {
+    // This test attempts to verify that a cancellation notification arriving after onCompleted
+    // does not interrupt commandThread, which by then may already run an unrelated command
+    // recycled from the same thread pool.
+    ServerCallStreamObserver<RunResponse> observer = mock(ServerCallStreamObserver.class);
+    when(observer.isReady()).thenReturn(true);
+    ArgumentCaptor<Runnable> onCancelHandler = ArgumentCaptor.forClass(Runnable.class);
+    BlockingStreamObserver<RunResponse> blockingStreamObserver =
+        new BlockingStreamObserver<>(observer, RunResponse.getDefaultInstance());
+    verify(observer).setOnCancelHandler(onCancelHandler.capture());
+
+    byte[] response = RunResponse.getDefaultInstance().toByteArray();
+    blockingStreamObserver.onNext(response); // the call commandThread gets remembered by
+    blockingStreamObserver.onCompleted();
+    when(observer.isCancelled()).thenReturn(true);
+    onCancelHandler.getValue().run(); // arrives late, as gRPC delivers it on its own schedule
+    assertThat(Thread.interrupted()).isFalse();
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/server/GrpcCommandServerImplTest.java
+++ b/src/test/java/com/google/devtools/build/lib/server/GrpcCommandServerImplTest.java
@@ -407,4 +407,22 @@ public final class GrpcCommandServerImplTest {
     onCancelHandler.getValue().run(); // arrives late, as gRPC delivers it on its own schedule
     assertThat(Thread.interrupted()).isFalse();
   }
+
+  @Test
+  public void testBlockingStreamObserverIgnoresOnNextAfterCompletion() throws Exception {
+    // This test attempts to verify that an onNext call arriving after onCompleted does not
+    // interrupt the thread making it, since a thread pool may already run an unrelated command on
+    // it by then.
+    ServerCallStreamObserver<RunResponse> observer = mock(ServerCallStreamObserver.class);
+    when(observer.isReady()).thenReturn(true);
+    BlockingStreamObserver<RunResponse> blockingStreamObserver =
+        new BlockingStreamObserver<>(observer, RunResponse.getDefaultInstance());
+
+    byte[] response = RunResponse.getDefaultInstance().toByteArray();
+    blockingStreamObserver.onNext(response); // the call commandThread gets remembered by
+    blockingStreamObserver.onCompleted();
+    when(observer.isCancelled()).thenReturn(true);
+    blockingStreamObserver.onNext(response); // arrives late, from some other thread in practice
+    assertThat(Thread.interrupted()).isFalse();
+  }
 }

--- a/src/test/shell/integration/client_test.sh
+++ b/src/test/shell/integration/client_test.sh
@@ -461,6 +461,75 @@ EOF
   fi
 }
 
+# Kills the client of a build blocked in an action, then reports how many seconds the
+# server took to release the command lock, or nothing at all if it never did.
+function kill_client_of_blocked_build() {
+  local -r extra_flag="$1"
+  # Before anything takes the lock: asking later would queue behind the very command
+  # this function is about to abandon.
+  local -r server_pid_file="$(bazel info output_base)/server/server.pid.txt"
+  local -r ready="${TEST_TMPDIR}/ready"  # entered by the genrule
+  local -r lock="${TEST_TMPDIR}/lock"  # waited on by the genrule
+  mkfifo "${ready}" || fail "couldn't create fifo ready"
+  mkfifo "${lock}" || fail "couldn't create fifo lock"
+  mkdir -p a
+  cat > a/BUILD <<EOF
+genrule(name = "a", outs = ["a.out"],
+        cmd = "cat ${ready} >/dev/null; cat ${lock} >/dev/null; touch \$@")
+EOF
+
+  # Local strategy, so that the action reaches both fifos.
+  bazel --client_debug build --spawn_strategy=local ${extra_flag} //a:a >"$TEST_log" 2>&1 &
+
+  # This write returns once the action reads it, which then blocks on the lock fifo.
+  echo entered > "${ready}"
+  local -r client_pid="$(cat "$TEST_log" | scrape_client_pid)"
+
+  # SIGKILL rather than SIGTERM, which would let the client send a Cancel RPC: the server
+  # has always acted upon those, so these tests would then pass either way.
+  kill -9 "${client_pid}" || fail "couldn't kill client ${client_pid}"
+
+  local exit_code=0
+  local i
+  for i in $(seq 1 30); do
+    exit_code=0
+    bazel --client_debug --noblock_for_lock info >"$TEST_log-2" 2>&1 || exit_code=$?
+    if [[ "${exit_code}" -eq 0 ]]; then
+      break
+    fi
+    sleep 1
+  done
+
+  # Free the slot *before* the caller checks expectations, otherwise the rest of the suite
+  # waits for this very command. Writing to the lock fifo would hang once the action is gone,
+  # leaving the server as the only way to release the lock, as on a CI runner holding a stale one.
+  kill "$(cat "${server_pid_file}")"
+  rm -rf a "${ready}" "${lock}"
+
+  cat "$TEST_log-2" >> "$TEST_log"
+  return "${exit_code}"
+}
+
+function test_command_lock_released_when_client_dies() {
+  # A command whose client is killed must not keep the server's command lock: the next
+  # invocation would then wait for a command nobody waits for, until its own timeout.
+  # Progress reporting gives the server a write, hence a chance to notice the client is
+  # gone, but that interrupt has to reach the command rather than the reporting thread.
+  # See https://github.com/bazelbuild/bazel/issues/30954.
+  local exit_code=0
+  kill_client_of_blocked_build "" || exit_code=$?
+  assert_equals 0 "${exit_code}" # 9 would be LOCK_HELD_NOBLOCK_FOR_LOCK
+}
+
+function test_command_lock_released_when_client_dies_without_further_output() {
+  # Same, for a command that reports nothing at all: with no write left to carry it, the
+  # interrupt has to come from the cancellation itself.
+  # See https://github.com/bazelbuild/bazel/issues/30954.
+  local exit_code=0
+  kill_client_of_blocked_build "--noshow_progress" || exit_code=$?
+  assert_equals 0 "${exit_code}" # 9 would be LOCK_HELD_NOBLOCK_FOR_LOCK
+}
+
 function test_noblock_for_lock_reuse_server() {
   # Use a FIFO to spoonfeed the Bazel server.
   mkdir -p a && mkfifo a/BUILD || fail "couldn't create fifo a"

--- a/src/test/shell/integration/client_test.sh
+++ b/src/test/shell/integration/client_test.sh
@@ -480,6 +480,7 @@ EOF
 
   # Local strategy, so that the action reaches both fifos.
   bazel --client_debug build --spawn_strategy=local ${extra_flag} //a:a >"$TEST_log" 2>&1 &
+  local -r client_job_pid="$!"
 
   # This write returns once the action reads it, which then blocks on the lock fifo.
   echo entered > "${ready}"
@@ -488,6 +489,8 @@ EOF
   # SIGKILL rather than SIGTERM, which would let the client send a Cancel RPC: the server
   # has always acted upon those, so these tests would then pass either way.
   kill -9 "${client_pid}" || fail "couldn't kill client ${client_pid}"
+  # Reap the backgrounded job so its "Killed" notice does not surface later.
+  wait "${client_job_pid}" || true
 
   local exit_code=0
   local i
@@ -503,7 +506,10 @@ EOF
   # Free the slot *before* the caller checks expectations, otherwise the rest of the suite
   # waits for this very command. Writing to the lock fifo would hang once the action is gone,
   # leaving the server as the only way to release the lock, as on a CI runner holding a stale one.
-  kill "$(cat "${server_pid_file}")"
+  if [[ -f "${server_pid_file}" ]]; then
+    local -r server_pid="$(cat "${server_pid_file}")"
+    kill -0 "${server_pid}" 2>/dev/null && kill "${server_pid}"
+  fi
   rm -rf a "${ready}" "${lock}"
 
   cat "$TEST_log-2" >> "$TEST_log"


### PR DESCRIPTION
### Description
Interrupt the thread running the command instead of whichever thread calls `onNext`, and do it once instead of on every write past the first cancellation.

Since `CommandServer` sends the command UUID before dispatching, `BlockingStreamObserver` takes that first write to capture the command thread, then interrupts it from the cancel handler, or from the next write when the client is already gone by then.

### Motivation
Fixes #30954.

A canceled CI job left a server holding the command lock, and the next job on that runner slot waited for it until its own 2-hour timeout.

058adaacae08 fixed the caller that spun on this in #30435, the coverage report evaluation, but left `BlockingStreamObserver` interrupting the wrong thread, on every write: a command that stops writing is never told its client is gone, `cli-update-thread` discards the interrupt when it writes first, and a retried interruptible step never converges since each attempt is aborted by the previous report.

### Build API Changes
No

### Checklist
- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes
RELNOTES: Fixed a Bazel server keeping its command lock after its client was killed, which stalled later invocations.