### PR TITLE
Fix rewinding when a lost artifact is under a subtree artifact in a runfiles tree

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/rewinding/ActionRewindStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/rewinding/ActionRewindStrategy.java
@@ -711,6 +711,18 @@ public final class ActionRewindStrategy {
         for (Artifact transitiveOwner : transitiveOwners) {
           checkDerived(transitiveOwner);
 
+          // The lost input may be included in a subtree artifact of a tree artifact that is
+          // included by a runfiles tree that the action directly depends on. Note that subtree
+          // artifacts cannot be nested, so one additional level is sufficient.
+          for (Artifact outerOwner : owners.get(transitiveOwner)) {
+            checkDerived(outerOwner);
+
+            if (expandedDeps.contains(Artifact.key(outerOwner))) {
+              lostInputOwningDirectDeps.add((DerivedArtifact) outerOwner);
+              foundLostInputDepOwner = true;
+            }
+          }
+
           if (expandedDeps.contains(Artifact.key(transitiveOwner))) {
             // The lost input is included in an aggregation artifact (e.g. a tree artifact or
             // fileset) that is included by an aggregation artifact (e.g. a runfiles tree) that the

--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTest.java
@@ -277,6 +277,12 @@ public final class RewindingTest extends BuildIntegrationTestCase {
   }
 
   @Test
+  public void actionTemplateExpansionRewound_fileUnderSubtreeArtifactInRunfilesLost()
+      throws Exception {
+    helper.runActionTemplateExpansionRewound_fileUnderSubtreeArtifactInRunfilesLost();
+  }
+
+  @Test
   public void actionTemplateExpansionRewound_siblingActionsReExecuteConcurrently()
       throws Exception {
     helper.runActionTemplateExpansionRewound_siblingActionsReExecuteConcurrently();

--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
@@ -2032,6 +2032,84 @@ public class RewindingTestsHelper {
     assertThat(executedSpawns).hasCount("Executing genrule //foo:consumer", 2);
   }
 
+  public final void runActionTemplateExpansionRewound_fileUnderSubtreeArtifactInRunfilesLost()
+      throws Exception {
+    testCase.addOptions("--experimental_allow_map_directory");
+    testCase.write(
+        "foo/map.bzl",
+        """
+        def _map_impl(template_ctx, input_directories, output_directories, tools, **kwargs):
+            for in_file in input_directories["in"].children:
+                out_subdir = template_ctx.declare_subdirectory(
+                  in_file.basename + "_subdir",
+                  directory = output_directories["out"],
+                )
+                template_ctx.run(
+                    progress_message = "Copying file to %{output}",
+                    inputs = [in_file],
+                    outputs = [out_subdir],
+                    executable = tools["copy_tool"],
+                    arguments = [out_subdir.path + "/file", in_file.path],
+                )
+
+        def _map_dir_impl(ctx):
+            tool = ctx.actions.declare_file(ctx.attr.name + ".bat")
+            ctx.actions.write(tool, r\"\"\"COPY_TOOL_SCRIPT\"\"\", is_executable = True)
+
+            in_dir = ctx.actions.declare_directory("in_tree")
+            ctx.actions.run_shell(
+                progress_message = "Creating in_tree",
+                outputs = [in_dir],
+                command = "echo 1 > $1/a && echo 2 > $1/b",
+                arguments = [in_dir.path],
+            )
+            out_dir = ctx.actions.declare_directory("out_tree")
+            ctx.actions.map_directory(
+                implementation = _map_impl,
+                input_directories = {"in": in_dir},
+                output_directories = {"out": out_dir},
+                tools = {"copy_tool": tool},
+            )
+            return DefaultInfo(files = depset([out_dir]))
+
+        map_dir = rule(implementation = _map_dir_impl)
+        """
+            .replace("COPY_TOOL_SCRIPT", COPY_TOOL_SCRIPT));
+    mockFooBinary("foo/foo_binary.bzl");
+    testCase.write(
+        "foo/BUILD",
+        """
+        load(":map.bzl", "map_dir")
+        load(":foo_binary.bzl", "foo_binary")
+        map_dir(name = "map")
+        foo_binary(name = "tool", srcs = ["tool.sh"], data = [":map"])
+        genrule(name = "consumer", outs = ["consumer.out"], cmd = "touch $@", tools = [":tool"])
+        """);
+    testCase.write("foo/tool.sh", "#!/bin/bash").setExecutable(true);
+
+    addSpawnShim(
+        "Executing genrule //foo:consumer",
+        (spawn, context) -> {
+          Artifact outTree =
+              SpawnInputUtils.getRunfilesArtifactWithName(spawn, context, "out_tree");
+          assertThat(outTree.isTreeArtifact()).isTrue();
+          Artifact lost =
+              SpawnInputUtils.getExpandedToArtifact("a_subdir/file", outTree, spawn, context);
+          assertThat(lost.getParent().isSubTreeArtifact()).isTrue();
+          return createLostInputsExecException(context, lost);
+        });
+
+    testCase.buildTarget("//foo:consumer");
+
+    verifyAllSpawnShimsConsumed();
+    var executedSpawns = ImmutableMultiset.copyOf(getExecutedSpawnDescriptions());
+    assertThat(executedSpawns).hasCount("Creating in_tree [for tool]", 1);
+    assertThat(executedSpawns).hasCount("Copying file to foo/out_tree/a_subdir [for tool]", 2);
+    assertThat(executedSpawns)
+        .hasCount("Copying file to foo/out_tree/b_subdir [for tool]", precise() ? 1 : 2);
+    assertThat(executedSpawns).hasCount("Executing genrule //foo:consumer", 2);
+  }
+
   /**
    * Verifies that sibling actions of a rewound {@link
    * com.google.devtools.build.lib.actions.ActionTemplate} expansion re-execute concurrently.


### PR DESCRIPTION
The ownership accounting in `ActionRewindStrategy` already extended for subtree artifacts in https://github.com/fmeum/bazel/commit/d4c275b89348663ec7b84e58f75ec8ab46f62101 now traverses one additional level to also cover subtree artifacts in tree artifacts in runfiles.