### PR TITLE
[9.3.0] Don't fail the build when invalidating dir entries

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -1714,6 +1714,11 @@ Strip the given number of leading components from file paths on extraction. Only
     }
   }
 
+  /**
+   * Records a watch on a directory's non-recursive contents.
+   *
+   * <p>Callers must have checked recently that the given path points to a directory.
+   */
   protected void maybeWatchDirents(Path path, ShouldWatch shouldWatch)
       throws EvalException, RepositoryFunctionException, InterruptedException {
     RepoCacheFriendlyPath repoCacheFriendlyPath = toRepoCacheFriendlyPath(path, shouldWatch);
@@ -1721,6 +1726,10 @@ Strip the given number of leading components from file paths on extraction. Only
       return;
     }
     try {
+      // Dirents can only be recorded for directories, so we have to additionally track the type of
+      // the file. When checking for invalidation, the type is verified first and if it doesn't
+      // match, the directory entries are never requested.
+      getValueAndRecordInput(new RepoRecordedInput.File(repoCacheFriendlyPath));
       getValueAndRecordInput(new RepoRecordedInput.Dirents(repoCacheFriendlyPath));
     } catch (IOException e) {
       throw new RepositoryFunctionException(e, Transience.TRANSIENT);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -575,6 +575,10 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       return;
     }
     try {
+      // DirTree can only be recorded for directories, so we have to additionally track the type of
+      // the file. When checking for invalidation, the type is verified first and if it doesn't
+      // match, the directory entries are never requested.
+      getValueAndRecordInput(new RepoRecordedInput.File(repoCacheFriendlyPath));
       getValueAndRecordInput(new RepoRecordedInput.DirTree(repoCacheFriendlyPath));
     } catch (IOException e) {
       throw new RepositoryFunctionException(e, Transience.TRANSIENT);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepoContentsCacheImpl.java
@@ -106,7 +106,7 @@ import javax.annotation.Nullable;
  */
 public final class RemoteRepoContentsCacheImpl implements RemoteRepoContentsCache {
   // Salts all cache keys; change it whenever previously cached entries may no longer be valid.
-  private static final UUID GUID = UUID.fromString("0336b325-9db8-4592-a5eb-79b4970bc4ce");
+  private static final UUID GUID = UUID.fromString("06a53d89-9f52-46ed-8064-f7af6ba27769");
   private static final String MARKER_FILE_PATH = ".recorded_inputs";
   private static final String REPO_DIRECTORY_PATH = "repo_contents";
   private static final Splitter SPLIT_ON_SPACE = Splitter.on(' ');

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInput.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInput.java
@@ -500,11 +500,11 @@ public abstract sealed class RepoRecordedInput {
     public MaybeValue getValue(Environment env, BlazeDirectories directories)
         throws InterruptedException {
       var skyKey = getSkyKey(directories);
+      var fileValue = (FileValue) env.getValue(skyKey);
+      if (fileValue == null) {
+        return MaybeValue.VALUES_MISSING;
+      }
       try {
-        var fileValue = (FileValue) env.getValueOrThrow(skyKey, IOException.class);
-        if (fileValue == null) {
-          return MaybeValue.VALUES_MISSING;
-        }
         return new MaybeValue.Valid(
             fileValueToMarkerValue((RootedPath) skyKey.argument(), fileValue));
       } catch (IOException e) {
@@ -518,7 +518,12 @@ public abstract sealed class RepoRecordedInput {
     }
   }
 
-  /** Represents the list of entries under a directory accessed during the fetch. */
+  /**
+   * Represents the list of entries under a directory accessed during the fetch.
+   *
+   * <p>May only be requested for paths that are known to represent existing directories, so
+   * consumers usually have to request a {@link RepoRecordedInput.File} first.
+   */
   public static final class Dirents extends RepoRecordedInput {
     public static final Parser PARSER =
         new Parser() {
@@ -587,9 +592,9 @@ public abstract sealed class RepoRecordedInput {
 
     @Override
     protected boolean canBeRequestedUnconditionally() {
-      // Requesting directories in external repositories can result in cycles if the external repo
-      // transitively depends on the requesting repo.
-      return !path.inExternalRepo();
+      // If the File input requested before this input has changed its type to non-directory, this
+      // input's DirectoryListingValue must not be requested as it would result in a build error.
+      return false;
     }
 
     @Override
@@ -613,6 +618,9 @@ public abstract sealed class RepoRecordedInput {
    * Represents an entire directory tree accessed during the fetch. Anything under the tree changing
    * (including adding/removing/renaming files or directories and changing file contents) will cause
    * it to go out of date.
+   *
+   * <p>May only be requested for paths that are known to represent existing directories, so
+   * consumers usually have to request a {@link RepoRecordedInput.File} first.
    */
   public static final class DirTree extends RepoRecordedInput {
     public static final Parser PARSER =
@@ -672,26 +680,20 @@ public abstract sealed class RepoRecordedInput {
 
     @Override
     protected boolean canBeRequestedUnconditionally() {
-      // Requesting directory trees in external repositories can result in cycles if the external
-      // repo now transitively depends on the requesting repo.
-      return !path.inExternalRepo();
+      // If the File input requested before this input has changed its type to non-directory, this
+      // input's DirectoryTreeDigestValue must not be requested as it would result in a build error.
+      return false;
     }
 
     @Override
     public MaybeValue getValue(Environment env, BlazeDirectories directories)
         throws InterruptedException {
       var skyKey = getSkyKey(directories);
-      try {
-        var directoryTreeDigestValue =
-            (DirectoryTreeDigestValue) env.getValueOrThrow(skyKey, IOException.class);
-        if (directoryTreeDigestValue == null) {
-          return MaybeValue.VALUES_MISSING;
-        }
-        return new MaybeValue.Valid(directoryTreeDigestValue.hexDigest());
-      } catch (IOException e) {
-        return new MaybeValue.Invalid(
-            "failed to digest directory tree at %s: %s".formatted(path, e.getMessage()));
+      var directoryTreeDigestValue = (DirectoryTreeDigestValue) env.getValue(skyKey);
+      if (directoryTreeDigestValue == null) {
+        return MaybeValue.VALUES_MISSING;
       }
+      return new MaybeValue.Valid(directoryTreeDigestValue.hexDigest());
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/skyframe/SkyFunction.java
+++ b/src/main/java/com/google/devtools/build/skyframe/SkyFunction.java
@@ -207,6 +207,11 @@ public interface SkyFunction {
      * <p>The exception class given cannot be a supertype or a subtype of {@link RuntimeException},
      * or a subtype of {@link InterruptedException}. See {@link
      * SkyFunctionException#validateExceptionType} for details.
+     *
+     * <p>Note that exceptions may not always be propagated in this way (e.g., when not in "keep
+     * going" mode), so callers must not depend on this for control flow. When it is necessary to
+     * allow recovery from a failed function evaluation in all cases, then the failure needs to be
+     * represented in that function's regular value instead.
      */
     @CanIgnoreReturnValue
     @Nullable

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/BUILD
@@ -35,6 +35,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/pkgcache",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/repo_recorded_input",
         "//src/main/java/com/google/devtools/build/lib/skyframe:configured_target_and_data",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:filesystem_keys",
         "//src/main/java/com/google/devtools/build/lib/skyframe:package_lookup_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
@@ -18,7 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -53,6 +53,7 @@ import com.google.devtools.build.lib.rules.repository.RepoRecordedInput;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor.ExecutionResult;
 import com.google.devtools.build.lib.skyframe.BazelSkyframeExecutorConstants;
+import com.google.devtools.build.lib.skyframe.FileKey;
 import com.google.devtools.build.lib.skyframe.PackageLookupValue;
 import com.google.devtools.build.lib.testutil.Scratch;
 import com.google.devtools.build.lib.vfs.Path;
@@ -172,7 +173,7 @@ public final class StarlarkRepositoryContextTest {
     fakeFileLabel = Label.parseCanonical("//:foo");
     when(environment.getValue(PackageLookupValue.key(fakeFileLabel.getPackageIdentifier())))
         .thenReturn(PackageLookupValue.success(root, BuildFileName.BUILD));
-    when(environment.getValueOrThrow(any(), eq(IOException.class)))
+    when(environment.getValue(argThat(key -> key instanceof FileKey)))
         .thenReturn(Mockito.mock(FileValue.class));
     PathPackageLocator packageLocator =
         new PathPackageLocator(

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -2925,6 +2925,168 @@ EOF
   expect_log "I'm running!"
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/30883.
+function test_path_readdir_deleted_dir() {
+  create_new_workspace
+  cat > $(setup_module_dot_bazel) <<EOF
+r = use_repo_rule("//:r.bzl", "r")
+r(name = "r")
+EOF
+  touch BUILD
+  cat > r.bzl <<EOF
+def _r(rctx):
+  p = rctx.workspace_root.get_child("foo")
+  rctx.watch(p)
+  if p.exists:
+    print("I see: " + ",".join(sorted([c.basename for c in p.readdir()])))
+  else:
+    print("I see: nothing")
+  rctx.file("BUILD", "filegroup(name='r')")
+r=repository_rule(_r)
+EOF
+
+  mkdir foo
+  touch foo/bar
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: bar"
+
+  # deleting the watched directory should trigger a refetch, not an error.
+  rm -r foo
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: nothing"
+
+  # recreating the watched directory should trigger a refetch again.
+  mkdir foo
+  touch foo/quux
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: quux"
+}
+
+# Regression test for https://github.com/bazelbuild/bazel/issues/30883.
+function test_path_readdir_deleted_dir_without_watch() {
+  create_new_workspace
+  cat > $(setup_module_dot_bazel) <<EOF
+r = use_repo_rule("//:r.bzl", "r")
+r(name = "r")
+EOF
+  touch BUILD
+  cat > r.bzl <<EOF
+def _r(rctx):
+  p = rctx.workspace_root.get_child("foo")
+  if p.exists:
+    print("I see: " + ",".join(sorted([c.basename for c in p.readdir()])))
+  else:
+    print("I see: nothing")
+  rctx.file("BUILD", "filegroup(name='r')")
+r=repository_rule(_r)
+EOF
+
+  mkdir foo
+  touch foo/bar
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: bar"
+
+  # deleting the directory whose entries are watched should trigger a refetch,
+  # not an error.
+  rm -r foo
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: nothing"
+}
+
+# Regression test for https://github.com/bazelbuild/bazel/issues/30883.
+function test_watch_tree_deleted_dir() {
+  create_new_workspace
+  cat > $(setup_module_dot_bazel) <<EOF
+r = use_repo_rule("//:r.bzl", "r")
+r(name = "r")
+EOF
+  touch BUILD
+  cat > r.bzl <<EOF
+def _r(rctx):
+  p = rctx.workspace_root.get_child("foo")
+  rctx.watch(p)
+  if p.is_dir:
+    rctx.watch_tree(p)
+    print("I see: a directory")
+  else:
+    print("I see: nothing")
+  rctx.file("BUILD", "filegroup(name='r')")
+r=repository_rule(_r)
+EOF
+
+  mkdir -p foo/sub
+  touch foo/sub/bar
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: a directory"
+
+  # deleting the watched directory tree should trigger a refetch, not an error.
+  rm -r foo
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: nothing"
+
+  # recreating the watched directory tree should trigger a refetch again.
+  mkdir foo
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: a directory"
+}
+
+# Documents the current behavior when a directory whose entries are recorded
+# as a repo or module extension input becomes non-readable between builds: the
+# build fails. This is not necessarily the desired behavior.
+function test_path_readdir_unreadable_dir() {
+  if is_windows; then
+    echo "Skipping test on Windows (no POSIX permissions)"
+    return 0
+  fi
+  if [[ "$(id -u)" == 0 ]]; then
+    echo "Skipping test when running as root (permissions are not enforced)"
+    return 0
+  fi
+
+  create_new_workspace
+  cat > $(setup_module_dot_bazel) <<EOF
+r = use_repo_rule("//:r.bzl", "r")
+r(name = "r")
+EOF
+  touch BUILD
+  cat > r.bzl <<EOF
+def _r(rctx):
+  p = rctx.workspace_root.get_child("foo")
+  rctx.watch(p)
+  if p.exists:
+    print("I see: " + ",".join(sorted([c.basename for c in p.readdir()])))
+  else:
+    print("I see: nothing")
+  rctx.file("BUILD", "filegroup(name='r')")
+r=repository_rule(_r)
+EOF
+
+  mkdir foo
+  touch foo/bar
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: bar"
+
+  chmod 000 foo
+  local exit_code=0
+  bazel build @r >& $TEST_log || exit_code=$?
+  chmod 755 foo
+  (( exit_code != 0 )) || fail "expected bazel to fail"
+  expect_log "foo (Permission denied)"
+
+  bazel shutdown
+  chmod 000 foo
+  exit_code=0
+  bazel build @r >& $TEST_log || exit_code=$?
+  chmod 755 foo
+  (( exit_code != 0 )) || fail "expected bazel to fail"
+  expect_log "foo (Permission denied)"
+
+  # After the directory becomes readable again, the build succeeds without a
+  # refetch since its contents didn't change.
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_not_log "I see:"
+}
+
 # Regression test for https://github.com/bazelbuild/bazel/issues/21823.
 function test_repository_cache_concurrency() {
   sha=cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94


### PR DESCRIPTION
### Description
`DirectoryListingValue` and `DirectoryTreeDigestValue` fail the build if requested on non-directories, but the `rctx.watch_tree` and `path.readdir` methods did not register their recorded inputs in a way that verifies the file type before requesting the values during repo or extension invalidation. This is fixed by always requesting a `RepoRecordedInput.File` first and disallowing batching of a `File` followed by a `Dirents` or `DirTree`.

Since existing remote repo contents cache entries lack the `File` input required as a precondition, the GUID is bumped to invalidate them and thus prevent them from failing builds on Bazel versions with this fix.

Also drop misleading calls to `Environment#getValueOrThrow` that looked like they recovered from such failures, but did not, and add a comment to that method.

A new integration test covers a directory whose contents are being watched that then becomes non-readable, which still results in a build failure. It is not clear whether this is the right behavior, but changing it is out of scope for this bug fix.

### Motivation
Fixes #30883

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None

Closes #30933

COPYBARA_INTEGRATE_REVIEW=https://github.com/bazelbuild/bazel/pull/30933 from fmeum:fix-dirent-crash 7006041b0af3614a582faf633acd515cd2befc91
PiperOrigin-RevId: 976396928
Change-Id: I323a668d1cf47b6588b3340f8f3d865e94ac76ba

(cherry picked from commit 6a3de202fe689c677b0c0bea8d76755e22bc21de)


9.3.0 adaptation: `RepoRecordedInput.DirTree` doesn't take `excludes` glob patterns on this branch, so the `watch_tree` call site keeps the single-argument constructor and the Javadoc paragraph about `excludes` is omitted.

Closes #30884
