### PR TITLE
Validate `map_directory`'s `additional_params` value types

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkMapActionTemplate.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkMapActionTemplate.java
@@ -83,6 +83,8 @@ public final class StarlarkMapActionTemplate extends ActionKeyComputer
   // The allowed classes for values for the different keys.
   private static final ImmutableSet<Class<?>> ADDITIONAL_INPUTS_CLASSES =
       ImmutableSet.of(Artifact.class, FilesToRunProvider.class, Depset.class);
+  private static final ImmutableSet<Class<?>> ADDITIONAL_PARAMS_CLASSES =
+      ImmutableSet.of(String.class, Boolean.class, StarlarkInt.class);
   private static final ImmutableSet<Class<?>> DIRECTORY_CLASSES =
       ImmutableSet.of(SpecialArtifact.class);
 
@@ -139,7 +141,8 @@ public final class StarlarkMapActionTemplate extends ActionKeyComputer
     addDictValuesToNestedSets(tools, TOOLS_KEY, allInputsNsBuilder, toolsNsBuilder);
     this.allInputs = allInputsNsBuilder.build();
     this.toolsNs = toolsNsBuilder.build();
-    this.additionalParams = Dict.<String, Object>immutableCopyOf(additionalParams);
+    this.additionalParams =
+        validateDictValues(additionalParams, ADDITIONAL_PARAMS_KEY, ADDITIONAL_PARAMS_CLASSES);
     this.spawnActionBuilder = spawnActionBuilder;
     this.executionRequirements = executionRequirements;
     this.outputPathsMode = outputPathsMode;

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -68,7 +68,7 @@ public interface StarlarkActionFactoryApi extends StarlarkValue {
           + " <code>ctx.version_file</code>. Therefore changes in this file will not retrigger"
           + " actions depending on it.";
   static final String TOOLS_ARG_DOC =
-"""
+      """
 List or <a href="../builtins/depset.html"><code>depset</code></a> of any tools needed by the \
 action. Tools are executable inputs that may have their own runfiles which are automatically made \
 available to the action. \
@@ -85,7 +85,7 @@ automatically added. All tools are implicitly added as inputs.
 </p>
 """;
   static final String MAP_DIRECTORY_IMPLEMENTATION_DOC =
-"""
+      """
 A Starlark function that gets called after input directories have been built to generate actions
 that output files to the specified output directories. This function is passed the following
 arguments:
@@ -372,7 +372,7 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             defaultValue = "None",
             named = true,
             positional = false,
-        doc = "A one-word description of the action, for example, CppCompile or GoLink."),
+            doc = "A one-word description of the action, for example, CppCompile or GoLink."),
         @Param(
             name = "execution_requirements",
             allowedTypes = {
@@ -477,7 +477,7 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             defaultValue = "None",
             named = true,
             positional = false,
-        doc = "A one-word description of the action, for example, CppCompile or GoLink."),
+            doc = "A one-word description of the action, for example, CppCompile or GoLink."),
         @Param(
             name = "progress_message",
             allowedTypes = {
@@ -697,7 +697,7 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             defaultValue = "None",
             named = true,
             positional = false,
-        doc = "A one-word description of the action, for example, CppCompile or GoLink."),
+            doc = "A one-word description of the action, for example, CppCompile or GoLink."),
         @Param(
             name = "command",
             allowedTypes = {
@@ -947,7 +947,8 @@ This function must be top-level, i.e. lambdas and nested functions are not allow
             named = true,
             positional = false,
             doc =
-                "A dictionary mapping of strings to additional parameters. The values specify any"
+                "A dictionary mapping of strings to additional parameters. Only strings, booleans,"
+                    + " and integers are allowed as values. The values specify any"
                     + " additional parameters that we want to make accessible to the implementation"
                     + " function that could be used to influence its behavior. The keys (strings)"
                     + " act as identifiers to easily reference a specific parameter from within the"

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkMapActionTemplateTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkMapActionTemplateTest.java
@@ -542,6 +542,45 @@ public final class StarlarkMapActionTemplateTest extends BuildIntegrationTestCas
   }
 
   @Test
+  public void invalidAdditionalParams(
+      @TestParameter({
+            "ctx.file.data",
+            "ctx.attr.cat_tool.files_to_run",
+            "depset([ctx.file.data])",
+            "[ctx.file.data]",
+            "{\"file\": ctx.file.data}",
+            "None"
+          })
+          String value)
+      throws Exception {
+    write(
+        "test/rule_def.bzl",
+        """
+        load(":helpers.bzl", "create_seed_dir", "unused_impl")
+
+        def rule_impl(ctx):
+            input_dir = create_seed_dir(ctx, "input_dir", 1, 3)
+            output_dir = ctx.actions.declare_directory(ctx.attr.name + "_output_dir")
+            ctx.actions.map_directory(
+                implementation = unused_impl,
+                input_directories = {"input_dir": input_dir},
+                output_directories = {"output_dir": output_dir},
+                tools = {},
+                additional_params = {"param": %s},
+            )
+            return [DefaultInfo(files = depset([output_dir]))]
+        """
+            .formatted(value));
+
+    RecordingOutErr recordingOutErr = new RecordingOutErr();
+    this.outErr = recordingOutErr;
+    assertThrows(ViewCreationFailedException.class, () -> buildTarget("//test:target"));
+    assertThat(recordingOutErr.errAsLatin1())
+        .contains("Expected one of [string, bool, int]; but got");
+    assertThat(recordingOutErr.errAsLatin1()).contains("in additional_params['param']");
+  }
+
+  @Test
   @TestParameters("{inputs: '{\"input_dir\": input_dir}', outputs: '{}', errorType: 'output'}")
   @TestParameters("{inputs: '{}', outputs: '{\"output_dir\": output_dir}', errorType: 'input'}")
   public void emptyInputOrOutputDirectoriesNotAllowed(


### PR DESCRIPTION
### Description

Reject `ctx.actions.map_directory(additional_params = ...)` values other than strings, booleans, and integers, as specified by the callback documentation. Report the offending dictionary key during analysis and clarify the restriction in the parameter documentation.

### Motivation

Artifact values were previously accepted without being added to the template's inputs and could then be passed on as inputs to expanded actions, which violates the analysis-time contract of `ActionTemplate`.

### Build API Changes

This enforces a restriction documented in a different place.

### Checklist

- [x] I have added tests for the new use cases.
- [x] I have updated the documentation.

### Release Notes

RELNOTES[INC]: `ctx.actions.map_directory` now rejects `additional_params` values that are not strings, booleans, or integers, matching the documentation of its implementation function. Pass files and tools through `additional_inputs` or `tools` instead.
