### PR TITLE
Convert scope metadata and configuration keys to records

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BUILD
@@ -520,7 +520,6 @@ java_library(
     srcs = ["Scope.java"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
-        "//third_party/java/guava:base",
         "//third_party/java/guava:collect",
         "//third_party/java/jsr305_annotations",
     ],

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/Scope.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/Scope.java
@@ -13,7 +13,6 @@
 // limitations under the License.
 package com.google.devtools.build.lib.analysis.config;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
@@ -23,7 +22,7 @@ import javax.annotation.Nullable;
  * Scope of a {@link BuildOptions} is defined by the {@link Scope.ScopeType} and {@link
  * Scope.ScopeDefinition}.
  */
-public class Scope {
+public record Scope(ScopeType scopeType, @Nullable ScopeDefinition scopeDefinition) {
   public static final String CUSTOM_EXEC_SCOPE_PREFIX = "exec:--";
 
   /** Type of supported scopes. */
@@ -78,45 +77,5 @@ public class Scope {
    * directory as the BUILD file where the scoped flags are defined or in a parent directory. This
    * is only relevant if the scope type is PROJECT.
    */
-  public static class ScopeDefinition {
-    private final ImmutableSet<String> ownedCodePaths;
-
-    public ScopeDefinition(ImmutableSet<String> ownedCodePaths) {
-      this.ownedCodePaths = ownedCodePaths;
-    }
-
-    public ImmutableSet<String> getOwnedCodePaths() {
-      return ownedCodePaths;
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this).add("ownedCodePaths", ownedCodePaths).toString();
-    }
-  }
-
-  ScopeType scopeType;
-  @Nullable ScopeDefinition scopeDefinition;
-
-  public Scope(ScopeType scopeType, @Nullable ScopeDefinition scopeDefinition) {
-    this.scopeType = scopeType;
-    this.scopeDefinition = scopeDefinition;
-  }
-
-  public ScopeType getScopeType() {
-    return scopeType;
-  }
-
-  @Nullable
-  public ScopeDefinition getScopeDefinition() {
-    return scopeDefinition;
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("scopeType", scopeType)
-        .add("scopeDefinition", scopeDefinition)
-        .toString();
-  }
+  public record ScopeDefinition(ImmutableSet<String> ownedCodePaths) {}
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyProducer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyProducer.java
@@ -278,7 +278,7 @@ public final class BuildConfigurationKeyProducer<C>
 
     boolean shouldApplyScopes =
         buildOptionsScopeValue.getFullyResolvedScopes().values().stream()
-            .anyMatch(scope -> scope.getScopeType().scopeType().equals(Scope.ScopeType.PROJECT));
+            .anyMatch(scope -> scope.scopeType().scopeType().equals(Scope.ScopeType.PROJECT));
 
     if (!shouldApplyScopes) {
       return finishConfigurationKeyProcessing(
@@ -350,10 +350,10 @@ public final class BuildConfigurationKeyProducer<C>
         Scope.ScopeType flagScopeType =
             transitionedOptionsWithScopeType.getScopeTypeMap().get(flagLabel);
         Verify.verify(!flagScopeType.scopeType().equals(Scope.ScopeType.PROJECT));
-      } else if (scope.getScopeType().scopeType().equals(Scope.ScopeType.PROJECT)) {
+      } else if (scope.scopeType().scopeType().equals(Scope.ScopeType.PROJECT)) {
         Object flagValue = flagEntry.getValue();
         Object baselineValue = baselineConfiguration.getStarlarkOptions().get(flagLabel);
-        if (flagValue != baselineValue && !isInScope(label, scope.getScopeDefinition())) {
+        if (flagValue != baselineValue && !isInScope(label, scope.scopeDefinition())) {
           if (baselineValue == null) {
             optionsWithScopeTypesBuilder.removeStarlarkOption(flagLabel);
             flagsRemoved = true;
@@ -387,7 +387,7 @@ public final class BuildConfigurationKeyProducer<C>
     if (scopeDefinition == null || label == null) {
       return false;
     }
-    for (String path : scopeDefinition.getOwnedCodePaths()) {
+    for (String path : scopeDefinition.ownedCodePaths()) {
       if (label.getCanonicalForm().startsWith(path)) {
         return true;
       }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BuildOptionsScopeFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BuildOptionsScopeFunction.java
@@ -150,7 +150,7 @@ public final class BuildOptionsScopeFunction implements SkyFunction {
       scopes.put(
           projectScopedFlag,
           new Scope(
-              scopes.get(projectScopedFlag).getScopeType(),
+              scopes.get(projectScopedFlag).scopeType(),
               projectValue.getDefaultProjectDirectories().isEmpty()
                   ? null
                   : new Scope.ScopeDefinition(projectValue.getDefaultProjectDirectories())));
@@ -170,7 +170,7 @@ public final class BuildOptionsScopeFunction implements SkyFunction {
 
     Map<Label, ProjectFilesLookupValue.Key> targetsToSkyKeys = new HashMap<>();
     for (Label starlarkOption : scopes.keySet()) {
-      if (scopes.get(starlarkOption).getScopeType().scopeType().equals(Scope.ScopeType.PROJECT)) {
+      if (scopes.get(starlarkOption).scopeType().scopeType().equals(Scope.ScopeType.PROJECT)) {
         targetsToSkyKeys.put(
             starlarkOption, ProjectFilesLookupValue.key(starlarkOption.getPackageIdentifier()));
       }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationKeyValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationKeyValue.java
@@ -17,7 +17,6 @@ import com.google.common.base.MoreObjects;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.concurrent.ThreadSafety;
 import com.google.devtools.build.lib.skyframe.SkyFunctions;
-import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerialization;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyKey;
@@ -31,49 +30,17 @@ public final class BuildConfigurationKeyValue implements SkyValue {
   /** Key for {@link BuildConfigurationKeyValue} based on the build options. */
   @ThreadSafety.Immutable
   @AutoCodec
-  public static final class Key implements SkyKey {
+  public record Key(BuildOptions buildOptions) implements SkyKey {
     private static final SkyKeyInterner<Key> interner = SkyKey.newInterner();
 
+    @AutoCodec.Instantiator
     public static Key create(BuildOptions buildOptions) {
       return interner.intern(new Key(buildOptions));
-    }
-
-    @VisibleForSerialization
-    @AutoCodec.Interner
-    static Key intern(Key key) {
-      return interner.intern(key);
-    }
-
-    private final BuildOptions buildOptions;
-
-    private Key(BuildOptions buildOptions) {
-      this.buildOptions = buildOptions;
-    }
-
-    public BuildOptions buildOptions() {
-      return buildOptions;
     }
 
     @Override
     public SkyFunctionName functionName() {
       return SkyFunctions.BUILD_CONFIGURATION_KEY;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      Key key = (Key) o;
-      return Objects.equals(buildOptions, key.buildOptions);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(buildOptions);
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationKeyValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationKeyValue.java
@@ -33,6 +33,12 @@ public final class BuildConfigurationKeyValue implements SkyValue {
   public record Key(BuildOptions buildOptions) implements SkyKey {
     private static final SkyKeyInterner<Key> interner = SkyKey.newInterner();
 
+    /**
+     * @deprecated Use {@link #create} instead to ensure interning.
+     */
+    @Deprecated
+    public Key {}
+
     @AutoCodec.Instantiator
     public static Key create(BuildOptions buildOptions) {
       return interner.intern(new Key(buildOptions));

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BuildOptionsScopeFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BuildOptionsScopeFunctionTest.java
@@ -17,7 +17,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
@@ -161,18 +160,14 @@ public final class BuildOptionsScopeFunctionTest extends BuildViewTestCase {
     BuildOptionsScopeValue buildOptionsScopeValue = executeFunction(key);
 
     // verify that the Scope is fully resolved for //test_flags:foo and //test_flags:bar
-    var unused =
-        assertThat(
-            buildOptionsScopeValue
-                .getFullyResolvedScopes()
-                .equals(
-                    ImmutableMap.of(
-                        Label.parseCanonical("//test_flags:foo"),
-                        new Scope(
-                            new Scope.ScopeType(Scope.ScopeType.PROJECT),
-                            new Scope.ScopeDefinition(ImmutableSet.of("//my_project/"))),
-                        Label.parseCanonical("//test_flags:bar"),
-                        new Scope(new Scope.ScopeType(Scope.ScopeType.UNIVERSAL), null))));
+    assertThat(buildOptionsScopeValue.getFullyResolvedScopes())
+        .containsExactly(
+            Label.parseCanonical("//test_flags:foo"),
+            new Scope(
+                new Scope.ScopeType(Scope.ScopeType.PROJECT),
+                new Scope.ScopeDefinition(ImmutableSet.of("//my_project/"))),
+            Label.parseCanonical("//test_flags:bar"),
+            new Scope(new Scope.ScopeType(Scope.ScopeType.UNIVERSAL), null));
 
     // verify that the BuildOptionsScopeValue.getResolvedBuildOptionsWithScopeTypes() has the
     // correct ScopeType map for all flags.
@@ -214,14 +209,10 @@ public final class BuildOptionsScopeFunctionTest extends BuildViewTestCase {
         BuildOptionsScopeValue.Key.create(buildOptionsWithoutScopes, scopedFlags);
 
     BuildOptionsScopeValue buildOptionsScopeValue = executeFunction(key);
-    var unused =
-        assertThat(
-            buildOptionsScopeValue
-                .getFullyResolvedScopes()
-                .equals(
-                    ImmutableMap.of(
-                        Label.parseCanonical("//test_flags:foo"),
-                        new Scope(new Scope.ScopeType(Scope.ScopeType.PROJECT), null))));
+    assertThat(buildOptionsScopeValue.getFullyResolvedScopes())
+        .containsExactly(
+            Label.parseCanonical("//test_flags:foo"),
+            new Scope(new Scope.ScopeType(Scope.ScopeType.PROJECT), null));
   }
 
   private BuildOptionsScopeValue executeFunction(BuildOptionsScopeValue.Key key) throws Exception {


### PR DESCRIPTION
### Description

Convert `Scope`, `Scope.ScopeDefinition`, and `BuildConfigurationKeyValue.Key` to records.

### Motivation

### Build API Changes

No

### Checklist

- [x] I have updated the existing tests to check scope value equality.
- [ ] I have updated the documentation (if applicable). Not applicable.

### Release Notes

RELNOTES: None
