### PR TITLE
Handle injected values for dirty nodes that had deps

### DIFF
--- a/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.skyframe.Differencer.DiffWithDelta.Delta;
 import com.google.devtools.build.skyframe.InvalidatingNodeVisitor.DeletingInvalidationState;
 import com.google.devtools.build.skyframe.InvalidatingNodeVisitor.DirtyingInvalidationState;
 import com.google.devtools.build.skyframe.InvalidatingNodeVisitor.InvalidationState;
+import com.google.devtools.build.skyframe.NodeEntry.LifecycleState;
 import com.google.devtools.build.skyframe.SkyframeGraphStatsEvent.EvaluationStats;
 import com.google.errorprone.annotations.ForOverride;
 import java.io.PrintStream;
@@ -496,8 +497,21 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
           // be injected.
           getInMemoryGraph().remove(key);
         }
+      } else if (prevEntry != null && keepEdges && hadDepsLastBuild(prevEntry)) {
+        // The node was dirtied by an earlier invalidation but has not been re-evaluated since, so
+        // it still holds the deps of its last build. Injecting a value would require the same
+        // reverse dep bookkeeping as for a done node with deps, so handle it the same way: just
+        // invalidate it and let it be evaluated freshly.
+        valuesToDirty.add(key);
+        it.remove();
       }
     }
+  }
+
+  /** Returns whether the given not-done entry had at least one dep the last time it was built. */
+  private static boolean hadDepsLastBuild(InMemoryNodeEntry entry) {
+    return entry.getLifecycleState() != LifecycleState.NOT_YET_EVALUATING
+        && !entry.noDepsLastBuild();
   }
 
   /** Injects values in {@code valuesToInject} into the graph. */

--- a/src/test/java/com/google/devtools/build/lib/skyframe/LocalDiffAwarenessIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/LocalDiffAwarenessIntegrationTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.skyframe;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.google.common.truth.TruthJUnit.assume;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
@@ -267,6 +268,71 @@ public class LocalDiffAwarenessIntegrationTest extends SkyframeIntegrationTestBa
     // It is important that the error message says "do not exist", not "are in error". The latter
     // would indicate that the corresponding FileStateValue still considers the file to exist.
     assertThat(e).hasMessageThat().contains("1 input file(s) do not exist");
