### PR TITLE
[9.3.0] Do not perform remoteOutputChecker.afterAnalysis on --nobuild (https://github.com/bazelbuild/bazel/pull/27138)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -1061,7 +1061,9 @@ public final class RemoteModule extends BlazeModule {
       AnalysisResult analysisResult) {
     BuildRequestOptions buildRequestOptions =
         env.getOptions().getOptions(BuildRequestOptions.class);
-    if (remoteOutputChecker != null && buildRequestOptions.getPerformExecutionPhase()) {
+    if (remoteOutputChecker != null
+        && buildRequestOptions != null
+        && buildRequestOptions.performExecutionPhase) {
       remoteOutputChecker.afterAnalysis(analysisResult);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -1059,7 +1059,9 @@ public final class RemoteModule extends BlazeModule {
       BuildRequest request,
       BuildOptions buildOptions,
       AnalysisResult analysisResult) {
-    if (remoteOutputChecker != null) {
+    BuildRequestOptions buildRequestOptions =
+        env.getOptions().getOptions(BuildRequestOptions.class);
+    if (remoteOutputChecker != null && buildRequestOptions.getPerformExecutionPhase()) {
       remoteOutputChecker.afterAnalysis(analysisResult);
     }
   }


### PR DESCRIPTION
This is a waste of time during builds that will not perform an execution

Closes #27138.

PiperOrigin-RevId: 975581368
Change-Id: I8b4f762133640b64e7dd6ff03539fd8058476855

Commit https://github.com/bazelbuild/bazel/commit/3edf2950e89742507c29aa4f00045419d4cbcdf1