### PR TITLE
Add --execution_logs_to_retain

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.exec.SpawnLogContext;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.runtime.BlazeModule;
+import com.google.devtools.build.lib.runtime.BlazeRuntime;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.Execution;
@@ -62,6 +63,7 @@ public final class SpawnLogModule extends BlazeModule {
 
   @Nullable private SpawnLogContext spawnLogContext;
   @Nullable private Path outputPath;
+  @Nullable private Path convenienceLink;
   @Nullable private ListenableFuture<String> uriFuture;
   @Nullable private String logName;
 
@@ -70,6 +72,7 @@ public final class SpawnLogModule extends BlazeModule {
   private void clear() {
     spawnLogContext = null;
     outputPath = null;
+    convenienceLink = null;
     uriFuture = null;
     logName = null;
     abruptExit = null;
@@ -152,6 +155,17 @@ public final class SpawnLogModule extends BlazeModule {
             new BufferedOutputStream(uploadContext.getOutputStream(), OUTPUT_BUFFER_SIZE);
         uriFuture = uploadContext.uriFuture();
         displayName = logName + "-stream";
+      } else if (executionOptions.getExecutionLogCompactFile() != null) {
+        outputPath =
+            BlazeRuntime.manageRetainedOutputs(
+                outputBase,
+                "execution_log-",
+                ".binpb.zst",
+                env.getCommandId().toString(),
+                executionOptions.getExecutionLogsToRetain());
+        convenienceLink = outputBase.getChild(logName);
+        outputStream = new BufferedOutputStream(outputPath.getOutputStream(), OUTPUT_BUFFER_SIZE);
+        displayName = outputPath.toString();
       } else {
         // Path is empty but streaming is not enabled. Disable logging.
         env.getBlazeModuleEnvironment()
@@ -160,7 +174,7 @@ public final class SpawnLogModule extends BlazeModule {
                     DetailedExitCode.of(
                         FailureDetail.newBuilder()
                             .setMessage(
-                                "--execution_log_{compact,binary,json}_file is empty, but"
+                                "--execution_log_{binary,json}_file is empty, but"
                                     + " --experimental_stream_log_file_uploads is not enabled."
                                     + " Execution log will not be uploaded to the BEP.")
                             .setExecutionOptions(
@@ -299,6 +313,11 @@ public final class SpawnLogModule extends BlazeModule {
 
     try {
       spawnLogContext.close();
+      if (convenienceLink != null) {
+        checkNotNull(outputPath);
+        convenienceLink.delete();
+        convenienceLink.createSymbolicLink(PathFragment.create(outputPath.getBaseName()));
+      }
       if (spawnLogContext.shouldPublish()) {
         checkNotNull(logName);
         if (uriFuture != null) {

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -515,13 +515,25 @@ public abstract class ExecutionOptions extends OptionsBase {
           "Log the executed spawns into this file as length-delimited ExecLogEntry protos,"
               + " according to src/main/protobuf/spawn.proto. The entire file is zstd compressed."
               + " The flag accepts boolean and string values. If string, it represents a local"
-              + " path. If true, then --experimental_stream_log_file_uploads must be set, whereby"
-              + " it will stream the execution log to remote storage. If false, then logging to the"
-              + " execution log is disabled. Related flags: --execution_log_binary_file (binary"
-              + " protobuf format; mutually exclusive), --execution_log_json_file (text JSON"
-              + " format; mutually exclusive), --subcommands (for displaying subcommands in"
-              + " terminal output).")
+              + " path. If true, the log is streamed when --experimental_stream_log_file_uploads"
+              + " is enabled; otherwise, it is written to the output base. If false, logging to"
+              + " the execution log is disabled. Related flags: --execution_logs_to_retain (number"
+              + " of default-location logs to keep), --execution_log_binary_file (binary protobuf"
+              + " format; mutually exclusive), --execution_log_json_file (text JSON format;"
+              + " mutually exclusive), --subcommands (for displaying subcommands in terminal"
+              + " output).")
   public abstract PathFragment getExecutionLogCompactFile();
+
+  @Option(
+      name = "execution_logs_to_retain",
+      defaultValue = "5",
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {OptionEffectTag.BAZEL_MONITORING},
+      help =
+          "Number of compact execution logs to retain in the output base when using the default"
+              + " local output path. If there are more than this number of logs, the oldest are"
+              + " deleted until the total is under the limit.")
+  public abstract int getExecutionLogsToRetain();
 
   @Option(
       name = "execution_log_sort",

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -332,20 +332,15 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
   }
 
   /**
-   * Implements automatic profile management.
+   * Returns a unique output path and deletes the oldest matching outputs outside the retention
+   * window.
    *
-   * <ul>
-   *   <li>computes the path to write the profile for the current command to
-   *   <li>does garbage collection for profiles from previous commands based on the <code>
-   * --profiles_to_retain</code> flag
-   * </ul>
-   *
-   * @return the path this command's profile should be written to
+   * <p>The returned path is included in the retention window, even though the file does not exist
+   * yet.
    */
-  @VisibleForTesting
-  static Path manageProfiles(Path dir, String commandId, int retentionWindow) throws IOException {
-    var prefix = "command-";
-    var suffix = ".profile.gz";
+  public static Path manageRetainedOutputs(
+      Path dir, String prefix, String suffix, String commandId, int retentionWindow)
+      throws IOException {
     record PathAndMtime(Path path, long mtime) {}
     var old = new ArrayList<PathAndMtime>();
     for (var dirent : dir.readdir(Symlinks.FOLLOW)) {
@@ -359,8 +354,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
     for (var i = 0; i < toRemove; i++) {
       old.get(i).path().delete();
     }
-    var profileName = prefix + commandId + suffix;
-    return dir.getChild(profileName);
+    return dir.getChild(prefix + commandId + suffix);
   }
 
   /** Configure profiling based on the provided options. */
@@ -400,8 +394,10 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
                     /* internal= */ null);
           } else {
             var profilePath =
-                manageProfiles(
+                manageRetainedOutputs(
                     workspace.getOutputBase(),
+                    "command-",
+                    ".profile.gz",
                     env.getCommandId().toString(),
                     commandOptions.getProfilesToRetain());
             profile =

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeRuntimeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeRuntimeTest.java
@@ -80,25 +80,25 @@ public class BlazeRuntimeTest {
   private final AtomicReference<String> shutdownReason = new AtomicReference<>();
 
   @Test
-  public void manageProfiles() throws Exception {
+  public void manageRetainedOutputs() throws Exception {
     var dir = fs.getPath("/output");
     dir.createDirectory();
     dir.getChild("foo").createDirectory();
     dir.getChild("bar").getOutputStream().close();
     clock.advanceMillis(10);
-    var p1 = BlazeRuntime.manageProfiles(dir, "p1", 3);
+    var p1 = BlazeRuntime.manageRetainedOutputs(dir, "command-", ".profile.gz", "p1", 3);
     assertThat(p1.getBaseName()).isEqualTo("command-p1.profile.gz");
     p1.getOutputStream().close();
     clock.advanceMillis(10);
-    var p2 = BlazeRuntime.manageProfiles(dir, "p2", 3);
+    var p2 = BlazeRuntime.manageRetainedOutputs(dir, "command-", ".profile.gz", "p2", 3);
     assertThat(p2.getBaseName()).isEqualTo("command-p2.profile.gz");
     p2.getOutputStream().close();
     clock.advanceMillis(10);
-    var p3 = BlazeRuntime.manageProfiles(dir, "p3", 3);
+    var p3 = BlazeRuntime.manageRetainedOutputs(dir, "command-", ".profile.gz", "p3", 3);
     assertThat(p3.getBaseName()).isEqualTo("command-p3.profile.gz");
     p3.getOutputStream().close();
     clock.advanceMillis(10);
-    var p4 = BlazeRuntime.manageProfiles(dir, "p4", 3);
+    var p4 = BlazeRuntime.manageRetainedOutputs(dir, "command-", ".profile.gz", "p4", 3);
     assertThat(p4.getBaseName()).isEqualTo("command-p4.profile.gz");
     p4.getOutputStream().close();
     assertThat(dir.readdir(Symlinks.FOLLOW).stream().map(Dirent::getName))
@@ -109,7 +109,7 @@ public class BlazeRuntimeTest {
             "command-p3.profile.gz",
             "command-p4.profile.gz");
     clock.advanceMillis(10);
-    var p5 = BlazeRuntime.manageProfiles(dir, "p5", 1);
+    var p5 = BlazeRuntime.manageRetainedOutputs(dir, "command-", ".profile.gz", "p5", 1);
     assertThat(p5.getBaseName()).isEqualTo("command-p5.profile.gz");
     p5.getOutputStream().close();
     assertThat(dir.readdir(Symlinks.FOLLOW).stream().map(Dirent::getName))

--- a/src/test/shell/bazel/bazel_execlog_test.sh
+++ b/src/test/shell/bazel/bazel_execlog_test.sh
@@ -172,7 +172,7 @@ EOF
   fi
 }
 
-function test_empty_path_fails_without_streaming() {
+function test_empty_path_fails_without_streaming_for_expanded_logs() {
   cat > BUILD <<'EOF'
 genrule(
       name = "rule",
@@ -183,20 +183,52 @@ EOF
   bazel build //:all \
     --experimental_stream_log_file_uploads=false \
     --execution_log_json_file=true >& $TEST_log && fail "build should have failed"
-  expect_log "--execution_log_{compact,binary,json}_file is empty"
+  expect_log "--execution_log_{binary,json}_file is empty"
   expect_log "--experimental_stream_log_file_uploads is not enabled"
 
   bazel build //:all \
     --experimental_stream_log_file_uploads=false \
     --execution_log_binary_file=true >& $TEST_log && fail "build should have failed"
-  expect_log "--execution_log_{compact,binary,json}_file is empty"
+  expect_log "--execution_log_{binary,json}_file is empty"
   expect_log "--experimental_stream_log_file_uploads is not enabled"
+}
 
-  bazel build //:all \
-    --experimental_stream_log_file_uploads=false \
-    --execution_log_compact_file=true >& $TEST_log && fail "build should have failed"
-  expect_log "--execution_log_{compact,binary,json}_file is empty"
-  expect_log "--experimental_stream_log_file_uploads is not enabled"
+function test_default_compact_log_retention() {
+  create_new_workspace
+  cat > BUILD <<'EOF'
+genrule(
+    name = "action",
+    outs = ["out.txt"],
+    cmd = "echo hello > $@",
+)
+EOF
+
+  local output_base="$(bazel info output_base)"
+  local uuid1=7c859c8f-87fd-46d0-9e5c-669410812722
+  local uuid2=e9d9df11-04a9-4f78-9f71-5a0153cb6f0c
+  local uuid3=04d6c879-630b-43e4-8ee4-4e2ada22a719
+
+  bazel build //:action \
+    --invocation_id="${uuid1}" \
+    --execution_log_compact_file=true \
+    --execution_logs_to_retain=2 >& $TEST_log || fail "first build failed"
+  bazel build //:action \
+    --invocation_id="${uuid2}" \
+    --execution_log_compact_file=true \
+    --execution_logs_to_retain=2 >& $TEST_log || fail "second build failed"
+  bazel build //:action \
+    --invocation_id="${uuid3}" \
+    --execution_log_compact_file=true \
+    --execution_logs_to_retain=2 >& $TEST_log || fail "third build failed"
+
+  [[ ! -e "${output_base}/execution_log-${uuid1}.binpb.zst" ]] \
+    || fail "oldest compact execution log was retained"
+  [[ -e "${output_base}/execution_log-${uuid2}.binpb.zst" ]] \
+    || fail "second compact execution log was not retained"
+  cmp \
+    "${output_base}/execution_log-${uuid3}.binpb.zst" \
+    "${output_base}/execution_log.binpb.zst" \
+    || fail "latest compact execution log not linked"
 }
 
 function test_no_output() {


### PR DESCRIPTION
Along with setting --execution_log_compact_file=true this now stores the
last N execution logs similar to the --profile behavior. The streaming
log flag still takes precedence over this.
