### PR TITLE
Test frozen provider dictionary compaction

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/packages/StarlarkProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/StarlarkProviderTest.java
@@ -27,6 +27,7 @@ import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import java.util.Map;
 import java.util.Optional;
 import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
@@ -604,18 +605,22 @@ public final class StarlarkProviderTest {
         new StarlarkProvider.Key(keyForBuild(Label.parseCanonical("//foo:bar.bzl")), "prov");
     StarlarkProvider provider =
         StarlarkProvider.builder(Location.BUILTIN)
-            .setSchema(ImmutableList.of("a"))
+            .setSchema(ImmutableList.of("a", "b"))
             .buildExported(key);
     StarlarkInfo instance;
+    Dict<String, String> dict;
     try (Mutability mu = Mutability.create()) {
       StarlarkThread thread = StarlarkThread.createTransient(mu, StarlarkSemantics.DEFAULT);
+      dict = Dict.of(mu);
+      dict.putEntry("z", "first");
+      dict.putEntry("a", "second");
       instance =
           (StarlarkInfo)
               Starlark.call(
                   thread,
                   provider,
                   /* args= */ ImmutableList.of(),
-                  /* kwargs= */ ImmutableMap.of("a", StarlarkList.of(mu, "x")));
+                  /* kwargs= */ ImmutableMap.of("a", StarlarkList.of(mu, "x"), "b", dict));
     }
     instance = instance.unsafeOptimizeMemoryLayout();
 
@@ -627,6 +632,11 @@ public final class StarlarkProviderTest {
     // verifies the fields of the frozen and optimised provider instance are immutable
     EvalException e = assertThrows(EvalException.class, () -> list.addElement("y"));
     assertThat(e).hasMessageThat().contains("trying to mutate a frozen list value");
+    assertThat((Map<?, ?>) instance.getValue("b"))
+        .containsExactly("z", "first", "a", "second")
+        .inOrder();
+    assertThat((Map<?, ?>) dict).containsExactly("z", "first", "a", "second").inOrder();
+    assertThrows(EvalException.class, () -> dict.putEntry("new", "value"));
   }
 
   @Test

--- a/src/test/java/net/starlark/java/eval/StarlarkMutableTest.java
+++ b/src/test/java/net/starlark/java/eval/StarlarkMutableTest.java
@@ -64,6 +64,7 @@ public final class StarlarkMutableTest {
             ImmutableMap.of(
                 StarlarkInt.of(1), StarlarkInt.of(2), StarlarkInt.of(3), StarlarkInt.of(4)));
     mutability.freeze();
+    ((Compactable) dict).unsafeOptimizeMemoryLayout();
 
     {
       Iterator<Map.Entry<Object, Object>> it = dict.entrySet().iterator();


### PR DESCRIPTION
Extend `StarlarkProviderTest` to verify dictionary insertion order through both the compacted provider and an existing dictionary reference, and reject mutation after compaction. Run `StarlarkMutableTest`'s dictionary-view mutation checks after `Compactable.unsafeOptimizeMemoryLayout()`.

These are the regression tests from dzbarsky/bazel#14, adapted to `master`. Provider dictionary compaction is already implemented by db3a03f22e29a170eb191229a855ff312b85639c; this PR changes only tests.

Validation: `EvalTests` and `PackagesTests` passed on Linux x86_64 with remote execution.

RELNOTES: None

-zbarskybot