### PR TITLE
[9.3.0] Restore modified facts for cached reproducible extensions (https://github.com/bazelbuild/bazel/pull/30937)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -116,6 +116,14 @@ public class BazelLockFileModule extends BlazeModule {
     combinedFacts.putAll(oldLockfile.getFacts());
     var combinedFactsVersions = new HashMap<ModuleExtensionId, Integer>(numExtensions);
     combinedFactsVersions.putAll(oldLockfile.getFactsVersions());
+    // The hidden lockfile's facts serve as the record of the facts produced by the most recent
+    // actual evaluation of each extension, which SingleExtensionEvalFunction compares against the
+    // workspace lockfile's facts to detect manual edits. They must thus only be combined with
+    // results of the current build, never with the workspace lockfile's (possibly edited) facts.
+    var combinedHiddenFacts = new HashMap<ModuleExtensionId, Facts>(numExtensions);
+    combinedHiddenFacts.putAll(oldHiddenLockfile.getFacts());
+    var combinedHiddenFactsVersions = new HashMap<ModuleExtensionId, Integer>(numExtensions);
+    combinedHiddenFactsVersions.putAll(oldHiddenLockfile.getFactsVersions());
     var doneValues = evaluator.getDoneValues();
     for (var extensionId : depGraphValue.getExtensionUsagesTable().rowKeySet()) {
       if (extensionId.isInnate()) {
@@ -127,26 +135,15 @@ public class BazelLockFileModule extends BlazeModule {
         newExtensionInfos.put(extensionId, value.lockFileInfo().get());
         combinedFacts.put(extensionId, value.facts());
         combinedFactsVersions.put(extensionId, value.factsVersion());
+        combinedHiddenFacts.put(extensionId, value.facts());
+        combinedHiddenFactsVersions.put(extensionId, value.factsVersion());
       }
     }
-    var relevantFacts =
-        ImmutableSortedMap.copyOf(
-            Maps.filterEntries(
-                combinedFacts,
-                entry ->
-                    depGraphValue.getExtensionUsagesTable().containsRow(entry.getKey())
-                        && !entry.getValue().equals(Facts.EMPTY)),
-            ModuleExtensionId.LEXICOGRAPHIC_COMPARATOR);
-    // Only store non-zero versions for extensions that have facts persisted; the default is 0.
-    var relevantFactsVersions =
-        ImmutableSortedMap.copyOf(
-            Maps.filterEntries(
-                combinedFactsVersions,
-                entry ->
-                    relevantFacts.containsKey(entry.getKey())
-                        && entry.getValue() != null
-                        && entry.getValue() != 0),
-            ModuleExtensionId.LEXICOGRAPHIC_COMPARATOR);
+    var relevantFacts = filterRelevantFacts(combinedFacts, depGraphValue);
+    var relevantFactsVersions = filterRelevantFactsVersions(combinedFactsVersions, relevantFacts);
+    var relevantHiddenFacts = filterRelevantFacts(combinedHiddenFacts, depGraphValue);
+    var relevantHiddenFactsVersions =
+        filterRelevantFactsVersions(combinedHiddenFactsVersions, relevantHiddenFacts);
 
     Thread updateLockfile =
         Thread.startVirtualThread(
@@ -207,8 +204,8 @@ public class BazelLockFileModule extends BlazeModule {
                   BazelLockFileValue.builder()
                       .setSelectedYankedVersions(ImmutableMap.of())
                       .setModuleExtensions(reproducibleExtensionInfos)
-                      .setFacts(relevantFacts)
-                      .setFactsVersions(relevantFactsVersions)
+                      .setFacts(relevantHiddenFacts)
+                      .setFactsVersions(relevantHiddenFactsVersions)
                       .build();
 
               if (!newHiddenLockfile.equals(oldHiddenLockfileFinal)) {
@@ -224,6 +221,31 @@ public class BazelLockFileModule extends BlazeModule {
       logger.atSevere().withCause(e).log(
           "Interrupted while updating MODULE.bazel.lock file: %s", e.getMessage());
     }
+  }
+
+  private static ImmutableSortedMap<ModuleExtensionId, Facts> filterRelevantFacts(
+      Map<ModuleExtensionId, Facts> combinedFacts, BazelDepGraphValue depGraphValue) {
+    return ImmutableSortedMap.copyOf(
+        Maps.filterEntries(
+            combinedFacts,
+            entry ->
+                depGraphValue.getExtensionUsagesTable().containsRow(entry.getKey())
+                    && !entry.getValue().equals(Facts.EMPTY)),
+        ModuleExtensionId.LEXICOGRAPHIC_COMPARATOR);
+  }
+
+  /** Only keeps non-zero versions for extensions that have facts persisted; the default is 0. */
+  private static ImmutableSortedMap<ModuleExtensionId, Integer> filterRelevantFactsVersions(
+      Map<ModuleExtensionId, Integer> combinedFactsVersions,
+      ImmutableSortedMap<ModuleExtensionId, Facts> relevantFacts) {
+    return ImmutableSortedMap.copyOf(
+        Maps.filterEntries(
+            combinedFactsVersions,
+            entry ->
+                relevantFacts.containsKey(entry.getKey())
+                    && entry.getValue() != null
+                    && entry.getValue() != 0),
+        ModuleExtensionId.LEXICOGRAPHIC_COMPARATOR);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -158,6 +158,16 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       if (workspaceLockfile == null || hiddenLockfile == null) {
         return null;
       }
+      // The facts recorded by the most recent actual evaluation of the extension, if there is
+      // such a record at the current facts_version. Unlike the workspace lockfile, the hidden
+      // lockfile is not subject to manual edits or merges, so this can be compared against the
+      // workspace lockfile's facts to detect that they have been modified.
+      @Nullable Facts hiddenLockfileFacts = null;
+      if (hiddenLockfile.getFacts().containsKey(extensionId)
+          && hiddenLockfile.getFactsVersions().getOrDefault(extensionId, 0)
+              == currentFactsVersion) {
+        hiddenLockfileFacts = hiddenLockfile.getFacts().get(extensionId);
+      }
       // Prefer the workspace lockfile facts when present, falling back to the hidden lockfile.
       // In both cases, facts whose stored factsVersion differs from the current extension's
       // facts_version are discarded: the extension's schema may have changed.
@@ -168,11 +178,8 @@ public class SingleExtensionEvalFunction implements SkyFunction {
           workspaceLockfileFacts = workspaceLockfile.getFacts().get(extensionId);
           lockfileFacts = workspaceLockfileFacts;
         }
-      } else {
-        int hiddenFactsVersion = hiddenLockfile.getFactsVersions().getOrDefault(extensionId, 0);
-        if (hiddenFactsVersion == currentFactsVersion) {
-          lockfileFacts = hiddenLockfile.getFacts().getOrDefault(extensionId, Facts.EMPTY);
-        }
+      } else if (hiddenLockfileFacts != null) {
+        lockfileFacts = hiddenLockfileFacts;
       }
       var lockedExtensionMap = workspaceLockfile.getModuleExtensions().get(extensionId);
       var lockedExtension =
@@ -194,7 +201,8 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                   usagesValue,
                   extension.getEvalFactors(),
                   lockedExtension,
-                  lockfileFacts);
+                  lockfileFacts,
+                  hiddenLockfileFacts);
           if (singleExtensionValue != null) {
             return singleExtensionValue;
           }
@@ -313,6 +321,10 @@ public class SingleExtensionEvalFunction implements SkyFunction {
    * Tries to get the evaluation result from the lockfile, if it's still up-to-date. Otherwise,
    * returns {@code null}.
    *
+   * @param facts the facts to attach to the reused result (workspace lockfile facts if present,
+   *     otherwise the hidden lockfile's)
+   * @param hiddenLockfileFacts the facts recorded by the most recent actual evaluation of the
+   *     extension (kept in the hidden lockfile), or {@code null} if there is no such record
    * @throws NeedsSkyframeRestartException in case we need a skyframe restart. Note that we
    *     <em>don't</em> return {@code null} in this case!
    */
@@ -324,7 +336,8 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       SingleExtensionUsagesValue usagesValue,
       ModuleExtensionEvalFactors evalFactors,
       LockFileModuleExtension lockedExtension,
-      Facts facts)
+      Facts facts,
+      @Nullable Facts hiddenLockfileFacts)
       throws SingleExtensionEvalFunctionException,
           InterruptedException,
           NeedsSkyframeRestartException {
@@ -354,10 +367,26 @@ public class SingleExtensionEvalFunction implements SkyFunction {
         diffRecorder.record(
             "an input to the extension '" + extensionId + "' changed: " + reason.get());
       }
+      // The results of a reproducible extension are persisted in the hidden lockfile, so whether
+      // such an extension reruns is determined by output base state. This could result in stale
+      // facts in the workspace lockfile (e.g., modified externally by an edit or VCS merge) not
+      // being recognized (in ERROR mode) or repaired (in UPDATE mode) depending on this essentially
+      // invisible state. Since the hidden lockfile is meant to be a fully transparent optimization,
+      // we avoid this by comparing the facts to the ones persisted in it, which have been obtained
+      // from a prior evaluation of the extension. Since it is reproducible and no other diffs have
+      // been detected up to this point, the facts must be what the workspace lockfile should
+      // contain.
+      if (lockedExtension.isReproducible()
+          && !facts.equals(Facts.EMPTY)
+          && !facts.equals(hiddenLockfileFacts)) {
+        diffRecorder.record(
+            "the facts recorded in the lockfile for the extension '"
+                + extensionId
+                + "' do not match the result of its most recent evaluation");
+      }
     } catch (DiffFoundEarlyExitException ignored) {
       // ignored
     }
-    // There is intentionally no diff check for facts - they are never invalidated by Bazel.
     if (!diffRecorder.anyDiffsDetected()) {
       return createSingleExtensionValue(
           lockedExtension.getGeneratedRepoSpecs(),

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -3411,6 +3411,229 @@ class BazelLockfileTest(test_base.TestBase):
     # Should not have "has changed its facts" error
     self.assertNotIn('has changed its facts', stderr)
 
+  def _setUpExtensionWithFacts(self, reproducible):
+    """Sets up a workspace with an extension producing two facts entries."""
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'lockfile_ext = use_extension("extension.bzl", "lockfile_ext")',
+            'use_repo(lockfile_ext, "hello")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel', ['filegroup(name = "unrelated")'])
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def impl(ctx):',
+            '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
+            'repo_rule = repository_rule(',
+            '    implementation = impl,',
+            '    attrs = {"hash": attr.string()},',
+            ')',
+            'def _mod_ext_impl(ctx):',
+            '    print("lockfile_ext is being evaluated")',
+            '    metadata = {',
+            '        "1.25.0": {"hash": "olleh"},',
+            '        "1.26.1": {"hash": "hello"},',
+            '    }',
+            '    repo_rule(',
+            '        name = "hello",',
+            '        hash = metadata["1.26.1"]["hash"],',
+            '    )',
+            '    return ctx.extension_metadata(',
+            '        reproducible = %s,' % repr(reproducible),
+            '        facts = metadata,',
+            '    )',
+            'lockfile_ext = module_extension(implementation = _mod_ext_impl)',
+        ],
+    )
+
+    # Initial build to generate the lockfile with facts.
+    self.RunBazel(['build', '@hello//:all', '--lockfile_mode=update'])
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read().strip())
+    extension_id = '//:extension.bzl%lockfile_ext'
+    self.assertEqual(
+        lockfile['facts'][extension_id],
+        {'1.25.0': {'hash': 'olleh'}, '1.26.1': {'hash': 'hello'}},
+    )
+    return extension_id
+
+  def _dropFactsFromLockfile(self, extension_id, fact_key=None):
+    """Deletes facts from the workspace lockfile, entirely or a single key."""
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read().strip())
+    if fact_key is None:
+      del lockfile['facts'][extension_id]
+    else:
+      del lockfile['facts'][extension_id][fact_key]
+    with open(self.Path('MODULE.bazel.lock'), 'w') as f:
+      json.dump(lockfile, f, indent=2)
+
+  def _addFactToLockfile(self, extension_id, fact_key, fact_value):
+    """Adds a facts entry to the workspace lockfile."""
+    # Simulates the workspace lockfile changing underneath a warm output base,
+    # e.g. due to a branch switch or pull that brings in facts produced by an
+    # evaluation of the extension on a different machine.
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read().strip())
+    lockfile['facts'][extension_id][fact_key] = fact_value
+    with open(self.Path('MODULE.bazel.lock'), 'w') as f:
+      json.dump(lockfile, f, indent=2)
+
+  def testDeletedFactsRegeneratedByUpdateMode(self):
+    """Facts deleted from the workspace lockfile are restored by UPDATE mode.
+
+    Regression test for https://github.com/bazelbuild/bazel/issues/29161. For a
+    non-reproducible extension, the deleted facts are restored from the hidden
+    lockfile's copy without rerunning the extension: its cached result is
+    locked in the workspace lockfile, so a cold machine would not rerun it
+    either.
+    """
+    extension_id = self._setUpExtensionWithFacts(reproducible=False)
+    self._dropFactsFromLockfile(extension_id)
+
+    _, _, stderr = self.RunBazel(
+        ['build', '@hello//:all', '--lockfile_mode=update']
+    )
+    self.assertNotIn('lockfile_ext is being evaluated', '\n'.join(stderr))
+
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read().strip())
+    self.assertEqual(
+        lockfile['facts'][extension_id],
+        {'1.25.0': {'hash': 'olleh'}, '1.26.1': {'hash': 'hello'}},
+    )
+
+  def testPartiallyDeletedFactsRegeneratedByUpdateMode(self):
+    """Individual facts entries deleted from the lockfile are regenerated.
+
+    Regression test for https://github.com/bazelbuild/bazel/issues/29161: the
+    original report deleted a single entry (e.g. "1.25.0") from an extension's
+    facts while keeping the others, so the extension's facts key itself is
+    still present in the lockfile.
+    """
+    extension_id = self._setUpExtensionWithFacts(reproducible=True)
+    self._dropFactsFromLockfile(extension_id, fact_key='1.25.0')
+
+    self.RunBazel(['build', '@hello//:all', '--lockfile_mode=update'])
+
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read().strip())
+    self.assertEqual(
+        lockfile['facts'][extension_id],
+        {'1.25.0': {'hash': 'olleh'}, '1.26.1': {'hash': 'hello'}},
+    )
+
+  def testDeletedFactsRegeneratedByUpdateModeAfterUnrelatedBuild(self):
+    """Facts are regenerated even if an unrelated build runs after the edit.
+
+    The unrelated build must not overwrite the hidden lockfile's record of the
+    facts produced by the extension's most recent evaluation with the manually
+    edited workspace facts, as that record is what allows a later build to
+    detect that the extension has to be rerun.
+    """
+    extension_id = self._setUpExtensionWithFacts(reproducible=True)
+    self._dropFactsFromLockfile(extension_id, fact_key='1.25.0')
+
+    # This build does not evaluate the extension.
+    self.RunBazel(['build', '//:unrelated', '--lockfile_mode=update'])
+
+    self.RunBazel(['build', '@hello//:all', '--lockfile_mode=update'])
+
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read().strip())
+    self.assertEqual(
+        lockfile['facts'][extension_id],
+        {'1.25.0': {'hash': 'olleh'}, '1.26.1': {'hash': 'hello'}},
+    )
+
+  def testExternallyUpdatedFactsKeptByUpdateModeForNonReproducibleExtension(
+      self,
+  ):
+    """UPDATE mode keeps updated facts of a non-reproducible extension.
+
+    The hidden lockfile records the facts produced by the most recent local
+    evaluation of the extension. If the workspace lockfile's facts for a
+    non-reproducible extension change without any of its inputs changing (e.g.
+    a branch switch or pull brings in a re-pin performed on another machine),
+    the cached result must be reused with the new facts as is: a cold machine
+    would not rerun the extension either and a rerun could require network
+    access or credentials that are only available to the person updating the
+    pins.
+    """
+    extension_id = self._setUpExtensionWithFacts(reproducible=False)
+    self._addFactToLockfile(extension_id, '1.27.0', {'hash': 'hola'})
+
+    _, _, stderr = self.RunBazel(
+        ['build', '@hello//:all', '--lockfile_mode=update']
+    )
+    self.assertNotIn('lockfile_ext is being evaluated', '\n'.join(stderr))
+
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read().strip())
+    self.assertEqual(
+        lockfile['facts'][extension_id],
+        {
+            '1.25.0': {'hash': 'olleh'},
+            '1.26.1': {'hash': 'hello'},
+            '1.27.0': {'hash': 'hola'},
+        },
+    )
+
+  def testExternallyUpdatedFactsRegenerateReproducibleExtension(self):
+    """UPDATE mode reruns a reproducible extension on changed facts.
+
+    A reproducible extension's facts can only legitimately change together
+    with its inputs, so facts that differ from the record of its most recent
+    evaluation despite unchanged inputs indicate an edited workspace lockfile
+    and the extension is rerun to regenerate them. This is safe: a reproducible
+    extension's result is only ever cached in the machine-local hidden
+    lockfile, so a cold machine would rerun it anyway.
+    """
+    extension_id = self._setUpExtensionWithFacts(reproducible=True)
+    self._addFactToLockfile(extension_id, '1.27.0', {'hash': 'hola'})
+
+    _, _, stderr = self.RunBazel(
+        ['build', '@hello//:all', '--lockfile_mode=update']
+    )
+    self.assertIn('lockfile_ext is being evaluated', '\n'.join(stderr))
+
+    with open(self.Path('MODULE.bazel.lock'), 'r') as f:
+      lockfile = json.loads(f.read().strip())
+    self.assertEqual(
+        lockfile['facts'][extension_id],
+        {'1.25.0': {'hash': 'olleh'}, '1.26.1': {'hash': 'hello'}},
+    )
+
+  def testDeletedFactsDetectedByErrorModeForReproducibleExtension(self):
+    """ERROR mode reruns a reproducible extension on edited facts and fails.
+
+    Regression test for https://github.com/bazelbuild/bazel/issues/29161
+    """
+    extension_id = self._setUpExtensionWithFacts(reproducible=True)
+    self._dropFactsFromLockfile(extension_id, fact_key='1.25.0')
+
+    exit_code, stdout, stderr = self.RunBazel(
+        ['build', '@hello//:all', '--lockfile_mode=error'], allow_failure=True
+    )
+    stderr = ''.join(stderr)
+    self.AssertExitCode(exit_code, 48, stderr, stdout)
+    self.assertIn('has changed its facts', stderr)
+
+  def testDeletedFactsIgnoredByErrorModeForNonReproducibleExtension(self):
+    """ERROR mode does not fail on edited facts of a non-reproducible extension.
+
+    A non-reproducible extension must not be rerun in ERROR mode and failing
+    based on the hidden lockfile's purely machine-local record could produce
+    false positives after a rollback of the extension together with the
+    workspace lockfile (https://github.com/bazelbuild/bazel/issues/28717).
+    """
+    extension_id = self._setUpExtensionWithFacts(reproducible=False)
+    self._dropFactsFromLockfile(extension_id)
+
+    self.RunBazel(['build', '@hello//:all', '--lockfile_mode=error'])
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
### Description
The results of a reproducible extension are persisted in the hidden lockfile, so whether such an extension reruns is determined by output base state. This could result in stale facts in the workspace lockfile (e.g., modified externally by an edit or VCS merge) not being recognized (in `ERROR` mode) or repaired (in `UPDATE` mode) depending on this essentially invisible state. Since the hidden lockfile is meant to be a fully transparent optimization, we avoid this by comparing the workspace lockfile's facts to the ones persisted in the hidden lockfile and ensure that the latter also reflect a prior evaluation of the extension. Since the extension is reproducible, these facts must be what the workspace lockfile should contain if none of the inputs changed.

### Motivation
Fixes #29161

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Facts of reproducible module extensions are now restored to the expected state after external modifications by every Bazel command that updates the lockfile.

Closes #30937.

PiperOrigin-RevId: 979720049
Change-Id: I01db68fc2bd29b61010ddde8ae215270f6555742

Commit https://github.com/bazelbuild/bazel/commit/c530b0ed19c7a6418e815452c737b5ed21db64f5