### PR TITLE
Preserve materialized files during RRCC reinjection

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExternalOverlayFileSystem.java
@@ -88,6 +88,11 @@ import javax.annotation.Nullable;
  */
 public final class RemoteExternalOverlayFileSystem extends FileSystem
     implements SubtreeMaterializer {
+  // This deliberately doesn't match the repository's predeclared input hash, so normal repository
+  // validation treats a partially materialized remote repository as out of date and consults the
+  // RRCC again after a server restart.
+  private static final String REMOTE_REPO_MARKER_PREFIX = "remote repository contents: ";
+
   private final PathFragment externalDirectory;
   private final int externalDirectorySegmentCount;
   private final FileSystem nativeFs;
@@ -205,12 +210,26 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
    * Injects the given remote contents, possibly prefetching some files, and returns true on
    * success.
    */
-  public boolean injectRemoteRepo(RepositoryName repo, Tree remoteContents, String markerFile)
+  public boolean injectRemoteRepo(
+      RepositoryName repo, Tree remoteContents, Digest remoteContentsDigest, String markerFile)
       throws IOException, InterruptedException {
     var repoDir = externalDirectory.getChild(repo.getName());
-    deleteTree(repoDir);
+    var markerPath = externalDirectory.getChild(repo.getMarkerFileName());
+    var nativeMarkerPath = nativeFs.getPath(markerPath);
+    var remoteRepoMarker = REMOTE_REPO_MARKER_PREFIX + DigestUtil.toString(remoteContentsDigest);
+    // Materialized files may have references outside the repository, such as runfile symlinks.
+    // Preserve them when reinjecting the exact same remote tree, including across server restarts.
+    var canPreserveMaterializedFiles =
+        nativeMarkerPath.exists()
+            && remoteRepoMarker.equals(
+                new String(FileSystemUtils.readContentAsLatin1(nativeMarkerPath)));
+    if (canPreserveMaterializedFiles) {
+      externalFs.getPath(repoDir).deleteTree();
+    } else {
+      deleteTree(repoDir);
+    }
     materializedRepos.remove(repo.getName());
-    var unused = delete(externalDirectory.getChild(repo.getMarkerFileName()));
+    var unused = delete(markerPath);
     var childMap =
         remoteContents.getChildrenList().stream()
             .collect(
@@ -243,6 +262,12 @@ public final class RemoteExternalOverlayFileSystem extends FileSystem
     // Create the repo directory on disk so that readdir reflects the overlaid state of the external
     // directory.
     nativeFs.createDirectoryAndParents(repoDir);
+    // Persist the tree identity so a future server can distinguish safe reinjection from changed
+    // repository contents without hashing the selectively materialized files.
+    var markerFileSibling =
+        nativeFs.getPath(markerPath.replaceName(markerPath.getBaseName() + ".tmp"));
+    FileSystemUtils.writeContentAsLatin1(markerFileSibling, remoteRepoMarker);
+    markerFileSibling.renameTo(nativeMarkerPath);
     // Keep the marker file contents in memory so that it can be written out when the repo is
     // materialized. This doubles as a presence marker for the in-memory repo contents.
     markerFileContents.put(repo.getName(), markerFile);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
@@ -301,7 +301,10 @@ public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCach
     }
 
     return remoteFs.injectRemoteRepo(
-        repoName, repoDirectoryContentFuture.resultNow(), markerFileContent);
+        repoName,
+        repoDirectoryContentFuture.resultNow(),
+        repoDirectory.getTreeDigest(),
+        markerFileContent);
   }
 
   private enum CacheOp {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -211,7 +211,10 @@ public class RemoteActionInputFetcherTest extends ActionInputPrefetcherTestBase 
           IOException.class,
           () ->
               overlayFs.injectRemoteRepo(
-                  RepositoryName.createUnvalidated("repo"), tree, "MARKER\n"));
+                  RepositoryName.createUnvalidated("repo"),
+                  tree,
+                  digestUtil.compute(tree.toByteArray()),
+                  "MARKER\n"));
     }
   }
 

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -2712,6 +2712,78 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     _, _, stderr = self.RunBazel(['build', '//main:use_data'])
     self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
 
+  def testReinjectionPreservesMaterializedFilesForSameContents(self):
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            (
+                '  rctx.file("BUILD", "exports_files([\'data.txt\'])\\n'
+                'filegroup(name=\'empty\')")'
+            ),
+            '  rctx.file("data.txt", rctx.attr.data)',
+            '  print("JUST FETCHED: %s" % rctx.attr.data)',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(',
+            '    implementation = _repo_impl,',
+            '    attrs = {"data": attr.string()},',
+            ')',
+        ],
+    )
+    self.ScratchFile(
+        'BUILD.bazel',
+        [
+            'genrule(',
+            '    name = "use_data",',
+            '    srcs = ["@my_repo//:data.txt"],',
+            '    outs = ["out.txt"],',
+            '    cmd = "cat $< > $@",',
+            '    tags = ["no-cache"],',
+            ')',
+        ],
+    )
+
+    def set_repo_data(data):
+      self.ScratchFile(
+          'MODULE.bazel',
+          [
+              'repo = use_repo_rule("//:repo.bzl", "repo")',
+              'repo(name = "my_repo", data = "%s")' % data,
+          ],
+      )
+
+    # Populate distinct cache entries for two repository contents.
+    set_repo_data('one')
+    self.RunBazel(['build', '//:use_data'])
+    set_repo_data('two')
+    self.RunBazel(['build', '//:use_data'])
+
+    # Restore the first entry, materializing data.txt as a local action input.
+    self.RunBazel(['clean', '--expunge'])
+    set_repo_data('one')
+    _, _, stderr = self.RunBazel(['build', '//:use_data'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    repo_dir = self.RepoDir('my_repo')
+    data_path = os.path.join(repo_dir, 'data.txt')
+    with open(data_path) as f:
+      self.assertEqual(f.read(), 'one')
+
+    # A server restart causes the repository to be injected again. Existing
+    # references to materialized files must remain valid when the Tree digest
+    # is unchanged.
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:empty'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    with open(data_path) as f:
+      self.assertEqual(f.read(), 'one')
+
+    # Different repository contents must not retain stale materialized files.
+    self.RunBazel(['shutdown'])
+    set_repo_data('two')
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:empty'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    self.assertFalse(os.path.exists(data_path))
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
### Description

Preserve native files materialized from the remote repository contents cache when the same repository Tree is injected again. Persist the injected Tree digest at the repository marker path, and use it to distinguish identical reinjection from changed contents.

### Motivation

The existing repository state machine has two stable states:

- Injected: the real marker exists only in memory while files may be selectively materialized on the native filesystem.
- Fully materialized: the complete repository and real marker exist on the native filesystem.

After a server restart, the injected state loses its in-memory marker and overlay. A subsequent RRCC hit unconditionally deletes the repository directory before reconstructing the overlay, including native files still referenced by runfile symlinks.

This adds a persisted transitional state:

- Injected Tree sentinel: the Tree digest is stored at the marker path while the real marker remains in memory.

The sentinel does not match the repository rule's predeclared input hash, so normal validation still consults the RRCC after a restart. Reinjection of the same Tree replaces only the in-memory overlay and preserves native files. A missing or different Tree digest retains the existing full deletion behavior. Full materialization atomically replaces the sentinel with the real marker.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Testing

The regression test was committed first and fails on unmodified `master` after same-Tree reinjection with `FileNotFoundError`.

### Release Notes

RELNOTES: The remote repository contents cache now preserves materialized files when reinjecting unchanged repository contents.

Generated with [Codex](https://openai.com/codex/).
