### PR TITLE
Resolve MODULE.bazel flag aliases to canonical labels

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -293,6 +293,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis/platform:platform_function",
         "//src/main/java/com/google/devtools/build/lib/analysis/producers",
         "//src/main/java/com/google/devtools/build/lib/analysis/producers:unloaded_toolchain_contexts_inputs",
+        "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:common",
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:resolution",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository:repo_definition_function",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository:repo_definition_value",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -120,6 +120,7 @@ import com.google.devtools.build.lib.analysis.producers.ConfiguredTargetAndDataP
 import com.google.devtools.build.lib.analysis.starlark.StarlarkAttributeTransitionProvider;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkBuildSettingsDetailsValue;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphValue;
+import com.google.devtools.build.lib.bazel.bzlmod.ModuleKey;
 import com.google.devtools.build.lib.bazel.repository.RepoDefinitionFunction;
 import com.google.devtools.build.lib.bazel.repository.RepoDefinitionValue;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions;
@@ -131,6 +132,7 @@ import com.google.devtools.build.lib.cmdline.Label.LabelInterner;
 import com.google.devtools.build.lib.cmdline.Label.PackageContext;
 import com.google.devtools.build.lib.cmdline.Label.RepoContext;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
+import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -3348,31 +3350,42 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     return detailedExitCode;
   }
 
-  /** Canonical Starlark flag aliases for {@link PythonOptions} flags. */
+  /**
+   * Starlark flag aliases for {@link PythonOptions} flags, as labels relative to the rules_python
+   * repo.
+   */
   // TODO: b/453809359 - Remove when Bazel 9+ can read Python flag alias definitions straight from
   // rules_python's MODULE.bazel.
   private static final ImmutableMap<String, String> PY_FLAG_ALIASES =
       ImmutableMap.of(
           "build_python_zip",
-          "@@rules_python+//python/config_settings:build_python_zip",
+          "//python/config_settings:build_python_zip",
           "incompatible_default_to_explicit_init_py",
-          "@@rules_python+//python/config_settings:incompatible_default_to_explicit_init_py");
+          "//python/config_settings:incompatible_default_to_explicit_init_py");
 
-  /** Canonical Starlark flag aliases for {@link BazelPythonConfiguration} flags. */
+  /**
+   * Starlark flag aliases for {@link BazelPythonConfiguration} flags, as labels relative to the
+   * rules_python repo.
+   */
   // TODO: b/453809359 - Remove when Bazel 9+ can read Python flag alias definitions straight from
   // rules_python's MODULE.bazel.
   private static final ImmutableMap<String, String> BAZEL_PY_FLAG_ALIASES =
       ImmutableMap.of(
           "python_path",
-          "@@rules_python+//python/config_settings:python_path",
+          "//python/config_settings:python_path",
           "experimental_python_import_all_repositories",
-          "@@rules_python+//python/config_settings:experimental_python_import_all_repositories");
+          "//python/config_settings:experimental_python_import_all_repositories");
 
   /**
    * Returns flag aliases from {@code MODULE.bazel} {@code flag_alias()} definitions.
    *
    * <p>These, along with whatever is set in {@code --flag_alias}, rewrite {@code --foo}-style
    * command line flags to canonical Starlark flags.
+   *
+   * <p>The returned labels are in canonical form (e.g. {@code
+   * @@rules_python+//python/config_settings:python_path}) since they are subsequently parsed with
+   * the main repo mapping, which only knows about the root module's direct dependencies: an alias
+   * defined by a transitive dependency would otherwise fail to resolve.
    *
    * @param eventHandler handler for Skyframe events
    */
@@ -3381,46 +3394,63 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     EvaluationResult<BazelDepGraphValue> evalResult =
         evaluate(
             ImmutableList.of(BazelDepGraphValue.KEY), false, DEFAULT_THREAD_COUNT, eventHandler);
-    var bzlmodDepGraph = evalResult.get(BazelDepGraphValue.KEY).getDepGraph();
+    BazelDepGraphValue depGraphValue = evalResult.get(BazelDepGraphValue.KEY);
+    var bzlmodDepGraph = depGraphValue.getDepGraph();
     LinkedHashMap<String, String> aliasesMap = new LinkedHashMap<>();
