### PR TITLE
docs: update Hermetiq product partner description

### DIFF
--- a/docs/community/partners.mdx
+++ b/docs/community/partners.mdx
@@ -64,7 +64,7 @@ Based in San Francisco and Sydney, Buildkite is a fast-growing software delivery
 
 <Columns cols={2}>
 <Card title="Hermetiq" img="/community/images/hermetiq-logo.png" cta="Learn more" href="https://www.hermetiq.com/">
-Hermetiq is the intelligence platform for Bazel, built for the era of agentic software development. Hermetiq delivers deep observability and analytics across cache performance, remote execution, and build failures — and exposes Bazel build data directly to AI agents via MCP so that you can ask any question about your builds directly to your AI Agent (Claude, Codex, etc) and get answers instantly. Backed by LAUNCH. Available as a cloud service or self-hosted deployment.
+Hermetiq provides managed remote caching and remote execution for Bazel, with build observability and AI-assisted diagnosis, fixes, and optimization. Teams can use Hermetiq Cloud or deploy the service in their own environment. Teams that already operate Buildbarn can connect it to Hermetiq-hosted intelligence or deploy Hermetiq intelligence in their own environment. Hermetiq's MCP integration gives coding agents access to connected build and infrastructure telemetry; repository changes and build verification run through the connected agent or CI.
 
 </Card>
 <Card title="Trunk" img="/community/images/trunk-logo-dark.svg" cta="Learn more" href="https://trunk.io">


### PR DESCRIPTION
### Description
Update Hermetiq’s existing product-partner description to include managed Bazel remote caching and execution, AI-assisted diagnosis and fixes, and the option to keep an existing Buildbarn deployment. Cloud and customer-hosted deployment options are explicit.

### Motivation
The current paragraph describes observability and question answering only. This update reflects the current product and explains how connected coding agents use build evidence for repository changes and verification.

The existing Hermetiq card, image, and website link are unchanged. Sources: [product overview](https://www.hermetiq.com/product), [remote execution setup](https://www.hermetiq.com/docs/remote-execution), and [AI agent setup](https://www.hermetiq.com/docs/mcp).

### Build API Changes
No.

### Validation
- Verified that the diff changes exactly one paragraph in `docs/community/partners.mdx`.
- Preserved the existing MDX structure, image path, card title, and destination URL.
- No executable code or examples changed; no build tests were run.

### Checklist
- [x] I have updated the documentation.
- [x] New test cases are not applicable to this prose-only description update.

### Release Notes
RELNOTES: None
