### PR TITLE
Don't invalidate materialized external repo files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileStateValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileStateValue.java
@@ -226,39 +226,59 @@ public abstract class FileStateValue extends RegularFileValue implements HasDige
   @Nullable
   public abstract FileContentsProxy getContentsProxy();
 
+  /** The result of {@link #compareContents}. */
+  public enum ContentsComparisonResult {
+    /**
+     * Both values describe the same file contents and can be used interchangeably, even if not
+     * equal.
+     */
+    SAME,
+    /**
+     * Both values have identical metadata except for ctime, which may have changed due to
+     * hardlinks.
+     */
+    SAME_EXCEPT_CHANGE_TIME,
+    /** The values may describe different contents. */
+    DIFFERENT
+  }
+
   /**
-   * Returns whether this value is equal to {@code other}, except that a change to ctime (last
-   * change time) only is permitted.
-   *
-   * <p>Use this rather than {@link #equals} when 1) hardlinks are involved, and 2) missing certain
-   * modifications in edge cases is acceptable.
+   * Compares the file contents described by this value and {@code other} regardless of how each
+   * value represents them, using either a digest or a proxy.
    */
-  public boolean equalsIgnoringChangeTime(FileStateValue other) {
+  public ContentsComparisonResult compareContents(FileStateValue other) {
     if (this.equals(other)) {
-      return true;
+      return ContentsComparisonResult.SAME;
     }
     if (getType() != other.getType()) {
-      return false;
+      return ContentsComparisonResult.DIFFERENT;
     }
     return switch (getType()) {
       case REGULAR_FILE, SPECIAL_FILE -> {
         if (getSize() != other.getSize()) {
-          yield false;
+          yield ContentsComparisonResult.DIFFERENT;
         }
         // Prefer comparing digests, the most robust signal, when both values have one.
         var thisDigest = getDigest();
         var otherDigest = other.getDigest();
         if (thisDigest != null && otherDigest != null) {
-          yield Arrays.equals(thisDigest, otherDigest);
+          yield Arrays.equals(thisDigest, otherDigest)
+              ? ContentsComparisonResult.SAME
+              : ContentsComparisonResult.DIFFERENT;
         }
         var thisProxy = getContentsProxy();
         var otherProxy = other.getContentsProxy();
-        if (thisProxy != null && otherProxy != null) {
-          yield !thisProxy.isModified(otherProxy);
+        if (thisProxy == null || otherProxy == null) {
+          yield ContentsComparisonResult.DIFFERENT;
         }
-        yield equals(other);
+        if (thisProxy.equals(otherProxy)) {
+          yield ContentsComparisonResult.SAME;
+        }
+        yield thisProxy.isModified(otherProxy)
+            ? ContentsComparisonResult.DIFFERENT
+            : ContentsComparisonResult.SAME_EXCEPT_CHANGE_TIME;
       }
-      default -> equals(other);
+      default -> ContentsComparisonResult.DIFFERENT;
     };
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/DirtinessCheckerUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/DirtinessCheckerUtils.java
@@ -19,7 +19,6 @@ import static com.google.devtools.build.lib.vfs.FileStateKey.FILE_STATE;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FileStateValue;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.skyframe.ExternalFilesHelper.FileType;
@@ -131,7 +130,7 @@ public class DirtinessCheckerUtils {
     }
 
     @Override
-    public SkyValueDirtinessChecker.DirtyResult check(
+    public DirtyResult check(
         SkyKey skyKey,
         SkyValue oldValue,
         @Nullable Version oldMtsv,
@@ -144,40 +143,33 @@ public class DirtinessCheckerUtils {
       SkyValue newValue =
           checker.createNewValue(skyKey, cacheable ? syscallCache : SyscallCache.NO_CACHE, tsgm);
       if (Objects.equal(newValue, oldValue)) {
-        return SkyValueDirtinessChecker.DirtyResult.notDirty();
+        return DirtyResult.notDirty();
       }
       if (cacheable) {
-        return SkyValueDirtinessChecker.DirtyResult.dirtyWithNewValue(newValue);
+        return DirtyResult.dirtyWithNewValue(newValue);
       }
-      if (fileType == FileType.EXTERNAL_REPO) {
-        // A file injected by a remote repo contents cache hit that is later materialized on disk
-        // should not cause invalidation. This matches the logic for output files lazily downloaded
-        // with BwoB (see FilesystemValueChecker#artifactIsDirtyWithDirectSystemCalls).
-        if (oldValue instanceof FileStateValue.RegularFileStateValueWithMetadata oldFileState
-            && newValue
-                instanceof FileStateValue.RegularFileStateValueWithContentsProxy newFileState) {
-          var newFileArtifactValue =
-              FileArtifactValue.createForNormalFile(
-                  /* digest= */ null, newFileState.getContentsProxy(), newFileState.getSize());
-          if (!newFileArtifactValue.couldBeModifiedSince(oldFileState.getMetadata())) {
-            return SkyValueDirtinessChecker.DirtyResult.notDirty();
+      if (fileType == FileType.EXTERNAL_REPO
+          && oldValue instanceof FileStateValue oldFileState
+          && newValue instanceof FileStateValue newFileState) {
+        return switch (newFileState.compareContents(oldFileState)) {
+          case SAME -> DirtyResult.notDirty();
+          case DIFFERENT -> {
+            var repositoryName = externalFilesHelper.getExternalRepoName(rootedPath);
+            if (repositoryName != null) {
+              dirtyExternalRepos.putIfAbsent(repositoryName, rootedPath);
+            }
+            yield DirtyResult.dirty();
           }
-        }
-        // The hermetic Linux sandbox uses hardlinks to stage inputs, which affects ctimes. Don't
-        // report files as modified and trigger a refetch of the repo just due to that.
-        if (!(oldValue instanceof FileStateValue oldFileState
-            && newValue instanceof FileStateValue newFileState
-            && newFileState.equalsIgnoringChangeTime(oldFileState))) {
-          var repositoryName = externalFilesHelper.getExternalRepoName(rootedPath);
-          if (repositoryName != null) {
-            dirtyExternalRepos.putIfAbsent(repositoryName, rootedPath);
-          }
-        }
+          // The hermetic Linux sandbox uses hardlinks to stage inputs, which affects ctimes.
+          // Re-evaluate the node to pick up the new ctime, but don't report the file as modified
+          // and trigger a refetch of the repo just due to that.
+          case SAME_EXCEPT_CHANGE_TIME -> DirtyResult.dirty();
+        };
       }
       // Files under output_base/external have a dependency on the WORKSPACE file, so we don't add
       // a new SkyValue to the graph yet because it might change once the WORKSPACE file has been
       // parsed. Similarly, output files might change during execution.
-      return SkyValueDirtinessChecker.DirtyResult.dirty();
+      return DirtyResult.dirty();
     }
 
     Map<RepositoryName, RootedPath> getDirtyExternalRepos() {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/DirtinessCheckerUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/DirtinessCheckerUtils.java
@@ -19,6 +19,7 @@ import static com.google.devtools.build.lib.vfs.FileStateKey.FILE_STATE;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FileStateValue;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.skyframe.ExternalFilesHelper.FileType;
@@ -148,15 +149,29 @@ public class DirtinessCheckerUtils {
       if (cacheable) {
         return SkyValueDirtinessChecker.DirtyResult.dirtyWithNewValue(newValue);
       }
-      // The hermetic Linux sandbox uses hardlinks to stage inputs, which affects ctimes. Don't
-      // report files as modified and trigger a refetch of the repo just due to that.
-      if (fileType == FileType.EXTERNAL_REPO
-          && !(oldValue instanceof FileStateValue oldFileState
-              && newValue instanceof FileStateValue newFileState
-              && newFileState.equalsIgnoringChangeTime(oldFileState))) {
-        var repositoryName = externalFilesHelper.getExternalRepoName(rootedPath);
-        if (repositoryName != null) {
-          dirtyExternalRepos.putIfAbsent(repositoryName, rootedPath);
+      if (fileType == FileType.EXTERNAL_REPO) {
+        // A file injected by a remote repo contents cache hit that is later materialized on disk
+        // should not cause invalidation. This matches the logic for output files lazily downloaded
+        // with BwoB (see FilesystemValueChecker#artifactIsDirtyWithDirectSystemCalls).
+        if (oldValue instanceof FileStateValue.RegularFileStateValueWithMetadata oldFileState
+            && newValue
+                instanceof FileStateValue.RegularFileStateValueWithContentsProxy newFileState) {
+          var newFileArtifactValue =
+              FileArtifactValue.createForNormalFile(
+                  /* digest= */ null, newFileState.getContentsProxy(), newFileState.getSize());
+          if (!newFileArtifactValue.couldBeModifiedSince(oldFileState.getMetadata())) {
+            return SkyValueDirtinessChecker.DirtyResult.notDirty();
+          }
+        }
+        // The hermetic Linux sandbox uses hardlinks to stage inputs, which affects ctimes. Don't
+        // report files as modified and trigger a refetch of the repo just due to that.
+        if (!(oldValue instanceof FileStateValue oldFileState
+            && newValue instanceof FileStateValue newFileState
+            && newFileState.equalsIgnoringChangeTime(oldFileState))) {
+          var repositoryName = externalFilesHelper.getExternalRepoName(rootedPath);
+          if (repositoryName != null) {
+            dirtyExternalRepos.putIfAbsent(repositoryName, rootedPath);
+          }
         }
       }
       // Files under output_base/external have a dependency on the WORKSPACE file, so we don't add

--- a/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/remote_repo_contents_cache_test.py
@@ -2713,5 +2713,102 @@ class RemoteRepoContentsCacheTest(test_base.TestBase):
     self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
 
 
+  def testMaterializedFileIsNotTreatedAsDirtied(self):
+    # Regression test for https://github.com/bazelbuild/bazel/issues/31006.
+    # Materializing a repo restored from the remote repo contents cache makes
+    # Bazel serve its files from disk instead of from memory, but this
+    # difference in representation should not result in Skyframe invalidation.
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'repo = use_repo_rule("//:repo.bzl", "repo")',
+            'repo(name = "my_repo")',
+            'other_repo = use_repo_rule("//:other_repo.bzl", "other_repo")',
+            'other_repo(name = "other", data_file = "@my_repo//:data.txt")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'repo.bzl',
+        [
+            'def _repo_impl(rctx):',
+            '  rctx.file("BUILD", "exports_files([\'data.txt\'])")',
+            '  rctx.file("defs.bzl", "DATA = \'data\'")',
+            '  rctx.file("data.txt", "hello")',
+            '  print("JUST FETCHED")',
+            '  return rctx.repo_metadata(reproducible=True)',
+            'repo = repository_rule(_repo_impl)',
+        ],
+    )
+    self.ScratchFile(
+        'other_repo.bzl',
+        [
+            'def _other_repo_impl(rctx):',
+            # Reading my_repo's data.txt forces full materialization of my_repo.
+            '  rctx.file("BUILD", "filegroup(name=\'haha\')")',
+            (
+                '  rctx.file("data_copy.txt",'
+                ' rctx.read(rctx.path(rctx.attr.data_file)))'
+            ),
+            '  return rctx.repo_metadata()',
+            (
+                'other_repo = repository_rule(_other_repo_impl,'
+                ' attrs={"data_file": attr.label()})'
+            ),
+        ],
+    )
+    self.ScratchFile(
+        'main/BUILD.bazel',
+        [
+            'load("@my_repo//:defs.bzl", "DATA")',
+            'genrule(',
+            '  name = "use_" + DATA,',
+            '  srcs = ["@my_repo//:data.txt"],',
+            '  outs = ["out.txt"],',
+            '  cmd = "cat $< > $@",',
+            ')',
+        ],
+    )
+
+    # Cold build: fetch my_repo and upload it to the remote repo contents cache.
+    _, _, stderr = self.RunBazel(['build', '--nobuild', '//main:use_data'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+    # Restore my_repo from the cache into the overlay. Its package and .bzl
+    # file are loaded from memory.
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '--nobuild', '//main:use_data'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+    # The lockfile is updated at the end of the first command after an expunge,
+    # which invalidates the repo definitions in the next command. Let that
+    # settle in a command that verifies all of the target's nodes so that the
+    # following commands only observe the effect of materialization.
+    _, _, stderr = self.RunBazel(['build', '--nobuild', '//main:use_data'])
+    stderr = '\n'.join(stderr)
+    self.assertNotIn('JUST FETCHED', stderr)
+    self.assertIn(
+        'Analyzed target //main:use_data (0 packages loaded, 0 targets'
+        ' configured).',
+        stderr,
+    )
+
+    # Fully materialize my_repo onto the local disk by fetching @other, which
+    # reads one of its files.
+    _, _, stderr = self.RunBazel(['build', '--nobuild', '@other//:haha'])
+    self.assertIn('Materializing remote repo', '\n'.join(stderr))
+
+    # Nothing has changed for //main:use_data, so nothing is reloaded or
+    # analyzed again.
+    _, _, stderr = self.RunBazel(['build', '--nobuild', '//main:use_data'])
+    stderr = '\n'.join(stderr)
+    self.assertNotIn('JUST FETCHED', stderr)
+    self.assertNotIn('will be fetched again', stderr)
+    self.assertIn(
+        'Analyzed target //main:use_data (0 packages loaded, 0 targets'
+        ' configured).',
+        stderr,
+    )
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION



<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description
The dirtiness check for files in external repos recognized files injected on a remote repo contents cache hit and then later materialized to disk as dirty since it lacked the analogue of the `FilesystemValueChecker` optimization for BwoB artifacts. Generalize the existing ctime-agnostic comparison logic to detect equivalent but non-equal `FileStateValue`s.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->
Fixes https://github.com/bazelbuild/bazel/issues/31006


### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
