### PR TITLE
(fix): glob recursive symlink

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/producers/PatternWithWildcardProducer.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/producers/PatternWithWildcardProducer.java
@@ -178,26 +178,18 @@ final class PatternWithWildcardProducer
         continue;
       }
 
-      // This check is more strict than necessary: we raise an error if globbing traverses into
-      // a directory for any reason, even though it's only necessary if that reason was the
-      // resolution of a recursive glob ("**"). Fixing this would require plumbing the ancestor
-      // symlink information through DirectoryListingValue.
-      if (symlinkValue.isDirectory()
-          && symlinkValue.unboundedAncestorSymlinkExpansionChain() != null) {
-        tasks.lookUp(
-            FileSymlinkInfiniteExpansionUniquenessFunction.key(
-                symlinkValue.unboundedAncestorSymlinkExpansionChain()),
-            v -> {});
-        resultSink.acceptGlobError(
-            GlobError.of(
-                new FileSymlinkInfiniteExpansionException(
-                    symlinkValue.pathToUnboundedAncestorSymlinkExpansionChain(),
-                    symlinkValue.unboundedAncestorSymlinkExpansionChain())));
-        return DONE;
-      }
-
       // Use the symlink path instead of the target path.
       PathFragment direntPath = symlinkKey.argument().getRootRelativePath();
