### PR TITLE
[9.3.0] {r,m}ctx.download*: report size of downloaded file

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -541,8 +541,10 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
   private StructImpl calculateDownloadResult(Optional<Checksum> checksum, Path downloadedPath)
       throws InterruptedException, RepositoryFunctionException {
     Checksum finalChecksum;
+    long size;
     try {
       finalChecksum = calculateChecksum(checksum, downloadedPath);
+      size = downloadedPath.getFileSize();
     } catch (IOException e) {
       throw new RepositoryFunctionException(
           new IOException(
@@ -558,6 +560,7 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
     if (finalChecksum.getKeyType() == KeyType.SHA256) {
       out.put("sha256", finalChecksum.toString());
     }
+    out.put("size_bytes", StarlarkInt.of(size));
     return StarlarkInfo.create(StructProvider.STRUCT, out.buildOrThrow(), Location.BUILTIN);
   }
 
@@ -671,7 +674,8 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
 Downloads a file to the output path for the provided url and returns a struct \
 containing <code>success</code>, a flag which is <code>true</code> if the \
 download completed successfully, and if successful, a hash of the file \
-with the fields <code>sha256</code> and <code>integrity</code>. \
+with the fields <code>sha256</code> and <code>integrity</code>, as well as \
+<code>size_bytes</code>, which contains the size of the downloaded file in bytes as an integer. \
 When <code>sha256</code> or <code>integrity</code> is user specified, setting an explicit \
 <code>canonical_id</code> is highly recommended. e.g. \
 <a href='/rules/lib/repo/cache#get_default_canonical_id'><code>get_default_canonical_id</code></a>
@@ -889,7 +893,8 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
 Downloads a file to the output path for the provided url, extracts it, and returns a \
 struct containing <code>success</code>, a flag which is <code>true</code> if the \
 download completed successfully, and if successful, a hash of the file with the \
-fields <code>sha256</code> and <code>integrity</code>. \
+fields <code>sha256</code> and <code>integrity</code>, as well as the <code>size_bytes</code> \
+of the downloaded file in bytes as an integer. \
 When <code>sha256</code> or <code>integrity</code> is user specified, setting an explicit \
 <code>canonical_id</code> is highly recommended. e.g. \
 <a href='/rules/lib/repo/cache#get_default_canonical_id'><code>get_default_canonical_id</code></a>


### PR DESCRIPTION
### Description

Adds a new structure field `size_bytes` in the return value of `rctx.download` (and friends) containing the file size of the downloaded file.

### Motivation

This is a useful piece of metadata Bazel provides to repository rules and module extensions. Motivation for adding this: I need the ability to annotate BUILD files with sizes of downloaded files in rules_runfiles_group (https://github.com/hermeticbuild/rules_runfiles_group). This makes it possible to merge runfiles groups based on their "weight", which may include actual file sizes of *_import targets (java_import, cc_import, ...).

### Build API Changes

It does affect the Build API, but is backwards compatible (adding a new field).
Existing users will not be impacted.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES[NEW]: {r,m}ctx.download* report the size of downloaded files
RELNOTES: Addition to the user-facing Build API

Closes #29463.

PiperOrigin-RevId: 910706646
Change-Id: I980cdee803810e1fb6222f69782fcad2648af68d

(cherry picked from commit 7896f7318db92b525ba2cdbd446301e464943b4c)

9.3.0 adaptation: only the production change applies. The branch's `StarlarkBaseExternalContextTest` predates the `rctx.download` tests entirely (it only holds `docSupportedFormats`), so the two `size_bytes` assertions have nowhere to go and the new field ships without test coverage on this branch (porting the harness would mean pulling in unrelated master-only test infrastructure). Additionally, the doc-string edits drop the master-only "If the value of the `success` field is false ..." paragraph, which does not exist on the branch.

Closes #29466