+  }
+
+  @Test
+  public void fileWithTransientErrorIsFixedAndModifiedAfterUnrelatedBuild() throws Exception {
+    // Builds garbage collect dirty nodes that they did not need by default, which would remove the
+    // dirty file state node this test is about. Commands that do not run BuildTool, such as query,
+    // never do so, and this option disables it for builds, too.
+    addOptions("--version_window_for_dirty_node_gc=-1");
+    write(
+        "sub/BUILD",
+        """
+        genrule(
+            name = "copy",
+            srcs = ["inner/f.txt"],
+            outs = ["copy.out"],
+            cmd = "cp $< $@",
+            tags = ["manual"],
+        )
+
+        genrule(
+            name = "other",
+            outs = ["other.out"],
+            cmd = "echo other > $@",
+        )
+        """);
+    Path file = write("sub/inner/f.txt", "v1");
+    Path inner = file.getParentDirectory();
+
+    // Populates the directory listing of sub/inner, which the diff processing below consults.
+    buildTarget("//sub/...");
+
+    try {
+      // Readable but not searchable: the listing stays valid, but stats of entries fail.
+      inner.chmod(0444);
+      assume()
+          .withMessage("Directory permissions are not enforced for the current user")
+          .that(statFails(file))
+          .isTrue();
+      // The file state of sub/inner/f.txt is evaluated to a transient error, which makes that node
+      // depend on the error transience node.
+      var e = assertThrows(BuildFailedException.class, () -> buildTarget("//sub:copy"));
+      assertThat(e).hasMessageThat().contains("1 input file(s) are in error");
+      // An unrelated build invalidates the error transience node and thereby dirties the file state
+      // node without re-evaluating it.
+      buildTarget("//sub:other");
+    } finally {
+      inner.chmod(0755);
+    }
+
+    // The user fixes the permissions and edits the file. The diff processing finds no usable old
+    // value for the dirty file state node and injects a freshly computed one.
+    write("sub/inner/f.txt", "v2");
+    buildTargetWithRetryUntilSeesChange("//sub:other", "sub/inner/f.txt");
+
+    buildTarget("//sub:copy");
+    assertContents("v2", "//sub:copy");
+  }
+
+  private static boolean statFails(Path path) {
+    try {
+      path.stat();
+      return false;
+    } catch (IOException e) {
+      return true;
+    }
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/skyframe/MemoizingEvaluatorTest.java
+++ b/src/test/java/com/google/devtools/build/skyframe/MemoizingEvaluatorTest.java
@@ -5160,6 +5160,31 @@ public abstract class MemoizingEvaluatorTest {
   }
 
   @Test
+  public void valueInjectionOverDirtyEntryWithDeps() throws Exception {
+    SkyKey dep = nonHermeticKey("dep");
+    SkyKey injectable = nonHermeticKey("injectable");
+    SkyKey other = skyKey("other");
+    tester.getOrCreate(injectable).addDependency(dep).setComputedValue(COPY);
+    tester.set(dep, new StringValue("dep1"));
+    tester.set(other, new StringValue("other"));
+    assertThat(tester.evalAndGet(/* keepGoing= */ false, injectable))
+        .isEqualTo(new StringValue("dep1"));
+
+    // Dirty `injectable` through its dep without requesting it, so that it stays dirty.
+    tester.set(dep, new StringValue("dep2"));
+    tester.invalidate();
+    assertThat(tester.evalAndGet(/* keepGoing= */ false, other))
+        .isEqualTo(new StringValue("other"));
+    assertThat(tester.getDirtyKeys()).containsExactly(dep, injectable);
+
+    // Like for a done node with deps, the injection is turned into an invalidation and the node is
+    // evaluated freshly instead of taking the injected value.
+    tester.differencer.inject(ImmutableMap.of(injectable, Delta.justNew(new StringValue("inj"))));
+    assertThat(tester.evalAndGet(/* keepGoing= */ false, injectable))
+        .isEqualTo(new StringValue("dep2"));
+  }
+
+  @Test
   public void valueInjectionOverExistingDirtyEntry() throws Exception {
     SkyKey key = nonHermeticKey("key");
     Delta delta = Delta.justNew(new StringValue("val"));


### PR DESCRIPTION
### Description

`AbstractInMemoryMemoizingEvaluator.pruneInjectedValues` only diverted injections over a *done* node with deps into a plain invalidation. A node that had been dirtied by an earlier invalidation but not re-evaluated since still holds the deps of its last build, and injecting over it crashed in `ParallelEvaluator.injectValues` with `existing entry for ... has deps`.

This change treats a dirty node that had deps in its last build like a done node with deps and turns the injection into an invalidation, so the node is evaluated freshly when it is next needed.

### Motivation

 The crash is reachable in Bazel with an exact diff awareness such as `--watchfs`:

1. A source file whose stat fails transiently (for example because its directory lost the search permission bit) gets a `FILE_STATE` node in error that depends on the error transience node.
2. The next command that does not need the file invalidates the error transience node and thereby dirties the `FILE_STATE` node without re-evaluating it. Builds garbage collect unneeded dirty nodes by default, so this command has to be one that does not run `BuildTool` (such as `query`), or `--version_window_for_dirty_node_gc` has to be non-zero.
3. The user fixes and edits the file. The reported change is processed by `FileSystemValueCheckerInferringAncestors`, which reads the dirty node's last value via `toValue()`, finds none for an error node and injects a freshly computed value. The next evaluation then crashes as above.

A new test in `LocalDiffAwarenessIntegrationTest` plays this out end to end with `--watchfs` and fails without the fix with:

```
java.lang.IllegalStateException: existing entry for [...]/[sub/inner/f.txt] has deps: IncrementalInMemoryNodeEntry{..., lastBuildDirectDeps=GroupedDeps{size=1, elements=[ErrorTransienceValue.KEY]}, ...}
	at com.google.devtools.build.skyframe.ParallelEvaluator.injectValues(ParallelEvaluator.java:626)
	at com.google.devtools.build.skyframe.AbstractInMemoryMemoizingEvaluator.injectValues(AbstractInMemoryMemoizingEvaluator.java:509)
	at com.google.devtools.build.skyframe.AbstractInMemoryMemoizingEvaluator.evaluate(AbstractInMemoryMemoizingEvaluator.java:155)
```

A pure Skyframe regression test is added to `MemoizingEvaluatorTest` as well.

### Build API Changes

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
