### PR TITLE
[9.3.0] Fix Action Cache mismatch for Java compilation when using path stripping and in-memory .jdeps (https://github.com/bazelbuild/bazel/pull/30849)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/BUILD
@@ -43,6 +43,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:commandline_item",
         "//src/main/java/com/google/devtools/build/lib/actions:execution_requirements",
+        "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/actions:localhost_capacity",
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/custom_command_line",
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/lazy_write_paths_file_action",

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -44,6 +44,7 @@ import com.google.devtools.build.lib.actions.CommandLines.CommandLineAndParamFil
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.ParamFileInfo;
 import com.google.devtools.build.lib.actions.ParameterFile;
@@ -844,8 +845,29 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
           .getOutputMetadataStore()
           .resetOutputs(ImmutableList.of(outputDepsProto));
       fsPath.setWritable(true);
+      byte[] rewritten = fullOutputDeps.toByteArray();
       try (var outputStream = fsPath.getOutputStream()) {
-        fullOutputDeps.writeTo(outputStream);
+        outputStream.write(rewritten);
+      }
+      if (spawnResult.getInMemoryOutput(outputDepsProto) != null) {
+        // Reached only with --experimental_output_paths=strip (otherwise the isNoOp() check above
+        // would have returned early).
+        // The executor may have stripped config prefixes from the .jdeps file, and we just rewrote
+        // it to restore the original paths. If the executor produced an in-memory version of the
+        // .jdeps file, we need to update the output metadata store with the new digest and size so
+        // that Bazel can read it from memory instead of reading the on-disk version.
+        actionExecutionContext
+            .getOutputMetadataStore()
+            .injectFile(
+                outputDepsProto,
+                FileArtifactValue.createForVirtualActionInput(
+                    fsPath
+                        .getFileSystem()
+                        .getDigestFunction()
+                        .getHashFunction()
+                        .hashBytes(rewritten)
+                        .asBytes(),
+                    rewritten.length));
       }
     }
 

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -284,6 +284,22 @@ function test_path_stripping_remote() {
   expect_not_log '[0-9] remote[^ ]'
 }
 
+function test_path_stripping_remote_action_cache() {
+  bazel build -c fastbuild \
+    --experimental_output_paths=strip \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //src/main/java/com/example:Main &> $TEST_log || fail "build failed unexpectedly"
+  expect_log '5 remote'
+
+  bazel shutdown
+
+  bazel build -c fastbuild \
+    --experimental_output_paths=strip \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //src/main/java/com/example:Main &> $TEST_log || fail "build failed unexpectedly"
+  expect_not_log '[0-9] remote'
+}
+
 function test_path_stripping_remote_multiple_configs() {
   mkdir rules
   cat > rules/defs.bzl <<'EOF'


### PR DESCRIPTION
### Description

When `--experimental_output_paths=strip` is enabled alongside in-memory `.jdeps` files (`--experimental_inmemory_jdeps_files=true`, which is enabled by default), remotely executed Java actions return `.jdeps` files whose paths have had configuration prefixes stripped.

During post-execution, `JavaCompileAction#createFullOutputDeps` unmaps those paths and writes the rewritten `.jdeps` file with full workspace paths to disk. However, when `RemoteActionFileSystem` is active, `ActionOutputMetadataStore#getOutputMetadata` continues to query `RemoteActionFileSystem.stat()`, which serves the stale stripped digest from its in-memory remote tree rather than the rewritten on-disk file.

Consequently:
1. `ActionCacheChecker#updateActionCache` stores the stale stripped digest in the Action Cache.
2. The local filesystem holds the rewritten unmapped digest.
3. On subsequent builds (e.g., after restarting the Bazel server or performing an incremental build), `ActionCacheChecker#isUpToDate` encounters a digest mismatch between disk and the action cache, forcing the action to re-execute every time.

This PR fixes the issue by explicitly injecting the rewritten `.jdeps` `FileArtifactValue` into the `OutputMetadataStore` when an in-memory output was produced by the executor. This ensures the Action Cache records the unmapped digest matching the file on disk.

### Motivation

Fixes unnecessary cache misses and forced re-executions of Java compilation actions when `--experimental_output_paths=strip` is used with remote execution.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Fix an issue where Java compilation actions re-execute on every build due to an Action Cache digest mismatch when `--experimental_output_paths=strip` and in-memory `.jdeps` files are enabled.

Closes #30849.

PiperOrigin-RevId: 976283623
Change-Id: I8c8ea3dc518931bd4ca0fbf2b68b68d184e2267e

Commit https://github.com/bazelbuild/bazel/commit/f72ac81d9b589a62012f49b32cf915f4a64c8cfb