### PR TITLE
Restore interrupt of cancelled repository downloads

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -609,7 +609,7 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
 
     @Override
     public boolean cancel() {
-      return !future.cancel(false);
+      return !future.cancel(true);
     }
 
     @Override


### PR DESCRIPTION
### Description

Restore the interruption of cancelled downloads, which was unintentionally dropped in f2b26596878a0b361b269631a2eddc8ac290dc94.

### Motivation

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
