### PR TITLE
Guard input discovery with the rewound action synchronizer

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRewoundActionSynchronizer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRewoundActionSynchronizer.java
@@ -119,13 +119,15 @@ public final class RemoteRewoundActionSynchronizer implements RewoundActionSynch
   acquires no other write lock.
 
   By inputKeysFor, an action acquires the read lock of the key of each action that generates one of
-  its inputs, including the artifacts of its runfiles trees, before it starts executing. For a tree
+  its inputs, including the artifacts of its runfiles trees, before it starts executing. While it
+  discovers inputs, it additionally holds the read locks of the keys of the actions generating its
+  scheduling dependencies, which are the artifacts it may read during discovery. For a tree
   artifact input, this is the action that generates the tree artifact, or the actions expanded
   from an ActionTemplate that populate it, including producers of empty subdirectories. In either
-  case, the reader depends on that action: ActionExecutionFunction requests all inputs, including
-  discovered ones, before executing, and ArtifactFunction resolves an artifact by requesting its
-  generating action, or, for a tree artifact declared by a template, exactly the expanded actions
-  that populate it.
+  case, the reader depends on that action: ActionExecutionFunction requests all inputs and
+  scheduling dependencies before discovering inputs and all discovered inputs before executing,
+  and ArtifactFunction resolves an artifact by requesting its generating action, or, for a tree
+  artifact declared by a template, exactly the expanded actions that populate it.
 
   Thus an action that holds or waits for the read lock of K depends on any action that can acquire
   the write lock of K.
