### PR TITLE
blake3: validate bounds and check null pointers in JNI - Fixes #31026

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/vfs/bazel/Blake3MessageDigest.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/bazel/Blake3MessageDigest.java
@@ -46,6 +46,12 @@ public final class Blake3MessageDigest extends MessageDigest {
 
   @Override
   public void engineUpdate(byte[] data, int offset, int length) {
+    if (data == null) {
+      throw new NullPointerException("data cannot be null");
+    }
+    if (offset < 0 || length < 0 || offset > data.length - length) {
+      throw new IndexOutOfBoundsException("offset or length is out of bounds");
+    }
     blake3_hasher_update(hasher, data, offset, length);
   }
 

--- a/src/main/native/blake3_jni.cc
+++ b/src/main/native/blake3_jni.cc
@@ -48,11 +48,25 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_google_devtools_build_lib_vfs_bazel_Blake3MessageDigest_blake3_1hasher_1update(
     JNIEnv *env, jobject obj, jbyteArray jhasher, jbyteArray input, jint offset,
     jint input_len) {
+  if (input == nullptr) {
+    return;
+  }
+  jsize input_size = env->GetArrayLength(input);
+  if (offset < 0 || input_len < 0 || offset > input_size - input_len) {
+    jclass ex_class = env->FindClass("java/lang/ArrayIndexOutOfBoundsException");
+    if (ex_class != nullptr) {
+      env->ThrowNew(ex_class, "Offset or length out of bounds");
+    }
+    return;
+  }
+
   blake3_hasher *hasher = (blake3_hasher *)get_byte_array(env, jhasher);
   if (hasher) {
     jbyte *input_addr = get_byte_array(env, input);
-    blake3_hasher_update(hasher, input_addr + offset, input_len);
-    release_byte_array(env, input, input_addr);
+    if (input_addr) {
+      blake3_hasher_update(hasher, input_addr + offset, input_len);
+      release_byte_array(env, input, input_addr);
+    }
     release_byte_array(env, jhasher, (jbyte *)hasher);
   }
 }
@@ -61,11 +75,25 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_google_devtools_build_lib_vfs_bazel_Blake3MessageDigest_blake3_1hasher_1finalize(
     JNIEnv *env, jobject obj, jbyteArray jhasher, jbyteArray out,
     jint out_len) {
+  if (out == nullptr) {
+    return;
+  }
+  jsize out_size = env->GetArrayLength(out);
+  if (out_len < 0 || out_len > out_size) {
+    jclass ex_class = env->FindClass("java/lang/ArrayIndexOutOfBoundsException");
+    if (ex_class != nullptr) {
+      env->ThrowNew(ex_class, "Output length out of bounds");
+    }
+    return;
+  }
+
   blake3_hasher *hasher = (blake3_hasher *)get_byte_array(env, jhasher);
   if (hasher) {
     jbyte *out_addr = get_byte_array(env, out);
-    blake3_hasher_finalize(hasher, (uint8_t *)out_addr, out_len);
-    release_byte_array(env, out, out_addr);
+    if (out_addr) {
+      blake3_hasher_finalize(hasher, (uint8_t *)out_addr, out_len);
+      release_byte_array(env, out, out_addr);
+    }
     release_byte_array(env, jhasher, (jbyte *)hasher);
   }
 }


### PR DESCRIPTION
In blake3_jni.cc, the JNI methods implementing BLAKE3 hashing did not validate the offset or input_len / out_len parameters against the underlying Java array lengths, nor did they check the pointers returned by GetPrimitiveArrayCritical for NULL.

As a result, calling Blake3MessageDigest.engineUpdate directly with invalid bounds (such as a negative length or an offset outside array boundaries) causes unchecked pointer arithmetic while the array is pinned, resulting in a native SIGSEGV inside libunix_jni.so.

While typical callers using the public java.security.MessageDigest.update pass through standard Java bounds checks, direct callers of engineUpdate (or native callers) could trigger undefined behavior and abort the JVM process.

Changes:
  Java Layer (Blake3MessageDigest.java):
    - Added explicit bounds and null checks in engineUpdate(byte[] data, int offset, int length).
    - Throws NullPointerException if data == null and IndexOutOfBoundsException if offset < 0, length < 0, or offset + length > data.length.
  Native Layer (src/main/native/blake3_jni.cc):
    - Added defensive bounds validation using env->GetArrayLength() in blake3_hasher_update and blake3_hasher_finalize.
    - Throws java/lang/ArrayIndexOutOfBoundsException via JNI if the bounds are invalid.
    -  Added nullptr checks on pointers returned by GetPrimitiveArrayCritical before dereferencing or performing pointer arithmetic.
    - Ensures pinned arrays are safely released in the event of an inner allocation failure.

Verified using a reproducer calling engineUpdate(data, 0, -1):

Before: Native SIGSEGV crash.
After: Clean java.lang.IndexOutOfBoundsException thrown.

Ran existing tests covering BLAKE3 digest functionality to ensure normal hashing paths are unaffected.