### PR TITLE
buildenv.sh: take the newest installed JDK on FreeBSD and OpenBSD

### DIFF
--- a/scripts/bootstrap/buildenv.sh
+++ b/scripts/bootstrap/buildenv.sh
@@ -93,13 +93,15 @@ linux)
   ;;
 
 freebsd)
-  # JAVA_HOME must point to a Java installation.
-  JAVA_HOME="${JAVA_HOME:-/usr/local/openjdk11}"
+  # JAVA_HOME must point to a Java installation. The packages install
+  # under /usr/local/openjdk<N>; take the newest one present.
+  JAVA_HOME="${JAVA_HOME:-$(ls -d /usr/local/openjdk[0-9]* 2>/dev/null | sort -V | tail -n 1)}"
   ;;
 
 openbsd)
-  # JAVA_HOME must point to a Java installation.
-  JAVA_HOME="${JAVA_HOME:-/usr/local/jdk-11}"
+  # JAVA_HOME must point to a Java installation. The packages install
+  # under /usr/local/jdk-<N>; take the newest one present.
+  JAVA_HOME="${JAVA_HOME:-$(ls -d /usr/local/jdk-[0-9]* 2>/dev/null | sort -V | tail -n 1)}"
   ;;
 
 darwin)


### PR DESCRIPTION
When JAVA_HOME is not set, buildenv.sh guesses it per platform. Linux
follows javac on the path, macOS asks java_home, and FreeBSD and OpenBSD
have /usr/local/openjdk11 and /usr/local/jdk-11 written in. Those were
current once; today they are below the JDK the bootstrap requires, and
on FreeBSD the bazel package still installs exactly that openjdk11, so a
fresh machine with a newer JDK installed next to it is sent to the old
one and compile.sh stops on the version check.

Following javac on the path does not work there: FreeBSD's javac is the
javavm wrapper, not a file inside a JDK. Take the newest JDK directory
the packages install instead, /usr/local/openjdk<N> on FreeBSD and
/usr/local/jdk-<N> on OpenBSD.

Checked by sourcing the script with JAVA_HOME unset on FreeBSD 15.1
(openjdk11 and openjdk21 installed: picks openjdk21; openjdk21 and
openjdk26: picks openjdk26) and on OpenBSD 7.9 (jdk-21 and jdk-25:
picks jdk-25).

This is what bazelbuild/continuous-integration#2836 runs into after
installing a JDK next to the bazel package.
