### PR TITLE
Disallow aspect_hints on native alias rules (fixes #31071)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/Alias.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/Alias.java
@@ -71,6 +71,7 @@ public class Alias implements RuleConfiguredTargetFactory {
           .removeAttribute("licenses")
           .removeAttribute("distribs")
           .removeAttribute(":action_listener")
+          .removeAttribute(RuleClass.ASPECT_HINTS_ATTR)
           .add(
               attr(ACTUAL_ATTRIBUTE_NAME, LABEL)
                   .allowedFileTypes(FileTypeSet.ANY_FILE)
@@ -141,6 +142,10 @@ public class Alias implements RuleConfiguredTargetFactory {
       When defining environment groups, the aliases to <code>environment</code> rules are not
       supported. They are not supported in the <code>--target_environment</code> command line
       option, either.
+    </li>
+    <li>
+      The <code>aspect_hints</code> attribute is not supported on <code>alias</code> rules.
+      Any aspect hints should be specified on the referenced target instead.
     </li>
   </ul>
 </p>

--- a/src/test/java/com/google/devtools/build/lib/rules/AliasTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/AliasTest.java
@@ -572,4 +572,20 @@ public class AliasTest extends BuildViewTestCase {
   public void testNoActual() throws Exception {
     checkError("a", "a", "missing value for mandatory attribute 'actual'", "alias(name='a')");
   }
+
+  @Test
+  public void aspectHintsNotAllowedOnAlias() throws Exception {
+    checkError(
+        "a",
+        "b",
+        "no such attribute 'aspect_hints' in 'alias' rule",
+        """
+        alias(
+            name = "b",
+            actual = ":a",
+            aspect_hints = [":hint"],
+        )
+        """);
+  }
 }
+


### PR DESCRIPTION
### Description

Explicitly disallows the `aspect_hints` attribute on native `alias` rules by removing `RuleClass.ASPECT_HINTS_ATTR` in `Alias.AliasRule.build()`.

### Motivation

Fixes #31071.

`aspect_hints` is generally available on rule targets so that Starlark aspects can read it via `ctx.rule.attr.aspect_hints`. The native `alias` rule previously accepted the `aspect_hints` attribute because it inherited it from `BaseRuleClasses.NativeBuildRule` -> `commonCoreAndStarlarkAttributes()`.

However, aliases are transparent to aspect propagation: aspect evaluation (`AspectFunction.java:createAliasAspect`) evaluates against the underlying `actual` target directly, not the alias itself. Consequently, any `aspect_hints` set on an `alias` target were silently dropped and never visited or observed by aspects.

Accepting `aspect_hints` on an `alias` target without warning or error creates a confusing, silent failure mode where hints appear configured correctly but are completely ineffective.

This PR removes `aspect_hints` from `AliasRule` (matching how `licenses`, `distribs`, and `:action_listener` are removed) so that specifying `aspect_hints` on an alias target fails with a clear attribute error at build time.

### Build API Changes

1. **Has this been discussed in an issue?** Yes, #31071.
2. **Is the change backward compatible?** Setting `aspect_hints` on an `alias` previously had zero effect (it was completely inert and silently ignored). Disallowing it turns that silent failure into an explicit, actionable error.
3. **If breaking change, what is migration plan?** If any user specified `aspect_hints` on an `alias`, move `aspect_hints` to the underlying rule referenced by `actual`.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [x] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: Disallow the `aspect_hints` attribute on native `alias` rules (fixes #31071).
