### PR TITLE
Share identical config_setting provider maps

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/RuleConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/RuleConfiguredTarget.java
@@ -42,6 +42,7 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.Info;
+import com.google.devtools.build.lib.packages.NativeInfo;
 import com.google.devtools.build.lib.packages.OutputFile;
 import com.google.devtools.build.lib.packages.PackageSpecification.PackageGroupContents;
 import com.google.devtools.build.lib.packages.Provider;
@@ -79,6 +80,10 @@ public final class RuleConfiguredTarget extends AbstractConfiguredTarget {
    * set of implicit deps so this reduces the memory load per build.
    */
   private static final Interner<ImmutableList<ConfiguredTargetKey>> IMPLICIT_DEPS_INTERNER =
+      BlazeInterners.newWeakInterner();
+
+  // Unrelated configuration differences often leave all config_setting providers unchanged.
+  private static final Interner<TransitiveInfoProviderMap> CONFIG_SETTING_PROVIDERS_INTERNER =
       BlazeInterners.newWeakInterner();
 
   private final TransitiveInfoProviderMap providers;
@@ -120,7 +125,7 @@ public final class RuleConfiguredTarget extends AbstractConfiguredTarget {
       }
     }
 
-    this.providers = providerBuilder.build();
+    this.providers = internConfigSettingProviders(providerBuilder.build(), ruleClassId);
     this.configConditions = configConditions;
     this.implicitDeps = IMPLICIT_DEPS_INTERNER.intern(implicitDeps);
     this.ruleClassId = ruleClassId;
@@ -184,11 +189,26 @@ public final class RuleConfiguredTarget extends AbstractConfiguredTarget {
       RuleClassId ruleClassId,
       ImmutableList<ActionAnalysisMetadata> actions) {
     super(lookupKey, visibility);
-    this.providers = providers;
+    this.providers = internConfigSettingProviders(providers, ruleClassId);
     this.configConditions = configConditions;
     this.implicitDeps = implicitDeps;
     this.ruleClassId = ruleClassId;
     this.actions = actions;
+  }
+
+  private static TransitiveInfoProviderMap internConfigSettingProviders(
+      TransitiveInfoProviderMap providers, RuleClassId ruleClassId) {
+    // Native rule keys are their names; Starlark rule keys include the defining .bzl label.
+    if (!ruleClassId.key().equals("config_setting")) {
+      return providers;
+    }
+    for (int i = 0; i < providers.getProviderCount(); i++) {
+      // NativeInfo equality can omit native-only state, such as coverage support files.
+      if (providers.getProviderInstanceAt(i) instanceof NativeInfo) {
+        return providers;
+      }
+    }
+    return CONFIG_SETTING_PROVIDERS_INTERNER.intern(providers);
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/rules/config/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/config/BUILD
@@ -26,6 +26,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target_value",
         "//src/main/java/com/google/devtools/build/lib/analysis:rule_definition_environment",
+        "//src/main/java/com/google/devtools/build/lib/analysis:test/instrumented_files_info",
         "//src/main/java/com/google/devtools/build/lib/analysis:transitive_info_collection",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:build_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:build_options",

--- a/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
@@ -17,6 +17,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.devtools.build.lib.actions.ActionLookupKey;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
 import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider.MatchResult.Match;
@@ -24,6 +25,7 @@ import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider.Matc
 import com.google.devtools.build.lib.analysis.config.Fragment;
 import com.google.devtools.build.lib.analysis.config.FragmentOptions;
 import com.google.devtools.build.lib.analysis.config.RequiresOptions;
+import com.google.devtools.build.lib.analysis.test.InstrumentedFilesInfo;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -2037,6 +2039,51 @@ public final class ConfigSettingTest extends BuildViewTestCase {
         "    allowed_values = ['right', 'valid'],",
         "    default_value = 'valid',",
         ")");
+  }
+
+  @Test
+  public void matchingBuildSetting_preservesCoverageEnvironment() throws Exception {
+    scratch.file(
+        "test/build_settings.bzl",
+        """
+        def _impl(ctx):
+            return [coverage_common.instrumented_files_info(
+                ctx,
+                coverage_environment = {"MARKER": ctx.attr.coverage_marker},
+                baseline_coverage_files = [],
+            )]
+
+        string_flag = rule(
+            implementation = _impl,
+            build_setting = config.string(flag = True),
+            attrs = {"coverage_marker": attr.string()},
+        )
+        """);
+    scratch.file(
+        "test/BUILD",
+        """
+        load(":build_settings.bzl", "string_flag")
+
+        config_setting(name = "one", values = {"define": "variant=one"})
+        string_flag(
+            name = "flag",
+            build_setting_default = "ok",
+            coverage_marker = select({":one": "one", "//conditions:default": "two"}),
+        )
+        config_setting(name = "condition", flag_values = {":flag": "ok"})
+        """);
+
+    useConfiguration("--collect_code_coverage", "--define=variant=one");
+    ConfiguredTarget first = getConfiguredTarget("//test:condition");
+    useConfiguration("--collect_code_coverage", "--define=variant=two");
+    ConfiguredTarget second = getConfiguredTarget("//test:condition");
+
+    assertThat(first.getProvider(ConfigMatchingProvider.class).result()).isInstanceOf(Match.class);
+    assertThat(second.getProvider(ConfigMatchingProvider.class).result()).isInstanceOf(Match.class);
+    assertThat(first.get(InstrumentedFilesInfo.STARLARK_CONSTRUCTOR).getCoverageEnvironment())
+        .containsExactly("MARKER", "one");
+    assertThat(second.get(InstrumentedFilesInfo.STARLARK_CONSTRUCTOR).getCoverageEnvironment())
+        .containsExactly("MARKER", "two");
   }
 
   @Test


### PR DESCRIPTION
`RuleConfiguredTarget` weakly interns complete provider maps for native `config_setting` targets during construction and deserialization. Maps containing `NativeInfo` are excluded because its equality can omit native coverage data. The new `ConfigSettingTest` regression verifies that identical match results in two configurations retain distinct coverage environments.

In one partial `--nobuild //... --keep_going` comparison (85 pre-existing failures), retained heap fell from 24,264 to 24,202 MB (62 MB) and the number of provider maps fell by 794,847. That comparison already included matcher sharing from bazelbuild/bazel#31065 (dzbarsky/bazel#12) and platform filtering from dzbarsky/bazel#10; the matcher change should land first. One comparison does not establish an analysis-time or peak-RSS improvement.

Validation against `master`: `ConfigRulesTests` and `RuleConfiguredTargetTest` pass. The combined 9.3 release branch passes these and four other targeted suites.

RELNOTES: None

-zbarskybot
