### PR TITLE
[9.3.0] Invalidate action execution salt when remote cache endpoints or insta…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -1254,7 +1254,8 @@ public final class RemoteModule extends BlazeModule {
     builder.setActionExecutionSalt(computeActionExecutionSalt(remoteOptions));
   }
 
-  private static String computeActionExecutionSalt(RemoteOptions remoteOptions) {
+  @VisibleForTesting
+  static String computeActionExecutionSalt(RemoteOptions remoteOptions) {
     Fingerprint fp = new Fingerprint();
 
     // When building without a remote cache following a build with one, cached actions may reference
@@ -1272,6 +1273,18 @@ public final class RemoteModule extends BlazeModule {
     // shouldn't be too bad, as we don't expect the defaults to change very often.
     fp.addStringMap(
         remoteOptions != null ? remoteOptions.getRemoteDefaultExecProperties() : ImmutableMap.of());
+
+    // When switching cache endpoints/instances across invocations, cached remote actions reference
+    // blobs stored in the previous cache instance which cannot be downloaded from the new cache
+    // instance. See https://github.com/bazelbuild/bazel/issues/23780.
+    if (remoteOptions != null) {
+      fp.addNullableString(remoteOptions.getRemoteCache());
+      fp.addNullableString(remoteOptions.getRemoteExecutor());
+      fp.addNullableString(remoteOptions.getRemoteDownloader());
+      fp.addNullableString(remoteOptions.getRemoteInstanceName());
+      fp.addNullableString(remoteOptions.getRemoteBytestreamUriPrefix());
+      fp.addNullableString(remoteOptions.getRemoteProxy());
+    }
 
     return fp.hexDigestAndReset();
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -1278,12 +1278,12 @@ public final class RemoteModule extends BlazeModule {
     // blobs stored in the previous cache instance which cannot be downloaded from the new cache
     // instance. See https://github.com/bazelbuild/bazel/issues/23780.
     if (remoteOptions != null) {
-      fp.addNullableString(remoteOptions.getRemoteCache());
-      fp.addNullableString(remoteOptions.getRemoteExecutor());
-      fp.addNullableString(remoteOptions.getRemoteDownloader());
-      fp.addNullableString(remoteOptions.getRemoteInstanceName());
-      fp.addNullableString(remoteOptions.getRemoteBytestreamUriPrefix());
-      fp.addNullableString(remoteOptions.getRemoteProxy());
+      fp.addNullableString(remoteOptions.remoteCache);
+      fp.addNullableString(remoteOptions.remoteExecutor);
+      fp.addNullableString(remoteOptions.remoteDownloader);
+      fp.addNullableString(remoteOptions.remoteInstanceName);
+      fp.addNullableString(remoteOptions.remoteBytestreamUriPrefix);
+      fp.addNullableString(remoteOptions.remoteProxy);
     }
 
     return fp.hexDigestAndReset();

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -771,4 +771,64 @@ public final class RemoteModuleTest {
       assertThat(circuitBreaker).isEqualTo(Retrier.ALLOW_ALL_CALLS);
     }
   }
+
+  @Test
+  public void testComputeActionExecutionSalt_changesWhenCacheInstanceChanges() throws Exception {
+    RemoteOptions baseOptions =
+        parseRemoteOptions(
+            "--remote_cache=grpc://cache1",
+            "--remote_executor=grpc://exec1",
+            "--remote_instance_name=instance1");
+    String baseSalt = RemoteModule.computeActionExecutionSalt(baseOptions);
+    assertThat(RemoteModule.computeActionExecutionSalt(null)).isNotNull();
+    assertThat(RemoteModule.computeActionExecutionSalt(baseOptions)).isEqualTo(baseSalt);
+
+    RemoteOptions changedInstanceName =
+        parseRemoteOptions(
+            "--remote_cache=grpc://cache1",
+            "--remote_executor=grpc://exec1",
+            "--remote_instance_name=instance2");
+    assertThat(RemoteModule.computeActionExecutionSalt(changedInstanceName)).isNotEqualTo(baseSalt);
+
+    RemoteOptions changedRemoteCache =
+        parseRemoteOptions(
+            "--remote_cache=grpc://cache2",
+            "--remote_executor=grpc://exec1",
+            "--remote_instance_name=instance1");
+    assertThat(RemoteModule.computeActionExecutionSalt(changedRemoteCache)).isNotEqualTo(baseSalt);
+
+    RemoteOptions changedRemoteExecutor =
+        parseRemoteOptions(
+            "--remote_cache=grpc://cache1",
+            "--remote_executor=grpc://exec2",
+            "--remote_instance_name=instance1");
+    assertThat(RemoteModule.computeActionExecutionSalt(changedRemoteExecutor))
+        .isNotEqualTo(baseSalt);
+
+    RemoteOptions changedRemoteDownloader =
+        parseRemoteOptions(
+            "--remote_cache=grpc://cache1",
+            "--remote_executor=grpc://exec1",
+            "--remote_instance_name=instance1",
+            "--remote_downloader=grpc://downloader1");
+    assertThat(RemoteModule.computeActionExecutionSalt(changedRemoteDownloader))
+        .isNotEqualTo(baseSalt);
+
+    RemoteOptions changedBytestreamPrefix =
+        parseRemoteOptions(
+            "--remote_cache=grpc://cache1",
+            "--remote_executor=grpc://exec1",
+            "--remote_instance_name=instance1",
+            "--remote_bytestream_uri_prefix=host/instance2");
+    assertThat(RemoteModule.computeActionExecutionSalt(changedBytestreamPrefix))
+        .isNotEqualTo(baseSalt);
+
+    RemoteOptions changedRemoteProxy =
+        parseRemoteOptions(
+            "--remote_cache=grpc://cache1",
+            "--remote_executor=grpc://exec1",
+            "--remote_instance_name=instance1",
+            "--remote_proxy=unix:/socket2");
+    assertThat(RemoteModule.computeActionExecutionSalt(changedRemoteProxy)).isNotEqualTo(baseSalt);
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -810,7 +810,7 @@ public final class RemoteModuleTest {
             "--remote_cache=grpc://cache1",
             "--remote_executor=grpc://exec1",
             "--remote_instance_name=instance1",
-            "--remote_downloader=grpc://downloader1");
+            "--experimental_remote_downloader=grpc://downloader1");
     assertThat(RemoteModule.computeActionExecutionSalt(changedRemoteDownloader))
         .isNotEqualTo(baseSalt);
 

--- a/src/test/shell/bazel/remote/remote_utils.sh
+++ b/src/test/shell/bazel/remote/remote_utils.sh
@@ -24,7 +24,10 @@ function start_worker() {
   pid_file="${TEST_TMPDIR}/remote.pid_file"
   mkdir -p "${work_path}"
   mkdir -p "${cas_path}"
-  worker_port=$(pick_random_unused_tcp_port) || fail "no port found"
+  # Preserve port across restarts so tests simulating cache eviction don't invalidate action execution salt.
+  if [[ -z "${worker_port:-}" ]]; then
+    worker_port=$(pick_random_unused_tcp_port) || fail "no port found"
+  fi
   native_lib="${BAZEL_RUNFILES}/src/main/native/"
   "${REMOTE_WORKER}" \
       --singlejar \


### PR DESCRIPTION
…nce name change.

Changing flags that specify the remote cache instance (such as `--remote_instance_name`, `--remote_cache`, or `--remote_executor`) across builds previously left the action execution salt unchanged. This caused Bazel to serve stale action cache entries referencing blobs in the old cache instance, triggering `SPAWN(REMOTE_CACHE_EVICTED)` errors.

Include `--remote_instance_name`, `--remote_cache`, `--remote_executor`, `--remote_downloader`, `--remote_bytestream_uri_prefix`, and `--remote_proxy` in `RemoteModule.computeActionExecutionSalt`. When any of these options change across invocations, Bazel invalidates cached action execution entries and re-evaluates actions against the new cache instance.

In `remote_utils.sh`, preserve `worker_port` across worker restarts so that shell integration tests testing remote cache eviction do not unintentionally change the remote executor endpoint port and invalidate the action execution salt.

RELNOTES: Invalidate cached action execution results when remote cache/executor endpoints or `--remote_instance_name` change between invocations.

Fixes https://github.com/bazelbuild/bazel/issues/23780

PiperOrigin-RevId: 974990607
Change-Id: Ibb623779f5e60440ccdae771b938f54b4f8cc027

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/6b1e640b64518a024d0d4a46bab677cb4d3c0b00