### PR TITLE
Fix linux-sandbox actions being killed prematurely when using virtual threads

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
@@ -14,8 +14,11 @@
 
 package com.google.devtools.build.lib.shell;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.devtools.build.lib.shell.SubprocessBuilder.StreamAction;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.StringEncoding;
@@ -24,6 +27,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.ProcessBuilder.Redirect;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
@@ -115,11 +122,31 @@ public class JavaSubprocessFactory implements SubprocessFactory {
     }
   }
 
-  public static final JavaSubprocessFactory INSTANCE = new JavaSubprocessFactory();
-  private final ReentrantLock lock = new ReentrantLock();
+  // Subprocesses fork from this platform thread to ensure the subprocess's parent is long lived,
+  // which prevents actions from being killed erroneously. See the doc comment on
+  // startOnPlatformThread for more details.
+  @VisibleForTesting
+  static final ExecutorService DEFAULT_FORK_EXECUTOR =
+      Executors.newSingleThreadExecutor(
+          runnable -> {
+            Thread thread = new Thread(runnable, "subprocess-fork");
+            thread.setDaemon(true);
+            return thread;
+          });
 
-  private JavaSubprocessFactory() {
-    // We are a singleton
+  private final ReentrantLock lock = new ReentrantLock();
+  private final ExecutorService forkExecutor;
+
+  public static final JavaSubprocessFactory INSTANCE =
+      new JavaSubprocessFactory(DEFAULT_FORK_EXECUTOR);
+
+  private JavaSubprocessFactory(ExecutorService forkExecutor) {
+    this.forkExecutor = forkExecutor;
+  }
+
+  @VisibleForTesting
+  static JavaSubprocessFactory createForTesting(ExecutorService forkExecutor) {
+    return new JavaSubprocessFactory(forkExecutor);
   }
 
   // since we are a singleton, we represent an ideal global lock for
@@ -143,7 +170,7 @@ public class JavaSubprocessFactory implements SubprocessFactory {
   private Process start(ProcessBuilder builder) throws IOException {
     lock.lock();
     try {
-      return builder.start();
+      return startOnPlatformThread(builder);
     } catch (IOException e) {
       if (e.getMessage().contains("Failed to exec spawn helper")) {
         // Detect permanent failures due to an upgrade of the underlying JDK version,
@@ -156,6 +183,31 @@ public class JavaSubprocessFactory implements SubprocessFactory {
       throw e;
     } finally {
       lock.unlock();
+    }
+  }
+
+  /**
+   * Starts a subprocess by forking from a long-lived platform thread, which prevents the parent
+   * thread from being killed when using virtual threads.
+   *
+   * <p>A virtual thread forks from its carrier thread. The carrier thread is detached while the
+   * virtual thread waits for the forked process to complete. If there isn't other work for the
+   * carrier thread to do, then it is idle and can be killed due to inactivity. The parent carrier
+   * thread being killed causes the linux-sandbox to die because it self destructs when its parent
+   * dies.
+   *
+   * <p>The default virtual thread scheduler uses a {@link java.util.concurrent.ForkJoinPool} for
+   * its carrier threads with an idle TTL of 30 seconds. Without a long-lived platform thread as
+   * the parent, builds can fail unexpectedly when actions take longer than 30 seconds.
+   */
+  private Process startOnPlatformThread(ProcessBuilder builder) throws IOException {
+    Future<Process> future = forkExecutor.submit(builder::start);
+    try {
+      return Uninterruptibles.getUninterruptibly(future);
+    } catch (ExecutionException e) {
+      Throwables.throwIfInstanceOf(e.getCause(), IOException.class);
+      Throwables.throwIfUnchecked(e.getCause());
+      throw new IllegalStateException("Unexpected error starting subprocess", e.getCause());
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/shell/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/shell/BUILD
@@ -285,6 +285,23 @@ java_test(
     ],
 )
 
+java_test(
+    name = "JavaSubprocessFactoryTest",
+    srcs = ["JavaSubprocessFactoryTest.java"],
+    tags = [
+        "no_windows",
+        "shell",
+    ],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/shell",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
+        "//third_party:guava",
+        "//third_party:junit4",
+        "//third_party:mockito",
+        "//third_party:truth",
+    ],
+)
+
 cc_binary(
     name = "killmyself",
     srcs = ["killmyself.cc"],

--- a/src/test/java/com/google/devtools/build/lib/shell/JavaSubprocessFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/shell/JavaSubprocessFactoryTest.java
@@ -1,0 +1,102 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.shell;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.util.OS;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class JavaSubprocessFactoryTest {
+
+  @Test
+  public void createFromVirtualThreadForksOnPlatformThread() throws Exception {
+    ExecutorService mockExecutorService = mock(ExecutorService.class);
+    AtomicReference<Thread> forkThread = new AtomicReference<>();
+
+    // Observe the thread executing the submit function, so we can tell if the fork happens from
+    // the correct thread. We still call the real submit function to actually run the callable.
+    doAnswer(
+            invocation -> {
+              Callable<?> original = invocation.getArgument(0);
+              return JavaSubprocessFactory.DEFAULT_FORK_EXECUTOR.submit(
+                  () -> {
+                    forkThread.set(Thread.currentThread());
+                    return original.call();
+                  });
+            })
+        .when(mockExecutorService)
+        .submit(any(Callable.class));
+
+    JavaSubprocessFactory subprocessFactory =
+        JavaSubprocessFactory.createForTesting(mockExecutorService);
+
+    AtomicReference<Boolean> callerWasVirtual = new AtomicReference<>();
+    AtomicReference<Integer> exitCode = new AtomicReference<>();
+    AtomicReference<Throwable> error = new AtomicReference<>();
+    CountDownLatch done = new CountDownLatch(1);
+
+    // Create and execute a subprocess on a virtual thread
+    Thread.ofVirtual()
+        .name("test-virtual")
+        .start(
+            () -> {
+              try {
+                SubprocessBuilder subprocessBuilder =
+                    new SubprocessBuilder(ImmutableMap.of(), subprocessFactory);
+                subprocessBuilder.setArgv(
+                    ImmutableList.of(OS.getCurrent() == OS.DARWIN ? "/usr/bin/true" : "/bin/true"));
+
+                Subprocess subprocess = subprocessBuilder.start();
+                callerWasVirtual.set(Thread.currentThread().isVirtual());
+                subprocess.waitFor();
+                exitCode.set(subprocess.exitValue());
+                subprocess.close();
+              } catch (Exception e) {
+                error.set(e);
+              } finally {
+                done.countDown();
+              }
+            });
+
+    done.await();
+    if (error.get() != null) {
+      throw new AssertionError("Error running subprocess from virtual thread", error.get());
+    }
+
+    // The subprocess creation happened successfully on a virtual thread
+    assertThat(callerWasVirtual.get()).isTrue();
+    assertThat(exitCode.get()).isEqualTo(0);
+
+    // The fork was routed through the correct executor and ran on the right thread
+    verify(mockExecutorService).submit(any(Callable.class));
+    assertThat(forkThread.get().getName()).isEqualTo("subprocess-fork");
+    assertThat(forkThread.get().isVirtual()).isFalse();
+    assertThat(forkThread.get().isDaemon()).isTrue();
+  }
+}


### PR DESCRIPTION
This is a version of https://github.com/bazelbuild/bazel/pull/29007 where the added test should pass for MacOS. The only change in this PR vs that PR is the location of `true` varies based on OS.

I think this should work, but I don't have a Mac handy to test this. If anyone has a Mac and can run `bazel test //src/test/java/com/google/devtools/build/lib/shell:JavaSubprocessFactoryTest` then that'd be much appreciated.

I forgot to account for the fact that MacOS places `true` at `/usr/bin/true` instead of `/bin/true`. This was the error during postsubmit from that test on MacOS:

```
1) createFromVirtualThreadForksOnPlatformThread(com.google.devtools.build.lib.shell.JavaSubprocessFactoryTest)
java.lang.AssertionError: Error running subprocess from virtual thread
	at com.google.devtools.build.lib.shell.JavaSubprocessFactoryTest.createFromVirtualThreadForksOnPlatformThread(JavaSubprocessFactoryTest.java:87)
	... 23 trimmed
Caused by: java.io.IOException: Cannot run program "/bin/true": Exec failed, error: 2 (No such file or directory) 
```