### PR TITLE
Fix NullPointerException in SandboxStash when runfiles directory is unrecorded or missing (fixes #31086)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxStash.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxStash.java
@@ -181,18 +181,23 @@ public class SandboxStash {
           stashExecroot.renameTo(sandboxExecroot);
           stash.deleteTree();
           if (isTestAction(mnemonic)) {
-            String relativeStashedRunfilesDir = stashPathToRunfilesDir.get(stashExecroot);
-            Path stashedRunfilesDir = sandboxExecroot.getRelative(relativeStashedRunfilesDir);
+            String relativeStashedRunfilesDir = stashPathToRunfilesDir.remove(stashExecroot);
             String relativeCurrentRunfilesDir = getCurrentRunfilesDir(environment);
-            Path currentRunfiles = sandboxExecroot.getRelative(relativeCurrentRunfilesDir);
-            currentRunfiles.getParentDirectory().createDirectoryAndParents();
-            stashedRunfilesDir.renameTo(currentRunfiles);
-            stashPathToRunfilesDir.remove(stashExecroot);
-            if (useInMemoryStashes() && pathToContents.containsKey(stash)) {
-              updateStashContentsAfterRunfilesMove(
-                  relativeStashedRunfilesDir,
-                  relativeCurrentRunfilesDir,
-                  pathToContents.get(stash));
+            if (relativeStashedRunfilesDir != null
+                && relativeCurrentRunfilesDir != null
+                && !relativeStashedRunfilesDir.equals(relativeCurrentRunfilesDir)) {
+              Path stashedRunfilesDir = sandboxExecroot.getRelative(relativeStashedRunfilesDir);
+              Path currentRunfiles = sandboxExecroot.getRelative(relativeCurrentRunfilesDir);
+              if (stashedRunfilesDir.exists()) {
+                currentRunfiles.getParentDirectory().createDirectoryAndParents();
+                stashedRunfilesDir.renameTo(currentRunfiles);
+                if (useInMemoryStashes() && pathToContents.containsKey(stash)) {
+                  updateStashContentsAfterRunfilesMove(
+                      relativeStashedRunfilesDir,
+                      relativeCurrentRunfilesDir,
+                      pathToContents.get(stash));
+                }
+              }
             }
           }
           sandboxToTarget.remove(stash);
@@ -287,12 +292,16 @@ public class SandboxStash {
             SandboxHelpers.updateContentMap(stashPathExecroot, lastModified, stashContents);
             if (isTestAction(mnemonic)) {
               if (environment.get("TEST_TMPDIR") != null
-                  && environment.get("TEST_TMPDIR").startsWith("_tmp")) {
+                  && environment.get("TEST_TMPDIR").startsWith("_tmp")
+                  && environment.get("TEST_WORKSPACE") != null) {
                 treeDeleter.deleteTree(
                     stashPathExecroot.getRelative(environment.get("TEST_WORKSPACE") + "/_tmp"));
               }
-              // We do this before adding to readyStashes to avoid a race condition.
-              stashPathToRunfilesDir.put(stashPathExecroot, getCurrentRunfilesDir(environment));
+              String currentRunfilesDir = getCurrentRunfilesDir(environment);
+              if (currentRunfilesDir != null) {
+                // We do this before adding to readyStashes to avoid a race condition.
+                stashPathToRunfilesDir.put(stashPathExecroot, currentRunfilesDir);
+              }
             }
             setPathContents(stashPath, stashContents);
             if (target != null) {
@@ -328,14 +337,16 @@ public class SandboxStash {
       Path stashPathExecroot = stashPath.getChild("execroot");
       if (isTestAction(mnemonic)) {
         if (environment.get("TEST_TMPDIR") != null
-            && environment.get("TEST_TMPDIR").startsWith("_tmp")) {
+            && environment.get("TEST_TMPDIR").startsWith("_tmp")
+            && environment.get("TEST_WORKSPACE") != null) {
           treeDeleter.deleteTree(
               path.getRelative("execroot/" + environment.get("TEST_WORKSPACE") + "/_tmp"));
         }
-      }
-      if (isTestAction(mnemonic)) {
-        // We do this before the rename operation to avoid a race condition.
-        stashPathToRunfilesDir.put(stashPathExecroot, getCurrentRunfilesDir(environment));
+        String currentRunfilesDir = getCurrentRunfilesDir(environment);
+        if (currentRunfilesDir != null) {
+          // We do this before the rename operation to avoid a race condition.
+          stashPathToRunfilesDir.put(stashPathExecroot, currentRunfilesDir);
+        }
       }
       path.getChild("execroot").renameTo(stashPathExecroot);
       if (target != null) {
@@ -564,8 +575,17 @@ public class SandboxStash {
     return isTestAction(mnemonic) && outputs.files().size() == 1;
   }
 
-  private static String getCurrentRunfilesDir(Map<String, String> environment) {
-    return environment.get("TEST_WORKSPACE") + "/" + environment.get(TEST_SRCDIR);
+  @Nullable
+  private static String getCurrentRunfilesDir(@Nullable Map<String, String> environment) {
+    if (environment == null) {
+      return null;
+    }
+    String testWorkspace = environment.get("TEST_WORKSPACE");
+    String testSrcdir = environment.get(TEST_SRCDIR);
+    if (testWorkspace == null || testSrcdir == null) {
+      return null;
+    }
+    return testWorkspace + "/" + testSrcdir;
   }
 
   private ImmutableList<Path> sortStashesByMatchingTargetSegments(
@@ -594,16 +614,29 @@ public class SandboxStash {
 
   private void updateStashContentsAfterRunfilesMove(
       String stashedRunfiles, String currentRunfiles, SandboxContents stashContents) {
+    if (stashContents == null) {
+      return;
+    }
     ImmutableList<String> stashedRunfilesSegments =
         ImmutableList.copyOf(PathFragment.create(stashedRunfiles).segments());
     SandboxContents runfilesStashContents = stashContents;
     for (int i = 0; i < stashedRunfilesSegments.size() - 1; i++) {
-      runfilesStashContents =
-          Preconditions.checkNotNull(
-              runfilesStashContents.dirMap().get(stashedRunfilesSegments.get(i)));
+      if (runfilesStashContents.dirMap() == null) {
+        return;
+      }
+      runfilesStashContents = runfilesStashContents.dirMap().get(stashedRunfilesSegments.get(i));
+      if (runfilesStashContents == null) {
+        return;
+      }
     }
-    runfilesStashContents =
+    if (runfilesStashContents.dirMap() == null) {
+      return;
+    }
+    SandboxContents removedStashContents =
         runfilesStashContents.dirMap().remove(stashedRunfilesSegments.getLast());
+    if (removedStashContents == null) {
+      return;
+    }
 
     ImmutableList<String> currentRunfilesSegments =
         ImmutableList.copyOf(PathFragment.create(currentRunfiles).segments());
@@ -612,8 +645,11 @@ public class SandboxStash {
       String segment = currentRunfilesSegments.get(i);
       currentStashContents.dirMap().putIfAbsent(segment, new SandboxContents());
       currentStashContents = currentStashContents.dirMap().get(segment);
+      if (currentStashContents == null || currentStashContents.dirMap() == null) {
+        return;
+      }
     }
-    currentStashContents.dirMap().put(currentRunfilesSegments.getLast(), runfilesStashContents);
+    currentStashContents.dirMap().put(currentRunfilesSegments.getLast(), removedStashContents);
   }
 }
 

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
@@ -1279,5 +1279,97 @@ public class SandboxHelpersTest {
           null);
     }
   }
+
+  @Test
+  public void sandboxStash_testRunnerReusesStashWithoutRunfilesDirRecord() throws Exception {
+    SandboxOptions options =
+        Options.parse(
+                SandboxOptions.class,
+                "--reuse_sandbox_directories")
+            .getOptions();
+    Path sandboxBase = scratch.dir("/sandbox_stash_testrunner");
+    SandboxStash.initialize("ws", sandboxBase, options, new SynchronousTreeDeleter());
+    try {
+      Path sandbox1 = scratch.dir("/sandbox_stash_testrunner/1");
+      Path execroot1 = sandbox1.getChild("execroot");
+      execroot1.createDirectoryAndParents();
+      scratch.file(execroot1.getChild("file.txt").asFragment().getPathString(), "data");
+
+      // Stash with TestRunner mnemonic but without TEST_WORKSPACE / TEST_SRCDIR
+      SandboxStash.stashSandbox(
+          sandbox1,
+          "TestRunner",
+          ImmutableMap.of(),
+          SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
+          new SynchronousTreeDeleter(),
+          null);
+
+      Path sandbox2 = scratch.dir("/sandbox_stash_testrunner/2");
+      // takeStashedSandbox should not throw NullPointerException when runfiles dir was unrecorded
+      Optional<SandboxContents> taken =
+          SandboxStash.takeStashedSandbox(
+              sandbox2,
+              "TestRunner",
+              ImmutableMap.of("TEST_WORKSPACE", "ws", "TEST_SRCDIR", "srcdir"),
+              SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
+              null);
+
+      assertThat(taken).isNotNull();
+      assertThat(sandbox2.getChild("execroot").getChild("file.txt").exists()).isTrue();
+    } finally {
+      SandboxStash.initialize(
+          "ws",
+          sandboxBase,
+          Options.parse(SandboxOptions.class, "--noreuse_sandbox_directories").getOptions(),
+          null);
+    }
+  }
+
+  @Test
+  public void sandboxStash_testRunnerMovesRunfilesDirWhenDifferent() throws Exception {
+    SandboxOptions options =
+        Options.parse(
+                SandboxOptions.class,
+                "--reuse_sandbox_directories")
+            .getOptions();
+    Path sandboxBase = scratch.dir("/sandbox_stash_testrunner_move");
+    SandboxStash.initialize("ws", sandboxBase, options, new SynchronousTreeDeleter());
+    try {
+      Path sandbox1 = scratch.dir("/sandbox_stash_testrunner_move/1");
+      Path execroot1 = sandbox1.getChild("execroot");
+      execroot1.createDirectoryAndParents();
+      Path oldRunfiles = execroot1.getRelative("ws/old_srcdir");
+      oldRunfiles.createDirectoryAndParents();
+      scratch.file(oldRunfiles.getChild("runfile.txt").asFragment().getPathString(), "test_input");
+
+      SandboxStash.stashSandbox(
+          sandbox1,
+          "TestRunner",
+          ImmutableMap.of("TEST_WORKSPACE", "ws", "TEST_SRCDIR", "old_srcdir"),
+          SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
+          new SynchronousTreeDeleter(),
+          null);
+
+      Path sandbox2 = scratch.dir("/sandbox_stash_testrunner_move/2");
+      Optional<SandboxContents> taken =
+          SandboxStash.takeStashedSandbox(
+              sandbox2,
+              "TestRunner",
+              ImmutableMap.of("TEST_WORKSPACE", "ws", "TEST_SRCDIR", "new_srcdir"),
+              SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
+              null);
+
+      assertThat(taken).isNotNull();
+      Path newRunfiles = sandbox2.getChild("execroot").getRelative("ws/new_srcdir");
+      assertThat(newRunfiles.getChild("runfile.txt").exists()).isTrue();
+      assertThat(sandbox2.getChild("execroot").getRelative("ws/old_srcdir").exists()).isFalse();
+    } finally {
+      SandboxStash.initialize(
+          "ws",
+          sandboxBase,
+          Options.parse(SandboxOptions.class, "--noreuse_sandbox_directories").getOptions(),
+          null);
+    }
+  }
 }
 


### PR DESCRIPTION
### Description
When `--reuse_sandbox_directories` is enabled, `SandboxStash.takeStashedSandboxInternal` attempts to rename the stashed test runfiles directory to the current test runfiles directory. If the stash was created without a recorded runfiles directory (e.g. across server restarts, or when test environment variables were unrecorded or missing), `stashPathToRunfilesDir.get(stashExecroot)` returns `null`. Calling `sandboxExecroot.getRelative(relativeStashedRunfilesDir)` then triggers a `NullPointerException`, crashing the Bazel server during action execution.

This change fixes the regression by:
1. Safely guarding `relativeStashedRunfilesDir` and `relativeCurrentRunfilesDir` against `null` in `takeStashedSandboxInternal`, skipping the directory rename optimization if either is unrecorded or null.
2. Skipping renaming if `relativeStashedRunfilesDir.equals(relativeCurrentRunfilesDir)` or if `stashedRunfilesDir.exists()` is false.
3. Adding null-safety checks in `getCurrentRunfilesDir` when `environment`, `TEST_WORKSPACE`, or `TEST_SRCDIR` is null.
4. Adding null checks in `updateStashContentsAfterRunfilesMove` to guard in-memory stash directory traversal.
5. Adding regression tests in `SandboxHelpersTest`.

### Motivation
Fixes #31086

### Build API Changes
No

### Checklist
- [x] I have added tests for the new use cases.
- [ ] I have updated the documentation (if applicable).

### Release Notes
RELNOTES: Fixed a NullPointerException in SandboxStash when reusing test sandboxes with unrecorded runfiles directories.
