### PR TITLE
Use a separate spawn output to avoid in-place `.jdeps` rewriting

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1314,6 +1314,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
         "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization:visible-for-serialization",
+        "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec:serialization-constant",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/CustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/CustomCommandLine.java
@@ -40,7 +40,9 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
+import com.google.devtools.build.lib.skyframe.serialization.ObjectCodec.MemoizationEquality;
 import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerialization;
+import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.SerializationConstant;
 import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.util.OnDemandString;
@@ -528,6 +530,67 @@ public class CustomCommandLine extends AbstractCommandLine {
     }
   }
 
+  @AutoCodec(memoizationEquality = MemoizationEquality.BY_VALUE)
+  static final class FormattedExecPathArg implements ArgvFragment {
+    private static final Interner<FormattedExecPathArg> interner =
+        BlazeInterners.newStrongInterner();
+    private static final UUID FORMAT_EXEC_PATH_UUID =
+        UUID.fromString("e9743384-0274-4424-9805-b920214694f5");
+
+    private final String argName;
+    private final String format;
+
+    private FormattedExecPathArg(String argName, String format) {
+      this.argName = Preconditions.checkNotNull(argName);
+      Preconditions.checkArgument(
+          SingleStringArgFormatter.isValid(format), "Invalid single-argument format: %s", format);
+      this.format = format;
+    }
+
+    @AutoCodec.Instantiator
+    static FormattedExecPathArg create(String argName, String format) {
+      return interner.intern(new FormattedExecPathArg(argName, format));
+    }
+
+    @Override
+    public int eval(
+        List<Object> arguments,
+        int argi,
+        ImmutableList.Builder<String> builder,
+        PathMapper pathMapper) {
+      Artifact artifact = (Artifact) arguments.get(argi++);
+      builder.add(argName);
+      builder.add(
+          SingleStringArgFormatter.format(format, pathMapper.getMappedExecPathString(artifact)));
+      return argi;
+    }
+
+    @Override
+    public int addToFingerprint(
+        List<Object> arguments,
+        int argi,
+        ActionKeyContext actionKeyContext,
+        Fingerprint fingerprint) {
+      fingerprint.addUUID(FORMAT_EXEC_PATH_UUID);
+      fingerprint.addString(argName);
+      fingerprint.addString(format);
+      fingerprint.addString(((Artifact) arguments.get(argi++)).getExecPathString());
+      return argi;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof FormattedExecPathArg other
+          && argName.equals(other.argName)
+          && format.equals(other.format);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(argName, format);
+    }
+  }
+
   @VisibleForSerialization
   static class FormatArg implements ArgvFragment {
     @SerializationConstant @VisibleForSerialization
@@ -891,6 +954,25 @@ public class CustomCommandLine extends AbstractCommandLine {
     @CanIgnoreReturnValue
     public Builder addExecPath(@CompileTimeConstant String arg, @Nullable Artifact value) {
       return addObjectInternal(arg, value);
+    }
+
+    /**
+     * Adds the arg followed by the artifact's exec path, with path mapping applied before
+     * formatting.
+     *
+     * <p>The format must contain exactly one {@code %s}, and may escape {@code %} as {@code %%}. If
+     * value is null, neither argument is added.
+     */
+    @CanIgnoreReturnValue
+    public Builder addFormattedExecPath(
+        @CompileTimeConstant String arg,
+        @CompileTimeConstant String format,
+        @Nullable Artifact value) {
+      if (value != null) {
+        arguments.add(FormattedExecPathArg.create(arg, format));
+        arguments.add(value);
+      }
+      return this;
     }
 
     /** Adds a lazily expanded string. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -393,6 +393,16 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     return getOwner().getBuildConfigurationInfo().getCommandLineLimits();
   }
 
+  protected final OutputPathsMode getOutputPathsMode() {
+    return outputPathsMode;
+  }
+
+  /** Returns the spawn outputs, which may differ from this action's declared outputs. */
+  @ForOverride
+  protected Collection<? extends ActionInput> getSpawnOutputs() {
+    return getOutputs();
+  }
+
   @Override
   protected void computeKey(
       ActionKeyContext actionKeyContext,
@@ -527,7 +537,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
   private static final class ActionSpawn extends BaseSpawn {
     private final SpawnInputs inputs;
     private final ImmutableMap<String, String> effectiveEnvironment;
-    private final boolean reportOutputs;
+    private final Collection<? extends ActionInput> outputs;
     private final PathMapper pathMapper;
 
     /**
@@ -554,7 +564,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
       this.inputs = SpawnInputs.of(inputs, additionalInputs);
       this.pathMapper = pathMapper;
       this.effectiveEnvironment = parent.getEffectiveEnvironment(clientEnv, pathMapper);
-      this.reportOutputs = reportOutputs;
+      this.outputs = reportOutputs ? parent.getSpawnOutputs() : ImmutableSet.of();
     }
 
     @Override
@@ -574,7 +584,14 @@ public class SpawnAction extends AbstractAction implements CommandAction {
 
     @Override
     public Collection<? extends ActionInput> getOutputFiles() {
-      return reportOutputs ? super.getOutputFiles() : ImmutableSet.of();
+      return outputs;
+    }
+
+    @Override
+    public Collection<Artifact> getOutputEdgesForExecutionGraph() {
+      // Downstream spawns consume the action's declared outputs, which may differ from the spawn
+      // outputs (see SpawnAction#getSpawnOutputs).
+      return getResourceOwner().getOutputs();
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1288,12 +1288,16 @@ public class RemoteExecutionService {
     ActionInput inMemoryOutput = null;
     AtomicReference<ByteString> inMemoryOutputData = new AtomicReference<>(null);
     PathFragment inMemoryOutputPath = getInMemoryOutputPath(action.getSpawn());
-    if (inMemoryOutputPath != null) {
-      for (ActionInput output : action.getSpawn().getOutputFiles()) {
-        if (output.getExecPath().equals(inMemoryOutputPath)) {
-          inMemoryOutput = output;
-          break;
-        }
+    Set<PathFragment> spawnOnlyOutputs = new HashSet<>();
+    for (ActionInput output : action.getSpawn().getOutputFiles()) {
+      if (output.getExecPath().equals(inMemoryOutputPath)) {
+        inMemoryOutput = output;
+      }
+      if (!(output instanceof Artifact)) {
+        // Spawn outputs that aren't action outputs can't be fetched lazily through
+        // RemoteActionFileSystem as it only resolves inputs. Mark them so that the non-in-memory
+        // outputs among them can be downloaded eagerly below.
+        spawnOnlyOutputs.add(output.getExecPath());
       }
     }
 
@@ -1313,7 +1317,9 @@ public class RemoteExecutionService {
 
       var execPath = file.path.relativeTo(execRoot);
       var isInMemoryOutputFile = inMemoryOutput != null && execPath.equals(inMemoryOutputPath);
-      if (!isInMemoryOutputFile && shouldDownload(result, execPath, /* treeRootExecPath= */ null)) {
+      if (!isInMemoryOutputFile
+          && ((!hasBazelOutputService && spawnOnlyOutputs.contains(execPath))
+              || shouldDownload(result, execPath, /* treeRootExecPath= */ null))) {
         Path tmpPath = tempPathGenerator.generateTempPath();
         realToTmpPath.put(file.path, tmpPath);
         downloadsBuilder.add(

--- a/src/main/java/com/google/devtools/build/lib/rules/java/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/BUILD
@@ -41,6 +41,7 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:action_input",
+        "//src/main/java/com/google/devtools/build/lib/actions:action_input_helper",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:execution_requirements",
         "//src/main/java/com/google/devtools/build/lib/actions:localhost_capacity",

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionException;
 import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.ActionResult;
@@ -79,8 +80,8 @@ import com.google.devtools.build.lib.view.proto.Deps;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.ExtensionRegistry;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -379,6 +380,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
   @Override
   public ActionResult execute(ActionExecutionContext actionExecutionContext)
       throws ActionExecutionException, InterruptedException {
+    ActionInput spawnOutputDepsProto = getSpawnOutputDepsProto();
     NestedSet<Artifact> reducedClasspath;
     Spawn spawn;
     try {
@@ -410,12 +412,16 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
       throw ActionExecutionException.fromExecException(e, this);
     }
 
-    if (reducedClasspath == null) {
+    if (reducedClasspath == null && spawnOutputDepsProto == outputDepsProto) {
       return ActionResult.create(primaryResults);
     }
 
     Deps.Dependencies dependencies =
-        readFullOutputDeps(primaryResults, actionExecutionContext, spawn.getPathMapper());
+        readFullOutputDeps(
+            primaryResults, spawnOutputDepsProto, actionExecutionContext, spawn.getPathMapper());
+    if (reducedClasspath == null) {
+      return ActionResult.create(primaryResults);
+    }
 
     if (compilationType == CompilationType.TURBINE) {
       actionExecutionContext
@@ -465,18 +471,15 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
       throw ActionExecutionException.fromExecException(e, this);
     }
 
-    if (compilationType == CompilationType.TURBINE) {
-      actionExecutionContext
-          .getContext(JavaCompileActionContext.class)
-          .insertDependencies(
-              outputDepsProto,
-              readFullOutputDeps(fallbackResults, actionExecutionContext, spawn.getPathMapper()));
-    } else if (!spawn.getPathMapper().isNoop()) {
-      // As a side effect, readFullOutputDeps rewrites the on-disk .jdeps file from mapped to
-      // unmapped paths. To make path mapping fully transparent to consumers of this action's
-      // output, we ensure that the file always contains unmapped paths.
-      var unused =
-          readFullOutputDeps(fallbackResults, actionExecutionContext, spawn.getPathMapper());
+    if (compilationType == CompilationType.TURBINE || spawnOutputDepsProto != outputDepsProto) {
+      Deps.Dependencies fallbackDependencies =
+          readFullOutputDeps(
+              fallbackResults, spawnOutputDepsProto, actionExecutionContext, spawn.getPathMapper());
+      if (compilationType == CompilationType.TURBINE) {
+        actionExecutionContext
+            .getContext(JavaCompileActionContext.class)
+            .insertDependencies(outputDepsProto, fallbackDependencies);
+      }
     }
     return ActionResult.create(
         ImmutableList.copyOf(Iterables.concat(primaryResults, fallbackResults)));
@@ -576,13 +579,14 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
 
   private final class JavaSpawn extends BaseSpawn {
     private final SpawnInputs inputs;
-    private final Artifact onlyMandatoryOutput;
+    private final Collection<? extends ActionInput> outputs;
+    private final ActionInput onlyMandatoryOutput;
     private final PathMapper pathMapper;
 
     JavaSpawn(
         CommandLines.ExpandedCommandLines expandedCommandLines,
         Map<String, String> environment,
-        Map<String, String> executionInfo,
+        ImmutableMap<String, String> executionInfo,
         NestedSet<Artifact> inputs,
         @Nullable Artifact onlyMandatoryOutput,
         PathMapper pathMapper) {
@@ -592,14 +596,27 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
           executionInfo,
           JavaCompileAction.this,
           LOCAL_RESOURCES);
-      this.onlyMandatoryOutput = onlyMandatoryOutput;
+      ActionInput spawnOutputDepsProto = getSpawnOutputDepsProto();
+      this.onlyMandatoryOutput = onlyMandatoryOutput == null ? null : spawnOutputDepsProto;
       this.inputs = SpawnInputs.of(inputs, expandedCommandLines.getParamFiles());
+      this.outputs = getSpawnOutputs(getOutputs(), outputDepsProto, spawnOutputDepsProto);
       this.pathMapper = pathMapper;
     }
 
     @Override
     public SpawnInputs getInputFiles() {
       return inputs;
+    }
+
+    @Override
+    public Collection<? extends ActionInput> getOutputFiles() {
+      return outputs;
+    }
+
+    @Override
+    public Collection<Artifact> getOutputEdgesForExecutionGraph() {
+      // Downstream spawns consume the declared .jdeps output, not the spawn's .jdeps.unstripped.
+      return getOutputs();
     }
 
     @Override
@@ -658,8 +675,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
     return mergeMaps(
         result,
         ImmutableMap.of(
-            ExecutionRequirements.REMOTE_EXECUTION_INLINE_OUTPUTS,
-            outputDepsProto.getExecPathString()));
+            ExecutionRequirements.REMOTE_EXECUTION_INLINE_OUTPUTS, getSpawnOutputDepsProtoPath()));
   }
 
   @Override
@@ -693,14 +709,58 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
 
   @Override
   public boolean mayModifySpawnOutputsAfterExecution() {
-    // Causes of spawn output modification after execution:
-    // - Fallback to the full classpath with --experimental_java_classpath=bazel.
-    // - In-place rewriting of .jdeps files with --experimental_output_paths=strip.
+    // Fallback to the full classpath with --experimental_java_classpath=bazel modifies spawn
+    // outputs after execution.
     return true;
   }
 
+  @Override
+  protected ImmutableList<PathFragment> getAdditionalPathOutputsToDelete() {
+    var spawnOutputDepsProto = getSpawnOutputDepsProto();
+    return spawnOutputDepsProto == outputDepsProto
+        ? ImmutableList.of()
+        : ImmutableList.of(spawnOutputDepsProto.getExecPath());
+  }
+
+  @Nullable
+  private String getSpawnOutputDepsProtoPath() {
+    if (outputDepsProto == null) {
+      return null;
+    }
+    String outputPath = outputDepsProto.getExecPathString();
+    return PathMappers.getEffectiveOutputPathsMode(
+                PathMappers.getOutputPathsMode(configuration), getMnemonic(), executionInfo)
+            == CoreOptions.OutputPathsMode.OFF
+        ? outputPath
+        : outputPath + ".unstripped";
+  }
+
+  /** Constructs the spawn-only input on demand, without retaining it on the action. */
+  @Nullable
+  private ActionInput getSpawnOutputDepsProto() {
+    String outputPath = getSpawnOutputDepsProtoPath();
+    return outputDepsProto == null || outputDepsProto.getExecPathString().equals(outputPath)
+        ? outputDepsProto
+        : ActionInputHelper.fromPath(PathFragment.create(outputPath));
+  }
+
+  static Collection<? extends ActionInput> getSpawnOutputs(
+      Collection<Artifact> outputs,
+      @Nullable Artifact outputDepsProto,
+      @Nullable ActionInput spawnOutputDepsProto) {
+    if (spawnOutputDepsProto == outputDepsProto) {
+      return outputs;
+    }
+    ImmutableList.Builder<ActionInput> spawnOutputs = ImmutableList.builder();
+    for (Artifact output : outputs) {
+      spawnOutputs.add(output.equals(outputDepsProto) ? spawnOutputDepsProto : output);
+    }
+    return spawnOutputs.build();
+  }
+
   /**
-   * Locally rewrites a .jdeps file to replace missing config prefixes.
+   * Writes the action's .jdeps output from the spawn's .jdeps.unstripped output, restoring config
+   * prefixes removed by path mapping.
    *
    * <p>For example: {@code bazel-out/bin/foo/foo.jar -> bazel-out/x86-fastbuild/bin/foo/foo.jar}.
    *
@@ -716,8 +776,9 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
    * <p>So this method's ultimate purpose is to translate the executor-optimized version of a .jdeps
    * to the original Bazel-safe version.
    *
-   * <p>If the executor doesn't strip config prefixes (i.e. config stripping isn't turned on as a
-   * feature), this is a trivial copy.
+   * <p>If path mapping isn't enabled, the executor writes the action output directly and this
+   * method only reads it. If it is enabled but cannot be applied due to path collisions, this
+   * method copies the spawn output to the action output without changing its contents.
    *
    * <p>If config stripping is on, this method won't work with {@link
    * JavaConfiguration.JavaClasspathMode#JAVABUILDER}. That mode causes downstream Java compilations
@@ -728,6 +789,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
    *
    * @param spawnResult the executor action that created the possibly stripped .jdeps output
    * @param outputDepsProto path to the .jdeps output
+   * @param spawnOutputDepsProto dependency output produced by the executor
    * @param actionInputs all inputs to the current action
    * @param additionalArtifactsForPathMapping any additional artifacts that may be referenced in the
    *     .jdeps file by path
@@ -737,24 +799,45 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
   static Deps.Dependencies createFullOutputDeps(
       SpawnResult spawnResult,
       Artifact outputDepsProto,
+      ActionInput spawnOutputDepsProto,
       NestedSet<Artifact> actionInputs,
       NestedSet<Artifact> additionalArtifactsForPathMapping,
       ActionExecutionContext actionExecutionContext,
       PathMapper pathMapper)
       throws IOException {
 
-    Deps.Dependencies executorJdeps =
-        readExecutorJdeps(spawnResult, outputDepsProto, actionExecutionContext);
-
-    if (pathMapper.isNoop()) {
-      return executorJdeps;
+    ByteString executorJdeps =
+        readExecutorJdeps(spawnResult, spawnOutputDepsProto, actionExecutionContext);
+    Deps.Dependencies fullOutputDeps =
+        Deps.Dependencies.parseFrom(executorJdeps, ExtensionRegistry.getEmptyRegistry());
+    if (spawnOutputDepsProto == outputDepsProto) {
+      return fullOutputDeps;
+    }
+    ByteString outputDeps = executorJdeps;
+    if (!pathMapper.isNoop() && fullOutputDeps.getDependencyCount() > 0) {
+      fullOutputDeps =
+          restoreDependencyPaths(
+              fullOutputDeps,
+              outputDepsProto,
+              actionInputs,
+              additionalArtifactsForPathMapping,
+              pathMapper);
+      outputDeps = fullOutputDeps.toByteString();
     }
 
-    // No paths to rewrite.
-    if (executorJdeps.getDependencyCount() == 0) {
-      return executorJdeps;
+    Path fsPath = actionExecutionContext.getInputPath(outputDepsProto);
+    try (var outputStream = fsPath.getOutputStream()) {
+      outputDeps.writeTo(outputStream);
     }
+    return fullOutputDeps;
+  }
 
+  private static Deps.Dependencies restoreDependencyPaths(
+      Deps.Dependencies executorJdeps,
+      Artifact outputDepsProto,
+      NestedSet<Artifact> actionInputs,
+      NestedSet<Artifact> additionalArtifactsForPathMapping,
+      PathMapper pathMapper) {
     // For each of the action's generated inputs, revert its mapped path back to its original path.
     HashMap<String, PathFragment> mappedToOriginalPath = new HashMap<>();
     HashSet<String> originalPaths = new HashSet<>();
@@ -801,43 +884,27 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
       dep.setPath(
           originalPath == null ? pathOnExecutor.getPathString() : originalPath.getPathString());
     }
-    Deps.Dependencies fullOutputDeps = fullDepsBuilder.build();
-
-    // Write the updated proto back to the filesystem. If the executor produced in-memory-only
-    // outputs (see getInMemoryOutput above), the filesystem version doesn't exist and we can skip
-    // this. Note that in-memory and filesystem outputs aren't necessarily mutually exclusive.
-    Path fsPath = actionExecutionContext.getInputPath(outputDepsProto);
-    if (fsPath.exists()) {
-      // Make sure to clear the output store cache if it has an entry from before the rewrite.
-      actionExecutionContext
-          .getOutputMetadataStore()
-          .resetOutputs(ImmutableList.of(outputDepsProto));
-      fsPath.setWritable(true);
-      try (var outputStream = fsPath.getOutputStream()) {
-        fullOutputDeps.writeTo(outputStream);
-      }
-    }
-
-    return fullOutputDeps;
+    return fullDepsBuilder.build();
   }
 
-  private static Deps.Dependencies readExecutorJdeps(
+  private static ByteString readExecutorJdeps(
       SpawnResult spawnResult,
-      Artifact outputDepsProto,
+      ActionInput outputDepsProto,
       ActionExecutionContext actionExecutionContext)
       throws IOException {
     ByteString inMemoryOutput = spawnResult.getInMemoryOutput(outputDepsProto);
-    try (InputStream inputStream =
-        inMemoryOutput == null
-            ? actionExecutionContext.getInputPath(outputDepsProto).getInputStream()
-            : inMemoryOutput.newInput()) {
-      return Deps.Dependencies.parseFrom(inputStream, ExtensionRegistry.getEmptyRegistry());
+    if (inMemoryOutput != null) {
+      return inMemoryOutput;
+    }
+    try (var inputStream = actionExecutionContext.getInputPath(outputDepsProto).getInputStream()) {
+      return ByteString.readFrom(inputStream);
     }
   }
 
   /** Reads the full {@code .jdeps} output from the given spawn results. */
   private Deps.Dependencies readFullOutputDeps(
       List<SpawnResult> results,
+      ActionInput spawnOutputDepsProto,
       ActionExecutionContext actionExecutionContext,
       PathMapper pathMapper)
       throws ActionExecutionException {
@@ -846,6 +913,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
       return createFullOutputDeps(
           result,
           outputDepsProto,
+          spawnOutputDepsProto,
           getInputs(),
           getAdditionalArtifactsForPathMapping(),
           actionExecutionContext,
@@ -864,7 +932,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
     return new ActionExecutionException(e, this, /* catastrophe= */ false, detailedExitCode);
   }
 
-  private static FailureDetail createFailureDetail(String message, Code detailedCode) {
+  static FailureDetail createFailureDetail(String message, Code detailedCode) {
     return FailureDetail.newBuilder()
         .setMessage(message)
         .setJavaCompile(JavaCompile.newBuilder().setCode(detailedCode))

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
@@ -29,7 +29,9 @@ import com.google.devtools.build.lib.actions.extra.ExtraActionInfo;
 import com.google.devtools.build.lib.actions.extra.JavaCompileInfo;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.actions.CustomCommandLine;
+import com.google.devtools.build.lib.analysis.actions.PathMappers;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.StrictDepsMode;
+import com.google.devtools.build.lib.analysis.config.CoreOptions.OutputPathsMode;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
@@ -244,6 +246,12 @@ public final class JavaCompileActionBuilder {
             .getActionEnvironment()
             .withAdditionalFixedVariables(utf8Environment);
 
+    boolean useUnstrippedOutputDepsProto =
+        PathMappers.getEffectiveOutputPathsMode(
+                PathMappers.getOutputPathsMode(ruleContext.getConfiguration()),
+                MNEMONIC,
+                ruleContext.getConfiguration().modifiedExecutionInfo(executionInfo, MNEMONIC))
+            != OutputPathsMode.OFF;
     return new JavaCompileAction(
         /* compilationType= */ JavaCompileAction.CompilationType.JAVAC,
         /* owner= */ ruleContext.getActionOwner(execGroup),
@@ -261,7 +269,7 @@ public final class JavaCompileActionBuilder {
         /* executionInfo= */ executionInfo,
         /* extraActionInfoSupplier= */ extraActionInfoSupplier,
         /* executableLine= */ executableLine,
-        /* flagLine= */ buildParamFileContents(javacOpts),
+        /* flagLine= */ buildParamFileContents(javacOpts, useUnstrippedOutputDepsProto),
         /* extraCommandLineArgs= */ extraCommandLineArgs,
         /* configuration= */ ruleContext.getConfiguration(),
         /* dependencyArtifacts= */ compileTimeDependencyArtifacts,
@@ -278,7 +286,8 @@ public final class JavaCompileActionBuilder {
     return result.build();
   }
 
-  private CustomCommandLine buildParamFileContents(ImmutableList<String> javacOpts)
+  private CustomCommandLine buildParamFileContents(
+      ImmutableList<String> javacOpts, boolean useUnstrippedOutputDepsProto)
       throws RuleErrorException, InterruptedException {
 
     CustomCommandLine.Builder result = CustomCommandLine.builder();
@@ -290,7 +299,10 @@ public final class JavaCompileActionBuilder {
     if (compressJar) {
       result.add("--compress_jar");
     }
-    result.addExecPath("--output_deps_proto", outputs.depsProto());
+    result.addFormattedExecPath(
+        "--output_deps_proto",
+        useUnstrippedOutputDepsProto ? "%s.unstripped" : "%s",
+        outputs.depsProto());
     result.addExecPaths("--bootclasspath", bootClassPath.bootclasspath());
     if (bootClassPath.systemPath().isPresent()) {
       result.addPath("--system", bootClassPath.systemPath().get());

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
@@ -28,9 +28,13 @@ import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.actions.AbstractAction;
 import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
+import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.CommandLines;
+import com.google.devtools.build.lib.actions.EnvironmentalExecException;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ParamFileInfo;
 import com.google.devtools.build.lib.actions.PathMapper;
@@ -51,10 +55,13 @@ import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.rules.java.JavaCompileAction.ProgressMessage;
 import com.google.devtools.build.lib.rules.java.JavaConfiguration.JavaClasspathMode;
 import com.google.devtools.build.lib.rules.java.JavaPluginInfo.JavaPluginData;
+import com.google.devtools.build.lib.server.FailureDetails.JavaCompile.Code;
 import com.google.devtools.build.lib.util.OnDemandString;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.view.proto.Deps;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -121,12 +128,46 @@ public final class JavaHeaderCompileAction extends SpawnAction {
     if (!inMemoryJdeps) {
       return result;
     }
-    Artifact outputDepsProto = Iterables.get(getOutputs(), 1);
     return mergeMaps(
         result,
         ImmutableMap.of(
-            ExecutionRequirements.REMOTE_EXECUTION_INLINE_OUTPUTS,
-            outputDepsProto.getExecPathString()));
+            ExecutionRequirements.REMOTE_EXECUTION_INLINE_OUTPUTS, getSpawnOutputDepsProtoPath()));
+  }
+
+  @Override
+  protected ImmutableList<PathFragment> getAdditionalPathOutputsToDelete() {
+    var spawnOutputDepsProto = getSpawnOutputDepsProto();
+    return spawnOutputDepsProto == Iterables.get(getOutputs(), 1)
+        ? ImmutableList.of()
+        : ImmutableList.of(spawnOutputDepsProto.getExecPath());
+  }
+
+  private String getSpawnOutputDepsProtoPath() {
+    Artifact outputDepsProto = Iterables.get(getOutputs(), 1);
+    String outputPath = outputDepsProto.getExecPathString();
+    // Use the same execution info as the builder, which excludes the owner's exec properties, so
+    // that the spawn output matches the --output_deps path on the command line. If exec properties
+    // disable path mapping at execution time, the spawn output is copied to the action output.
+    return PathMappers.getEffectiveOutputPathsMode(
+                getOutputPathsMode(), getMnemonic(), sortedExecutionInfo)
+            == OutputPathsMode.OFF
+        ? outputPath
+        : outputPath + ".unstripped";
+  }
+
+  /** Constructs the spawn-only input on demand, without retaining it on the action. */
+  private ActionInput getSpawnOutputDepsProto() {
+    Artifact outputDepsProto = Iterables.get(getOutputs(), 1);
+    String outputPath = getSpawnOutputDepsProtoPath();
+    return outputDepsProto.getExecPathString().equals(outputPath)
+        ? outputDepsProto
+        : ActionInputHelper.fromPath(PathFragment.create(outputPath));
+  }
+
+  @Override
+  protected Collection<? extends ActionInput> getSpawnOutputs() {
+    return JavaCompileAction.getSpawnOutputs(
+        getOutputs(), Iterables.get(getOutputs(), 1), getSpawnOutputDepsProto());
   }
 
   @Override
@@ -136,15 +177,18 @@ public final class JavaHeaderCompileAction extends SpawnAction {
 
   @Override
   protected void afterExecute(
-      ActionExecutionContext context, List<SpawnResult> spawnResults, PathMapper pathMapper) {
+      ActionExecutionContext context, List<SpawnResult> spawnResults, PathMapper pathMapper)
+      throws ExecException {
     // The first entry represents the successful execution, see SpawnStrategy#exec
     SpawnResult spawnResult = spawnResults.get(0);
     Artifact outputDepsProto = Iterables.get(getOutputs(), 1);
+    ActionInput spawnOutputDepsProto = getSpawnOutputDepsProto();
     try {
       Deps.Dependencies fullOutputDeps =
           JavaCompileAction.createFullOutputDeps(
               spawnResult,
               outputDepsProto,
+              spawnOutputDepsProto,
               getInputs(),
               getAdditionalArtifactsForPathMapping(),
               context,
@@ -154,17 +198,15 @@ public final class JavaHeaderCompileAction extends SpawnAction {
         javaContext.insertDependencies(outputDepsProto, fullOutputDeps);
       }
     } catch (IOException e) {
-      // Left empty. If we cannot read the .jdeps file now, we will read it later or throw an
-      // appropriate error then.
+      if (spawnOutputDepsProto == outputDepsProto) {
+        // The spawn already produced the action output, so dependencies can be read later.
+        return;
+      }
+      throw new EnvironmentalExecException(
+          e,
+          JavaCompileAction.createFailureDetail(
+              ".jdeps read IOException", Code.JDEPS_READ_IO_EXCEPTION));
     }
-  }
-
-  @Override
-  public boolean mayModifySpawnOutputsAfterExecution() {
-    // Causes of spawn output modification after execution:
-    // - In-place rewriting of .jdeps files with --experimental_output_paths=strip.
-    // TODO: Use separate files as action and spawn output to avoid in-place modification.
-    return true;
   }
 
   public static Builder newBuilder(RuleContext ruleContext) {
@@ -507,7 +549,6 @@ public final class JavaHeaderCompileAction extends SpawnAction {
               .addExecPath("--gensrc_output", gensrcOutputJar)
               .addExecPath("--resource_output", resourceOutputJar)
               .addExecPath("--output_manifest_proto", manifestOutput)
-              .addExecPath("--output_deps", outputDepsProto)
               .addExecPaths("--bootclasspath", bootclasspathEntries)
               .addExecPaths("--sources", sourceFiles)
               .addExecPaths("--source_jars", sourceJars)
@@ -553,6 +594,24 @@ public final class JavaHeaderCompileAction extends SpawnAction {
       if (cpuReservation > 1) {
         executionInfo.put("cpu:" + cpuReservation, "");
       }
+      String mnemonic =
+          useDirectClasspath
+              ? DIRECT_CLASSPATH_MNEMONIC
+              : JavaCompileAction.CompilationType.TURBINE.mnemonic;
+      ImmutableMap<String, String> effectiveExecutionInfo =
+          ruleContext
+              .getConfiguration()
+              .modifiedExecutionInfo(executionInfo.buildKeepingLast(), mnemonic);
+      commandLine.addFormattedExecPath(
+          "--output_deps",
+          PathMappers.getEffectiveOutputPathsMode(
+                      PathMappers.getOutputPathsMode(ruleContext.getConfiguration()),
+                      mnemonic,
+                      effectiveExecutionInfo)
+                  == OutputPathsMode.OFF
+              ? "%s"
+              : "%s.unstripped",
+          outputDepsProto);
 
       ActionOwner actionOwner =
           ruleContext.useAutoExecGroups()
@@ -596,17 +655,14 @@ public final class JavaHeaderCompileAction extends SpawnAction {
                     .addCommandLine(commandLine.build(), PARAM_FILE_INFO)
                     .build(),
                 /* env= */ actionEnvironment,
-                /* executionInfo= */ ruleContext
-                    .getConfiguration()
-                    .modifiedExecutionInfo(
-                        executionInfo.buildKeepingLast(), DIRECT_CLASSPATH_MNEMONIC),
+                /* executionInfo= */ effectiveExecutionInfo,
                 /* progressMessage= */ progressMessage,
                 /* mnemonic= */ DIRECT_CLASSPATH_MNEMONIC,
                 /* outputPathsMode= */ PathMappers.getOutputPathsMode(
                     ruleContext.getConfiguration()),
                 // If classPathMode == BAZEL, also make sure to inject the dependencies to be
                 // available to downstream actions. Else just do enough work to locally create the
-                // full .jdeps from the .stripped .jdeps produced on the executor.
+                // full .jdeps from the .jdeps.unstripped produced on the executor.
                 /* insertDependencies= */ classpathMode == JavaClasspathMode.BAZEL
                     || classpathMode == JavaClasspathMode.BAZEL_NO_FALLBACK,
                 javaConfiguration.inmemoryJdepsFiles(),

--- a/src/test/java/com/google/devtools/build/lib/actions/CustomCommandLineTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/CustomCommandLineTest.java
@@ -122,6 +122,33 @@ public final class CustomCommandLineTest {
   public void addFormatted_addsCorrectlyFormattedArgument() throws Exception {
     assertThat(builder().addFormatted("%s%s", "hello", "world").build().arguments())
         .containsExactly("helloworld");
+    assertThat(builder().addFormattedExecPath("--arg", "%%/%s/%%", artifact1).build().arguments())
+        .containsExactly("--arg", "%/dir/file1.txt/%")
+        .inOrder();
+  }
+
+  @Test
+  public void addFormattedExecPath_mapsBeforeFormatting(
+      @TestParameter boolean pathMapping, @TestParameter boolean unstripped) throws Exception {
+    PathMapper pathMapper =
+        pathMapping
+            ? execPath -> PathFragment.create("mapped").getRelative(execPath)
+            : PathMapper.NOOP;
+    assertThat(
+            builder()
+                .add("before")
+                .addFormattedExecPath("--deps", unstripped ? "%s.unstripped" : "%s", artifact1)
+                .addFormattedExecPath("--omitted", "%s", null)
+                .add("after")
+                .build()
+                .arguments(null, pathMapper))
+        .containsExactly(
+            "before",
+            "--deps",
+            (pathMapping ? "mapped/dir/file1.txt" : "dir/file1.txt")
+                + (unstripped ? ".unstripped" : ""),
+            "after")
+        .inOrder();
   }
 
   @Test
@@ -668,6 +695,10 @@ public final class CustomCommandLineTest {
         ImmutableList.<CustomCommandLine>builder()
             .add(builder().add("arg").build())
             .add(builder().addFormatted("--foo=%s", "arg").build())
+            .add(builder().addFormattedExecPath("--deps", "%s", artifact1).build())
+            .add(builder().addFormattedExecPath("--deps", "%s.unstripped", artifact1).build())
+            .add(builder().addFormattedExecPath("--other", "%s", artifact1).build())
+            .add(builder().addFormattedExecPath("--deps", "%s", artifact2).build())
             .add(builder().addPrefixed("--foo=%s", "arg").build())
             .add(builder().addAll(values).build())
             .add(builder().addAll(VectorArg.addBefore("--foo=%s").each(values)).build())

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
@@ -95,7 +95,7 @@ public class PathMappersTest extends BuildViewTestCase {
             format("%s/cfg/bin/java/com/google/test/liba.jar", outDir),
             format("%s/cfg/bin/java/com/google/test/liba-native-header.jar", outDir),
             format("%s/cfg/bin/java/com/google/test/liba.jar_manifest_proto", outDir),
-            format("%s/cfg/bin/java/com/google/test/liba.jdeps", outDir),
+            format("%s/cfg/bin/java/com/google/test/liba.jdeps.unstripped", outDir),
             format("-XepOpt:foo:bar=%s/cfg/bin/java/com/google/test/B.java", outDir),
             format(
                 "-XepOpt:baz=%s/cfg/bin/java/com/google/test/C.java,%s/cfg/bin/java/com/google/test/B.java",

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -285,6 +285,145 @@ function test_path_stripping_remote() {
   expect_not_log '[0-9] remote[^ ]'
 }
 
+function write_jdeps_test_files() {
+  mkdir -p jdeps
+  cat > jdeps/BUILD <<'EOF'
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+java_binary(name = "main", srcs = ["Main.java"], main_class = "Main", deps = [":a"])
+java_library(name = "a", srcs = ["A.java"], deps = [":b"])
+java_library(name = "b", srcs = ["B.java"], deps = [":c"])
+java_library(name = "c", srcs = ["C.java"], deps = [":d"])
+java_library(name = "d", srcs = ["D.java"])
+EOF
+  cat > jdeps/Main.java <<'EOF'
+public class Main {
+  public static void main(String[] args) { new A(); }
+}
+EOF
+  # Compiling A requires falling back to the full classpath to access D.
+  cat > jdeps/A.java <<'EOF'
+public class A { public void f(B b) { b.getC().getD(); } }
+EOF
+  cat > jdeps/B.java <<'EOF'
+public class B { public C getC() { return null; } }
+EOF
+  cat > jdeps/C.java <<'EOF'
+public class C { public D getD() { return null; } }
+EOF
+  cat > jdeps/D.java <<'EOF'
+public class D {}
+EOF
+}
+
+function assert_jdeps_outputs() {
+  local -r compilation_mode="$1"
+  local -r in_memory="$2"
+  local jdeps
+  for jdeps in bazel-bin/jdeps/*.jdeps; do
+    [[ -s "$jdeps" ]] || fail "Missing action output: $jdeps"
+    assert_not_contains 'bazel-out/cfg/' "$jdeps"
+    if [[ "$in_memory" == false ]]; then
+      [[ -s "$jdeps.unstripped" ]] || fail "Missing spawn output: $jdeps.unstripped"
+    else
+      [[ ! -e "$jdeps.unstripped" ]] || fail "In-memory spawn output written to disk: $jdeps.unstripped"
+    fi
+  done
+  # Both Javac and Turbine must restore the configuration in their dependency paths.
+  assert_contains "bazel-out/[^/]*-$compilation_mode/bin/jdeps/" bazel-bin/jdeps/liba.jdeps
+  assert_contains "bazel-out/[^/]*-$compilation_mode/bin/jdeps/" bazel-bin/jdeps/libb-hjar.jdeps
+  [[ -s bazel-bin/jdeps/libd-hjar.jdeps ]] || fail "Missing empty dependency output"
+  if [[ "$in_memory" == false ]]; then
+    # The executor's versions must retain mapped paths, including after a cache hit or fallback.
+    assert_contains 'bazel-out/cfg/bin/jdeps/' bazel-bin/jdeps/liba.jdeps.unstripped
+    assert_contains 'bazel-out/cfg/bin/jdeps/' bazel-bin/jdeps/libb-hjar.jdeps.unstripped
+    cmp bazel-bin/jdeps/libd-hjar.jdeps bazel-bin/jdeps/libd-hjar.jdeps.unstripped \
+      || fail "Empty dependency output was not copied"
+  fi
+}
+
+function test_jdeps_outputs_sandboxed() {
+  write_jdeps_test_files
+  local -r cache_dir=$(mktemp -d)
+  local compilation_mode
+  for compilation_mode in fastbuild opt; do
+    bazel build -c "$compilation_mode" \
+      --experimental_output_paths=strip \
+      --noexperimental_inmemory_jdeps_files \
+      --disk_cache="$cache_dir" \
+      --spawn_strategy=sandboxed \
+      //jdeps:main &> "$TEST_log" || fail "build failed"
+    assert_jdeps_outputs "$compilation_mode" false
+    if [[ "$compilation_mode" == opt ]]; then
+      expect_log 'disk cache hit'
+      expect_not_log '[0-9] \(linux\|darwin\|processwrapper\)-sandbox'
+    fi
+  done
+
+  # The full-classpath compilation must also materialize the action output. Clean first so that
+  # the header compilations are re-executed instead of hitting the action cache.
+  bazel clean &> "$TEST_log"
+  bazel build --experimental_output_paths=strip --experimental_java_classpath=off \
+    --noexperimental_inmemory_jdeps_files --spawn_strategy=sandboxed \
+    //jdeps:main &> "$TEST_log" || fail "full-classpath build failed"
+  assert_jdeps_outputs fastbuild false
+
+  # Without path mapping, the spawn writes .jdeps directly and no intermediate is needed.
+  bazel clean &> "$TEST_log"
+  bazel build --experimental_output_paths=off --experimental_java_classpath=off \
+    --spawn_strategy=sandboxed \
+    --execution_log_json_file="$TEST_TMPDIR/jdeps-spawns.json" \
+    //jdeps:main &> "$TEST_log" || fail "build without path mapping failed"
+  assert_not_contains '\.jdeps\.unstripped' "$TEST_TMPDIR/jdeps-spawns.json"
+  local jdeps
+  for jdeps in bazel-bin/jdeps/*.jdeps; do
+    [[ -s "$jdeps" ]] || fail "Missing dependency output: $jdeps"
+    [[ ! -e "$jdeps.unstripped" ]] || fail "Unexpected intermediate without path mapping: $jdeps"
+  done
+}
+
+function do_test_jdeps_outputs_remote() {
+  local -r in_memory="$1"
+  write_jdeps_test_files
+  local compilation_mode
+  for compilation_mode in fastbuild opt; do
+    bazel build -c "$compilation_mode" \
+      --experimental_output_paths=strip \
+      --experimental_inmemory_jdeps_files="$in_memory" \
+      --remote_download_outputs=minimal \
+      --remote_executor=grpc://localhost:"${worker_port}" \
+      //jdeps:main &> "$TEST_log" || fail "remote build failed"
+    assert_jdeps_outputs "$compilation_mode" "$in_memory"
+    if [[ "$compilation_mode" == opt ]]; then
+      expect_log 'remote cache hit'
+      expect_not_log '[0-9] remote[^ ]'
+    fi
+  done
+}
+
+function test_jdeps_outputs_remote_inmemory() {
+  do_test_jdeps_outputs_remote true
+}
+
+function test_jdeps_outputs_remote_without_inmemory() {
+  do_test_jdeps_outputs_remote false
+}
+
+function test_path_stripping_remote_action_cache() {
+  bazel build -c fastbuild \
+    --experimental_output_paths=strip \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //src/main/java/com/example:Main &> $TEST_log || fail "build failed unexpectedly"
+  expect_log '5 remote'
+
+  bazel shutdown
+
+  bazel build -c fastbuild \
+    --experimental_output_paths=strip \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //src/main/java/com/example:Main &> $TEST_log || fail "build failed unexpectedly"
+  expect_not_log '[0-9] remote'
+}
+
 function test_path_stripping_remote_multiple_configs() {
   mkdir rules
   cat > rules/defs.bzl <<'EOF'

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -315,24 +315,34 @@ public class D {}
 EOF
 }
 
+function assert_jdeps_output() {
+  local -r expect_unstripped="$1"
+  local -r jdeps="bazel-bin/jdeps/$2.jdeps"
+  [[ -s "$jdeps" ]] || fail "Missing action output: $jdeps"
+  assert_not_contains 'bazel-out/cfg/' "$jdeps"
+  if [[ "$expect_unstripped" == true ]]; then
+    [[ -s "$jdeps.unstripped" ]] || fail "Missing spawn output: $jdeps.unstripped"
+  else
+    [[ ! -e "$jdeps.unstripped" ]] || fail "Unexpected spawn output on disk: $jdeps.unstripped"
+  fi
+}
+
 function assert_jdeps_outputs() {
   local -r compilation_mode="$1"
-  local -r in_memory="$2"
-  local jdeps
-  for jdeps in bazel-bin/jdeps/*.jdeps; do
-    [[ -s "$jdeps" ]] || fail "Missing action output: $jdeps"
-    assert_not_contains 'bazel-out/cfg/' "$jdeps"
-    if [[ "$in_memory" == false ]]; then
-      [[ -s "$jdeps.unstripped" ]] || fail "Missing spawn output: $jdeps.unstripped"
-    else
-      [[ ! -e "$jdeps.unstripped" ]] || fail "In-memory spawn output written to disk: $jdeps.unstripped"
-    fi
-  done
+  local -r expect_unstripped="$2"
+  assert_jdeps_output "$expect_unstripped" main
+  assert_jdeps_output "$expect_unstripped" liba
+  assert_jdeps_output "$expect_unstripped" liba-hjar
+  assert_jdeps_output "$expect_unstripped" libb
+  assert_jdeps_output "$expect_unstripped" libb-hjar
+  assert_jdeps_output "$expect_unstripped" libc
+  assert_jdeps_output "$expect_unstripped" libc-hjar
+  assert_jdeps_output "$expect_unstripped" libd
+  assert_jdeps_output "$expect_unstripped" libd-hjar
   # Both Javac and Turbine must restore the configuration in their dependency paths.
   assert_contains "bazel-out/[^/]*-$compilation_mode/bin/jdeps/" bazel-bin/jdeps/liba.jdeps
   assert_contains "bazel-out/[^/]*-$compilation_mode/bin/jdeps/" bazel-bin/jdeps/libb-hjar.jdeps
-  [[ -s bazel-bin/jdeps/libd-hjar.jdeps ]] || fail "Missing empty dependency output"
-  if [[ "$in_memory" == false ]]; then
+  if [[ "$expect_unstripped" == true ]]; then
     # The executor's versions must retain mapped paths, including after a cache hit or fallback.
     assert_contains 'bazel-out/cfg/bin/jdeps/' bazel-bin/jdeps/liba.jdeps.unstripped
     assert_contains 'bazel-out/cfg/bin/jdeps/' bazel-bin/jdeps/libb-hjar.jdeps.unstripped
@@ -341,71 +351,135 @@ function assert_jdeps_outputs() {
   fi
 }
 
-function test_jdeps_outputs_sandboxed() {
+function do_test_jdeps_outputs_sandboxed() {
+  local -r java_classpath="$1"
   write_jdeps_test_files
   local -r cache_dir=$(mktemp -d)
-  local compilation_mode
-  for compilation_mode in fastbuild opt; do
-    bazel build -c "$compilation_mode" \
-      --experimental_output_paths=strip \
-      --noexperimental_inmemory_jdeps_files \
-      --disk_cache="$cache_dir" \
-      --spawn_strategy=sandboxed \
-      //jdeps:main &> "$TEST_log" || fail "build failed"
-    assert_jdeps_outputs "$compilation_mode" false
-    if [[ "$compilation_mode" == opt ]]; then
-      expect_log 'disk cache hit'
-      expect_not_log '[0-9] \(linux\|darwin\|processwrapper\)-sandbox'
-    fi
-  done
-
-  # The full-classpath compilation must also materialize the action output. Clean first so that
-  # the header compilations are re-executed instead of hitting the action cache.
-  bazel clean &> "$TEST_log"
-  bazel build --experimental_output_paths=strip --experimental_java_classpath=off \
-    --noexperimental_inmemory_jdeps_files --spawn_strategy=sandboxed \
-    //jdeps:main &> "$TEST_log" || fail "full-classpath build failed"
-  assert_jdeps_outputs fastbuild false
-
-  # Without path mapping, the spawn writes .jdeps directly and no intermediate is needed.
-  bazel clean &> "$TEST_log"
-  bazel build --experimental_output_paths=off --experimental_java_classpath=off \
+  bazel build -c fastbuild \
+    --experimental_output_paths=strip \
+    --experimental_java_classpath="$java_classpath" \
+    --noexperimental_inmemory_jdeps_files \
+    --disk_cache="$cache_dir" \
     --spawn_strategy=sandboxed \
+    //jdeps:main &> "$TEST_log" || fail "build failed"
+  assert_jdeps_outputs fastbuild true
+
+  bazel build -c opt \
+    --experimental_output_paths=strip \
+    --experimental_java_classpath="$java_classpath" \
+    --noexperimental_inmemory_jdeps_files \
+    --disk_cache="$cache_dir" \
+    --spawn_strategy=sandboxed \
+    //jdeps:main &> "$TEST_log" || fail "cached build failed"
+  assert_jdeps_outputs opt true
+  expect_log 'disk cache hit'
+  expect_not_log '[0-9] \(linux\|darwin\|processwrapper\)-sandbox'
+}
+
+function test_jdeps_outputs_sandboxed_reduced_classpath() {
+  do_test_jdeps_outputs_sandboxed bazel
+}
+
+# Keep classpath modes in separate tests: switching the mode can leave Turbine's command line
+# unchanged, letting its action cache skip the output-rewriting code under test. The harness cleans
+# between tests; users do not need to run bazel clean when switching modes.
+function test_jdeps_outputs_sandboxed_full_classpath() {
+  do_test_jdeps_outputs_sandboxed off
+}
+
+function do_test_jdeps_outputs_without_path_mapping() {
+  write_jdeps_test_files
+  bazel build --experimental_output_paths=off --experimental_java_classpath=off \
+    --noexperimental_inmemory_jdeps_files \
     --execution_log_json_file="$TEST_TMPDIR/jdeps-spawns.json" \
+    "$@" \
     //jdeps:main &> "$TEST_log" || fail "build without path mapping failed"
+  assert_jdeps_outputs fastbuild false
   assert_not_contains '\.jdeps\.unstripped' "$TEST_TMPDIR/jdeps-spawns.json"
-  local jdeps
-  for jdeps in bazel-bin/jdeps/*.jdeps; do
-    [[ -s "$jdeps" ]] || fail "Missing dependency output: $jdeps"
-    [[ ! -e "$jdeps.unstripped" ]] || fail "Unexpected intermediate without path mapping: $jdeps"
-  done
+}
+
+function test_jdeps_outputs_sandboxed_without_path_mapping() {
+  do_test_jdeps_outputs_without_path_mapping --spawn_strategy=sandboxed
 }
 
 function do_test_jdeps_outputs_remote() {
-  local -r in_memory="$1"
+  local -r java_classpath="$1"
+  local -r in_memory="$2"
+  shift 2
+  local expect_unstripped=true
+  if [[ "$in_memory" == true ]]; then
+    expect_unstripped=false
+  fi
   write_jdeps_test_files
-  local compilation_mode
-  for compilation_mode in fastbuild opt; do
-    bazel build -c "$compilation_mode" \
-      --experimental_output_paths=strip \
-      --experimental_inmemory_jdeps_files="$in_memory" \
-      --remote_download_outputs=minimal \
-      --remote_executor=grpc://localhost:"${worker_port}" \
-      //jdeps:main &> "$TEST_log" || fail "remote build failed"
-    assert_jdeps_outputs "$compilation_mode" "$in_memory"
-    if [[ "$compilation_mode" == opt ]]; then
-      expect_log 'remote cache hit'
-      expect_not_log '[0-9] remote[^ ]'
-    fi
-  done
+  bazel build -c fastbuild \
+    --experimental_output_paths=strip \
+    --experimental_java_classpath="$java_classpath" \
+    --experimental_inmemory_jdeps_files="$in_memory" \
+    --remote_download_outputs=minimal \
+    --remote_executor=grpc://localhost:"${worker_port}" \
+    "$@" \
+    //jdeps:main &> "$TEST_log" || fail "remote build failed"
+  assert_jdeps_outputs fastbuild "$expect_unstripped"
+
+  bazel build -c opt \
+    --experimental_output_paths=strip \
+    --experimental_java_classpath="$java_classpath" \
+    --experimental_inmemory_jdeps_files="$in_memory" \
+    --remote_download_outputs=minimal \
+    --remote_executor=grpc://localhost:"${worker_port}" \
+    "$@" \
+    //jdeps:main &> "$TEST_log" || fail "cached remote build failed"
+  assert_jdeps_outputs opt "$expect_unstripped"
+  expect_log 'remote cache hit'
+  expect_not_log '[0-9] remote[^ ]'
 }
 
-function test_jdeps_outputs_remote_inmemory() {
-  do_test_jdeps_outputs_remote true
+function test_jdeps_outputs_remote_inmemory_reduced_classpath() {
+  do_test_jdeps_outputs_remote bazel true
 }
 
-function test_jdeps_outputs_remote_without_inmemory() {
-  do_test_jdeps_outputs_remote false
+function test_jdeps_outputs_remote_inmemory_full_classpath() {
+  do_test_jdeps_outputs_remote off true
+}
+
+function test_jdeps_outputs_remote_without_inmemory_reduced_classpath() {
+  do_test_jdeps_outputs_remote bazel false
+}
+
+function test_jdeps_outputs_remote_without_inmemory_full_classpath() {
+  do_test_jdeps_outputs_remote off false
+}
+
+function test_jdeps_outputs_remote_download_regex_inmemory() {
+  # Matching both paths must not force the in-memory spawn output onto disk.
+  do_test_jdeps_outputs_remote bazel true --remote_download_regex='.*\.jdeps(\.unstripped)?$'
+}
+
+function test_jdeps_outputs_remote_download_regex_without_inmemory() {
+  # Matching only the action output must still fetch the spawn output needed for rewriting.
+  do_test_jdeps_outputs_remote bazel false --remote_download_regex='.*\.jdeps$'
+}
+
+function test_jdeps_outputs_remote_without_path_mapping() {
+  do_test_jdeps_outputs_without_path_mapping \
+    --remote_download_outputs=minimal \
+    --remote_download_regex='.*\.jdeps$' \
+    --remote_executor=grpc://localhost:"${worker_port}"
+}
+
+function test_jdeps_outputs_remote_inmemory_without_path_mapping() {
+  write_jdeps_test_files
+  bazel build --experimental_output_paths=off --experimental_java_classpath=off \
+    --experimental_inmemory_jdeps_files \
+    --remote_download_outputs=minimal \
+    --remote_download_regex='.*\.jdeps(\.unstripped)?$' \
+    --remote_executor=grpc://localhost:"${worker_port}" \
+    --execution_log_json_file="$TEST_TMPDIR/jdeps-spawns.json" \
+    //jdeps:main &> "$TEST_log" || fail "remote build without path mapping failed"
+  assert_not_contains '\.jdeps\.unstripped' "$TEST_TMPDIR/jdeps-spawns.json"
+  if compgen -G 'bazel-bin/jdeps/*.jdeps*' > /dev/null; then
+    fail "In-memory dependency outputs should not be written to disk without path mapping"
+  fi
 }
 
 function test_path_stripping_remote_action_cache() {

--- a/src/test/shell/integration/config_stripped_outputs_test.sh
+++ b/src/test/shell/integration/config_stripped_outputs_test.sh
@@ -324,6 +324,11 @@ EOF
   assert_contains "\(bazel\|blaze\)-out/[^/]\+-fastbuild/bin/$pkg/java/liblib.jar-0.params" "$TEST_log"
   # lib header jar compilation should not be stripped due to conflicting paths
   assert_contains "--output \(bazel\|blaze\)-out/[^/]\+-fastbuild/bin/$pkg/java/liblib-hjar.jar" "$TEST_log"
+  # The separate spawn outputs must still be copied when collisions disable path mapping.
+  cmp "${bazel_bin}/$pkg/java/liblib.jdeps" "${bazel_bin}/$pkg/java/liblib.jdeps.unstripped" \
+    || fail "Unmapped Javac dependency output was not copied"
+  cmp "${bazel_bin}/$pkg/java/liblib-hjar.jdeps" "${bazel_bin}/$pkg/java/liblib-hjar.jdeps.unstripped" \
+    || fail "Unmapped Turbine dependency output was not copied"
   # jdeps files should contain the original paths since they are read by downstream actions that may
   # not use path mapping.
   assert_contains_no_stripped_path "${bazel_bin}/$pkg/java/Main.jdeps"


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description
Instead of rewriting the `.jdeps` file of a Java (header) compilation action in place when path mapping is applied, use a separate spawn output that is rewritten to the actual action output. 

This requires:
* registering the correct set of outputs with the execution graph module;
* adding a new `addFormattedExecPath` method to `CustomCommandLine` to avoid a memory regression (note that `ctx.actions.args` already has the capability to path map formatted args).

### Motivation
In-place rewriting of `.jdeps` is tricky to get right (see https://github.com/bazelbuild/bazel/pull/30849), forces Java compilation to opt out of `--remote_cache_async`, and doesn't generalize well to a Starlarkifiable concept.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
