### PR TITLE
Give split coverage postprocessing a distinct mnemonic

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
@@ -32,6 +32,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class SimpleSpawn implements Spawn {
   private final ActionExecutionMetadata owner;
+  @Nullable private final String mnemonic;
   private final ImmutableList<String> arguments;
   private final ImmutableMap<String, String> environment;
   private final ImmutableMap<String, String> executionInfo;
@@ -46,6 +47,7 @@ public final class SimpleSpawn implements Spawn {
 
   private SimpleSpawn(
       ActionExecutionMetadata owner,
+      @Nullable String mnemonic,
       ImmutableList<String> arguments,
       ImmutableMap<String, String> environment,
       ImmutableMap<String, String> executionInfo,
@@ -57,6 +59,7 @@ public final class SimpleSpawn implements Spawn {
       @Nullable LocalResourcesSupplier localResourcesSupplier,
       PathMapper pathMapper) {
     this.owner = Preconditions.checkNotNull(owner);
+    this.mnemonic = mnemonic;
     this.arguments = Preconditions.checkNotNull(arguments);
     this.environment = Preconditions.checkNotNull(environment);
     this.executionInfo = Preconditions.checkNotNull(executionInfo);
@@ -90,6 +93,34 @@ public final class SimpleSpawn implements Spawn {
       ResourceSet localResources) {
     this(
         owner,
+        /* mnemonic= */ null,
+        arguments,
+        environment,
+        executionInfo,
+        inputs,
+        tools,
+        outputs,
+        mandatoryOutputs,
+        localResources,
+        /* localResourcesSupplier= */ null,
+        PathMapper.NOOP);
+  }
+
+  /** Creates a spawn whose mnemonic can differ from that of its owning action. */
+  public SimpleSpawn(
+      ActionExecutionMetadata owner,
+      String mnemonic,
+      ImmutableList<String> arguments,
+      ImmutableMap<String, String> environment,
+      ImmutableMap<String, String> executionInfo,
+      SpawnInputs inputs,
+      NestedSet<? extends ActionInput> tools,
+      Collection<? extends ActionInput> outputs,
+      @Nullable Set<? extends ActionInput> mandatoryOutputs,
+      ResourceSet localResources) {
+    this(
+        owner,
+        Preconditions.checkNotNull(mnemonic),
         arguments,
         environment,
         executionInfo,
@@ -115,6 +146,7 @@ public final class SimpleSpawn implements Spawn {
       LocalResourcesSupplier localResourcesSupplier) {
     this(
         owner,
+        /* mnemonic= */ null,
         arguments,
         environment,
         executionInfo,
@@ -140,6 +172,7 @@ public final class SimpleSpawn implements Spawn {
       PathMapper pathMapper) {
     this(
         owner,
+        /* mnemonic= */ null,
         arguments,
         environment,
         executionInfo,
@@ -165,6 +198,7 @@ public final class SimpleSpawn implements Spawn {
       PathMapper pathMapper) {
     this(
         owner,
+        /* mnemonic= */ null,
         arguments,
         environment,
         executionInfo,
@@ -260,7 +294,7 @@ public final class SimpleSpawn implements Spawn {
 
   @Override
   public String getMnemonic() {
-    return owner.getMnemonic();
+    return mnemonic != null ? mnemonic : owner.getMnemonic();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -366,7 +366,8 @@ public class TestConfiguration extends Fragment {
         metadataTags = {OptionMetadataTag.EXPERIMENTAL},
         help =
             "If true, then Bazel will run coverage postprocessing for each test in a separate spawn"
-                + " with the CoveragePostProcessing mnemonic.")
+                + " with the CoveragePostProcessing mnemonic. --strategy and --modify_execution_info"
+                + " can configure this spawn independently of TestRunner.")
     public abstract boolean getSplitCoveragePostProcessing();
 
     @Option(

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -364,7 +364,9 @@ public class TestConfiguration extends Fragment {
         documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
         effectTags = {OptionEffectTag.EXECUTION},
         metadataTags = {OptionMetadataTag.EXPERIMENTAL},
-        help = "If true, then Bazel will run coverage postprocessing for test in a new spawn.")
+        help =
+            "If true, then Bazel will run coverage postprocessing for each test in a separate spawn"
+                + " with the CoveragePostProcessing mnemonic.")
     public abstract boolean getSplitCoveragePostProcessing();
 
     @Option(

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
@@ -108,6 +108,7 @@ public class TestRunnerAction extends AbstractAction
 
   private static final String GUID = "cc41f9d0-47a6-11e7-8726-eb6ce83a8cc8";
   public static final String MNEMONIC = "TestRunner";
+  public static final String COVERAGE_POST_PROCESSING_MNEMONIC = "CoveragePostProcessing";
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
@@ -543,6 +544,9 @@ public class TestRunnerAction extends AbstractAction
     fp.addBoolean(configuration.isCodeCoverageEnabled());
     fp.addBoolean(testConfiguration.getZipUndeclaredTestOutputs());
     fp.addStringMap(getExecutionInfo());
+    if (isCoverageMode() && splitCoveragePostProcessing) {
+      fp.addStringMap(getCoveragePostProcessingExecutionInfo());
+    }
     fp.addNullableString(unrunnableReason);
   }
 
@@ -984,6 +988,10 @@ public class TestRunnerAction extends AbstractAction
   @Override
   public ImmutableMap<String, String> getExecutionInfo() {
     return testProperties.getExecutionInfo();
+  }
+
+  public ImmutableMap<String, String> getCoveragePostProcessingExecutionInfo() {
+    return testProperties.getCoveragePostProcessingExecutionInfo();
   }
 
   public TestTargetExecutionSettings getExecutionSettings() {

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
@@ -65,6 +65,7 @@ public class TestTargetProperties {
   private final boolean isExternal;
   private final String language;
   private final ImmutableMap<String, String> executionInfo;
+  private final ImmutableMap<String, String> coveragePostProcessingExecutionInfo;
   private final TestConfiguration testConfiguration;
 
   /**
@@ -118,13 +119,23 @@ public class TestTargetProperties {
       // This will overwrite whatever TargetUtils put there, which might be confusing.
       executionInfo.putAll(executionRequirements.getExecutionInfo());
     }
-    ruleContext.getConfiguration().modifyExecutionInfo(executionInfo, TestRunnerAction.MNEMONIC);
-    this.executionInfo = ImmutableMap.copyOf(executionInfo);
+    // Both spawns inherit the target's requirements, but mnemonic-specific modifiers must not leak
+    // from one spawn to the other.
+    ImmutableMap<String, String> baseExecutionInfo = ImmutableMap.copyOf(executionInfo);
+    this.executionInfo =
+        ruleContext
+            .getConfiguration()
+            .modifiedExecutionInfo(baseExecutionInfo, TestRunnerAction.MNEMONIC);
+    coveragePostProcessingExecutionInfo =
+        ruleContext
+            .getConfiguration()
+            .modifiedExecutionInfo(
+                baseExecutionInfo, TestRunnerAction.COVERAGE_POST_PROCESSING_MNEMONIC);
 
     isRemotable =
-        !executionInfo.containsKey(ExecutionRequirements.LOCAL)
-            && !executionInfo.containsKey(ExecutionRequirements.NO_REMOTE)
-            && !executionInfo.containsKey(ExecutionRequirements.NO_REMOTE_EXEC);
+        !this.executionInfo.containsKey(ExecutionRequirements.LOCAL)
+            && !this.executionInfo.containsKey(ExecutionRequirements.NO_REMOTE)
+            && !this.executionInfo.containsKey(ExecutionRequirements.NO_REMOTE_EXEC);
 
     language = TargetUtils.getRuleLanguage(rule);
   }
@@ -171,6 +182,11 @@ public class TestTargetProperties {
    */
   public ImmutableMap<String, String> getExecutionInfo() {
     return executionInfo;
+  }
+
+  /** Returns execution info with modifiers applied for split coverage postprocessing only. */
+  public ImmutableMap<String, String> getCoveragePostProcessingExecutionInfo() {
+    return coveragePostProcessingExecutionInfo;
   }
 
   public String getLanguage() {

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -511,6 +511,7 @@ public class StandaloneTestStrategy extends TestStrategy {
 
     return new SimpleSpawn(
         action,
+        "CoveragePostProcessing",
         args,
         ImmutableMap.copyOf(testEnvironment),
         action.getExecutionInfo(),

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -511,10 +511,10 @@ public class StandaloneTestStrategy extends TestStrategy {
 
     return new SimpleSpawn(
         action,
-        "CoveragePostProcessing",
+        TestRunnerAction.COVERAGE_POST_PROCESSING_MNEMONIC,
         args,
         ImmutableMap.copyOf(testEnvironment),
-        action.getExecutionInfo(),
+        action.getCoveragePostProcessingExecutionInfo(),
         SpawnInputs.of(
             action.getInputs(),
             ImmutableList.<ActionInput>builderWithExpectedSize(expandedCoverageDir.size() + 1)

--- a/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
@@ -418,6 +418,38 @@ public class TestActionBuilderTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testCoverageExecutionInfoChangesActionKey(
+      @TestParameter boolean collectCoverage, @TestParameter boolean splitCoveragePostProcessing)
+      throws Exception {
+    useConfiguration(
+        "--collect_code_coverage=" + collectCoverage,
+        "--experimental_split_coverage_postprocessing=" + splitCoveragePostProcessing,
+        "--experimental_fetch_all_coverage_outputs");
+    Artifact testStatus1 = Iterables.getOnlyElement(getTestStatusArtifacts("//tests:small_test_1"));
+    TestRunnerAction action1 = (TestRunnerAction) getGeneratingAction(testStatus1);
+
+    initializeSkyframeExecutor();
+
+    useConfiguration(
+        "--collect_code_coverage=" + collectCoverage,
+        "--experimental_split_coverage_postprocessing=" + splitCoveragePostProcessing,
+        "--experimental_fetch_all_coverage_outputs",
+        "--modify_execution_info=CoveragePostProcessing=+no-remote-exec");
+    Artifact testStatus2 = Iterables.getOnlyElement(getTestStatusArtifacts("//tests:small_test_1"));
+    TestRunnerAction action2 = (TestRunnerAction) getGeneratingAction(testStatus2);
+
+    assertThat(action1.isCoverageMode()).isEqualTo(collectCoverage);
+    assertThat(action2.getExecutionInfo()).isEqualTo(action1.getExecutionInfo());
+    String key1 = action1.getKey(actionKeyContext, /* inputMetadataProvider= */ null);
+    String key2 = action2.getKey(actionKeyContext, /* inputMetadataProvider= */ null);
+    if (collectCoverage && splitCoveragePostProcessing) {
+      assertThat(key1).isNotEqualTo(key2);
+    } else {
+      assertThat(key1).isEqualTo(key2);
+    }
+  }
+
+  @Test
   public void testRunsPerTestWithSharding() throws Exception {
     useConfiguration("--runs_per_test=2");
     scratch.file(

--- a/src/test/java/com/google/devtools/build/lib/exec/StandaloneTestStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/StandaloneTestStrategyTest.java
@@ -1193,10 +1193,70 @@ public final class StandaloneTestStrategyTest extends BuildViewTestCase {
 
   @Test
   public void splitCoveragePostprocessingHasDistinctMnemonic() throws Exception {
+    List<Spawn> spawns = runTestWithSplitCoverage();
+    TestRunnerAction testRunnerAction = (TestRunnerAction) spawns.get(0).getResourceOwner();
+
+    assertThat(spawns.stream().map(Spawn::getMnemonic))
+        .containsExactly("TestRunner", "CoveragePostProcessing", "TestRunner")
+        .inOrder();
+    Spawn coverageSpawn = spawns.get(1);
+    assertThat(coverageSpawn.getResourceOwner()).isSameInstanceAs(testRunnerAction);
+    assertThat(coverageSpawn.getExecutionPlatform()).isEqualTo(testRunnerAction.getExecutionPlatform());
+    assertThat(coverageSpawn.getExecutionInfo()).isEqualTo(testRunnerAction.getExecutionInfo());
+    assertThat(coverageSpawn.getExecutionInfo()).containsKey("no-remote-exec");
+    assertThat(coverageSpawn.getOutputFiles()).containsExactly(testRunnerAction.getCoverageData());
+  }
+
+  @Test
+  public void splitCoveragePostprocessingExecutionInfoIsModifiedIndependently() throws Exception {
+    List<Spawn> spawns =
+        runTestWithSplitCoverage(
+            "--modify_execution_info=TestRunner=-no-remote-exec,TestRunner=+no-cache,"
+                + "CoveragePostProcessing=+no-sandbox");
+
+    for (Spawn testSpawn : ImmutableList.of(spawns.get(0), spawns.get(2))) {
+      assertThat(testSpawn.getMnemonic()).isEqualTo("TestRunner");
+      assertThat(testSpawn.getExecutionInfo()).doesNotContainKey("no-remote-exec");
+      assertThat(testSpawn.getExecutionInfo()).containsEntry("no-cache", "");
+      assertThat(testSpawn.getExecutionInfo()).doesNotContainKey("no-sandbox");
+    }
+    Spawn coverageSpawn = spawns.get(1);
+    assertThat(coverageSpawn.getMnemonic()).isEqualTo("CoveragePostProcessing");
+    assertThat(coverageSpawn.getExecutionInfo())
+        .containsExactly("no-remote-exec", "", "no-sandbox", "");
+  }
+
+  @Test
+  public void splitCoveragePostprocessingCanRemoveExecutionInfoWithoutAffectingTest()
+      throws Exception {
+    List<Spawn> spawns =
+        runTestWithSplitCoverage("--modify_execution_info=CoveragePostProcessing=-no-remote-exec");
+
+    assertThat(spawns.get(0).getExecutionInfo()).containsEntry("no-remote-exec", "");
+    assertThat(spawns.get(1).getExecutionInfo()).isEmpty();
+    assertThat(spawns.get(2).getExecutionInfo()).containsEntry("no-remote-exec", "");
+  }
+
+  @Test
+  public void splitCoveragePostprocessingExecutionInfoMatchesWildcardModifier() throws Exception {
+    List<Spawn> spawns = runTestWithSplitCoverage("--modify_execution_info=.*=+no-sandbox");
+
+    for (Spawn spawn : spawns) {
+      assertThat(spawn.getExecutionInfo()).containsEntry("no-remote-exec", "");
+      assertThat(spawn.getExecutionInfo()).containsEntry("no-sandbox", "");
+    }
+  }
+
+  private List<Spawn> runTestWithSplitCoverage(String... extraOptions) throws Exception {
     useConfiguration(
-        "--collect_code_coverage",
-        "--experimental_split_coverage_postprocessing",
-        "--experimental_fetch_all_coverage_outputs");
+        ImmutableList.<String>builder()
+            .add(
+                "--collect_code_coverage",
+                "--experimental_split_coverage_postprocessing",
+                "--experimental_fetch_all_coverage_outputs")
+            .add(extraOptions)
+            .build()
+            .toArray(new String[0]));
     scratch.file("standalone/coverage.sh", "mocked");
     scratch.file(
         "standalone/BUILD",
@@ -1237,15 +1297,7 @@ public final class StandaloneTestStrategyTest extends BuildViewTestCase {
             Options.getDefaults(TestSummaryOptions.class),
             outputBase));
 
-    assertThat(spawns.stream().map(Spawn::getMnemonic))
-        .containsExactly("TestRunner", "CoveragePostProcessing", "TestRunner")
-        .inOrder();
-    Spawn coverageSpawn = spawns.get(1);
-    assertThat(coverageSpawn.getResourceOwner()).isSameInstanceAs(testRunnerAction);
-    assertThat(coverageSpawn.getExecutionPlatform()).isEqualTo(testRunnerAction.getExecutionPlatform());
-    assertThat(coverageSpawn.getExecutionInfo()).isEqualTo(testRunnerAction.getExecutionInfo());
-    assertThat(coverageSpawn.getExecutionInfo()).containsKey("no-remote-exec");
-    assertThat(coverageSpawn.getOutputFiles()).containsExactly(testRunnerAction.getCoverageData());
+    return spawns;
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/exec/StandaloneTestStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/StandaloneTestStrategyTest.java
@@ -69,6 +69,7 @@ import com.google.devtools.build.lib.runtime.TestSummaryOptions;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.Spawn.Code;
+import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.FileSystem;
@@ -1188,6 +1189,63 @@ public final class StandaloneTestStrategyTest extends BuildViewTestCase {
             outputBase));
 
     verify(outputMetadataStore, atLeastOnce()).resetOutputs(any());
+  }
+
+  @Test
+  public void splitCoveragePostprocessingHasDistinctMnemonic() throws Exception {
+    useConfiguration(
+        "--collect_code_coverage",
+        "--experimental_split_coverage_postprocessing",
+        "--experimental_fetch_all_coverage_outputs");
+    scratch.file("standalone/coverage.sh", "mocked");
+    scratch.file(
+        "standalone/BUILD",
+        """
+        load('//test_defs:foo_test.bzl', 'foo_test')
+        foo_test(
+            name = "coverage",
+            srcs = ["coverage.sh"],
+            tags = ["no-remote-exec"],
+        )
+        """);
+    TestRunnerAction testRunnerAction = getTestAction("//standalone:coverage");
+    OutputMetadataStore outputMetadataStore = org.mockito.Mockito.mock(OutputMetadataStore.class);
+    when(outputMetadataStore.getTreeArtifactValue(any())).thenReturn(TreeArtifactValue.empty());
+    List<Spawn> spawns = new ArrayList<>();
+    when(spawnStrategy.exec(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              Spawn spawn = invocation.getArgument(0);
+              spawns.add(spawn);
+              if (spawn.getEnvironment().containsKey("IS_COVERAGE_SPAWN")) {
+                FileSystemUtils.touchFile(testRunnerAction.getCoverageData().getPath());
+              }
+              return ImmutableList.of(PASSED_TEST_SPAWN);
+            });
+    ActionExecutionContext context =
+        new FakeActionExecutionContext(
+            createTempOutErr(outputBase),
+            toContextRegistry(spawnStrategy, fileSystem, directories),
+            inputMetadataFor(testRunnerAction),
+            outputMetadataStore);
+
+    execute(
+        testRunnerAction,
+        context,
+        new TestedStandaloneTestStrategy(
+            Options.getDefaults(ExecutionOptions.class),
+            Options.getDefaults(TestSummaryOptions.class),
+            outputBase));
+
+    assertThat(spawns.stream().map(Spawn::getMnemonic))
+        .containsExactly("TestRunner", "CoveragePostProcessing", "TestRunner")
+        .inOrder();
+    Spawn coverageSpawn = spawns.get(1);
+    assertThat(coverageSpawn.getResourceOwner()).isSameInstanceAs(testRunnerAction);
+    assertThat(coverageSpawn.getExecutionPlatform()).isEqualTo(testRunnerAction.getExecutionPlatform());
+    assertThat(coverageSpawn.getExecutionInfo()).isEqualTo(testRunnerAction.getExecutionInfo());
+    assertThat(coverageSpawn.getExecutionInfo()).containsKey("no-remote-exec");
+    assertThat(coverageSpawn.getOutputFiles()).containsExactly(testRunnerAction.getCoverageData());
   }
 
   @Test


### PR DESCRIPTION
### Description

Give the spawn created by `--experimental_split_coverage_postprocessing` its own `CoveragePostProcessing` mnemonic. Add an explicit-mnemonic constructor to `SimpleSpawn`, preserving owner-derived mnemonics for existing callers.

Apply `--modify_execution_info` independently for `TestRunner` and `CoveragePostProcessing` during analysis. Both start from the same target execution requirements, before either mnemonic's modifiers are applied. Include the coverage execution information in the owning action's cache key when split coverage postprocessing is enabled.

Regression tests check the test / coverage postprocessing / XML-generation spawn sequence, inherited requirements without overrides, independent additions and removals, wildcard modifiers, and action-key invalidation. The flag's help text documents the mnemonic and independent configuration.

### Motivation

Split coverage postprocessing currently inherits `TestRunner` from its owning test action. This makes it indistinguishable from test execution in spawn logs and mnemonic-based configuration, even though collecting coverage can have quite different execution costs.

Users can select a strategy specifically for postprocessing, for example `--strategy=CoveragePostProcessing=local`, or modify its execution requirements with `--modify_execution_info=CoveragePostProcessing=+no-remote-exec`, without changing test execution. Similarly, `--modify_execution_info=CoveragePostProcessing=-no-remote-exec` removes an inherited requirement only from postprocessing, leaving the test's requirement intact.

The owning action, execution platform, platform `exec_properties`, timeout handling, and default resource accounting are unchanged. Execution-info modifiers do not select a different execution platform.

### Build API Changes

The mnemonic of the experimental split postprocessing spawn changes from `TestRunner` to `CoveragePostProcessing`. Existing `--strategy=TestRunner=...` and mnemonic-specific `--modify_execution_info` overrides continue to apply to test execution and XML-generation spawns, but no longer apply to split coverage postprocessing. Users who want to configure both should also match `CoveragePostProcessing`; wildcard modifiers matching both mnemonics apply independently to both. No Starlark API or command-line flag is added.

### Validation

- Verified that the independent-override and cache-key regressions fail before the execution-info fix and pass afterward.
- All 790 tests passed across these four complete suites:
  - `//src/test/java/com/google/devtools/build/lib/actions:ActionsTests`
  - `//src/test/java/com/google/devtools/build/lib/exec:ExecTests`
  - `//src/test/java/com/google/devtools/build/lib/analysis/test:TestActionBuilderTest`
  - `//src/test/java/com/google/devtools/build/lib/rules/test:TestRulesTests`
- `git diff --check`

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Coverage postprocessing spawns created by `--experimental_split_coverage_postprocessing` now use the `CoveragePostProcessing` mnemonic instead of `TestRunner`, allowing independent execution strategy selection and `--modify_execution_info` overrides.

Generated with [Codex](https://openai.com/codex/).
