### PR TITLE
[9.3.0] Avoid CPU-load scheduling deadlocks

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
@@ -610,9 +610,10 @@ public class ResourceManager implements ResourceEstimator {
   }
 
   private <T extends Number> boolean isAvailable(
-      T available, T used, T requested, String resourceName) throws UserExecException {
+      T available, T trackedUsage, T effectiveUsage, T requested, String resourceName)
+      throws UserExecException {
     if (!allowOneActionOnResourceUnavailable
-        && available.doubleValue() + used.doubleValue() < requested.doubleValue()) {
+        && available.doubleValue() + effectiveUsage.doubleValue() < requested.doubleValue()) {
       throw new UserExecException(
           FailureDetails.FailureDetail.newBuilder()
               .setMessage(
@@ -630,15 +631,13 @@ public class ResourceManager implements ResourceEstimator {
     }
     // Resources are considered available if any one of the conditions below is true:
     // 1) If resource is not requested at all, it is available.
-    // 2) If resource is not used at the moment and the flag
+    // 2) If resource is not tracked as used at the moment and the flag
     // "allow_one_action_on_resource_unavailable" is enabled, it is considered to be
-    // available regardless of how much is requested. This is necessary to
-    // ensure that at any given time, at least one thread is able to acquire
-    // resources even if it requests more than available.
-    // 3) If used resource amount is less than total available resource amount.
+    // available regardless of how much is requested.
+    // 3) If effective resource usage and the requested amount fit within the available amount.
     return requested.doubleValue() == 0
-        || (allowOneActionOnResourceUnavailable && used.doubleValue() == 0)
-        || used.doubleValue() + requested.doubleValue() <= available.doubleValue();
+        || (allowOneActionOnResourceUnavailable && trackedUsage.doubleValue() == 0)
+        || effectiveUsage.doubleValue() + requested.doubleValue() <= available.doubleValue();
   }
 
   // Method will return true if all requested resources are considered to be available.
@@ -664,6 +663,7 @@ public class ResourceManager implements ResourceEstimator {
     if (!isAvailable(
         availableLocalTestCount,
         usedLocalTestCount,
+        usedLocalTestCount,
         resources.getLocalTestCount(),
         "local_test_count")) {
       return false;
@@ -687,7 +687,7 @@ public class ResourceManager implements ResourceEstimator {
           resource.getValue() * MIN_NECESSARY_RATIO.getOrDefault(key, DEFAULT_MIN_NECESSARY_RATIO);
       double used = usedResources.getOrDefault(key, 0.0);
       double available = availableResources.get(key);
-      if (!isAvailable(available, used, requested, key)) {
+      if (!isAvailable(available, used, used, requested, key)) {
         return false;
       }
     }
@@ -703,16 +703,19 @@ public class ResourceManager implements ResourceEstimator {
     double used = usedResources.getOrDefault(key, 0.0);
 
     if (cpuLoadScheduling) {
-      double currentUsage = machineLoadProvider.getCurrentCpuUsage();
-      double windowEstimation = windowEstimationCpu;
-      // Don't allow to run more than x3 of number cores actions simultaneously.
-      if (runningActions >= MAX_ACTIONS_PER_CPU * availableResources.get(ResourceSet.CPU)) {
+      // Allow the first action past the cap when no local action is running.
+      if (runningActions != 0 && runningActions >= MAX_ACTIONS_PER_CPU * available) {
         return false;
       }
-      return isAvailable(available, windowEstimation + currentUsage, requested, key);
+      return isAvailable(
+          available,
+          used,
+          windowEstimationCpu + machineLoadProvider.getCurrentCpuUsage(),
+          requested,
+          key);
     }
 
-    return isAvailable(available, used, requested, key);
+    return isAvailable(available, used, used, requested, key);
   }
 
   @VisibleForTesting

--- a/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
@@ -798,6 +798,56 @@ public final class ResourceManagerTest {
   }
 
   @Test
+  public void testCPULoadScheduling_allowsOneActionWhenCpuUnavailable() throws Exception {
+    manager.setAllowOneActionOnResourceUnavailable(true);
+    manager.initializeCpuLoadFunctionality(machineLoadProvider, true, Duration.ofSeconds(5));
+    when(machineLoadProvider.getCurrentCpuUsage()).thenReturn(1.0);
+
+    for (double availableCpu : new double[] {1, 0, -1}) {
+      manager.setAvailableResources(
+          ResourceSet.create(
+              /* memoryMb= */ 1000, /* cpu= */ availableCpu, /* localTestCount= */ 2));
+
+      assertThat(isAvailable(manager, 0, 1, 0)).isTrue();
+      ResourceHandle handle = acquire(0, 1, 0);
+      assertThat(isAvailable(manager, 0, 1, 0)).isFalse();
+      release(handle);
+    }
+  }
+
+  @Test
+  public void testCPULoadScheduling_allowsExplicitZeroCpuWithNoCpuCapacity() throws Exception {
+    manager.initializeCpuLoadFunctionality(machineLoadProvider, true, Duration.ofSeconds(5));
+    manager.setAvailableResources(
+        ResourceSet.create(/* memoryMb= */ 1000, /* cpu= */ 0, /* localTestCount= */ 2));
+    when(machineLoadProvider.getCurrentCpuUsage()).thenReturn(1.0);
+
+    for (boolean allowOneAction : new boolean[] {false, true}) {
+      manager.setAllowOneActionOnResourceUnavailable(allowOneAction);
+      TestThread thread =
+          new TestThread(
+              () -> {
+                ResourceHandle handle = acquire(0, 0, 0);
+                release(handle);
+              });
+      thread.setDaemon(true);
+      thread.start();
+      thread.joinAndAssertState(TestUtils.WAIT_TIMEOUT_MILLISECONDS);
+    }
+  }
+
+  @Test
+  public void testCPULoadScheduling_allowsOneCpuActionWhileMemoryIsInUse() throws Exception {
+    manager.setAllowOneActionOnResourceUnavailable(true);
+    manager.initializeCpuLoadFunctionality(machineLoadProvider, true, Duration.ofSeconds(5));
+    when(machineLoadProvider.getCurrentCpuUsage()).thenReturn(1.0);
+
+    ResourceHandle memoryHandle = acquire(1, 0, 0);
+    assertThat(isAvailable(manager, 0, 1, 0)).isTrue();
+    release(memoryHandle);
+  }
+
+  @Test
   public void testCPULoadScheduling_cantAcquireX3Cpu() throws Exception {
     manager.initializeCpuLoadFunctionality(machineLoadProvider, true, Duration.ofSeconds(5));
     // Set load only for 0.1 CPU
@@ -807,13 +857,18 @@ public final class ResourceManagerTest {
       TestThread thread =
           new TestThread(
               () -> {
-                acquire(0, 1, 0);
+                acquire(0, 0, 0);
                 latch.countDown();
               });
       thread.start();
       latch.await();
       manager.windowUpdate();
     }
+    manager.setAllowOneActionOnResourceUnavailable(true);
+    assertThat(isAvailable(manager, 0, 0, 0)).isFalse();
+    assertThat(isAvailable(manager, 0, 1, 0)).isFalse();
+    manager.setAllowOneActionOnResourceUnavailable(false);
+
     TestThread thread4 =
         new TestThread(
             () -> {


### PR DESCRIPTION
CPU-load scheduling rejects the first action when CPU capacity is zero because the action cap evaluates 0 >= 3 * 0. The request is then queued on a latch that no running action can release.

Check the hard action cap before sampling machine load, allow only the first local action past a zero-capacity cap, and distinguish tracked CPU usage from effective machine load when applying the allow-one policy. Enforce the cap on subsequent zero- and positive-CPU requests.

Cover loaded positive, zero, and negative CPU capacity; explicit zero-CPU requests; non-CPU resource use; and the action cap.

Fixes #28713.

Closes #30310.

PiperOrigin-RevId: 975003327
Change-Id: I153308322b807f983b1815e039a8d5860f930408

(cherry picked from commit 38e4a849b331f021353987c505d08c14579cdb62)

9.3.0 adaptation: this branch's `isAvailable` is the generic `<T extends Number>` overload that also takes a `resourceName` and throws `UserExecException` when a request can never be satisfied. The new `trackedUsage`/`effectiveUsage` split is threaded through that signature; the unsatisfiable-request guard keeps using the effective usage, which leaves its behavior unchanged at every existing call site. The branch has no memory-load scheduling, so `isMemoryAvailable` and the memory-load tests are not part of the pick, and the three new tests use the branch's 3-argument `initializeCpuLoadFunctionality`. All 23 `ResourceManagerTest` cases pass locally.

Closes #30324