+
+      // If the directory symlink has an unbounded ancestor expansion chain, do not descend into
+      // it to prevent infinite recursion, but add it if files/dirs are matched.
+      if (symlinkValue.isDirectory()
+          && symlinkValue.unboundedAncestorSymlinkExpansionChain() != null) {
+        if (FragmentProducer.shouldAddFileMatchingToResult(fragmentIndex, globDetail)) {
+          resultSink.acceptPathFragmentWithPackageFragment(direntPath);
+        }
+        continue;
+      }
       if (symlinkValue.isDirectory()) {
         tasks.enqueue(
             new DirectoryDirentProducer(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/GlobFunctionWithMultipleRecursiveFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/GlobFunctionWithMultipleRecursiveFunctions.java
@@ -255,29 +255,18 @@ public final class GlobFunctionWithMultipleRecursiveFunctions extends GlobFuncti
           continue;
         }
 
-        // This check is more strict than necessary: we raise an error if globbing traverses into
-        // a directory for any reason, even though it's only necessary if that reason was the
-        // resolution of a recursive glob ("**"). Fixing this would require plumbing the ancestor
-        // symlink information through DirectoryListingValue.
-        if (symlinkFileValue.isDirectory()
-            && symlinkFileValue.unboundedAncestorSymlinkExpansionChain() != null) {
-          SkyKey uniquenessKey =
-              FileSymlinkInfiniteExpansionUniquenessFunction.key(
-                  symlinkFileValue.unboundedAncestorSymlinkExpansionChain());
-          env.getValue(uniquenessKey);
-          if (env.valuesMissing()) {
-            return null;
-          }
-
-          FileSymlinkInfiniteExpansionException symlinkException =
-              new FileSymlinkInfiniteExpansionException(
-                  symlinkFileValue.pathToUnboundedAncestorSymlinkExpansionChain(),
-                  symlinkFileValue.unboundedAncestorSymlinkExpansionChain());
-          throw new GlobException(symlinkException, Transience.PERSISTENT);
-        }
-
         Dirent dirent = symlinkFileMap.get(subdirAndSymlinksKey);
         String fileName = dirent.getName();
+
+        // If the directory symlink has an unbounded ancestor expansion chain, do not descend into
+        // it to prevent infinite recursion, but add it if files/dirs are matched.
+        if (symlinkFileValue.isDirectory()
+            && symlinkFileValue.unboundedAncestorSymlinkExpansionChain() != null) {
+          if (globMatchesBareFile && globberOperation != Globber.Operation.SUBPACKAGES) {
+            sortedResultMap.put(dirent, glob.getSubdir().getRelative(fileName));
+          }
+          continue;
+        }
         if (symlinkFileValue.isDirectory()) {
           SkyKey keyToRequest = getSkyKeyForSubdir(fileName, glob, subdirPattern);
           if (keyToRequest != null) {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/GlobTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/GlobTestBase.java
@@ -808,20 +808,11 @@ public abstract class GlobTestBase {
     FileSystemUtils.ensureSymbolicLink(
         pkgPath.getRelative("parent/sub/symlink"), pkgPath.getRelative("parent"));
 
-    String globPattern = withRecursiveWildcard ? "parent/**" : "parent/sub/symlink";
-    SkyKey skyKey = createdGlobRelatedSkyKey(globPattern, Globber.Operation.FILES_AND_DIRS);
-
-    EvaluationResult<GlobValue> result =
-        evaluator.evaluate(ImmutableList.of(skyKey), EVALUATION_OPTIONS);
-
-    if (withRecursiveWildcard || alwaysUsesDirListing()) {
-      assertThat(result.hasError()).isTrue();
-      ErrorInfo errorInfo = result.getError(skyKey);
-      assertThat(errorInfo.getException())
-          .isInstanceOf(FileSymlinkInfiniteExpansionException.class);
-      assertThat(errorInfo.getException()).hasMessageThat().contains("Infinite symlink expansion");
+    if (withRecursiveWildcard) {
+      assertSingleGlobMatches(
+          "parent/**", Operation.FILES_AND_DIRS, "parent/sub", "parent/sub/symlink", "parent");
     } else {
-      assertThat(result.hasError()).isFalse();
+      assertSingleGlobMatches("parent/sub/symlink", Operation.FILES_AND_DIRS, "parent/sub/symlink");
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/GlobsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/GlobsFunctionTest.java
@@ -137,13 +137,15 @@ public final class GlobsFunctionTest extends GlobTestBase {
             PKG_ID,
             Root.fromPath(root),
             ImmutableSet.of(unboundedSymlinksGlobRequest, goodGlobRequest));
-    EvaluationResult<GlobValue> result =
+    EvaluationResult<GlobsValue> result =
         evaluator.evaluate(ImmutableList.of(globsKey), EVALUATION_OPTIONS);
 
-    assertThat(result.hasError()).isTrue();
-    ErrorInfo errorInfo = result.getError(globsKey);
-    assertThat(errorInfo.getException()).isInstanceOf(FileSymlinkInfiniteExpansionException.class);
-    assertThat(errorInfo.getException()).hasMessageThat().contains("Infinite symlink expansion");
+    assertThat(result.hasError()).isFalse();
+    assertThat(
+            result.get(globsKey).getMatches().stream()
+                .map(PathFragment::getPathString)
+                .collect(toImmutableSet()))
+        .containsExactly("parent/sub/symlink", "foo/bar/wiz/file");
   }
 
   @Test
@@ -161,20 +163,14 @@ public final class GlobsFunctionTest extends GlobTestBase {
     GlobsValue.Key globsKey =
         GlobsValue.key(
             PKG_ID, Root.fromPath(root), ImmutableSet.of(symlinkGlobRequest1, symlinkGlobRequest2));
-    EvaluationResult<GlobValue> result =
+    EvaluationResult<GlobsValue> result =
         evaluator.evaluate(ImmutableList.of(globsKey), EVALUATION_OPTIONS);
 
-    assertThat(result.hasError()).isTrue();
-    ErrorInfo errorInfo = result.getError(globsKey);
-    assertThat(errorInfo.getException()).isInstanceOf(FileSymlinkInfiniteExpansionException.class);
-    assertThat(errorInfo.getException()).hasMessageThat().contains("Infinite symlink expansion");
-
-    // The two globs are evaluated in parallel inside GlobsFunction, so it is non-deterministic
-    // which SymlinkInfiniteExpansionException is thrown and caught first. So this test only needs
-    // to verify the output error is from either one of the SymlinkInfiniteExpansion errors.
-    assertThat(((FileSymlinkInfiniteExpansionException) errorInfo.getException()).getChain())
-        .containsAnyOf(
-            RootedPath.toRootedPath(Root.fromPath(root), pkgPath.getRelative("parent/sub1/self1")),
-            RootedPath.toRootedPath(Root.fromPath(root), pkgPath.getRelative("parent/sub2/self2")));
+    assertThat(result.hasError()).isFalse();
+    assertThat(
+            result.get(globsKey).getMatches().stream()
+                .map(PathFragment::getPathString)
+                .collect(toImmutableSet()))
+        .containsExactly("parent/sub1/self1", "parent/sub2/self2");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PackageFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PackageFunctionTest.java
@@ -668,6 +668,24 @@ public class PackageFunctionTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testGlobWithExcludedRecursiveSymlinks(
+      @TestParameter ComputationMode computationMode) throws Exception {
+    scratch.file(
+        "foo/BUILD",
+        "filegroup(",
+        "    name = 'foo',",
+        "    srcs = glob(include = ['**'], exclude = ['bar', 'bar/**']),",
+        ")");
+    scratch.file("foo/payload.txt", "hello");
+    Path barSymlink = scratch.resolve("foo/bar");
+    FileSystemUtils.ensureSymbolicLink(barSymlink, scratch.resolve("foo"));
+
+    preparePackageLoading(computationMode, rootDirectory);
+    Packageoid pkg = validPackageoidWithoutErrors("foo");
+    assertSrcs(pkg, "foo", "//foo:BUILD", "//foo:payload.txt");
+  }
+
+  @Test
   public void testGlobOrderStableWithNonSkyframeAndSkyframeComponents(
       @TestParameter ComputationMode computationMode) throws Exception {
     scratch.file("foo/BUILD", "filegroup(name = 'foo', srcs = glob(['*.txt']))");


### PR DESCRIPTION
### Description

When `glob()` encounters a directory symlink that forms a cycle (e.g. `foo/bar -> ../`), Bazel immediately throws `FileSymlinkInfiniteExpansionException` during directory traversal — before exclude filtering (`UnixGlob.removeExcludes`) ever runs. This means `exclude=["foo/bar", "foo/bar/**"]` has no effect and the build fails unconditionally.

This PR fixes the issue by treating cyclic directory symlinks as **leaf nodes** instead of fatal errors. When glob traversal detects `unboundedAncestorSymlinkExpansionChain() != null` on a directory symlink, it:
1. Adds the symlink path to the result if it matches the include pattern
2. Does **not** recurse into it (preventing infinite expansion)
3. Lets downstream `removeExcludes` filtering handle exclusion as usual

The fix is applied in both glob evaluation codepaths:
- `PatternWithWildcardProducer.java` (Skyframe producer-based evaluator)
- `GlobFunctionWithMultipleRecursiveFunctions.java` (legacy multi-function evaluator)

### Motivation

Fixes https://github.com/bazelbuild/bazel/issues/13950

Recursive symlinks are common in real-world projects (e.g. `node_modules`, build output directories, ROS workspaces). Users expect `exclude` patterns to prevent Bazel from traversing into these paths, but the current implementation crashes before exclusion is ever evaluated.

An alternative approach of plumbing `exclude` patterns into `GlobDescriptor`/Skyframe was considered, but rejected because:
- It would change `GlobDescriptor` cache keys with broad caching implications
- It conflates "don't include in results" with "don't visit at all," which can cause subtle correctness bugs (e.g. `exclude=["b"]` where `a -> b` should still include `a`)

### Build API Changes

No


### Release Notes

RELNOTES: `glob()` no longer crashes with "Infinite symlink expansion" when encountering cyclic directory symlinks. Cyclic symlinks are treated as leaf nodes and can be filtered via `exclude` patterns.

### Error Reproduction Result: https://pastebin.com/BGXk3LGt
### Fix Results: https://pastebin.com/GXCzQQbM
### Existing Test Result: https://pastebin.com/CqFe5tWy