### PR TITLE
[9.3.0] Skip chunk downloads by lazily indexing output files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -295,12 +295,14 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
    * Downloads file to the given path via its metadata.
    *
    * @param tempPath the temporary path which the input should be written to.
+   * @param finalPath the path the downloaded file will be moved to once the download completes.
    */
   protected abstract ListenableFuture<Void> doDownloadFile(
       @Nullable ActionExecutionMetadata action,
       Reporter reporter,
       ActionInput input,
       Path tempPath,
+      Path finalPath,
       FileArtifactValue metadata,
       Priority priority,
       Reason reason)
@@ -673,6 +675,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
                                 reporter,
                                 input,
                                 tempPath.forHostFileSystem(),
+                                finalPath,
                                 metadata,
                                 priority,
                                 reason),

--- a/src/main/java/com/google/devtools/build/lib/remote/ChunkLocationMap.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ChunkLocationMap.java
@@ -1,0 +1,110 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote;
+
+import build.bazel.remote.execution.v2.Digest;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
+import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.vfs.Path;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * A bounded map from a chunk digest to a place on local disk where that chunk was recently seen: a
+ * whole file and a byte offset into it.
+ *
+ * <p>A location is only a hint. It points into a build output, which may be deleted or rewritten at
+ * any time, including while it is being read. Chunks read from a location are therefore always
+ * verified against the requested digest, and anything unexpected is reported as a miss.
+ *
+ * <p>The map stores no content of its own and is never written to disk. Losing it costs nothing
+ * beyond the downloads it would have saved, so it lives in memory for as long as the server does.
+ */
+@ThreadSafe
+public final class ChunkLocationMap {
+  private static final int MAX_ENTRIES = 100_000; // ~20MB of heap.
+
+  private final Cache<Digest, ChunkLocation> locations =
+      Caffeine.newBuilder().maximumSize(MAX_ENTRIES).build();
+
+  /**
+   * Records where each chunk of {@code path} can be found, given that the contents of the file are
+   * the concatenation of {@code chunkDigests}.
+   */
+  void addFile(Path path, List<Digest> chunkDigests) {
+    Path hostPath = path.forHostFileSystem();
+    long offset = 0;
+    for (Digest chunkDigest : chunkDigests) {
+      locations.put(chunkDigest, new ChunkLocation(hostPath, offset));
+      offset += chunkDigest.getSizeBytes();
+    }
+  }
+
+  /**
+   * Reads a chunk from the location it was most recently seen at, verifying it against {@code
+   * digest}.
+   *
+   * @param destination the file the chunk is about to be written to, if it is known. Locations
+   *     inside that file are ignored, as the download in progress is overwriting it.
+   * @return the contents of the chunk, or {@code null} if no usable location is known
+   */
+  @Nullable
+  byte[] read(Digest digest, @Nullable Path destination, DigestUtil digestUtil) {
+    ChunkLocation location = locations.getIfPresent(digest);
+    if (location == null) {
+      return null;
+    }
+    // Skipping the destination is an optimization, not a correctness requirement: the location
+    // could still alias the destination through a symlink or hard link, in which case the read
+    // below races with the download overwriting it. Since every chunk is verified, bytes that
+    // match the digest are the correct chunk content no matter which file they were read from,
+    // and anything else is reported as a miss.
+    if (destination != null && location.path().equals(destination.forHostFileSystem())) {
+      return null;
+    }
+
+    byte[] chunk = location.read(digest, digestUtil);
+    if (chunk == null) {
+      locations.asMap().remove(digest, location);
+    }
+    return chunk;
+  }
+
+  /** Removes all entries. */
+  void clear() {
+    locations.invalidateAll();
+  }
+
+  /** The byte offset of a chunk within a file that contained it when it was last seen. */
+  private record ChunkLocation(Path path, long offset) {
+
+    /** Returns the chunk at this location, or {@code null} if it is no longer there. */
+    @Nullable
+    byte[] read(Digest digest, DigestUtil digestUtil) {
+      try (InputStream in = path.getInputStream()) {
+        int size = Math.toIntExact(digest.getSizeBytes());
+        in.skipNBytes(offset);
+        byte[] chunk = in.readNBytes(size);
+        return chunk.length == size && digest.equals(digestUtil.compute(chunk)) ? chunk : null;
+      } catch (IOException | ArithmeticException e) {
+        return null;
+      }
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloader.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.remote;
 
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 
@@ -22,10 +23,12 @@ import build.bazel.remote.execution.v2.SplitBlobResponse;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.remote.common.BlobNotSplittableException;
+import com.google.devtools.build.lib.remote.common.MaybePathBacked;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.util.DigestOutputStream;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.Utils;
+import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -45,12 +48,17 @@ public class ChunkedBlobDownloader {
   private final GrpcCacheClient grpcCacheClient;
   private final CombinedCache combinedCache;
   private final DigestUtil digestUtil;
+  private final ChunkLocationMap chunkLocationMap;
 
-  public ChunkedBlobDownloader(
-      GrpcCacheClient grpcCacheClient, CombinedCache combinedCache, DigestUtil digestUtil) {
+  ChunkedBlobDownloader(
+      GrpcCacheClient grpcCacheClient,
+      CombinedCache combinedCache,
+      DigestUtil digestUtil,
+      ChunkLocationMap chunkLocationMap) {
     this.grpcCacheClient = grpcCacheClient;
     this.combinedCache = combinedCache;
     this.digestUtil = digestUtil;
+    this.chunkLocationMap = chunkLocationMap;
   }
 
   /**
@@ -61,6 +69,14 @@ public class ChunkedBlobDownloader {
   public void downloadChunked(
       RemoteActionExecutionContext context, Digest blobDigest, OutputStream out)
       throws IOException, InterruptedException {
+    // The file being written to must not be used as a chunk source, while the final path (which
+    // differs when the caller stages the download in a temporary location) is recorded as one.
+    @Nullable Path destination = null;
+    @Nullable Path finalDestination = null;
+    if (out instanceof MaybePathBacked pathBacked) {
+      destination = pathBacked.maybeGetPath();
+      finalDestination = pathBacked.maybeGetFinalPath();
+    }
     @Nullable DigestOutputStream digestOut = null;
     if (grpcCacheClient.shouldVerifyDownloads()) {
       digestOut = digestUtil.newDigestOutputStream(out);
@@ -68,9 +84,15 @@ public class ChunkedBlobDownloader {
     }
 
     List<Digest> chunkDigests = getChunkDigests(context, blobDigest);
-    downloadAndReassembleChunks(context, chunkDigests, out);
+    new DownloadSession(context, chunkDigests, destination, out).run();
     if (digestOut != null) {
       Utils.verifyBlobContents(blobDigest, digestOut.digest());
+    }
+    if (finalDestination != null) {
+      // The content may not be at the final destination yet (out may not be flushed, and a staged
+      // download has yet to be moved into place), but locations are only hints: an early read is
+      // just a miss.
+      chunkLocationMap.addFile(finalDestination, chunkDigests);
     }
   }
 
@@ -125,12 +147,6 @@ public class ChunkedBlobDownloader {
     }
   }
 
-  private void downloadAndReassembleChunks(
-      RemoteActionExecutionContext context, List<Digest> chunkDigests, OutputStream out)
-      throws IOException, InterruptedException {
-    new DownloadSession(context, chunkDigests, out).run();
-  }
-
   private final class DownloadSession {
     private final LinkedBlockingQueue<PendingDownload> completedDownloads =
         new LinkedBlockingQueue<>();
@@ -139,14 +155,19 @@ public class ChunkedBlobDownloader {
     private final Map<Integer, byte[]> readyChunks = new HashMap<>(MAX_IN_FLIGHT_CHUNK_DOWNLOADS);
     private final RemoteActionExecutionContext context;
     private final List<Digest> chunkDigests;
+    @Nullable private final Path destination;
     private final OutputStream out;
     private int nextToStart = 0;
     private int nextToWrite = 0;
 
     DownloadSession(
-        RemoteActionExecutionContext context, List<Digest> chunkDigests, OutputStream out) {
+        RemoteActionExecutionContext context,
+        List<Digest> chunkDigests,
+        @Nullable Path destination,
+        OutputStream out) {
       this.context = context;
       this.chunkDigests = chunkDigests;
+      this.destination = destination;
       this.out = out;
     }
 
@@ -182,10 +203,17 @@ public class ChunkedBlobDownloader {
 
     private void startDownload(Digest chunkDigest, int chunkIndex) {
       PendingDownload download =
-          new PendingDownload(
-              chunkDigest, combinedCache.downloadBlob(context, chunkDigest), chunkIndex);
+          new PendingDownload(chunkDigest, fetchChunk(chunkDigest), chunkIndex);
       activeDownloads.put(chunkDigest, download);
       download.future().addListener(() -> completedDownloads.add(download), directExecutor());
+    }
+
+    /** Returns the contents of a chunk, preferring a copy already on local disk over a download. */
+    private ListenableFuture<byte[]> fetchChunk(Digest chunkDigest) {
+      byte[] local = chunkLocationMap.read(chunkDigest, destination, digestUtil);
+      return local != null
+          ? immediateFuture(local)
+          : combinedCache.downloadBlob(context, chunkDigest);
     }
 
     private void drainCompletedDownloads() throws IOException, InterruptedException {

--- a/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CombinedCache.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -108,6 +109,7 @@ public class CombinedCache extends AbstractReferenceCounted {
   @Nullable protected final String symlinkTemplate;
   protected final DigestUtil digestUtil;
   private final boolean chunkingEnabled;
+  private final ChunkLocationMap chunkLocationMap;
 
   // Delays the initialization of the chunking support logic until first use to avoid blocking on
   // a server capabilities check at construction time.
@@ -128,7 +130,9 @@ public class CombinedCache extends AbstractReferenceCounted {
         synchronized (this) {
           config = ChunkingConfig.fromServerCapabilities(getRemoteServerCapabilities());
           if (config != null) {
-            downloader = new ChunkedBlobDownloader(grpcClient, CombinedCache.this, digestUtil);
+            downloader =
+                new ChunkedBlobDownloader(
+                    grpcClient, CombinedCache.this, digestUtil, chunkLocationMap);
             uploader = new ChunkedBlobUploader(grpcClient, CombinedCache.this, config, digestUtil);
           }
           initialized = true;
@@ -157,7 +161,8 @@ public class CombinedCache extends AbstractReferenceCounted {
       @Nullable DiskCacheClient diskCacheClient,
       @Nullable String symlinkTemplate,
       DigestUtil digestUtil,
-      boolean chunkingEnabled) {
+      boolean chunkingEnabled,
+      ChunkLocationMap chunkLocationMap) {
     checkArgument(
         remoteCacheClient != null || diskCacheClient != null,
         "remoteCacheClient and diskCacheClient cannot be null at the same time");
@@ -166,6 +171,7 @@ public class CombinedCache extends AbstractReferenceCounted {
     this.symlinkTemplate = symlinkTemplate;
     this.digestUtil = digestUtil;
     this.chunkingEnabled = chunkingEnabled;
+    this.chunkLocationMap = chunkLocationMap;
   }
 
   public CacheCapabilities getRemoteCacheCapabilities() throws IOException {
@@ -679,15 +685,25 @@ public class CombinedCache extends AbstractReferenceCounted {
     }
   }
 
+  /**
+   * Downloads a file (that is not a directory) into {@code localPath}.
+   *
+   * @param localPath the path to write the file to
+   * @param finalPath the path the content will remain at after the command, e.g. when {@code
+   *     localPath} is a temporary staging path, or {@code null} if that is {@code localPath}
+   *     itself. Used to remember where chunks of the file can be found so that later chunked
+   *     downloads can read them from local disk instead of the remote cache.
+   */
   public ListenableFuture<Void> downloadFile(
       RemoteActionExecutionContext context,
       String outputPath,
       @Nullable PathFragment execPath,
       Path localPath,
+      @Nullable Path finalPath,
       Digest digest,
       DownloadProgressReporter reporter)
       throws IOException {
-    ListenableFuture<Void> f = downloadFile(context, localPath, digest, reporter);
+    ListenableFuture<Void> f = downloadFile(context, localPath, finalPath, digest, reporter);
     return Futures.catchingAsync(
         f,
         Throwable.class,
@@ -707,9 +723,9 @@ public class CombinedCache extends AbstractReferenceCounted {
   /**
    * Downloads a file (that is not a directory). The content is fetched from the digest.
    *
-   * <p>Use {@link #downloadFile(RemoteActionExecutionContext, String, PathFragment, Path, Digest,
-   * DownloadProgressReporter)} instead for build outputs as it provides progress information and
-   * correctly handles unexpected cache misses.
+   * <p>Use {@link #downloadFile(RemoteActionExecutionContext, String, PathFragment, Path, Path,
+   * Digest, DownloadProgressReporter)} instead for build outputs as it provides progress
+   * information and correctly handles unexpected cache misses.
    */
   public ListenableFuture<Void> downloadFile(
       RemoteActionExecutionContext context, Path path, Digest digest) throws IOException {
@@ -718,6 +734,7 @@ public class CombinedCache extends AbstractReferenceCounted {
         path.getPathString(),
         /* execPath= */ null,
         path,
+        /* finalPath= */ null,
         digest,
         new DownloadProgressReporter(NO_ACTION, "", 0));
   }
@@ -726,6 +743,7 @@ public class CombinedCache extends AbstractReferenceCounted {
   private ListenableFuture<Void> downloadFile(
       RemoteActionExecutionContext context,
       Path path,
+      @Nullable Path finalPath,
       Digest digest,
       DownloadProgressReporter reporter)
       throws IOException {
@@ -749,7 +767,9 @@ public class CombinedCache extends AbstractReferenceCounted {
     }
 
     reporter.started();
-    OutputStream out = new ReportingOutputStream(new LazyFileOutputStream(path), reporter);
+    OutputStream out =
+        new ReportingOutputStream(
+            new LazyFileOutputStream(path), reporter, firstNonNull(finalPath, path));
 
     ListenableFuture<Void> f = downloadBlob(context, digest, out);
     f.addListener(
@@ -879,10 +899,12 @@ public class CombinedCache extends AbstractReferenceCounted {
 
     private final OutputStream out;
     private final DownloadProgressReporter reporter;
+    private final Path finalPath;
 
-    ReportingOutputStream(OutputStream out, DownloadProgressReporter reporter) {
+    ReportingOutputStream(OutputStream out, DownloadProgressReporter reporter, Path finalPath) {
       this.out = out;
       this.reporter = reporter;
+      this.finalPath = finalPath;
     }
 
     @Override
@@ -917,6 +939,11 @@ public class CombinedCache extends AbstractReferenceCounted {
     @Override
     public Path maybeGetPath() {
       return out instanceof MaybePathBacked maybePathBacked ? maybePathBacked.maybeGetPath() : null;
+    }
+
+    @Override
+    public Path maybeGetFinalPath() {
+      return finalPath;
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -115,6 +115,7 @@ public class RemoteActionInputFetcher extends AbstractActionInputPrefetcher {
       Reporter reporter,
       ActionInput input,
       Path tempPath,
+      Path finalPath,
       FileArtifactValue metadata,
       Priority priority,
       Reason reason)
@@ -142,6 +143,7 @@ public class RemoteActionInputFetcher extends AbstractActionInputPrefetcher {
             input.getExecPathString(),
             input.getExecPath(),
             tempPath.forHostFileSystem(),
+            finalPath,
             digest,
             new CombinedCache.DownloadProgressReporter(
                 progress -> {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
@@ -130,13 +130,15 @@ public class RemoteExecutionCache extends CombinedCache implements MerkleTreeUpl
       @Nullable DiskCacheClient diskCacheClient,
       @Nullable String symlinkTemplate,
       DigestUtil digestUtil,
-      boolean chunkingEnabled) {
+      boolean chunkingEnabled,
+      ChunkLocationMap chunkLocationMap) {
     super(
         checkNotNull(remoteCacheClient),
         diskCacheClient,
         symlinkTemplate,
         digestUtil,
-        chunkingEnabled);
+        chunkingEnabled,
+        chunkLocationMap);
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -848,6 +848,7 @@ public class RemoteExecutionService {
               internalToUnicode(remotePathResolver.localPathToOutputPath(file.path())),
               remotePathResolver.localPathToExecPath(file.path().asFragment()),
               tmpPath,
+              /* finalPath= */ file.path(),
               file.digest(),
               new CombinedCache.DownloadProgressReporter(
                   progressStatusListener,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -142,6 +142,7 @@ public final class RemoteModule extends BlazeModule {
       MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1));
 
   private final Set<Digest> knownMissingCasDigests = Sets.newConcurrentHashSet();
+  private final ChunkLocationMap chunkLocationMap = new ChunkLocationMap();
   private boolean useRemoteRepoContentsCache;
 
   @Nullable private PathFragment outputBase;
@@ -296,7 +297,8 @@ public final class RemoteModule extends BlazeModule {
             combinedCacheClient.diskCacheClient(),
             Strings.emptyToNull(remoteOptions.remoteDownloadSymlinkTemplate),
             digestUtil,
-            remoteOptions.experimentalRemoteCacheChunking);
+            remoteOptions.experimentalRemoteCacheChunking,
+            chunkLocationMap);
     actionContextProvider =
         RemoteActionContextProvider.createForRemoteCaching(
             env,
@@ -392,6 +394,7 @@ public final class RemoteModule extends BlazeModule {
     Preconditions.checkState(outputService == null, "remoteOutputService must be null");
 
     if ("clean".equals(env.getCommandName())) {
+      chunkLocationMap.clear();
       knownMissingCasDigests.clear();
     }
 
@@ -823,7 +826,8 @@ public final class RemoteModule extends BlazeModule {
               diskCacheClient,
               Strings.emptyToNull(remoteOptions.remoteDownloadSymlinkTemplate),
               digestUtil,
-              remoteOptions.experimentalRemoteCacheChunking);
+              remoteOptions.experimentalRemoteCacheChunking,
+              chunkLocationMap);
       actionContextProvider =
           RemoteActionContextProvider.createForRemoteExecution(
               env,
@@ -853,7 +857,8 @@ public final class RemoteModule extends BlazeModule {
               diskCacheClient,
               Strings.emptyToNull(remoteOptions.remoteDownloadSymlinkTemplate),
               digestUtil,
-              remoteOptions.experimentalRemoteCacheChunking);
+              remoteOptions.experimentalRemoteCacheChunking,
+              chunkLocationMap);
       actionContextProvider =
           RemoteActionContextProvider.createForRemoteCaching(
               env,

--- a/src/main/java/com/google/devtools/build/lib/remote/common/MaybePathBacked.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/MaybePathBacked.java
@@ -24,4 +24,16 @@ public interface MaybePathBacked {
   /** If this stream is backed by a Path, returns that Path. Otherwise, returns null. */
   @Nullable
   Path maybeGetPath();
+
+  /**
+   * Returns the path where the content written to this stream is expected to remain after the
+   * enclosing operation completes, or {@code null} if unknown.
+   *
+   * <p>This differs from {@link #maybeGetPath} when the stream writes to a temporary staging
+   * location that is later moved into place, e.g. when downloading an action output.
+   */
+  @Nullable
+  default Path maybeGetFinalPath() {
+    return maybeGetPath();
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -307,7 +307,7 @@ public abstract class ActionInputPrefetcherTestBase {
             action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
 
     verify(prefetcher, never())
-        .doDownloadFile(eq(action), any(), eq(a), any(), any(), any(), any());
+        .doDownloadFile(eq(action), any(), eq(a), any(), any(), any(), any(), any());
     assertThat(prefetcher.downloadedFiles()).containsExactly(a.getPath());
     assertThat(prefetcher.downloadsInProgress()).isEmpty();
   }
@@ -345,7 +345,7 @@ public abstract class ActionInputPrefetcherTestBase {
         prefetcher.prefetchFilesInterruptibly(
             action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
 
-    verify(prefetcher).doDownloadFile(eq(action), any(), eq(a), any(), any(), any(), any());
+    verify(prefetcher).doDownloadFile(eq(action), any(), eq(a), any(), any(), any(), any(), any());
     assertThat(prefetcher.downloadedFiles()).containsExactly(a.getPath());
     assertThat(prefetcher.downloadsInProgress()).isEmpty();
     assertThat(FileSystemUtils.readContent(a.getPath(), UTF_8)).isEqualTo("hello world remote");
@@ -400,7 +400,7 @@ public abstract class ActionInputPrefetcherTestBase {
     // still in place, but doesn't download it again as it is intact.
     verify(fs).statIfFound(a.getPath().asFragment(), /* followSymlinks= */ true);
     verify(prefetcher, times(1))
-        .doDownloadFile(eq(action), any(), eq(a), any(), any(), any(), any());
+        .doDownloadFile(eq(action), any(), eq(a), any(), any(), any(), any(), any());
     assertThat(FileSystemUtils.readContent(a.getPath(), UTF_8)).isEqualTo("hello world");
   }
 
@@ -1188,7 +1188,7 @@ public abstract class ActionInputPrefetcherTestBase {
     doAnswer(
             invocation -> {
               Path path = invocation.getArgument(3);
-              FileArtifactValue metadata = invocation.getArgument(4);
+              FileArtifactValue metadata = invocation.getArgument(5);
               byte[] content = cas.get(HashCode.fromBytes(metadata.getDigest()));
               if (content == null) {
                 return Futures.immediateFailedFuture(new IOException("Not found"));
@@ -1197,7 +1197,7 @@ public abstract class ActionInputPrefetcherTestBase {
               return resultSupplier.get();
             })
         .when(prefetcher)
-        .doDownloadFile(any(), any(), any(), any(), any(), any(), any());
+        .doDownloadFile(any(), any(), any(), any(), any(), any(), any(), any());
   }
 
   private void assertReadableNonWritableAndExecutable(Path path) throws IOException {

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -311,6 +311,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/remote/util:tracing_metadata_utils",
         "//src/main/java/com/google/devtools/build/lib/standalone",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/protobuf:remote_execution_log_java_proto",
         "//src/test/java/com/google/devtools/build/lib/buildtool/util",
         "//src/test/java/com/google/devtools/build/lib/remote/util:integration_test_utils",
         "//third_party:guava",

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -702,7 +702,8 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         /* diskCacheClient= */ null,
         /* symlinkTemplate= */ null,
         DIGEST_UTIL,
-        /* chunkingEnabled= */ false);
+        /* chunkingEnabled= */ false,
+        new ChunkLocationMap());
   }
 
   private ByteStreamBuildEventArtifactUploader newArtifactUploader(CombinedCache combinedCache) {

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkLocationMapTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkLocationMapTest.java
@@ -1,0 +1,144 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import build.bazel.remote.execution.v2.Digest;
+import com.google.common.primitives.Bytes;
+import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.testutil.TestUtils;
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.SyscallCache;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ChunkLocationMap}. */
+@RunWith(JUnit4.class)
+public final class ChunkLocationMapTest {
+  private static final DigestUtil DIGEST_UTIL =
+      new DigestUtil(SyscallCache.NO_CACHE, DigestHashFunction.SHA256);
+
+  private static final byte[] FIRST = "first chunk".getBytes(UTF_8);
+  private static final byte[] SECOND = "second chunk".getBytes(UTF_8);
+  private static final Digest FIRST_DIGEST = DIGEST_UTIL.compute(FIRST);
+  private static final Digest SECOND_DIGEST = DIGEST_UTIL.compute(SECOND);
+
+  private final ChunkLocationMap map = new ChunkLocationMap();
+
+  private Path root;
+
+  @Before
+  public void setUp() throws Exception {
+    root = TestUtils.createUniqueTmpDir(null);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    root.deleteTree();
+  }
+
+  @Test
+  public void read_unknownChunk_returnsNull() {
+    assertThat(read(FIRST_DIGEST)).isNull();
+  }
+
+  @Test
+  public void read_returnsChunksAtRecordedOffsets() throws Exception {
+    Path file = writeFile("out", Bytes.concat(FIRST, SECOND));
+
+    map.addFile(file, List.of(FIRST_DIGEST, SECOND_DIGEST));
+
+    assertThat(read(FIRST_DIGEST)).isEqualTo(FIRST);
+    assertThat(read(SECOND_DIGEST)).isEqualTo(SECOND);
+  }
+
+  @Test
+  public void read_rewrittenFile_returnsNullAndForgetsLocation() throws Exception {
+    Path file = writeFile("out", FIRST);
+    map.addFile(file, List.of(FIRST_DIGEST));
+
+    writeFile("out", SECOND);
+    assertThat(read(FIRST_DIGEST)).isNull();
+
+    // The location is gone for good, even once the file happens to hold the chunk again.
+    writeFile("out", FIRST);
+    assertThat(read(FIRST_DIGEST)).isNull();
+  }
+
+  @Test
+  public void read_deletedFile_returnsNullAndForgetsLocation() throws Exception {
+    Path file = writeFile("out", FIRST);
+    map.addFile(file, List.of(FIRST_DIGEST));
+
+    file.delete();
+    assertThat(read(FIRST_DIGEST)).isNull();
+
+    writeFile("out", FIRST);
+    assertThat(read(FIRST_DIGEST)).isNull();
+  }
+
+  @Test
+  public void read_locationIsDestination_returnsNullButKeepsLocation() throws Exception {
+    Path file = writeFile("out", FIRST);
+    map.addFile(file, List.of(FIRST_DIGEST));
+
+    // A download writing to this very file may not read from it, but another one still may.
+    assertThat(map.read(FIRST_DIGEST, file, DIGEST_UTIL)).isNull();
+    assertThat(read(FIRST_DIGEST)).isEqualTo(FIRST);
+  }
+
+  @Test
+  public void addFile_mostRecentFileWins() throws Exception {
+    Path stale = writeFile("stale", FIRST);
+    Path fresh = writeFile("fresh", Bytes.concat(SECOND, FIRST));
+
+    map.addFile(stale, List.of(FIRST_DIGEST));
+    map.addFile(fresh, List.of(SECOND_DIGEST, FIRST_DIGEST));
+    stale.delete();
+
+    assertThat(read(FIRST_DIGEST)).isEqualTo(FIRST);
+  }
+
+  @Test
+  public void clear_forgetsLocations() throws Exception {
+    Path file = writeFile("out", FIRST);
+    map.addFile(file, List.of(FIRST_DIGEST));
+
+    map.clear();
+
+    assertThat(read(FIRST_DIGEST)).isNull();
+  }
+
+  private byte[] read(Digest digest) {
+    return map.read(digest, /* destination= */ null, DIGEST_UTIL);
+  }
+
+  @CanIgnoreReturnValue
+  private Path writeFile(String name, byte[] contents) throws Exception {
+    Path path = root.getRelative("execroot/" + name);
+    path.getParentDirectory().createDirectoryAndParents();
+    FileSystemUtils.writeContent(path, contents);
+    return path;
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedBlobDownloaderTest.java
@@ -23,21 +23,28 @@ import static org.mockito.Mockito.when;
 
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.SplitBlobResponse;
+import com.google.common.primitives.Bytes;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.remote.common.BlobNotSplittableException;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
+import com.google.devtools.build.lib.remote.common.LazyFileOutputStream;
 import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.testutil.TestUtils;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.SyscallCache;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,11 +68,20 @@ public class ChunkedBlobDownloaderTest {
   @Mock private RemoteActionExecutionContext context;
 
   private ChunkedBlobDownloader downloader;
+  private Path tmpDir;
 
   @Before
-  public void setUp() {
+  public void setUp() throws Exception {
     when(grpcCacheClient.shouldVerifyDownloads()).thenReturn(true);
-    downloader = new ChunkedBlobDownloader(grpcCacheClient, combinedCache, DIGEST_UTIL);
+    downloader =
+        new ChunkedBlobDownloader(
+            grpcCacheClient, combinedCache, DIGEST_UTIL, new ChunkLocationMap());
+    tmpDir = TestUtils.createUniqueTmpDir(null);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    tmpDir.deleteTree();
   }
 
   @Test
@@ -166,6 +182,41 @@ public class ChunkedBlobDownloaderTest {
     verify(combinedCache).downloadBlob(any(), eq(chunk1Digest));
     verify(combinedCache).downloadBlob(any(), eq(chunk2Digest));
     verify(combinedCache).downloadBlob(any(), eq(chunk3Digest));
+  }
+
+  @Test
+  public void downloadChunked_readsSharedChunkFromPreviouslyDownloadedFile() throws Exception {
+    SharedChunkBlobs blobs = stubTwoBlobsSharingAChunk();
+
+    Path firstFile = tmpDir.getChild("first-output");
+    try (LazyFileOutputStream firstOut = new LazyFileOutputStream(firstFile)) {
+      downloader.downloadChunked(context, blobs.firstBlob(), firstOut);
+    }
+    assertThat(FileSystemUtils.readContent(firstFile)).isEqualTo(blobs.firstContent());
+
+    ByteArrayOutputStream secondOut = new ByteArrayOutputStream();
+    downloader.downloadChunked(context, blobs.secondBlob(), secondOut);
+
+    assertThat(secondOut.toByteArray()).isEqualTo(blobs.secondContent());
+    verify(combinedCache, times(1)).downloadBlob(any(), eq(blobs.sharedChunk()));
+  }
+
+  @Test
+  public void downloadChunked_stagedDownload_reusesChunksAfterMoveToFinalPath() throws Exception {
+    SharedChunkBlobs blobs = stubTwoBlobsSharingAChunk();
+
+    Path stagingFile = tmpDir.getChild("staging-tmp");
+    Path finalFile = tmpDir.getChild("final-output");
+    try (OutputStream firstOut = new StagedOutputStream(stagingFile, finalFile)) {
+      downloader.downloadChunked(context, blobs.firstBlob(), firstOut);
+    }
+    stagingFile.renameTo(finalFile);
+
+    ByteArrayOutputStream secondOut = new ByteArrayOutputStream();
+    downloader.downloadChunked(context, blobs.secondBlob(), secondOut);
+
+    assertThat(secondOut.toByteArray()).isEqualTo(blobs.secondContent());
+    verify(combinedCache, times(1)).downloadBlob(any(), eq(blobs.sharedChunk()));
   }
 
   @Test
@@ -507,5 +558,66 @@ public class ChunkedBlobDownloaderTest {
 
     assertThat(downloadThread.isAlive()).isFalse();
     assertThat(cancelledDownload.isCancelled()).isTrue();
+  }
+
+  @SuppressWarnings("ArrayRecordComponent")
+  private record SharedChunkBlobs(
+      Digest sharedChunk,
+      Digest firstBlob,
+      byte[] firstContent,
+      Digest secondBlob,
+      byte[] secondContent) {}
+
+  /** Stubs SplitBlob and all chunk downloads for two blobs that share their first chunk. */
+  private SharedChunkBlobs stubTwoBlobsSharingAChunk() {
+    byte[] shared = new byte[] {1, 2, 3};
+    byte[] firstTail = new byte[] {4, 5, 6};
+    byte[] secondTail = new byte[] {7, 8, 9};
+    Digest sharedDigest = DIGEST_UTIL.compute(shared);
+    Digest firstTailDigest = DIGEST_UTIL.compute(firstTail);
+    Digest secondTailDigest = DIGEST_UTIL.compute(secondTail);
+    byte[] firstContent = Bytes.concat(shared, firstTail);
+    byte[] secondContent = Bytes.concat(shared, secondTail);
+    Digest firstBlobDigest = DIGEST_UTIL.compute(firstContent);
+    Digest secondBlobDigest = DIGEST_UTIL.compute(secondContent);
+
+    when(grpcCacheClient.splitBlob(any(), eq(firstBlobDigest)))
+        .thenReturn(
+            Futures.immediateFuture(
+                SplitBlobResponse.newBuilder()
+                    .addChunkDigests(sharedDigest)
+                    .addChunkDigests(firstTailDigest)
+                    .build()));
+    when(grpcCacheClient.splitBlob(any(), eq(secondBlobDigest)))
+        .thenReturn(
+            Futures.immediateFuture(
+                SplitBlobResponse.newBuilder()
+                    .addChunkDigests(sharedDigest)
+                    .addChunkDigests(secondTailDigest)
+                    .build()));
+    when(combinedCache.downloadBlob(any(), eq(sharedDigest)))
+        .thenReturn(Futures.immediateFuture(shared));
+    when(combinedCache.downloadBlob(any(), eq(firstTailDigest)))
+        .thenReturn(Futures.immediateFuture(firstTail));
+    when(combinedCache.downloadBlob(any(), eq(secondTailDigest)))
+        .thenReturn(Futures.immediateFuture(secondTail));
+
+    return new SharedChunkBlobs(
+        sharedDigest, firstBlobDigest, firstContent, secondBlobDigest, secondContent);
+  }
+
+  /** Writes to a staging path while declaring the final path the content will be moved to. */
+  private static final class StagedOutputStream extends LazyFileOutputStream {
+    private final Path finalPath;
+
+    StagedOutputStream(Path stagingPath, Path finalPath) {
+      super(stagingPath);
+      this.finalPath = finalPath;
+    }
+
+    @Override
+    public Path maybeGetFinalPath() {
+      return finalPath;
+    }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedCacheIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedCacheIntegrationTest.java
@@ -32,6 +32,7 @@ import com.google.common.hash.Hashing;
 import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialModule;
 import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
+import com.google.devtools.build.lib.remote.logging.RemoteExecutionLog.LogEntry;
 import com.google.devtools.build.lib.remote.util.IntegrationTestUtils;
 import com.google.devtools.build.lib.remote.util.IntegrationTestUtils.WorkerInstance;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
@@ -109,6 +110,17 @@ public class ChunkedCacheIntegrationTest extends BuildIntegrationTestCase {
   private Digest computeDigest(byte[] data) {
     HashCode hash = Hashing.sha256().hashBytes(data);
     return Digest.newBuilder().setHash(hash.toString()).setSizeBytes(data.length).build();
+  }
+
+  private static List<String> readRpcMethodNames(Path logPath) throws IOException {
+    ImmutableList.Builder<String> methodNames = ImmutableList.builder();
+    try (InputStream in = logPath.getInputStream()) {
+      LogEntry entry;
+      while ((entry = LogEntry.parseDelimitedFrom(in)) != null) {
+        methodNames.add(entry.getMethodName());
+      }
+    }
+    return methodNames.build();
   }
 
   @Test
@@ -240,11 +252,72 @@ public class ChunkedCacheIntegrationTest extends BuildIntegrationTestCase {
     outputCombined.delete();
     cleanAndRestartServer();
 
-    buildTarget("//:combined");
+    buildTarget("//:data_a", "//:data_b", "//:combined");
 
     assertThat(readFileBytes(outputA)).isEqualTo(contentA);
     assertThat(readFileBytes(outputB)).isEqualTo(contentB);
     assertThat(readFileBytes(outputCombined)).isEqualTo(contentCombined);
+  }
+
+  @Test
+  public void secondInvocation_reusesChunksFromPreviouslyDownloadedOutputs() throws Exception {
+    // Both outputs are identical, so they consist of the same chunks.
+    write(
+        "BUILD",
+        """
+        genrule(
+            name = "first",
+            srcs = [],
+            outs = ["first.bin"],
+            cmd = "dd if=/dev/zero bs=1M count=3 2>/dev/null | tr '\\\\0' 'R' > $@",
+        )
+        genrule(
+            name = "second",
+            srcs = [],
+            outs = ["second.bin"],
+            cmd = "dd if=/dev/zero bs=1M count=3 2>/dev/null | tr '\\\\0' 'R' > $@",
+        )
+        """);
+
+    // Upload synchronously so the action results are cached before the runtime restart below.
+    addOptions("--noremote_cache_async");
+    buildTarget("//:first", "//:second");
+
+    Path firstOutput = getOutputPath("first.bin");
+    Path secondOutput = getOutputPath("second.bin");
+    byte[] content = readFileBytes(firstOutput);
+    assertThat(readFileBytes(secondOutput)).isEqualTo(content);
+
+    // Make both actions remote cache hits whose outputs have to be downloaded again.
+    firstOutput.delete();
+    secondOutput.delete();
+    cleanAndRestartServer();
+
+    Path firstInvocationLog = getOutputBase().getRelative("grpc-log-first-invocation");
+    Path secondInvocationLog = getOutputBase().getRelative("grpc-log-second-invocation");
+
+    addOptions("--remote_grpc_log=" + firstInvocationLog.getPathString());
+    buildTarget("//:first");
+    assertThat(readFileBytes(firstOutput)).isEqualTo(content);
+
+    addOptions("--remote_grpc_log=" + secondInvocationLog.getPathString());
+    buildTarget("//:second");
+    assertThat(readFileBytes(secondOutput)).isEqualTo(content);
+
+    // Start a new command so that the previous one finishes flushing its gRPC log.
+    runtimeWrapper.newCommand();
+
+    String splitBlobMethod = ContentAddressableStorageGrpc.getSplitBlobMethod().getFullMethodName();
+    String readMethod = ByteStreamGrpc.getReadMethod().getFullMethodName();
+
+    List<String> firstInvocationMethods = readRpcMethodNames(firstInvocationLog);
+    assertThat(firstInvocationMethods).contains(splitBlobMethod);
+    assertThat(firstInvocationMethods).contains(readMethod);
+
+    // Every chunk was served from the file downloaded by the first invocation.
+    List<String> secondInvocationMethods = readRpcMethodNames(secondInvocationLog);
+    assertThat(secondInvocationMethods).contains(splitBlobMethod);
+    assertThat(secondInvocationMethods).doesNotContain(readMethod);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkedTransferBenchmark.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkedTransferBenchmark.java
@@ -144,7 +144,9 @@ public class ChunkedTransferBenchmark {
       when(grpcCacheClient.splitBlob(any(), any(Digest.class)))
           .thenReturn(Futures.immediateFuture(splitBlobResponse));
 
-      downloader = new ChunkedBlobDownloader(grpcCacheClient, combinedCache, DIGEST_UTIL);
+      downloader =
+          new ChunkedBlobDownloader(
+              grpcCacheClient, combinedCache, DIGEST_UTIL, new ChunkLocationMap());
     }
 
     @TearDown(Level.Trial)

--- a/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/CombinedCacheTest.java
@@ -925,7 +925,8 @@ public class CombinedCacheTest {
             /* diskCacheClient= */ null,
             /* symlinkTemplate= */ null,
             digestUtil,
-            /* chunkingEnabled= */ true);
+            /* chunkingEnabled= */ true,
+            new ChunkLocationMap());
     byte[] data = new byte[8192];
     Path file = execRoot.getRelative("chunked-output");
     try (var out = file.getOutputStream()) {
@@ -1124,7 +1125,8 @@ public class CombinedCacheTest {
         /* diskCacheClient= */ null,
         /* symlinkTemplate= */ null,
         digestUtil,
-        /* chunkingEnabled= */ true);
+        /* chunkingEnabled= */ true,
+        new ChunkLocationMap());
   }
 
   private InMemoryCombinedCache newCombinedCache() {
@@ -1142,7 +1144,8 @@ public class CombinedCacheTest {
         /* diskCacheClient= */ null,
         /* symlinkTemplate= */ null,
         digestUtil,
-        /* chunkingEnabled= */ false);
+        /* chunkingEnabled= */ false,
+        new ChunkLocationMap());
   }
 
   private RemoteExecutionCache newRemoteExecutionCache(RemoteCacheClient remoteCacheClient) {
@@ -1151,7 +1154,8 @@ public class CombinedCacheTest {
         /* diskCacheClient= */ null,
         /* symlinkTemplate= */ null,
         digestUtil,
-        /* chunkingEnabled= */ false);
+        /* chunkingEnabled= */ false,
+        new ChunkLocationMap());
   }
 
   private static ServerCapabilities chunkingCapabilities() {

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -313,7 +313,8 @@ public class GrpcCacheClientTest {
             /* diskCacheClient= */ null,
             /* symlinkTemplate= */ null,
             DIGEST_UTIL,
-            /* chunkingEnabled= */ false);
+            /* chunkingEnabled= */ false,
+            new ChunkLocationMap());
     PathFragment execPath = PathFragment.create("my/exec/path");
     var virtualActionInput =
         new VirtualActionInput() {
@@ -601,7 +602,8 @@ public class GrpcCacheClientTest {
             /* diskCacheClient= */ null,
             /* symlinkTemplate= */ null,
             DIGEST_UTIL,
-            /* chunkingEnabled= */ false);
+            /* chunkingEnabled= */ false,
+            new ChunkLocationMap());
 
     Digest fooDigest = DIGEST_UTIL.computeAsUtf8("foo-contents");
     Digest barDigest = DIGEST_UTIL.computeAsUtf8("bar-contents");
@@ -631,7 +633,8 @@ public class GrpcCacheClientTest {
             /* diskCacheClient= */ null,
             /* symlinkTemplate= */ null,
             DIGEST_UTIL,
-            /* chunkingEnabled= */ false);
+            /* chunkingEnabled= */ false,
+            new ChunkLocationMap());
 
     final Digest fooDigest =
         fakeFileCache.createScratchInput(ActionInputHelper.fromPath("a/foo"), "xyz");
@@ -705,7 +708,8 @@ public class GrpcCacheClientTest {
             /* diskCacheClient= */ null,
             /* symlinkTemplate= */ null,
             DIGEST_UTIL,
-            /* chunkingEnabled= */ false);
+            /* chunkingEnabled= */ false,
+            new ChunkLocationMap());
 
     final Digest barDigest =
         fakeFileCache.createScratchInputDirectory(
@@ -754,7 +758,8 @@ public class GrpcCacheClientTest {
             /* diskCacheClient= */ null,
             /* symlinkTemplate= */ null,
             DIGEST_UTIL,
-            /* chunkingEnabled= */ false);
+            /* chunkingEnabled= */ false,
+            new ChunkLocationMap());
 
     final Digest wobbleDigest =
         fakeFileCache.createScratchInput(ActionInputHelper.fromPath("bar/test/wobble"), "xyz");
@@ -923,7 +928,8 @@ public class GrpcCacheClientTest {
             /* diskCacheClient= */ null,
             /* symlinkTemplate= */ null,
             DIGEST_UTIL,
-            /* chunkingEnabled= */ false);
+            /* chunkingEnabled= */ false,
+            new ChunkLocationMap());
     var unused =
         combinedCache.downloadActionResult(
             context,
@@ -942,7 +948,8 @@ public class GrpcCacheClientTest {
             /* diskCacheClient= */ null,
             /* symlinkTemplate= */ null,
             DIGEST_UTIL,
-            /* chunkingEnabled= */ false);
+            /* chunkingEnabled= */ false,
+            new ChunkLocationMap());
 
     final Digest fooDigest =
         fakeFileCache.createScratchInput(ActionInputHelper.fromPath("a/foo"), "xyz");
@@ -1024,7 +1031,8 @@ public class GrpcCacheClientTest {
             /* diskCacheClient= */ null,
             /* symlinkTemplate= */ null,
             DIGEST_UTIL,
-            /* chunkingEnabled= */ false);
+            /* chunkingEnabled= */ false,
+            new ChunkLocationMap());
 
     final Digest fooDigest =
         fakeFileCache.createScratchInput(ActionInputHelper.fromPath("a/foo"), "xyz");
@@ -1095,7 +1103,8 @@ public class GrpcCacheClientTest {
             /* diskCacheClient= */ null,
             /* symlinkTemplate= */ null,
             DIGEST_UTIL,
-            /* chunkingEnabled= */ false);
+            /* chunkingEnabled= */ false,
+            new ChunkLocationMap());
 
     final Digest fooDigest =
         fakeFileCache.createScratchInput(ActionInputHelper.fromPath("a/foo"), "xyz");

--- a/src/test/java/com/google/devtools/build/lib/remote/InMemoryCombinedCache.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/InMemoryCombinedCache.java
@@ -35,7 +35,8 @@ class InMemoryCombinedCache extends RemoteExecutionCache {
         /* diskCacheClient= */ null,
         /* symlinkTemplate= */ null,
         digestUtil,
-        /* chunkingEnabled= */ false);
+        /* chunkingEnabled= */ false,
+        new ChunkLocationMap());
   }
 
   InMemoryCombinedCache(
@@ -45,7 +46,8 @@ class InMemoryCombinedCache extends RemoteExecutionCache {
         /* diskCacheClient= */ null,
         symlinkTemplate,
         digestUtil,
-        /* chunkingEnabled= */ false);
+        /* chunkingEnabled= */ false,
+        new ChunkLocationMap());
   }
 
   InMemoryCombinedCache(DigestUtil digestUtil) {
@@ -54,7 +56,8 @@ class InMemoryCombinedCache extends RemoteExecutionCache {
         /* diskCacheClient= */ null,
         /* symlinkTemplate= */ null,
         digestUtil,
-        /* chunkingEnabled= */ false);
+        /* chunkingEnabled= */ false,
+        new ChunkLocationMap());
   }
 
   InMemoryCombinedCache(RemoteCacheClient remoteCacheClient, DigestUtil digestUtil) {
@@ -63,7 +66,8 @@ class InMemoryCombinedCache extends RemoteExecutionCache {
         /* diskCacheClient= */ null,
         /* symlinkTemplate= */ null,
         digestUtil,
-        /* chunkingEnabled= */ false);
+        /* chunkingEnabled= */ false,
+        new ChunkLocationMap());
   }
 
   Digest addContents(RemoteActionExecutionContext context, String txt)

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -220,6 +220,7 @@ public class RemoteActionInputFetcherTest extends ActionInputPrefetcherTestBase 
         /* diskCacheClient= */ null,
         /* symlinkTemplate= */ null,
         digestUtil,
-        /* chunkingEnabled= */ false);
+        /* chunkingEnabled= */ false,
+        new ChunkLocationMap());
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -464,7 +464,8 @@ public class RemoteSpawnCacheTest {
                   diskCacheClient,
                   /* symlinkTemplate= */ null,
                   digestUtil,
-                  /* chunkingEnabled= */ false));
+                  /* chunkingEnabled= */ false,
+                  new ChunkLocationMap()));
 
       var remoteSpawnCache = remoteSpawnCacheWithOptions(remoteOptions);
       for (String requirement :
@@ -506,7 +507,8 @@ public class RemoteSpawnCacheTest {
                 /* diskCacheClient= */ null,
                 /* symlinkTemplate= */ null,
                 digestUtil,
-                /* chunkingEnabled= */ false));
+                /* chunkingEnabled= */ false,
+                new ChunkLocationMap()));
     RemoteSpawnCache remoteSpawnCache = remoteSpawnCacheWithOptions(remoteCacheOptions);
     for (String requirement :
         ImmutableList.of(
@@ -554,7 +556,8 @@ public class RemoteSpawnCacheTest {
                 diskCacheClient,
                 /* symlinkTemplate= */ null,
                 digestUtil,
-                /* chunkingEnabled= */ false));
+                /* chunkingEnabled= */ false,
+                new ChunkLocationMap()));
 
     for (String requirement :
         ImmutableList.of(ExecutionRequirements.NO_CACHE, ExecutionRequirements.LOCAL)) {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
@@ -340,7 +340,8 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
             /* diskCacheClient= */ null,
             /* symlinkTemplate= */ null,
             DIGEST_UTIL,
-            /* chunkingEnabled= */ false);
+            /* chunkingEnabled= */ false,
+            new ChunkLocationMap());
     RemoteExecutionService remoteExecutionService =
         new RemoteExecutionService(
             reporter,

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CasServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CasServer.java
@@ -33,13 +33,17 @@ import build.bazel.remote.execution.v2.SpliceBlobResponse;
 import build.bazel.remote.execution.v2.SplitBlobRequest;
 import build.bazel.remote.execution.v2.SplitBlobResponse;
 import com.google.common.flogger.GoogleLogger;
+import com.google.devtools.build.lib.remote.Store;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
+import com.google.devtools.build.lib.remote.disk.DiskCacheClient;
 import com.google.devtools.build.lib.remote.util.DigestOutputStream;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
+import com.google.devtools.build.lib.vfs.Path;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.rpc.Code;
 import io.grpc.stub.StreamObserver;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayDeque;
@@ -204,13 +208,7 @@ final class CasServer extends ContentAddressableStorageImplBase {
         }
       }
 
-      DigestOutputStream digestOut =
-          cache.getDigestUtil().newDigestOutputStream(OutputStream.nullOutputStream());
-      for (Digest chunkDigest : chunkDigests) {
-        byte[] chunkData = getFromFuture(cache.downloadBlob(context, chunkDigest));
-        digestOut.write(chunkData);
-      }
-      Digest computedDigest = digestOut.digest();
+      Digest computedDigest = spliceIntoCas(context, chunkDigests, blobDigest);
       if (!computedDigest.equals(blobDigest)) {
         String err =
             "Splice digest " + blobDigest + " did not match computed digest: " + computedDigest;
@@ -230,6 +228,44 @@ final class CasServer extends ContentAddressableStorageImplBase {
     } catch (Exception e) {
       logger.atWarning().withCause(e).log("SpliceBlob request failed");
       responseObserver.onError(StatusUtils.internalError(e));
+    }
+  }
+
+  /**
+   * Concatenates the chunks into the full blob and, if it matches {@code blobDigest}, stores it in
+   * the CAS. Chunks remain the primary read path; the full blob is stored so that action results
+   * referencing it pass existence checks and plain (non-SplitBlob) reads work.
+   *
+   * @return the digest of the concatenated chunks
+   */
+  private Digest spliceIntoCas(
+      RemoteActionExecutionContext context, List<Digest> chunkDigests, Digest blobDigest)
+      throws IOException, InterruptedException {
+    DiskCacheClient diskCacheClient = cache.getDiskCacheClient();
+    Path tempPath = diskCacheClient.getTempPath();
+    try {
+      Digest computedDigest;
+      OutputStream rawOut = tempPath.getOutputStream();
+      try (DigestOutputStream digestOut = cache.getDigestUtil().newDigestOutputStream(rawOut)) {
+        for (Digest chunkDigest : chunkDigests) {
+          digestOut.write(getFromFuture(cache.downloadBlob(context, chunkDigest)));
+        }
+        computedDigest = digestOut.digest();
+        // Fsync so a machine crash cannot publish a CAS entry whose data never reached disk.
+        if (rawOut instanceof FileOutputStream fos) {
+          fos.getFD().sync();
+        }
+      }
+      if (computedDigest.equals(blobDigest)) {
+        diskCacheClient.captureFile(tempPath, blobDigest, Store.CAS);
+      }
+      return computedDigest;
+    } finally {
+      try {
+        tempPath.delete();
+      } catch (IOException e) {
+        logger.atWarning().withCause(e).log("Failed to delete temporary file %s", tempPath);
+      }
     }
   }
 }

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
@@ -28,6 +28,7 @@ import build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy;
 import build.bazel.remote.execution.v2.SymlinkNode;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.remote.ChunkLocationMap;
 import com.google.devtools.build.lib.remote.CombinedCache;
 import com.google.devtools.build.lib.remote.Store;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
@@ -60,7 +61,8 @@ class OnDiskBlobStoreCache extends CombinedCache {
         new DiskCacheClient(cacheDir, digestUtil),
         /* symlinkTemplate= */ null,
         digestUtil,
-        /* chunkingEnabled= */ false);
+        /* chunkingEnabled= */ false,
+        new ChunkLocationMap());
     this.remoteWorkerOptions = remoteWorkerOptions;
   }
 


### PR DESCRIPTION
There are many valid reasons to run without a disk cache, but without one there are no download savings. Even when `SplitBlob` reports that a new blob shares most of its chunks with an output already on disk, the client refetches every chunk from the remote cache.

This adds a `ChunkLocationMap`, an in-memory map from chunk digest to a file and byte offset where that chunk was recently downloaded. Locations are recorded after each chunked download and checked before each chunk fetch. On a hit the chunk is read locally instead. Locations are only hints into files that may be rewritten at any time, so every local read is verified against the chunk digest and any failure is just a miss. This saves downloads without the storage overhead and complexity of a disk cache. The map stores no content, is capped at 100k entries, and follows the pattern of `knownMissingCasDigests`. It is held on `RemoteModule` across commands and cleared on clean. This has been enabled in BuildBuddy executors for some time. Hit rates are about 20-50% of chunks even within an invocation, and can get much higher.

To measure, I built `//src:bazel-dev` (114 outputs over the 2MB chunking threshold) at each of the last 40 commits of master, using BuildBuddy's production cache (blake3, zstd, no disk cache, `--remote_download_all`). All numbers come from `--remote_grpc_log`, comparing SplitBlob responses to ByteStream reads. A cold full download after a clean served 22-31% of chunk fetches locally. Walking the commits again, each build downloads its changed outputs with the previous commit's outputs already on disk. Across those builds, 85.7% of chunk fetches were served locally (11.6 GB of 13.3 GB). A rebuilt large output fetched 60-90 MB instead of ~526 MB, mostly reusing chunks from its own previous version. After the walk the map held 2,622 entries, about 540 KB. The map costs ~205 bytes per entry, so the 100k cap bounds it at ~20 MB. With chunking disabled the map has no entries and no measurable memory.

Closes #30531.

PiperOrigin-RevId: 970424427
Change-Id: I8ff60850f65f17f72790110a2c205b54f5f2f11b

(cherry picked from commit 6fec0932718b11b117227bd852d099ca5f4167f7)

9.3.0 adaptation: this branch predates the selectable chunking function (#30131), so `CombinedCache` and `RemoteExecutionCache` keep their `boolean chunkingEnabled` parameter and `ChunkedBlobDownloader` keeps its `ChunkingConfig`-free constructor; each simply gains the `ChunkLocationMap`. Master's fine-grained `remote/BUILD` dependency hunks are no-ops against the branch's monolithic `remote` library and are dropped, and `RemoteSpawnCacheTest` (a call site that only exists here) was updated for the new constructor. Note that `//src/test/java/com/google/devtools/build/lib/remote:ChunkedTransferBenchmark` does not analyze on this branch even before this change, because its `//src/main/java/com/google/devtools/build/lib/remote:combined_cache` dep does not exist; the benchmark source is updated but cannot be compiled here. The rest of `//src/main/java/.../remote/...`, `//src/tools/remote/...` and `//src/test/java/.../remote/...` builds, and `RemoteTests` (147 tests) passes locally.

Closes #30562
