### PR TITLE
Do not drop another thread's sandbox stash bookkeeping on a lost race

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxStash.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxStash.java
@@ -181,18 +181,22 @@ public class SandboxStash {
           stashExecroot.renameTo(sandboxExecroot);
           stash.deleteTree();
           if (isTestAction(mnemonic)) {
-            String relativeStashedRunfilesDir = stashPathToRunfilesDir.get(stashExecroot);
-            Path stashedRunfilesDir = sandboxExecroot.getRelative(relativeStashedRunfilesDir);
-            String relativeCurrentRunfilesDir = getCurrentRunfilesDir(environment);
-            Path currentRunfiles = sandboxExecroot.getRelative(relativeCurrentRunfilesDir);
-            currentRunfiles.getParentDirectory().createDirectoryAndParents();
-            stashedRunfilesDir.renameTo(currentRunfiles);
-            stashPathToRunfilesDir.remove(stashExecroot);
-            if (useInMemoryStashes() && pathToContents.containsKey(stash)) {
-              updateStashContentsAfterRunfilesMove(
-                  relativeStashedRunfilesDir,
-                  relativeCurrentRunfilesDir,
-                  pathToContents.get(stash));
+            String relativeStashedRunfilesDir = stashPathToRunfilesDir.remove(stashExecroot);
+            // The location of the stashed runfiles directory may be unknown, e.g. if the stash was
+            // created with --experimental_inmemory_sandbox_stashes but is taken without it. Leave
+            // it in place in that case: it is cleaned up like any other stale sandbox content.
+            if (relativeStashedRunfilesDir != null) {
+              Path stashedRunfilesDir = sandboxExecroot.getRelative(relativeStashedRunfilesDir);
+              String relativeCurrentRunfilesDir = getCurrentRunfilesDir(environment);
+              Path currentRunfiles = sandboxExecroot.getRelative(relativeCurrentRunfilesDir);
+              currentRunfiles.getParentDirectory().createDirectoryAndParents();
+              stashedRunfilesDir.renameTo(currentRunfiles);
+              if (useInMemoryStashes() && pathToContents.containsKey(stash)) {
+                updateStashContentsAfterRunfilesMove(
+                    relativeStashedRunfilesDir,
+                    relativeCurrentRunfilesDir,
+                    pathToContents.get(stash));
+              }
             }
           }
           sandboxToTarget.remove(stash);
@@ -202,14 +206,16 @@ public class SandboxStash {
           return useInMemoryStashes() && pathToContents.containsKey(stash)
               ? Optional.of(pathToContents.remove(stash))
               : Optional.empty();
-        } catch (IOException e) {
-          sandboxToTarget.remove(stash);
-          pathToContents.remove(stash);
-          stashPathToRunfilesDir.remove(stash.getChild("execroot"));
-          if (e instanceof FileNotFoundException) {
-            // Try the next one, somebody else took this one.
-            continue;
+        } catch (FileNotFoundException e) {
+          if (useInMemoryStashes()) {
+            // We held the only claim on this stash, so nobody else will ever use its bookkeeping.
+            forgetStash(stash);
           }
+          // Otherwise, somebody else took this stash (or it is still being created) and its
+          // bookkeeping now belongs to them: in particular, they still have to look up the
+          // location of its runfiles directory. Try the next one.
+        } catch (IOException e) {
+          forgetStash(stash);
           turnOffReuse("Error renaming sandbox stash %s to %s: %s\n", stash, sandboxPath, e);
           return null;
         }
@@ -219,6 +225,13 @@ public class SandboxStash {
       turnOffReuse("Failed to prepare for reusing stashed sandbox for %s: %s", sandboxPath, e);
       return null;
     }
+  }
+
+  /** Drops all in-memory bookkeeping for a stash that can no longer be reused. */
+  private void forgetStash(Path stash) {
+    sandboxToTarget.remove(stash);
+    pathToContents.remove(stash);
+    stashPathToRunfilesDir.remove(stash.getChild("execroot"));
   }
 
   /** Atomically moves the sandboxPath directory aside for later reuse. */
@@ -493,6 +506,11 @@ public class SandboxStash {
   @VisibleForTesting
   static SandboxStash getInstanceForTesting() {
     return instance;
+  }
+
+  @VisibleForTesting
+  Map<Path, String> getStashPathToRunfilesDirForTesting() {
+    return stashPathToRunfilesDir;
   }
 
   @VisibleForTesting

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
@@ -1146,6 +1146,128 @@ public class SandboxHelpersTest {
   }
 
   @Test
+  public void sandboxStash_losingRaceForStashKeepsWinnersRunfilesMapping() throws Exception {
+    // Regression test for https://github.com/bazelbuild/bazel/issues/31086: without in-memory
+    // stashes, concurrent test actions compete for stashes by renaming them. The loser must not
+    // drop the bookkeeping that the winner still needs to relocate the stashed runfiles directory.
+    SandboxOptions options =
+        Options.parse(SandboxOptions.class, "--reuse_sandbox_directories").getOptions();
+    Path sandboxBase = scratch.dir("/sandbox_stash_runfiles_race");
+    Path sandbox1 = scratch.dir("/sandbox_stash_runfiles_race/1");
+    String firstRunfiles = "bazel-out/bin/pkg/first_test.runfiles";
+    String secondRunfiles = "bazel-out/bin/pkg/second_test.runfiles";
+    scratch.file(
+        "/sandbox_stash_runfiles_race/1/execroot/ws/" + firstRunfiles + "/ws/pkg/first_test",
+        "content");
+    ImmutableMap<String, String> firstEnv =
+        ImmutableMap.of(
+            "TEST_WORKSPACE", "ws", "TEST_SRCDIR", firstRunfiles, "TEST_TMPDIR", "/tmp");
+    ImmutableMap<String, String> secondEnv =
+        ImmutableMap.of(
+            "TEST_WORKSPACE", "ws", "TEST_SRCDIR", secondRunfiles, "TEST_TMPDIR", "/tmp");
+    // Two outputs so that this is not mistaken for a test XML generation spawn.
+    SandboxOutputs testOutputs =
+        SandboxOutputs.create(
+            ImmutableSet.of(PathFragment.create("test.log"), PathFragment.create("test.xml")),
+            ImmutableSet.of());
+
+    SandboxStash.initialize("ws", sandboxBase, options, new SynchronousTreeDeleter());
+    try {
+      SandboxStash stash = SandboxStash.getInstanceForTesting();
+      assertThat(stash).isNotNull();
+
+      SandboxStash.stashSandbox(
+          sandbox1, "TestRunner", firstEnv, testOutputs, new SynchronousTreeDeleter(), null);
+
+      Path stashDir = sandboxBase.getChild(SandboxStash.SANDBOX_STASH_BASE).getChild("TestRunner");
+      Path stashedSandbox = Iterables.getOnlyElement(stashDir.getDirectoryEntries());
+      Path stashedExecroot = stashedSandbox.getChild("execroot");
+      assertThat(stash.getStashPathToRunfilesDirForTesting())
+          .containsEntry(stashedExecroot, "ws/" + firstRunfiles);
+
+      // Simulate another thread having just moved the stashed execroot into its own sandbox, but
+      // not yet having looked up where the runfiles directory is located within it.
+      Path movedExecroot = sandboxBase.getChild("moved_execroot");
+      stashedExecroot.renameTo(movedExecroot);
+
+      Path sandbox2 = scratch.dir("/sandbox_stash_runfiles_race/2");
+      assertThat(
+              SandboxStash.takeStashedSandbox(sandbox2, "TestRunner", secondEnv, testOutputs, null))
+          .isNull();
+      assertThat(stash.getStashPathToRunfilesDirForTesting())
+          .containsEntry(stashedExecroot, "ws/" + firstRunfiles);
+
+      // The other thread must still be able to relocate the runfiles directory of its stash.
+      movedExecroot.renameTo(stashedExecroot);
+      Path sandbox3 = scratch.dir("/sandbox_stash_runfiles_race/3");
+      Optional<SandboxContents> taken =
+          SandboxStash.takeStashedSandbox(sandbox3, "TestRunner", secondEnv, testOutputs, null);
+      assertThat(taken).isNotNull();
+      assertThat(taken).isEmpty();
+      assertThat(
+              sandbox3.getRelative("execroot/ws/" + secondRunfiles + "/ws/pkg/first_test").exists())
+          .isTrue();
+      assertThat(sandbox3.getRelative("execroot/ws/" + firstRunfiles).exists()).isFalse();
+      assertThat(stash.getStashPathToRunfilesDirForTesting()).doesNotContainKey(stashedExecroot);
+    } finally {
+      SandboxStash.initialize(
+          "ws",
+          sandboxBase,
+          Options.parse(SandboxOptions.class, "--noreuse_sandbox_directories").getOptions(),
+          null);
+    }
+  }
+
+  @Test
+  public void sandboxStash_stashWithUnknownRunfilesDirIsReusedWithoutRelocation() throws Exception {
+    SandboxOptions options =
+        Options.parse(SandboxOptions.class, "--reuse_sandbox_directories").getOptions();
+    Path sandboxBase = scratch.dir("/sandbox_stash_unknown_runfiles");
+    String firstRunfiles = "bazel-out/bin/pkg/first_test.runfiles";
+    String secondRunfiles = "bazel-out/bin/pkg/second_test.runfiles";
+    ImmutableMap<String, String> secondEnv =
+        ImmutableMap.of(
+            "TEST_WORKSPACE", "ws", "TEST_SRCDIR", secondRunfiles, "TEST_TMPDIR", "/tmp");
+    SandboxOutputs testOutputs =
+        SandboxOutputs.create(
+            ImmutableSet.of(PathFragment.create("test.log"), PathFragment.create("test.xml")),
+            ImmutableSet.of());
+
+    SandboxStash.initialize("ws", sandboxBase, options, new SynchronousTreeDeleter());
+    try {
+      // The first access clears out any existing stashes, so trigger it before creating one.
+      Path sandbox1 = scratch.dir("/sandbox_stash_unknown_runfiles/1");
+      assertThat(
+              SandboxStash.takeStashedSandbox(sandbox1, "TestRunner", secondEnv, testOutputs, null))
+          .isNull();
+
+      // A stash whose runfiles directory is not tracked, e.g. because it was created while
+      // --experimental_inmemory_sandbox_stashes was enabled.
+      Path stashDir = sandboxBase.getChild(SandboxStash.SANDBOX_STASH_BASE).getChild("TestRunner");
+      Path stashedRunfile =
+          stashDir.getRelative("1/execroot/ws/" + firstRunfiles + "/ws/pkg/first_test");
+      scratch.file(stashedRunfile.getPathString(), "content");
+
+      Path sandbox2 = scratch.dir("/sandbox_stash_unknown_runfiles/2");
+      Optional<SandboxContents> taken =
+          SandboxStash.takeStashedSandbox(sandbox2, "TestRunner", secondEnv, testOutputs, null);
+      assertThat(taken).isNotNull();
+      assertThat(taken).isEmpty();
+      // The runfiles directory is left in place and will be cleaned up as stale content.
+      assertThat(
+              sandbox2.getRelative("execroot/ws/" + firstRunfiles + "/ws/pkg/first_test").exists())
+          .isTrue();
+      assertThat(sandbox2.getRelative("execroot/ws/" + secondRunfiles).exists()).isFalse();
+    } finally {
+      SandboxStash.initialize(
+          "ws",
+          sandboxBase,
+          Options.parse(SandboxOptions.class, "--noreuse_sandbox_directories").getOptions(),
+          null);
+    }
+  }
+
+  @Test
   public void sandboxStash_directoryCachingAvoidsRepeatedSyscalls() throws Exception {
     SandboxOptions options =
         Options.parse(


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description

Without `--experimental_inmemory_sandbox_stashes`, concurrent actions compete for a stashed sandbox by renaming its execroot. Since 27b17a54, the thread that loses this race (or that lists a stash still being created) removed the stash from `stashPathToRunfilesDir` and the other bookkeeping maps. For test actions, the winning thread then failed to look up where the stashed runfiles directory lives and crashed the server with a `NullPointerException` in
`SandboxStash.takeStashedSandboxInternal`.

Only drop the bookkeeping on `FileNotFoundException` when in-memory stashes are enabled, in which case the current thread holds the only claim on the stash. Also tolerate a stash whose runfiles location is unknown (e.g. one created while in-memory stashes were enabled) by leaving its runfiles directory in place, where it is cleaned up like any other stale sandbox content, instead of crashing.

### Motivation
Fixes https://github.com/bazelbuild/bazel/issues/31086

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
