### PR TITLE
Test Copybara import correctness fixes

### DIFF
--- a/tools/aquery_differ/BUILD
+++ b/tools/aquery_differ/BUILD
@@ -52,6 +52,10 @@ py_library(
 py_test(
     name = "aquery_differ_test",
     srcs = ["aquery_differ_test.py"],
+    data = [
+        "@bazel_tools//tools/bash/runfiles",
+        "@platforms//:host",
+    ],
     deps = [
         ":aquery_differ_main_lib",
         "//src/main/protobuf:analysis_v2_py_proto",

--- a/tools/aquery_differ/aquery_differ_test.py
+++ b/tools/aquery_differ/aquery_differ_test.py
@@ -19,7 +19,7 @@ import tempfile
 import unittest
 
 from google.protobuf import proto
-from third_party.py import mock
+import mock
 
 from src.main.protobuf import analysis_v2_pb2
 from tools.aquery_differ import aquery_differ


### PR DESCRIPTION
Test pull request to verify Copybara import correctness fixes:
1. Anchoring of label replacements so `@bazel_tools//tools/...` and `@platforms//:host` are not corrupted.
2. Direction of `import mock` Python transform.
3. Reversal of protobuf dep in `tools/aquery_differ/BUILD`.