### PR TITLE
[9.3.0] Retry HTTP 408 and 429 in HTTP_RESULT_CLASSIFIER

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -245,7 +245,9 @@ public final class RemoteModule extends BlazeModule {
             return Result.SUCCESS;
           }
           retry =
-              status == HttpResponseStatus.INTERNAL_SERVER_ERROR.code()
+              status == HttpResponseStatus.REQUEST_TIMEOUT.code()
+                  || status == HttpResponseStatus.TOO_MANY_REQUESTS.code()
+                  || status == HttpResponseStatus.INTERNAL_SERVER_ERROR.code()
                   || status == HttpResponseStatus.BAD_GATEWAY.code()
                   || status == HttpResponseStatus.SERVICE_UNAVAILABLE.code()
                   || status == HttpResponseStatus.GATEWAY_TIMEOUT.code();


### PR DESCRIPTION
### Description

Add REQUEST_TIMEOUT (408) and TOO_MANY_REQUESTS (429) to the retryable status set for the HTTP remote cache client, alongside the existing 500/502/503/504.

### Motivation

With --experimental_remote_repo_contents_cache pointed at an HTTP backend like GCS, a burst of concurrent CI jobs against a cold repo-contents object can trip GCS's per-object ramp-up throttling. GCS surfaces the throttle as HTTP 429 SlowDown. The current classifier does not treat 429 as retryable, so a single throttled lookup propagates as an IOException and aborts the load phase with:

> ERROR: error loading package '@@repo//pkg': 429 Too Many Requests <?xml ...><Error><Code>SlowDown</Code>...

Precedent: HttpConnector is used for http_archive/go_repository fetches and has always retried 408/429 with exponential backoff and jitter. The remote-cache HTTP client is the only HTTP path in Bazel that treats them as terminal.

Related #29744.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Retry 408 and 429 status codes with HTTP remote caching.

Closes #30130.

PiperOrigin-RevId: 956343172
Change-Id: Ic54dcd1b87985a93c1dbbcd9ec4b75bcafe8b92b

(cherry picked from commit 6f42e59a175801c5986f840a13ea46d5c935dc5e)

Closes #30133
