### PR TITLE
Use provider equality in the exec transition cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/ExecutionTransitionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/ExecutionTransitionFactory.java
@@ -66,10 +66,11 @@ public class ExecutionTransitionFactory
    * While that makes this cache seem unnecessary, it still has value. The exec transition uniquely
    * takes an extra parameter: the execution platform label. This is provided by toolchain
    * resolution - the transition can't read it from input build options. So we need to cache on
-   * {@code label, originalTransition} pairs.
+   * {@code label, provider} pairs.
    */
-  private static final Cache<Pair<Label, Integer>, PatchTransition> transitionInstanceCache =
-      Caffeine.newBuilder().weakValues().build();
+  private static final Cache<
+          Pair<Label, TransitionFactory<AttributeTransitionData>>, PatchTransition>
+      transitionInstanceCache = Caffeine.newBuilder().weakValues().build();
 
   @Override
   public PatchTransition create(AttributeTransitionData dataWithTargetAttributes)
@@ -116,7 +117,7 @@ public class ExecutionTransitionFactory
 
     return transitionInstanceCache.get(
         // A Starlark transition keeps the same instance unless we modify its .bzl file.
-        Pair.of(data.executionPlatform(), starlarkExecTransitionProvider.hashCode()),
+        Pair.of(data.executionPlatform(), starlarkExecTransitionProvider),
         (p) ->
             new ExecTransitionFinalizer(
                 data.executionPlatform(), starlarkExecTransitionProvider.create(data)));

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttributeTransitionProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttributeTransitionProvider.java
@@ -70,6 +70,13 @@ public class StarlarkAttributeTransitionProvider
   }
 
   @Override
+  public boolean equals(Object obj) {
+    return obj instanceof StarlarkAttributeTransitionProvider other
+        && getClass() == obj.getClass()
+        && starlarkDefinedConfigTransition.equals(other.starlarkDefinedConfigTransition);
+  }
+
+  @Override
   public SplitTransition create(AttributeTransitionData data) {
     AttributeMap attributeMap = data.attributes();
     Preconditions.checkArgument(

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/ExecutionTransitionFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/ExecutionTransitionFactoryTest.java
@@ -53,6 +53,12 @@ public class ExecutionTransitionFactoryTest extends BuildViewTestCase {
   }
 
   @Test
+  public void executionTransition_cached() throws Exception {
+    PatchTransition transition = getExecTransition(EXECUTION_PLATFORM);
+    assertThat(getExecTransition(EXECUTION_PLATFORM)).isSameInstanceAs(transition);
+  }
+
+  @Test
   public void executionTransition() throws Exception {
     PatchTransition transition = getExecTransition(EXECUTION_PLATFORM);
     assertThat(transition).isNotNull();


### PR DESCRIPTION
### Description

Don't use `hashCode` for the exec transition cache as it is prone to conflicts.

### Motivation

Also prepares for planned future changes to `hashCode` that may not include all fields.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable). Not applicable.

### Release Notes

RELNOTES: None
