### PR TITLE
Add OSC 8 escape sequence for BES URL

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
@@ -75,6 +75,7 @@ import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.util.ExitCode;
+import com.google.devtools.build.lib.util.io.AnsiTerminal;
 import com.google.devtools.build.lib.util.io.AnsiTerminal.Color;
 import com.google.devtools.build.lib.util.io.OutErr;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -122,6 +123,7 @@ public abstract class BuildEventServiceModule<OptionsT extends BuildEventService
   private AuthAndTLSOptions authTlsOptions;
   private BuildEventStreamOptions besStreamOptions;
   private boolean uiUsesColor;
+  private boolean uiUsesHyperlinks;
   private boolean isRunsPerTestOverTheLimit;
   private BuildEventArtifactUploaderFactory uploaderFactoryToCleanup;
 
@@ -373,8 +375,9 @@ public abstract class BuildEventServiceModule<OptionsT extends BuildEventService
                     (perLabelOptions) ->
                         Integer.parseInt(Iterables.getOnlyElement(perLabelOptions.getOptions()))
                             > RUNS_PER_TEST_LIMIT);
-    this.uiUsesColor =
-        Preconditions.checkNotNull(parsingResult.getOptions(UiOptions.class)).useColor();
+    UiOptions uiOptions = Preconditions.checkNotNull(parsingResult.getOptions(UiOptions.class));
+    this.uiUsesColor = uiOptions.useColor();
+    this.uiUsesHyperlinks = uiOptions.useHyperlinks();
 
     ConnectivityStatus status = connectivityProvider.getStatus(CONNECTIVITY_CACHE_KEY);
     String buildEventUploadStrategy =
@@ -713,19 +716,23 @@ public abstract class BuildEventServiceModule<OptionsT extends BuildEventService
 
   private void constructAndMaybeReportInvocationIdUrl() {
     if (!getInvocationIdPrefix().isEmpty()) {
-      StringBuilder msg = new StringBuilder();
-      msg.append("Streaming build results to: ");
-      if (uiUsesColor) {
-        msg.append(new String(Color.CYAN.getEscapeSeq(), StandardCharsets.US_ASCII));
-      }
-      msg.append(getInvocationIdPrefix());
-      msg.append(invocationId);
-      if (uiUsesColor) {
-        msg.append(new String(Color.DEFAULT.getEscapeSeq(), StandardCharsets.US_ASCII));
-      }
-
-      reporter.handle(Event.info(msg.toString()));
+      String url = getInvocationIdPrefix() + invocationId;
+      reporter.handle(
+          Event.info(
+              "Streaming build results to: "
+                  + formatUrlForTerminal(url, uiUsesColor, uiUsesHyperlinks)));
     }
+  }
+
+  private static String formatUrlForTerminal(String url, boolean useColor, boolean useHyperlinks) {
+    String text = useHyperlinks ? AnsiTerminal.hyperlink(url, url) : url;
+    if (!useColor) {
+      return text;
+    }
+
+    return new String(Color.CYAN.getEscapeSeq(), StandardCharsets.US_ASCII)
+        + text
+        + new String(Color.DEFAULT.getEscapeSeq(), StandardCharsets.US_ASCII);
   }
 
   private void constructAndMaybeReportBuildRequestIdUrl() {

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiOptions.java
@@ -293,8 +293,8 @@ public abstract class UiOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
       help =
-          "If true (or auto with color enabled and a tty), format terminal file paths and test"
-              + " logs as clickable OSC 8 hyperlinks.")
+          "If true (or auto with color enabled), format terminal file paths, test logs, and build"
+              + " results URLs as clickable OSC 8 hyperlinks.")
   public abstract TriState getTerminalHyperlinks();
 
   public abstract void setTerminalHyperlinks(TriState value);

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModuleTest.java
@@ -366,6 +366,38 @@ public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTest
   }
 
   @Test
+  public void testReportsBesResultsUrlWithTerminalOptions(
+      @TestParameter({"yes", "no"}) String color,
+      @TestParameter({"yes", "no", "auto"}) String terminalHyperlinks)
+      throws Exception {
+    String invocationId = "00000000-0000-0000-0000-000000000000";
+    runBuildWithOptions(
+        "--color=" + color,
+        "--terminal_hyperlinks=" + terminalHyperlinks,
+        "--invocation_id=" + invocationId,
+        "--bes_backend=inprocess",
+        "--bes_upload_mode=FULLY_ASYNC",
+        "--bes_results_url=http://results-ui/");
+
+    String url = "http://results-ui/" + invocationId;
+    String expectedUrl = url;
+    if (terminalHyperlinks.equals("yes")
+        || (terminalHyperlinks.equals("auto") && color.equals("yes"))) {
+      expectedUrl = "\u001B]8;;" + url + "\u001B\\" + url + "\u001B]8;;\u001B\\";
+    }
+    if (color.equals("yes")) {
+      expectedUrl = "\u001B[36m" + expectedUrl + "\u001B[0m";
+    }
+    String expectedMessage = "Streaming build results to: " + expectedUrl;
+    events.assertContainsEventsInOrder(expectedMessage, "Found 0 targets", "Found 0 targets");
+
+    afterBuildCommand();
+
+    events.assertContainsEventsInOrder(
+        expectedMessage, "Found 0 targets", "Found 0 targets", expectedMessage, expectedMessage);
+  }
+
+  @Test
   public void testAfterCommandGrpcReportsBesResultsUrl() throws Exception {
     runBuildWithOptions(
         "--color=no", // disable ANSI color sequences


### PR DESCRIPTION
Terminals try to make URLs clickable but that can break when the URLs
wrap because of terminal width. This wraps the BES URL with the OSC 8
escape sequence which terminals will prefer over their default logic to
find URLs.
