### PR TITLE
[9.3.0] Add `-Djava.net.preferIPv6Addresses=system` to startup JVM args (https://github.com/bazelbuild/bazel/pull/29237)

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -448,6 +448,9 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
   // TODO: Drop this when protobuf uses VarHandle.
   result.push_back("-Dsun.misc.unsafe.memory.access=allow");
 
+  // Let the system decide whether to prefer IPv6
+  result.push_back("-Djava.net.preferIPv6Addresses=system");
+
 #if defined(_WIN32)
   // See and use more than 64 CPUs on Windows.
   // https://bugs.openjdk.org/browse/JDK-6942632

--- a/src/test/py/bazel/remote/cache_decompression_test.py
+++ b/src/test/py/bazel/remote/cache_decompression_test.py
@@ -68,17 +68,28 @@ class HTTPServerV6(HTTPServer):
   address_family = socket.AF_INET6
 
 
+class HTTPServerDualStack(HTTPServer):
+  address_family = socket.AF_INET6
+
+  def server_bind(self):
+    # Disable IPV6_V6ONLY to allow IPv4 connections
+    self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+    super().server_bind()
+
+
 class CacheDecompressionTest(test_base.TestBase):
 
   def setUp(self):
     test_base.TestBase.setUp(self)
-    server_port = self.GetFreeTCPPort()
-    if self.IsDarwin():
-      self.httpd = HTTPServerV6(
-          ('localhost', server_port), MemoryStorageHandler
-      )
+    if socket.has_dualstack_ipv6():
+      self.httpd = HTTPServerDualStack(('::', 0), MemoryStorageHandler)
+      _, server_port, _, _ = self.httpd.server_address
+    elif socket.has_ipv6:
+      self.httpd = HTTPServerV6(('::', 0), MemoryStorageHandler)
+      _, server_port, _, _ = self.httpd.server_address
     else:
       self.httpd = HTTPServer(('localhost', server_port), MemoryStorageHandler)
+      _, server_port = self.httpd.server_address
     self.httpd.storage = {}
     self.url = 'http://localhost:{}'.format(server_port)
     self.background = threading.Thread(target=self.httpd.serve_forever)
@@ -122,13 +133,6 @@ class CacheDecompressionTest(test_base.TestBase):
 
     self.AssertFileContentEqual(
         os.path.join(bazel_genfiles, 'genrule.txt'), content)
-
-  def GetFreeTCPPort(self):
-    tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    tcp.bind(('localhost', 0))
-    _, port = tcp.getsockname()
-    tcp.close()
-    return port
 
   def AssertFileContentEqual(self, file_path, entry):
     with open(file_path, 'r') as f:

--- a/src/test/shell/bazel/testing_server.py
+++ b/src/test/shell/bazel/testing_server.py
@@ -45,6 +45,15 @@ class TCPServerV6(TCPServer):
   address_family = socket.AF_INET6
 
 
+class TCPServerDualStack(TCPServer):
+  address_family = socket.AF_INET6
+
+  def server_bind(self):
+    # Disable IPV6_V6ONLY to allow IPv4 connections
+    self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+    super().server_bind()
+
+
 class Handler(BaseHTTPRequestHandler):
   """Handlers for testing HTTP server."""
   auth = False
@@ -156,8 +165,10 @@ def main(argv):
     while port is None:
       try:
         port = random.randrange(32760, 59760)
-        if sys.platform == 'darwin':
-          httpd = TCPServerV6(('', port), Handler)
+        if socket.has_dualstack_ipv6():
+          httpd = TCPServerDualStack(('::', port), Handler)
+        elif socket.has_ipv6:
+          httpd = TCPServerV6(('::', port), Handler)
         else:
           httpd = TCPServer(('', port), Handler)
       except socket.error:


### PR DESCRIPTION
See #2486 for more discussion.

### Description

Adds -Djava.net.preferIPv6Addresses=system to startup JVM args, which instructs the JVM to respect the order of IP addresses returned by `getaddrinfo()`, rather than forcing IPv4 first (default) or IPv6 first (when this JVM arg is set to `true`).

### Motivation

The goal with this change is to ship a default that has the best chance of working in either IPv4-only or IPv6-only environments. Currently Bazel fails by default in IPv6-only environments when accessing dual-stack endpoints, such as bcr.bazel.build.

The risk of this change is that the first entry in the results of `getaddrinfo()` is not accessible, and connections fail in IPv4 environments where they previously succeeded. See the description at https://bugs.openjdk.org/browse/JDK-8170568 for an overview of the components involved.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Adds `-Djava.net.preferIPv6Addresses=system` to startup JVM args which may impact certain IPv4-only environments. Override as necessary with `--host_jvm_args`.

Closes #29237.

PiperOrigin-RevId: 896359329
Change-Id: I128a49f47af359b736e4d3af65a924ca250c46be

Commit https://github.com/bazelbuild/bazel/commit/324d2c5a7bf4912cf276e14e939eda764971d156