### PR TITLE
[9.3.0] Fix Skymeld external repository package root loss on warm server.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -277,7 +277,8 @@ public class ExecutionTool {
               env.getDirectories().getProductName() + "-",
               skyframeExecutor.getIgnoredPaths(),
               request.getOptions(BuildLanguageOptions.class).experimentalSiblingRepositoryLayout,
-              runtime.getWorkspace().doesAllowExternalRepositories());
+              runtime.getWorkspace().doesAllowExternalRepositories(),
+              skyframeExecutor::getRootForDonePackage);
       incrementalPackageRoots.eagerlyPlantSymlinksToSingleSourceRoot();
 
       env.getSkyframeBuildView()

--- a/src/main/java/com/google/devtools/build/lib/skyframe/IncrementalPackageRoots.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/IncrementalPackageRoots.java
@@ -89,6 +89,7 @@ public class IncrementalPackageRoots implements PackageRoots {
 
   private final boolean allowExternalRepositories;
   @Nullable private EventBus eventBus;
+  @Nullable private final PackageRootLookup fallbackPackageRootLookup;
 
   // "maybe" because some conflicts in a case-insensitive FS may not be in a case-sensitive one.
   private ImmutableSet<String> maybeConflictingBaseNamesLowercase = ImmutableSet.of();
@@ -100,7 +101,8 @@ public class IncrementalPackageRoots implements PackageRoots {
       String prefix,
       IgnoredSubdirectories ignoredPaths,
       boolean useSiblingRepositoryLayout,
-      boolean allowExternalRepositories) {
+      boolean allowExternalRepositories,
+      @Nullable PackageRootLookup fallbackPackageRootLookup) {
     this.threadSafeExternalRepoPackageRootsMap = Maps.newConcurrentMap();
     this.execroot = execroot;
     this.singleSourceRoot = singleSourceRoot;
@@ -109,6 +111,7 @@ public class IncrementalPackageRoots implements PackageRoots {
     this.eventBus = eventBus;
     this.useSiblingRepositoryLayout = useSiblingRepositoryLayout;
     this.allowExternalRepositories = allowExternalRepositories;
+    this.fallbackPackageRootLookup = fallbackPackageRootLookup;
     this.symlinkPlantingPool =
         MoreExecutors.listeningDecorator(
             Executors.newFixedThreadPool(
@@ -124,6 +127,26 @@ public class IncrementalPackageRoots implements PackageRoots {
       IgnoredSubdirectories ignoredSubdirectories,
       boolean useSiblingRepositoryLayout,
       boolean allowExternalRepositories) {
+    return createAndRegisterToEventBus(
+        execroot,
+        singleSourceRoot,
+        eventBus,
+        prefix,
+        ignoredSubdirectories,
+        useSiblingRepositoryLayout,
+        allowExternalRepositories,
+        /* fallbackPackageRootLookup= */ null);
+  }
+
+  public static IncrementalPackageRoots createAndRegisterToEventBus(
+      Path execroot,
+      Root singleSourceRoot,
+      EventBus eventBus,
+      String prefix,
+      IgnoredSubdirectories ignoredSubdirectories,
+      boolean useSiblingRepositoryLayout,
+      boolean allowExternalRepositories,
+      @Nullable PackageRootLookup fallbackPackageRootLookup) {
     IncrementalPackageRoots incrementalPackageRoots =
         new IncrementalPackageRoots(
             execroot,
@@ -132,7 +155,8 @@ public class IncrementalPackageRoots implements PackageRoots {
             prefix,
             ignoredSubdirectories,
             useSiblingRepositoryLayout,
-            allowExternalRepositories);
+            allowExternalRepositories,
+            fallbackPackageRootLookup);
     eventBus.register(incrementalPackageRoots);
     return incrementalPackageRoots;
   }
@@ -184,12 +208,53 @@ public class IncrementalPackageRoots implements PackageRoots {
         "IncrementalPackageRoots does not provide the package roots map directly.");
   }
 
+  /**
+   * Returns a lookup function for package roots.
+   *
+   * <p>For packages in the main repository, the lookup unconditionally returns {@link
+   * #singleSourceRoot}.
+   *
+   * <p>For external repositories, the lookup consults {@link
+   * #threadSafeExternalRepoPackageRootsMap} and falls back to {@code fallbackPackageRootLookup} if
+   * present. Both are required:
+   *
+   * <ol>
+   *   <li>Why {@code fallbackPackageRootLookup} is necessary: External packages evaluated in
+   *       earlier builds or retained across an analysis cache discard (such as toolchains whose
+   *       transitive package metadata was cleared to save heap memory) may not be included in the
+   *       current build's {@link TopLevelTargetReadyForSymlinkPlanting} events. The fallback
+   *       queries Skyframe's graph directly to recover roots for any completed {@code PackageValue}
+   *       nodes.
+   *   <li>Why {@link #threadSafeExternalRepoPackageRootsMap} cannot be replaced:
+   *       <ul>
+   *         <li>In memory-saving modes (e.g. {@code --notrack_incremental_state} or node dropping),
+   *             Skyframe may discard {@code PackageValue} nodes before or during execution. Storing
+   *             roots during analysis symlink planting preserves them throughout execution.
+   *         <li>It acts as a fast thread-safe cache for concurrent action execution (e.g. parallel
+   *             C++ header discovery), avoiding repeated lookups against Skyframe's node graph.
+   *             Successful fallback lookups are memoized into this map via {@code putIfAbsent}.
+   *       </ul>
+   * </ol>
+   */
   @Override
   public PackageRootLookup getPackageRootLookup() {
-    return packageId ->
-        packageId.getRepository().isMain()
-            ? singleSourceRoot
-            : threadSafeExternalRepoPackageRootsMap.get(packageId);
+    return packageId -> {
+      if (packageId.getRepository().isMain()) {
+        return singleSourceRoot;
+      }
+      Root root = threadSafeExternalRepoPackageRootsMap.get(packageId);
+      if (root != null) {
+        return root;
+      }
+      if (fallbackPackageRootLookup != null) {
+        root = fallbackPackageRootLookup.getRootForPackage(packageId);
+        if (root != null) {
+          threadSafeExternalRepoPackageRootsMap.putIfAbsent(packageId, root);
+          return root;
+        }
+      }
+      return null;
+    };
   }
 
   // Intentionally don't allow concurrent events here to prevent a race condition between planting

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -2421,6 +2421,22 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     return ImmutableMap.copyOf(roots);
   }
 
+  /**
+   * Returns the {@link Root} for a done package, or {@code null} if the package is not done or
+   * failed evaluation.
+   */
+  @Nullable
+  public Root getRootForDonePackage(PackageIdentifier packageIdentifier) {
+    InMemoryNodeEntry entry = memoizingEvaluator.getInMemoryGraph().getIfPresent(packageIdentifier);
+    if (entry != null && entry.isDone()) {
+      PackageValue packageValue = (PackageValue) entry.getValue();
+      if (packageValue != null) {
+        return packageValue.getPackage().getSourceRoot();
+      }
+    }
+    return null;
+  }
+
   public void clearSyscallCache() {
     syscallCache.clear();
   }

--- a/src/test/shell/integration/discard_analysis_cache_test.sh
+++ b/src/test/shell/integration/discard_analysis_cache_test.sh
@@ -221,4 +221,135 @@ EOF
   [[ "$ct_count" -le 20 ]] || fail "Too many configured targets: $ct_count"
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/30800.
+#
+# Real-world scenario:
+# A C++ toolchain (or system library) is vendored in an external repository,
+# and headers (e.g. Windows SDK headers) are reached dynamically via relative
+# include search paths (e.g. cxx_builtin_include_directories or -isystem)
+# rather than declared target inputs (srcs/hdrs/deps).
+#
+# On a warm server following an analysis cache discard (e.g. build option change),
+# Skymeld re-instantiates IncrementalPackageRoots with an empty map. Because the
+# headers are reached dynamically rather than via declared target dependency edges,
+# the external package root is not re-registered in the second build's
+# TopLevelTargetReadyForSymlinkPlanting event. Post-execution HeaderDiscovery
+# then fails to resolve the relative path, causing spurious "undeclared inclusion(s)".
+#
+# Test setup:
+# Setting up a full custom cc_toolchain in an external repository in a shell test
+# is heavy and fragile across platforms. As noted in issue #30800, this failure
+# affects any header reached via system include paths without a declared target
+# dependency. Here we export system_includes via CcInfo from @other_repo//pkg_tool:tool_lib
+# pointing to @other_repo//pkg_header to test this exact Skyframe state:
+# 1. Build 1 loads @other_repo//pkg_header via target_a, caching PackageValue in Skyframe.
+# 2. Build 2 discards analysis cache (--cxxopt change) and builds target_b.
+# 3. target_b depends on tool_lib (which exports pkg_header as system_includes,
+#    so CppCompileAction validates the inclusion) but does NOT declare a dependency
+#    on pkg_header.
+# 4. In Build 2, IncrementalPackageRoots has an empty map. With standalone spawn
+#    strategy, the compiler finds the header in the execroot. HeaderDiscovery
+#    requires the fallback package root lookup in IncrementalPackageRoots to
+#    resolve the package root. Without the fallback, HeaderDiscovery fails.
+function test_skymeld_external_repo_package_root_preserved_after_discard_analysis_cache() {
+  if [[ "${PRODUCT_NAME}" != "bazel" ]]; then
+    return 0
+  fi
+
+  add_rules_cc MODULE.bazel
+
+  mkdir -p ../other_repo/pkg_header ../other_repo/pkg_tool
+  touch ../other_repo/REPO.bazel
+  cat > ../other_repo/pkg_header/BUILD << 'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+cc_library(
+    name = "header_lib",
+    hdrs = ["header.h"],
+    visibility = ["//visibility:public"],
+)
+EOF
+  cat > ../other_repo/pkg_header/header.h << 'EOF'
+#pragma once
+#define FOO_VALUE 42
+EOF
+
+  cat > ../other_repo/pkg_tool/defs.bzl << 'EOF'
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+
+def _tool_lib_impl(ctx):
+    return [
+        CcInfo(
+            compilation_context = cc_common.create_compilation_context(
+                system_includes = depset([ctx.label.workspace_root + "/pkg_header"]),
+            ),
+        ),
+    ]
+
+tool_lib = rule(
+    implementation = _tool_lib_impl,
+)
+EOF
+
+  cat > ../other_repo/pkg_tool/BUILD << 'EOF'
+load(":defs.bzl", "tool_lib")
+tool_lib(
+    name = "tool_lib",
+    visibility = ["//visibility:public"],
+)
+EOF
+
+  cat >> MODULE.bazel << 'EOF'
+local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+local_repository(
+    name = "other_repo",
+    path = "../other_repo",
+)
+EOF
+
+  mkdir -p foo
+  cat > foo/BUILD << 'EOF'
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+cc_library(
+    name = "target_a",
+    srcs = ["a.cc"],
+    deps = ["@other_repo//pkg_header:header_lib"],
+)
+cc_library(
+    name = "target_b",
+    srcs = ["b.cc"],
+    deps = ["@other_repo//pkg_tool:tool_lib"],
+)
+EOF
+
+  cat > foo/a.cc << 'EOF'
+#include "pkg_header/header.h"
+int a() { return FOO_VALUE; }
+EOF
+
+  cat > foo/b.cc << 'EOF'
+#include "header.h"
+int b() { return FOO_VALUE; }
+EOF
+
+  bazel build --experimental_merged_skyframe_analysis_execution \
+      --lockfile_mode=off \
+      //foo:target_a >& "$TEST_log" \
+      || fail "First build of target_a failed"
+
+  # In the second build, target_b depends on @other_repo//pkg_tool:tool_lib (so
+  # the @other_repo symlink is planted in the execroot), but includes header.h
+  # from @other_repo//pkg_header via system_includes.
+  # Following analysis cache discard (--cxxopt change), IncrementalPackageRoots
+  # has an empty map. With standalone spawn strategy, the compiler accesses the
+  # header from the execroot. HeaderDiscovery then requires the fallback
+  # package root lookup in IncrementalPackageRoots to resolve the package root.
+  bazel build --experimental_merged_skyframe_analysis_execution \
+      --lockfile_mode=off \
+      --spawn_strategy=standalone \
+      --cxxopt=-O3 //foo:target_b >& "$TEST_log" \
+      || fail "Second build of target_b failed"
+}
+
 run_suite "test for --discard_analysis_cache"
+


### PR DESCRIPTION
Fixes #30800.

Step-by-step failure mode:
1. Initial build: On a cold server, Bazel builds a target A. Loading-phase nodes (PackageValue) and configured targets for external repositories (e.g. vendored C++ toolchains) are evaluated. Following analysis, memory optimizations call clear(false) on analyzed targets (AbstractConfiguredTargetValue.java), clearing transitivePackages to save heap memory.
2. Analysis cache discard: A subsequent build is invoked on the warm server with changed flags (e.g. --cxxopt). Bazel discards the target analysis cache, but retains loading-phase PackageValue nodes and exec-configured toolchain targets in Skyframe.
3. Fresh IncrementalPackageRoots: In Skymeld mode, a brand-new IncrementalPackageRoots is created with an empty threadSafeExternalRepoPackageRootsMap for each build.
4. Lack of symlink planting events: When the top-level target B is analyzed in the second build, it links to the existing, cached toolchain node whose transitivePackages was _already cleared_ (as part of a memory optimization). Consequently, the top-level target's new transitivePackages does not receive the external toolchain package, so the TopLevelTargetReadyForSymlinkPlanting event emitted does not include the toolchain package.
5. C++ header discovery: During action execution, a CppCompileAction runs. Unlike rules where inputs are declared upfront during analysis, C++ compilation discovers included headers dynamically post-execution via HeaderDiscovery.findInputs().
6. Relative inclusion paths: The compiler discovers an inclusion from an external repository (e.g. toolchain SDK headers)
7. Package root lookup returns null: HeaderDiscovery attempts to resolve the path by calling PackageRoots.getPackageRootLookup().getRootForPackage(packageId). Because the package was never added to IncrementalPackageRoots's map, the lookup returns null.
8. Spurious build failure: With no root found, HeaderDiscovery treats the path as unresolvable (unresolvablePathProblems), failing the build with a spurious error: "undeclared inclusion(s) in rule ... this rule is missing dependency declarations for the following files included by ...: 'external/<repo>/...'".

Why it did not fail in Non-Skymeld:
- Non-Skymeld: collectPackageRoots() runs at the end of analysis and scans the entire InMemoryGraph for all done PackageValue nodes, building MapAsPackageRoots with every package known to the server. IncrementalPackageRoots is irrelevant here.
- Skymeld: Execution runs concurrently with analysis, so collectPackageRoots() cannot run upfront. Instead, IncrementalPackageRoots is instantiated fresh per build with an empty map, relying on dynamic discovery via TopLevelTargetReadyForSymlinkPlanting events.

Solution:
Allow IncrementalPackageRoots to fall back to an O(1) package root lookup against Skyframe's InMemoryGraph via SkyframeExecutor.getRootForDonePackage(PackageIdentifier) when an external package is not found in threadSafeExternalRepoPackageRootsMap. PiperOrigin-RevId: 975667669
Change-Id: I4e4045e95249460b8c447ac186cb3912692772d1

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None

Commit https://github.com/bazelbuild/bazel/commit/7c0e2110a4901bd87e1e56239e15a67d46a288fc