### PR TITLE
fix(remote): validate OutputFile, OutputDirectory, and OutputSymlink paths in ActionResultMetadata (fixes #30714)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1100,6 +1100,15 @@ public class RemoteExecutionService {
     }
   }
 
+  private static void validateOutputPath(String path) throws IOException {
+    if (path.isEmpty()
+        || PathFragment.containsUplevelReferences(path)
+        || PathFragment.create(path).isAbsolute()
+        || PathFragment.create(path).isEmpty()) {
+      throw new IOException("Malformed output path: " + path);
+    }
+  }
+
   private static DirectoryMetadata parseDirectory(
       Path parent, Directory dir, Map<Digest, Directory> childDirectoriesMap) throws IOException {
     ImmutableList.Builder<FileMetadata> filesBuilder = ImmutableList.builder();
@@ -1159,8 +1168,9 @@ public class RemoteExecutionService {
     Map<Path, ListenableFuture<Tree>> dirMetadataDownloads =
         Maps.newHashMapWithExpectedSize(result.getOutputDirectoriesCount());
     for (OutputDirectory dir : result.getOutputDirectoriesList()) {
-      var outputPath = dir.getPath();
-      var localPath = remotePathResolver.outputPathToLocalPath(unicodeToInternal(outputPath));
+      var outputPath = unicodeToInternal(dir.getPath());
+      validateOutputPath(outputPath);
+      var localPath = remotePathResolver.outputPathToLocalPath(outputPath);
       if (dir.getTreeDigest().getSizeBytes() == 2) {
         // A valid Tree message contains at least a non-empty root field. The only way for a Tree
         // message to have a size of 2 bytes is if the root field is the only non-empty field and
@@ -1175,7 +1185,7 @@ public class RemoteExecutionService {
             Futures.transformAsync(
                 combinedCache.downloadBlobAsByteString(
                     context,
-                    outputPath,
+                    dir.getPath(),
                     remotePathResolver.localPathToExecPath(localPath.asFragment()),
                     dir.getTreeDigest()),
                 (treeBytes) ->
@@ -1202,8 +1212,9 @@ public class RemoteExecutionService {
 
     ImmutableMap.Builder<Path, FileMetadata> files = ImmutableMap.builder();
     for (OutputFile outputFile : result.getOutputFilesList()) {
-      Path localPath =
-          remotePathResolver.outputPathToLocalPath(unicodeToInternal(outputFile.getPath()));
+      var outputPath = unicodeToInternal(outputFile.getPath());
+      validateOutputPath(outputPath);
+      Path localPath = remotePathResolver.outputPathToLocalPath(outputPath);
       files.put(
           localPath,
           new FileMetadata(
@@ -1220,8 +1231,9 @@ public class RemoteExecutionService {
             result.getOutputDirectorySymlinksList(),
             result.getOutputSymlinksList());
     for (var symlink : outputSymlinks) {
-      var localPath =
-          remotePathResolver.outputPathToLocalPath(unicodeToInternal(symlink.getPath()));
+      var outputPath = unicodeToInternal(symlink.getPath());
+      validateOutputPath(outputPath);
+      var localPath = remotePathResolver.outputPathToLocalPath(outputPath);
       var target = PathFragment.create(unicodeToInternal(symlink.getTarget()));
       var existingMetadata = symlinkMap.get(localPath);
       if (existingMetadata != null) {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -186,6 +186,17 @@ public class RemoteExecutionServiceTest {
   private static final ImmutableList<String> INVALID_PATH_COMPONENTS =
       ImmutableList.of("..", ".", "/", "a/b", "");
 
+  private static final ImmutableList<String> INVALID_OUTPUT_PATHS =
+      ImmutableList.of(
+          "",
+          ".",
+          "./.",
+          "..",
+          "../outside",
+          "a/../../outside",
+          "a/../b",
+          "/abs/path");
+
   @Mock private RemoteOutputChecker remoteOutputChecker; // download nothing by default.
 
   @Mock private OutputService outputService;
@@ -3594,5 +3605,69 @@ public class RemoteExecutionServiceTest {
                 RemoteExecutionService.parseActionResultMetadata(
                     cache, digestUtil, remoteActionExecutionContext, ar, remotePathResolver));
     assertThat(e).hasMessageThat().contains("Malformed path component: " + expectedName);
+  }
+
+  @Test
+  public void parseActionResultMetadata_invalidOutputFilePaths_rejected() throws Exception {
+    for (String invalidPath : INVALID_OUTPUT_PATHS) {
+      ActionResult ar =
+          ActionResult.newBuilder()
+              .addOutputFiles(
+                  OutputFile.newBuilder()
+                      .setPath(invalidPath)
+                      .setDigest(digestUtil.compute("content".getBytes(UTF_8))))
+              .build();
+
+      IOException e =
+          assertThrows(
+              IOException.class,
+              () ->
+                  RemoteExecutionService.parseActionResultMetadata(
+                      cache, digestUtil, remoteActionExecutionContext, ar, remotePathResolver));
+      assertThat(e).hasMessageThat().contains("Malformed output path: " + invalidPath);
+    }
+  }
+
+  @Test
+  public void parseActionResultMetadata_invalidOutputDirectoryPaths_rejected() throws Exception {
+    for (String invalidPath : INVALID_OUTPUT_PATHS) {
+      ActionResult ar =
+          ActionResult.newBuilder()
+              .addOutputDirectories(
+                  OutputDirectory.newBuilder()
+                      .setPath(invalidPath)
+                      .setTreeDigest(
+                          cache.addContents(
+                              remoteActionExecutionContext,
+                              Tree.newBuilder().setRoot(Directory.getDefaultInstance()).build())))
+              .build();
+
+      IOException e =
+          assertThrows(
+              IOException.class,
+              () ->
+                  RemoteExecutionService.parseActionResultMetadata(
+                      cache, digestUtil, remoteActionExecutionContext, ar, remotePathResolver));
+      assertThat(e).hasMessageThat().contains("Malformed output path: " + invalidPath);
+    }
+  }
+
+  @Test
+  public void parseActionResultMetadata_invalidOutputSymlinkPaths_rejected() throws Exception {
+    for (String invalidPath : INVALID_OUTPUT_PATHS) {
+      ActionResult ar =
+          ActionResult.newBuilder()
+              .addOutputSymlinks(
+                  OutputSymlink.newBuilder().setPath(invalidPath).setTarget("target"))
+              .build();
+
+      IOException e =
+          assertThrows(
+              IOException.class,
+              () ->
+                  RemoteExecutionService.parseActionResultMetadata(
+                      cache, digestUtil, remoteActionExecutionContext, ar, remotePathResolver));
+      assertThat(e).hasMessageThat().contains("Malformed output path: " + invalidPath);
+    }
   }
 }


### PR DESCRIPTION
## Description
Fixes #30714.

In `RemoteExecutionService.parseActionResultMetadata()`, output paths from cached or returned `ActionResult` entries were resolved directly against the execution root via `RemotePathResolver.outputPathToLocalPath()` without validating that the paths are well-formed relative paths.

While `Directory` and `Tree` child nodes validate each individual path component via `validatePathComponent()`, top-level `OutputFile.getPath()`, `OutputDirectory.getPath()`, and `OutputSymlink.getPath()` lacked equivalent containment validation. A poisoned cache entry containing uplevel references (e.g., `../../outside`) or absolute paths could attempt to escape the execution root.

### Changes
1. Added `validateOutputPath(String path)` in `RemoteExecutionService.java` to enforce that output paths:
   - are not empty,
   - do not contain uplevel references (`..`),
   - are not absolute paths, and
   - do not resolve to empty fragments (e.g. `.`).
2. Called `validateOutputPath(outputPath)` across:
   - `dir.getPath()` in `result.getOutputDirectoriesList()`
   - `outputFile.getPath()` in `result.getOutputFilesList()`
   - `symlink.getPath()` in `outputSymlinks`
3. Added unit tests in `RemoteExecutionServiceTest.java`:
   - `parseActionResultMetadata_invalidOutputFilePaths_rejected`
   - `parseActionResultMetadata_invalidOutputDirectoryPaths_rejected`
   - `parseActionResultMetadata_invalidOutputSymlinkPaths_rejected`
   verifying that malformed paths (`""`, `"."`, `"./."`, `".."` `"../outside"`, `"a/../../outside"`, `"a/../b"`, `"/abs/path"`) are rejected with an `IOException`.

Closes #30714.
