### PR TITLE
Reject template output directories passed as tools

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTemplateContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTemplateContext.java
@@ -89,26 +89,16 @@ public final class StarlarkTemplateContext implements StarlarkTemplateContextApi
 
     StarlarkActionFactory.buildCommandLine(builder, arguments, repoMappingSupplier);
 
-    List<Artifact> inputArtifacts;
     switch (inputs) {
       case Sequence<?> sequence -> {
-        inputArtifacts = Sequence.cast(inputs, Artifact.class, "inputs");
-        builder.addInputs(inputArtifacts);
+        builder.addInputs(Sequence.cast(sequence, Artifact.class, "inputs"));
       }
       case Depset depset -> {
         NestedSet<Artifact> inputNestedSet = Depset.cast(depset, Artifact.class, "inputs");
-        inputArtifacts = inputNestedSet.toList();
         builder.addTransitiveInputs(inputNestedSet);
       }
       default -> {
         throw Starlark.errorf("Expected a list or depset but got %s", Starlark.type(inputs));
-      }
-    }
-
-    for (Artifact input : inputArtifacts) {
-      if (outputDirectories.contains(input)) {
-        throw Starlark.errorf(
-            "Output directory %s cannot be used as an input to template_ctx.run()", input);
       }
     }
 
@@ -148,7 +138,16 @@ public final class StarlarkTemplateContext implements StarlarkTemplateContextApi
       }
     }
 
-    actions.add(builder.buildForStarlarkActionTemplate(actionOwner));
+    var action = builder.buildForStarlarkActionTemplate(actionOwner);
+    // Tools and the executable are inputs too, so validate the complete input set. Expanded actions
+    // may consume individual outputs of sibling actions, but not an entire template output directory.
+    for (Artifact input : action.getInputs().toList()) {
+      if (outputDirectories.contains(input)) {
+        throw Starlark.errorf(
+            "Output directory %s cannot be used as an input to template_ctx.run()", input);
+      }
+    }
+    actions.add(action);
   }
 
   public void registerAction(AbstractAction action) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTemplateContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTemplateContext.java
@@ -139,7 +139,7 @@ public final class StarlarkTemplateContext implements StarlarkTemplateContextApi
     }
 
     var action = builder.buildForStarlarkActionTemplate(actionOwner);
-    for (Artifact input : action.getInputs().toList()) {
+    for (var input : action.getInputs().toList()) {
       if (outputDirectories.contains(input)) {
         throw Starlark.errorf(
             "Output directory %s cannot be used as an input to template_ctx.run()", input);

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTemplateContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTemplateContext.java
@@ -139,8 +139,6 @@ public final class StarlarkTemplateContext implements StarlarkTemplateContextApi
     }
 
     var action = builder.buildForStarlarkActionTemplate(actionOwner);
-    // Tools and the executable are inputs too, so validate the complete input set. Expanded actions
-    // may consume individual outputs of sibling actions, but not an entire template output directory.
     for (Artifact input : action.getInputs().toList()) {
       if (outputDirectories.contains(input)) {
         throw Starlark.errorf(

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkMapActionTemplateTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkMapActionTemplateTest.java
@@ -645,6 +645,54 @@ public final class StarlarkMapActionTemplateTest extends BuildIntegrationTestCas
   }
 
   @Test
+  public void cannotConsumeOutputDirectory(
+      @TestParameter({
+            "inputs = [first_dir]",
+            "inputs = depset([first_dir])",
+            "tools = [first_dir]",
+            "tools = depset([first_dir])",
+            "tools = [depset([first_dir])]"
+          })
+          String inputArgument)
+      throws Exception {
+    write(
+        "test/rule_def.bzl",
+        """
+        load(":helpers.bzl", "create_seed_dir")
+
+        def map_impl(template_ctx, input_directories, output_directories, tools, **kwargs):
+            first_dir = output_directories["first"]
+            first = template_ctx.declare_file("first", directory = first_dir)
+            template_ctx.run(outputs = [first], executable = tools["tool"])
+            second = template_ctx.declare_file("second", directory = output_directories["second"])
+            template_ctx.run(
+                outputs = [second],
+                executable = tools["tool"],
+                %s,
+            )
+
+        def rule_impl(ctx):
+            first_dir = ctx.actions.declare_directory("first_dir")
+            second_dir = ctx.actions.declare_directory("second_dir")
+            ctx.actions.map_directory(
+                implementation = map_impl,
+                input_directories = {"input": create_seed_dir(ctx, "input", 1, 3)},
+                output_directories = {"first": first_dir, "second": second_dir},
+                tools = {"tool": ctx.attr.cat_tool.files_to_run},
+            )
+            return [DefaultInfo(files = depset([first_dir, second_dir]))]
+        """
+            .formatted(inputArgument));
+
+    RecordingOutErr recordingOutErr = new RecordingOutErr();
+    this.outErr = recordingOutErr;
+    assertThrows(BuildFailedException.class, () -> buildTarget("//test:target"));
+    assertThat(recordingOutErr.errAsLatin1())
+        .containsMatch(
+            "Output directory .*first_dir.* cannot be used as an input to template_ctx.run");
+  }
+
+  @Test
   public void actionConflicts_conflictingOutputsInSameDirectory() throws Exception {
     // Don't check serialization here, since the action conflict only occurs during execution,
     // but serialization checks end up throwing (due to action conflicts) before we get there.


### PR DESCRIPTION
### Description

Reject a `map_directory` template's own output directories from becoming an expanded action's inputs via `template_ctx.run(tools = ...)`, in addition the existing check preventing this via `inputs = ...`.


### Motivation

The difference in behavior is likely unintentional and would make action rewinding much more difficult to implement.

### Build API Changes

Previously accepted uses of a template's own output directory as a tool are now rejected, matching the existing behavior for explicit inputs.

### Checklist

- [x] I have added tests for the new use cases.
- [x] I have updated the documentation: N/A

### Release Notes

RELNOTES[INC]: `template_ctx.run` now rejects a template's own output directories passed through `tools`, as it already did for `inputs`. Pass individual files produced by sibling actions instead.
