### PR TITLE
Add proper error ordering for mobile install command

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/mobileinstall/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/runtime/mobileinstall/BUILD
@@ -37,6 +37,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/runtime/commands:paths_to_replace_utils",
         "//src/main/java/com/google/devtools/build/lib/shell",
         "//src/main/java/com/google/devtools/build/lib/util:command",
+        "//src/main/java/com/google/devtools/build/lib/util:interrupted_failure_details",
         "//src/main/java/com/google/devtools/build/lib/util/io:out-err",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/main/java/com/google/devtools/build/lib/runtime/mobileinstall/MobileInstallCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/mobileinstall/MobileInstallCommand.java
@@ -48,6 +48,7 @@ import com.google.devtools.build.lib.server.FailureDetails.MobileInstall.Code;
 import com.google.devtools.build.lib.shell.BadExitStatusException;
 import com.google.devtools.build.lib.shell.CommandException;
 import com.google.devtools.build.lib.util.CommandBuilder;
+import com.google.devtools.build.lib.util.InterruptedFailureDetails;
 import com.google.devtools.build.lib.util.io.OutErr;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.common.options.Converters;
@@ -198,21 +199,27 @@ public class MobileInstallCommand implements BlazeCommand {
 
     AtomicReference<ExecRequest> deployerRequestRef = new AtomicReference<>();
     BuildResult result =
-        new BuildTool(env)
-            .processRequest(
-                request,
-                /* validator= */ null,
-                successfulTargets ->
-                    doMobileInstall(
-                        env, options, runTargetArgs, successfulTargets, deployerRequestRef),
-                options,
-                /* targetsForProjectResolution= */ null);
+        new BuildTool(env).processRequest(request, /* validator= */ null, options);
     if (!result.getSuccess()) {
       env.getReporter().handle(Event.error("Build failed. Not running mobile-install on target."));
       return BlazeCommandResult.detailedExitCode(result.getDetailedExitCode());
     }
 
-    FailureDetail failureDetail = result.getPostBuildCallBackFailureDetail();
+    // The deployer must run after processRequest() has returned, not as a post-build callback
+    // inside it: the build summary ("Build completed successfully") is emitted at the end of
+    // processRequest(), and a deployer failure reported before it would be followed by a success
+    // message as the last line of output.
+    FailureDetail failureDetail;
+    try {
+      failureDetail =
+          doMobileInstall(
+              env, options, runTargetArgs, result.getSuccessfulTargets(), deployerRequestRef);
+    } catch (InterruptedException e) {
+      String message = "mobile-install: deployer interrupted";
+      env.getReporter().handle(Event.error(message));
+      return BlazeCommandResult.detailedExitCode(
+          InterruptedFailureDetails.detailedExitCode(message));
+    }
     if (failureDetail == null) {
       return deployerRequestRef.get() == null
           ? BlazeCommandResult.success()

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -601,6 +601,14 @@ sh_test(
 )
 
 sh_test(
+    name = "mobile_install_test",
+    size = "small",
+    srcs = ["mobile_install_test.sh"],
+    data = [":test-deps"],
+    tags = ["no_windows"],
+)
+
+sh_test(
     name = "modify_execution_info_test",
     size = "medium",
     srcs = ["modify_execution_info_test.sh"],

--- a/src/test/shell/integration/mobile_install_test.sh
+++ b/src/test/shell/integration/mobile_install_test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Tests for the mobile-install command's handling of the deployer process.
+# Uses a fake mobile-install aspect so that no Android SDK or device is
+# required: mobile-install just builds the requested output groups and then
+# executes <bindir>/<target>_mi/launcher as a child process.
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CURRENT_DIR}/../integration_test_setup.sh" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+# Exit code that MobileInstall.Code.NON_ZERO_EXIT maps to in
+# failure_details.proto.
+readonly MOBILE_INSTALL_NON_ZERO_EXIT=6
+
+function setup_fake_mi_workspace() {
+  mkdir -p mi
+  cat > mi/mi.bzl <<'EOF'
+# Minimal stand-in for @rules_android//mobile_install:mi.bzl. The launcher
+# emitted for targets whose name starts with "fail" exits with code 1,
+# simulating a deployer failure (e.g. an adb install timeout).
+def _mi_aspect_impl(target, ctx):
+    launcher = ctx.actions.declare_file(target.label.name + "_mi/launcher")
+    if target.label.name.startswith("fail"):
+        script = "#!/bin/bash\necho 'fake deployer: install failed' >&2\nexit 1\n"
+    else:
+        script = "#!/bin/bash\necho 'fake deployer: install finished'\n"
+    ctx.actions.write(output = launcher, content = script, is_executable = True)
+    return [OutputGroupInfo(
+        mobile_install_INTERNAL_ = depset([launcher]),
+        mobile_install_launcher_INTERNAL_ = depset([launcher]),
+    )]
+
+MIASPECT = aspect(implementation = _mi_aspect_impl)
+
+def _fake_binary_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name + ".txt")
+    ctx.actions.write(out, "fake app")
+    return [DefaultInfo(files = depset([out]))]
+
+fake_binary = rule(implementation = _fake_binary_impl)
+EOF
+  cat > mi/BUILD <<'EOF'
+load(":mi.bzl", "fake_binary")
+
+fake_binary(name = "fail_app")
+
+fake_binary(name = "ok_app")
+EOF
+}
+
+function mobile_install() {
+  bazel mobile-install \
+      --mobile_install_aspect=//mi:mi.bzl \
+      --mobile_install_supported_rules=fake_binary \
+      "$@"
+}
+
+function test_deployer_success() {
+  setup_fake_mi_workspace
+  mobile_install //mi:ok_app &> "$TEST_log" \
+      || fail "mobile-install should succeed when the deployer exits 0"
+  expect_log "fake deployer: install finished"
+  expect_log "Build completed successfully"
+}
+
+function test_deployer_failure_sets_exit_code() {
+  setup_fake_mi_workspace
+  local exit_code=0
+  mobile_install //mi:fail_app &> "$TEST_log" || exit_code=$?
+  assert_equals "$MOBILE_INSTALL_NON_ZERO_EXIT" "$exit_code"
+  expect_log "fake deployer: install failed"
+  expect_log "Non-zero return code '1' from command"
+}
+
+function test_deployer_failure_reported_after_build_summary() {
+  # Regression test: the deployer runs after the build has completed, so its
+  # failure must be reported after the "Build completed successfully" summary.
+  # It used to run as a post-build callback inside the build request, which
+  # made a successful build summary the last thing printed after a deploy
+  # failure.
+  setup_fake_mi_workspace
+  mobile_install //mi:fail_app &> "$TEST_log" \
+      && fail "mobile-install should fail when the deployer exits 1"
+  expect_log "Build completed successfully"
+  local summary_line error_line
+  summary_line="$(grep -n "Build completed successfully" "$TEST_log" | head -1 | cut -d: -f1)"
+  error_line="$(grep -n "Non-zero return code '1' from command" "$TEST_log" | head -1 | cut -d: -f1)"
+  if [[ -z "$error_line" ]]; then
+    fail "deployer failure was not reported"
+  fi
+  if (( error_line < summary_line )); then
+    fail "deployer failure (line $error_line) was reported before the build \
+summary (line $summary_line), so the log ends with a success message"
+  fi
+}
+
+run_suite "mobile-install integration tests"


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

 Add proper error ordering for mobile install command

Before, a successful build with a failed mobile-install command will return something such as
```
    ERROR: Non-zero return code '1' from command: Process exited with status 1
    INFO: Elapsed time: 316.915s, Critical Path: 0.00s
    INFO: 1 process: 1 internal.
    INFO: Build completed successfully, 1 total action
```
which can be confusing to users, now a mobile-install command will report something such as

```
    INFO: Build completed successfully, 2 total actions
    fake deployer: install failed
    ERROR: Non-zero return code '1' from command: Process exited with status 1
```

Showing that while the build suceeds, the command actually failed.


### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->

Make it less confusing for downstream users.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Add proper error ordering for bazel mobile-install command
