### PR TITLE
[9.3.0] Avoid cc toolchain fieldValue access NPE

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
@@ -885,6 +885,9 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
           }
           return new Sequence(expandedIterable.build());
         }
+        if (fieldValue == null) {
+          return null;
+        }
         return asVariableValue(fieldValue);
       } catch (EvalException e) {
         if (throwOnMissingVariable) {


### PR DESCRIPTION
### Description
Interpret null fieldValue in cc toolchain variable info structure enumeration with NoneType behavior to avoid NPE

### Motivation
A CC Toolchain Variables Info struct member field may be absent, resulting in a null fieldValue, and attempted access in asVariableValue(). This NPE was observed with rules_rs at latest 0.0.98, and occurs because of the intolerance of null in Java's switch expression:

```
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.RuntimeException: Unrecoverable error while evaluating node 'ToolchainDependencyConfiguredTargetKey{label=@@rules_rs++toolchains+default_rust_toolchains//:linux_x86_64_1_94_0_rust_toolchain, config=BuildConfigurationKey[a337dd2dab759f1f66b2c79b8b8f48ef5c1353e0b6cdeded439a4ecf9bc4019c], executionPlatformLabel=//platform:label}' (requested by nodes 'ConfiguredTargetKey{label=//tools/pathstrip:pathstrip, config=BuildConfigurationKey[a337dd2dab759f1f66b2c79b8b8f48ef5c1353e0b6cdeded439a4ecf9bc4019c]}', 'ConfiguredTargetKey{label=//tools/toolchains/musl/test:hello_rs, config=BuildConfigurationKey[a337dd2dab759f1f66b2c79b8b8f48ef5c1353e0b6cdeded439a4ecf9bc4019c]}', 'ConfiguredTargetKey{label=@@rules_rs++rules_rust+rules_rust//ffi/rs:empty_allocator_libraries, config=BuildConfigurationKey[a337dd2dab759f1f66b2c79b8b8f48ef5c1353e0b6cdeded439a4ecf9bc4019c]}', 'ConfiguredTargetKey{label=@@rules_rs++crate+crates__clap-4.6.1//:clap, config=BuildConfigurationKey[a337dd2dab759f1f66b2c79b8b8f48ef5c1353e0b6cdeded439a4ecf9bc4019c]}', 'ConfiguredTargetKey{label=@@rules_rs++crate+crates__clap_derive-4.6.1//:clap_derive, config=BuildConfigurationKey[a337dd2dab759f1f66b2c79b8b8f48ef5c1353e0b6cdeded439a4ecf9bc4019c]}', 'ConfiguredTargetKey{label=@@rules_rs++crate+crates__clap_builder-4.6.0//:clap_builder, config=BuildConfigurationKey[a337dd2dab759f1f66b2c79b8b8f48ef5c1353e0b6cdeded439a4ecf9bc4019c]}', ...)
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:552)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:435)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask$InterruptibleTask.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Unknown Source)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainVariables.asVariableValue(CcToolchainVariables.java:826)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainVariables$StarlarkStructureAdapter.getFieldValue(CcToolchainVariables.java:886)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainVariables.getStructureVariable(CcToolchainVariables.java:425)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainVariables.lookupVariable(CcToolchainVariables.java:371)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainVariables.getVariable(CcToolchainVariables.java:330)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$FlagGroup.expand(CcToolchainFeatures.java:225)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$FlagGroup.expand(CcToolchainFeatures.java:229)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$FlagGroup.expandCommandLine(CcToolchainFeatures.java:296)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$FlagSet.expandCommandLine(CcToolchainFeatures.java:344)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$Feature.expandCommandLine(CcToolchainFeatures.java:466)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$FeatureConfiguration.getCommandLine(CcToolchainFeatures.java:931)
	at com.google.devtools.build.lib.rules.cpp.LinkCommandLine.getParamCommandLine(LinkCommandLine.java:105)
	at com.google.devtools.build.lib.rules.cpp.LinkCommandLine.arguments(LinkCommandLine.java:164)
	at com.google.devtools.build.lib.rules.cpp.LinkCommandLine.arguments(LinkCommandLine.java:42)
	at com.google.devtools.build.lib.actions.AbstractCommandLine.addToFingerprint(AbstractCommandLine.java:61)
	at com.google.devtools.build.lib.actions.CommandLines.addToFingerprint(CommandLines.java:186)
	at com.google.devtools.build.lib.analysis.actions.SpawnAction.computeKey(SpawnAction.java:404)
	at com.google.devtools.build.lib.actions.ActionKeyComputer.getKey(ActionKeyComputer.java:43)
	at com.google.devtools.build.lib.actions.Actions.canBeShared(Actions.java:92)
	at com.google.devtools.build.lib.actions.Actions.canBeSharedLogForPotentialFalsePositives(Actions.java:130)
	at com.google.devtools.build.lib.actions.Actions.verifyGeneratingActionKeys(Actions.java:218)
	at com.google.devtools.build.lib.actions.Actions.assignOwnersAndThrowIfConflictMaybeToleratingSharedActions(Actions.java:261)
	at com.google.devtools.build.lib.actions.Actions.assignOwnersAndThrowIfConflictToleratingSharedActions(Actions.java:196)
	at com.google.devtools.build.lib.analysis.RuleConfiguredTargetBuilder.build(RuleConfiguredTargetBuilder.java:279)
	at com.google.devtools.build.lib.analysis.starlark.StarlarkRuleConfiguredTargetUtil.createTarget(StarlarkRuleConfiguredTargetUtil.java:199)
	at com.google.devtools.build.lib.analysis.ConfiguredTargetFactory.createRule(ConfiguredTargetFactory.java:476)
	at com.google.devtools.build.lib.analysis.ConfiguredTargetFactory.createConfiguredTarget(ConfiguredTargetFactory.java:240)
	at com.google.devtools.build.lib.skyframe.SkyframeBuildView.createConfiguredTarget(SkyframeBuildView.java:1398)
	at com.google.devtools.build.lib.skyframe.ConfiguredTargetFunction.createConfiguredTarget(ConfiguredTargetFunction.java:453)
	at com.google.devtools.build.lib.skyframe.ConfiguredTargetFunction.compute(ConfiguredTargetFunction.java:371)
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:471)
	... 8 more
```

Solution adopted in this change was to consider asVariableValue case of 'NoneType' equivalent to null response, having "the same behavior as omitted field." Bazel seems otherwise unperturbed by the null response here, resulting in successful builds.

### Build API Changes
No

### Release Notes
RELNOTES: None

Closes #30502.

PiperOrigin-RevId: 956561096
Change-Id: Ic625d4e49dd1f7c014a906330ac764d6e505ef34

(cherry picked from commit 29a68ab937b274ec867f6287352485f48eba85a3)

Cherry-picks cleanly; no adaptation was needed. The whole `//src/test/java/com/google/devtools/build/lib/rules/cpp:all` suite (34 tests) passes locally.

Opened because the existing cherry-pick #30551 has been blocked on a CLA check since 2026-08-17.

Note that `cla/google` fails here too: it inspects commit authors and `Co-authored-by` trailers rather than the PR author, so any pick that credits the original author trips it. This commit is authored by me with `Co-authored-by: George Gensure <werkt@gmail.com>` preserving credit, which needs the `cla: yes` label to go green. Dropping the trailer would also clear the check if that is preferred — the original authorship is recorded on master in 29a68ab937.

Please close whichever of this PR and #30551 is redundant.

Closes #30550
