### PR TITLE
Normalize line endings to LF on checkin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,8 +9,9 @@ site/* linguist-documentation
 #   https://docs.github.com/en/search-github/searching-on-github/finding-files-on-github#customizing-excluded-files
 **/build/** linguist-generated=false
 
-# Files should not use CRLF line endings, even on Windows.
-* -text
+# Normalize line endings to LF on checkin and always check out LF, even on
+# Windows. Binary files are detected by content and left untouched.
+* text=auto eol=lf
 
 # A custom merge driver for the Bazel lockfile.
 # https://bazel.build/external/lockfile#automatic-resolution


### PR DESCRIPTION
### Description

Replace the `* -text` rule in `.gitattributes` with `* text=auto eol=lf`.

`-text` disables Git's end-of-line conversion in both directions. It keeps Windows checkouts on LF (the fix for #26467 in #26469), but it also makes Git store CRLF verbatim whenever a contributor's editor writes it. `text=auto eol=lf` keeps checkouts on LF regardless of `core.autocrlf` and additionally converts CRLF to LF on checkin for files that Git detects as text, so stray CRLF can no longer reach the repository.

Existing files and clones are unaffected.

### Motivation

#31056 shows as +2820/−2769 on GitHub, but only +54/−3 with carriage returns ignored.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
