### PR TITLE
handle EXDEV when moving aside a corrupted action cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -177,6 +177,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization:visible-for-serialization",
         "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi",
+        "//src/main/java/com/google/devtools/build/lib/unix:native_posix_files_service",
         "//src/main/java/com/google/devtools/build/lib/unsafe:string",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -35,6 +35,7 @@ import com.google.devtools.build.lib.concurrent.ThreadSafety.ConditionallyThread
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.events.NullEventHandler;
+import com.google.devtools.build.lib.unix.NativePosixFilesException;
 import com.google.devtools.build.lib.unsafe.StringUnsafe;
 import com.google.devtools.build.lib.util.MapCodec;
 import com.google.devtools.build.lib.util.MapCodec.IncompatibleFormatException;
@@ -482,12 +483,25 @@ public class CompactPersistentActionCache implements ActionCache {
       // This also ensures that the next initialization attempt will create an empty cache.
       // To avoid using too much disk space, only keep the most recent corrupted cache around.
       corruptedCacheRoot.deleteTree();
-      cacheRoot.renameTo(corruptedCacheRoot);
+      try {
+        cacheRoot.renameTo(corruptedCacheRoot);
+
+        logger.atWarning().withCause(e).log(
+            "Failed to load action cache, preexisting files kept in %s", corruptedCacheRoot);
+      } catch (IOException renameException) {
+        if (!(renameException.getCause() instanceof NativePosixFilesException posixException)
+            || posixException.getError() != NativePosixFilesException.PosixError.EXDEV) {
+          throw renameException;
+        }
+        cacheRoot.deleteTree();
+
+        logger.atWarning().withCause(e).log(
+            "Failed to load action cache; could not move it to %s (cross-device link),"
+                + " deleted it instead",
+            corruptedCacheRoot);
+      }
 
       e = new IOException("%s: %s".formatted(message, e.getMessage()), e);
-
-      logger.atWarning().withCause(e).log(
-          "Failed to load action cache, preexisting files kept in %s", corruptedCacheRoot);
 
       reporterForInitializationErrors.handle(
           Event.warn(

--- a/src/main/java/com/google/devtools/build/lib/unix/NativePosixFilesException.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/NativePosixFilesException.java
@@ -26,6 +26,7 @@ public final class NativePosixFilesException extends Exception {
     public static final PosixError EACCES = new PosixError("EACCES");
     public static final PosixError ELOOP = new PosixError("ELOOP");
     public static final PosixError ETIMEDOUT = new PosixError("ETIMEDOUT");
+    public static final PosixError EXDEV = new PosixError("EXDEV");
     public static final PosixError OTHER = new PosixError("OTHER");
 
     private final String name;

--- a/src/main/native/unix_jni.cc
+++ b/src/main/native/unix_jni.cc
@@ -117,6 +117,8 @@ static jobject GetPosixError(JNIEnv* env, int error_number) {
       getStaticObjectField(env, error_class, "ELOOP", field_sig);
   static const jobject error_etimedout =
       getStaticObjectField(env, error_class, "ETIMEDOUT", field_sig);
+  static const jobject error_exdev =
+      getStaticObjectField(env, error_class, "EXDEV", field_sig);
   static const jobject error_other =
       getStaticObjectField(env, error_class, "OTHER", field_sig);
 
@@ -129,6 +131,8 @@ static jobject GetPosixError(JNIEnv* env, int error_number) {
       return error_eacces;
     case ELOOP:  // Too many symbolic links encountered
       return error_eloop;
+    case EXDEV:  // Cross-device link
+      return error_exdev;
     case EBADF:         // Bad file number or descriptor already closed.
     case ENAMETOOLONG:  // File name too long
     case ENODATA:    // No data available
@@ -145,7 +149,6 @@ static jobject GetPosixError(JNIEnv* env, int error_number) {
     case EFBIG:      // File too large
     case EPIPE:      // Broken pipe
     case ENOSPC:     // No space left on device
-    case EXDEV:      // Cross-device link
     case EROFS:      // Read-only file system
     case EEXIST:     // File exists
     case EMLINK:     // Too many links


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description
<!--
Please provide a brief summary of the changes in this PR.
-->
If moving a corrupted action cache aside fails with `EXDEV` (cross-device link), delete it and continue with a fresh cache instead of crashing. `EXDEV` now gets its own `NativePosixFilesException.PosixError` constant instead of collapsing into `OTHER`.

### Motivation
<!--
Why is this change important? Does it fix a specific bug or add a new feature?
If this PR fixes an existing issue, please link it here (e.g. "Fixes #1234").
-->
fixes #31042

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: Fixed action cache initialization failing with "Invalid cross-device link" when the output base is on overlayfs; a corrupted action cache that cannot be moved aside is now deleted and recreated.
