### PR TITLE
[9.3.0] Support pass-through `Args` for `JavaBuilder` in `java_common.create_compilation_action`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.CommandLine;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ParamFileInfo;
 import com.google.devtools.build.lib.actions.ParameterFile;
@@ -73,6 +74,7 @@ public final class JavaCompilationHelper {
   private final ImmutableList<Artifact> additionalInputsForDatabinding;
   private boolean enableJspecify = true;
   private boolean enableDirectClasspath = true;
+  private ImmutableList<CommandLine> extraCommandLineArgs = ImmutableList.of();
   private final String execGroup;
 
   public JavaCompilationHelper(
@@ -102,6 +104,10 @@ public final class JavaCompilationHelper {
 
   public void enableJspecify(boolean enableJspecify) {
     this.enableJspecify = enableJspecify;
+  }
+
+  public void setExtraCommandLineArgs(ImmutableList<CommandLine> extraCommandLineArgs) {
+    this.extraCommandLineArgs = Preconditions.checkNotNull(extraCommandLineArgs);
   }
 
   JavaTargetAttributes getAttributes() {
@@ -296,6 +302,7 @@ public final class JavaCompilationHelper {
     builder.setStrictJavaDeps(attributes.getStrictJavaDeps());
     builder.setFixDepsTool(getJavaConfiguration().getFixDepsTool());
     builder.setCompileTimeDependencyArtifacts(attributes.getCompileTimeDependencyArtifacts());
+    builder.setExtraCommandLineArgs(extraCommandLineArgs);
     builder.setTargetLabel(
         attributes.getTargetLabel() == null ? label : attributes.getTargetLabel());
     builder.setInjectingRuleKind(attributes.getInjectingRuleKind());

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -123,6 +123,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
   private final ImmutableMap<String, String> executionInfo;
   private final CommandLine executableLine;
   private final CommandLine flagLine;
+  private final ImmutableList<CommandLine> extraCommandLineArgs;
   private final BuildConfigurationValue configuration;
   private final OnDemandString progressMessage;
 
@@ -149,6 +150,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
       ExtraActionInfoSupplier extraActionInfoSupplier,
       CommandLine executableLine,
       CommandLine flagLine,
+      ImmutableList<CommandLine> extraCommandLineArgs,
       BuildConfigurationValue configuration,
       NestedSet<Artifact> dependencyArtifacts,
       Artifact outputDepsProto,
@@ -171,6 +173,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
         configuration.modifiedExecutionInfo(executionInfo, compilationType.mnemonic);
     this.executableLine = executableLine;
     this.flagLine = flagLine;
+    this.extraCommandLineArgs = extraCommandLineArgs;
     this.configuration = configuration;
     this.progressMessage = progressMessage;
     this.extraActionInfoSupplier = extraActionInfoSupplier;
@@ -230,6 +233,10 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
         actionKeyContext, inputMetadataProvider, effectiveOutputPathsMode, fp);
     flagLine.addToFingerprint(
         actionKeyContext, inputMetadataProvider, effectiveOutputPathsMode, fp);
+    for (CommandLine extraCommandLine : extraCommandLineArgs) {
+      extraCommandLine.addToFingerprint(
+          actionKeyContext, inputMetadataProvider, effectiveOutputPathsMode, fp);
+    }
     // As the classpath is no longer part of commandLines implicitly, we need to explicitly add
     // the transitive inputs to the key here.
     actionKeyContext.addNestedSetToFingerprint(fp, transitiveInputs);
@@ -323,12 +330,15 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
       classpathLine.add("--reduce_classpath_mode", fallback ? "BAZEL_FALLBACK" : "BAZEL_REDUCED");
     }
 
-    CommandLines reducedCommandLine =
+    CommandLines.Builder commandLinesBuilder =
         CommandLines.builder()
             .addCommandLine(executableLine)
             .addCommandLine(flagLine, PARAM_FILE_INFO)
-            .addCommandLine(classpathLine.build(), PARAM_FILE_INFO)
-            .build();
+            .addCommandLine(classpathLine.build(), PARAM_FILE_INFO);
+    for (CommandLine extraCommandLine : extraCommandLineArgs) {
+      commandLinesBuilder.addCommandLine(extraCommandLine, PARAM_FILE_INFO);
+    }
+    CommandLines reducedCommandLine = commandLinesBuilder.build();
     CommandLines.ExpandedCommandLines expandedCommandLines =
         reducedCommandLine.expand(
             actionExecutionContext.getInputMetadataProvider(),
@@ -575,11 +585,12 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
   public ExtraActionInfo.Builder getExtraActionInfo(ActionKeyContext actionKeyContext)
       throws CommandLineExpansionException, InterruptedException {
     ExtraActionInfo.Builder builder = super.getExtraActionInfo(actionKeyContext);
-    CommandLines commandLinesWithoutExecutable =
-        CommandLines.builder()
-            .addCommandLine(flagLine)
-            .addCommandLine(getFullClasspathLine())
-            .build();
+    CommandLines.Builder commandLinesBuilder =
+        CommandLines.builder().addCommandLine(flagLine).addCommandLine(getFullClasspathLine());
+    for (CommandLine extraCommandLine : extraCommandLineArgs) {
+      commandLinesBuilder.addCommandLine(extraCommandLine);
+    }
+    CommandLines commandLinesWithoutExecutable = commandLinesBuilder.build();
     if (extraActionInfoSupplier != null) {
       extraActionInfoSupplier.extend(builder, commandLinesWithoutExecutable.allArguments());
     }
@@ -630,11 +641,15 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
 
   @VisibleForTesting
   public CommandLines getCommandLines() {
-    return CommandLines.builder()
-        .addCommandLine(executableLine)
-        .addCommandLine(flagLine, PARAM_FILE_INFO)
-        .addCommandLine(getFullClasspathLine(), PARAM_FILE_INFO)
-        .build();
+    CommandLines.Builder builder =
+        CommandLines.builder()
+            .addCommandLine(executableLine)
+            .addCommandLine(flagLine, PARAM_FILE_INFO)
+            .addCommandLine(getFullClasspathLine(), PARAM_FILE_INFO);
+    for (CommandLine extraCommandLine : extraCommandLineArgs) {
+      builder.addCommandLine(extraCommandLine, PARAM_FILE_INFO);
+    }
+    return builder.build();
   }
 
   private CommandLine getFullClasspathLine() {

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.ActionAnalysisMetadata;
 import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.CommandLine;
 import com.google.devtools.build.lib.actions.extra.ExtraActionInfo;
 import com.google.devtools.build.lib.actions.extra.JavaCompileInfo;
 import com.google.devtools.build.lib.analysis.RuleContext;
@@ -157,6 +158,7 @@ public final class JavaCompileActionBuilder {
   private NestedSet<Artifact> extraData = NestedSetBuilder.emptySet(Order.NAIVE_LINK_ORDER);
   private Label targetLabel;
   @Nullable private String injectingRuleKind;
+  private ImmutableList<CommandLine> extraCommandLineArgs = ImmutableList.of();
   private ImmutableList<Artifact> additionalInputs = ImmutableList.of();
   private Artifact genSourceOutput;
   private JavaCompileOutputs<Artifact> outputs;
@@ -260,6 +262,7 @@ public final class JavaCompileActionBuilder {
         /* extraActionInfoSupplier= */ extraActionInfoSupplier,
         /* executableLine= */ executableLine,
         /* flagLine= */ buildParamFileContents(javacOpts),
+        /* extraCommandLineArgs= */ extraCommandLineArgs,
         /* configuration= */ ruleContext.getConfiguration(),
         /* dependencyArtifacts= */ compileTimeDependencyArtifacts,
         /* outputDepsProto= */ outputs.depsProto(),
@@ -375,6 +378,13 @@ public final class JavaCompileActionBuilder {
       NestedSet<Artifact> dependencyArtifacts) {
     checkNotNull(compileTimeDependencyArtifacts, "dependencyArtifacts must not be null");
     this.compileTimeDependencyArtifacts = dependencyArtifacts;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public JavaCompileActionBuilder setExtraCommandLineArgs(
+      ImmutableList<CommandLine> extraCommandLineArgs) {
+    this.extraCommandLineArgs = checkNotNull(extraCommandLineArgs);
     return this;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
@@ -641,6 +641,7 @@ public final class JavaHeaderCompileAction extends SpawnAction {
               /* extraActionInfoSupplier= */ null,
               /* executableLine= */ executableLine,
               /* flagLine= */ commandLine.build(),
+              /* extraCommandLineArgs= */ ImmutableList.of(),
               /* configuration= */ ruleContext.getConfiguration(),
               /* dependencyArtifacts= */ compileTimeDependencyArtifacts,
               /* outputDepsProto= */ outputDepsProto,

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.CommandLine;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.Expander;
 import com.google.devtools.build.lib.analysis.RuleContext;
@@ -30,6 +31,7 @@ import com.google.devtools.build.lib.analysis.configuredtargets.AbstractConfigur
 import com.google.devtools.build.lib.analysis.configuredtargets.MergedConfiguredTarget;
 import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.analysis.platform.ToolchainInfo;
+import com.google.devtools.build.lib.analysis.starlark.Args;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkActionFactory;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkRuleContext;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -201,7 +203,8 @@ public class JavaStarlarkCommon
       boolean enableJSpecify,
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
-      Sequence<?> additionalOutputs)
+      Sequence<?> additionalOutputs,
+      Sequence<?> extraArgs)
       throws EvalException,
           TypeException,
           RuleErrorException,
@@ -217,6 +220,11 @@ public class JavaStarlarkCommon
             .nativeHeader(nativeHeader == Starlark.NONE ? null : (Artifact) nativeHeader)
             .manifestProto(manifestProto)
             .build();
+    ImmutableList.Builder<CommandLine> extraCommandLineArgs = ImmutableList.builder();
+    for (Args args : Sequence.cast(extraArgs, Args.class, "extra_args")) {
+      extraCommandLineArgs.add(
+          args.build(ctx.getRuleContext().getAnalysisEnvironment()::getMainRepoMapping));
+    }
     JavaTargetAttributes.Builder attributesBuilder =
         new JavaTargetAttributes.Builder()
             .addSourceJars(Sequence.cast(sourceJars, Artifact.class, "source_jars"))
@@ -261,6 +269,7 @@ public class JavaStarlarkCommon
         Depset.cast(javaBuilderJvmFlags, String.class, "javabuilder_jvm_flags"));
     compilationHelper.enableJspecify(enableJSpecify);
     compilationHelper.enableDirectClasspath(enableDirectClasspath);
+    compilationHelper.setExtraCommandLineArgs(extraCommandLineArgs.build());
     compilationHelper.createCompileAction(outputs);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.collect.nestedset.Depset.TypeException;
 import com.google.devtools.build.lib.packages.Info;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
+import com.google.devtools.build.lib.starlarkbuildapi.CommandLineArgsApi;
 import com.google.devtools.build.lib.starlarkbuildapi.FileApi;
 import com.google.devtools.build.lib.starlarkbuildapi.StarlarkActionFactoryApi;
 import com.google.devtools.build.lib.starlarkbuildapi.StarlarkRuleContextApi;
@@ -524,6 +525,14 @@ public interface JavaCommonApi<
         @Param(name = "enable_direct_classpath", defaultValue = "True", named = true),
         @Param(name = "additional_inputs", defaultValue = "[]", named = true),
         @Param(name = "additional_outputs", defaultValue = "[]", named = true),
+        @Param(
+            name = "extra_args",
+            allowedTypes = {
+              @ParamType(type = Sequence.class, generic1 = CommandLineArgsApi.class),
+            },
+            defaultValue = "[]",
+            named = true,
+            positional = false),
       })
   void createCompilationAction(
       StarlarkRuleContextT ctx,
@@ -553,7 +562,8 @@ public interface JavaCommonApi<
       boolean enableJSpecify,
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
-      Sequence<?> additionalOutputs)
+      Sequence<?> additionalOutputs,
+      Sequence<?> extraArgs)
       throws EvalException,
           TypeException,
           RuleErrorException,

--- a/src/main/starlark/builtins_bzl/common/java/java_common.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_common.bzl
@@ -18,6 +18,7 @@ _java_common_internal = _builtins.internal.java_common_internal_do_not_use
 
 def _internal_exports():
     _builtins.internal.cc_internal.check_private_api(allowlist = [
+        ("", "bazel_internal/test_rules"),
         ("", "javatests/com/google/devtools/grok/kythe/analyzers/build/testdata/pkg"),
         ("", "third_party/bazel_rules/rules_java"),
         ("rules_java", ""),

--- a/src/test/java/com/google/devtools/build/lib/rules/java/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/BUILD
@@ -64,6 +64,7 @@ java_test(
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
         "//src/test/java/com/google/devtools/build/lib/rules/java:java_compile_action_test_helper",
         "//src/test/java/com/google/devtools/build/lib/testutil:JunitUtils",
+        "//src/test/java/com/google/devtools/build/lib/testutil:TestConstants",
         "//third_party:junit4",
         "//third_party:truth",
     ],

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.testutil.MoreAsserts;
+import com.google.devtools.build.lib.testutil.TestConstants;
 import com.google.devtools.build.lib.view.proto.Deps;
 import com.google.devtools.build.lib.view.proto.Deps.Dependency.Kind;
 import java.util.ArrayList;
@@ -203,5 +204,59 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
                 action.getReducedClasspath(new ActionExecutionContextBuilder().build(), context)))
         .containsExactly(
             "bin java/com/google/test/libb-hjar.jar", "bin java/com/google/test/libc-hjar.jar");
+  }
+
+  @Test
+  public void testExtraArgsPropagated() throws Exception {
+    scratch.file("bazel_internal/test_rules/BUILD");
+    scratch.file(
+        "bazel_internal/test_rules/rule.bzl",
+        String.format(
+            """
+            load("@rules_java//java:defs.bzl", "JavaPluginInfo", rules_java_common = "java_common")
+            internal_common = java_common.internal_DO_NOT_USE()
+            def _my_rule_impl(ctx):
+                output = ctx.outputs.jar
+                args = ctx.actions.args()
+                args.add("--foo=bar")
+                internal_common.create_compilation_action(
+                    ctx,
+                    ctx.toolchains["%1$s"].java,
+                    output,
+                    ctx.actions.declare_file(ctx.label.name + ".manifest"),
+                    JavaPluginInfo(runtime_deps = []),
+                    depset(),
+                    depset(),
+                    depset(),
+                    depset(),
+                    depset(),
+                    depset(),
+                    "ERROR",
+                    ctx.label,
+                    extra_args = [args],
+                )
+                return [DefaultInfo(files = depset([output]))]
+
+            my_rule = rule(
+                implementation = _my_rule_impl,
+                outputs = {
+                    "jar": "%%{name}.jar",
+                },
+                fragments = ["java"],
+                toolchains = ["%1$s"],
+            )
+            """,
+            TestConstants.JAVA_TOOLCHAIN_TYPE));
+    scratch.file(
+        "java/com/google/test/BUILD",
+        """
+        load("//bazel_internal/test_rules:rule.bzl", "my_rule")
+        my_rule(name = "a")
+        """);
+
+    JavaCompileAction compileAction =
+        (JavaCompileAction) getGeneratingActionForLabel("//java/com/google/test:a.jar");
+    List<String> command = getJavacArguments(compileAction);
+    assertThat(command).contains("--foo=bar");
   }
 }


### PR DESCRIPTION
This allows faster iteration on the `rules_java` <> `JavaBuilder` contract without having to wait for Bazel changes/releases. In the immediate future, this will be used for the unused-deps checking. Longer term this should also help in migrating off the native compilation code.

Note: the added integration shell test is currently a no-op on CI (since we need the corresponding rules_java changes) but does allow for local testing with an overridden `@rules_java`.

Closes #30808.

PiperOrigin-RevId: 971826913
Change-Id: I8047e057716475a7a4d8bff48b8c7bfe6d79ba1c

(cherry picked from commit 0e6f09da6d84d0f5048838b9992d95d2a6281043)

9.3.0 adaptation: `java_common.bzl` has no `_ALLOWLIST` constant on this branch, so `bazel_internal/test_rules` is added to the allowlist passed inline to `check_private_api`. `JavaCompileActionBuilderTest` needed a `testutil:TestConstants` dep for the new test. The `bazel_java_test.sh` cases are left out: they exercise `--experimental_check_unused_deps`, which is a JavaBuilder option added by #30807 and not present on this branch, and they are a no-op on CI anyway. `JavaCompileActionBuilderTest` and all four shards of `//src/test/shell/bazel:bazel_java_test_jdk17_toolchain_head` pass locally.

Closes #30968
