### PR TITLE
[9.3.0] Don't mutate an action's input map after it has been executed (https://github.com/bazelbuild/bazel/pull/30693)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
@@ -760,7 +760,7 @@ public final class ActionExecutionFunction implements SkyFunction {
             action);
       }
 
-      addDiscoveredInputs(state, env, action);
+      addDiscoveredInputs(state, env, action, /* afterExecution= */ false);
       if (env.valuesMissing()) {
         return null;
       }
@@ -807,30 +807,42 @@ public final class ActionExecutionFunction implements SkyFunction {
         throws InterruptedException, ActionExecutionException {
       if (action.discoversInputs()) {
         state.discoveredInputs = action.getInputs();
-        addDiscoveredInputs(state, env, action);
+        addDiscoveredInputs(state, env, action, /* afterExecution= */ true);
         if (env.valuesMissing()) {
           return;
         }
       }
       checkState(!env.valuesMissing(), action);
       skyframeActionExecutor.updateActionCache(
-          action, inputMetadataProvider, outputMetadataStore, state.token, clientEnv);
+          action,
+          state.inputMetadataProviderIncludingLateDiscoveredInputs(inputMetadataProvider),
+          outputMetadataStore,
+          state.token,
+          clientEnv);
     }
   }
 
+  /**
+   * Adds the metadata of {@link InputDiscoveryState#discoveredInputs} that isn't known yet to the
+   * state.
+   *
+   * <p>Before the action is executed, the metadata is added to {@link
+   * InputDiscoveryState#inputArtifactData} so that the action can access it. Afterwards, it is
+   * added to {@link InputDiscoveryState#lateDiscoveredInputArtifactData} instead: the action file
+   * system reads {@code inputArtifactData} and outlives the action itself, but {@link
+   * ActionInputMap} is not thread-safe, so mutating it at that point would race with those reads.
+   */
   private void addDiscoveredInputs(
-      InputDiscoveryState state, Environment env, Action actionForError)
+      InputDiscoveryState state, Environment env, Action actionForError, boolean afterExecution)
       throws InterruptedException, ActionExecutionException {
     // TODO(janakr): This code's assumptions are wrong in the face of Starlark actions with unused
     //  inputs, since ActionExecutionExceptions can come through here and should be aggregated. Fix.
-
-    ActionInputMap inputData = state.inputArtifactData;
 
     // Filter down to unknown discovered inputs eagerly instead of using a lazy Iterables#filter to
     // reduce iteration cost.
     List<Artifact> unknownDiscoveredInputs = new ArrayList<>();
     for (Artifact input : state.discoveredInputs.toList()) {
-      if (inputData.getInputMetadata(input) == null) {
+      if (state.getKnownDiscoveredInputMetadata(input) == null) {
         unknownDiscoveredInputs.add(input);
       }
     }
@@ -838,6 +850,11 @@ public final class ActionExecutionFunction implements SkyFunction {
     if (unknownDiscoveredInputs.isEmpty()) {
       return;
     }
+
+    ActionInputMap inputData =
+        afterExecution
+            ? state.getOrCreateLateDiscoveredInputArtifactData(unknownDiscoveredInputs.size())
+            : state.inputArtifactData;
 
     SkyframeLookupResult nonMandatoryDiscovered =
         env.getValuesAndExceptions(Artifact.keys(unknownDiscoveredInputs));
@@ -1201,6 +1218,17 @@ public final class ActionExecutionFunction implements SkyFunction {
      */
     DelegatingPairInputMetadataProvider compositeInputMetadataProvider = null;
 
+    /**
+     * Metadata for inputs that were only discovered after the action was executed.
+     *
+     * <p>Deliberately not part of {@link #inputArtifactData}: that map is read by the action file
+     * system, which outlives the action itself and is read asynchronously. {@link ActionInputMap}
+     * is not thread-safe, so mutating it concurrently corrupts it for the reader.
+     */
+    @Nullable private ActionInputMap lateDiscoveredInputArtifactData = null;
+
+    @Nullable private InputMetadataProvider lateDiscoveredInputMetadataProvider = null;
+
     Token token = null;
     NestedSet<Artifact> discoveredInputs = null;
     FileSystem actionFileSystem = null;
@@ -1218,6 +1246,40 @@ public final class ActionExecutionFunction implements SkyFunction {
 
     boolean hasArtifactData() {
       return inputArtifactData != null;
+    }
+
+    /**
+     * Returns the metadata already known for a discovered input, or null if it hasn't been looked
+     * up yet.
+     */
+    @Nullable
+    FileArtifactValue getKnownDiscoveredInputMetadata(Artifact input) {
+      FileArtifactValue metadata = inputArtifactData.getInputMetadata(input);
+      if (metadata != null || lateDiscoveredInputArtifactData == null) {
+        return metadata;
+      }
+      return lateDiscoveredInputArtifactData.getInputMetadata(input);
+    }
+
+    ActionInputMap getOrCreateLateDiscoveredInputArtifactData(int sizeHint) {
+      if (lateDiscoveredInputArtifactData == null) {
+        lateDiscoveredInputArtifactData = new ActionInputMap(sizeHint);
+        lateDiscoveredInputMetadataProvider =
+            new ActionInputMetadataProvider(lateDiscoveredInputArtifactData);
+      }
+      return lateDiscoveredInputArtifactData;
+    }
+
+    /**
+     * Returns a provider that also covers inputs discovered after the action was executed, which
+     * are kept out of {@link #inputArtifactData}.
+     */
+    InputMetadataProvider inputMetadataProviderIncludingLateDiscoveredInputs(
+        InputMetadataProvider inputMetadataProvider) {
+      return lateDiscoveredInputMetadataProvider == null
+          ? inputMetadataProvider
+          : new DelegatingPairInputMetadataProvider(
+              lateDiscoveredInputMetadataProvider, inputMetadataProvider);
     }
 
     boolean hasCheckedActionCache() {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -917,9 +917,9 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/test/java/com/google/devtools/build/lib/actions/util",
-        "//third_party/java/guava:collect",
-        "//third_party/java/junit",
-        "//third_party/java/truth",
+        "//third_party:guava",
+        "//third_party:junit4",
+        "//third_party:truth",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -907,6 +907,23 @@ java_test(
 )
 
 java_test(
+    name = "LateDiscoveredInputsTest",
+    timeout = "short",
+    srcs = ["LateDiscoveredInputsTest.java"],
+    deps = [
+        ":TimestampBuilderTestCase",
+        "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/test/java/com/google/devtools/build/lib/actions/util",
+        "//third_party/java/guava:collect",
+        "//third_party/java/junit",
+        "//third_party/java/truth",
+    ],
+)
+
+java_test(
     name = "StarlarkBuiltinsFunctionTest",
     timeout = "short",
     srcs = ["StarlarkBuiltinsFunctionTest.java"],

--- a/src/test/java/com/google/devtools/build/lib/skyframe/LateDiscoveredInputsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/LateDiscoveredInputsTest.java
@@ -1,0 +1,124 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.skyframe;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.actions.ActionExecutionContext;
+import com.google.devtools.build.lib.actions.ActionExecutionException;
+import com.google.devtools.build.lib.actions.ActionInputMap;
+import com.google.devtools.build.lib.actions.ActionResult;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.InputMetadataProvider;
+import com.google.devtools.build.lib.actions.util.TestAction;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.Order;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Timestamp builder tests for inputs that are only discovered after an action was executed. */
+@RunWith(JUnit4.class)
+public class LateDiscoveredInputsTest extends TimestampBuilderTestCase {
+
+  /**
+   * The action file system reads the {@link ActionInputMap} that backs the {@link
+   * InputMetadataProvider} handed to the action, and it outlives the action: build events
+   * referencing it are uploaded asynchronously. Since the map is only thread-compatible, inputs
+   * discovered after execution must not be added to it. See
+   * https://github.com/bazelbuild/bazel/issues/30683.
+   */
+  @Test
+  public void inputsDiscoveredAfterExecution_notAddedToInputMetadataProviderOfAction()
+      throws Exception {
+    Artifact hello = createSourceArtifact("hello");
+    hello.getPath().getParentDirectory().createDirectoryAndParents();
+    FileSystemUtils.writeContentAsLatin1(hello.getPath(), "content1");
+    Artifact late = createSourceArtifact("late");
+    FileSystemUtils.writeContentAsLatin1(late.getPath(), "late1");
+    Artifact goodbye = createDerivedArtifact("goodbye");
+
+    Button button = new Button();
+    AtomicReference<InputMetadataProvider> inputMetadataProvider = new AtomicReference<>();
+    registerAction(
+        new LateInputDiscoveringAction(
+            button,
+            NestedSetBuilder.create(Order.STABLE_ORDER, hello),
+            ImmutableSet.of(goodbye),
+            late,
+            inputMetadataProvider));
+
+    button.pressed = false;
+    buildArtifacts(cachingBuilder(), goodbye);
+    assertThat(button.pressed).isTrue(); // built
+
+    assertThat(inputMetadataProvider.get().getInput(late.getExecPath())).isNull();
+
+    // The late-discovered input is still tracked by the action cache.
+    button.pressed = false;
+    buildArtifacts(cachingBuilder(), goodbye);
+    assertThat(button.pressed).isFalse(); // not rebuilt
+
+    FileSystemUtils.writeContentAsLatin1(late.getPath(), "late2");
+
+    button.pressed = false;
+    buildArtifacts(cachingBuilder(), goodbye);
+    assertThat(button.pressed).isTrue(); // rebuilt
+  }
+
+  /** A {@link TestAction} that only learns about {@code late} once it has been executed. */
+  private static final class LateInputDiscoveringAction extends TestAction {
+    private final Artifact late;
+    private final AtomicReference<InputMetadataProvider> inputMetadataProvider;
+
+    LateInputDiscoveringAction(
+        Runnable effect,
+        NestedSet<Artifact> inputs,
+        ImmutableSet<Artifact> outputs,
+        Artifact late,
+        AtomicReference<InputMetadataProvider> inputMetadataProvider) {
+      super(effect, inputs, outputs);
+      this.late = late;
+      this.inputMetadataProvider = inputMetadataProvider;
+    }
+
+    @Override
+    public boolean discoversInputs() {
+      return true;
+    }
+
+    @Override
+    public NestedSet<Artifact> discoverInputs(ActionExecutionContext actionExecutionContext) {
+      return NestedSetBuilder.emptySet(Order.STABLE_ORDER);
+    }
+
+    @Override
+    public ActionResult execute(ActionExecutionContext actionExecutionContext)
+        throws ActionExecutionException, InterruptedException {
+      inputMetadataProvider.set(actionExecutionContext.getInputMetadataProvider());
+      ActionResult result = super.execute(actionExecutionContext);
+      updateInputs(
+          NestedSetBuilder.<Artifact>stableOrder()
+              .addTransitive(getMandatoryInputs())
+              .add(late)
+              .build());
+      return result;
+    }
+  }
+}


### PR DESCRIPTION
### Description

`ActionInputMap` is thread-compatible, but the action filesystem reads the map belonging to the action being executed, and that map is read from other threads *after* the action has finished:

- build events referencing the filesystem's `Path`s are uploaded asynchronously by `ByteStreamBuildEventArtifactUploader`;
- with `--remote_cache_async` (on by default), `RemoteExecutionService#doUploadOutputs` runs on a background thread and digests the action's stdout/stderr, which live under the exec root and are resolved through the action filesystem.

`ActionExecutionFunction#addDiscoveredInputs` mutated that map from the Skyframe thread after execution, for actions that discover new inputs while running (`CppCompileAction` via its `.d` file, `LtoBackendAction`, `StarlarkAction` with an unused inputs list). Since `putIfAbsent` links a new entry into its hash bucket before filling in the corresponding slot, a concurrent reader can observe a half-initialized entry:

```
java.lang.NullPointerException: Cannot invoke "String.hashCode()" because "this.paths[index]" is null
	at com.google.devtools.build.lib.actions.ActionInputMap.getIndex(ActionInputMap.java:196)
	at com.google.devtools.build.lib.actions.ActionInputMap.getInput(ActionInputMap.java:343)
	at com.google.devtools.build.lib.skyframe.ActionInputMetadataProvider.getInput(ActionInputMetadataProvider.java:128)
	at com.google.devtools.build.lib.actions.DelegatingPairInputMetadataProvider.getInput(DelegatingPairInputMetadataProvider.java:103)
	at com.google.devtools.build.lib.remote.RemoteActionFileSystem.statInternal(RemoteActionFileSystem.java:686)
	at com.google.devtools.build.lib.remote.RemoteActionFileSystem.getFastDigest(RemoteActionFileSystem.java:467)
	...
	at com.google.devtools.build.lib.remote.ByteStreamBuildEventArtifactUploader.readPathMetadata(ByteStreamBuildEventArtifactUploader.java:203)
```

Inputs that are only discovered after execution now go into a separate map, so the map the action filesystem reads is immutable from the moment the action starts executing. The pre-execution call is unchanged — nothing else can observe the filesystem yet at that point. The action cache update, the only consumer of the late-discovered metadata, receives a provider that covers both maps.

### Motivation

Fixes a flaky internal-error crash. The new test in `TimestampBuilderTest` fails without the change (the input metadata provider handed to the action reports the late-discovered input afterwards) and additionally asserts that the input is still tracked by the action cache.

Fixes #30683.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Fixed a rare crash with `NullPointerException` in `ActionInputMap.getIndex` when an action discovers additional inputs while executing.

Closes #30693.

PiperOrigin-RevId: 975665353
Change-Id: I8786147c9847e5ed2a38d118fd54b62954bf6acd

Commit https://github.com/bazelbuild/bazel/commit/6ea95086c919be3d70f7feb327dccfdcf0e17b58