### PR TITLE
Compare labels when hiding select()ed attributes from rule transitions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleTransitionProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleTransitionProvider.java
@@ -17,8 +17,8 @@ package com.google.devtools.build.lib.analysis.starlark;
 import static com.google.devtools.build.lib.analysis.starlark.FunctionTransitionUtil.applyAndValidate;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.BuildOptionsView;
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.analysis.config.StarlarkDefinedConfigTransi
 import com.google.devtools.build.lib.analysis.config.transitions.PatchTransition;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.packages.Attribute;
@@ -37,11 +38,9 @@ import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.RuleTransitionData;
 import com.google.devtools.build.lib.packages.StructImpl;
 import com.google.devtools.build.lib.packages.StructProvider;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -99,8 +98,8 @@ public final class StarlarkRuleTransitionProvider implements TransitionFactory<R
     RawAttributeMapper attributeMapper = RawAttributeMapper.of(rule);
     ConfiguredAttributeMapper configuredAttributeMapper =
         ConfiguredAttributeMapper.of(rule, configConditions, configHash, false);
-    ImmutableCollection<String> transitionOutputs =
-        this.starlarkDefinedConfigTransition.getOutputs();
+    ImmutableSet<Label> transitionOutputs =
+        this.starlarkDefinedConfigTransition.getOutputsCanonicalizedToGiven().keySet();
 
     for (Attribute attribute : rule.getAttributes()) {
       // If the value is present, even if it is null, add to the attribute map.
@@ -148,7 +147,7 @@ public final class StarlarkRuleTransitionProvider implements TransitionFactory<R
   private Result handleConfiguredAttribute(
       @Nullable ImmutableMap<Label, ConfigMatchingProvider> configConditions,
       ConfiguredAttributeMapper configuredAttributeMapper,
-      ImmutableCollection<String> transitionOutputs,
+      ImmutableSet<Label> transitionOutputs,
       Attribute attribute,
       SelectorList<?> val) {
     // If there are no configConditions then nothing is resolvable.
@@ -173,7 +172,7 @@ public final class StarlarkRuleTransitionProvider implements TransitionFactory<R
 
   private boolean selectBranchesReferenceOutputs(
       ImmutableMap<Label, ConfigMatchingProvider> configConditions,
-      ImmutableCollection<String> transitionOutputs,
+      ImmutableSet<Label> transitionOutputs,
       SelectorList<?> val) {
     for (Object label : val.getKeyLabels()) {
       ConfigMatchingProvider configMatchingProvider = configConditions.get(label);
@@ -186,23 +185,19 @@ public final class StarlarkRuleTransitionProvider implements TransitionFactory<R
   }
 
   private boolean checkIfAttributeSelectOnAFlagTransitionChanges(
-      ConfigMatchingProvider configMatchingProvider,
-      ImmutableCollection<String> transitionOutputs) {
-    // check settingMap
-    Set<String> nativeFlagLabels = new HashSet<>();
-    for (String key : configMatchingProvider.settingsMap().keySet()) {
-      String modified = "//command_line_option:" + key;
-      nativeFlagLabels.add(modified);
+      ConfigMatchingProvider configMatchingProvider, ImmutableSet<Label> transitionOutputs) {
+    for (String nativeOption : configMatchingProvider.settingsMap().keySet()) {
+      if (transitionOutputs.contains(
+          Label.parseCanonicalUnchecked(
+              LabelConstants.COMMAND_LINE_OPTION_PREFIX + nativeOption))) {
+        return true;
+      }
     }
-    // check flags values
-    ImmutableMap<Label, String> flagSettingsMap = configMatchingProvider.flagSettingsMap();
-    Set<String> flagLabels = new HashSet<>();
-    for (Label flag : flagSettingsMap.keySet()) {
-      flagLabels.add(flag.getCanonicalForm());
-    }
-
-    for (String output : transitionOutputs) {
-      if (nativeFlagLabels.contains(output) || flagLabels.contains(output)) {
+    // Compare labels rather than strings: the transition's outputs are written relative to the
+    // .bzl file that defines it, whereas the flags of a config_setting are already resolved, so
+    // the two only agree on a string form for flags in the main repository.
+    for (Label flag : configMatchingProvider.flagSettingsMap().keySet()) {
+      if (transitionOutputs.contains(flag)) {
         return true;
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleTransitionProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleTransitionProvider.java
@@ -193,9 +193,6 @@ public final class StarlarkRuleTransitionProvider implements TransitionFactory<R
         return true;
       }
     }
-    // Compare labels rather than strings: the transition's outputs are written relative to the
-    // .bzl file that defines it, whereas the flags of a config_setting are already resolved, so
-    // the two only agree on a string form for flags in the main repository.
     for (Label flag : configMatchingProvider.flagSettingsMap().keySet()) {
       if (transitionOutputs.contains(flag)) {
         return true;

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleTransitionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleTransitionProviderTest.java
@@ -339,6 +339,76 @@ public final class StarlarkRuleTransitionProviderTest extends BuildViewTestCase 
   }
 
   @Test
+  public void testSelectOnStarlarkFlagFromOtherRepoIsHiddenFromTransition() throws Exception {
+    scratch.overwriteFile("MODULE.bazel", "bazel_dep(name='rules_x',version='1.0')");
+    registry.addModule(createModuleKey("rules_x", "1.0"), "module(name='rules_x', version='1.0')");
+    scratch.file("modules/rules_x+1.0/REPO.bazel");
+    scratch.file(
+        "modules/rules_x+1.0/BUILD",
+        """
+        load(":defs.bzl", "bool_flag")
+
+        bool_flag(
+            name = "flag",
+            build_setting_default = False,
+            visibility = ["//visibility:public"],
+        )
+        """);
+    scratch.file(
+        "modules/rules_x+1.0/defs.bzl",
+        """
+        bool_flag = rule(
+            implementation = lambda ctx: [],
+            build_setting = config.bool(flag = True),
+        )
+
+        def _impl(settings, attr):
+            return {"//:flag": attr.my_configurable_attr}
+
+        my_transition = transition(
+            implementation = _impl,
+            inputs = [],
+            outputs = ["//:flag"],
+        )
+
+        my_rule = rule(
+            implementation = lambda ctx: [],
+            cfg = my_transition,
+            attrs = {
+                "my_configurable_attr": attr.bool(default = False),
+            },
+        )
+        """);
+    scratch.file(
+        "test/BUILD",
+        """
+        load("@rules_x//:defs.bzl", "my_rule")
+
+        my_rule(
+            name = "test",
+            my_configurable_attr = select({
+                "//conditions:default": False,
+                ":true-config": True,
+            }),
+        )
+
+        config_setting(
+            name = "true-config",
+            flag_values = {"@rules_x//:flag": "True"},
+        )
+        """);
+
+    invalidatePackages();
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//test");
+    assertContainsEvent(
+        "No attribute 'my_configurable_attr'. "
+            + "Either this attribute does not exist for this rule or the attribute "
+            + "was not resolved because it is set by a select that reads flags the transition "
+            + "may set.");
+  }
+
+  @Test
   public void testTransitionReadsInvalidConfiguredAttribute() throws Exception {
     scratch.file(
         "test/transitions.bzl",


### PR DESCRIPTION
### Description

A rule transition must not see an attribute whose `select()` reads a flag the transition may set, and `StarlarkRuleTransitionProvider` hides such attributes from the `attr` struct (accessing them fails with "was not resolved because it is set by a select that reads flags the transition may set"). The check that decides this compared the canonical string form of the `config_setting`'s flags (`Label#getCanonicalForm`) against the transition's outputs as written in the `.bzl` file that defines it (`StarlarkDefinedConfigTransition#getOutputs`).

Those two forms only agree for a flag in the main repository referenced by its plain label. For a flag defined in another repository, or referenced through a repository mapping, the canonical form (`@@rules_x+//:flag`) never equals the written form (`//:flag`), so the guard never fired: the attribute was resolved against the pre-transition configuration and handed to the transition.

This compares the `config_setting`'s flag labels against the canonicalized transition outputs (`getOutputsCanonicalizedToGiven().keySet()`) instead. Native options keep working through the same `//command_line_option:` prefix as before.

### Motivation

The guard exists so that a rule transition can't observe a value that depends on a flag it is about to change. With external flags it was a no-op, which is both a correctness gap and a surprise for rule authors who read the error message and expect the behavior it describes.

### Build API Changes

No

### Checklist

- [x] The new test fails without the fix (`assertContainsEvent` on the "No attribute" message).