@@ -271,6 +273,20 @@ public final class RemoteRewoundActionSynchronizer implements RewoundActionSynch
     try (SilentCloseable c =
         Profiler.instance().profile(ProfilerTask.ACTION_LOCK, "action.enterActionExecution")) {
       return lockArtifactsForConsumption(action.getInputs().toList(), metadataProvider);
+    }
+  }
+
+  @Override
+  public SilentCloseable enterInputDiscovery(Action action, InputMetadataProvider metadataProvider)
+      throws InterruptedException {
+    try (SilentCloseable c =
+        Profiler.instance().profile(ProfilerTask.ACTION_LOCK, "action.enterInputDiscovery")) {
+      // Input discovery may read any input or scheduling dependency of the action (e.g. a header
+      // reachable via #include), even ones that are not discovered to be inputs in the end.
+      return lockArtifactsForConsumption(
+          Iterables.concat(
+              action.getInputs().toList(), action.getSchedulingDependencies().toList()),
+          metadataProvider);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRewoundActionSynchronizer.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRewoundActionSynchronizer.java
@@ -281,8 +281,6 @@ public final class RemoteRewoundActionSynchronizer implements RewoundActionSynch
       throws InterruptedException {
     try (SilentCloseable c =
         Profiler.instance().profile(ProfilerTask.ACTION_LOCK, "action.enterInputDiscovery")) {
-      // Input discovery may read any input or scheduling dependency of the action (e.g. a header
-      // reachable via #include), even ones that are not discovered to be inputs in the end.
       return lockArtifactsForConsumption(
           Iterables.concat(
               action.getInputs().toList(), action.getSchedulingDependencies().toList()),

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -978,7 +978,12 @@ public final class SkyframeActionExecutor {
     eventHandler.post(new ScanningActionEvent(action));
 
     ActionExecutionException finalException = null;
-    try {
+    // Input discovery reads generated files just like execution does, so the actions generating
+    // them must not be rewound while it is running.
+    try (SilentCloseable lock =
+        outputService
+            .getRewoundActionSynchronizer()
+            .enterInputDiscovery(action, compositeInputMetadataProvider)) {
       NestedSet<Artifact> artifacts = action.discoverInputs(actionExecutionContext);
 
       // Input discovery may have been affected by lost inputs. If an action filesystem is used, it

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -978,8 +978,6 @@ public final class SkyframeActionExecutor {
     eventHandler.post(new ScanningActionEvent(action));
 
     ActionExecutionException finalException = null;
-    // Input discovery reads generated files just like execution does, so the actions generating
-    // them must not be rewound while it is running.
     try (SilentCloseable lock =
         outputService
             .getRewoundActionSynchronizer()

--- a/src/main/java/com/google/devtools/build/lib/vfs/OutputService.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/OutputService.java
@@ -296,6 +296,13 @@ public interface OutputService {
         throws InterruptedException;
 
     /**
+     * Guards an action from the beginning to the end of its {@link Action#discoverInputs input
+     * discovery}, during which it may read any of its inputs and scheduling dependencies.
+     */
+    SilentCloseable enterInputDiscovery(Action action, InputMetadataProvider metadataProvider)
+        throws InterruptedException;
+
+    /**
      * A no-op implementation of {@link RewoundActionSynchronizer}, suitable for action filesystems
      * that support racy access to action outputs.
      */
@@ -309,6 +316,12 @@ public interface OutputService {
           @Override
           public SilentCloseable enterActionExecution(
               Action action, boolean wasRewound, InputMetadataProvider metadataProvider) {
+            return () -> {};
+          }
+
+          @Override
+          public SilentCloseable enterInputDiscovery(
+              Action action, InputMetadataProvider metadataProvider) {
             return () -> {};
           }
         };

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteRewoundActionSynchronizerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteRewoundActionSynchronizerTest.java
@@ -160,6 +160,41 @@ public final class RemoteRewoundActionSynchronizerTest {
   }
 
   /**
+   * Input discovery may read scheduling dependencies (e.g. headers reachable via {@code #include})
+   * that are not declared inputs, so their producers must not be rewound while it is running.
+   */
+  @Test
+  public void inputDiscovery_locksProducersOfSchedulingDependencies() throws Exception {
+    FileSystem fs = new InMemoryFileSystem(DigestHashFunction.SHA256);
+    ArtifactRoot root = ArtifactRoot.asDerivedRoot(fs.getPath("/exec"), RootType.OUTPUT, "out");
+    var owner = ActionsTestUtil.NULL_ARTIFACT_OWNER;
+    DerivedArtifact header = (DerivedArtifact) ActionsTestUtil.createArtifact(root, "header.h");
+    header.setGeneratingActionKey(ActionLookupData.create(owner, 0));
+    Action headerProducer = newAction(ImmutableList.of(header), ImmutableList.of());
+    DerivedArtifact source = (DerivedArtifact) ActionsTestUtil.createArtifact(root, "source.cc");
+    source.setGeneratingActionKey(ActionLookupData.create(owner, 1));
+    DerivedArtifact object = (DerivedArtifact) ActionsTestUtil.createArtifact(root, "object.o");
+    object.setGeneratingActionKey(ActionLookupData.create(owner, 2));
+    Action compile =
+        newAction(
+            ImmutableList.of(object),
+            /* inputs= */ ImmutableList.of(source),
+            /* schedulingDependencies= */ ImmutableList.of(header));
+    InputMetadataProvider metadataProvider = mock(InputMetadataProvider.class);
+
+    // Switch to the fine locks with an unrelated rewound action first: the coarse lock would
+    // exclude every rewound action regardless of which keys guard the discovery.
+    rewind(newAction());
+
+    var headerProducerPreparation = new TestThread(() -> rewind(headerProducer));
+    try (SilentCloseable discovery = synchronizer.enterInputDiscovery(compile, metadataProvider)) {
+      headerProducerPreparation.start();
+      waitUntilBlocked(headerProducerPreparation);
+    }
+    headerProducerPreparation.joinAndAssertState(DEADLOCK_TIMEOUT_MILLIS);
+  }
+
+  /**
    * A runfiles tree is guarded by the keys of the actions generating the artifacts it contains,
    * which are taken from its metadata rather than from all runfiles trees known to the metadata
    * provider. The action generating the runfiles tree itself isn't excluded, as it doesn't write to
@@ -448,10 +483,19 @@ public final class RemoteRewoundActionSynchronizerTest {
 
   private static Action newAction(
       ImmutableList<? extends Artifact> outputs, ImmutableList<? extends Artifact> inputs) {
+    return newAction(outputs, inputs, /* schedulingDependencies= */ ImmutableList.of());
+  }
+
+  private static Action newAction(
+      ImmutableList<? extends Artifact> outputs,
+      ImmutableList<? extends Artifact> inputs,
+      ImmutableList<? extends Artifact> schedulingDependencies) {
     Action action = mock(Action.class);
     when(action.getPrimaryOutput()).thenReturn(outputs.get(0));
     when(action.getOutputs()).thenReturn(ImmutableList.copyOf(outputs));
     when(action.getInputs()).thenReturn(NestedSetBuilder.wrap(Order.STABLE_ORDER, inputs));
+    when(action.getSchedulingDependencies())
+        .thenReturn(NestedSetBuilder.wrap(Order.STABLE_ORDER, schedulingDependencies));
     return action;
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Bazel!
Please read the contribution guidelines: https://bazel.build/contribute
-->

### Description
Add `RewoundActionSynchronizer.enterInputDiscovery`, which holds the read locks of the producers of the action's inputs and scheduling dependencies (the files discovery may read) for the duration of discovery. 

### Motivation
This avoids FS races between a rewound action producing a header and include scanning reading it.

### Build API Changes
<!--
Does this PR affect the Build API? (e.g. Starlark API, providers, command-line flags, native rules)
If yes, please answer the following:
1. Has this been discussed in a design doc or issue? (Please link it)
2. Is the change backward compatible?
3. If it's a breaking change, what is the migration plan?
-->

No

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

<!--
If this is a new feature, please add 'RELNOTES[NEW]: <description>' here.
If this is a breaking change, please add 'RELNOTES[INC]: <reason>' here.
If this change should be mentioned in release notes, please add 'RELNOTES: <reason>' here.
-->

RELNOTES: None
