### PR TITLE
Remove the Phaser-based wait for cancelled repository downloads

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -53,7 +53,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.Phaser;
 import javax.annotation.Nullable;
 
 /**
@@ -134,14 +133,9 @@ public class DownloadManager {
       Path output,
       Map<String, String> clientEnv,
       String context,
-      Phaser downloadPhaser,
       boolean mayHardlink) {
     return executorService.submit(
         () -> {
-          if (downloadPhaser.register() != 0) {
-            // Not in download phase, must already have been cancelled.
-            throw new InterruptedException();
-          }
           try (SilentCloseable c = Profiler.instance().profile("fetching: " + context)) {
             return downloadInExecutor(
                 originalUrls,
@@ -154,8 +148,6 @@ public class DownloadManager {
                 clientEnv,
                 context,
                 mayHardlink);
-          } finally {
-            downloadPhaser.arrive();
           }
         });
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -93,7 +93,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.Phaser;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.ParamType;
@@ -120,10 +119,10 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
    *
    * <p>The main property of such tasks is that they should under no circumstances keep running
    * after fetching the repository is finished, whether successfully or not. To this end, the {@link
-   * #cancel()} method may be called to interrupt the work and {@link #close()} must be called to
-   * wait for all such work to finish.
+   * #cancel()} method must cancel all such work; {@link StarlarkBaseExternalContext#close()} then
+   * waits for any threads still executing cancelled work to finish.
    */
-  private interface AsyncTask extends SilentCloseable {
+  private interface AsyncTask {
     /** Returns a user-friendly description of the task. */
     String getDescription();
 
@@ -133,21 +132,14 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
     /**
      * Cancels the task, if not done yet. Returns false if the task was still in progress.
      *
-     * <p>Note that the task may still be running after this method returns, the task has just got a
-     * signal to interrupt. Call {@link #close()} to wait for the task to finish.
+     * <p>Note that the task may still be running after this method returns. {@link
+     * StarlarkBaseExternalContext#close()} waits for it to finish.
      *
      * <p>No means of error reporting is provided. Any errors should be reported by other means. The
      * only possible error reported as a consequence of calling this method is one that tells the
      * user that they didn't wait for an async task they should have waited for.
      */
     boolean cancel();
-
-    /**
-     * Waits uninterruptibly until the task is no longer running, even in case it was cancelled but
-     * its underlying thread is still running.
-     */
-    @Override
-    void close();
   }
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
@@ -231,11 +223,7 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
     // Wait for all (cancelled) async tasks to complete before cleaning up the working directory.
     // This is necessary because downloads may still be in progress and could end up writing to the
     // working directory during deletion, which would cause an error.
-    // Note that just calling executorService.close() doesn't suffice as it considers tasks to be
-    // completed immediately after they are cancelled, without waiting for their underlying thread
-    // to complete.
     executorService.close();
-    asyncTasks.forEach(AsyncTask::close);
 
     if (shouldDeleteWorkingDirectoryOnClose(wasSuccessful)) {
       workingDirectory.deleteTree();
@@ -575,7 +563,6 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
     private final Optional<Checksum> checksum;
     private final RepositoryFunctionException checksumValidation;
     private final Future<Path> future;
-    private final Phaser downloadPhaser;
     private final Location location;
 
     private PendingDownload(
@@ -585,7 +572,6 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
         Optional<Checksum> checksum,
         RepositoryFunctionException checksumValidation,
         Future<Path> future,
-        Phaser downloadPhaser,
         Location location) {
       this.executable = executable;
       this.allowFail = allowFail;
@@ -593,7 +579,6 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
       this.checksum = checksum;
       this.checksumValidation = checksumValidation;
       this.future = future;
-      this.downloadPhaser = downloadPhaser;
       this.location = location;
     }
 
@@ -610,18 +595,6 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
     @Override
     public boolean cancel() {
       return !future.cancel(false);
-    }
-
-    @Override
-    public void close() {
-      if (downloadPhaser.register() != 0) {
-        // Not in the download phase, either the download completed normally or
-        // it has completed after a cancellation.
-        return;
-      }
-      try (SilentCloseable c = Profiler.instance().profile("Cancelling download " + outputPath)) {
-        downloadPhaser.arriveAndAwaitAdvance();
-      }
     }
 
     @StarlarkMethod(
@@ -668,8 +641,6 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
           Starlark.errorf(
               "Could not create output path %s: %s", pendingDownload.outputPath, e.getMessage()),
           Transience.PERSISTENT);
-    } finally {
-      pendingDownload.close();
     }
     if (pendingDownload.checksumValidation != null) {
       throw pendingDownload.checksumValidation;
@@ -843,7 +814,6 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
       checkInOutputDirectory("write", outputPath);
       makeDirectories(outputPath.getPath());
     } catch (IOException e) {
-      Phaser downloadPhaser = new Phaser();
       download =
           new PendingDownload(
               executable,
@@ -852,11 +822,9 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
               checksum,
               checksumValidation,
               Futures.immediateFailedFuture(e),
-              downloadPhaser,
               thread.getCallerLocation());
     }
     if (download == null) {
-      Phaser downloadPhaser = new Phaser();
       Future<Path> downloadFuture =
           downloadManager.startDownload(
               executorService,
@@ -869,7 +837,6 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
               outputPath.getPath(),
               nonstrictRepoEnv,
               identifyingStringForLogging,
-              downloadPhaser,
               // The repo rule may modify the file after the download, so we cannot guarantee that
               // hardlinking is safe.
               /* mayHardlink= */ false);
@@ -881,7 +848,6 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
               checksum,
               checksumValidation,
               downloadFuture,
-              downloadPhaser,
               thread.getCallerLocation());
       registerAsyncTask(download);
     }