-    var rootModule = bzlmodDepGraph.entrySet().iterator().next().getValue();
     for (var module : bzlmodDepGraph.entrySet()) {
+      ModuleKey moduleKey = module.getKey();
+      RepositoryName canonicalRepoName =
+          depGraphValue.getCanonicalRepoNameLookup().inverse().get(moduleKey);
       ImmutableMap<String, String> flagAliases = module.getValue().getFlagAliases();
-      for (var flagAlias : flagAliases.entrySet()) {
-        aliasesMap.put(
-            flagAlias.getKey(),
-            flagAlias.getValue().startsWith("//")
-                ? module.getKey().getCanonicalRepoNameWithoutVersion() + flagAlias.getValue()
-                : flagAlias.getValue());
+      if (!flagAliases.isEmpty()) {
+        // flag_alias() labels are stored in the apparent form seen from the defining module (e.g.
+        // "@rules_python//python/config_settings:python_path"), so resolve them with that module's
+        // repo mapping rather than the main repo's.
+        RepoContext repoContext =
+            RepoContext.of(canonicalRepoName, depGraphValue.getFullRepoMapping(moduleKey));
+        for (var flagAlias : flagAliases.entrySet()) {
+          aliasesMap.put(
+              flagAlias.getKey(), toCanonicalLabelString(flagAlias.getValue(), repoContext));
+        }
       }
       if (!module.getValue().getName().equals("rules_python")) {
         continue;
       }
       // Don't apply hard-coded aliases if rules_python uses MODULE.bazel aliases.
-      if (!module.getValue().getFlagAliases().isEmpty()) {
+      if (!flagAliases.isEmpty()) {
         continue;
       }
       // Add Python flags that haven't already been added by rules_python's MODULE.bazel.
       PY_FLAG_ALIASES.entrySet().stream()
           .filter(e -> !flagAliases.containsKey(e.getKey()))
-          .map(
-              e ->
-                  rootModule.getName().equals("rules_python")
-                      ? Map.entry(e.getKey(), e.getValue().substring(e.getValue().indexOf("/")))
-                      : e)
-          .forEach(e -> aliasesMap.put(e.getKey(), e.getValue()));
+          .forEach(
+              e -> aliasesMap.put(e.getKey(), canonicalRepoName.getNameWithAt() + e.getValue()));
       // Add Bazel Python flags that haven't already been added by rules_python's MODULE.bazel.
       BAZEL_PY_FLAG_ALIASES.entrySet().stream()
           .filter(e -> !flagAliases.containsKey(e.getKey()))
-          .map(
-              e ->
-                  rootModule.getName().equals("rules_python")
-                      ? Map.entry(e.getKey(), e.getValue().substring(e.getValue().indexOf("/")))
-                      : e)
-          .forEach(e -> aliasesMap.put(e.getKey(), e.getValue()));
+          .forEach(
+              e -> aliasesMap.put(e.getKey(), canonicalRepoName.getNameWithAt() + e.getValue()));
     }
 
     return ImmutableMap.copyOf(aliasesMap);
+  }
+
+  /**
+   * Resolves a {@code flag_alias()} label against the defining module's repo mapping and returns
+   * its unambiguous canonical form. Falls back to the original string if it can't be resolved, in
+   * which case parsing it with the main repo mapping reports the error.
+   */
+  private static String toCanonicalLabelString(String starlarkFlag, RepoContext repoContext) {
+    Label label;
+    try {
+      label = Label.parseWithRepoContext(starlarkFlag, repoContext);
+    } catch (LabelSyntaxException e) {
+      return starlarkFlag;
+    }
+    if (!label.getRepository().isVisible()) {
+      return starlarkFlag;
+    }
+    return label.getUnambiguousCanonicalForm();
   }
 
   public RepositoryMapping getMainRepoMapping(ExtendedEventHandler eventHandler)

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -3384,8 +3384,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
    *
    * <p>The returned labels are in canonical form (e.g. {@code
    * @@rules_python+//python/config_settings:python_path}) since they are subsequently parsed with
-   * the main repo mapping, which only knows about the root module's direct dependencies: an alias
-   * defined by a transitive dependency would otherwise fail to resolve.
+   * the main repo mapping, which only knows about the root module's direct dependencies.
    *
    * @param eventHandler handler for Skyframe events
    */

--- a/src/test/shell/bazel/starlark_configurations_external_workspaces_test.sh
+++ b/src/test/shell/bazel/starlark_configurations_external_workspaces_test.sh
@@ -341,4 +341,80 @@ EOF
       "Expected both aliases to be in --flag_alias option value list"
 }
 
+function test_bzl_module_flag_alias_from_transitive_dep() {
+  local -r pkg=$FUNCNAME
+  local -r barpkg="$pkg/bar"
+  local -r subpkg="$pkg/sub"
+  mkdir -p $barpkg $subpkg
+
+  ## Set up the root module, which depends on "bar" but not on "sub".
+  cat > $(setup_module_dot_bazel "$pkg/MODULE.bazel") <<EOF
+bazel_dep(name = "bar")
+local_path_override(module_name = "bar", path = "./bar")
+local_path_override(module_name = "sub", path = "./sub")
+EOF
+  touch $pkg/BUILD
+
+  ## Set up "bar", which depends on "sub" and reads its flag.
+  cat > $barpkg/MODULE.bazel <<EOF
+module(name = "bar")
+bazel_dep(name = "sub")
+EOF
+
+  cat > $barpkg/BUILD <<EOF
+load("@sub//:rules.bzl", "flag_reader")
+flag_reader(
+    name = "reader",
+    flag = "@sub//:my_flag",
+    visibility = ["//visibility:public"],
+)
+EOF
+
+  ## Set up "sub", which defines a flag, a rule that reads it and a flag alias.
+  cat > $subpkg/MODULE.bazel <<EOF
+module(name = "sub")
+flag_alias(name = "myflag", starlark_flag = "//:my_flag")
+EOF
+
+  cat > $subpkg/BUILD <<EOF
+load(":rules.bzl", "my_flag")
+my_flag(
+    name = "my_flag",
+    build_setting_default = "default_value",
+    visibility = ["//visibility:public"],
+)
+EOF
+
+  cat > $subpkg/rules.bzl <<EOF
+BuildSettingInfo = provider(fields = ['value'])
+
+def _flag_impl(ctx):
+    return BuildSettingInfo(value = ctx.build_setting_value)
+
+my_flag = rule(
+    implementation = _flag_impl,
+    build_setting = config.string(flag = True),
+)
+
+def _flag_reader_impl(ctx):
+    print("flag value: " + ctx.attr.flag[BuildSettingInfo].value)
+    return []
+
+flag_reader = rule(
+    implementation = _flag_reader_impl,
+    attrs = {
+        "flag": attr.label(),
+    },
+)
+EOF
+
+  cd $pkg
+
+  # The alias must resolve even though "sub" isn't visible from the root module.
+  bazel build @bar//:reader --myflag=custom_value >& "$TEST_log" \
+      || fail "Expected success"
+  expect_log "flag value: custom_value"
+  expect_not_log "No repository visible as '@sub'"
+}
+
 run_suite "${PRODUCT_NAME} starlark configurations tests"


### PR DESCRIPTION



<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->

`flag_alias()` labels are stored in the apparent form seen from the defining module, e.g. `@rules_python//python/config_settings:python_path`. `SkyframeExecutor#getFlagAliases` passed these strings through verbatim as `--flag_alias` values, which are parsed with the main repo mapping. If the defining module is only a transitive dependency of the root module, this failed with "No repository visible as '@rules_python' from main repository." as soon as the aliased flag was used on the command line.

Resolve each alias against its defining module's repo mapping instead and emit the unambiguous canonical form (`@@rules_python+//...`), which the main repo mapping can always parse. The hard-coded Python aliases now also use the module's actual canonical repo name rather than a fixed `@@rules_python+` prefix.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->
Fixes builds with `--incompatible_default_to_explicit_init_py` (and other rules_python flag aliases) in repos that depend on rules_python only transitively.


### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
