### PR TITLE
[9.3.0] Preserve nested MODULE.bazel includes across Skyframe restarts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -493,12 +493,19 @@ public class ModuleFileFunction implements SkyFunction {
     result =
         env.getValuesAndExceptions(
             rootedPaths.stream().map(FileValue::key).collect(toImmutableSet()));
-    var newHorizon = ImmutableList.<IncludeStatement>builder();
-    for (int i = 0; i < pending.size(); i++) {
-      FileValue fileValue = (FileValue) result.get(FileValue.key(rootedPaths.get(i)));
+    // Resolve all file dependencies before compiling so a restart cannot retain a compiled file
+    // while discarding its nested includes from the next horizon.
+    var fileValues = new ArrayList<FileValue>(pending.size());
+    for (var rootedPath : rootedPaths) {
+      FileValue fileValue = (FileValue) result.get(FileValue.key(rootedPath));
       if (fileValue == null) {
         return null;
       }
+      fileValues.add(fileValue);
+    }
+    var newHorizon = ImmutableList.<IncludeStatement>builder();
+    for (int i = 0; i < pending.size(); i++) {
+      FileValue fileValue = fileValues.get(i);
       if (!fileValue.isFile()) {
         throw errorf(
             Code.BAD_MODULE,

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.FileStateValue;
+import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
@@ -402,6 +403,50 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
             "java-foo",
             SingleVersionOverride.create(
                 Version.parse("2.0"), "", ImmutableList.of(), ImmutableList.of(), 0));
+  }
+
+  @Test
+  public void testRootModule_include_nestedIncludeSurvivesRestart() throws Exception {
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa')",
+        "include('//:first.MODULE.bazel')",
+        "include('//:second.MODULE.bazel')");
+    scratch.overwriteFile(rootDirectory.getRelative("BUILD").getPathString());
+    Path first =
+        scratch.overwriteFile(
+            rootDirectory.getRelative("first.MODULE.bazel").getPathString(),
+            "include('//:nested.MODULE.bazel')");
+    scratch.overwriteFile(
+        rootDirectory.getRelative("nested.MODULE.bazel").getPathString(),
+        "bazel_dep(name='nested', version='1.0')");
+    scratch.overwriteFile(
+        rootDirectory.getRelative("second.MODULE.bazel").getPathString(),
+        "bazel_dep(name='second', version='1.0')");
+    FakeRegistry registry = registryFactory.newFakeRegistry("/foo");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+
+    // Warm only the first FileValue so its nested include is discovered before the second
+    // FileValue causes a Skyframe restart.
+    EvaluationResult<FileValue> firstFileResult =
+        evaluator.evaluate(
+            ImmutableList.of(
+                FileValue.key(RootedPath.toRootedPath(Root.fromPath(rootDirectory), first))),
+            evaluationContext);
+    assertThat(firstFileResult.hasError()).isFalse();
+
+    EvaluationResult<RootModuleFileValue> result =
+        evaluator.evaluate(
+            ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
+
+    assertThat(result.hasError()).isFalse();
+    assertThat(result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE).module().getDeps())
+        .containsExactly(
+            "nested",
+            createDepSpec("nested", "1.0", -1),
+            "second",
+            createDepSpec("second", "1.0", -1))
+        .inOrder();
   }
 
   @Test


### PR DESCRIPTION
Resolve every pending include's `FileValue` in `ModuleFileFunction.advanceHorizon` before reading or compiling included files. Previously, a missing sibling `FileValue` could trigger a Skyframe restart after caching a compiled parent but before retaining its nested includes. The regression test primes only the first parent's `FileValue` and checks that evaluation preserves the nested and sibling dependencies in order.

Validation: `//src/test/java/com/google/devtools/build/lib/bazel/bzlmod:BzlmodTests` passed on this upstream commit (282 tests) and the 9.3 release branch (286 tests), using BuildBuddy remote execution. Both runs include `testRootModule_include_nestedIncludeSurvivesRestart`.

Build API changes: None.

RELNOTES: None

-zbarskybot

Closes #30999

COPYBARA_INTEGRATE_REVIEW=https://github.com/bazelbuild/bazel/pull/30999 from dzbarsky:codex/preserve-nested-module-includes 43dcd9a059f083332347a868ee956da5bb0c3e76
PiperOrigin-RevId: 978482842
Change-Id: I6fa2d7d12354227721afb0e800946ae483a527a3

(cherry picked from commit 41062a45840232d8d7dc35ed043ce171649da601)


9.3.0 adaptation: On the release branch `InterimModule#getDeps` still returns `DepSpec` values rather than `ModuleKey`s, so the new test's expected deps use `createDepSpec(..., -1)` like the neighboring include test instead of `createModuleKey(...)`. This is the assertion that failed in the presubmit of the bot cherry-pick #31052.

Closes #31001
