### PR TITLE
Share identical configuration matchers

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BUILD
@@ -168,6 +168,7 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/analysis:transitive_info_provider",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//third_party/java/auto:auto_value",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/ConfigMatchingProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/ConfigMatchingProvider.java
@@ -20,8 +20,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Interner;
 import com.google.devtools.build.lib.analysis.TransitiveInfoProvider;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import java.util.List;
@@ -37,6 +39,9 @@ import java.util.Map;
 @Immutable
 @AutoValue
 public abstract class ConfigMatchingProvider implements TransitiveInfoProvider {
+  // Configurations that differ in unrelated options often produce identical match results.
+  private static final Interner<ConfigMatchingProvider> interner = BlazeInterners.newWeakInterner();
+
   /**
    * Potential values for result field.
    *
@@ -182,8 +187,9 @@ public abstract class ConfigMatchingProvider implements TransitiveInfoProvider {
       ImmutableMap<Label, String> flagSettingsMap,
       ImmutableSet<Label> constraintValueSettings,
       MatchResult result) {
-    return new AutoValue_ConfigMatchingProvider(
-        label, settingsMap, flagSettingsMap, constraintValueSettings, result);
+    return interner.intern(
+        new AutoValue_ConfigMatchingProvider(
+            label, settingsMap, flagSettingsMap, constraintValueSettings, result));
   }
 
   /** The target's label. */


### PR DESCRIPTION
`ConfigMatchingProvider.create` weakly interns values with the same label, settings, constraints, and complete `MatchResult`. Configurations that differ in unrelated options can share the retained settings collections and mismatch diagnostics without keeping the matcher alive.

In three interleaved partial `--nobuild //... --keep_going` analyses (85 pre-existing failures), retained heap fell from 24,570 to 24,253 MB (317 MB, 1.29%). Median analysis time rose from 192.159 to 193.689 seconds (0.80%); peak RSS was effectively unchanged. Those runs also included the platform filter from dzbarsky/bazel#10, so this is not a standalone `master` measurement.

Validation against `master`: `ConfigRulesTests`, `SelectTests`, and `ConfigurableAttributesTest` pass. The `config_matching_provider` BUILD target gains its direct `BlazeInterners` dependency.

RELNOTES: None

-zbarskybot
