### PR TITLE
Fix verify_module_bazel_lock connection timeout on macOS CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -169,6 +169,7 @@ tasks:
       # Increase the test timeout by 20% to avoid flaky test failures due to timeout
       - "--test_timeout=72,360,1080,4320"
     test_targets:
+      - "//:verify_module_bazel_lock"
       - "//src:embedded_tools_size_test"
       - "//src/test/java/com/google/devtools/build/lib/rules/apple:AppleRulesTests"
       - "//src/test/java/com/google/devtools/build/lib/rules/objc:ObjcRulesTests"

--- a/verify_module_bazel_lock.sh
+++ b/verify_module_bazel_lock.sh
@@ -106,7 +106,12 @@ cp "$(rlocation io_bazel/third_party/remoteapis/MODULE.bazel)" \
 # and in update mode rewrites MODULE.bazel.lock if and only if its contents
 # are no longer up-to-date.
 echo "Running: bazel query --lockfile_mode=update to verify the lockfile."
+extra_startup_args=()
+if [[ "$os" == "darwin" ]]; then
+  extra_startup_args+=("--host_jvm_args=-Djava.net.preferIPv6Addresses=true")
+fi
 "$bazel" --batch --ignore_all_rc_files \
+    "${extra_startup_args[@]}" \
     --output_user_root="$TEST_TMPDIR/output_user_root" \
     query --check_direct_dependencies=error --lockfile_mode=update :all \
   || die "Module resolution failed. If the error above mentions a file that does not exist in this test's workspace, please add it to the data of //:verify_module_bazel_lock in BUILD and copy it into place above."


### PR DESCRIPTION
### Description

On MacService macOS CI workers, direct IPv4 traffic to external dual-stack endpoints (such as `bcr.bazel.build`) times out; IPv6 is required.

Because `verify_module_bazel_lock.sh` runs Bazel with `--ignore_all_rc_files`, it ignores `/etc/bazel.bazelrc` which sets `startup --host_jvm_args=-Djava.net.preferIPv6Addresses=true`. Furthermore, Bazel 9.2.0 (specified in `.bazelversion`) defaults to preferring IPv4 in the JVM.

This PR passes `--host_jvm_args=-Djava.net.preferIPv6Addresses=true` on macOS so the inner Bazel invocation can reach BCR over IPv6.

### Motivation

Fixes CI failure on `:darwin: macOS arm64` in `bazel-bazel` pipeline (e.g. [build #36909](https://buildkite.com/bazel/bazel-bazel/builds/36909#01a0785f-7b8d-4cff-adc2-54d8411f1e56)).

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None