### PR TITLE
Add error on passing aspect_hints to native.alias

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/Alias.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/Alias.java
@@ -52,6 +52,14 @@ public class Alias implements RuleConfiguredTargetFactory {
               + "https://github.com/bazelbuild/bazel/issues/8622 for details.");
     }
 
+    if (!ruleContext.attributes().get("aspect_hints", BuildType.LABEL_LIST).isEmpty()) {
+      throw ruleContext.throwWithAttributeError(
+          "aspect_hints",
+          "aspect_hints cannot be set on an alias: aspects propagate straight through an alias "
+              + "to its 'actual' target, so the alias is never visited and its aspect_hints "
+              + "would be silently ignored. Set aspect_hints on the 'actual' target instead.");
+    }
+
     return AliasConfiguredTarget.create(ruleContext, actual, ruleContext.getVisibility());
   }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/AliasTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/AliasTest.java
@@ -425,6 +425,27 @@ public class AliasTest extends BuildViewTestCase {
   }
 
   @Test
+  public void assertNoAspectHints() throws Exception {
+    scratch.file(
+        "a/BUILD",
+        """
+        filegroup(name = "hint")
+
+        filegroup(name = "a")
+
+        alias(
+            name = "b",
+            actual = ":a",
+            aspect_hints = [":hint"],
+        )
+        """);
+
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//a:b");
+    assertContainsEvent("aspect_hints cannot be set on an alias");
+  }
+
+  @Test
   public void passesTargetTypeCheck() throws Exception {
     scratch.file(
         "a/BUILD",


### PR DESCRIPTION
### Description

Adds an explicit error when the aspect_hints argument is passed to native.alias.

### Motivation

Fixes #31071.

### Build API Changes

Yes, it adds explicit error for a previously non-functional argument.

### Checklist

- [X] I have added tests for the new use cases (if any).

### Release Notes

Add an explicit error when the aspect_hints argument is passed to native alias rules.
