### PR TITLE
[9.3.0] Fix PatchUtil failure on patches with "\ No newline at end of file" (#31034)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/PatchUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/decompressor/PatchUtil.java
@@ -88,6 +88,7 @@ public class PatchUtil {
     NEW_MODE,
     NEW_FILE_MODE,
     OTHER_GIT_LINE,
+    CHUNK_NO_NEWLINE,
     UNKNOWN
   }
 
@@ -106,6 +107,10 @@ public class PatchUtil {
   };
 
   private static LineType getLineType(String line, boolean isReadingChunk, boolean isGitDiff) {
+    // A line starting with '\' is a diff comment line, such as "\ No newline at end of file".
+    if (line.startsWith("\\")) {
+      return LineType.CHUNK_NO_NEWLINE;
+    }
     if (isReadingChunk) {
       if (line.startsWith("+")) {
         return LineType.CHUNK_ADD;
@@ -544,6 +549,11 @@ public class PatchUtil {
                     + ": "
                     + line
                     + ", does not expect a context line here.");
+          }
+        }
+        case CHUNK_NO_NEWLINE -> {
+          if (!patchContent.isEmpty() && header != null) {
+            patchContent.add(line);
           }
         }
         case RENAME_FROM -> {

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/PatchUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/decompressor/PatchUtilTest.java
@@ -706,4 +706,142 @@ public final class PatchUtilTest {
         .hasMessageThat()
         .contains("The patch content must start with ---/+++ prelude lines at line 3");
   }
+
+  @Test
+  public void testApplyPatchWithNoNewlineAtEndOfFile_addNewline()
+      throws IOException, PatchFailedException {
+    // Regression test for https://github.com/bazelbuild/bazel/issues/17376
+    Path foo =
+        scratch.file(
+            "/root/FormatTokenSource.h",
+            "class IndexedTokenSource : public FormatTokenSource {",
+            "",
+            "#undef DEBUG_TYPE",
+            "",
+            "#endif");
+    Path patchFile =
+        scratch.file(
+            "/root/patchfile",
+            "--- FormatTokenSource.h",
+            "+++ FormatTokenSource.h",
+            "@@ -1,5 +1,5 @@",
+            "-class IndexedTokenSource : public FormatTokenSource {",
+            "+class LLVM_GSL_POINTER IndexedTokenSource : public FormatTokenSource {",
+            " ",
+            " #undef DEBUG_TYPE",
+            " ",
+            "-#endif",
+            "\\ No newline at end of file",
+            "+#endif");
+    PatchUtil.apply(patchFile, 0, root);
+    ImmutableList<String> expected =
+        ImmutableList.of(
+            "class LLVM_GSL_POINTER IndexedTokenSource : public FormatTokenSource {",
+            "",
+            "#undef DEBUG_TYPE",
+            "",
+            "#endif");
+    assertThat(FileSystemUtils.readLines(foo, UTF_8)).isEqualTo(expected);
+  }
+
+  @Test
+  public void testApplyPatchWithNoNewlineAtEndOfFile_stillNoNewline()
+      throws IOException, PatchFailedException {
+    Path foo = scratch.file("/root/foo.txt", "line1", "line2", "#endif");
+    Path patchFile =
+        scratch.file(
+            "/root/patchfile",
+            "--- a/foo.txt",
+            "+++ b/foo.txt",
+            "@@ -1,3 +1,3 @@",
+            " line1",
+            " line2",
+            "-#endif",
+            "\\ No newline at end of file",
+            "+#endif_modified",
+            "\\ No newline at end of file");
+    PatchUtil.apply(patchFile, 1, root);
+    ImmutableList<String> expected = ImmutableList.of("line1", "line2", "#endif_modified");
+    assertThat(FileSystemUtils.readLines(foo, UTF_8)).isEqualTo(expected);
+  }
+
+  @Test
+  public void testApplyPatchWithNoNewlineAtEndOfFile_contextLine()
+      throws IOException, PatchFailedException {
+    Path foo = scratch.file("/root/foo.txt", "old", "tail");
+    Path patchFile =
+        scratch.file(
+            "/root/patchfile",
+            "--- a/foo.txt",
+            "+++ b/foo.txt",
+            "@@ -1,2 +1,2 @@",
+            "-old",
+            "+new",
+            " tail",
+            "\\ No newline at end of file");
+    PatchUtil.apply(patchFile, 1, root);
+    ImmutableList<String> expected = ImmutableList.of("new", "tail");
+    assertThat(FileSystemUtils.readLines(foo, UTF_8)).isEqualTo(expected);
+  }
+
+  @Test
+  public void testApplyPatchWithNoNewlineAtEndOfFile_addFile()
+      throws IOException, PatchFailedException {
+    Path patchFile =
+        scratch.file(
+            "/root/patchfile",
+            "diff --git a/newfile b/newfile",
+            "new file mode 100644",
+            "--- /dev/null",
+            "+++ b/newfile",
+            "@@ -0,0 +1 @@",
+            "+hello, world",
+            "\\ No newline at end of file");
+    PatchUtil.apply(patchFile, 1, root);
+    Path newFile = root.getRelative("newfile");
+    assertThat(FileSystemUtils.readLines(newFile, UTF_8)).containsExactly("hello, world");
+  }
+
+  @Test
+  public void testApplyPatchWithNoNewlineAtEndOfFile_deleteFile()
+      throws IOException, PatchFailedException {
+    Path oldFile = scratch.file("/root/oldfile", "bye, world");
+    Path patchFile =
+        scratch.file(
+            "/root/patchfile",
+            "--- a/oldfile",
+            "+++ /dev/null",
+            "@@ -1 +0,0 @@",
+            "-bye, world",
+            "\\ No newline at end of file");
+    PatchUtil.apply(patchFile, 1, root);
+    assertThat(oldFile.exists()).isFalse();
+  }
+
+  @Test
+  public void testApplyPatchWithNoNewlineAtEndOfFile_multipleFiles()
+      throws IOException, PatchFailedException {
+    Path foo = scratch.file("/root/foo.txt", "foo_old");
+    Path bar = scratch.file("/root/bar.txt", "bar_old");
+    Path patchFile =
+        scratch.file(
+            "/root/patchfile",
+            "diff --git a/foo.txt b/foo.txt",
+            "--- a/foo.txt",
+            "+++ b/foo.txt",
+            "@@ -1 +1 @@",
+            "-foo_old",
+            "\\ No newline at end of file",
+            "+foo_new",
+            "diff --git a/bar.txt b/bar.txt",
+            "--- a/bar.txt",
+            "+++ b/bar.txt",
+            "@@ -1 +1 @@",
+            "-bar_old",
+            "+bar_new",
+            "\\ No newline at end of file");
+    PatchUtil.apply(patchFile, 1, root);
+    assertThat(FileSystemUtils.readLines(foo, UTF_8)).containsExactly("foo_new");
+    assertThat(FileSystemUtils.readLines(bar, UTF_8)).containsExactly("bar_new");
+  }
 }


### PR DESCRIPTION
Fixes #17376.

In unified diffs and git diffs, lines starting with `\` (such as `\ No newline at end of file`) are metadata comments indicating that the preceding line did not end with a newline.

Previously, `PatchUtil` treated such lines as `UNKNOWN`, causing chunks to terminate prematurely and fail with:
```
Error in patch: Error applying patch ...: Expecting more chunk line at line <N>
```

This PR treats lines starting with `\` as chunk comments (`LineType.CHUNK_NO_NEWLINE`), preserving them in `patchContent` without modifying chunk line counters, allowing unified diff deltas to be properly parsed and applied.

Closes #31034

COPYBARA_INTEGRATE_REVIEW=https://github.com/bazelbuild/bazel/pull/31034 from meteorcloudy:fix-17376 9cbe625ae93e8d702b650ec71150c6c0f0ea2b4c
PiperOrigin-RevId: 977467091
Change-Id: I86ff0b9c280cf64d26c33987725b6bae10d60e82

Commit https://github.com/bazelbuild/bazel/commit/870abbbd4bfca78e15b6fd6cc3e0985dc9cb7243