@@ -1126,7 +1092,6 @@ Strip the given number of leading components from file paths on extraction. Only
       // Download to temp directory inside the outputDirectory and delete it after extraction
       downloadDirectory = outputPath.getPath().createTempDirectory("temp");
 
-      Phaser downloadPhaser = new Phaser();
       Future<Path> pendingDownload =
           downloadManager.startDownload(
               executorService,
@@ -1139,7 +1104,6 @@ Strip the given number of leading components from file paths on extraction. Only
               downloadDirectory,
               nonstrictRepoEnv,
               identifyingStringForLogging,
-              downloadPhaser,
               // The archive is not going to be modified and not accessible to the user, so its safe
               // to hardlink.
               /* mayHardlink= */ true);
@@ -1153,7 +1117,6 @@ Strip the given number of leading components from file paths on extraction. Only
               checksum,
               checksumValidation,
               pendingDownload,
-              downloadPhaser,
               thread.getCallerLocation());
       registerAsyncTask(pendingTask);
       downloadedPath = downloadManager.finalizeDownload(pendingDownload);

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -60,7 +60,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.Phaser;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Ignore;
@@ -1387,7 +1386,6 @@ public class HttpDownloaderTest {
       Map<String, String> clientEnv,
       String context)
       throws IOException, InterruptedException {
-    Phaser downloadPhaser = new Phaser();
     try (ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor()) {
       Future<Path> future =
           downloadManager.startDownload(
@@ -1401,12 +1399,8 @@ public class HttpDownloaderTest {
               output,
               clientEnv,
               context,
-              downloadPhaser,
               /* mayHardlink= */ true);
-      Path downloadedPath = downloadManager.finalizeDownload(future);
-      // Should not be in the download phase.
-      assertThat(downloadPhaser.getPhase()).isNotEqualTo(0);
-      return downloadedPath;
+      return downloadManager.finalizeDownload(future);
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContextTest.java
@@ -214,7 +214,6 @@ public class StarlarkBaseExternalContextTest {
               /* output= */ any(),
               /* clientEnv= */ any(),
               /* context= */ any(),
-              /* downloadPhaser= */ any(),
               /* mayHardlink= */ anyBoolean()))
           .thenReturn(testFuture);
 
@@ -258,7 +257,6 @@ public class StarlarkBaseExternalContextTest {
               /* output= */ any(),
               /* clientEnv= */ any(),
               /* context= */ any(),
-              /* downloadPhaser= */ any(),
               /* mayHardlink= */ anyBoolean()))
           .thenReturn(failingFuture);
       Object failingDownload =
@@ -314,7 +312,6 @@ public class StarlarkBaseExternalContextTest {
             /* output= */ any(),
             /* clientEnv= */ any(),
             /* context= */ any(),
-            /* downloadPhaser= */ any(),
             /* mayHardlink= */ anyBoolean()))
         .thenReturn(new CompletableFuture<>());
 
@@ -380,7 +377,6 @@ public class StarlarkBaseExternalContextTest {
             /* output= */ any(),
             /* clientEnv= */ any(),
             /* context= */ any(),
-            /* downloadPhaser= */ any(),
             /* mayHardlink= */ anyBoolean()))
         .thenReturn(new CompletableFuture<>());
     try (StarlarkBaseExternalContext sbec = setupStarlarkContext(testPath)) {
@@ -438,7 +434,6 @@ public class StarlarkBaseExternalContextTest {
             /* output= */ any(),
             /* clientEnv= */ any(),
             /* context= */ any(),
-            /* downloadPhaser= */ any(),
             /* mayHardlink= */ anyBoolean()))
         .thenReturn(new CompletableFuture<>());
     try (StarlarkBaseExternalContext sbec = setupStarlarkContext(testPath)) {


### PR DESCRIPTION
### Description

Removes the per-download `Phaser` and the `AsyncTask#close` hook that `StarlarkBaseExternalContext#close` used to wait for the threads of cancelled downloads before deleting the working directory. `ExecutorService#close` now covers that wait on its own.

### Motivation

48338d2ff33 (#23837) added this bookkeeping because `ThreadPerTaskExecutor#close` treated a cancelled task as complete as soon as it was cancelled, without waiting for its thread to exit (JDK-8347039). That bug is fixed in JDK 25, which Bazel now runs on.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
