### PR TITLE
Make the repo fetching worker environment block only on unavailable deps

### DIFF
--- a/src/main/java/com/google/devtools/build/skyframe/WorkerSkyFunctionEnvironment.java
+++ b/src/main/java/com/google/devtools/build/skyframe/WorkerSkyFunctionEnvironment.java
@@ -40,6 +40,21 @@ class WorkerSkyFunctionEnvironment
   private SkyFunction.Environment delegate;
   private final InterruptibleSupplier<SkyFunction.Environment> newDelegateSupplier;
 
+  /**
+   * Accepts every value and exception so that {@link SkyframeLookupResult#queryDep} returns {@code
+   * false} only if the dep is not available in the delegate.
+   */
+  private static final QueryDepCallback AVAILABILITY_PROBE =
+      new QueryDepCallback() {
+        @Override
+        public void acceptValue(SkyKey key, SkyValue value) {}
+
+        @Override
+        public boolean tryHandleException(SkyKey key, Exception exception) {
+          return true;
+        }
+      };
+
   WorkerSkyFunctionEnvironment(
       SkyFunction.Environment initialDelegate,
       InterruptibleSupplier<SkyFunction.Environment> newDelegateSupplier) {
@@ -55,19 +70,45 @@ class WorkerSkyFunctionEnvironment
   @Override
   public SkyframeLookupResult getValuesAndExceptions(Iterable<? extends SkyKey> depKeys)
       throws InterruptedException {
-    delegate.getValuesAndExceptions(depKeys);
-    if (!delegate.valuesMissing()) {
-      // Do NOT just return the return value of `delegate.getValuesAndExceptions` here! That would
-      // cause anyone holding onto the returned result object to potentially use a stale version
-      // of it after a skyfunction restart.
-      return this;
+    // The keys are iterated more than once below.
+    ImmutableList<? extends SkyKey> keys = ImmutableList.copyOf(depKeys);
+    delegate.getValuesAndExceptions(keys);
+    while (anyUnavailable(keys)) {
+      refreshDelegate();
+      delegate.getValuesAndExceptions(keys);
     }
+    // Do NOT just return the return value of `delegate.getValuesAndExceptions` here! That would
+    // cause anyone holding onto the returned result object to potentially use a stale version
+    // of it after a skyfunction restart.
+    return this;
+  }
+
+  /**
+   * Returns whether any of the given keys, which must already have been requested from the current
+   * delegate, is not available in it.
+   *
+   * <p>This deliberately does not consult {@link SkyFunction.Environment#valuesMissing}: that flag
+   * is sticky for the lifetime of the delegate and is also set by earlier lookups of unrelated deps
+   * that were missing or in error and by {@link #dependOnFuture}. Using it would trigger a Skyframe
+   * restart for a lookup whose values are all present and, in the case of a registered future,
+   * block this thread until that future completes.
+   */
+  private boolean anyUnavailable(Iterable<? extends SkyKey> depKeys) {
+    SkyframeLookupResult result = delegate.getLookupHandleForPreviouslyRequestedDeps();
+    for (SkyKey depKey : depKeys) {
+      if (!result.queryDep(depKey, AVAILABILITY_PROBE)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Blocks until the host SkyFunction has restarted and hands over a fresh delegate. */
+  private void refreshDelegate() throws InterruptedException {
     // We null out `delegate` before blocking for the fresh env so that the old one becomes
     // eligible for GC.
     delegate = null;
     delegate = newDelegateSupplier.get();
-    delegate.getValuesAndExceptions(depKeys);
-    return this;
   }
 
   @Nullable
@@ -117,14 +158,11 @@ class WorkerSkyFunctionEnvironment
           SkyKey depKey, Class<E1> e1, Class<E2> e2, Class<E3> e3, Class<E4> e4)
           throws E1, E2, E3, E4, InterruptedException {
     SkyValue value = delegate.getValueOrThrow(depKey, e1, e2, e3, e4);
-    if (value != null) {
-      return value;
+    while (value == null && anyUnavailable(ImmutableList.of(depKey))) {
+      refreshDelegate();
+      value = delegate.getValueOrThrow(depKey, e1, e2, e3, e4);
     }
-    // We null out `delegate` before blocking for the fresh env so that the old one becomes
-    // eligible for GC.
-    delegate = null;
-    delegate = newDelegateSupplier.get();
-    return delegate.getValueOrThrow(depKey, e1, e2, e3, e4);
+    return value;
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/skyframe/BUILD
@@ -70,6 +70,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/events:event_bus_event_handler",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/testutils:round-tripping",
+        "//src/main/java/com/google/devtools/build/lib/supplier",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/skyframe",
         "//src/main/java/com/google/devtools/build/skyframe:cpu_heavy_skykey",

--- a/src/test/java/com/google/devtools/build/skyframe/WorkerSkyFunctionEnvironmentTest.java
+++ b/src/test/java/com/google/devtools/build/skyframe/WorkerSkyFunctionEnvironmentTest.java
@@ -1,0 +1,206 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.skyframe;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.supplier.InterruptibleSupplier;
+import com.google.devtools.build.skyframe.GraphTester.StringValue;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link WorkerSkyFunctionEnvironment}. */
+@RunWith(JUnit4.class)
+public final class WorkerSkyFunctionEnvironmentTest {
+  private static final SkyKey KEY_A = GraphTester.skyKey("a");
+  private static final SkyKey KEY_B = GraphTester.skyKey("b");
+  private static final StringValue VALUE_A = new StringValue("a");
+  private static final StringValue VALUE_B = new StringValue("b");
+
+  private final AtomicInteger freshEnvRequests = new AtomicInteger();
+
+  /**
+   * A delegate that serves values, exceptions or missing deps from a fixed map, with the same
+   * sticky {@link #valuesMissing} semantics as the real environment.
+   */
+  private static final class FakeEnvironment extends AbstractSkyFunctionEnvironmentForTesting {
+    private final ImmutableMap<SkyKey, ValueOrUntypedException> deps;
+
+    FakeEnvironment(ImmutableMap<SkyKey, ValueOrUntypedException> deps) {
+      this.deps = deps;
+    }
+
+    private ValueOrUntypedException lookup(SkyKey key) {
+      return deps.getOrDefault(key, ValueOrUntypedException.ofNull());
+    }
+
+    @Override
+    protected ImmutableMap<SkyKey, ValueOrUntypedException> getValueOrUntypedExceptions(
+        Iterable<? extends SkyKey> depKeys) {
+      ImmutableMap.Builder<SkyKey, ValueOrUntypedException> result = ImmutableMap.builder();
+      for (SkyKey key : depKeys) {
+        ValueOrUntypedException voe = lookup(key);
+        if (voe.getValue() == null && voe.getException() == null) {
+          valuesMissing = true;
+        }
+        result.put(key, voe);
+      }
+      return result.buildKeepingLast();
+    }
+
+    @Override
+    public SkyframeLookupResult getLookupHandleForPreviouslyRequestedDeps() {
+      return new SimpleSkyframeLookupResult(() -> valuesMissing = true, this::lookup);
+    }
+
+    @Override
+    public void dependOnFuture(ListenableFuture<?> future) {
+      if (externalDeps == null) {
+        externalDeps = new ArrayList<>();
+      }
+      externalDeps.add(future);
+    }
+
+    @Override
+    public ExtendedEventHandler getListener() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private WorkerSkyFunctionEnvironment createWorkerEnv(
+      FakeEnvironment initial, FakeEnvironment... fresh) {
+    Iterator<FakeEnvironment> freshEnvs = ImmutableList.copyOf(fresh).iterator();
+    InterruptibleSupplier<SkyFunction.Environment> supplier =
+        () -> {
+          freshEnvRequests.incrementAndGet();
+          assertThat(freshEnvs.hasNext()).isTrue();
+          return freshEnvs.next();
+        };
+    return new WorkerSkyFunctionEnvironment(initial, supplier);
+  }
+
+  @Test
+  public void missingDep_blocksForFreshEnvironmentAndRetries() throws Exception {
+    FakeEnvironment initial = new FakeEnvironment(ImmutableMap.of());
+    FakeEnvironment fresh =
+        new FakeEnvironment(
+            ImmutableMap.of(KEY_A, ValueOrUntypedException.ofValueUntyped(VALUE_A)));
+    WorkerSkyFunctionEnvironment workerEnv = createWorkerEnv(initial, fresh);
+
+    assertThat(workerEnv.getValue(KEY_A)).isEqualTo(VALUE_A);
+    assertThat(freshEnvRequests.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void earlierUnhandledError_doesNotForceFreshEnvironmentForAvailableDep()
+      throws Exception {
+    FakeEnvironment env =
+        new FakeEnvironment(
+            ImmutableMap.of(
+                KEY_A, ValueOrUntypedException.ofExn(new SomeErrorException("a")),
+                KEY_B, ValueOrUntypedException.ofValueUntyped(VALUE_B)));
+    WorkerSkyFunctionEnvironment workerEnv = createWorkerEnv(env);
+
+    // The dep is in error, but not with a handled exception type, so the lookup yields null and the
+    // delegate's valuesMissing flag becomes sticky.
+    assertThat(workerEnv.getValueOrThrow(KEY_A, IOException.class)).isNull();
+    assertThat(env.valuesMissing()).isTrue();
+
+    assertThat(workerEnv.getValue(KEY_B)).isEqualTo(VALUE_B);
+    assertThat(
+            workerEnv.getValueOrThrow(
+                KEY_B,
+                IOException.class,
+                java.util.concurrent.TimeoutException.class,
+                ReflectiveOperationException.class,
+                CloneNotSupportedException.class))
+        .isEqualTo(VALUE_B);
+    assertThat(freshEnvRequests.get()).isEqualTo(0);
+  }
+
+  @Test
+  public void unhandledError_returnsNullWithoutFreshEnvironment() throws Exception {
+    FakeEnvironment env =
+        new FakeEnvironment(
+            ImmutableMap.of(KEY_A, ValueOrUntypedException.ofExn(new SomeErrorException("a"))));
+    WorkerSkyFunctionEnvironment workerEnv = createWorkerEnv(env);
+
+    assertThat(workerEnv.getValueOrThrow(KEY_A, IOException.class)).isNull();
+    assertThat(
+            workerEnv.getValueOrThrow(
+                KEY_A,
+                IOException.class,
+                java.util.concurrent.TimeoutException.class,
+                ReflectiveOperationException.class,
+                CloneNotSupportedException.class))
+        .isNull();
+    assertThat(freshEnvRequests.get()).isEqualTo(0);
+  }
+
+  @Test
+  public void handledError_isThrownWithoutFreshEnvironment() {
+    FakeEnvironment env =
+        new FakeEnvironment(
+            ImmutableMap.of(KEY_A, ValueOrUntypedException.ofExn(new SomeErrorException("a"))));
+    WorkerSkyFunctionEnvironment workerEnv = createWorkerEnv(env);
+
+    assertThrows(
+        SomeErrorException.class, () -> workerEnv.getValueOrThrow(KEY_A, SomeErrorException.class));
+    assertThat(freshEnvRequests.get()).isEqualTo(0);
+  }
+
+  @Test
+  public void registeredFuture_doesNotForceFreshEnvironmentForAvailableDep() throws Exception {
+    FakeEnvironment env =
+        new FakeEnvironment(
+            ImmutableMap.of(KEY_B, ValueOrUntypedException.ofValueUntyped(VALUE_B)));
+    WorkerSkyFunctionEnvironment workerEnv = createWorkerEnv(env);
+
+    workerEnv.dependOnFuture(SettableFuture.create());
+    assertThat(env.valuesMissing()).isTrue();
+
+    assertThat(workerEnv.getValue(KEY_B)).isEqualTo(VALUE_B);
+    assertThat(freshEnvRequests.get()).isEqualTo(0);
+  }
+
+  @Test
+  public void batchLookup_blocksOnlyIfSomeDepIsMissing() throws Exception {
+    FakeEnvironment initial =
+        new FakeEnvironment(
+            ImmutableMap.of(KEY_A, ValueOrUntypedException.ofValueUntyped(VALUE_A)));
+    FakeEnvironment fresh =
+        new FakeEnvironment(
+            ImmutableMap.of(
+                KEY_A, ValueOrUntypedException.ofValueUntyped(VALUE_A),
+                KEY_B, ValueOrUntypedException.ofValueUntyped(VALUE_B)));
+    WorkerSkyFunctionEnvironment workerEnv = createWorkerEnv(initial, fresh);
+
+    SkyframeLookupResult result = workerEnv.getValuesAndExceptions(ImmutableList.of(KEY_A, KEY_B));
+
+    assertThat(freshEnvRequests.get()).isEqualTo(1);
+    assertThat(result.get(KEY_A)).isEqualTo(VALUE_A);
+    assertThat(result.get(KEY_B)).isEqualTo(VALUE_B);
+  }
+}


### PR DESCRIPTION
### Description

`WorkerSkyFunctionEnvironment` decided whether to block for a fresh host environment based on `delegate.valuesMissing()`. That flag is sticky for the lifetime of the delegate: it stays set after an earlier lookup of an unrelated dep that was missing or in error, and it is also set by `dependOnFuture`. As a result, a lookup whose values were all present could trigger a Skyframe restart of the host function, and after registering a future the worker thread was blocked until that future completed even though the dep it asked for was available.

This change probes the availability of exactly the keys that were just requested via the delegate's lookup handle and only waits for a fresh environment while one of them is unavailable. As a side effect, a dep in error with an exception type the caller does not handle now yields `null` right away, as documented on the class, instead of after one spurious restart.

### Motivation

Found while reviewing the core Skyframe package for concurrency and incrementality issues. The affected users are repo rules and module extensions, which run on worker threads.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
