### PR TITLE
Guard the producers of top-level runfiles during their download

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteImportantOutputHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteImportantOutputHandler.java
@@ -18,6 +18,7 @@ import static com.google.devtools.build.lib.remote.util.BulkTransfers.mergeBulkT
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher;
@@ -77,8 +78,18 @@ public final class RemoteImportantOutputHandler implements ImportantOutputHandle
   public LostArtifacts processOutputsAndGetLostArtifacts(
       Iterable<Artifact> importantOutputs, InputMetadataProvider metadataProvider)
       throws ImportantOutputException, InterruptedException {
+    // ensureToplevelArtifacts also downloads the artifacts of every runfiles tree known to the
+    // metadata provider. Runfiles trees are hidden top-level outputs and thus not among the
+    // important outputs, but the producers of the artifacts they contain must be guarded from
+    // rewinding during the download just like those of the important outputs.
+    Iterable<Artifact> artifactsToGuard =
+        Iterables.concat(
+            importantOutputs,
+            Iterables.concat(
+                Iterables.transform(
+                    metadataProvider.getRunfilesTrees(), tree -> tree.getArtifacts().toList())));
     try (SilentCloseable lock =
-        maybeEnterProcessOutputsAndGetLostArtifacts(importantOutputs, metadataProvider)) {
+        maybeEnterProcessOutputsAndGetLostArtifacts(artifactsToGuard, metadataProvider)) {
       ensureToplevelArtifacts(importantOutputs, metadataProvider);
     } catch (IOException e) {
       if (e instanceof BulkTransferException bulkTransferException) {


### PR DESCRIPTION

<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description
Since 2fd36c34ed6, runfiles of top-level targets are no longer read-locked for action rewinding since `RemoteImportantOutputHandler.processOutputsAndGetLostArtifacts` only passes the important outputs to the synchronizer, which don't contain the runfiles trees.

### Motivation
Regression caused by 2fd36c34ed6

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
